### PR TITLE
Adds more family heirlooms

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -51,7 +51,7 @@
 			if("Cook")
 				heirloom_type = pick(/obj/item/reagent_containers/food/condiment/saltshaker, /obj/item/kitchen/rollingpin, /obj/item/clothing/head/chefhat)
 			if("Botanist")
-				heirloom_type = pick(/obj/item/cultivator, /obj/item/reagent_containers/glass/bucket)
+				heirloom_type = pick(/obj/item/cultivator, /obj/item/reagent_containers/glass/bucket, /obj/item/storage/bag/plants)
 			if("Bartender")
 				heirloom_type = pick(/obj/item/reagent_containers/glass/rag, /obj/item/clothing/head/that, /obj/item/reagent_containers/food/drinks/shaker)
 			if("Curator")
@@ -77,7 +77,7 @@
 			if("Scientist")
 				heirloom_type = /obj/item/toy/plush/slimeplushie
 			if("Roboticist")
-				heirloom_type = pick(subtypesof(/obj/item/toy/prize)) //nerd
+				heirloom_type = pick(subtypesof(/obj/item/toy/prize)) //look at this nerd
 			//Medical
 			if("Chief Medical Officer")
 				heirloom_type = pick(/obj/item/clothing/neck/stethoscope, /obj/item/bodybag)
@@ -89,16 +89,16 @@
 				heirloom_type = /obj/item/reagent_containers/syringe
 			//Engineering
 			if("Chief Engineer")
-				heirloom_type = pick(/obj/item/clothing/head/hardhat/white, /obj/item/airlock_painter)
+				heirloom_type = pick(/obj/item/clothing/head/hardhat/white, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters)
 			if("Station Engineer")
-				heirloom_type = pick(/obj/item/clothing/head/hardhat, /obj/item/airlock_painter)
+				heirloom_type = pick(/obj/item/clothing/head/hardhat, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters)
 			if("Atmospheric Technician")
 				heirloom_type = pick(/obj/item/lighter, /obj/item/lighter/greyscale, /obj/item/storage/box/matches)
 			//Supply
 			if("Quartermaster")
-				heirloom_type = /obj/item/stamp
+				heirloom_type = pick(/obj/item/stamp, /obj/item/stamp/denied)
 			if("Cargo Technician")
-				heirloom_type = /obj/item/clothing/gloves/fingerless
+				heirloom_type = /obj/item/clipboard
 			if("Shaft Miner")
 				heirloom_type = pick(/obj/item/pickaxe/mini, /obj/item/shovel)
 

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -36,67 +36,71 @@
 /datum/quirk/family_heirloom/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/heirloom_type
-	switch(quirk_holder.mind.assigned_role)
-		//Service jobs
-		if("Clown")
-			heirloom_type = /obj/item/bikehorn/golden
-		if("Mime")
-			heirloom_type = /obj/item/reagent_containers/food/snacks/baguette
-		if("Janitor")
-			heirloom_type = pick(/obj/item/mop, /obj/item/caution, /obj/item/reagent_containers/glass/bucket)
-		if("Cook")
-			heirloom_type = pick(/obj/item/reagent_containers/food/condiment/saltshaker, /obj/item/kitchen/rollingpin, /obj/item/clothing/head/chefhat)
-		if("Botanist")
-			heirloom_type = pick(/obj/item/cultivator, /obj/item/reagent_containers/glass/bucket)
-		if("Bartender")
-			heirloom_type = pick(/obj/item/reagent_containers/glass/rag, /obj/item/clothing/head/that, /obj/item/reagent_containers/food/drinks/shaker)
-		if("Curator")
-			heirloom_type = pick(/obj/item/pen/fountain, /obj/item/storage/pill_bottle/dice)
-		if("Assistant")
-			heirloom_type = /obj/item/storage/toolbox/mechanical/old/heirloom
-		//Security/Command
-		if("Captain")
-			heirloom_type = /obj/item/reagent_containers/food/drinks/flask/gold
-		if("Head of Security")
-			heirloom_type = /obj/item/book/manual/wiki/security_space_law
-		if("Warden")
-			heirloom_type = /obj/item/book/manual/wiki/security_space_law
-		if("Security Officer")
-			heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec)
-		if("Detective")
-			heirloom_type = /obj/item/reagent_containers/food/drinks/bottle/whiskey
-		if("Lawyer")
-			heirloom_type = pick(/obj/item/gavelhammer, /obj/item/book/manual/wiki/security_space_law)
-		//RnD
-		if("Research Director")
-			heirloom_type = /obj/item/toy/plush/slimeplushie
-		if("Scientist")
-			heirloom_type = /obj/item/toy/plush/slimeplushie
-		if("Roboticist")
-			heirloom_type = pick(subtypesof(/obj/item/toy/prize)) //nerd
-		//Medical
-		if("Chief Medical Officer")
-			heirloom_type = pick(/obj/item/clothing/neck/stethoscope, /obj/item/bodybag)
-		if("Medical Doctor")
-			heirloom_type = pick(/obj/item/clothing/neck/stethoscope, /obj/item/bodybag)
-		if("Chemist")
-			heirloom_type = /obj/item/book/manual/wiki/chemistry
-		if("Virologist")
-			heirloom_type = /obj/item/reagent_containers/syringe
-		//Engineering
-		if("Chief Engineer")
-			heirloom_type = pick(/obj/item/clothing/head/hardhat/white, /obj/item/airlock_painter)
-		if("Station Engineer")
-			heirloom_type = pick(/obj/item/clothing/head/hardhat, /obj/item/airlock_painter)
-		if("Atmospheric Technician")
-			heirloom_type = pick(/obj/item/lighter, /obj/item/lighter/greyscale, /obj/item/storage/box/matches)
-		//Supply
-		if("Quartermaster")
-			heirloom_type = /obj/item/stamp
-		if("Cargo Technician")
-			heirloom_type = /obj/item/clothing/gloves/fingerless
-		if("Shaft Miner")
-			heirloom_type = pick(/obj/item/pickaxe/mini, /obj/item/shovel)
+
+	if(is_species(H, /datum/species/moth))
+		heirloom_type = pick(/obj/item/flashlight/lantern, /obj/item/flashlight)
+	else
+		switch(quirk_holder.mind.assigned_role)
+			//Service jobs
+			if("Clown")
+				heirloom_type = /obj/item/bikehorn/golden
+			if("Mime")
+				heirloom_type = /obj/item/reagent_containers/food/snacks/baguette
+			if("Janitor")
+				heirloom_type = pick(/obj/item/mop, /obj/item/caution, /obj/item/reagent_containers/glass/bucket)
+			if("Cook")
+				heirloom_type = pick(/obj/item/reagent_containers/food/condiment/saltshaker, /obj/item/kitchen/rollingpin, /obj/item/clothing/head/chefhat)
+			if("Botanist")
+				heirloom_type = pick(/obj/item/cultivator, /obj/item/reagent_containers/glass/bucket)
+			if("Bartender")
+				heirloom_type = pick(/obj/item/reagent_containers/glass/rag, /obj/item/clothing/head/that, /obj/item/reagent_containers/food/drinks/shaker)
+			if("Curator")
+				heirloom_type = pick(/obj/item/pen/fountain, /obj/item/storage/pill_bottle/dice)
+			if("Assistant")
+				heirloom_type = /obj/item/storage/toolbox/mechanical/old/heirloom
+			//Security/Command
+			if("Captain")
+				heirloom_type = /obj/item/reagent_containers/food/drinks/flask/gold
+			if("Head of Security")
+				heirloom_type = /obj/item/book/manual/wiki/security_space_law
+			if("Warden")
+				heirloom_type = /obj/item/book/manual/wiki/security_space_law
+			if("Security Officer")
+				heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec)
+			if("Detective")
+				heirloom_type = /obj/item/reagent_containers/food/drinks/bottle/whiskey
+			if("Lawyer")
+				heirloom_type = pick(/obj/item/gavelhammer, /obj/item/book/manual/wiki/security_space_law)
+			//RnD
+			if("Research Director")
+				heirloom_type = /obj/item/toy/plush/slimeplushie
+			if("Scientist")
+				heirloom_type = /obj/item/toy/plush/slimeplushie
+			if("Roboticist")
+				heirloom_type = pick(subtypesof(/obj/item/toy/prize)) //nerd
+			//Medical
+			if("Chief Medical Officer")
+				heirloom_type = pick(/obj/item/clothing/neck/stethoscope, /obj/item/bodybag)
+			if("Medical Doctor")
+				heirloom_type = pick(/obj/item/clothing/neck/stethoscope, /obj/item/bodybag)
+			if("Chemist")
+				heirloom_type = /obj/item/book/manual/wiki/chemistry
+			if("Virologist")
+				heirloom_type = /obj/item/reagent_containers/syringe
+			//Engineering
+			if("Chief Engineer")
+				heirloom_type = pick(/obj/item/clothing/head/hardhat/white, /obj/item/airlock_painter)
+			if("Station Engineer")
+				heirloom_type = pick(/obj/item/clothing/head/hardhat, /obj/item/airlock_painter)
+			if("Atmospheric Technician")
+				heirloom_type = pick(/obj/item/lighter, /obj/item/lighter/greyscale, /obj/item/storage/box/matches)
+			//Supply
+			if("Quartermaster")
+				heirloom_type = /obj/item/stamp
+			if("Cargo Technician")
+				heirloom_type = /obj/item/clothing/gloves/fingerless
+			if("Shaft Miner")
+				heirloom_type = pick(/obj/item/pickaxe/mini, /obj/item/shovel)
 
 	if(!heirloom_type)
 		heirloom_type = pick(

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -38,7 +38,7 @@
 	var/obj/item/heirloom_type
 
 	if(is_species(H, /datum/species/moth))
-		heirloom_type = /obj/item/flashlight/lantern
+		heirloom_type = /obj/item/flashlight/lantern/heirloom_moth
 	else
 		switch(quirk_holder.mind.assigned_role)
 			//Service jobs

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -38,7 +38,7 @@
 	var/obj/item/heirloom_type
 
 	if(is_species(H, /datum/species/moth))
-		heirloom_type = pick(/obj/item/flashlight/lantern, /obj/item/flashlight)
+		heirloom_type = /obj/item/flashlight/lantern
 	else
 		switch(quirk_holder.mind.assigned_role)
 			//Service jobs

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -37,20 +37,67 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/heirloom_type
 	switch(quirk_holder.mind.assigned_role)
+		//Service jobs
 		if("Clown")
 			heirloom_type = /obj/item/bikehorn/golden
 		if("Mime")
 			heirloom_type = /obj/item/reagent_containers/food/snacks/baguette
-		if("Lawyer")
-			heirloom_type = /obj/item/gavelhammer
 		if("Janitor")
-			heirloom_type = /obj/item/mop
-		if("Security Officer")
-			heirloom_type = /obj/item/book/manual/wiki/security_space_law
-		if("Scientist")
-			heirloom_type = /obj/item/toy/plush/slimeplushie
+			heirloom_type = pick(/obj/item/mop, /obj/item/caution, /obj/item/reagent_containers/glass/bucket)
+		if("Cook")
+			heirloom_type = pick(/obj/item/reagent_containers/food/condiment/saltshaker, /obj/item/kitchen/rollingpin, /obj/item/clothing/head/chefhat)
+		if("Botanist")
+			heirloom_type = pick(/obj/item/cultivator, /obj/item/reagent_containers/glass/bucket)
+		if("Bartender")
+			heirloom_type = pick(/obj/item/reagent_containers/glass/rag, /obj/item/clothing/head/that, /obj/item/reagent_containers/food/drinks/shaker)
+		if("Curator")
+			heirloom_type = pick(/obj/item/pen/fountain, /obj/item/storage/pill_bottle/dice)
 		if("Assistant")
 			heirloom_type = /obj/item/storage/toolbox/mechanical/old/heirloom
+		//Security/Command
+		if("Captain")
+			heirloom_type = /obj/item/reagent_containers/food/drinks/flask/gold
+		if("Head of Security")
+			heirloom_type = /obj/item/book/manual/wiki/security_space_law
+		if("Warden")
+			heirloom_type = /obj/item/book/manual/wiki/security_space_law
+		if("Security Officer")
+			heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec)
+		if("Detective")
+			heirloom_type = /obj/item/reagent_containers/food/drinks/bottle/whiskey
+		if("Lawyer")
+			heirloom_type = pick(/obj/item/gavelhammer, /obj/item/book/manual/wiki/security_space_law)
+		//RnD
+		if("Research Director")
+			heirloom_type = /obj/item/toy/plush/slimeplushie
+		if("Scientist")
+			heirloom_type = /obj/item/toy/plush/slimeplushie
+		if("Roboticist")
+			heirloom_type = pick(subtypesof(/obj/item/toy/prize)) //nerd
+		//Medical
+		if("Chief Medical Officer")
+			heirloom_type = pick(/obj/item/clothing/neck/stethoscope, /obj/item/bodybag)
+		if("Medical Doctor")
+			heirloom_type = pick(/obj/item/clothing/neck/stethoscope, /obj/item/bodybag)
+		if("Chemist")
+			heirloom_type = /obj/item/book/manual/wiki/chemistry
+		if("Virologist")
+			heirloom_type = /obj/item/reagent_containers/syringe
+		//Engineering
+		if("Chief Engineer")
+			heirloom_type = pick(/obj/item/clothing/head/hardhat/white, /obj/item/airlock_painter)
+		if("Station Engineer")
+			heirloom_type = pick(/obj/item/clothing/head/hardhat, /obj/item/airlock_painter)
+		if("Atmospheric Technician")
+			heirloom_type = pick(/obj/item/lighter, /obj/item/lighter/greyscale, /obj/item/storage/box/matches)
+		//Supply
+		if("Quartermaster")
+			heirloom_type = /obj/item/stamp
+		if("Cargo Technician")
+			heirloom_type = /obj/item/clothing/gloves/fingerless
+		if("Shaft Miner")
+			heirloom_type = pick(/obj/item/pickaxe/mini, /obj/item/shovel)
+
 	if(!heirloom_type)
 		heirloom_type = pick(
 		/obj/item/toy/cards/deck,

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -341,6 +341,10 @@
 	desc = "A mining lantern."
 	brightness_on = 6			// luminosity when on
 
+/obj/item/flashlight/lantern/heirloom_moth
+	name = "old lantern"
+	desc = "An old lantern that has seen plenty of use."
+	brightness_on = 4
 
 /obj/item/flashlight/slime
 	gender = PLURAL
@@ -358,7 +362,6 @@
 	var/emp_max_charges = 4
 	var/emp_cur_charges = 4
 	var/charge_tick = 0
-
 
 /obj/item/flashlight/emp/New()
 	..()


### PR DESCRIPTION
:cl: Denton
add: Added more job specific items for the family heirloom trait.
tweak: Moths that have the heirloom trait now always have a lantern as their heirloom.
/:cl:

This PR adds a whole bunch of new family heirlooms:

- Moths: old lantern with reduced light range. Thanks cobby

Service:
- Janitor: caution sign, bucket
- Cook: salt shaker, rolling pin, chef's hat
- Botanist: cultivator, bucket, plant bag
- Bartender: damp rag, top hat, shaker
- Curator: fountain pen, bag of dice

Sec/command:
- Captain: golden flask
- HoS, warden, lawyer: space law
- Sec officer: same as above, plus sec beret
- Detective: whiskey bottle

RnD:
- RD: slime plush
- Roboticist: any mech figurine. what a nerd!

Medical:
- CMO, doc: stethoscope, body bag
- Chemist: chemistry textbook
- Virologist: syringe

Engineering:
- CE: white hard hat, basic tools
- Engineer: yellow hard hat, basic tools
- Atmos tech: random lighter or matchbook

Supply:
- QM: stamp
- Cargo tech: clipboard
- Shaft miner: shovel, compact pickaxe