### PR TITLE
Tweaks reagent bounties

### DIFF
--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -155,7 +155,7 @@ datum/bounty/reagent/chemical_simple/New()
 	var/reagent_type = pick(possible_reagents)
 	wanted_reagent = new reagent_type
 	name = wanted_reagent.name
-	description = "CentCom is requesting the chemical [name]. Ship a container of it to be rewarded."
+	description = "CentCom is in desperate need of the chemical [name]. Ship a container of it to be rewarded."
 	reward += rand(0, 4) * 500 //4000 to 6000 credits
 
 /datum/bounty/reagent/chemical_complex

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -102,16 +102,17 @@ datum/bounty/reagent/complex_drink/New()
 		/datum/reagent/consumable/ethanol/drunkenblumpkin,\
 		/datum/reagent/consumable/ethanol/fetching_fizz,\
 		/datum/reagent/consumable/ethanol/goldschlager,\
-		/datum/reagent/consumable/ethanol/hearty_punch,\
 		/datum/reagent/consumable/ethanol/manhattan_proj,\
 		/datum/reagent/consumable/ethanol/narsour,\
 		/datum/reagent/consumable/ethanol/neurotoxin,\
 		/datum/reagent/consumable/ethanol/patron,\
 		/datum/reagent/consumable/ethanol/quadruple_sec,\
-		/datum/reagent/consumable/ethanol/quintuple_sec,\
 		/datum/reagent/consumable/bluecherryshake,\
 		/datum/reagent/consumable/doctor_delight,\
-		/datum/reagent/consumable/ethanol/silencer)
+		/datum/reagent/consumable/ethanol/silencer,\
+		/datum/reagent/consumable/ethanol/peppermint_patty,\
+		/datum/reagent/consumable/ethanol/aloe,\
+		/datum/reagent/consumable/pumpkin_latte)
 		
 	var/reagent_type = pick(possible_reagents)
 	wanted_reagent = new reagent_type
@@ -119,54 +120,72 @@ datum/bounty/reagent/complex_drink/New()
 	description = "CentCom is offering a reward for talented mixologists. Ship a container of [name] to claim the prize."
 	reward += rand(0, 4) * 500
 
-/datum/bounty/reagent/chemical
-	name = "Chemical"
+/datum/bounty/reagent/chemical_simple
+	name = "Simple Chemical"
 	reward = 4000
 	required_volume = 30
 
-datum/bounty/reagent/chemical/New()
-	// Don't worry about making this comprehensive. It doesn't matter if some chems are skipped.
+datum/bounty/reagent/chemical_simple/New()
+	// Chemicals that can be mixed by a single skilled Chemist.
 	var/static/list/possible_reagents = list(\
 		/datum/reagent/medicine/leporazine,\
 		/datum/reagent/medicine/clonexadone,\
-		/datum/reagent/medicine/pyroxadone,\
-		/datum/reagent/medicine/rezadone,\
 		/datum/reagent/medicine/mine_salve,\
-		/datum/reagent/medicine/pen_acid,\
 		/datum/reagent/medicine/perfluorodecalin,\
 		/datum/reagent/medicine/ephedrine,\
 		/datum/reagent/medicine/diphenhydramine,\
-		/datum/reagent/medicine/atropine,\
-		/datum/reagent/medicine/strange_reagent,\
-		/datum/reagent/medicine/regen_jelly,\
 		/datum/reagent/drug/space_drugs,\
 		/datum/reagent/drug/crank,\
-		/datum/reagent/drug/krokodil,\
-		/datum/reagent/drug/methamphetamine,\
-		/datum/reagent/drug/bath_salts,\
-		/datum/reagent/drug/aranesp,\
-		/datum/reagent/nitroglycerin,\
 		/datum/reagent/blackpowder,\
 		/datum/reagent/napalm,\
-		/datum/reagent/teslium,\
 		/datum/reagent/firefighting_foam,\
-		/datum/reagent/consumable/honey,\
 		/datum/reagent/consumable/mayonnaise,\
-		/datum/reagent/consumable/frostoil,\
-		/datum/reagent/toxin/slimejelly,\
 		/datum/reagent/toxin/itching_powder,\
-		/datum/reagent/toxin/amanitin,\
-		/datum/reagent/toxin/coniine,\
 		/datum/reagent/toxin/cyanide,\
 		/datum/reagent/toxin/heparin,\
-		/datum/reagent/toxin/skewium,\
+		/datum/reagent/medicine/pen_acid,\
+		/datum/reagent/medicine/atropine,\
+		/datum/reagent/drug/aranesp,\
+		/datum/reagent/drug/krokodil,\
+		/datum/reagent/drug/methamphetamine,\
+		/datum/reagent/teslium,\
 		/datum/reagent/toxin/anacea,\
-		/datum/reagent/toxin/mimesbane,\
 		/datum/reagent/pax)
 
 	var/reagent_type = pick(possible_reagents)
 	wanted_reagent = new reagent_type
 	name = wanted_reagent.name
-	description = "CentCom is in desperate need of the chemical [name]. Ship a container of it to be rewarded."
-	reward += rand(0, 4) * 500
+	description = "CentCom is requesting the chemical [name]. Ship a container of it to be rewarded."
+	reward += rand(0, 4) * 500 //4000 to 6000 credits
 
+/datum/bounty/reagent/chemical_complex
+	name = "Rare Chemical"
+	reward = 6000
+	required_volume = 20
+
+datum/bounty/reagent/chemical_complex/New()
+	// Reagents that require interaction with multiple departments or are a pain to mix. Lower required_volume since acquiring 30u of some is unrealistic
+	var/static/list/possible_reagents = list(\
+		/datum/reagent/medicine/pyroxadone,\
+		/datum/reagent/medicine/rezadone,\
+		/datum/reagent/medicine/regen_jelly,\
+		/datum/reagent/drug/bath_salts,\
+		/datum/reagent/hair_dye,\
+		/datum/reagent/consumable/honey,\
+		/datum/reagent/consumable/frostoil,\
+		/datum/reagent/toxin/slimejelly,\
+		/datum/reagent/teslium/energized_jelly,\
+		/datum/reagent/toxin/skewium,\
+		/datum/reagent/toxin/mimesbane,\
+		/datum/reagent/medicine/strange_reagent,\
+		/datum/reagent/nitroglycerin,\
+		/datum/reagent/medicine/rezadone,\
+		/datum/reagent/toxin/zombiepowder,\
+		/datum/reagent/toxin/ghoulpowder,\
+		/datum/reagent/mulligan)
+
+	var/reagent_type = pick(possible_reagents)
+	wanted_reagent = new reagent_type
+	name = wanted_reagent.name
+	description = "CentCom is paying premium for the chemical [name]. Ship a container of it to be rewarded."
+	reward += rand(0, 5) * 750 //6000 to 9750 credits

--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -29,7 +29,7 @@
 /datum/bounty/more_bounties
 	name = "More Bounties"
 	description = "Complete enough bounties and CentCom will issue new ones!"
-	reward = 3 // number of bounties
+	reward = 5 // number of bounties
 	var/required_bounties = 5
 
 /datum/bounty/more_bounties/can_claim()

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -95,7 +95,9 @@ GLOBAL_LIST_EMPTY(bounties_list)
 				return new /datum/bounty/reagent/simple_drink
 			return new /datum/bounty/reagent/complex_drink
 		if(6)
-			return new /datum/bounty/reagent/chemical
+			if(rand(2) == 1)
+				return new /datum/bounty/reagent/chemical_simple
+			return new /datum/bounty/reagent/chemical_complex
 		if(7)
 			var/subtype = pick(subtypesof(/datum/bounty/virus))
 			return new subtype
@@ -142,8 +144,9 @@ GLOBAL_LIST_EMPTY(bounties_list)
 	/********************************Strict Type Gens********************************/
 	var/list/easy_add_list_strict_types = list(/datum/bounty/reagent/simple_drink = 1,
 											/datum/bounty/reagent/complex_drink = 1,
-											/datum/bounty/reagent/chemical = 1)
-
+											/datum/bounty/reagent/chemical_simple = 1,
+											/datum/bounty/reagent/chemical_complex = 1)
+											
 	for(var/the_strict_type in easy_add_list_strict_types)
 		for(var/i in 1 to easy_add_list_strict_types[the_strict_type])
 			try_add_bounty(new the_strict_type)


### PR DESCRIPTION
:cl: Denton
tweak: Split chemical bounties into simple/complex ones and removed some that are disproportionately hard to acquire.
tweak: The "More Bounties" bounty now awards five instead of three new bounties.
/:cl:

tl;dr of this PR is:

A) Reagent bounties are split into two different categories - simple and complex.

Simple bounties can be mixed by a single chemist, but complex ones require either cooperation with a third department or some serious mixing.
Also, removed amanitin/coniine bounties since those should be added to botany bounties instead.

B) Tweaked bartender bounties

- Removed quintuple sec, as it relies on Bananium which can't be obtained every round
- Removed hearty punch, as it takes a disproportionate amount of effort to mix in large quantities
- Added bounties for peppermint patty, pumpkin latte and aloe

C) Increased the amount of "more bounties"

The variety and amount of available bounties has increased since the original PR; it only makes sense to increase the number of new bounties offered by this as well.
