### PR TITLE
Runtimestation: Uplinks, darkroom, ARCD/RLD

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -547,15 +547,18 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/closet/secure_closet/captains{
-	locked = 0
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/uplink/debug{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/uplink/nuclear/debug,
 /turf/open/floor/plasteel,
 /area/bridge)
 "bH" = (
@@ -571,13 +574,13 @@
 "bJ" = (
 /obj/structure/table,
 /obj/item/card/id/ert{
-	pixel_x = 4;
-	pixel_y = -4
+	pixel_x = 6;
+	pixel_y = -6
 	},
 /obj/item/card/id/syndicate/nuke_leader,
 /obj/item/card/id/captains_spare{
-	pixel_x = -4;
-	pixel_y = 4
+	pixel_x = -6;
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -595,14 +598,14 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "bM" = (
-/obj/structure/closet/secure_closet/hop{
-	locked = 0
-	},
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/construction/rld,
+/obj/item/construction/rcd/arcd,
 /turf/open/floor/plasteel,
 /area/bridge)
 "bN" = (
@@ -658,13 +661,13 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/mob/living/carbon/human,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/mob/living/carbon/human,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -673,20 +676,20 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/mob/living/carbon/human,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/mob/living/carbon/human,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/medical/medbay)
 "bW" = (
 /obj/machinery/camera/autoname,
-/mob/living/carbon/human,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/mob/living/carbon/human,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -821,9 +824,6 @@
 /obj/structure/closet/secure_closet/engineering_chief{
 	locked = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -838,6 +838,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/bridge)
 "cr" = (
@@ -875,12 +876,9 @@
 	dir = 1
 	},
 /area/medical/medbay)
-"cv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/bridge)
 "cw" = (
 /obj/machinery/door/airlock,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/bridge)
 "cx" = (
@@ -917,12 +915,14 @@
 /area/hallway/primary/central)
 "cC" = (
 /obj/machinery/camera/autoname,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -1015,14 +1015,6 @@
 "cP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/construction)
-"cQ" = (
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/plasteel,
-/area/construction)
-"cR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
 /area/construction)
 "cS" = (
 /turf/closed/wall/r_wall,
@@ -1662,9 +1654,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "eM" = (
-/obj/machinery/airalarm/unlocked{
-	pixel_x = 32
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "eN" = (
@@ -2532,6 +2522,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"ii" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -20
+	},
+/turf/open/floor/plasteel,
+/area/construction)
 "jb" = (
 /obj/machinery/door/airlock,
 /obj/structure/cable{
@@ -2743,13 +2742,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
-"EI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+"EG" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/light_switch{
+	pixel_x = 20
+	},
+/turf/open/floor/plasteel,
+/area/construction)
+"EI" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/closet/secure_closet/captains{
+	locked = 0
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -2830,6 +2838,16 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"RM" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/hop{
+	locked = 0
+	},
+/turf/open/floor/plasteel,
+/area/bridge)
 "Sj" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue{
@@ -2868,6 +2886,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"Wq" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "WT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6274,12 +6302,12 @@ cO
 cW
 dm
 dy
-dy
+ii
 dX
 dy
 dy
 gG
-dy
+ii
 dy
 dm
 dK
@@ -6454,7 +6482,7 @@ jb
 ES
 bE
 bE
-cQ
+ef
 cY
 dn
 dn
@@ -6546,7 +6574,7 @@ gd
 cA
 bE
 bE
-cQ
+ef
 cY
 dn
 dn
@@ -6730,7 +6758,7 @@ bu
 cB
 bE
 bE
-cR
+cN
 cY
 dn
 dn
@@ -6818,11 +6846,11 @@ bu
 bG
 ce
 cp
-cv
+bu
 cC
 lX
 bE
-cR
+cN
 cY
 dn
 dn
@@ -6914,7 +6942,7 @@ bv
 dU
 bE
 bE
-cR
+cN
 cY
 dn
 dn
@@ -7095,10 +7123,10 @@ bJ
 cf
 cq
 cw
-cD
+Wq
 bE
 bE
-cQ
+ef
 cY
 dn
 dn
@@ -7190,7 +7218,7 @@ bu
 cD
 bE
 bE
-cQ
+ef
 cY
 dn
 dn
@@ -7277,7 +7305,7 @@ ac
 bv
 bL
 cf
-cq
+RM
 bv
 cD
 bE
@@ -7286,12 +7314,12 @@ cN
 cZ
 do
 dz
-dz
+EG
 gy
 dz
 dz
 gy
-dz
+EG
 dz
 do
 dM

--- a/code/modules/uplink/uplink_devices.dm
+++ b/code/modules/uplink/uplink_devices.dm
@@ -23,10 +23,27 @@
 	. = ..()
 	AddComponent(/datum/component/uplink, owner, FALSE, TRUE, null, tc_amount)
 
+/obj/item/uplink/debug
+	name = "debug uplink"
+
+/obj/item/uplink/debug/Initialize(mapload, owner, tc_amount = 9000)
+	. = ..()
+	GET_COMPONENT(hidden_uplink, /datum/component/uplink)
+	hidden_uplink.name = "debug uplink"
+
 /obj/item/uplink/nuclear/Initialize()
 	. = ..()
 	GET_COMPONENT(hidden_uplink, /datum/component/uplink)
 	hidden_uplink.set_gamemode(/datum/game_mode/nuclear)
+
+/obj/item/uplink/nuclear/debug
+	name = "debug nuclear uplink"
+
+/obj/item/uplink/nuclear/debug/Initialize(mapload, owner, tc_amount = 9000)
+	. = ..()
+	GET_COMPONENT(hidden_uplink, /datum/component/uplink)
+	hidden_uplink.set_gamemode(/datum/game_mode/nuclear)
+	hidden_uplink.name = "debug nuclear uplink"
 
 /obj/item/uplink/nuclear_restricted/Initialize()
 	. = ..()


### PR DESCRIPTION
:cl: Denton
tweak: Tweaked Runtimestation to include uplinks as well as a room for lighting testing.
/:cl:

I added regular and nuke ops uplinks to runtimestation, so testing those doesn't require you to spawn them in (not to mention extra TC).

Does anyone know how to make them ignore the min player limit for certain items like deswords?

Also, added light switches to the western room so it can be used as a darkroom for light testing. ARCD and RLD too; they're nice to have if you want to check lighting/construction without having to enable buildmode.