### PR TITLE
Fixes pacman power output not using displaypower

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -221,7 +221,7 @@
 	dat += text("[capitalize(sheet_name)]: [sheets] - <A href='?src=[REF(src)];action=eject'>Eject</A><br>")
 	var/stack_percent = round(sheet_left * 100, 1)
 	dat += text("Current stack: [stack_percent]% <br>")
-	dat += text("Power output: <A href='?src=[REF(src)];action=lower_power'>-</A> [power_gen * power_output] <A href='?src=[REF(src)];action=higher_power'>+</A><br>")
+	dat += text("Power output: <A href='?src=[REF(src)];action=lower_power'>-</A> [DisplayPower(power_gen * power_output)] <A href='?src=[REF(src)];action=higher_power'>+</A><br>")
 	dat += text("Power current: [(powernet == null ? "Unconnected" : "[DisplayPower(avail())]")]<br>")
 	dat += text("Heat: [current_heat]<br>")
 	dat += "<br><A href='?src=[REF(src)];action=close'>Close</A>"


### PR DESCRIPTION
:cl: ShizCalev
fix: Pac-Man / portable generators will now show the correct power output.
/:cl:

