### PR TITLE
Fixes delivery chute runtime

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -121,10 +121,12 @@
 	B.icon = I
 	B.name = "broken [name]"
 	if(prob(33))
-		new/obj/item/shard(drop_location())
+		var/obj/item/shard/S = new(drop_location())
+		target.Bumped(S)
 	playsound(src, "shatter", 70, 1)
 	transfer_fingerprints_to(B)
 	qdel(src)
+	target.Bumped(B)
 
 
 
@@ -303,6 +305,7 @@
 	B.desc = "A carton with the bottom half burst open. Might give you a papercut."
 	transfer_fingerprints_to(B)
 	qdel(src)
+	target.Bumped(B)
 
 /obj/item/reagent_containers/food/drinks/sillycup/smallcarton/on_reagent_change(changetype)
 	if (reagents.reagent_list.len)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -32,7 +32,8 @@
 
 	if(isGlass)
 		if(prob(33))
-			new/obj/item/shard(drop_location())
+			var/obj/item/shard/S = new(drop_location())
+			target.Bumped(S)
 		playsound(src, "shatter", 70, 1)
 	else
 		B.force = 0
@@ -42,6 +43,7 @@
 	transfer_fingerprints_to(B)
 
 	qdel(src)
+	target.Bumped(B)
 
 /obj/item/reagent_containers/food/drinks/bottle/attack(mob/living/target, mob/living/user)
 

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -459,7 +459,7 @@
 		flush()
 
 /obj/machinery/disposal/deliveryChute/Bumped(atom/movable/AM) //Go straight into the chute
-	if(!AM.CanEnterDisposals())
+	if(QDELETED(AM) || !AM.CanEnterDisposals())
 		return
 	switch(dir)
 		if(NORTH)


### PR DESCRIPTION
```
[22:29:07] Runtime in bin.dm, line 469: Cannot read null.y
proc name: Bumped (/obj/machinery/disposal/deliveryChute/Bumped)
src: the delivery chute (/obj/machinery/disposal/deliveryChute)
src.loc: the floor (107,116,2) (/turf/open/floor/plasteel)
call stack:
the delivery chute (/obj/machinery/disposal/deliveryChute): Bumped(Atomic Bomb (/obj/item/reagent_containers/food/drinks/drinkingglass))
Atomic Bomb (/obj/item/reagent_containers/food/drinks/drinkingglass): Bump(the delivery chute (/obj/machinery/disposal/deliveryChute))
the floor (107,116,2) (/turf/open/floor/plasteel): Enter(Atomic Bomb (/obj/item/reagent_containers/food/drinks/drinkingglass), the floor (107,115,2) (/turf/open/floor/plasteel))
Atomic Bomb (/obj/item/reagent_containers/food/drinks/drinkingglass): Move(the floor (107,116,2) (/turf/open/floor/plasteel), 1)
Atomic Bomb (/obj/item/reagent_containers/food/drinks/drinkingglass): Move(the floor (107,116,2) (/turf/open/floor/plasteel), 1)
/datum/thrownthing (/datum/thrownthing): tick()
Throwing (/datum/controller/subsystem/throwing): fire(0)
Throwing (/datum/controller/subsystem/throwing): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```