### PR TITLE
Makes syndicate chestrigs (belts) and backpacks fireproof

### DIFF
--- a/_maps/RandomZLevels/VR/syndicate_trainer.dmm
+++ b/_maps/RandomZLevels/VR/syndicate_trainer.dmm
@@ -1540,7 +1540,7 @@
 /obj/structure/table/wood{
 	dir = 5
 	},
-/obj/item/storage/backpack/satchel,
+/obj/item/storage/backpack/satchel/fireproof,
 /turf/open/indestructible,
 /area/awaymission/centcomAway/general)
 "iW" = (

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -115,7 +115,7 @@
 	uniform = /obj/item/clothing/under/syndicate
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
-	back = /obj/item/storage/backpack
+	back = /obj/item/storage/backpack/fireproof
 	ears = /obj/item/radio/headset/syndicate/alt
 	l_pocket = /obj/item/pinpointer/nuke/syndicate
 	id = /obj/item/card/id/syndicate

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -204,6 +204,9 @@
 /obj/item/storage/backpack/satchel/leather/withwallet/PopulateContents()
 	new /obj/item/storage/wallet/random(src)
 
+/obj/item/storage/backpack/satchel/fireproof
+	resistance_flags = FIRE_PROOF
+
 /obj/item/storage/backpack/satchel/eng
 	name = "industrial satchel"
 	desc = "A tough satchel with extra pockets."
@@ -412,12 +415,16 @@
 	for(var/i in 1 to 10)
 		new /obj/item/reagent_containers/food/snacks/pie/cream(src)
 
+/obj/item/storage/backpack/fireproof
+	resistance_flags = FIRE_PROOF
+
 /obj/item/storage/backpack/duffelbag/syndie
 	name = "suspicious looking duffel bag"
 	desc = "A large duffel bag for holding extra tactical supplies."
 	icon_state = "duffel-syndie"
 	item_state = "duffel-syndieammo"
 	slowdown = 0
+	resistance_flags = FIRE_PROOF
 
 /obj/item/storage/backpack/duffelbag/syndie/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -321,6 +321,7 @@
 	desc = "A set of tactical webbing worn by Syndicate boarding parties."
 	icon_state = "militarywebbing"
 	item_state = "militarywebbing"
+	resistance_flags = FIRE_PROOF
 
 /obj/item/storage/belt/military/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
:cl: ShizCalev
balance: Syndicate chestrigs (belts) & bags now have fireproofing.
/:cl:

Resolves a concern raised in #40348