### PR TITLE
Enables all clothing/hair customization for all humans

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -28,14 +28,11 @@
 		//this is largely copypasted from there.
 
 		//handle facial hair (if necessary)
-		if(H.gender == MALE)
-			var/new_style = input(user, "Select a facial hair style", "Grooming")  as null|anything in GLOB.facial_hair_styles_list
-			if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
-				return	//no tele-grooming
-			if(new_style)
-				H.facial_hair_style = new_style
-		else
-			H.facial_hair_style = "Shaved"
+		var/new_style = input(user, "Select a facial hair style", "Grooming")  as null|anything in GLOB.facial_hair_styles_list
+		if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+			return	//no tele-grooming
+		if(new_style)
+			H.facial_hair_style = new_style
 
 		//handle normal hair
 		var/new_style = input(user, "Select a hair style", "Grooming")  as null|anything in GLOB.hair_styles_list

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -35,7 +35,7 @@
 			H.facial_hair_style = new_style
 
 		//handle normal hair
-		var/new_style = input(user, "Select a hair style", "Grooming")  as null|anything in GLOB.hair_styles_list
+		new_style = input(user, "Select a hair style", "Grooming")  as null|anything in GLOB.hair_styles_list
 		if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 			return	//no tele-grooming
 		if(new_style)

--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -522,7 +522,7 @@
 
 /datum/sprite_accessory/facial_hair
 	icon = 'icons/mob/human_face.dmi'
-	gender = NEUTER
+
 // please make sure they're sorted alphabetically and categorized
 
 /datum/sprite_accessory/facial_hair/abe
@@ -611,7 +611,6 @@
 ///////////////////////////
 /datum/sprite_accessory/underwear
 	icon = 'icons/mob/underwear.dmi'
-	gender = NEUTER
 
 /datum/sprite_accessory/underwear/nude
 	name = "Nude"
@@ -791,7 +790,6 @@
 
 /datum/sprite_accessory/undershirt
 	icon = 'icons/mob/underwear.dmi'
-	gender = NEUTER
 
 /datum/sprite_accessory/undershirt/nude
 	name = "Nude"
@@ -1075,7 +1073,6 @@
 
 /datum/sprite_accessory/socks
 	icon = 'icons/mob/underwear.dmi'
-	gender = NEUTER
 
 /datum/sprite_accessory/socks/nude
 	name = "Nude"

--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -522,8 +522,7 @@
 
 /datum/sprite_accessory/facial_hair
 	icon = 'icons/mob/human_face.dmi'
-	gender = MALE // barf (unless you're a dorf, dorfs dig chix w/ beards :P)
-
+	gender = NEUTER
 // please make sure they're sorted alphabetically and categorized
 
 /datum/sprite_accessory/facial_hair/abe
@@ -601,7 +600,6 @@
 /datum/sprite_accessory/facial_hair/shaved
 	name = "Shaved"
 	icon_state = null
-	gender = NEUTER
 
 /datum/sprite_accessory/facial_hair/elvis
 	name = "Sideburns (Elvis)"
@@ -613,201 +611,179 @@
 ///////////////////////////
 /datum/sprite_accessory/underwear
 	icon = 'icons/mob/underwear.dmi'
+	gender = NEUTER
 
 /datum/sprite_accessory/underwear/nude
 	name = "Nude"
 	icon_state = null
-	gender = NEUTER
 
 /datum/sprite_accessory/underwear/male_mankini
 	name = "Mankini"
 	icon_state = "male_mankini"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_black
 	name = "Men's Black"
 	icon_state = "male_black"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_blackalt
 	name = "Men's Black Boxer"
 	icon_state = "male_blackalt"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_blue
 	name = "Men's Blue"
 	icon_state = "male_blue"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_green
 	name = "Men's Green"
 	icon_state = "male_green"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_grey
 	name = "Men's Grey"
 	icon_state = "male_grey"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_greyalt
 	name = "Men's Grey Boxer"
 	icon_state = "male_greyalt"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_hearts
 	name = "Men's Hearts Boxer"
 	icon_state = "male_hearts"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_kinky
 	name = "Men's Kinky"
 	icon_state = "male_kinky"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_red
 	name = "Men's Red"
 	icon_state = "male_red"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_stripe
 	name = "Men's Striped Boxer"
 	icon_state = "male_stripe"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_commie
 	name = "Men's Striped Commie Boxer"
 	icon_state = "male_commie"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_usastripe
 	name = "Men's Striped Freedom Boxer"
 	icon_state = "male_assblastusa"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_uk
 	name = "Men's Striped UK Boxer"
 	icon_state = "male_uk"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/male_white
 	name = "Men's White"
 	icon_state = "male_white"
-	gender = MALE
+
 
 /datum/sprite_accessory/underwear/female_babydoll
 	name = "Babydoll"
 	icon_state = "female_babydoll"
-	gender = FEMALE
+
 
 /datum/sprite_accessory/underwear/female_babyblue
 	name = "Ladies' Baby-Blue"
 	icon_state = "female_babyblue"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_black
 	name = "Ladies' Black"
 	icon_state = "female_black"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_black_neko
 	name = "Ladies' Black Neko"
 	icon_state = "female_neko_black"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_blackalt
 	name = "Ladies' Black Sport"
 	icon_state = "female_blackalt"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_blue
 	name = "Ladies' Blue"
 	icon_state = "female_blue"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_commie
 	name = "Ladies' Commie"
 	icon_state = "female_commie"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_usastripe
 	name = "Ladies' Freedom"
 	icon_state = "female_assblastusa"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_green
 	name = "Ladies' Green"
 	icon_state = "female_green"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_kinky
 	name = "Ladies' Kinky"
 	icon_state = "female_kinky"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_pink
 	name = "Ladies' Pink"
 	icon_state = "female_pink"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_red
 	name = "Ladies' Red"
 	icon_state = "female_red"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/swimsuit
 	name = "Ladies' Swimsuit (Black)"
 	icon_state = "swim_black"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/swimsuit_blue
 	name = "Ladies' Swimsuit (Blue)"
 	icon_state = "swim_blue"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/swimsuit_green
 	name = "Ladies' Swimsuit (Green)"
 	icon_state = "swim_green"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/swimsuit_purple
 	name = "Ladies' Swimsuit (Purple)"
 	icon_state = "swim_purple"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/swimsuit_red
 	name = "Ladies' Swimsuit (Red)"
 	icon_state = "swim_red"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_thong
 	name = "Ladies' Thong"
 	icon_state = "female_thong"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_uk
 	name = "Ladies' UK"
 	icon_state = "female_uk"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_white
 	name = "Ladies' White"
 	icon_state = "female_white"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_white_neko
 	name = "Ladies' White Neko"
 	icon_state = "female_neko_white"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_whitealt
 	name = "Ladies' White Sport"
 	icon_state = "female_whitealt"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_yellow
 	name = "Ladies' Yellow"
 	icon_state = "female_yellow"
-	gender = FEMALE
 
 ////////////////////////////
 // Undershirt Definitions //
@@ -815,283 +791,283 @@
 
 /datum/sprite_accessory/undershirt
 	icon = 'icons/mob/underwear.dmi'
+	gender = NEUTER
 
 /datum/sprite_accessory/undershirt/nude
 	name = "Nude"
 	icon_state = null
-	gender = NEUTER
+
 
 // please make sure they're sorted alphabetically and categorized
 
 /datum/sprite_accessory/undershirt/bluejersey
 	name = "Jersey (Blue)"
 	icon_state = "shirt_bluejersey"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/redjersey
 	name = "Jersey (Red)"
 	icon_state = "shirt_redjersey"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/bluepolo
 	name = "Polo Shirt (Blue)"
 	icon_state = "bluepolo"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/grayyellowpolo
 	name = "Polo Shirt (Gray-Yellow)"
 	icon_state = "grayyellowpolo"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/redpolo
 	name = "Polo Shirt (Red)"
 	icon_state = "redpolo"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/whitepolo
 	name = "Polo Shirt (White)"
 	icon_state = "whitepolo"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/alienshirt
 	name = "Shirt (Alien)"
 	icon_state = "shirt_alien"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/mondmondjaja
 	name = "Shirt (Band)"
 	icon_state = "band"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/shirt_black
 	name = "Shirt (Black)"
 	icon_state = "shirt_black"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/blueshirt
 	name = "Shirt (Blue)"
 	icon_state = "shirt_blue"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/clownshirt
 	name = "Shirt (Clown)"
 	icon_state = "shirt_clown"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/commie
 	name = "Shirt (Commie)"
 	icon_state = "shirt_commie"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/greenshirt
 	name = "Shirt (Green)"
 	icon_state = "shirt_green"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/shirt_grey
 	name = "Shirt (Grey)"
 	icon_state = "shirt_grey"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/ian
 	name = "Shirt (Ian)"
 	icon_state = "ian"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/ilovent
 	name = "Shirt (I Love NT)"
 	icon_state = "ilovent"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/lover
 	name = "Shirt (Lover)"
 	icon_state = "lover"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/matroska
 	name = "Shirt (Matroska)"
 	icon_state = "matroska"
-	gender = NEUTER
 
 /datum/sprite_accessory/undershirt/meat
 	name = "Shirt (Meat)"
 	icon_state = "shirt_meat"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/nano
 	name = "Shirt (Nanotrasen)"
 	icon_state = "shirt_nano"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/peace
 	name = "Shirt (Peace)"
 	icon_state = "peace"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/pacman
 	name = "Shirt (Pogoman)"
 	icon_state = "pogoman"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/question
 	name = "Shirt (Question)"
 	icon_state = "shirt_question"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/redshirt
 	name = "Shirt (Red)"
 	icon_state = "shirt_red"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/skull
 	name = "Shirt (Skull)"
 	icon_state = "shirt_skull"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/ss13
 	name = "Shirt (SS13)"
 	icon_state = "shirt_ss13"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/stripe
 	name = "Shirt (Striped)"
 	icon_state = "shirt_stripes"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/tiedye
 	name = "Shirt (Tie-dye)"
 	icon_state = "shirt_tiedye"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/uk
 	name = "Shirt (UK)"
 	icon_state = "uk"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/usa
 	name = "Shirt (USA)"
 	icon_state = "shirt_assblastusa"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/shirt_white
 	name = "Shirt (White)"
 	icon_state = "shirt_white"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/blackshortsleeve
 	name = "Short-sleeved Shirt (Black)"
 	icon_state = "blackshortsleeve"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/blueshortsleeve
 	name = "Short-sleeved Shirt (Blue)"
 	icon_state = "blueshortsleeve"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/greenshortsleeve
 	name = "Short-sleeved Shirt (Green)"
 	icon_state = "greenshortsleeve"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/purpleshortsleeve
 	name = "Short-sleeved Shirt (Purple)"
 	icon_state = "purpleshortsleeve"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/whiteshortsleeve
 	name = "Short-sleeved Shirt (White)"
 	icon_state = "whiteshortsleeve"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/sports_bra
 	name = "Sports Bra"
 	icon_state = "sports_bra"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/sports_bra2
 	name = "Sports Bra (Alt)"
 	icon_state = "sports_bra_alt"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/blueshirtsport
 	name = "Sports Shirt (Blue)"
 	icon_state = "blueshirtsport"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/greenshirtsport
 	name = "Sports Shirt (Green)"
 	icon_state = "greenshirtsport"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/redshirtsport
 	name = "Sports Shirt (Red)"
 	icon_state = "redshirtsport"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/tank_black
 	name = "Tank Top (Black)"
 	icon_state = "tank_black"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/tankfire
 	name = "Tank Top (Fire)"
 	icon_state = "tank_fire"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/tank_grey
 	name = "Tank Top (Grey)"
 	icon_state = "tank_grey"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/female_midriff
 	name = "Tank Top (Midriff)"
 	icon_state = "tank_midriff"
-	gender = FEMALE
+
 
 /datum/sprite_accessory/undershirt/tank_red
 	name = "Tank Top (Red)"
 	icon_state = "tank_red"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/tankstripe
 	name = "Tank Top (Striped)"
 	icon_state = "tank_stripes"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/tank_white
 	name = "Tank Top (White)"
 	icon_state = "tank_white"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/redtop
 	name = "Top (Red)"
 	icon_state = "redtop"
-	gender = FEMALE
+
 
 /datum/sprite_accessory/undershirt/whitetop
 	name = "Top (White)"
 	icon_state = "whitetop"
-	gender = FEMALE
+
 
 /datum/sprite_accessory/undershirt/tshirt_blue
 	name = "T-Shirt (Blue)"
 	icon_state = "blueshirt"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/tshirt_green
 	name = "T-Shirt (Green)"
 	icon_state = "greenshirt"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/tshirt_red
 	name = "T-Shirt (Red)"
 	icon_state = "redshirt"
-	gender = NEUTER
+
 
 /datum/sprite_accessory/undershirt/yellowshirt
 	name = "T-Shirt (Yellow)"
 	icon_state = "yellowshirt"
-	gender = NEUTER
+
 
 ///////////////////////
 // Socks Definitions //
@@ -1099,6 +1075,7 @@
 
 /datum/sprite_accessory/socks
 	icon = 'icons/mob/underwear.dmi'
+	gender = NEUTER
 
 /datum/sprite_accessory/socks/nude
 	name = "Nude"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -614,10 +614,7 @@
 
 //Used for new human mobs created by cloning/goleming/podding
 /mob/living/carbon/human/proc/set_cloned_appearance()
-	if(gender == MALE)
-		facial_hair_style = "Full Beard"
-	else
-		facial_hair_style = "Shaved"
+	facial_hair_style = "Full Beard"
 	hair_style = pick("Bedhead", "Bedhead 2", "Bedhead 3")
 	underwear = "Nude"
 	update_body()


### PR DESCRIPTION
With catpeople getting axed, I do feel a little bad about the lost character customization(what little it provided, anyways), so I figured I'd unlock the rest of the character customization to all humans and ayyliens so that they can use them without restriction.

:cl: Iamgoofball
add: All character preference screen items now can be used regardless of gender.
/:cl: