### PR TITLE
Makes it so the Food Cart can be bolted down with a wrench.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -62,6 +62,9 @@
 	return food_stored >= STORAGE_CAPACITY
 
 /obj/machinery/food_cart/attackby(obj/item/O, mob/user, params)
+	if(O.tool_behaviour == TOOL_WRENCH)
+		default_unfasten_wrench(user, O, 0)
+		return 1
 	if(istype(O, /obj/item/reagent_containers/food/drinks/drinkingglass))
 		var/obj/item/reagent_containers/food/drinks/drinkingglass/DG = O
 		if(!DG.reagents.total_volume) //glass is empty

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -63,8 +63,8 @@
 
 /obj/machinery/food_cart/attackby(obj/item/O, mob/user, params)
 	if(O.tool_behaviour == TOOL_WRENCH)
-		default_unfasten_wrench(user, O, TRUE)
-		return 1
+		default_unfasten_wrench(user, O, 0)
+		return TRUE
 	if(istype(O, /obj/item/reagent_containers/food/drinks/drinkingglass))
 		var/obj/item/reagent_containers/food/drinks/drinkingglass/DG = O
 		if(!DG.reagents.total_volume) //glass is empty

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -63,7 +63,7 @@
 
 /obj/machinery/food_cart/attackby(obj/item/O, mob/user, params)
 	if(O.tool_behaviour == TOOL_WRENCH)
-		default_unfasten_wrench(user, O, 0)
+		default_unfasten_wrench(user, O, TRUE)
 		return 1
 	if(istype(O, /obj/item/reagent_containers/food/drinks/drinkingglass))
 		var/obj/item/reagent_containers/food/drinks/drinkingglass/DG = O


### PR DESCRIPTION

:cl: Coconutwarrior97
tweak: Food Cart can now be bolted down.
/:cl:

Would encourage chefs to use the food cart more as they wouldn't have to deal with people moving their food cart around all the time on the shuttle or in the halls.