### PR TITLE
Enables nanite viruses

### DIFF
--- a/tgstation.dme
+++ b/tgstation.dme
@@ -416,6 +416,7 @@
 #include "code\datums\diseases\advance\symptoms\headache.dm"
 #include "code\datums\diseases\advance\symptoms\heal.dm"
 #include "code\datums\diseases\advance\symptoms\itching.dm"
+#include "code\datums\diseases\advance\symptoms\nanites.dm"
 #include "code\datums\diseases\advance\symptoms\narcolepsy.dm"
 #include "code\datums\diseases\advance\symptoms\oxygen.dm"
 #include "code\datums\diseases\advance\symptoms\sensory.dm"


### PR DESCRIPTION
@XDTM missed a checkbox.

:cl: ShizCalev
fix: Nanite viruses are now enabled.
/:cl:

