### PR TITLE
Fixes sechuds not updating when removing & inserting an ID from/into a PDA/wallet/computer

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -591,6 +591,10 @@ GLOBAL_LIST_EMPTY(PDAs)
 		to_chat(usr, "<span class='notice'>You remove the ID from the [name].</span>")
 		id = null
 		update_icon()
+		if(ishuman(loc))
+			var/mob/living/carbon/human/H = loc
+			if(H.wear_id == src)
+				H.sec_hud_set_ID()
 
 /obj/item/pda/proc/msg_input(mob/living/U = usr)
 	var/t = stripped_input(U, "Please enter message", name)
@@ -770,6 +774,10 @@ GLOBAL_LIST_EMPTY(PDAs)
 			return FALSE
 		var/obj/old_id = id
 		id = I
+		if(ishuman(loc))
+			var/mob/living/carbon/human/H = loc
+			if(H.wear_id == src)
+				H.sec_hud_set_ID()
 		if(old_id)
 			user.put_in_hands(old_id)
 		update_icon()

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -50,6 +50,10 @@
 			front_id = I
 		LAZYINITLIST(combined_access)
 		combined_access |= I.access
+	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
+		if(H.wear_id == src)
+			H.sec_hud_set_ID()
 	update_icon()
 
 /obj/item/storage/wallet/Entered(atom/movable/AM)

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -64,6 +64,9 @@
 		stored_card2 = I
 	to_chat(user, "<span class='notice'>You insert \the [I] into \the [src].</span>")
 	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.sec_hud_set_ID()
 
 	return TRUE
 
@@ -98,7 +101,9 @@
 			for(var/I in holder.idle_threads)
 				var/datum/computer_file/program/P = I
 				P.event_idremoved(1, slot)
-
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			H.sec_hud_set_ID()
 		to_chat(user, "<span class='notice'>You remove the card[ejected>1 ? "s" : ""] from \the [src].</span>")
 		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
 		return TRUE


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed sechuds not updating when a user removes/inserts an ID from/into their PDA/wallet/computer while it's in their ID slot.
/:cl:
