### PR TITLE
Gutlunches may now lunch on guts.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -39,7 +39,7 @@
 	animal_species = /mob/living/simple_animal/hostile/asteroid/gutlunch
 	childtype = list(/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck = 45, /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen = 55)
 
-	wanted_objects = list(/obj/effect/decal/cleanable/xenoblood/xgibs, /obj/effect/decal/cleanable/blood/gibs/)
+	wanted_objects = list(/obj/effect/decal/cleanable/xenoblood/xgibs, /obj/effect/decal/cleanable/blood/gibs/, /obj/item/organ)
 	var/obj/item/udder/gutlunch/udder = null
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/Initialize()


### PR DESCRIPTION
:cl: Fel
fix: Gutlunches (AKA Guthen / Gubbuck) now eat all kinds of guts, not just generic gibs! Ashwalkers have their basic healing source back, now.
/:cl:

I'm surprised nobody did this earlier, since we moved from humans becoming piles of generic giblets to piles of actual organs.

Basically, it just adds `/obj/item/organ` to the list of things gutlunches can eat.
Tested and is functional. They don't eat limbs and such, either, so you can still have a head to put on a pike.