### PR TITLE
Cameras now use timSort instead of insertionsort

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -3,7 +3,7 @@
 	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
 		L.Add(C)
 
-	camera_sort(L)
+	sortTim(L, cmp=/proc/cam_tag_sort, FALSE)
 
 	var/list/T = list()
 
@@ -138,14 +138,5 @@
 		return
 	user.switchCamera(src)
 
-/proc/camera_sort(list/L)
-	var/obj/machinery/camera/a
-	var/obj/machinery/camera/b
-
-	for (var/i = L.len, i > 0, i--)
-		for (var/j = 1 to i - 1)
-			a = L[j]
-			b = L[j + 1]
-			if (sorttext(a.c_tag, b.c_tag) < 0)
-				L.Swap(j, j + 1)
-	return L
+/proc/cam_tag_sort(obj/machinery/camera/a, obj/machinery/camera/b)
+	return sorttext(a.c_tag, b.c_tag) 

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -136,8 +136,7 @@
 			continue
 		L.Add(C)
 
-	camera_sort(L)
-
+	sortTim(L, cmp=/proc/cam_tag_sort, FALSE)
 	var/list/D = list()
 	D["Cancel"] = "Cancel"
 	for(var/obj/machinery/camera/C in L)

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -246,7 +246,7 @@
 			continue
 		L.Add(cam)
 
-	camera_sort(L)
+	sortTim(L, cmp=/proc/cam_tag_sort, FALSE)
 
 	var/list/T = list()
 


### PR DESCRIPTION
Changes the camera sort to use sortTim instead of it's own handrolled insertion sort.