### PR TITLE
Fixes cult halo not removing on deconversion

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -13,7 +13,7 @@
 	var/give_equipment = FALSE
 	var/datum/team/cult/cult_team
 
-	
+
 /datum/antagonist/cult/get_team()
 	return cult_team
 
@@ -114,7 +114,7 @@
 		cult_team.rise(current)
 		if(cult_team.cult_ascendent)
 			cult_team.ascend(current)
-			
+
 /datum/antagonist/cult/remove_innate_effects(mob/living/mob_override)
 	. = ..()
 	var/mob/living/current = owner.current
@@ -131,7 +131,9 @@
 		H.eye_color = initial(H.eye_color)
 		H.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
 		H.remove_trait(CULT_EYES)
-		H.update_body()
+		H.cut_overlays()
+		H.regenerate_icons()
+
 /datum/antagonist/cult/on_removal()
 	SSticker.mode.cult -= owner
 	SSticker.mode.update_cult_icons_removed(owner)
@@ -215,14 +217,6 @@
 	throwing.Remove(current)
 	current.update_action_buttons_icon()
 	current.remove_status_effect(/datum/status_effect/cult_master)
-	
-	if(ishuman(current))
-		var/mob/living/carbon/human/H = current
-		H.eye_color = initial(H.eye_color)
-		H.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
-		H.remove_trait(CULT_EYES)
-		H.cut_overlays()
-		H.regenerate_icons()
 
 /datum/team/cult
 	name = "Cult"
@@ -236,7 +230,7 @@
 	var/reckoning_complete = FALSE
 	var/cult_risen = FALSE
 	var/cult_ascendent = FALSE
-	
+
 /datum/team/cult/proc/check_size()
 	if(cult_ascendent)
 		return
@@ -257,7 +251,7 @@
 				to_chat(B.current, "<span class='cultlarge'>The veil weakens as your cult grows, your eyes begin to glow...")
 				addtimer(CALLBACK(src, .proc/rise, B.current), 200)
 		cult_risen = TRUE
-		
+
 	if(ratio > CULT_ASCENDENT && !cult_ascendent)
 		for(var/datum/mind/B in members)
 			if(B.current)
@@ -265,8 +259,8 @@
 				to_chat(B.current, "<span class='cultlarge'>Your cult is ascendent and the red harvest approaches - you cannot hide your true nature for much longer!!")
 				addtimer(CALLBACK(src, .proc/ascend, B.current), 200)
 		cult_ascendent = TRUE
-		
-		
+
+
 /datum/team/cult/proc/rise(cultist)
 	if(ishuman(cultist))
 		var/mob/living/carbon/human/H = cultist
@@ -274,7 +268,7 @@
 		H.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
 		H.add_trait(CULT_EYES)
 		H.update_body()
-		
+
 /datum/team/cult/proc/ascend(cultist)
 	if(ishuman(cultist))
 		var/mob/living/carbon/human/H = cultist
@@ -322,7 +316,7 @@
 	summon_objective.team = src
 	objectives += summon_objective
 
-	
+
 /datum/objective/sacrifice
 	var/sacced = FALSE
 	var/sac_image

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -130,10 +130,7 @@
 		to_chat(user, "<span class='cult italic'>The magic in [src] is weak, it will be ready to use again in [DisplayTimeText(cooldowntime - world.time)].</span>")
 		return
 	var/choice
-	if(user.mind.has_antag_datum(/datum/antagonist/cult/master))
-		choice = alert(user,"You study the schematics etched into the forge...",,"Shielded Robe","Flagellant's Robe","Mirror Shield")
-	else
-		choice = alert(user,"You study the schematics etched into the forge...",,"Shielded Robe","Flagellant's Robe","Mirror Shield")
+	choice = alert(user,"You study the schematics etched into the forge...",,"Shielded Robe","Flagellant's Robe","Mirror Shield")
 	var/list/pickedtype = list()
 	switch(choice)
 		if("Shielded Robe")


### PR DESCRIPTION
Fixes #40631

also cleaned up duplicated removal of innate effects, and a redundant check for cult forges

🆑 ShizCalev
fix: Deconverted cultists will no longer keep their halos.
/🆑