### PR TITLE
Makes /datum/gas_mixture/share() roughly 5% faster by removing fairly useless abstraction, also contains a small boost to pipelines

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -29,6 +29,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/last_share = 0
 	var/list/reaction_results
 	var/list/analyzer_results //used for analyzer feedback - not initialized until its used
+	var/gc_share = FALSE // Whether to call garbage_collect() on the sharer during shares, used for immutable mixtures
 
 /datum/gas_mixture/New(volume)
 	gases = new
@@ -153,9 +154,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 /datum/gas_mixture/proc/share(datum/gas_mixture/sharer)
 	//Performs air sharing calculations between two gas_mixtures assuming only 1 boundary length
 	//Returns: amount of gas exchanged (+ if sharer received)
-
-/datum/gas_mixture/proc/after_share(datum/gas_mixture/sharer)
-	//called on share's sharer to let it know it just got some gases
 
 /datum/gas_mixture/proc/temperature_share(datum/gas_mixture/sharer, conduction_coefficient)
 	//Performs temperature sharing calculations (via conduction) between two gas_mixtures assuming only 1 boundary length
@@ -354,16 +352,14 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	if(length(cached_gases ^ sharer_gases)) //if all gases were present in both mixtures, we know that no gases are 0
 		garbage_collect(cached_gases - sharer_gases) //any gases the sharer had, we are guaranteed to have. gases that it didn't have we are not.
 		sharer.garbage_collect(sharer_gases - cached_gases) //the reverse is equally true
-	sharer.after_share(src, atmos_adjacent_turfs)
+	if (initial(sharer.gc_share))
+		sharer.garbage_collect()
 	if(temperature_delta > MINIMUM_TEMPERATURE_TO_MOVE || abs(moved_moles) > MINIMUM_MOLES_DELTA_TO_MOVE)
 		var/our_moles
 		TOTAL_MOLES(cached_gases,our_moles)
 		var/their_moles
 		TOTAL_MOLES(sharer_gases,their_moles)
 		return (temperature_archived*(our_moles + moved_moles) - sharer.temperature_archived*(their_moles - moved_moles)) * R_IDEAL_GAS_EQUATION / volume
-
-/datum/gas_mixture/after_share(datum/gas_mixture/sharer, atmos_adjacent_turfs = 4)
-	return
 
 /datum/gas_mixture/temperature_share(datum/gas_mixture/sharer, conduction_coefficient, sharer_temperature, sharer_heat_capacity)
 	//transfer of thermal energy (via conduction) between self and sharer

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -3,6 +3,7 @@
 
 /datum/gas_mixture/immutable
 	var/initial_temperature
+	gc_share = TRUE
 
 /datum/gas_mixture/immutable/New()
 	..()
@@ -21,9 +22,6 @@
 
 /datum/gas_mixture/immutable/share(datum/gas_mixture/sharer, atmos_adjacent_turfs = 4)
 	. = ..(sharer, 0)
-	garbage_collect()
-
-/datum/gas_mixture/immutable/after_share()
 	garbage_collect()
 
 /datum/gas_mixture/immutable/react()

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -221,13 +221,16 @@
 		if(!P)
 			continue
 		GL += P.return_air()
-		for(var/obj/machinery/atmospherics/components/binary/valve/V in P.other_atmosmch)
-			if(V.on)
-				PL |= V.parents[1]
-				PL |= V.parents[2]
-		for(var/obj/machinery/atmospherics/components/unary/portables_connector/C in P.other_atmosmch)
-			if(C.connected_device)
-				GL += C.portableConnectorReturnAir()
+		for(var/atmosmch in P.other_atmosmch)
+			if (istype(atmosmch, /obj/machinery/atmospherics/components/binary/valve))
+				var/obj/machinery/atmospherics/components/binary/valve/V = atmosmch
+				if(V.on)
+					PL |= V.parents[1]
+					PL |= V.parents[2]
+			else if (istype(atmosmch, /obj/machinery/atmospherics/components/unary/portables_connector))
+				var/obj/machinery/atmospherics/components/unary/portables_connector/C = atmosmch
+				if(C.connected_device)
+					GL += C.portableConnectorReturnAir()
 
 	var/total_thermal_energy = 0
 	var/total_heat_capacity = 0


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20017308/46236208-60b04980-c386-11e8-878c-24098bbde2cf.png)

![image](https://user-images.githubusercontent.com/20017308/46236229-74f44680-c386-11e8-9a26-91cbaba8f88b.png)

This removes gas_mixture.after_share() in favor of a var that controls whether gc will be called on the gas. Var access is much faster than calling a proc.

The pipeline proc looped through other_atmosmch twice, I condensed it to one loop


:cl: Naksu
code: squeezed a little bit more perf out of atmos
/:cl: