### PR TITLE
Re-adds showing your ID [GOOF YOU LITERALLY HAD TO CHANGE ONE WORD, GOD]

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -132,7 +132,7 @@
 	if(mapload && access_txt)
 		access = text2access(access_txt)
 
-/obj/item/card/id/AltClick(mob/user)
+/obj/item/card/id/attack_self(mob/user)
 	if(Adjacent(user))
 		user.visible_message("<span class='notice'>[user] shows you: [icon2html(src, viewers(user))] [src.name].</span>", "<span class='notice'>You show \the [src.name].</span>")
 	add_fingerprint(user)
@@ -152,7 +152,7 @@
 			to_chat(user, "You insert [holochip] into [src], adding [holochip.credits] credits to your account.")
 			qdel(holochip)
 
-/obj/item/card/id/attack_self(mob/user)
+/obj/item/card/id/AltClick(mob/user)
 	if(!registered_account)
 		var/new_bank_id = input(user, "Enter your account ID.", "Account Reclamation", 111111) as num
 		if(!new_bank_id || new_bank_id < 111111 || new_bank_id > 999999)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -153,7 +153,7 @@
 			qdel(holochip)
 
 /obj/item/card/id/AltClick(mob/living/user)
-	if(Adjacent(user))
+	if(Adjacent(user) && isliving(user) && user.mind)
 		if(!registered_account)
 			var/new_bank_id = input(user, "Enter your account ID.", "Account Reclamation", 111111) as num
 			if(!new_bank_id || new_bank_id < 111111 || new_bank_id > 999999)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -111,7 +111,8 @@
 
 /obj/item/card/id
 	name = "identification card"
-	desc = "A card used to provide ID and determine access across the station. Alt+Cick to withdraw funds from a linked account."
+	desc = "A card used to provide ID and determine access across the station. \
+	<span class='notice'>Alt-click to rotate it clockwise.</span>"
 	icon_state = "id"
 	item_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -111,7 +111,7 @@
 
 /obj/item/card/id
 	name = "identification card"
-	desc = "A card used to provide ID and determine access across the station."
+	desc = "A card used to provide ID and determine access across the station. Alt+Cick to withdraw funds from a linked account."
 	icon_state = "id"
 	item_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -152,32 +152,33 @@
 			to_chat(user, "You insert [holochip] into [src], adding [holochip.credits] credits to your account.")
 			qdel(holochip)
 
-/obj/item/card/id/AltClick(mob/user)
-	if(!registered_account)
-		var/new_bank_id = input(user, "Enter your account ID.", "Account Reclamation", 111111) as num
-		if(!new_bank_id || new_bank_id < 111111 || new_bank_id > 999999)
-			to_chat(user, "The ID needs to be between 111111 and 999999.")
-			return
-		for(var/A in SSeconomy.bank_accounts)
-			var/datum/bank_account/B = A
-			if(B.account_id == new_bank_id)
-				B.bank_cards += src
-				registered_account = B
-				to_chat(user, "Your account has been assigned to this ID card.")
+/obj/item/card/id/AltClick(mob/living/user)
+	if(Adjacent(user))
+		if(!registered_account)
+			var/new_bank_id = input(user, "Enter your account ID.", "Account Reclamation", 111111) as num
+			if(!new_bank_id || new_bank_id < 111111 || new_bank_id > 999999)
+				to_chat(user, "The ID needs to be between 111111 and 999999.")
 				return
-		to_chat(user, "The ID provided is not a real account.")
-		return
-	var/amount_to_remove = input(user, "How much do you want to withdraw?", "Account Reclamation", 5) as num
-	if(!amount_to_remove || amount_to_remove < 0)
-		return
-	if(registered_account.adjust_money(-amount_to_remove))
-		var/obj/item/holochip/holochip = new (get_turf(user), amount_to_remove)
-		user.put_in_hands(holochip)
-		to_chat(user, "You withdraw [amount_to_remove] credits into a holochip.")
-		return
-	else
-		to_chat(user, "You don't have the funds for that.")
-		return
+			for(var/A in SSeconomy.bank_accounts)
+				var/datum/bank_account/B = A
+				if(B.account_id == new_bank_id)
+					B.bank_cards += src
+					registered_account = B
+					to_chat(user, "Your account has been assigned to this ID card.")
+					return
+			to_chat(user, "The ID provided is not a real account.")
+			return
+		var/amount_to_remove = input(user, "How much do you want to withdraw?", "Account Reclamation", 5) as num
+		if(!amount_to_remove || amount_to_remove < 0)
+			return
+		if(registered_account.adjust_money(-amount_to_remove))
+			var/obj/item/holochip/holochip = new (get_turf(user), amount_to_remove)
+			user.put_in_hands(holochip)
+			to_chat(user, "You withdraw [amount_to_remove] credits into a holochip.")
+			return
+		else
+			to_chat(user, "You don't have the funds for that.")
+			return
 
 /obj/item/card/id/examine(mob/user)
 	..()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -111,8 +111,7 @@
 
 /obj/item/card/id
 	name = "identification card"
-	desc = "A card used to provide ID and determine access across the station. \
-	<span class='notice'>Alt-click to rotate it clockwise.</span>"
+	desc = "A card used to provide ID and determine access across the station."
 	icon_state = "id"
 	item_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
@@ -130,6 +129,7 @@
 
 /obj/item/card/id/Initialize(mapload)
 	. = ..()
+	desc +=  "\n<span class='notice'>Alt-click to withdraw funds from a linked account.</span>"
 	if(mapload && access_txt)
 		access = text2access(access_txt)
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -153,7 +153,7 @@
 			qdel(holochip)
 
 /obj/item/card/id/AltClick(mob/living/user)
-	if(Adjacent(user) && isliving(user) && user.mind)
+	if(Adjacent(user) && isliving(user))
 		if(!registered_account)
 			var/new_bank_id = input(user, "Enter your account ID.", "Account Reclamation", 111111) as num
 			if(!new_bank_id || new_bank_id < 111111 || new_bank_id > 999999)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -156,32 +156,33 @@
 	if(user.get_active_held_item() != src)
 		to_chat(user, "You must hold the ID in your hand to do this.")
 		return
-	if(user.canUseTopic(src, BE_CLOSE) && isliving(user))
-		if(!registered_account)
-			var/new_bank_id = input(user, "Enter your account ID.", "Account Reclamation", 111111) as num
-			if(!new_bank_id || new_bank_id < 111111 || new_bank_id > 999999)
-				to_chat(user, "The ID needs to be between 111111 and 999999.")
+	if (!user.canUseTopic(src, BE_CLOSE) || !isliving(user))
+		return
+	if(!registered_account)
+		var/new_bank_id = input(user, "Enter your account ID.", "Account Reclamation", 111111) as num
+		if(!new_bank_id || new_bank_id < 111111 || new_bank_id > 999999)
+			to_chat(user, "The ID needs to be between 111111 and 999999.")
+			return
+		for(var/A in SSeconomy.bank_accounts)
+			var/datum/bank_account/B = A
+			if(B.account_id == new_bank_id)
+				B.bank_cards += src
+				registered_account = B
+				to_chat(user, "Your account has been assigned to this ID card.")
 				return
-			for(var/A in SSeconomy.bank_accounts)
-				var/datum/bank_account/B = A
-				if(B.account_id == new_bank_id)
-					B.bank_cards += src
-					registered_account = B
-					to_chat(user, "Your account has been assigned to this ID card.")
-					return
-			to_chat(user, "The ID provided is not a real account.")
-			return
-		var/amount_to_remove = input(user, "How much do you want to withdraw?", "Account Reclamation", 5) as num
-		if(!amount_to_remove || amount_to_remove < 0)
-			return
-		if(registered_account.adjust_money(-amount_to_remove))
-			var/obj/item/holochip/holochip = new (get_turf(user), amount_to_remove)
-			user.put_in_hands(holochip)
-			to_chat(user, "You withdraw [amount_to_remove] credits into a holochip.")
-			return
-		else
-			to_chat(user, "You don't have the funds for that.")
-			return
+		to_chat(user, "The ID provided is not a real account.")
+		return
+	var/amount_to_remove = input(user, "How much do you want to withdraw?", "Account Reclamation", 5) as num
+	if(!amount_to_remove || amount_to_remove < 0)
+		return
+	if(registered_account.adjust_money(-amount_to_remove))
+		var/obj/item/holochip/holochip = new (get_turf(user), amount_to_remove)
+		user.put_in_hands(holochip)
+		to_chat(user, "You withdraw [amount_to_remove] credits into a holochip.")
+		return
+	else
+		to_chat(user, "You don't have the funds for that.")
+		return
 
 /obj/item/card/id/examine(mob/user)
 	..()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -129,7 +129,6 @@
 
 /obj/item/card/id/Initialize(mapload)
 	. = ..()
-	desc +=  "\n<span class='notice'>Alt-click to withdraw funds from a linked account.</span>"
 	if(mapload && access_txt)
 		access = text2access(access_txt)
 
@@ -192,7 +191,7 @@
 			var/datum/bank_account/D = SSeconomy.get_dep_account(registered_account.account_job.paycheck_department)
 			if(D)
 				to_chat(user, "The [D.account_holder] reports a balance of $[D.account_balance].")
-		to_chat(user, "Use your ID in-hand to pull money from your account in the form of holochips.")
+		to_chat(user, "Alt-Click your ID in-hand to pull money from your account in the form of holochips.")
 		to_chat(user, "You can insert credits into your account by pressing holochips against the ID.")
 		to_chat(user, "If you lose this ID card, you can reclaim your account by using a blank ID card inhand and punching in the account ID.")
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -153,7 +153,10 @@
 			qdel(holochip)
 
 /obj/item/card/id/AltClick(mob/living/user)
-	if(Adjacent(user) && isliving(user))
+	if(user.get_active_held_item() != src)
+		to_chat(user, "You must hold the ID in your hand to do this.")
+		return
+	if(user.canUseTopic(src, BE_CLOSE) && isliving(user))
 		if(!registered_account)
 			var/new_bank_id = input(user, "Enter your account ID.", "Account Reclamation", 111111) as num
 			if(!new_bank_id || new_bank_id < 111111 || new_bank_id > 999999)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -127,12 +127,15 @@
 	var/datum/bank_account/registered_account
 	var/obj/machinery/paystand/my_store
 
-
-
 /obj/item/card/id/Initialize(mapload)
 	. = ..()
 	if(mapload && access_txt)
 		access = text2access(access_txt)
+
+/obj/item/card/id/AltClick(mob/user)
+	if(Adjacent(user))
+		user.visible_message("<span class='notice'>[user] shows you: [icon2html(src, viewers(user))] [src.name].</span>", "<span class='notice'>You show \the [src.name].</span>")
+	add_fingerprint(user)
 
 /obj/item/card/id/vv_edit_var(var_name, var_value)
 	. = ..()


### PR DESCRIPTION
Fixes #40530
Fixes #40554 

**beesting+everyone:** 
_goof i need you to fix your code_ 
**goof:**
_uuuuh ill get back to you in half a week this is a uuuh difficult undertaking uuh am i being paid for this uuuh syndicate cards already use the alt+click function i swear uuh_ 

**meanwhile, the task that needed to be done:** 
change
`/obj/item/card/id/after_attack(mob/user)` _to_
`/obj/item/card/id/AltClick(mob/user)`

----

:cl: MrDoomBringer
add: Nanotrasen's ID cards are once again clearly readable from a distance, meaning employees can  show their ID's to eachother again. The Director of ID-Card technology promises that the temporary unreadability of said cards was not an oversight, and was in fact an intended, yet undocumented feature. promise. Alt+Clicking cards now dispenses money, and clicking on the card in-hand shows it off.
/:cl:

also, from #40530

>"Agent IDs probably are fine, since they used a different method anyways."

as a side note, agent ID cards aren't fine, as they dont use a different method of being shown off, and as such were also broken. but i mean who has time to read code
