### PR TITLE
Fixes the service cyborgs RSF.

### DIFF
--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -65,14 +65,14 @@ RSF
 	if (!(istype(A, /obj/structure/table) || isfloorturf(A)))
 		return
 
-	if(matter < 1)
-		to_chat(user, "<span class='warning'>\The [src] doesn't have enough matter left.</span>")
-		return
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/R = user
 		if(!R.cell || R.cell.charge < 200)
 			to_chat(user, "<span class='warning'>You do not have enough power to use [src].</span>")
 			return
+	else if (matter < 1)
+		to_chat(user, "<span class='warning'>\The [src] doesn't have enough matter left.</span>")
+		return
 
 	var/turf/T = get_turf(A)
 	playsound(src.loc, 'sound/machines/click.ogg', 10, 1)


### PR DESCRIPTION
Since service cyborgs do not use matter for their RSF, I changed the
RSF to no longer check for matter if the user is a service cyborg, as I have
described in my comment on issue #40446. This pull request would also
allow the issue to be closed if it is accepted.

I am making this pull request because service borgs currently can not
use their RSF. This change benefits the game by allowing service cyborgs
to use their RSF again.

[Changelogs]: 
:cl: Fixes the service cyborg's RSF

fix: Service cyborg's RSF can now dispense items again.

/:cl:

[why]: Service cyborgs should be able to use their RSF. This allows service cyborgs to use their RSF again.
I believe that this will improve the game.