### PR TITLE
Nerfs beam rifles vs blobs by 70%

### DIFF
--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -487,6 +487,8 @@
 		return 0.4
 	if(istype(target, /obj/structure/window))
 		return 0.5
+	if(istype(target, /obj/structure/blob))
+		return 0.3
 	return 1
 
 /obj/item/projectile/beam/beam_rifle/proc/handle_impact(atom/target)


### PR DESCRIPTION
220 dmg direct hit + 100 to aoe 3x3 to 66 direct hit 33 aoe 3x3 
with the cooldown this makes them on PAR (haha pun) with dualwielding aegs which has a far higher dps.
this makes them effective if you get a firing line of crew iwth it but if you're just soloing a blob you won't do much.

:cl:
balance: Beam rifle damage both direct and AOE reduced by 70% to blob structures.
/:cl: