### PR TITLE
Cleans up and adds more concise admin logging to the centcom podlauncher

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1283,8 +1283,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 			pod.damage = 40
 			pod.explosionSize = list(0,0,0,2)
 			pod.effectStun = TRUE
-			if (isnull(target_path))
-				alert("ERROR: NULL path given.")
+			if (isnull(target_path)) //The user pressed "Cancel"
 				return
 			if (target_path != "empty")//if you didn't type empty, we want to load the pod with a delivery
 				var/delivery = text2path(target_path)
@@ -1292,6 +1291,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 					delivery = pick_closest_path(target_path)
 					if(!delivery)
 						alert("ERROR: Incorrect / improper path given.")
+						return
 				new delivery(pod)
 			new /obj/effect/DPtarget(get_turf(target), pod)
 		if(ADMIN_PUNISHMENT_SUPPLYPOD)
@@ -1306,17 +1306,20 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 			plaunch.temp_pod.explosionSize = list(0,0,0,2)
 			plaunch.temp_pod.effectStun = TRUE
 			plaunch.ui_interact(usr)
+			return //We return here because punish_log() is handled by the centcom_podlauncher datum
 
 		if(ADMIN_PUNISHMENT_MAZING)
 			if(!puzzle_imprison(target))
 				to_chat(usr,"<span class='warning'>Imprisonment failed!</span>")
 				return
 
-	var/msg = "[key_name_admin(usr)] punished [key_name_admin(target)] with [punishment]."
-	message_admins(msg)
-	admin_ticket_log(target, msg)
-	log_admin("[key_name(usr)] punished [key_name(target)] with [punishment].")
+	punish_log(target, punishment)
 
+/client/proc/punish_log(var/whom, var/punishment)
+	var/msg = "[key_name_admin(usr)] punished [key_name_admin(whom)] with [punishment]."
+	message_admins(msg)
+	admin_ticket_log(whom, msg)
+	log_admin("[key_name(usr)] punished [key_name(whom)] with [punishment].")
 
 /client/proc/trigger_centcom_recall()
 	if(!check_rights(R_ADMIN))

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -523,7 +523,7 @@ force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.adm
 
 /datum/centcom_podlauncher/proc/supplypod_punish_log(var/mob/whom)
 	var/podString = effectBurst ? "5 pods" : "a pod"
-	var/whoString = whom ? " at [whom]" : ""
+	var/whomString = whom ? " at [whom]" : ""
 	var/delayString = temp_pod.landingDelay == initial(temp_pod.landingDelay) ? "" : " Delay=[temp_pod.landingDelay*0.1]s"
 	var/damageString = temp_pod.damage == 0 ? "" : " Dmg=[temp_pod.damage]"
 	var/explosionString = ""

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -522,9 +522,8 @@ force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.adm
 /datum/centcom_podlauncher/proc/supplypod_punish_log(var/list/whoDyin)
 	var/podString = effectBurst ? "5 pods" : "a pod"
 	var/whomString = ""
-	if (!isemptylist(whoDyin))
-		whomString = "at "
-		for (var/mob/living/M in whoDyin)
+	if (LAZYLEN(whoDyin))
+		for (var/mob/living/M in whoDyin) 
 			whomString += "[key_name(M)], "
 
 	var/delayString = temp_pod.landingDelay == initial(temp_pod.landingDelay) ? "" : " Delay=[temp_pod.landingDelay*0.1]s"

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -415,12 +415,10 @@ force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.adm
 				return //if target is null and we don't have a specific target, cancel
 			if (effectAnnounce)
 				deadchat_broadcast("<span class='deadsay'>A special package is being launched at the station!</span>", turf_target = target)
-			var/mob/M = locate(/mob/living, target)
-			if (M)
-				for (var/mob/bouttadie in target)
-					supplypod_punish_log(bouttadie)
-			else
-				supplypod_punish_log(null)
+			var/list/bouttaDie = list()
+			for (var/mob/living/M in target)
+				bouttaDie.Add(M)
+			supplypod_punish_log(bouttaDie)
 			if (!effectBurst) //If we're not using burst mode, just launch normally.
 				launch(target)
 			else
@@ -521,9 +519,14 @@ force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.adm
 	qdel(selector) //Delete the selector effect
 	. = ..()
 
-/datum/centcom_podlauncher/proc/supplypod_punish_log(var/mob/whom)
+/datum/centcom_podlauncher/proc/supplypod_punish_log(var/list/whoDyin)
 	var/podString = effectBurst ? "5 pods" : "a pod"
-	var/whomString = whom ? " at [whom]" : ""
+	var/whomString = ""
+	if (!isemptylist(whoDyin))
+		var/whomString = "at "
+		for (var/mob/living/M in whoDyin)
+			whomString += "[M], "
+
 	var/delayString = temp_pod.landingDelay == initial(temp_pod.landingDelay) ? "" : " Delay=[temp_pod.landingDelay*0.1]s"
 	var/damageString = temp_pod.damage == 0 ? "" : " Dmg=[temp_pod.damage]"
 	var/explosionString = ""
@@ -533,7 +536,7 @@ force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.adm
 			explosionString += "[X]|"
 	
 	var/msg = "launched [podString][whomString].[delayString][damageString][explosionString]]"
-	message_admins("[key_name_admin(usr)] [msg]")
-	if (whom && whom.key)
-		admin_ticket_log(whom, "[key_name_admin(usr)] [msg]")
-	log_admin("[key_name(usr)] [msg] in [AREACOORD(whom)].")
+	message_admins("[key_name_admin(usr)] [msg] in [AREACOORD(whom)].")
+	if (!isemptylist(whoDyin))
+		for (var/mob/living/M in whoDyin)
+			admin_ticket_log(M, "[key_name_admin(usr)] [msg]")

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -525,7 +525,7 @@ force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.adm
 	var/explosionString = "|"
 	for (var/X in temp_pod.explosionSize)
 		explosionString += "[X]|"
-	var/msg = "launched [effectBurst ? "5 pods" : "a pod"][whom ? " at [whom]" : ""]. Delay=[temp_pod.landingDelay*.1]s, dmg=[temp_pod.damage]dmg, stun=[temp_pod.effectStun], boom=([explosionString])] "
+	var/msg = "launched [effectBurst ? "5 pods" : "a pod"][whom ? " at [whom]" : ""]. Delay=[temp_pod.landingDelay*0.1]s, dmg=[temp_pod.damage]dmg, stun=[temp_pod.effectStun], boom=([explosionString])] "
 	message_admins("[key_name_admin(usr)] [msg]")
 	if (whom && whom.key)
 		admin_ticket_log(whom, "[key_name_admin(usr)] [msg]")

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -525,7 +525,7 @@ force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.adm
 	if (!isemptylist(whoDyin))
 		whomString = "at "
 		for (var/mob/living/M in whoDyin)
-			whomString += "[M], "
+			whomString += "[key_name(M)], "
 
 	var/delayString = temp_pod.landingDelay == initial(temp_pod.landingDelay) ? "" : " Delay=[temp_pod.landingDelay*0.1]s"
 	var/damageString = temp_pod.damage == 0 ? "" : " Dmg=[temp_pod.damage]"

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -522,10 +522,17 @@ force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.adm
 	. = ..()
 
 /datum/centcom_podlauncher/proc/supplypod_punish_log(var/mob/whom)
-	var/explosionString = "|"
-	for (var/X in temp_pod.explosionSize)
-		explosionString += "[X]|"
-	var/msg = "launched [effectBurst ? "5 pods" : "a pod"][whom ? " at [whom]" : ""]. Delay=[temp_pod.landingDelay*0.1]s, dmg=[temp_pod.damage]dmg, stun=[temp_pod.effectStun], boom=([explosionString])] "
+	var/podString = effectBurst ? "5 pods" : "a pod"
+	var/whoString = whom ? " at [whom]" : ""
+	var/delayString = temp_pod.landingDelay == initial(temp_pod.landingDelay) ? "" : " Delay=[temp_pod.landingDelay*0.1]s"
+	var/damageString = temp_pod.damage == 0 ? "" : " Dmg=[temp_pod.damage]"
+	var/explosionString = ""
+	if (counterlist_sum(temp_pod.explosionSize) != 0)
+		explosionString = " Boom=|"
+		for (var/X in temp_pod.explosionSize)
+			explosionString += "[X]|"
+	
+	var/msg = "launched [podString][whomString].[delayString][damageString][explosionString]]"
 	message_admins("[key_name_admin(usr)] [msg]")
 	if (whom && whom.key)
 		admin_ticket_log(whom, "[key_name_admin(usr)] [msg]")

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -32,7 +32,7 @@
 	var/effectAnnounce = TRUE
 	var/numTurfs = 0 //Counts the number of turfs with things we can launch in the chosen bay (in the centcom map)
 	var/launchCounter = 1 //Used with the "Ordered" launch mode (launchChoice = 1) to see what item is launched
-	var/specificTarget //Do we want to target a specific mob instead of where we click? Also used for smiting
+	var/atom/specificTarget //Do we want to target a specific mob instead of where we click? Also used for smiting
 	var/list/orderedArea = list() //Contains an ordered list of turfs in an area (filled in the createOrderedArea() proc), read top-left to bottom-right. Used for the "ordered" launch mode (launchChoice = 1)
 	var/list/acceptableTurfs = list() //Contians a list of turfs (in the "bay" area on centcom) that have items that can be launched. Taken from orderedArea
 	var/list/launchList = list() //Contains whatever is going to be put in the supplypod and fired. Taken from acceptableTurfs
@@ -523,7 +523,7 @@ force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.adm
 	var/podString = effectBurst ? "5 pods" : "a pod"
 	var/whomString = ""
 	if (!isemptylist(whoDyin))
-		var/whomString = "at "
+		whomString = "at "
 		for (var/mob/living/M in whoDyin)
 			whomString += "[M], "
 
@@ -536,7 +536,7 @@ force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.adm
 			explosionString += "[X]|"
 	
 	var/msg = "launched [podString][whomString].[delayString][damageString][explosionString]]"
-	message_admins("[key_name_admin(usr)] [msg] in [AREACOORD(whom)].")
+	message_admins("[key_name_admin(usr)] [msg] in [AREACOORD(specificTarget)].")
 	if (!isemptylist(whoDyin))
 		for (var/mob/living/M in whoDyin)
 			admin_ticket_log(M, "[key_name_admin(usr)] [msg]")

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -523,10 +523,10 @@ force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.adm
 
 /datum/centcom_podlauncher/proc/supplypod_punish_log(var/mob/whom)
 	var/explosionString = "|"
-	for (var/X in explosionSize)
+	for (var/X in temp_pod.explosionSize)
 		explosionString += "[X]|"
 	var/msg = "launched [effectBurst ? "5 pods" : "a pod"][whom ? " at [whom]" : ""]. Delay=[temp_pod.landingDelay*.1]s, dmg=[temp_pod.damage]dmg, stun=[temp_pod.effectStun], boom=([explosionString])] "
 	message_admins("[key_name_admin(usr)] [msg]")
-	if (whom)
+	if (whom && whom.key)
 		admin_ticket_log(whom, "[key_name_admin(usr)] [msg]")
 	log_admin("[key_name(usr)] [msg] in [AREACOORD(whom)].")

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -522,7 +522,10 @@ force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.adm
 	. = ..()
 
 /datum/centcom_podlauncher/proc/supplypod_punish_log(var/mob/whom)
-	var/msg = "launched [effectBurst ? "a pod" : "5 pods"][whom ? " at [whom]" : ""]. Delay=[temp_pod.landingDelay*10]s, dmg=[temp_pod.damage]dmg, stun=[temp_pod.effectStun], explosion=[temp_pod.explosionSize] "
+	var/explosionString = "|"
+	for (var/X in explosionSize)
+		explosionString += "[X]|"
+	var/msg = "launched [effectBurst ? "5 pods" : "a pod"][whom ? " at [whom]" : ""]. Delay=[temp_pod.landingDelay*.1]s, dmg=[temp_pod.damage]dmg, stun=[temp_pod.effectStun], boom=([explosionString])] "
 	message_admins("[key_name_admin(usr)] [msg]")
 	if (whom)
 		admin_ticket_log(whom, "[key_name_admin(usr)] [msg]")

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -107,7 +107,7 @@
 			M.gib() //After adjusting the fuck outta that brute loss we finish the job with some satisfying gibs
 		M.adjustBruteLoss(damage)
 
-	if (counterlist_sum(explosion_size) != 0) //If the explosion list isn't all zeroes, call an explosion
+	if (counterlist_sum(explosionSize) != 0) //If the explosion list isn't all zeroes, call an explosion
 		explosion(get_turf(src), B[1], B[2], B[3], flame_range = B[4], silent = effectQuiet, ignorecap = istype(src, /obj/structure/closet/supplypod/centcompod)) //less advanced equipment than bluespace pod, so larger explosion when landing
 	else if (!effectQuiet) //If our explosion list IS all zeroes, we still make a nice explosion sound (unless the effectQuiet var is true)
 		playsound(src, "explosion", landingSound ? 15 : 80, 1)

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -107,7 +107,7 @@
 			M.gib() //After adjusting the fuck outta that brute loss we finish the job with some satisfying gibs
 		M.adjustBruteLoss(damage)
 
-	if (B[1] || B[2] || B[3] || B[4]) //If the explosion list isn't all zeroes, call an explosion
+	if (counterlist_sum(explosion_size) != 0) //If the explosion list isn't all zeroes, call an explosion
 		explosion(get_turf(src), B[1], B[2], B[3], flame_range = B[4], silent = effectQuiet, ignorecap = istype(src, /obj/structure/closet/supplypod/centcompod)) //less advanced equipment than bluespace pod, so larger explosion when landing
 	else if (!effectQuiet) //If our explosion list IS all zeroes, we still make a nice explosion sound (unless the effectQuiet var is true)
 		playsound(src, "explosion", landingSound ? 15 : 80, 1)


### PR DESCRIPTION
Fixes: #40688

:cl: MrDoomBringer
admin: The centcom podlauncher now has better logging
fix: Cancelling a supplypod smite will now not throw an error message
/:cl:


