### PR TITLE
Port paradise goonchat uridecode fix

### DIFF
--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -158,7 +158,16 @@ function byondDecode(message) {
 	// The replace for + is because FOR SOME REASON, BYOND replaces spaces with a + instead of %20, and a plus with %2b.
 	// Marvelous.
 	message = message.replace(/\+/g, "%20");
-	message = decoder(message);
+	try { 
+		// This is a workaround for the above not always working when BYOND's shitty url encoding breaks. (byond bug id:2399401)
+		if (decodeURIComponent) {
+			message = decodeURIComponent(message);
+		} else {
+			throw new Error("Easiest way to trigger the fallback")
+		}
+	} catch (err) {
+		message = unescape(message);
+	}
 	return message;
 }
 


### PR DESCRIPTION
:cl: tigercat2000@Paradise
fix: fixed invalid characters breaking chat output for that message
/:cl:

Port of https://github.com/ParadiseSS13/Paradise/pull/9674

> It basically[sp] just makes it so that goonchat falls back to unescape if decodeURIComponent throws any URIErrors. 

Workaround for byond bug id:2399401

Fixes #28953