### PR TITLE
[s]Stops pirates counterfeiting currency

### DIFF
--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -148,6 +148,7 @@
 /obj/machinery/shuttle_scrambler/proc/dump_loot(mob/user)
 	new /obj/item/holochip(drop_location(), credits_stored)
 	to_chat(user,"<span class='notice'>You retrieve the siphoned credits!</span>")
+	credits_stored = 0
 
 /obj/machinery/shuttle_scrambler/proc/send_notification()
 	priority_announce("Data theft signal detected, source registered on local gps units.")


### PR DESCRIPTION
:cl: XDTM
fix: Retrieving credits from a pirate syphon now properly removes them from the syphon, instead of duplicating them.
/:cl:

Fixes #40834

[s] because exploit
