### PR TITLE
Fixes nameless mechs

### DIFF
--- a/code/game/mecha/mecha_topic.dm
+++ b/code/game/mecha/mecha_topic.dm
@@ -280,8 +280,9 @@
 		send_byjax(src.occupant,"exosuit.browser","rfreq","[format_frequency(radio.frequency)]")
 
 	if (href_list["change_name"])
-		var/newname = copytext(sanitize(input(occupant, "Choose new exosuit name", "Rename exosuit", "") as null|text),1,MAX_NAME_LEN)
-		if(!isnull(newname))
+		var/userinput = input(occupant, "Choose new exosuit name", "Rename exosuit", "") as null|text
+		if(!isnull(userinput))
+			var/newname = copytext(sanitize(userinput),1,MAX_NAME_LEN)
 			name = newname ? newname : initial(name)
 
 	if (href_list["toggle_id_upload"])

--- a/code/game/mecha/mecha_topic.dm
+++ b/code/game/mecha/mecha_topic.dm
@@ -281,7 +281,8 @@
 
 	if (href_list["change_name"])
 		var/newname = copytext(sanitize(input(occupant, "Choose new exosuit name", "Rename exosuit", "") as null|text),1,MAX_NAME_LEN)
-		name = newname ? newname : initial(name)
+		if(!isnull(newname))
+			name = newname ? newname : initial(name)
 
 	if (href_list["toggle_id_upload"])
 		add_req_access = !add_req_access

--- a/code/game/mecha/mecha_topic.dm
+++ b/code/game/mecha/mecha_topic.dm
@@ -280,11 +280,8 @@
 		send_byjax(src.occupant,"exosuit.browser","rfreq","[format_frequency(radio.frequency)]")
 
 	if (href_list["change_name"])
-		var/newname = stripped_input(occupant,"Choose new exosuit name","Rename exosuit","", MAX_NAME_LEN)
-		if(newname && trim(newname))
-			name = newname
-		else
-			alert(occupant, "nope.avi")
+		var/newname = copytext(sanitize(input(occupant, "Choose new exosuit name", "Rename exosuit", "") as null|text),1,MAX_NAME_LEN)
+		name = newname ? newname : initial(name)
 
 	if (href_list["toggle_id_upload"])
 		add_req_access = !add_req_access
@@ -337,4 +334,3 @@
 			else
 				occupant_message("<span class='warning'>Recalibration failed!</span>")
 				log_message("Recalibration of coordination system failed with 1 error.", LOG_MECHA, color="red")
-


### PR DESCRIPTION
Fixes #40650 
Mech code is decade-old spaghetti code but fixing that absolute mess is out of this PR's scope
Also reduces the change_name topic to ~~two~~ ~~three~~ four lines, down from five lines

:cl: deathride58
fix: Mechs now properly filter out non-ascii input, and can no longer have null names
/:cl:
