### PR TITLE
More orbit fixes

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -9,8 +9,7 @@
 //rotation_speed: how fast to rotate (how many ds should it take for a rotation to complete)
 //rotation_segments: the resolution of the orbit circle, less = a more block circle, this can be used to produce hexagons (6 segments) triangles (3 segments), and so on, 36 is the best default.
 //pre_rotation: Chooses to rotate src 90 degress towards the orbit dir (clockwise/anticlockwise), useful for things to go "head first" like ghosts
-//lockinorbit: Forces src to always be on A's turf, otherwise the orbit cancels when src gets too far away (eg: ghosts)
-/datum/component/orbiter/Initialize(atom/movable/orbiter, radius, clockwise, rotation_speed, rotation_segments, pre_rotation, lockinorbit)
+/datum/component/orbiter/Initialize(atom/movable/orbiter, radius, clockwise, rotation_speed, rotation_segments, pre_rotation)
 	if(!istype(orbiter) || !isatom(parent) || isarea(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -21,7 +20,7 @@
 	var/atom/master = parent
 	master.orbiters = src
 
-	begin_orbit(orbiter, radius, clockwise, rotation_speed, rotation_segments, pre_rotation, lockinorbit)
+	begin_orbit(orbiter, radius, clockwise, rotation_speed, rotation_segments, pre_rotation)
 
 /datum/component/orbiter/RegisterWithParent()
 	var/atom/target = parent
@@ -57,13 +56,13 @@
 		return COMPONENT_INCOMPATIBLE
 	move_react()
 
-/datum/component/orbiter/proc/begin_orbit(atom/movable/orbiter, radius, clockwise, rotation_speed, rotation_segments, pre_rotation, lockinorbit)
+/datum/component/orbiter/proc/begin_orbit(atom/movable/orbiter, radius, clockwise, rotation_speed, rotation_segments, pre_rotation)
 	if(orbiter.orbiting)
 		if(orbiter.orbiting == src)
 			orbiter.orbiting.end_orbit(orbiter, TRUE)
 		else
 			orbiter.orbiting.end_orbit(orbiter)
-	orbiters[orbiter] = lockinorbit
+	orbiters[orbiter] = TRUE
 	orbiter.orbiting = src
 	RegisterSignal(orbiter, COMSIG_MOVABLE_MOVED, orbiter_spy)
 	var/matrix/initial_transform = matrix(orbiter.transform)
@@ -89,7 +88,7 @@
 	to_chat(orbiter, "<span class='notice'>Now orbiting [parent].</span>")
 
 /datum/component/orbiter/proc/end_orbit(atom/movable/orbiter, refreshing=FALSE)
-	if(isnull(orbiters[orbiter]))
+	if(!orbiters[orbiter])
 		return
 	UnregisterSignal(orbiter, COMSIG_MOVABLE_MOVED)
 	orbiter.SpinAnimation(0, 0)
@@ -107,7 +106,6 @@
 	if(master.loc == oldloc)
 		return
 
-	var/turf/oldturf = get_turf(oldloc)
 	var/turf/newturf = get_turf(parent)
 	if(!newturf)
 		qdel(src)
@@ -129,9 +127,6 @@
 		var/atom/movable/thing = i
 		if(thing.loc == newturf)
 			continue
-		if(!newturf || (oldloc && !orbiters[thing] && thing.loc != oldturf && thing.loc != newturf))
-			end_orbit(thing)
-			continue
 		thing.forceMove(newturf)
 		CHECK_TICK
 
@@ -142,11 +137,11 @@
 
 /////////////////////
 
-/atom/movable/proc/orbit(atom/A, radius = 10, clockwise = FALSE, rotation_speed = 20, rotation_segments = 36, pre_rotation = TRUE, lockinorbit = FALSE)
+/atom/movable/proc/orbit(atom/A, radius = 10, clockwise = FALSE, rotation_speed = 20, rotation_segments = 36, pre_rotation = TRUE)
 	if(!istype(A) || !get_turf(A) || A == src)
 		return
 
-	return A.AddComponent(/datum/component/orbiter, src, radius, clockwise, rotation_speed, rotation_segments, pre_rotation, lockinorbit)
+	return A.AddComponent(/datum/component/orbiter, src, radius, clockwise, rotation_speed, rotation_segments, pre_rotation)
 
 /atom/movable/proc/stop_orbit(datum/component/orbiter/orbits)
 	return // We're just a simple hook

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -25,13 +25,13 @@
 
 /datum/component/orbiter/RegisterWithParent()
 	var/atom/target = parent
-	while(!isturf(target))
+	while(ismovableatom(target))
 		RegisterSignal(target, COMSIG_MOVABLE_MOVED, orbited_spy)
 		target = target.loc
 
 /datum/component/orbiter/UnregisterFromParent()
 	var/atom/target = parent
-	while(!isturf(target))
+	while(ismovableatom(target))
 		UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
 		target = target.loc
 
@@ -116,12 +116,12 @@
 	// These are prety rarely activated, how often are you following something in a bag?
 	if(oldloc && !isturf(oldloc)) // We used to be registered to it, probably
 		var/atom/target = oldloc
-		while(!isturf(target))
+		while(ismovableatom(target))
 			UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
 			target = target.loc
 	if(orbited?.loc && orbited.loc != newturf) // We want to know when anything holding us moves too
 		var/atom/target = orbited.loc
-		while(!isturf(target))
+		while(ismovableatom(target))
 			RegisterSignal(target, COMSIG_MOVABLE_MOVED, orbited_spy, TRUE)
 			target = target.loc
 	
@@ -152,5 +152,6 @@
 	return // We're just a simple hook
 
 /atom/proc/transfer_observers_to(atom/target)
-	var/datum/component/orbiter/orbits = GetComponent(/datum/component/orbiter)
-	target.TakeComponent(orbits)
+	if(!orbiters || !istype(target) || !get_turf(target) || target == src)
+		return
+	target.TakeComponent(orbiters)

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -229,11 +229,11 @@
 		sparkles += S
 		switch(i)
 			if(1 to 8)
-				S.orbit(src, 30, TRUE, 60, 36, TRUE, FALSE)
+				S.orbit(src, 30, TRUE, 60, 36, TRUE)
 			if(9 to 16)
-				S.orbit(src, 62, TRUE, 60, 36, TRUE, FALSE)
+				S.orbit(src, 62, TRUE, 60, 36, TRUE)
 			if(17 to 24)
-				S.orbit(src, 95, TRUE, 60, 36, TRUE, FALSE)
+				S.orbit(src, 95, TRUE, 60, 36, TRUE)
 			if(25)
 				S.pixel_y = 7
 				S.forceMove(get_turf(src))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -143,7 +143,7 @@
 		if(INCORPOREAL_MOVE_BASIC)
 			var/T = get_step(L,direct)
 			if(T)
-				L.loc = T
+				L.forceMove(T)
 			L.setDir(direct)
 		if(INCORPOREAL_MOVE_SHADOW)
 			if(prob(50))
@@ -185,7 +185,7 @@
 				new /obj/effect/temp_visual/dir_setting/ninja/shadow(mobloc, L.dir)
 				var/T = get_step(L,direct)
 				if(T)
-					L.loc = T
+					L.forceMove(T)
 			L.setDir(direct)
 		if(INCORPOREAL_MOVE_JAUNT) //Incorporeal move, but blocked by holy-watered tiles and salt piles.
 			var/turf/open/floor/stepTurf = get_step(L, direct)
@@ -204,7 +204,7 @@
 					to_chat(L, "<span class='warning'>Holy energies block your path!</span>")
 					return
 
-				L.loc = get_step(L, direct)
+				L.forceMove(stepTurf)
 			L.setDir(direct)
 	return TRUE
 

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -150,8 +150,8 @@
 		var/obj/singularity/energy_ball/orbitingball = orbiting.parent
 		orbitingball.orbiting_balls -= src
 		orbitingball.dissipate_strength = orbitingball.orbiting_balls.len
-	..()
-	if (!loc && !QDELETED(src))
+	. = ..()
+	if (!QDELETED(src))
 		qdel(src)
 
 


### PR DESCRIPTION
Attempt 2 at fixing the remaining bugs with orbits

Incorpmove had to be converted to `forceMove()` to make orbits able to tell when they move. They used loc setting before. This likely breaks some things but I couldn't find any particular issues. We should be overriding forceMove anyway for things that need to handle loc changes like that differently.

fixes #40544
fixes #40522