### PR TITLE
Restores the hazy effect to the saboteur borg's chameleon module

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -50,6 +50,19 @@
 	else
 		to_chat(user, "<span class='notice'>You activate \the [src].</span>")
 		playsound(src, 'sound/effects/seedling_chargeup.ogg', 100, 1, -6)
+		var/start = user.filters.len
+		var/X,Y,rsq,i,f
+		for(i=1, i<=7, ++i)
+			do
+				X = 60*rand() - 30
+				Y = 60*rand() - 30
+				rsq = X*X + Y*Y
+			while(rsq<100 || rsq>900)
+			user.filters += filter(type="wave", x=X, y=Y, size=rand()*2.5+0.5, offset=rand())
+		for(i=1, i<=7, ++i)
+			f = user.filters[start+i]
+			animate(f, offset=f:offset, time=0, loop=3, flags=ANIMATION_PARALLEL)
+			animate(offset=f:offset-1, time=rand()*20+10)
 		if (do_after(user, 50, target=user) && user.cell.use(activationCost))
 			playsound(src, 'sound/effects/bamf.ogg', 100, 1, -6)
 			to_chat(user, "<span class='notice'>You are now disguised as the Nanotrasen engineering borg \"[friendlyName]\".</span>")
@@ -57,6 +70,10 @@
 		else
 			to_chat(user, "<span class='warning'>The chameleon field fizzles.</span>")
 			do_sparks(3, FALSE, user)
+			for(i=1, i<=min(7, user.filters.len), ++i) // removing filters that are animating does nothing, we gotta stop the animations first
+				f = user.filters[start+i]
+				animate(f)
+		user.filters = null
 
 /obj/item/borg_chameleon/process()
 	if (user)


### PR DESCRIPTION
It was removed because animating filters crashing the server, hopefully http://www.byond.com/forum/?post=2403778 is the fix

:cl: Naksu
tweak: the hazy chameleon effect has been restored to the saboteur borg's chameleon module
/:cl:
