### PR TITLE
Makes anchored=FALSE spawners have move_resist so they ACTUALLY CAN BE MOVED

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -42,6 +42,7 @@
 	roundstart = FALSE
 	death = FALSE
 	anchored = FALSE
+	move_resist = MOVE_FORCE_NORMAL
 	density = FALSE
 	flavour_text = "<span class='big bold'>You are an ash walker.</span><b> Your tribe worships <span class='danger'>the Necropolis</span>. The wastes are sacred ground, its monsters a blessed bounty. \
 	You have seen lights in the distance... they foreshadow the arrival of outsiders that seek to tear apart the Necropolis and its domain. Fresh sacrifices for your nest.</b>"
@@ -114,6 +115,7 @@
 	roundstart = FALSE
 	death = FALSE
 	anchored = FALSE
+	move_resist = MOVE_FORCE_NORMAL
 	density = FALSE
 	var/has_owner = FALSE
 	var/can_transfer = TRUE //if golems can switch bodies to this new shell


### PR DESCRIPTION
fix your shit kevinz; for now this ~~untested~~ tested and works unless copypasta into local somehow produced different results webedit SHOULD do

:cl: Barhandar
fix: Golem shells and ashwalker eggs can be pulled again.
/:cl:

Fixes #40489