### PR TITLE
Fixes l6 saw having ridiculous ammo caliber

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/lmg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/lmg.dm
@@ -1,23 +1,23 @@
-// 1.95x129mm (SAW)
+// 7.12x82mm (SAW)
 
-/obj/item/ammo_casing/mm195x129
-	name = "1.95x129mm bullet casing"
-	desc = "A 1.95x129mm bullet casing."
+/obj/item/ammo_casing/mm712x82
+	name = "7.12x82mm bullet casing"
+	desc = "A 7.12x82mm bullet casing."
 	icon_state = "762-casing"
-	caliber = "mm195129"
-	projectile_type = /obj/item/projectile/bullet/mm195x129
+	caliber = "mm71282"
+	projectile_type = /obj/item/projectile/bullet/mm712x82
 
-/obj/item/ammo_casing/mm195x129/ap
-	name = "1.95x129mm armor-piercing bullet casing"
-	desc = "A 1.95x129mm bullet casing designed with a hardened-tipped core to help penetrate armored targets."
-	projectile_type = /obj/item/projectile/bullet/mm195x129_ap
+/obj/item/ammo_casing/mm712x82/ap
+	name = "7.12x82mm armor-piercing bullet casing"
+	desc = "A 7.12x82mm bullet casing designed with a hardened-tipped core to help penetrate armored targets."
+	projectile_type = /obj/item/projectile/bullet/mm712x82_ap
 
-/obj/item/ammo_casing/mm195x129/hollow
-	name = "1.95x129mm hollow-point bullet casing"
-	desc = "A 1.95x129mm bullet casing designed to cause more damage to unarmored targets."
-	projectile_type = /obj/item/projectile/bullet/mm195x129_hp
+/obj/item/ammo_casing/mm712x82/hollow
+	name = "7.12x82mm hollow-point bullet casing"
+	desc = "A 7.12x82mm bullet casing designed to cause more damage to unarmored targets."
+	projectile_type = /obj/item/projectile/bullet/mm712x82_hp
 
-/obj/item/ammo_casing/mm195x129/incen
-	name = "1.95x129mm incendiary bullet casing"
-	desc = "A 1.95x129mm bullet casing designed with a chemical-filled capsule on the tip that when bursted, reacts with the atmosphere to produce a fireball, engulfing the target in flames."
-	projectile_type = /obj/item/projectile/bullet/incendiary/mm195x129
+/obj/item/ammo_casing/mm712x82/incen
+	name = "7.12x82mm incendiary bullet casing"
+	desc = "A 7.12x82mm bullet casing designed with a chemical-filled capsule on the tip that when bursted, reacts with the atmosphere to produce a fireball, engulfing the target in flames."
+	projectile_type = /obj/item/projectile/bullet/incendiary/mm712x82

--- a/code/modules/projectiles/boxes_magazines/external/lmg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/lmg.dm
@@ -1,22 +1,22 @@
-/obj/item/ammo_box/magazine/mm195x129
-	name = "box magazine (1.95x129mm)"
+/obj/item/ammo_box/magazine/mm712x82
+	name = "box magazine (7.12x82mm)"
 	icon_state = "a762-50"
-	ammo_type = /obj/item/ammo_casing/mm195x129
-	caliber = "mm195129"
+	ammo_type = /obj/item/ammo_casing/mm712x82
+	caliber = "mm71282"
 	max_ammo = 50
 
-/obj/item/ammo_box/magazine/mm195x129/hollow
-	name = "box magazine (Hollow-Point 1.95x129mm)"
-	ammo_type = /obj/item/ammo_casing/mm195x129/hollow
+/obj/item/ammo_box/magazine/mm712x82/hollow
+	name = "box magazine (Hollow-Point 7.12x82mm)"
+	ammo_type = /obj/item/ammo_casing/mm712x82/hollow
 
-/obj/item/ammo_box/magazine/mm195x129/ap
-	name = "box magazine (Armor Penetrating 1.95x129mm)"
-	ammo_type = /obj/item/ammo_casing/mm195x129/ap
+/obj/item/ammo_box/magazine/mm712x82/ap
+	name = "box magazine (Armor Penetrating 7.12x82mm)"
+	ammo_type = /obj/item/ammo_casing/mm712x82/ap
 
-/obj/item/ammo_box/magazine/mm195x129/incen
-	name = "box magazine (Incendiary 1.95x129mm)"
-	ammo_type = /obj/item/ammo_casing/mm195x129/incen
+/obj/item/ammo_box/magazine/mm712x82/incen
+	name = "box magazine (Incendiary 7.12x82mm)"
+	ammo_type = /obj/item/ammo_casing/mm712x82/incen
 
-/obj/item/ammo_box/magazine/mm195x129/update_icon()
+/obj/item/ammo_box/magazine/mm712x82/update_icon()
 	..()
 	icon_state = "a762-[round(ammo_count(),10)]"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -274,12 +274,12 @@
 
 /obj/item/gun/ballistic/automatic/l6_saw
 	name = "\improper L6 SAW"
-	desc = "A heavily modified 1.95x129mm light machine gun, designated 'L6 SAW'. Has 'Aussec Armoury - 2531' engraved on the receiver below the designation."
+	desc = "A heavily modified 7.12x82mm light machine gun, designated 'L6 SAW'. Has 'Aussec Armoury - 2531' engraved on the receiver below the designation."
 	icon_state = "l6closed100"
 	item_state = "l6closedmag"
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = 0
-	mag_type = /obj/item/ammo_box/magazine/mm195x129
+	mag_type = /obj/item/ammo_box/magazine/mm712x82
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
 	var/cover_open = FALSE

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -21,24 +21,24 @@
 /obj/item/projectile/bullet/syndicate_turret
 	damage = 20
 
-// 1.95x129mm (SAW)
+// 7.12x82mm (SAW)
 
-/obj/item/projectile/bullet/mm195x129
-	name = "1.95x129mm bullet"
+/obj/item/projectile/bullet/mm712x82
+	name = "7.12x82mm bullet"
 	damage = 45
 	armour_penetration = 5
 
-/obj/item/projectile/bullet/mm195x129_ap
-	name = "1.95x129mm armor-piercing bullet"
+/obj/item/projectile/bullet/mm712x82_ap
+	name = "7.12x82mm armor-piercing bullet"
 	damage = 40
 	armour_penetration = 75
 
-/obj/item/projectile/bullet/mm195x129_hp
-	name = "1.95x129mm hollow-point bullet"
+/obj/item/projectile/bullet/mm712x82_hp
+	name = "7.12x82mm hollow-point bullet"
 	damage = 60
 	armour_penetration = -60
 
-/obj/item/projectile/bullet/incendiary/mm195x129
-	name = "1.95x129mm incendiary bullet"
+/obj/item/projectile/bullet/incendiary/mm712x82
+	name = "7.12x82mm incendiary bullet"
 	damage = 20
 	fire_stacks = 3

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -539,7 +539,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/ammo/carbine
 	name = "5.56mm Toploader Magazine"
 	desc = "An additional 30-round 5.56mm magazine; suitable for use with the M-90gl carbine. \
-			These bullets pack less punch than 1.95mm rounds, but they still offer more power than .45 ammo."
+			These bullets pack less punch than 7.12mm rounds, but they still offer more power than .45 ammo."
 	item = /obj/item/ammo_box/magazine/m556
 	cost = 4
 	include_modes = list(/datum/game_mode/nuclear)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -214,7 +214,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/dangerous/machinegun
 	name = "L6 Squad Automatic Weapon"
 	desc = "A fully-loaded Aussec Armoury belt-fed machine gun. \
-			This deadly weapon has a massive 50-round magazine of devastating 1.95x129mm ammunition."
+			This deadly weapon has a massive 50-round magazine of devastating 7.12x82mm ammunition."
 	item = /obj/item/gun/ballistic/automatic/l6_saw
 	cost = 18
 	surplus = 0
@@ -558,29 +558,29 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/machinegun/basic
-	name = "1.95x129mm Box Magazine"
-	desc = "A 50-round magazine of 1.95x129mm ammunition for use with the L6 SAW. \
+	name = "7.12x82mm Box Magazine"
+	desc = "A 50-round magazine of 7.12x82mm ammunition for use with the L6 SAW. \
 			By the time you need to use this, you'll already be on a pile of corpses."
-	item = /obj/item/ammo_box/magazine/mm195x129
+	item = /obj/item/ammo_box/magazine/mm712x82
 
 /datum/uplink_item/ammo/machinegun/hollow
-	name = "1.95x129mm (Hollow-Point) Box Magazine"
-	desc = "A 50-round magazine of 1.95x129mm ammunition for use in the L6 SAW; equipped with hollow-point tips to help \
+	name = "7.12x82mm (Hollow-Point) Box Magazine"
+	desc = "A 50-round magazine of 7.12x82mm ammunition for use in the L6 SAW; equipped with hollow-point tips to help \
 			with the unarmored masses of crew."
-	item = /obj/item/ammo_box/magazine/mm195x129/hollow
+	item = /obj/item/ammo_box/magazine/mm712x82/hollow
 
 /datum/uplink_item/ammo/machinegun/ap
-	name = "1.95x129mm (Armor Penetrating) Box Magazine"
-	desc = "A 50-round magazine of 1.95x129mm ammunition for use in the L6 SAW; equipped with special properties \
+	name = "7.12x82mm (Armor Penetrating) Box Magazine"
+	desc = "A 50-round magazine of 7.12x82mm ammunition for use in the L6 SAW; equipped with special properties \
 			to puncture even the most durable armor."
-	item = /obj/item/ammo_box/magazine/mm195x129/ap
+	item = /obj/item/ammo_box/magazine/mm712x82/ap
 	cost = 9
 
 /datum/uplink_item/ammo/machinegun/incen
-	name = "1.95x129mm (Incendiary) Box Magazine"
-	desc = "A 50-round magazine of 1.95x129mm ammunition for use in the L6 SAW; tipped with a special flammable \
+	name = "7.12x82mm (Incendiary) Box Magazine"
+	desc = "A 50-round magazine of 7.12x82mm ammunition for use in the L6 SAW; tipped with a special flammable \
 			mixture that'll ignite anyone struck by the bullet. Some men just want to watch the world burn."
-	item = /obj/item/ammo_box/magazine/mm195x129/incen
+	item = /obj/item/ammo_box/magazine/mm712x82/incen
 
 /datum/uplink_item/ammo/rocket
 	include_modes = list(/datum/game_mode/nuclear)


### PR DESCRIPTION
I made L6 saw use a ridiculous 1.95x129mm ammo (basically a pin covered in gunpowder) because it needed to be changed from 5.56 flavor-wise, but I didn't really know what the numbers meant at all. 
Now I know a little more, and I'm so sorry. This is a more realistic (yet still fictional) ammo caliber.
