### PR TITLE
Stealthmode dsay now supports joke rank names

### DIFF
--- a/code/__HELPERS/_string_lists.dm
+++ b/code/__HELPERS/_string_lists.dm
@@ -7,7 +7,7 @@ GLOBAL_VAR(string_filename_current_key)
 
 
 /proc/strings_replacement(filename, key, directory = "strings")
-	load_strings_file(filename)
+	load_strings_file(filename, directory)
 
 	if((filename in GLOB.string_cache) && (key in GLOB.string_cache[filename]))
 		var/response = pick(GLOB.string_cache[filename][key])

--- a/code/__HELPERS/_string_lists.dm
+++ b/code/__HELPERS/_string_lists.dm
@@ -6,7 +6,7 @@ GLOBAL_LIST(string_cache)
 GLOBAL_VAR(string_filename_current_key)
 
 
-/proc/strings_replacement(filename, key)
+/proc/strings_replacement(filename, key, directory = "strings")
 	load_strings_file(filename)
 
 	if((filename in GLOB.string_cache) && (key in GLOB.string_cache[filename]))
@@ -15,19 +15,19 @@ GLOBAL_VAR(string_filename_current_key)
 		response = r.Replace(response, /proc/strings_subkey_lookup)
 		return response
 	else
-		CRASH("strings list not found: strings/[filename], index=[key]")
+		CRASH("strings list not found: [directory]/[filename], index=[key]")
 
-/proc/strings(filename as text, key as text)
-	load_strings_file(filename)
+/proc/strings(filename as text, key as text, directory = "strings")
+	load_strings_file(filename, directory)
 	if((filename in GLOB.string_cache) && (key in GLOB.string_cache[filename]))
 		return GLOB.string_cache[filename][key]
 	else
-		CRASH("strings list not found: strings/[filename], index=[key]")
+		CRASH("strings list not found: [directory]/[filename], index=[key]")
 
 /proc/strings_subkey_lookup(match, group1)
 	return pick_list(GLOB.string_filename_current_key, group1)
 
-/proc/load_strings_file(filename)
+/proc/load_strings_file(filename, directory = "strings")
 	GLOB.string_filename_current_key = filename
 	if(filename in GLOB.string_cache)
 		return //no work to do
@@ -35,7 +35,7 @@ GLOBAL_VAR(string_filename_current_key)
 	if(!GLOB.string_cache)
 		GLOB.string_cache = new
 
-	if(fexists("strings/[filename]"))
-		GLOB.string_cache[filename] = json_load("strings/[filename]")
+	if(fexists("[directory]/[filename]"))
+		GLOB.string_cache[filename] = json_load("[directory]/[filename]")
 	else
-		CRASH("file not found: strings/[filename]")
+		CRASH("file not found: [directory]/[filename]")

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -2,16 +2,16 @@
 	set category = "Special Verbs"
 	set name = "Dsay"
 	set hidden = 1
-	if(!src.holder)
+	if(!holder)
 		to_chat(src, "Only administrators may use this command.")
 		return
-	if(!src.mob)
+	if(!mob)
 		return
 	if(prefs.muted & MUTE_DEADCHAT)
 		to_chat(src, "<span class='danger'>You cannot send DSAY messages (muted).</span>")
 		return
 
-	if (src.handle_spam_prevention(msg,MUTE_DEADCHAT))
+	if (handle_spam_prevention(msg,MUTE_DEADCHAT))
 		return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
@@ -19,9 +19,12 @@
 
 	if (!msg)
 		return
-	var/static/nicknames = world.file2list("[global.config.directory]/admin_nicknames.txt")
-
-	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[uppertext(holder.rank)]([src.holder.fakekey ? pick(nicknames) : src.key])</span> says, <span class='message'>\"[emoji_parse(msg)]\"</span></span>"
+	var/rank_name = holder.rank
+	var/admin_name = key
+	if(holder.fakekey)
+		rank_name = pick(strings("admin_nicknames.json", "ranks", "config"))
+		admin_name = pick(strings("admin_nicknames.json", "names", "config"))
+	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[rank_name]([admin_name])</span> says, <span class='message'>\"[emoji_parse(msg)]\"</span></span>"
 
 	for (var/mob/M in GLOB.player_list)
 		if(isnewplayer(M))

--- a/config/admin_nicknames.json
+++ b/config/admin_nicknames.json
@@ -1,0 +1,10 @@
+{
+    "ranks": [
+        "Dedmin",
+        "Sir Madam Headmin"
+    ],
+    "names": [
+        "Badmin",
+        "<span class='adminooc'>Spanmin</span>"
+    ]
+}

--- a/config/admin_nicknames.txt
+++ b/config/admin_nicknames.txt
@@ -1,2 +1,0 @@
-Badmin
-<span class='adminooc'>Spanmin</span>


### PR DESCRIPTION
Converted `admin_nicknames.txt` to a json and made it use the strings system for less file handling.
Removed some `src.`
Strings system now allows specifying a directory for files, defaults to `"strings"` so everything else works the same.

Dedicated to @Arianya 