### PR TITLE
Adjusts ignition snowflake in hotspot_expose to enable welders etc to start plasma fires again

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -37,7 +37,7 @@
 
 		active_hotspot = new /obj/effect/hotspot(src)
 		active_hotspot.temperature = exposed_temperature
-		active_hotspot.volume = exposed_volume
+		active_hotspot.volume = exposed_volume*25
 
 		active_hotspot.just_spawned = (current_cycle < SSair.times_fired)
 			//remove just_spawned protection if no longer processing this cell


### PR DESCRIPTION
hotspot_expose used to get called with completely bogus values before it was made to heat up air as an alternative to igniting stuff. Ignition stuff scales off the values used, this PR readjusts the mostly meaningless snowflake to allow ignition to happen again. 25 seems like a good multiplier, it gives you a chance of picking up a lit welder before Bad Shit happens like i remember doing last year.

Honestly, we could use completely bogus static values since this is just the "hey let's start a fire" snowflake branch, but I sleep easier with a volume multiplier.

:cl: Naksu
fix: welding tools etc should be able to properly ignite plasma fires again
/:cl:


