### PR TITLE
Fixes gamemode reports to not generate duplicates

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -227,11 +227,12 @@
 				modes += M.config_tag
 				mode_names[M.config_tag] = M.name
 				probabilities[M.config_tag] = M.probability
-				mode_reports[M.config_tag] = M.generate_report()
+				mode_reports[M.report_type] = M.generate_report()
 				if(probabilities[M.config_tag]>0)
-					mode_false_report_weight[M.config_tag] = M.false_report_weight
+					mode_false_report_weight[M.report_type] = M.false_report_weight
 				else
-					mode_false_report_weight[M.config_tag] = 1
+					//"impossible" modes will still falsly show up occasionally, else they'll stick out like a sore thumb if an admin decides to force a disabled gamemode.
+					mode_false_report_weight[M.report_type] = Min(1, M.false_report_weight)
 				if(M.votable)
 					votable_modes += M.config_tag
 		qdel(M)

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -232,7 +232,7 @@
 					mode_false_report_weight[M.report_type] = M.false_report_weight
 				else
 					//"impossible" modes will still falsly show up occasionally, else they'll stick out like a sore thumb if an admin decides to force a disabled gamemode.
-					mode_false_report_weight[M.report_type] = Min(1, M.false_report_weight)
+					mode_false_report_weight[M.report_type] = min(1, M.false_report_weight)
 				if(M.votable)
 					votable_modes += M.config_tag
 		qdel(M)

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -8,6 +8,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 /datum/game_mode/changeling
 	name = "changeling"
 	config_tag = "changeling"
+	report_type = "changeling"
 	antag_flag = ROLE_CHANGELING
 	false_report_weight = 10
 	restricted_jobs = list("AI", "Cyborg")

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -1,6 +1,7 @@
 /datum/game_mode/traitor/changeling
 	name = "traitor+changeling"
 	config_tag = "traitorchan"
+	report_type = "traitorchan"
 	false_report_weight = 10
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("AI", "Cyborg")

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -128,6 +128,7 @@ Credit where due:
 /datum/game_mode/clockwork_cult
 	name = "clockwork cult"
 	config_tag = "clockwork_cult"
+	report_type = "clockwork_cult"
 	antag_flag = ROLE_SERVANT_OF_RATVAR
 	false_report_weight = 10
 	required_players = 24

--- a/code/game/gamemodes/clown_ops/clown_ops.dm
+++ b/code/game/gamemodes/clown_ops/clown_ops.dm
@@ -26,12 +26,6 @@
 			the_op.assigned_role = "Clown Operative"
 			the_op.special_role = "Clown Operative"
 
-/datum/game_mode/nuclear/clown_ops/generate_report()
-	return "One of Central Command's trading routes was recently disrupted by a raid carried out by the Gorlex Marauders. They seemed to only be after one ship - a highly-sensitive \
-			transport containing a bananium fission explosive, although it is useless without the proper code and authorization disk. While the code was likely found in minutes, the only disk that \
-			can activate this explosive is on your station. Ensure that it is protected at all times, and remain alert for possible intruders."
-
-
 /datum/outfit/syndicate/clownop
 	name = "Clown Operative - Basic"
 	uniform = /obj/item/clothing/under/syndicate

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -33,6 +33,7 @@
 /datum/game_mode/cult
 	name = "cult"
 	config_tag = "cult"
+	report_type = "cult"
 	antag_flag = ROLE_CULTIST
 	false_report_weight = 10
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")

--- a/code/game/gamemodes/devil/devil agent/devil_agent.dm
+++ b/code/game/gamemodes/devil/devil agent/devil_agent.dm
@@ -42,7 +42,3 @@
 		D.objectives += outsellobjective
 		return 1
 	return 0
-
-/datum/game_mode/devil/devil_agents/generate_report()
-	return "Multiple soul merchants have been spotted in the quadrant, and appear to be competing over who can purchase the most souls.  Be advised that they are likely to manufacture \
-			emergencies to encourage employees to sell their souls. If anyone sells their soul in error, contact an attorney to overrule the sale."

--- a/code/game/gamemodes/devil/devil_game_mode.dm
+++ b/code/game/gamemodes/devil/devil_game_mode.dm
@@ -1,6 +1,7 @@
 /datum/game_mode/devil
 	name = "devil"
 	config_tag = "devil"
+	report_type = "devil"
 	antag_flag = ROLE_DEVIL
 	false_report_weight = 1
 	protected_jobs = list("Lawyer", "Curator", "Chaplain", "Head of Security", "Captain", "AI")

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -1,6 +1,7 @@
 /datum/game_mode/extended
 	name = "secret extended"
 	config_tag = "secret_extended"
+	report_type = "extended"
 	false_report_weight = 5
 	required_players = 0
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -18,6 +18,7 @@
 	var/votable = 1
 	var/probability = 0
 	var/false_report_weight = 0 //How often will this show up incorrectly in a centcom report?
+	var/report_type = "invalid" //gamemodes with the same report type will not show up in the command report together.
 	var/station_was_nuked = 0 //see nuclearbomb.dm and malfunction.dm
 	var/nuke_off_station = 0 //Used for tracking where the nuke hit
 	var/round_ends_with_antag_death = 0 //flags the "one verse the station" antags as such
@@ -257,11 +258,11 @@
 	intercepttext += "<b>Central Command has intercepted and partially decoded a Syndicate transmission with vital information regarding their movements. The following report outlines the most \
 	likely threats to appear in your sector.</b>"
 	var/list/report_weights = config.mode_false_report_weight.Copy()
-	report_weights[config_tag] = 0 //Prevent the current mode from being falsely selected.
+	report_weights[report_type] = 0 //Prevent the current mode from being falsely selected.
 	var/list/reports = list()
 	var/Count = 0 //To compensate for missing correct report
 	if(prob(65)) // 65% chance the actual mode will appear on the list
-		reports += config.mode_reports[config_tag]
+		reports += config.mode_reports[report_type]
 		Count++
 	for(var/i in Count to rand(3,5)) //Between three and five wrong entries on the list.
 		var/false_report_type = pickweightAllowZero(report_weights)

--- a/code/game/gamemodes/hivemind/hivemind.dm
+++ b/code/game/gamemodes/hivemind/hivemind.dm
@@ -1,6 +1,7 @@
 /datum/game_mode/hivemind
 	name = "Assimilation"
 	config_tag = "hivemind"
+	report_type = "hivemind"
 	antag_flag = ROLE_HIVE
 	false_report_weight = 5
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -1,6 +1,7 @@
 /datum/game_mode/meteor
 	name = "meteor"
 	config_tag = "meteor"
+	report_type = "meteor"
 	false_report_weight = 1
 	var/meteordelay = 2000
 	var/nometeors = 0

--- a/code/game/gamemodes/monkey/monkey.dm
+++ b/code/game/gamemodes/monkey/monkey.dm
@@ -5,6 +5,7 @@
 /datum/game_mode/monkey
 	name = "monkey"
 	config_tag = "monkey"
+	report_type = "monkey"
 	antag_flag = ROLE_MONKEY
 	false_report_weight = 1
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -1,6 +1,7 @@
 /datum/game_mode/nuclear
 	name = "nuclear emergency"
 	config_tag = "nuclear"
+	report_type = "nuclear"
 	false_report_weight = 10
 	required_players = 30 // 30 players - 3 players to be the nuke ops = 27 players remaining
 	required_enemies = 2

--- a/code/game/gamemodes/overthrow/overthrow.dm
+++ b/code/game/gamemodes/overthrow/overthrow.dm
@@ -2,6 +2,7 @@
 /datum/game_mode/overthrow
 	name = "overthrow"
 	config_tag = "overthrow"
+	report_type = "overthrow"
 	antag_flag = ROLE_OVERTHROW
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer")
 	required_players = 20 // the core idea is of a swift, bloodless coup, so it shouldn't be as chaotic as revs.

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -10,6 +10,7 @@
 /datum/game_mode/revolution
 	name = "revolution"
 	config_tag = "revolution"
+	report_type = "revolution"
 	antag_flag = ROLE_REV
 	false_report_weight = 10
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer")

--- a/code/game/gamemodes/sandbox/sandbox.dm
+++ b/code/game/gamemodes/sandbox/sandbox.dm
@@ -1,6 +1,7 @@
 /datum/game_mode/sandbox
 	name = "sandbox"
 	config_tag = "sandbox"
+	report_type = "sandbox"
 	required_players = 0
 
 	announce_span = "info"

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -5,6 +5,7 @@
 /datum/game_mode/traitor/internal_affairs
 	name = "Internal Affairs"
 	config_tag = "internal_affairs"
+	report_type = "internal_affairs"
 	false_report_weight = 10
 	required_players = 25
 	required_enemies = 5

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -8,6 +8,7 @@
 /datum/game_mode/traitor
 	name = "traitor"
 	config_tag = "traitor"
+	report_type = "traitor"
 	antag_flag = ROLE_TRAITOR
 	false_report_weight = 20 //Reports of traitors are pretty common.
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -5,6 +5,7 @@
 /datum/game_mode/wizard
 	name = "wizard"
 	config_tag = "wizard"
+	report_type = "wizard"
 	antag_flag = ROLE_WIZARD
 	false_report_weight = 10
 	required_players = 20


### PR DESCRIPTION
Fixes:#40895

So, the gamemode generation code was not equipped to handle gamemode subtypes, and would sometimes generate very strange reports because of that.

Contrary to popular belief, they couldn't be used to meta, as it was possible to get two rev reports on the same sheet, even when it's not revs.