### PR TITLE
Changes honkmother staff projectile name

### DIFF
--- a/code/modules/projectiles/projectile/bullets/special.dm
+++ b/code/modules/projectiles/projectile/bullets/special.dm
@@ -1,6 +1,7 @@
 // Honker
 
 /obj/item/projectile/bullet/honker
+	name = "banana"
 	damage = 0
 	knockdown = 60
 	forcedodge = TRUE


### PR DESCRIPTION
This just changes the banana projectile name to "banana". I mean it's a magic banana that slips people, not a boring normal bullet that puts holes in people.