### PR TITLE
Makes moths spawn with lamp heirloom only half the time

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -37,7 +37,7 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/heirloom_type
 
-	if(is_species(H, /datum/species/moth))
+	if(is_species(H, /datum/species/moth) && prob(50))
 		heirloom_type = /obj/item/flashlight/lantern/heirloom_moth
 	else
 		switch(quirk_holder.mind.assigned_role)


### PR DESCRIPTION
:cl: Denton
tweak: Moths now only have a 50% chance to spawn with a lamp as an heirloom.
/:cl:

Mala pointed out that always giving moths a lamp as an heirloom locks them out of all other items. With this PR, moths have a 50/50 chance to either spawn with a lamp or a job appropriate heirloom.

(also I can't believe I had to ask on coderbus for the simple `&& prob(50)`)