### PR TITLE
Makes smashed chairs drop rods

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -304,6 +304,8 @@
 	if(remaining_mats)
 		for(var/M=1 to remaining_mats)
 			new stack_type(get_turf(loc))
+	else if(materials[MAT_METAL])
+		new /obj/item/stack/rods(get_turf(loc), 2)
 	qdel(src)
 
 


### PR DESCRIPTION
:cl: Swindly
add: Chairs made of one sheet of metal now drop two rods when smashed
/:cl:

[why]: # Fixes https://github.com/tgstation/tgstation/issues/28408
