### PR TITLE
Rebalances KA cooldown modifier

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -327,7 +327,7 @@
 /obj/item/borg/upgrade/modkit/cooldown
 	name = "cooldown decrease"
 	desc = "Decreases the cooldown of a kinetic accelerator. Not rated for minebot use."
-	modifier = 2.5
+	modifier = 3.2
 	minebot_upgrade = FALSE
 
 /obj/item/borg/upgrade/modkit/cooldown/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)


### PR DESCRIPTION
:cl:The Dreamweaver
balance: Rebalances the Kinetic Accelerators cooldown mod so that it's on par with other mods.
/:cl:

The cooldown mod in its current state is entirely useless. An all damage modded KA outranks any combination of cooldowns in terms of DPS, and even a max cooldown modded KA is outranked in terms of mining speed by almost all mining tech. The new modifier value was calculated specifically to just barely put it on par with the other mods as to avoid overcompensating.