### PR TITLE
[READY]Contrabands are once again free for Seed Servitor

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -41,6 +41,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	payment_department = ACCOUNT_SRV
 	var/active = 1		//No sales pitches if off!
 	var/vend_ready = 1	//Are we ready to vend?? Is it time??
+	var/free_contraband = 0 //Is the Contraband free for the departament?
 
 	// To be filled out at compile time
 	var/list/products	= list()	//For each, use the following pattern:
@@ -331,9 +332,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 				price_listed = "$[R.custom_price]"
 			if(!onstation || account && account.account_job && account.account_job.paycheck_department == payment_department)
 				price_listed = "FREE"
-				if(name == "\improper MegaSeed Servitor" && coin_records.Find(R))
+				if(free_contraband && coin_records.Find(R))
 					price_listed = "$[extra_price]"
-			if(coin_records.Find(R) || is_hidden && name != "\improper MegaSeed Servitor")
+			if(coin_records.Find(R) || is_hidden && !free_contraband)
 				price_listed = "$[extra_price]"
 			dat += "<li>"
 			if(R.amount > 0 && ((C && C.registered_account && onstation) || (!onstation && iscarbon(user))))
@@ -456,9 +457,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			var/datum/bank_account/account = C.registered_account
 			if(account.account_job && account.account_job.paycheck_department == payment_department)
 				price_to_use = 0
-				if(name == "\improper MegaSeed Servitor" && coin_records.Find(R))
+				if(free_contraband && coin_records.Find(R))
 					price_to_use = extra_price
-			if(coin_records.Find(R) || hidden_records.Find(R) && name != "\improper MegaSeed Servitor")
+			if(coin_records.Find(R) || hidden_records.Find(R) && !free_contraband)
 				price_to_use = extra_price
 			if(price_to_use && !account.adjust_money(-price_to_use))
 				say("You do not possess the funds to purchase [R.name].")

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -331,7 +331,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 				price_listed = "$[R.custom_price]"
 			if(!onstation || account && account.account_job && account.account_job.paycheck_department == payment_department)
 				price_listed = "FREE"
-			if(coin_records.Find(R) || is_hidden)
+				if(coin_records.Find(R))
+					price_listed = "$[extra_price]"
+			else if(coin_records.Find(R) || is_hidden)
 				price_listed = "$[extra_price]"
 			dat += "<li>"
 			if(R.amount > 0 && ((C && C.registered_account && onstation) || (!onstation && iscarbon(user))))
@@ -454,7 +456,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			var/datum/bank_account/account = C.registered_account
 			if(account.account_job && account.account_job.paycheck_department == payment_department)
 				price_to_use = 0
-			if(coin_records.Find(R) || hidden_records.Find(R))
+				if(coin_records.Find(R))
+					price_to_use = extra_price
+			else if(coin_records.Find(R) || hidden_records.Find(R))
 				price_to_use = extra_price
 			if(price_to_use && !account.adjust_money(-price_to_use))
 				say("You do not possess the funds to purchase [R.name].")

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -331,9 +331,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 				price_listed = "$[R.custom_price]"
 			if(!onstation || account && account.account_job && account.account_job.paycheck_department == payment_department)
 				price_listed = "FREE"
-				if(coin_records.Find(R))
+				if(name == "\improper MegaSeed Servitor" && coin_records.Find(R))
 					price_listed = "$[extra_price]"
-			else if(coin_records.Find(R) || is_hidden)
+			if(coin_records.Find(R) || is_hidden && name != "\improper MegaSeed Servitor")
 				price_listed = "$[extra_price]"
 			dat += "<li>"
 			if(R.amount > 0 && ((C && C.registered_account && onstation) || (!onstation && iscarbon(user))))
@@ -456,9 +456,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			var/datum/bank_account/account = C.registered_account
 			if(account.account_job && account.account_job.paycheck_department == payment_department)
 				price_to_use = 0
-				if(coin_records.Find(R))
+				if(name == "\improper MegaSeed Servitor" && coin_records.Find(R))
 					price_to_use = extra_price
-			else if(coin_records.Find(R) || hidden_records.Find(R))
+			if(coin_records.Find(R) || hidden_records.Find(R) && name != "\improper MegaSeed Servitor")
 				price_to_use = extra_price
 			if(price_to_use && !account.adjust_money(-price_to_use))
 				say("You do not possess the funds to purchase [R.name].")

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -4,6 +4,7 @@
 	product_slogans = "THIS'S WHERE TH' SEEDS LIVE! GIT YOU SOME!;Hands down the best seed selection on the station!;Also certain mushroom varieties available, more for experts! Get certified today!"
 	product_ads = "We like plants!;Grow some crops!;Grow, baby, growww!;Aw h'yeah son!"
 	icon_state = "seeds"
+	free_contraband = 1
 	products = list(/obj/item/seeds/ambrosia = 3,
 		            /obj/item/seeds/apple = 3,
 		            /obj/item/seeds/cotton = 3,
@@ -54,3 +55,4 @@
 	default_price = 25
 	extra_price = 50
 	payment_department = ACCOUNT_SRV
+

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -55,4 +55,3 @@
 	default_price = 25
 	extra_price = 50
 	payment_department = ACCOUNT_SRV
-


### PR DESCRIPTION
[Changelogs]: #40624 made that Premium and contraband items were no longer free for departments, this backfired at botany since the contraband seeds are important for their work.
:cl: BebeYoshi
tweak: Being sued by Hydroponics Space Labor Committee for botanists' right violations, Nanotransen decided to make Contrabands free for Seed Servitor once again!
/:cl:

[why]: Botany rely on contraband items.
