### PR TITLE
Revert "Use rust-g for revision info instead of parsing .git (#40167)"

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -3,8 +3,5 @@
 
 #define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
 
-#define rustg_git_revparse(rev) call(RUST_G, "rg_git_revparse")(rev)
-#define rustg_git_commit_date(rev) call(RUST_G, "rg_git_commit_date")(rev)
-
 #define rustg_log_write(fname, text) call(RUST_G, "log_write")(fname, text)
 /proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -131,11 +131,6 @@ GLOBAL_VAR(restart_counter)
 	if(GLOB.round_id)
 		log_game("Round ID: [GLOB.round_id]")
 
-	// This was printed early in startup to the world log and config_error.log,
-	// but those are both private, so let's put the commit info in the runtime
-	// log which is ultimately public.
-	log_runtime(GLOB.revdata.get_log_message())
-
 /world/Topic(T, addr, master, key)
 	TGS_TOPIC	//redirect to server tools if necessary
 

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,7 +11,7 @@ export BYOND_MINOR=${LIST[1]}
 unset LIST
 
 #rust_g git tag
-export RUST_G_VERSION=0.4.1
+export RUST_G_VERSION=0.4.0
 
 #bsql git tag
 export BSQL_VERSION=v1.4.0.0


### PR DESCRIPTION
This reverts commit c0561362cec20fafb9a0618c239a99eee5432f31, reversing
changes made to 11c1ca3c46776b78efe4bdbda953c3b7b5368c9d.

( #40167 )

It broke get rev on the server because tgs3 only copies over the log/head file and not the entire .git folder.

I warned about this on the pr, cyberboss said tgs3 would override it in that case, but the fact its still not working suggests otherwise.

@SpaceManiac @Cyberboss @nfreader 