### PR TITLE
Fixes an orbit runtime from orbiters deleting at inopportune times

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -106,7 +106,7 @@
 	if(master.loc == oldloc)
 		return
 
-	var/turf/newturf = get_turf(parent)
+	var/turf/newturf = get_turf(master)
 	if(!newturf)
 		qdel(src)
 
@@ -122,10 +122,13 @@
 		while(ismovableatom(target))
 			RegisterSignal(target, COMSIG_MOVABLE_MOVED, orbited_spy, TRUE)
 			target = target.loc
-	
+
+	var/atom/curloc = master.loc
 	for(var/i in orbiters)
 		var/atom/movable/thing = i
-		if(thing.loc == newturf)
+		if(master.loc != curloc) // We moved again, cancel current operation
+			break
+		if(QDELETED(thing) || thing.loc == newturf)
 			continue
 		thing.forceMove(newturf)
 		CHECK_TICK

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -126,12 +126,13 @@
 	var/atom/curloc = master.loc
 	for(var/i in orbiters)
 		var/atom/movable/thing = i
-		if(master.loc != curloc) // We moved again, cancel current operation
-			break
 		if(QDELETED(thing) || thing.loc == newturf)
 			continue
 		thing.forceMove(newturf)
-		CHECK_TICK
+		if(CHECK_TICK && master.loc != curloc)
+			// We moved again during the checktick, cancel current operation
+			break
+
 
 /datum/component/orbiter/proc/orbiter_move_react(atom/movable/orbiter, atom/oldloc, direction)
 	if(orbiter.loc == get_turf(parent))


### PR DESCRIPTION
Can happen because of checktick. This *may* be a cause of some drops but based on logs this was really rare. Also fixes another possible error from checkticking the orbit move.