### PR TITLE
Fixes the name of the syndicate infiltrator nuke storage windoor

### DIFF
--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -1047,7 +1047,7 @@
 /obj/machinery/nuclearbomb/syndicate,
 /obj/machinery/door/window{
 	dir = 1;
-	name = "Theatre Stage"
+	name = "interior door"
 	},
 /turf/open/floor/circuit/red,
 /area/shuttle/syndicate/hallway)

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -1046,8 +1046,7 @@
 "cm" = (
 /obj/machinery/nuclearbomb/syndicate,
 /obj/machinery/door/window{
-	dir = 1;
-	name = "interior door"
+	dir = 1
 	},
 /turf/open/floor/circuit/red,
 /area/shuttle/syndicate/hallway)


### PR DESCRIPTION
:cl: 
spellcheck: The Syndicate Infiltrator's nuke storage windoor is no longer called "Theatre Stage". 
/:cl:

mostly just did this to test that I have the map merger set up correctly. this typo has been in the game since the current infiltrator was added cause someone did a copy/paste job with one of the theatre windoors. 