### PR TITLE
Updates Implant Pads

### DIFF
--- a/code/game/objects/items/implants/implant_track.dm
+++ b/code/game/objects/items/implants/implant_track.dm
@@ -32,9 +32,3 @@
 				<b>Integrity:</b> Gradient creates slight risk of being overcharged and frying the
 				circuitry. As a result neurotoxins can cause massive damage."}
 	return dat
-
-
-/obj/item/implantcase/track
-	name = "implant case - 'Tracking'"
-	desc = "A glass case containing a tracking implant."
-	imp_type = /obj/item/implant/tracking

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -401,7 +401,7 @@
 	id = "implant_tracking"
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 500, MAT_GLASS = 500)
-	build_path = /obj/item/implantcase/track
+	build_path = /obj/item/implantcase/tracking
 	category = list("Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_MEDICAL
 
@@ -467,7 +467,7 @@
 	research_icon = 'icons/obj/surgery.dmi'
 	research_icon_state = "surgery_any"
 	var/surgery
-	
+
 /datum/design/surgery/experimental_dissection
 	name = "Experimental Dissection"
 	desc = "A surgical procedure which deeply analyzes the biology of a corpse, and automatically adds new findings to the research database."


### PR DESCRIPTION
Fixes #40620

:cl: ShizCalev
fix: Updated the implant pad. Implants are now removed by alt-clicking it (no more meme hand swapping BS.) Implants will no longer disappear into the void if it didn't go into your hand. Dialog screens will now properly update when inserting and removing an implant. 
/:cl:

Also cleaned up a duplicate/redirect typepath, /obj/item/implantcase/track