### PR TITLE
Makes Box/Delta/Meta biogenerators publicly accessible

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -19102,10 +19102,26 @@
 /area/hydroponics)
 "aSS" = (
 /obj/machinery/seed_extractor,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aST" = (
-/obj/machinery/biogenerator,
+/obj/machinery/vending/hydronutrients,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aSU" = (
@@ -19577,12 +19593,31 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aUj" = (
-/obj/machinery/vending/hydronutrients,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aUk" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -21623,21 +21658,13 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aYO" = (
-/obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aYP" = (
 /obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"aYQ" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aYR" = (
@@ -21671,6 +21698,12 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aYU" = (
@@ -22166,28 +22199,20 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bal" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "bam" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hydroponics)
 "ban" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/northleft{
-	name = "Hydroponics Desk";
-	req_access_txt = "35"
-	},
+/obj/machinery/biogenerator,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bao" = (
@@ -53192,11 +53217,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"cBg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/hydroponics)
 "cBh" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/blue{
@@ -56686,6 +56706,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"nAF" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "nEP" = (
 /obj/structure/closet/l3closet/scientist{
 	pixel_x = -2
@@ -56977,6 +57007,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"reY" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "rfW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -57012,6 +57049,15 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"rLd" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/hydroponics)
 "rOY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57595,6 +57641,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"wQA" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "wUY" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bucket,
@@ -97634,7 +97684,7 @@ aSR
 aUi
 aVJ
 aOX
-aYP
+aOX
 bal
 bam
 aYV
@@ -97891,8 +97941,8 @@ aSQ
 aVI
 aVI
 aVI
-aYO
-aRJ
+aVI
+nAF
 bbB
 aYV
 aYV
@@ -98149,7 +98199,7 @@ aRJ
 aVK
 aRJ
 aRJ
-aRJ
+reY
 bbB
 aYV
 aYV
@@ -98404,9 +98454,9 @@ aRJ
 aSS
 aUj
 aRJ
-aRJ
-aYQ
-cBg
+wQA
+aYP
+bam
 bam
 aYV
 aYV
@@ -98662,8 +98712,8 @@ aST
 aUk
 aRJ
 aRJ
-aYQ
-bam
+aRJ
+rLd
 aYV
 aYV
 aYV

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -22213,6 +22213,10 @@
 "ban" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/biogenerator,
+/obj/machinery/door/window/northleft{
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bao" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -37930,13 +37930,12 @@
 /obj/machinery/door/firedoor,
 /obj/item/folder,
 /obj/item/pen,
-/obj/machinery/door/window/eastleft{
-	dir = 8;
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/westright{
 	name = "Hydroponics Desk";
 	req_access_txt = "35"
 	},
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bqE" = (
@@ -39157,11 +39156,6 @@
 "bsz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/eastright{
-	dir = 8;
-	name = "Hydroponics Desk";
-	req_access_txt = "35"
-	},
 /obj/item/seeds/lime{
 	pixel_x = 6
 	},
@@ -39173,6 +39167,10 @@
 /obj/item/reagent_containers/food/snacks/grown/watermelon,
 /obj/item/reagent_containers/food/snacks/grown/banana,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/westleft{
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bsA" = (
@@ -127664,6 +127662,10 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/machinery/biogenerator,
+/obj/machinery/door/window/westleft{
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "oIl" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -36621,9 +36621,9 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "boz" = (
-/obj/machinery/biogenerator,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
+/obj/machinery/seed_extractor,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "boA" = (
@@ -36642,10 +36642,6 @@
 	},
 /obj/structure/table,
 /turf/open/floor/plasteel,
-/area/hydroponics)
-"boD" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
 /area/hydroponics)
 "boE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37907,13 +37903,17 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bqA" = (
-/obj/machinery/seed_extractor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
+/obj/structure/table/glass,
+/obj/item/book/manual/hydroponics_pod_people,
+/obj/item/paper/guides/jobs/hydroponics,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bqB" = (
-/obj/machinery/biogenerator,
+/obj/structure/table/glass,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -40342,14 +40342,21 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bum" = (
-/obj/structure/table/glass,
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/stack/packageWrap,
-/obj/item/book/manual/hydroponics_pod_people,
-/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/effect/turf_decal/bot,
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bun" = (
@@ -127653,6 +127660,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/science/explab)
+"oDh" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "oIl" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -128001,6 +128014,10 @@
 	dir = 9
 	},
 /area/science/circuit)
+"rwK" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "rzc" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/bot,
@@ -162086,7 +162103,7 @@ blk
 bnm
 boC
 bqC
-bqC
+rwK
 bum
 bvD
 bwQ
@@ -162341,10 +162358,10 @@ bhG
 bjw
 bll
 bar
-boD
-bqD
-bsz
 bgk
+bqD
+oDh
+bsz
 bvE
 bar
 bar

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -49992,20 +49992,18 @@
 /area/hydroponics)
 "bSV" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	dir = 1;
-	name = "Kitchen Window";
-	req_access_txt = "28"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/paper,
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	name = "Hydroponics Window";
-	req_one_access_txt = "30;35"
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/southleft{
+	name = "Hydroponics Window";
+	req_one_access_txt = "35"
+	},
+/obj/machinery/door/window/northleft{
+	name = "Kitchen Window";
+	req_access_txt = "28"
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bSW" = (
@@ -51208,11 +51206,6 @@
 "bVr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Hydroponics Desk";
-	req_one_access_txt = "30;35"
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -51230,6 +51223,10 @@
 /obj/item/folder/white{
 	pixel_x = 4;
 	pixel_y = -3
+	},
+/obj/machinery/door/window/eastleft{
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -51961,6 +51958,10 @@
 	dir = 8
 	},
 /obj/machinery/biogenerator,
+/obj/machinery/door/window/eastright{
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bWL" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -51223,6 +51223,14 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bVs" = (
@@ -51938,24 +51946,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bWK" = (
-/obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/westright{
-	dir = 4;
-	name = "Hydroponics Desk";
-	req_one_access_txt = "30;35"
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -51966,6 +51960,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/biogenerator,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bWL" = (
@@ -52658,10 +52653,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bYl" = (
-/obj/item/seeds/wheat,
-/obj/item/seeds/sugarcane,
-/obj/item/seeds/potato,
-/obj/item/seeds/apple,
 /obj/item/grown/corncob,
 /obj/item/reagent_containers/food/snacks/grown/carrot,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -53268,13 +53259,17 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bZv" = (
-/obj/machinery/biogenerator,
 /obj/machinery/light_switch{
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/table/glass,
+/obj/item/seeds/wheat,
+/obj/item/seeds/sugarcane,
+/obj/item/seeds/potato,
+/obj/item/seeds/apple,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bZw" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -51967,10 +51967,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -83744,6 +83740,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"nSa" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start/botanist,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "nSo" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -117981,7 +117993,7 @@ bQB
 bRQ
 bST
 bUf
-bVs
+nSa
 bWL
 bYe
 bZt


### PR DESCRIPTION
:cl: Denton
tweak: Hydroponics biogenerators in Box/Delta/Metastation have been moved to be accessible by crew.
/:cl:

I like what Pubbystation did with the biogenerator - letting other players access it means that botanists can easily provide them with items that aren't exploding wheat.

This will also tie in nicely with economy, once someone makes it into a sort of vending machine (probably won't happen before the year 2030).

Screenshots:

![meta](https://user-images.githubusercontent.com/32391752/46579672-8f799000-ca16-11e8-800a-5aa3db47d7c1.PNG)
![delta](https://user-images.githubusercontent.com/32391752/46579673-8f799000-ca16-11e8-96e6-83f7123bc77a.PNG)
![box](https://user-images.githubusercontent.com/32391752/46579674-8f799000-ca16-11e8-958b-249e9a2fa4bc.PNG)
