### PR TITLE
Removes infinite duplication for service borg glasses

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -69,14 +69,8 @@
 			to_chat(user, "<span class='warning'>[target] is full.</span>")
 			return
 
-		var/refill = reagents.get_master_reagent_id()
 		var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this)
 		to_chat(user, "<span class='notice'>You transfer [trans] units of the solution to [target].</span>")
-
-		if(iscyborg(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
-			var/mob/living/silicon/robot/bro = user
-			bro.cell.use(30)
-			addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent, refill, trans), 600)
 
 	else if(target.is_drainable()) //A dispenser. Transfer FROM it TO us.
 		if (!is_refillable())


### PR DESCRIPTION
:cl: Swindly
balance: Service cyborgs can no longer reproduce infinite amounts of arbitrary reagents
/:cl:

[why]: Fixes https://github.com/tgstation/tgstation/issues/20383
