### PR TITLE
Tweaks map lighting

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -11684,9 +11684,6 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "aAK" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/sink{
 	pixel_y = 30
 	},
@@ -16172,6 +16169,9 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -32977,6 +32977,9 @@
 /obj/item/cautery{
 	pixel_x = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bzT" = (
@@ -36806,6 +36809,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bIJ" = (
@@ -38179,6 +38185,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bMb" = (
@@ -38988,9 +38995,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bOn" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -39249,6 +39253,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bOQ" = (
@@ -42051,6 +42056,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bWg" = (
@@ -42383,9 +42391,6 @@
 /obj/structure/table/glass,
 /obj/item/radio/intercom{
 	pixel_x = -25
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /obj/item/storage/box/beakers{
 	pixel_x = 2;
@@ -55874,6 +55879,13 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"dPH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eit" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -56237,6 +56249,13 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"iHT" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden)
 "iNn" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room"
@@ -56646,6 +56665,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"mSB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "noK" = (
 /obj/structure/girder,
 /turf/open/floor/plasteel/dark,
@@ -57482,6 +57508,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"vIU" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden)
 "vPE" = (
 /obj/item/assembly/signaler{
 	pixel_y = 8
@@ -57635,6 +57668,18 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ydA" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/locker)
 
 (1,1,1) = {"
 aaa
@@ -72649,7 +72694,7 @@ alU
 alU
 azF
 aAP
-aAP
+vIU
 aAP
 aEF
 aFN
@@ -74191,7 +74236,7 @@ atO
 asK
 azF
 aAP
-aAP
+iHT
 aAP
 aAQ
 aFO
@@ -75494,7 +75539,7 @@ aUq
 aWq
 aXs
 aYH
-aZx
+ydA
 bbO
 aPA
 bdM
@@ -77293,7 +77338,7 @@ aQW
 aUZ
 aXx
 aYU
-aYU
+mSB
 aYU
 bbr
 bcu
@@ -82967,7 +83012,7 @@ bwg
 aJw
 aJq
 aJq
-bBi
+dPH
 aJw
 aaa
 bEU

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -459,6 +459,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "acF" = (
@@ -761,6 +764,9 @@
 /obj/structure/closet/secure_closet/miner/unlocked,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13975,6 +13981,9 @@
 	name = "cargo camera"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aEh" = (
@@ -15330,6 +15339,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18283,6 +18295,9 @@
 	},
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/bot,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aLq" = (
@@ -29194,6 +29209,9 @@
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bci" = (
@@ -30767,6 +30785,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "beR" = (
@@ -32321,6 +32340,9 @@
 	},
 /obj/item/storage/box/syringes,
 /obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bhD" = (
@@ -38779,8 +38801,9 @@
 	dir = 1;
 	layer = 2.9
 	},
+/obj/machinery/light,
 /turf/open/space,
-/area/space/nearstation)
+/area/aisat)
 "brR" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -39094,6 +39117,9 @@
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bsx" = (
@@ -41564,6 +41590,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bwx" = (
@@ -41834,6 +41861,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bwQ" = (
@@ -45673,13 +45701,13 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/item/clothing/gloves/color/yellow,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
@@ -60610,7 +60638,6 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bYk" = (
-/obj/structure/window/reinforced,
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
 	dir = 2;
@@ -60628,6 +60655,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bYl" = (
@@ -62968,6 +62996,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68131,6 +68162,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "cke" = (
@@ -69225,6 +69259,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cmd" = (
@@ -72126,6 +72161,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
 "crr" = (
@@ -74233,6 +74271,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cuS" = (
@@ -78949,6 +78988,9 @@
 	name = "engineering camera"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cCC" = (
@@ -80494,6 +80536,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "cFd" = (
@@ -81147,6 +81190,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cGh" = (
@@ -81185,6 +81229,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cGn" = (
@@ -84864,6 +84909,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
@@ -91077,6 +91123,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cWW" = (
@@ -92765,6 +92814,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cZL" = (
@@ -93326,6 +93378,9 @@
 "daB" = (
 /obj/machinery/processor/slime,
 /obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "daC" = (
@@ -93836,6 +93891,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -95751,6 +95809,9 @@
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
@@ -98621,6 +98682,9 @@
 	network = list("rd");
 	pixel_x = -28
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white/corner,
 /area/science/circuit)
 "djo" = (
@@ -98635,12 +98699,12 @@
 /area/science/circuit)
 "djq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white/side,
 /area/science/circuit)
 "djr" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white/side,
 /area/science/circuit)
 "djs" = (
@@ -100371,6 +100435,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -102953,6 +103020,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "dra" = (
@@ -103225,6 +103295,7 @@
 	network = list("rd");
 	pixel_x = -28
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
@@ -103240,7 +103311,6 @@
 	},
 /area/science/circuit)
 "drB" = (
-/obj/machinery/light,
 /obj/structure/closet/crate,
 /obj/item/target/alien,
 /obj/item/target/alien,
@@ -104432,6 +104502,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dtR" = (
@@ -105056,6 +105129,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -108776,6 +108852,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "dBr" = (
@@ -111233,6 +111312,9 @@
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dFC" = (
@@ -111244,9 +111326,6 @@
 /area/science/mixing)
 "dFD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -112216,6 +112295,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -113333,6 +113415,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "dIR" = (
@@ -113944,6 +114027,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dJV" = (
@@ -114064,6 +114148,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
 "dKg" = (
@@ -116512,9 +116597,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/science/research)
 "dOr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -116530,6 +116623,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -121680,6 +121776,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dXV" = (
@@ -126709,6 +126808,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
+"gXw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmospherics_engine)
 "hcP" = (
 /obj/structure/cable/white{
 	icon_state = "1-8"
@@ -126901,6 +127016,18 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"iAW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "iQh" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -127075,6 +127202,25 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"krX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "kvf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -127172,6 +127318,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"lgc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "ljr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -127320,6 +127474,7 @@
 /area/science/mixing)
 "lXM" = (
 /obj/structure/target_stake,
+/obj/machinery/light,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -127437,8 +127592,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
@@ -127484,6 +127638,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"olS" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "ovg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -127636,6 +127797,22 @@
 	dir = 1
 	},
 /area/science/circuit)
+"pop" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmospherics_engine)
 "pqq" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/turf_decal/bot,
@@ -127829,6 +128006,12 @@
 	dir = 9
 	},
 /area/science/circuit)
+"rzc" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "rCv" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 6
@@ -127910,6 +128093,18 @@
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"sJw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "tbR" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
@@ -128084,6 +128279,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"vzc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "vAb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -141085,7 +141290,7 @@ aad
 bNF
 aad
 bRP
-bTH
+krX
 bVT
 bYk
 aJD
@@ -152148,7 +152353,7 @@ cjf
 ckA
 clV
 cnC
-cpa
+sJw
 cqs
 cqr
 ctq
@@ -152595,7 +152800,7 @@ aad
 alT
 amG
 amH
-amH
+pop
 amH
 amH
 ark
@@ -155679,7 +155884,7 @@ aad
 alT
 amK
 amH
-amH
+gXw
 amH
 aqM
 ars
@@ -160088,7 +160293,7 @@ bng
 boy
 bqy
 bsw
-bng
+bwN
 bvz
 bwM
 bar
@@ -161195,7 +161400,7 @@ dJZ
 dKF
 dLZ
 dLZ
-dOo
+olS
 dOT
 dPJ
 dQC
@@ -162223,7 +162428,7 @@ dKd
 dKH
 dMa
 dMa
-dMa
+rzc
 dOT
 dLX
 dQG
@@ -162427,7 +162632,7 @@ bvL
 cjw
 bYU
 bvL
-bvL
+vzc
 bvL
 bun
 bvL
@@ -162436,7 +162641,7 @@ bvL
 bvL
 cyh
 bvL
-bvL
+vzc
 bvL
 bvL
 bvL
@@ -164273,7 +164478,7 @@ dCn
 dDx
 dmY
 dFX
-dmY
+lgc
 dIK
 dmY
 cOS
@@ -177362,7 +177567,7 @@ dbz
 ddk
 deK
 cPy
-dhj
+iAW
 diN
 dkv
 dma

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3461,6 +3461,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "agw" = (
@@ -20863,6 +20866,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "aOg" = (
@@ -20940,6 +20946,9 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -21220,6 +21229,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22902,6 +22914,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aSm" = (
@@ -22916,7 +22929,6 @@
 "aSn" = (
 /obj/item/storage/bag/plants/portaseeder,
 /obj/structure/table,
-/obj/machinery/light,
 /obj/item/plant_analyzer,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -23635,6 +23647,7 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTI" = (
@@ -47069,6 +47082,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "bMT" = (
@@ -48105,6 +48121,9 @@
 	pixel_x = 27
 	},
 /obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -54947,7 +54966,6 @@
 /area/hydroponics)
 "ccw" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/light,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Hydroponics APC";
@@ -55028,6 +55046,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ccC" = (
@@ -60143,6 +60162,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/explab)
 "cmX" = (
@@ -60985,6 +61007,9 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 4
@@ -62072,6 +62097,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cqu" = (
@@ -64257,9 +64283,6 @@
 	name = "Genetics Requests Console";
 	pixel_y = 30
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/storage/box/monkeycubes,
 /obj/item/radio/headset/headset_medsci,
 /obj/item/flashlight/pen{
@@ -64835,6 +64858,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "cvy" = (
@@ -64892,6 +64918,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -70332,6 +70361,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cGm" = (
@@ -73922,6 +73952,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "cMz" = (
@@ -79107,6 +79138,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "ddd" = (
@@ -80465,6 +80499,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "dht" = (
@@ -84292,6 +84327,14 @@
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"tYS" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "uaC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -84423,6 +84466,15 @@
 	dir = 8
 	},
 /area/engine/storage_shared)
+"vKx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vLD" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -118710,7 +118762,7 @@ bWO
 bYg
 bWT
 caN
-ccv
+tYS
 bST
 dDr
 cgq
@@ -119738,7 +119790,7 @@ bWS
 bYi
 bWT
 caN
-ccv
+tYS
 bST
 ceZ
 cgq
@@ -125596,7 +125648,7 @@ avt
 awJ
 axS
 axY
-aCO
+vKx
 ddW
 aCT
 aEp

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -18728,6 +18728,9 @@
 /obj/item/storage/box/beanbag,
 /obj/item/assembly/mousetrap,
 /obj/item/storage/box/mousetraps,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aSR" = (
@@ -19661,6 +19664,9 @@
 /area/hydroponics)
 "aUX" = (
 /obj/machinery/icecream_vat,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aUY" = (
@@ -21627,6 +21633,9 @@
 /obj/item/radio/intercom{
 	pixel_y = 26
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aYV" = (
@@ -22140,9 +22149,6 @@
 /area/janitor)
 "aZR" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -28
@@ -22669,6 +22675,9 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "bba" = (
@@ -31135,6 +31144,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "buW" = (
@@ -41372,6 +41382,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQu" = (
@@ -45156,6 +45169,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYJ" = (
@@ -47042,10 +47058,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdP" = (
-/obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -49863,6 +49879,9 @@
 	pixel_y = 29
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "cnP" = (
@@ -54959,6 +54978,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "gHZ" = (
@@ -56465,6 +56487,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"kJN" = (
+/obj/machinery/field/generator,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "kKI" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet,
@@ -56491,8 +56521,7 @@
 /obj/structure/table,
 /obj/machinery/microwave,
 /obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
+	dir = 1
 	},
 /obj/structure/noticeboard{
 	pixel_y = 32
@@ -56938,13 +56967,6 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/airless,
-/area/engine/engineering)
-"mhl" = (
-/obj/machinery/power/emitter,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/engine/engineering)
 "mlr" = (
 /obj/structure/lattice,
@@ -59032,6 +59054,13 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
+"rqj" = (
+/obj/machinery/power/emitter,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "rrb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -61502,6 +61531,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ydZ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "yfO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow,
@@ -87348,11 +87390,11 @@ aUS
 aRL
 aWP
 aXQ
-aYN
+ydZ
 aZR
 aYN
 aYN
-aYN
+ydZ
 aXQ
 bfj
 bdm
@@ -88181,8 +88223,8 @@ mci
 cbX
 ceq
 ceq
+rqj
 ceq
-mhl
 ceq
 ceq
 bXk
@@ -88952,7 +88994,7 @@ tuL
 ccR
 cbV
 cbV
-ccQ
+kJN
 ccQ
 ccQ
 ccQ


### PR DESCRIPTION
:cl: Denton
tweak: Tweaked lighting in some areas to better account for night lighting.
/:cl:

The night shift lighting PR didn't account for a few areas which are almost completely dark when it's enabled. I had a look at all maps and adjusted some of them.

A gallery of some examples:
https://imgur.com/a/Z1Jnm9O

