### PR TITLE
Makes modular computer examine text more robust

### DIFF
--- a/code/modules/modular_computers/computers/_modular_computer_shared.dm
+++ b/code/modules/modular_computers/computers/_modular_computer_shared.dm
@@ -1,0 +1,63 @@
+
+/obj/proc/is_modular_computer()
+	return
+
+/obj/proc/get_modular_computer_part(part_type)
+	return null
+
+/obj/item/modular_computer/is_modular_computer()
+	return TRUE
+
+/obj/item/modular_computer/get_modular_computer_part(part_type)
+	if(!part_type)
+		stack_trace("get_modular_computer_part() called without a valid part_type")
+		return null
+	return all_components[part_type]
+
+
+/obj/machinery/modular_computer/is_modular_computer()
+	return TRUE
+
+/obj/machinery/modular_computer/get_modular_computer_part(part_type)
+	if(!part_type)
+		stack_trace("get_modular_computer_part() called without a valid part_type")
+		return null
+	return cpu?.all_components[part_type]
+
+
+/obj/proc/get_modular_computer_parts_examine(mob/user)
+	if(!is_modular_computer())
+		return
+
+	var/user_is_adjacent = Adjacent(user) //don't reveal full details unless they're close enough to see it on the screen anyway.
+
+	var/obj/item/computer_hardware/ai_slot/ai_slot = get_modular_computer_part(MC_AI)
+	if(ai_slot)
+		if(ai_slot.stored_card)
+			if(user_is_adjacent)
+				to_chat(user, "It has a slot installed for an intelliCard which contains: [ai_slot.stored_card.name]")
+			else
+				to_chat(user, "It has a slot installed for an intelliCard, which appears to be occupied.")
+			to_chat(user, "<span class='info'>Alt-click to eject the intelliCard.</span>")
+		else
+			to_chat(user, "It has a slot installed for an intelliCard.")
+
+	var/obj/item/computer_hardware/card_slot/card_slot = get_modular_computer_part(MC_CARD)
+	if(card_slot)
+		if(card_slot.stored_card || card_slot.stored_card2)
+			var/obj/item/card/id/first_ID = card_slot.stored_card
+			var/obj/item/card/id/second_ID = card_slot.stored_card2
+			var/multiple_cards = istype(first_ID) && istype(second_ID)
+			if(user_is_adjacent)
+				to_chat(user, "It has two slots for identification cards installed[multiple_cards ? " which contain [first_ID] and [second_ID]" : ", one of which contains [first_ID ? first_ID : second_ID]"].")
+			else
+				to_chat(user, "It has two slots for identification cards installed, [multiple_cards ? "both of which appear" : "and one of them appears"] to be occupied.")
+			to_chat(user, "<span class='info'>Alt-click [src] to eject the identification card[multiple_cards ? "s":""].</span>")
+		else
+			to_chat(user, "It has two slots installed for identification cards.")
+
+	var/obj/item/computer_hardware/printer/printer_slot = get_modular_computer_part(MC_PRINT)
+	if(printer_slot)
+		to_chat(user, "It has a printer installed.")
+		if(user_is_adjacent)
+			to_chat(user, "The printer's paper levels are at: [printer_slot.stored_paper]/[printer_slot.max_paper].</span>]")

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -193,6 +193,8 @@
 	else if(obj_integrity < max_integrity)
 		to_chat(user, "<span class='warning'>It is damaged.</span>")
 
+	get_modular_computer_parts_examine(user)
+
 /obj/item/modular_computer/update_icon()
 	cut_overlays()
 	if(!enabled)

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -46,10 +46,6 @@
 	desc = "A stationary computer. This one comes preloaded with research programs."
 	_has_ai = TRUE
 
-/obj/machinery/modular_computer/console/preset/research/examine(mob/user)
-	..()
-	to_chat(user, "<span class='notice'>Alt-click to eject the intelliCard.</span>")
-
 /obj/machinery/modular_computer/console/preset/research/install_programs()
 	var/obj/item/computer_hardware/hard_drive/hard_drive = cpu.all_components[MC_HDD]
 	hard_drive.store_file(new/datum/computer_file/program/ntnetmonitor())
@@ -65,10 +61,6 @@
 	desc = "A stationary computer. This one comes preloaded with command programs."
 	_has_id_slot = TRUE
 	_has_printer = TRUE
-
-/obj/machinery/modular_computer/console/preset/command/examine(mob/user)
-	..()
-	to_chat(user, "<span class='notice'>Alt-click [src] to eject the identification card.</span>")
 
 /obj/machinery/modular_computer/console/preset/command/install_programs()
 	var/obj/item/computer_hardware/hard_drive/hard_drive = cpu.all_components[MC_HDD]

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -36,6 +36,10 @@
 	QDEL_NULL(cpu)
 	return ..()
 
+/obj/machinery/modular_computer/examine(mob/user)
+	..()
+	get_modular_computer_parts_examine(user)
+
 /obj/machinery/modular_computer/attack_ghost(mob/dead/observer/user)
 	. = ..()
 	if(.)

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -9,6 +9,10 @@
 	var/obj/item/aicard/stored_card = null
 	var/locked = FALSE
 
+/obj/item/computer_hardware/ai_slot/handle_atom_del(atom/A)
+	if(A == stored_card)
+		try_eject(0, null, TRUE)
+	. = ..()
 
 /obj/item/computer_hardware/ai_slot/examine(mob/user)
 	..()
@@ -50,12 +54,14 @@
 		return FALSE
 
 	if(stored_card)
-		stored_card.forceMove(get_turf(src))
+		to_chat(user, "<span class='notice'>You remove [stored_card] from [src].</span>")
 		locked = FALSE
-		stored_card.verb_pickup()
+		if(user)
+			user.put_in_hands(stored_card)
+		else
+			stored_card.forceMove(drop_location())
 		stored_card = null
 
-		to_chat(user, "<span class='notice'>You remove the card from \the [src].</span>")
 		return TRUE
 	return FALSE
 

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -12,6 +12,11 @@
 		battery = new battery_type(src)
 	..()
 
+/obj/item/computer_hardware/battery/handle_atom_del(atom/A)
+	if(A == battery)
+		try_eject(0, null, TRUE)
+	. = ..()
+
 /obj/item/computer_hardware/battery/try_insert(obj/item/I, mob/living/user = null)
 	if(!holder)
 		return FALSE
@@ -41,7 +46,10 @@
 		to_chat(user, "<span class='warning'>There is no power cell connected to \the [src].</span>")
 		return FALSE
 	else
-		battery.forceMove(get_turf(src))
+		if(user)
+			user.put_in_hands(battery)
+		else
+			battery.forceMove(drop_location())
 		to_chat(user, "<span class='notice'>You detach \the [battery] from \the [src].</span>")
 		battery = null
 

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -9,6 +9,13 @@
 	var/obj/item/card/id/stored_card = null
 	var/obj/item/card/id/stored_card2 = null
 
+/obj/item/computer_hardware/card_slot/handle_atom_del(atom/A)
+	if(A == stored_card)
+		try_eject(1, null, TRUE)
+	if(A == stored_card2)
+		try_eject(2, null, TRUE)
+	. = ..()
+
 /obj/item/computer_hardware/card_slot/Destroy()
 	try_eject()
 	return ..()
@@ -71,7 +78,7 @@
 		if(user)
 			user.put_in_hands(stored_card)
 		else
-			stored_card.forceMove(get_turf(src))
+			stored_card.forceMove(drop_location())
 		stored_card = null
 		ejected++
 
@@ -79,7 +86,7 @@
 		if(user)
 			user.put_in_hands(stored_card2)
 		else
-			stored_card2.forceMove(get_turf(src))
+			stored_card2.forceMove(drop_location())
 		stored_card2 = null
 		ejected++
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2156,6 +2156,7 @@
 #include "code\modules\mob\living\simple_animal\slime\slime.dm"
 #include "code\modules\mob\living\simple_animal\slime\subtypes.dm"
 #include "code\modules\modular_computers\laptop_vendor.dm"
+#include "code\modules\modular_computers\computers\_modular_computer_shared.dm"
 #include "code\modules\modular_computers\computers\item\computer.dm"
 #include "code\modules\modular_computers\computers\item\computer_components.dm"
 #include "code\modules\modular_computers\computers\item\computer_damage.dm"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6209658/46516154-0b68b200-c836-11e8-844d-2ec846991372.png)


:cl: ShizCalev
fix: Examine text for modular computers now properly reflect their modularity and state which components are installed, as well as what is contained within those components. At this time, AI card slots, ID slots, and printers are implemented.
/:cl:


also added item deletion handling and cleaned up try_eject a bit.