### PR TITLE
My disappointment is immeasurable, and my day is ruined. Renames the power-fist to power-puncher and removes "fisted" from the attack verbs

### DIFF
--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -1,12 +1,12 @@
 /obj/item/melee/powerfist
-	name = "power-fist"
+	name = "power-puncher"
 	desc = "A metal gauntlet with a piston-powered ram ontop for that extra 'ompfh' in your punch."
 	icon_state = "powerfist"
 	item_state = "powerfist"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
-	attack_verb = list("whacked", "fisted", "power-punched")
+	attack_verb = list("whacked", "power-punched")
 	force = 20
 	throwforce = 10
 	throw_range = 7

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -89,7 +89,7 @@
 
 	target.throw_at(throw_target, 5 * fisto_setting, 0.2)
 
-	log_combat(user, target, "power fisted", src)
+	log_combat(user, target, "power punched", src)
 
 	user.changeNext_move(CLICK_CD_MELEE * click_delay)
 


### PR DESCRIPTION
```
[no] ATTACK: John Doe(jondoe69) power fisted The Suspect(suspect_the) with The power-fist (NEWHP: 78) (captain's office)
[no] EMOTE: suspect_the/(The Suspect) : <b>The Suspect</b> appears visibly aroused. ((captain's office)
```

You lost your power fisting privileges. This was a shameful display from all involved. Names censored to avoid harassment of users as one user in this was not consenting to the ERP that occurred.
 