### PR TITLE
Suiciding no longer counts towards completing the "Die a glorious death." objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -432,6 +432,8 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 	for(var/datum/mind/M in owners)
 		if(considered_alive(M))
 			return FALSE
+		if(M.current?.suiciding) //killing yourself ISN'T glorious.
+			return FALSE
 	return TRUE
 
 /datum/objective/nuclear


### PR DESCRIPTION
:cl: ShizCalev
balance: Suiciding no longer counts towards the "Die a glorious death" objective. Getting drunk on Bahama Mama's in the bar and blowing your brains out with a revolver while Pun-Pun is watching isn't very glorious.
/:cl: