### PR TITLE
map_template area load fix

### DIFF
--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -38,7 +38,7 @@
 	for(var/L in turfs)
 		var/turf/B = L
 		atoms += B
-		areas |= get_area(B)
+		areas |= B.loc
 		for(var/A in B)
 			atoms += A
 			if(istype(A, /obj/structure/cable))
@@ -50,12 +50,7 @@
 		var/turf/T = L
 		T.air_update_turf(TRUE) //calculate adjacent turfs along the border to prevent runtimes
 
-	for(var/I in areas)
-		var/area/A = I
-		if(!(A.flags_1 & INITIALIZED_1))
-			A.Initialize()
-
-	SSatoms.InitializeAtoms(atoms)
+	SSatoms.InitializeAtoms(areas|atoms)
 	SSmachines.setup_template_powernets(cables)
 	SSair.setup_template_machinery(atmos_machines)
 

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -29,6 +29,7 @@
 	var/list/obj/machinery/atmospherics/atmos_machines = list()
 	var/list/obj/structure/cable/cables = list()
 	var/list/atom/atoms = list()
+	var/list/area/areas = list()
 
 	var/list/turfs = block(	locate(bounds[MAP_MINX], bounds[MAP_MINY], bounds[MAP_MINZ]),
 							locate(bounds[MAP_MAXX], bounds[MAP_MAXY], bounds[MAP_MAXZ]))
@@ -37,6 +38,7 @@
 	for(var/L in turfs)
 		var/turf/B = L
 		atoms += B
+		areas |= get_area(B)
 		for(var/A in B)
 			atoms += A
 			if(istype(A, /obj/structure/cable))
@@ -47,6 +49,11 @@
 	for(var/L in border)
 		var/turf/T = L
 		T.air_update_turf(TRUE) //calculate adjacent turfs along the border to prevent runtimes
+
+	for(var/I in areas)
+		var/area/A = I
+		if(!(A.flags_1 & INITIALIZED_1))
+			A.Initialize()
 
 	SSatoms.InitializeAtoms(atoms)
 	SSmachines.setup_template_powernets(cables)

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -302,6 +302,9 @@
 	//Instanciation
 	////////////////
 
+	//turn off base new Initialization until the whole thing is loaded
+	SSatoms.map_loader_begin()
+
 	//The next part of the code assumes there's ALWAYS an /area AND a /turf on a given tile
 	//first instance the /area and remove it from the members list
 	index = members.len
@@ -326,8 +329,6 @@
 	while(!ispath(members[first_turf_index], /turf)) //find first /turf object in members
 		first_turf_index++
 
-	//turn off base new Initialization until the whole thing is loaded
-	SSatoms.map_loader_begin()
 	//instanciate the first /turf
 	var/turf/T
 	if(members[first_turf_index] != /turf/template_noop)


### PR DESCRIPTION
Now areas placed by templates correctly initializes in initTemplateBounds()**
fix #40602
:cl:
fix: Now areas placed by templates correctly initializes in initTemplateBounds()
/:cl:
