### PR TITLE
Fixes gas tanks not changing their layer at roundstart

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
@@ -20,6 +20,7 @@
 		air_contents.assert_gas(gas_type)
 		air_contents.gases[gas_type][MOLES] = AIR_CONTENTS
 		name = "[name] ([air_contents.gases[gas_type][GAS_META][META_GAS_NAME]])"
+	setPipingLayer(piping_layer)
 
 /obj/machinery/atmospherics/components/unary/tank/carbon_dioxide
 	gas_type = /datum/gas/carbon_dioxide


### PR DESCRIPTION
:cl: Nichlas0010
fix: air tanks now respect the layer they have been set to
/:cl:

[why]: # Because I'm changing all supply/waste piping downstream to be on layer 1/3, and airtanks not connecting to the proper layer is a pain
