### PR TITLE
Hotfix for burnchamber mounted igniters

### DIFF
--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -126,7 +126,7 @@
 	use_power(1000)
 	var/turf/location = src.loc
 	if (isturf(location))
-		location.hotspot_expose(1000,100,1)
+		location.hotspot_expose(1000,2500,1)
 	return 1
 
 /obj/machinery/sparker/emp_act(severity)


### PR DESCRIPTION
Now, mounted sparkers will dramatically, dramatically increase the temperature of the turf they're activated on.

This is necessary in order to get the burn chamber igniting in a reasonable timeframe again, after the big hotspot_expose() change ( #38232 ) killed it.

(There _might_ be reasonable values below 2500, but this works, and works fairly reliably, which is important for toxins. If you wanted to find a minimal value, 1000 might be a good place to start, and work upwards.)

:cl: ChemicalRascal
fix: The toxins burn chamber mounted igniters have been cleaned and should work again.
/:cl:

closes: #40867
