### PR TITLE
Summon magic items now count as magical artifacts

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -31,14 +31,14 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 		if ((possible_target != src) && ishuman(possible_target.current))
 			possible_targets += possible_target.current
 
-	
+
 	if(target && target.current)
 		def_value = target.current
 
 	var/mob/new_target = input(admin,"Select target:", "Objective target", def_value) as null|anything in possible_targets
 	if (!new_target)
 		return
-	
+
 	if (new_target == "Free objective")
 		target = null
 	else if (new_target == "Random")
@@ -168,7 +168,7 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 
 /datum/objective/assassinate/admin_edit(mob/admin)
 	admin_simple_target_pick(admin)
-	
+
 /datum/objective/assassinate/internal
 	var/stolen = 0 		//Have we already eliminated this target?
 
@@ -797,7 +797,11 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 /datum/objective/steal_five_of_type/summon_magic
 	name = "steal magic"
 	explanation_text = "Steal at least five magical artefacts!"
-	wanted_items = list(/obj/item/spellbook, /obj/item/gun/magic, /obj/item/clothing/suit/space/hardsuit/wizard, /obj/item/scrying, /obj/item/antag_spawner/contract, /obj/item/necromantic_stone)
+	wanted_items = list()
+
+/datum/objective/steal_five_of_type/summon_magic/New()
+	wanted_items = GLOB.summoned_magic_objectives
+	..()
 
 /datum/objective/steal_five_of_type/check_completion()
 	var/list/datum/mind/owners = get_owners()
@@ -1011,7 +1015,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		/datum/objective/absorb,
 		/datum/objective/custom
 	)
-	
+
 	for(var/T in allowed_types)
 		var/datum/objective/X = T
 		GLOB.admin_objective_list[initial(X.name)] = T

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -47,6 +47,7 @@ GLOBAL_LIST_INIT(summoned_guns, list(
 	/obj/item/gun/energy/laser/scatter,
 	/obj/item/gun/energy/gravity_gun))
 
+//if you add anything that isn't covered by the typepaths below, add it to summon_magic_objective_types
 GLOBAL_LIST_INIT(summoned_magic, list(
 	/obj/item/book/granter/spell/fireball,
 	/obj/item/book/granter/spell/smoke,
@@ -81,6 +82,21 @@ GLOBAL_LIST_INIT(summoned_special_magic, list(
 	/obj/item/gun/magic/staff/chaos,
 	/obj/item/necromantic_stone,
 	/obj/item/blood_contract))
+
+//everything above except for single use spellbooks, because those are for basic bitches
+GLOBAL_LIST_INIT(summoned_magic_objectives, list(
+	/obj/item/antag_spawner/contract,
+	/obj/item/blood_contract,
+	/obj/item/clothing/suit/space/hardsuit/shielded/wizard,
+	/obj/item/gun/magic,
+	/obj/item/immortality_talisman,
+	/obj/item/melee/ghost_sword,
+	/obj/item/necromantic_stone,
+	/obj/item/scrying,
+	/obj/item/spellbook,
+	/obj/item/storage/belt/wands/full,
+	/obj/item/voodoo,
+	/obj/item/warpwhistle))
 
 // If true, it's the probability of triggering "survivor" antag.
 GLOBAL_VAR_INIT(summon_guns_triggered, FALSE)


### PR DESCRIPTION
:cl: ShizCalev
fix: Everything spawned by summon magic (with the exception of single-use spellbooks) now count towards the "Steal at least five magical artefacts" objective.
/:cl:

