### PR TITLE
Moves explosion effects above lighting layer

### DIFF
--- a/code/game/objects/effects/effect_system/effects_explosion.dm
+++ b/code/game/objects/effects/effect_system/effects_explosion.dm
@@ -3,6 +3,8 @@
 	icon_state = "explosion_particle"
 	opacity = 1
 	anchored = TRUE
+	layer = ABOVE_LIGHTING_LAYER
+	plane = ABOVE_LIGHTING_PLANE
 
 /obj/effect/particle_effect/expl_particles/Initialize()
 	. = ..()
@@ -28,6 +30,8 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	pixel_x = -32
 	pixel_y = -32
+	layer = ABOVE_LIGHTING_LAYER
+	plane = ABOVE_LIGHTING_PLANE
 
 /obj/effect/explosion/Initialize()
 	. = ..()

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -301,6 +301,8 @@
 	pixel_x = -32
 	pixel_y = -32
 	duration = 8
+	layer = ABOVE_LIGHTING_LAYER
+	plane = ABOVE_LIGHTING_PLANE
 
 /obj/effect/temp_visual/explosion/fast
 	icon_state = "explosionfast"


### PR DESCRIPTION
Broken off from #40358

:cl: ShizCalev
fix: Explosion icons will no longer be effected by lighting. No more dark explosions!
/:cl:
