### PR TITLE
Restores Deoxyribonucleic Saboteur

### DIFF
--- a/tgstation.dme
+++ b/tgstation.dme
@@ -412,6 +412,7 @@
 #include "code\datums\diseases\advance\symptoms\fever.dm"
 #include "code\datums\diseases\advance\symptoms\fire.dm"
 #include "code\datums\diseases\advance\symptoms\flesh_eating.dm"
+#include "code\datums\diseases\advance\symptoms\genetics.dm"
 #include "code\datums\diseases\advance\symptoms\hallucigen.dm"
 #include "code\datums\diseases\advance\symptoms\headache.dm"
 #include "code\datums\diseases\advance\symptoms\heal.dm"


### PR DESCRIPTION
Fixes #40616

:cl: ShizCalev
fix: Deoxyribonucleic Saboteur now exists again.
/:cl:
