### PR TITLE
Monkey Head-revs can now properly convert people, you can now convert player-monkeys to rev

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -177,8 +177,8 @@
 		return
 	AOE_flash()
 
-/obj/item/assembly/flash/proc/terrible_conversion_proc(mob/living/carbon/human/H, mob/user)
-	if(istype(H) && ishuman(user) && H.stat != DEAD)
+/obj/item/assembly/flash/proc/terrible_conversion_proc(mob/living/carbon/H, mob/user)
+	if(istype(H) && H.stat != DEAD)
 		if(user.mind)
 			var/datum/antagonist/rev/head/converter = user.mind.has_antag_datum(/datum/antagonist/rev/head)
 			if(!converter)


### PR DESCRIPTION
Fixes #40836

:cl: Iamgoofball
fix: If you are somehow a revolutionary head as a monkey, you can now properly teach others the plight of the working class.
fix: A monkey with superior intellect can also now be taught the way of Marx.
/:cl: