### PR TITLE
nerfs agent box a smidgen

### DIFF
--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -12,7 +12,7 @@
 	move_speed_multiplier = 0.5
 
 /obj/structure/closet/cardboard/agent/proc/go_invisible()
-	animate(src, , alpha = 0, time = 8)
+	animate(src, , alpha = 0, time = 20)
 
 /obj/structure/closet/cardboard/agent/Initialize()
 	. = ..()

--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -12,7 +12,7 @@
 	move_speed_multiplier = 0.5
 
 /obj/structure/closet/cardboard/agent/proc/go_invisible()
-	animate(src, , alpha = 0, time = 5)
+	animate(src, , alpha = 0, time = 8)
 
 /obj/structure/closet/cardboard/agent/Initialize()
 	. = ..()


### PR DESCRIPTION
changed the time to turn invisible from 0.5 seconds to 2 seconds

:cl: basilman
balance: changed the time for agent box to turn invisible from half a second to 2 seconds
/:cl:

[why]: # cuz it's too short and the few seconds at the beginning where it's highly visible are what matters
