### PR TITLE
[s] Fixes sechuds having no icon if you wear a PDA/wallet with no ID inside it.

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -224,7 +224,7 @@
 	var/icon/I = icon(icon, icon_state, dir)
 	holder.pixel_y = I.Height() - world.icon_size
 	holder.icon_state = "hudno_id"
-	if(wear_id)
+	if(wear_id?.GetID())
 		holder.icon_state = "hud[ckey(wear_id.GetJobName())]"
 	sec_hud_set_security_status()
 


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed a bug that would result in sechuds not showing a user's assignment as unknown if they have no ID.
/:cl:
