### PR TITLE
Price adjustments for clothing vendors

### DIFF
--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -128,8 +128,8 @@
 		           /obj/item/skub = 1,)
 
 	refill_canister = /obj/item/vending_refill/autodrobe
-	default_price = 100
-	extra_price = 200
+	default_price = 5
+	extra_price = 25
 	payment_department = ACCOUNT_SRV
 /obj/machinery/vending/autodrobe/all_access
 	desc = "A vending machine for costumes. This model appears to have no access restrictions."

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -128,8 +128,8 @@
 		           /obj/item/skub = 1,)
 
 	refill_canister = /obj/item/vending_refill/autodrobe
-	default_price = 5
-	extra_price = 25
+	default_price = 50
+	extra_price = 75
 	payment_department = ACCOUNT_SRV
 /obj/machinery/vending/autodrobe/all_access
 	desc = "A vending machine for costumes. This model appears to have no access restrictions."

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -115,8 +115,8 @@
 		           /obj/item/clothing/neck/necklace/dope = 3,
 		           /obj/item/clothing/suit/jacket/letterman_nanotrasen = 1)
 	refill_canister = /obj/item/vending_refill/clothing
-	default_price = 50
-	extra_price = 75
+	default_price = 5
+	extra_price = 25
 	payment_department = NO_FREEBIES
 /obj/item/vending_refill/clothing
 	machine_name = "ClothesMate"

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -115,8 +115,8 @@
 		           /obj/item/clothing/neck/necklace/dope = 3,
 		           /obj/item/clothing/suit/jacket/letterman_nanotrasen = 1)
 	refill_canister = /obj/item/vending_refill/clothing
-	default_price = 5
-	extra_price = 25
+	default_price = 50
+	extra_price = 75
 	payment_department = NO_FREEBIES
 /obj/item/vending_refill/clothing
 	machine_name = "ClothesMate"

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -2,8 +2,8 @@
 	icon_state = "refill_clothes"
 
 /obj/machinery/vending/wardrobe
-	default_price = 0
-	extra_price = 25
+	default_price = 50
+	extra_price = 75
 	payment_department = NO_FREEBIES
 
 /obj/machinery/vending/wardrobe/sec_wardrobe

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -2,8 +2,8 @@
 	icon_state = "refill_clothes"
 
 /obj/machinery/vending/wardrobe
-	default_price = 50
-	extra_price = 100
+	default_price = 0
+	extra_price = 25
 	payment_department = NO_FREEBIES
 
 /obj/machinery/vending/wardrobe/sec_wardrobe


### PR DESCRIPTION
:cl:
tweak: Prices have been lowered for the AutoDrobe, ClothesMate, and all departmental clothing vendors.
/:cl:

The ClothesMate and AutoDrobe are meaningless cosmetic items. I reduced their prices but they still cost just a bit of money. It's more realistic for low income jobs to be able to buy one or two of these meaningless cosmetic items without having to do something like steal from other people.

Departmental clothing vendors only exist because it's more convenient to update them than it is clothing lockers. They're all locked behind multiple ID locked doors, and people with access already get the items for free. The items contained within are absolutely harmless, so I see no reason why large sums of money should be charged for these items should someone happen to break all the way in there. It functionally just gates people without access from acquiring something should they get all the way into the department, but unlike the many other ways we have of doing this, the only real way to fix it is to steal someone else's ID. ID cards are a very important item to anyone and requiring that people steal them in order to attain meaningless cosmetic items just makes the game worse. The only departmental clothing vendor that uses premium pricing currently is the Security one, so it's a modest 25 space bucks. 