### PR TITLE
Improves Issue Report Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,15 +1,20 @@
 ---
 name: Bug report
 about: Create a report to help reproduce and fix the issue
-
 ---
+<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable -->
+## Round ID:
 
-[Round ID]: # (If you discovered this issue from playing tgstation hosted servers:)
-[Round ID]: # (**INCLUDE THE ROUND ID**)
-[Round ID]: # (It can be found in the Status panel or retrieved from https://atlantaned.space/statbus/round.php ! The round id let's us look up valuable information and logs for the round the bug happened.)
+<!--- **INCLUDE THE ROUND ID**
+If you discovered this issue from playing tgstation hosted servers:
+[Round ID]: # (It can be found in the Status panel or retrieved from https://atlantaned.space/statbus/round.php ! The round id let's us look up valuable information and logs for the round the bug happened.)-->
 
-[Testmerges]: # (If you believe the issue to be caused by a test merge [OOC tab -> Show Server Revision], report it in the pull request's comment section instead.)
+## Testmerges:
 
-[Reproduction]: # (Explain your issue in detail, including the steps to reproduce it. Issues without proper reproduction steps or explanation are open to being ignored/closed by maintainers.)
+<!-- If you believe the issue to be caused by a test merge [OOC tab -> Show Server Revision], report it in the pull request's comment section instead. If None, feel free to remove this section. -->
 
-[For Admins]: # (Oddities induced by var-edits and other admin tools are not necessarily bugs. Verify that your issues occur under regular circumstances before reporting them.)
+## Reproduction:
+
+<!-- Explain your issue in detail, including the steps to reproduce it. Issues without proper reproduction steps or explanation are open to being ignored/closed by maintainers.-->
+
+<!-- **For Admins:** Oddities induced by var-edits and other admin tools are not necessarily bugs. Verify that your issues occur under regular circumstances before reporting them. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ If you discovered this issue from playing tgstation hosted servers:
 
 ## Testmerges:
 
-<!-- If you believe the issue to be caused by a test merge [OOC tab -> Show Server Revision], report it in the pull request's comment section as well (You can refer to the issue number by prefixing said number with #. The issue number can be found beside the title after submitting it to the tracker). If None, feel free to remove this section. -->
+<!-- If you're certain the issue is to be caused by a test merge [OOC tab -> Show Server Revision], report it in the pull request's comment section rather than on the tracker(You can refer to the issue number by prefixing said number with #. The issue number can be found beside the title after submitting it to the tracker).If no testmerges are active, feel free to remove this section. -->
 
 ## Reproduction:
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ If you discovered this issue from playing tgstation hosted servers:
 
 ## Testmerges:
 
-<!-- If you're certain the issue is to be caused by a test merge [OOC tab -> Show Server Revision], report it in the pull request's comment section rather than on the tracker(You can refer to the issue number by prefixing said number with #. The issue number can be found beside the title after submitting it to the tracker).If no testmerges are active, feel free to remove this section. -->
+<!-- If you're certain the issue is to be caused by a test merge [OOC tab -> Show Server Revision], report it in the pull request's comment section rather than on the tracker(If you're unsure you can refer to the issue number by prefixing said number with #. The issue number can be found beside the title after submitting it to the tracker).If no testmerges are active, feel free to remove this section. -->
 
 ## Reproduction:
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ If you discovered this issue from playing tgstation hosted servers:
 
 ## Testmerges:
 
-<!-- If you believe the issue to be caused by a test merge [OOC tab -> Show Server Revision], report it in the pull request's comment section as well (You can refer to the issue number by prefixing said number with #). If None, feel free to remove this section. -->
+<!-- If you believe the issue to be caused by a test merge [OOC tab -> Show Server Revision], report it in the pull request's comment section as well (You can refer to the issue number by prefixing said number with #. The issue number can be found beside the title after submitting it to the tracker). If None, feel free to remove this section. -->
 
 ## Reproduction:
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ If you discovered this issue from playing tgstation hosted servers:
 
 ## Testmerges:
 
-<!-- If you believe the issue to be caused by a test merge [OOC tab -> Show Server Revision], report it in the pull request's comment section instead. If None, feel free to remove this section. -->
+<!-- If you believe the issue to be caused by a test merge [OOC tab -> Show Server Revision], report it in the pull request's comment section as well (You can refer to the issue number by prefixing said number with #). If None, feel free to remove this section. -->
 
 ## Reproduction:
 


### PR DESCRIPTION
Purpose:

Fixes issues [like these](https://github.com/tgstation/tgstation/issues/40912#issuecomment-429643560).

Makes it clear WHERE TO WRITE for those not familiar with github markup so it doesn't get lost.

Headers allow you to link to a specific aspect of your issue report for slightly easier viewing and now don't go away in the issue report due to current markup. 