### PR TITLE
Clarifys that blobs are considered dead when they don't have an overmind

### DIFF
--- a/code/modules/antagonists/blob/blob/theblob.dm
+++ b/code/modules/antagonists/blob/blob/theblob.dm
@@ -331,7 +331,7 @@
 /obj/structure/blob/proc/get_chem_name()
 	if(overmind)
 		return overmind.blob_reagent_datum.name
-	return "some kind of organic tissue."
+	return "some kind of organic tissue"
 
 /obj/structure/blob/normal
 	name = "normal blob"

--- a/code/modules/antagonists/blob/blob/theblob.dm
+++ b/code/modules/antagonists/blob/blob/theblob.dm
@@ -331,7 +331,7 @@
 /obj/structure/blob/proc/get_chem_name()
 	if(overmind)
 		return overmind.blob_reagent_datum.name
-	return "an unknown variant"
+	return "some kind of organic tissue."
 
 /obj/structure/blob/normal
 	name = "normal blob"
@@ -354,8 +354,13 @@
 		name = "fragile blob"
 		desc = "A thin lattice of slightly twitching tendrils."
 		brute_resist = 0.5
-	else
+	else if (overmind)
 		icon_state = "blob"
 		name = "blob"
 		desc = "A thick wall of writhing tendrils."
+		brute_resist = 0.25
+	else
+		icon_state = "blob"
+		name = "dead blob"
+		desc = "A thick wall of lifeless tendrils."
 		brute_resist = 0.25


### PR DESCRIPTION
:cl: MrDoomBringer
add: Nanotrasen's Alien Life Detection Department has issued new training for crewmembers when facing blobs: the crew is now able to actually discern when a blob is dead.
/:cl:

Before, when a blob died, it would turn white and stop doing anything - but other than that it wasn't actually anything stating that the blob was dead (causing some confusion for new players)