### PR TITLE
Buffs agent ID cards by giving them a line of examine text

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -195,7 +195,8 @@
 		to_chat(user, "Alt-Click your ID in-hand to pull money from your account in the form of holochips.")
 		to_chat(user, "You can insert credits into your account by pressing holochips against the ID.")
 		to_chat(user, "If you lose this ID card, you can reclaim your account by using a blank ID card inhand and punching in the account ID.")
-
+	else if(registered_account)
+		to_chat(user, "There is no registered account on this card. Alt-Click to add one.")
 	if(mining_points)
 		to_chat(user, "There's [mining_points] mining equipment redemption point\s loaded onto this card.")
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -195,7 +195,7 @@
 		to_chat(user, "Alt-Click your ID in-hand to pull money from your account in the form of holochips.")
 		to_chat(user, "You can insert credits into your account by pressing holochips against the ID.")
 		to_chat(user, "If you lose this ID card, you can reclaim your account by using a blank ID card inhand and punching in the account ID.")
-	else if(registered_account)
+	else
 		to_chat(user, "There is no registered account on this card. Alt-Click to add one.")
 	if(mining_points)
 		to_chat(user, "There's [mining_points] mining equipment redemption point\s loaded onto this card.")

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -194,7 +194,7 @@
 				to_chat(user, "The [D.account_holder] reports a balance of $[D.account_balance].")
 		to_chat(user, "Alt-Click your ID in-hand to pull money from your account in the form of holochips.")
 		to_chat(user, "You can insert credits into your account by pressing holochips against the ID.")
-		to_chat(user, "If you lose this ID card, you can reclaim your account by using a blank ID card inhand and punching in the account ID.")
+		to_chat(user, "If you lose this ID card, you can reclaim your account by Alt-Clicking a blank ID card inhand and punching in the account ID.")
 	else
 		to_chat(user, "There is no registered account on this card. Alt-Click to add one.")
 	if(mining_points)


### PR DESCRIPTION
Fixes #40745 

:cl: MrDoomBringer
tweak: Cards will now let you know if there is no registered account with the card, and how to add one.
/:cl:

Makes Agent ID cards less obvious
old:
![image](https://user-images.githubusercontent.com/43486478/46568299-e93f6480-c907-11e8-928e-14692b3246b3.png)
new:
![image](https://user-images.githubusercontent.com/29008542/46577265-03814d00-c9b1-11e8-99ab-e487a93b109b.png)


