### PR TITLE
Fixes chem dispensers not receiving extra reagents with T4 manips

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -49,7 +49,7 @@
 		"bromine",
 		"stable_plasma"
 	)
-	//these become available once the manipulator has been upgraded to tier 4
+	//these become available once the manipulator has been upgraded to tier 4 (femto)
 	var/list/upgrade_reagents = list(
 		"oil",
 		"ash",

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -49,6 +49,14 @@
 		"bromine",
 		"stable_plasma"
 	)
+	var/list/upgrade_reagents = list(
+		"oil",
+		"ash",
+		"acetone",
+		"saltpetre",
+		"ammonia",
+		"diethylamine"
+	)
 	var/list/emagged_reagents = list(
 		"space_drugs",
 		"morphine",
@@ -346,6 +354,8 @@
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		if (M.rating > macrotier)
 			macrotier = M.rating
+		if (M.rating > 3)
+			dispensable_reagents |= upgrade_reagents
 	powerefficiency = round(newpowereff, 0.01)
 
 

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -49,6 +49,7 @@
 		"bromine",
 		"stable_plasma"
 	)
+	//these become available once the manipulator has been upgraded to tier 4
 	var/list/upgrade_reagents = list(
 		"oil",
 		"ash",


### PR DESCRIPTION
:cl: Denton
fix: Re-added missing reagents that chem dispensers receive once their manipulator is upgraded to tier 4.
/:cl:

Closes: #38614