### PR TITLE
Fixes the Elite Hardsuit not showing items in the eye or mouth slot when in combat mode

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -360,11 +360,7 @@
 	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 25, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	visor_flags_inv = 0
-	visor_flags = 0
-	on = FALSE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-
 
 /obj/item/clothing/suit/space/hardsuit/syndi/elite
 	name = "elite syndicate hardsuit"


### PR DESCRIPTION
:cl:
fix: The Syndicate Elite Hardsuit's combat mode will now show face masks and glasses.
/:cl:

Fixes https://github.com/tgstation/tgstation/issues/28450

This was caused by Robustin changing the combat mode icon to an open one without updating the code as well. Two side notes:

There's a separate, already existing issue where the Elite Hardsuit uses the wrong icon when you first engage the helmet, it should be the space mode icon but it's the combat mode icon instead. Additionally, the same issue I fixed in this PR also happens with the Syndicate shielded hardsuit. However, that hardsuit doesn't actually use all the combat mode code, it just has an open icon for when the suit's flashlight is off (i.e. it still gives you space protection too). I didn't think copy/pasting all the combat mode code again a couple hundred lines down was a very good solution so I didn't do it. If there's a more eloquent solution it's beyond me, but I'll do it if someone tells me how.
