### PR TITLE
Updates travis and removes a lie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM tgstation/byond:512.1452 as base
-#above version must be the same as the one in dependencies.sh
+FROM tgstation/byond:512.1453 as base
 
 FROM base as build_base
 


### PR DESCRIPTION
This bug mentioned in the 1453 patchnotes is probably what was causing some travis runs to fail without any seeming pattern.

`Another casualty of the refactor was found: Loading an /icon datum from a file() failed intermittently. (AlcaroIsAFrick)` http://www.byond.com/docs/notes/512.html

Also the comment isn't true anymore.