### PR TITLE
Fixes monkey revhead issues

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -167,7 +167,7 @@
 	for(var/datum/mind/rev_mind in revolution.head_revolutionaries())
 		var/turf/T = get_turf(rev_mind.current)
 		if(!considered_afk(rev_mind) && considered_alive(rev_mind) && is_station_level(T.z))
-			if(ishuman(rev_mind.current))
+			if(ishuman(rev_mind.current) || ismonkey(rev_mind.current))
 				return FALSE
 	return TRUE
 

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -200,7 +200,7 @@
 	to_chat(old_owner, "<span class='userdanger'>Revolution has been disappointed of your leader traits! You are a regular revolutionary now!</span>")
 
 /datum/antagonist/rev/farewell()
-	if(ishuman(owner.current))
+	if(ishuman(owner.current) || ismonkey(owner.current))
 		owner.current.visible_message("<span class='deconversion_message'>[owner.current] looks like [owner.current.p_theyve()] just remembered [owner.current.p_their()] real allegiance!</span>", null, null, null, owner.current)
 		to_chat(owner, "<span class='userdanger'>You are no longer a brainwashed revolutionary! Your memory is hazy from the time you were a rebel...the only thing you remember is the name of the one who brainwashed you...</span>")
 	else if(issilicon(owner.current))
@@ -224,8 +224,8 @@
 	. = ..()
 
 /datum/antagonist/rev/head/equip_rev()
-	var/mob/living/carbon/human/H = owner.current
-	if(!istype(H))
+	var/mob/living/carbon/H = owner.current
+	if(!ishuman(H) && !ismonkey(H))
 		return
 
 	if(remove_clumsy && owner.assigned_role == "Clown")
@@ -285,10 +285,16 @@
 		if(head_revolutionaries.len < max_headrevs && head_revolutionaries.len < round(heads.len - ((8 - sec.len) / 3)))
 			var/list/datum/mind/non_heads = members - head_revolutionaries
 			var/list/datum/mind/promotable = list()
+			var/list/datum/mind/nonhuman_promotable = list()
 			for(var/datum/mind/khrushchev in non_heads)
 				if(khrushchev.current && !khrushchev.current.incapacitated() && !khrushchev.current.restrained() && khrushchev.current.client && khrushchev.current.stat != DEAD)
 					if(ROLE_REV in khrushchev.current.client.prefs.be_special)
-						promotable += khrushchev
+						if(ishuman(khrushchev.current))
+							promotable += khrushchev
+						else
+							nonhuman_promotable += khrushchev
+			if(!promotable.len && nonhuman_promotable.len) //if only nonhuman revolutionaries remain, promote one of them to the leadership.
+				promotable = nonhuman_promotable
 			if(promotable.len)
 				var/datum/mind/new_leader = pick(promotable)
 				var/datum/antagonist/rev/rev = new_leader.has_antag_datum(/datum/antagonist/rev)


### PR DESCRIPTION
Missed that there weren't fixed yet by #40856

:cl: ShizCalev
fix: Monkey revheads now properly count towards active revheads.
fix: Nonhumanoid revolutionaries will now only be considered for promotion to a head-revolutionary role if there are no human revolutionaries remaining that are valid for promotion.
/:cl:
