### PR TITLE
Cleans up pixel_y = 0 in crashedship.dmm

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -2414,8 +2414,7 @@
 	},
 /obj/machinery/button/door{
 	id = "packerMine";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plating/airless,
 /area/awaymission/BMPship/Midship)
@@ -2441,8 +2440,7 @@
 	},
 /obj/machinery/button/door{
 	id = "packerMed";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plating/airless,
 /area/awaymission/BMPship/Midship)


### PR DESCRIPTION
Introduced in #40660

![image](https://user-images.githubusercontent.com/6209658/46767838-4cd4e380-ccb4-11e8-8f8e-a5f22912e23c.png)
