### PR TITLE
Prevents blob overminds, sentient diseases, etc. from dumping out boxes

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -233,7 +233,7 @@
 
 /datum/component/storage/proc/quick_empty(mob/M)
 	var/atom/A = parent
-	if(M.canUseStorage() && A.Adjacent(M) && (A.loc != M) && M.incapacitated())
+	if(M.canUseStorage() && (A.loc != M) && A.Adjacent(M) && M.incapacitated())
 		return
 	if(locked)
 		to_chat(M, "<span class='warning'>[parent] seems to be locked!</span>")

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -233,7 +233,7 @@
 
 /datum/component/storage/proc/quick_empty(mob/M)
 	var/atom/A = parent
-	if(M.canUseStorage() && A.Adjacent(M) && (A.loc != M)) && M.incapacitated())
+	if(M.canUseStorage() && A.Adjacent(M) && (A.loc != M) && M.incapacitated())
 		return
 	if(locked)
 		to_chat(M, "<span class='warning'>[parent] seems to be locked!</span>")

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -231,6 +231,9 @@
 	progress.update(progress.goal - things.len)
 	return FALSE
 
+/mob/proc/canUseStorage(var/atom/A)
+	return (A.Adjacent(src) && A.loc != src && ishuman(src) && stat == CONSCIOUS && !restrained() && canmove)
+
 /datum/component/storage/proc/quick_empty(mob/M)
 	var/atom/A = parent
 	if(M.canUseStorage() && A.Adjacent(M) && (A.loc != M)) && M.incapacitated())

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -231,9 +231,6 @@
 	progress.update(progress.goal - things.len)
 	return FALSE
 
-/mob/proc/canUseStorage(var/atom/A)
-	return (A.Adjacent(src) && A.loc != src && ishuman(src) && stat == CONSCIOUS && !restrained() && canmove)
-
 /datum/component/storage/proc/quick_empty(mob/M)
 	var/atom/A = parent
 	if(M.canUseStorage() && A.Adjacent(M) && (A.loc != M)) && M.incapacitated())

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -233,7 +233,7 @@
 
 /datum/component/storage/proc/quick_empty(mob/M)
 	var/atom/A = parent
-	if((!ishuman(M) && (A.loc != M)) || (M.stat != CONSCIOUS) || M.incapacitated())
+	if(M.canUseStorage() && A.Adjacent(M) && (A.loc != M)) && M.incapacitated())
 		return
 	if(locked)
 		to_chat(M, "<span class='warning'>[parent] seems to be locked!</span>")

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -233,7 +233,7 @@
 
 /datum/component/storage/proc/quick_empty(mob/M)
 	var/atom/A = parent
-	if(M.canUseStorage() && (A.loc != M) && A.Adjacent(M) && M.incapacitated())
+	if(!M.canUseStorage() && (A.loc != M) && !A.Adjacent(M) && M.incapacitated())
 		return
 	if(locked)
 		to_chat(M, "<span class='warning'>[parent] seems to be locked!</span>")

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -233,7 +233,7 @@
 
 /datum/component/storage/proc/quick_empty(mob/M)
 	var/atom/A = parent
-	if(!M.canUseStorage() && (A.loc != M) && !A.Adjacent(M) && M.incapacitated())
+	if(!M.canUseStorage() || !A.Adjacent(M) || M.incapacitated())
 		return
 	if(locked)
 		to_chat(M, "<span class='warning'>[parent] seems to be locked!</span>")

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -31,5 +31,8 @@
 	loc = destination
 	Moved(oldloc, NONE, TRUE)
 
+/mob/camera/proc/canUseStorage()
+	return FALSE
+
 /mob/camera/emote(act, m_type=1, message = null, intentional = FALSE)
 	return

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -31,7 +31,7 @@
 	loc = destination
 	Moved(oldloc, NONE, TRUE)
 
-/mob/camera/proc/canUseStorage()
+/mob/camera/canUseStorage()
 	return FALSE
 
 /mob/camera/emote(act, m_type=1, message = null, intentional = FALSE)

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -21,6 +21,9 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	set_focus(src)
 	return INITIALIZE_HINT_NORMAL
 
+/mob/dead/proc/canUseStorage()
+	return FALSE
+
 /mob/dead/dust(just_ash, drop_items, force)	//ghosts can't be vaporised.
 	return
 

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -21,7 +21,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	set_focus(src)
 	return INITIALIZE_HINT_NORMAL
 
-/mob/dead/proc/canUseStorage()
+/mob/dead/canUseStorage()
 	return FALSE
 
 /mob/dead/dust(just_ash, drop_items, force)	//ghosts can't be vaporised.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -311,6 +311,11 @@
 	if(stat || IsUnconscious() || IsStun() || IsParalyzed() || (check_immobilized && IsImmobilized()) || (!ignore_restraints && restrained(ignore_grab)))
 		return TRUE
 
+/mob/living/canUseStorage()
+	if (get_num_arms() <= 0)
+		return FALSE
+	return TRUE
+
 /mob/living/proc/InCritical()
 	return (health <= crit_threshold && (stat == SOFT_CRIT || stat == UNCONSCIOUS))
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -770,13 +770,7 @@
 	return
 
 /mob/proc/canUseStorage()
-	if (get_num_arms() <= 0)
-		return FALSE
-	if (stat != CONSCIOUS)
-		return FALSE
-	if (restrained() || !canmove)
-		return FALSE
-	return TRUE
+	return FALSE
 
 /mob/proc/faction_check_mob(mob/target, exact_match)
 	if(exact_match) //if we need an exact match, we need to do some bullfuckery.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -769,6 +769,9 @@
 /mob/proc/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE, no_tk=FALSE)
 	return
 
+/mob/proc/canUseStorage(var/atom/A)
+	return (A.Adjacent(src) && A.loc != src && ishuman(src) && stat == CONSCIOUS && !restrained() && canmove)
+
 /mob/proc/faction_check_mob(mob/target, exact_match)
 	if(exact_match) //if we need an exact match, we need to do some bullfuckery.
 		var/list/faction_src = faction.Copy()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -769,8 +769,10 @@
 /mob/proc/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE, no_tk=FALSE)
 	return
 
-/mob/proc/canUseStorage(var/atom/A)
-	return (A.Adjacent(src) && A.loc != src && ishuman(src) && stat == CONSCIOUS && !restrained() && canmove)
+/mob/proc/canUseStorage()
+	if (get_num_arms() <= 0)
+		return FALSE
+	return (stat == CONSCIOUS && !restrained() && canmove)
 
 /mob/proc/faction_check_mob(mob/target, exact_match)
 	if(exact_match) //if we need an exact match, we need to do some bullfuckery.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -772,7 +772,11 @@
 /mob/proc/canUseStorage()
 	if (get_num_arms() <= 0)
 		return FALSE
-	return (stat == CONSCIOUS && !restrained() && canmove)
+	if (stat != CONSCIOUS)
+		return FALSE
+	if (restrained() || !canmove)
+		return FALSE
+	return TRUE
 
 /mob/proc/faction_check_mob(mob/target, exact_match)
 	if(exact_match) //if we need an exact match, we need to do some bullfuckery.


### PR DESCRIPTION
Fixes #40811

:cl: MrDoomBringer
fix: Blob overminds, sentient diseases, etc. can no longer dump out boxes. Sorry gamers.
/:cl:
