### PR TITLE
fixes hitscan increments not using the multiplier

### DIFF
--- a/code/datums/position_point_vector.dm
+++ b/code/datums/position_point_vector.dm
@@ -186,8 +186,8 @@
 
 /datum/point/vector/proc/increment(multiplier = 1)
 	iteration++
-	x += mpx * 1
-	y += mpy * 1
+	x += mpx * (multiplier)
+	y += mpy * (multiplier)
 
 /datum/point/vector/proc/return_vector_after_increments(amount = 7, multiplier = 1, force_simulate = FALSE)
 	var/datum/point/vector/v = copy_to()


### PR DESCRIPTION
@kevinz000 

from what I can tell this only went unnoticed because the only thing that uses this as of now has an increment multiplier of 1. 

testing the hitscan beam rifle & laser tag guns (the only things that use this) show no change in behavior after correction.