### PR TITLE
Fixes servant_spawns empty list runtimes

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -178,16 +178,15 @@ Credit where due:
 	return 1
 
 /datum/game_mode/clockwork_cult/post_setup()
-	var/list/spread_out_spawns = GLOB.servant_spawns
+	var/list/spread_out_spawns = GLOB.servant_spawns.Copy()
 	for(var/S in servants_to_serve)
 		if(!spread_out_spawns.len) //cycle through the list again if we've used all the inital spawnpoints.
-			spread_out_spawns = GLOB.servant_spawns
+			spread_out_spawns = GLOB.servant_spawns.Copy()
 		var/datum/mind/servant = S
 		log_game("[key_name(servant)] was made an initial servant of Ratvar")
 		var/mob/living/L = servant.current
-		var/turf/T = pick(spread_out_spawns)
+		var/turf/T = pick_n_take(spread_out_spawns)
 		L.forceMove(T)
-		spread_out_spawns.Remove(T)
 		greet_servant(L)
 		equip_servant(L)
 		add_servant_of_ratvar(L, TRUE)

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -178,13 +178,16 @@ Credit where due:
 	return 1
 
 /datum/game_mode/clockwork_cult/post_setup()
+	var/list/spread_out_spawns = GLOB.servant_spawns
 	for(var/S in servants_to_serve)
+		if(!spread_out_spawns.len) //cycle through the list again if we've used all the inital spawnpoints.
+			spread_out_spawns = GLOB.servant_spawns
 		var/datum/mind/servant = S
 		log_game("[key_name(servant)] was made an initial servant of Ratvar")
 		var/mob/living/L = servant.current
-		var/turf/T = pick(GLOB.servant_spawns)
+		var/turf/T = pick(spread_out_spawns)
 		L.forceMove(T)
-		GLOB.servant_spawns -= T
+		spread_out_spawns.Remove(T)
 		greet_servant(L)
 		equip_servant(L)
 		add_servant_of_ratvar(L, TRUE)

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
@@ -199,11 +199,7 @@
 
 /datum/clockwork_scripture/abscond/scripture_effects()
 	var/take_pulling = invoker.pulling && isliving(invoker.pulling) && get_clockwork_power(ABSCOND_ABDUCTION_COST)
-	var/turf/T
-	if(GLOB.ark_of_the_clockwork_justiciar)
-		T = get_step(GLOB.ark_of_the_clockwork_justiciar, SOUTH)
-	else
-		T = get_turf(pick(GLOB.servant_spawns))
+	var/turf/T = GLOB.ark_of_the_clockwork_justiciar ? get_step(GLOB.ark_of_the_clockwork_justiciar, SOUTH) : get_turf(pick(GLOB.servant_spawns))
 	invoker.visible_message("<span class='warning'>[invoker] flickers and phases out of existence!</span>", \
 	"<span class='bold sevtug_small'>You feel a dizzying sense of vertigo as you're yanked back to Reebe!</span>")
 	T.visible_message("<span class='warning'>[invoker] flickers and phases into existence!</span>")


### PR DESCRIPTION
A couple things depend on this list being populated to teleport mobs around towards end game, so removing the spawnpoints just to spread players around at the very start of the round seems like a pretty blatant oversight.