### PR TITLE
Properly fixes supplypods exploding their contents, also fixes explosions damaging rod form wizards

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -198,7 +198,7 @@ GLOBAL_LIST_EMPTY(explosions)
 			var/list/items = list()
 			for(var/I in T)
 				var/atom/A = I
-				if (A.contents_explosion()) //The atom/contents_explosion() proc returns null if the contents ex_acting has been handled by the atom, and TRUE if it hasn't.
+				if (!A.prevent_content_explosion()) //The atom/contents_explosion() proc returns null if the contents ex_acting has been handled by the atom, and TRUE if it hasn't.
 					items += A.GetAllContents()
 			for(var/O in items)
 				var/atom/A = O

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -294,8 +294,11 @@
 		to_chat(user, "<span class='warning'>You can't move while buckled to [src]!</span>")
 	return
 
+/atom/proc/prevent_content_explosion()
+	return FALSE
+
 /atom/proc/contents_explosion(severity, target)
-	return TRUE //Return TRUE if the contents_explosion has not been overridden.
+	return //For handling the effects of explosions on contents that would not normally be effected
 
 /atom/proc/ex_act(severity, target)
 	set waitfor = FALSE

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -86,6 +86,9 @@
 /obj/structure/closet/supplypod/contents_explosion() //Supplypods also protect their contents from the harmful effects of fucking exploding.
 	return
 
+/obj/structure/closet/supplypod/prevent_content_explosion() //Useful for preventing epicenter explosions from damaging contents
+	return TRUE
+
 /obj/structure/closet/supplypod/toggle(mob/living/user) //Supplypods shouldn't be able to be manually opened under any circumstances, as the open() proc generates supply order datums
 	return
 

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -99,6 +99,9 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	walk(src,0)
 	walk_towards(src, destination, 1)
 
+/obj/structure/closet/supplypod/prevent_content_explosion()
+	return TRUE
+
 /obj/effect/immovablerod/ex_act(severity, target)
 	return 0
 


### PR DESCRIPTION
Fixes #40604

Adds a proc to check if an object protects its contents from explosions. For some reason I didn't do this in #40491 so dont tell antur pls

:cl: MrDoomBringer
fix: Explosions will no longer damage wizards in rod form
/:cl:

The issue was that when casting rod form, the wizard is forceMoved() into the rod. When an epicenter explosion happens, explosion.dm forcibly goes through the contents of EVERYTHING, and calls ex_act(). 

This caused the wizard in the contents of the rod to get damaged by epicenter explosions (ie if they hit a fuel tank in rod form)