### PR TITLE
[Ready] Light bulbs shatter and hurt players when stepped on, spill plasma if rigged

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -771,11 +771,22 @@
 			icon_state = "[base_state]-broken"
 			desc = "A broken [name]."
 
-
 /obj/item/light/Initialize()
 	. = ..()
 	update()
+	
+/obj/item/light/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/caltrop, force)
 
+/obj/item/light/Crossed(mob/living/L)
+	if(istype(L) && has_gravity(loc))
+		if(L.has_trait(TRAIT_LIGHT_STEP))
+			playsound(loc, 'sound/effects/glass_step.ogg', 30, 1)
+		else
+			playsound(loc, 'sound/effects/glass_step.ogg', 50, 1)	
+	if(status == LIGHT_BURNED || status == LIGHT_OK)
+		shatter()
 
 // attack bulb/tube with object
 // if a syringe, can inject plasma to make it explode

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -717,7 +717,7 @@
 	var/switchcount = 0	// number of times switched
 	materials = list(MAT_GLASS=100)
 	grind_results = list("silicon" = 5, "nitrogen" = 10) //Nitrogen is used as a cheaper alternative to argon in incandescent lighbulbs
-	var/rigged = 0		// true if rigged to explode
+	var/rigged = TRUE		// true if rigged to explode
 	var/brightness = 2 //how much light it gives off
 
 /obj/item/light/suicide_act(mob/living/carbon/user)
@@ -780,13 +780,14 @@
 	AddComponent(/datum/component/caltrop, force)
 
 /obj/item/light/Crossed(mob/living/L)
+	. = ..()
 	if(istype(L) && has_gravity(loc))
 		if(L.has_trait(TRAIT_LIGHT_STEP))
 			playsound(loc, 'sound/effects/glass_step.ogg', 30, 1)
 		else
 			playsound(loc, 'sound/effects/glass_step.ogg', 50, 1)	
-	if(status == LIGHT_BURNED || status == LIGHT_OK)
-		shatter()
+		if(status == LIGHT_BURNED || status == LIGHT_OK)
+			shatter()
 
 // attack bulb/tube with object
 // if a syringe, can inject plasma to make it explode
@@ -799,7 +800,7 @@
 
 		if(S.reagents.has_reagent("plasma", 5))
 
-			rigged = 1
+			rigged = TRUE
 
 		S.reagents.clear_reagents()
 	else
@@ -820,6 +821,8 @@
 		status = LIGHT_BROKEN
 		force = 5
 		playsound(src.loc, 'sound/effects/glasshit.ogg', 75, 1)
+		if(rigged)
+			atmos_spawn_air("plasma=5") //5u of plasma are required to rig a light bulb/tube
 		update()
 
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -717,7 +717,7 @@
 	var/switchcount = 0	// number of times switched
 	materials = list(MAT_GLASS=100)
 	grind_results = list("silicon" = 5, "nitrogen" = 10) //Nitrogen is used as a cheaper alternative to argon in incandescent lighbulbs
-	var/rigged = TRUE		// true if rigged to explode
+	var/rigged = FALSE		// true if rigged to explode
 	var/brightness = 2 //how much light it gives off
 
 /obj/item/light/suicide_act(mob/living/carbon/user)


### PR DESCRIPTION
:cl: Denton
tweak: Light bulbs now shatter and hurt people when stepped on.
tweak: Light bulbs that have been sabotaged with plasma will spill it when they shatter.
/:cl:

tl;dr is that light bulbs and tubes now shatter when stepped on. They also act like glass shards or D4s if you're wearing no shoes. If they have been rigged with plasma, they'll spill it when they shatter.