### PR TITLE
Fixes AI eyes being visible to living humans

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -180,7 +180,7 @@
 	if(!eyeobj)
 		return
 	eyeobj.mouse_opacity = state ? MOUSE_OPACITY_ICON : initial(eyeobj.mouse_opacity)
-	eyeobj.invisibility = state ? INVISIBILITY_OBSERVER : initial(eyeobj.mouse_opacity)
+	eyeobj.invisibility = state ? INVISIBILITY_OBSERVER : initial(eyeobj.invisibility)
 
 /mob/living/silicon/ai/verb/toggle_acceleration()
 	set category = "AI Commands"


### PR DESCRIPTION
Fixes #40837

:cl: MrDoomBringer
fix: AI Eyes are no longer be visible on AI disconnect
/:cl:

this should probably get speedmerged or something idk
@ShizCalev 
