### PR TITLE
Fixes ventcrawl runtime

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -339,7 +339,7 @@ Pipelines + Other Objects -> Pipe network
 
 
 /obj/machinery/atmospherics/AltClick(mob/living/L)
-	if(is_type_in_list(src, GLOB.ventcrawl_machinery))
+	if(istype(L) && is_type_in_list(src, GLOB.ventcrawl_machinery))
 		L.handle_ventcrawl(src)
 		return
 	..()


### PR DESCRIPTION
`[23:32:54] Runtime in atmosmachinery.dm, line 343: undefined proc or verb /mob/dead/observer/handle ventcrawl(). `