### PR TITLE
Fixes fully_replace_character_name not updating bank account names

### DIFF
--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -49,19 +49,12 @@ Clown
 
 	chameleon_extras = /obj/item/stamp/clown
 
-
-/datum/outfit/job/clown/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
-
-	H.fully_replace_character_name(H.real_name, pick(GLOB.clown_names))
-
 /datum/outfit/job/clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
 		return
 
+	H.fully_replace_character_name(H.real_name, pick(GLOB.clown_names)) //rename the mob AFTER they're equipped so their ID gets updated properly.
 	H.dna.add_mutation(CLOWNMUT)
 
 /*

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -833,6 +833,8 @@
 			if(ID.registered_name == oldname)
 				ID.registered_name = newname
 				ID.update_label()
+				if(ID.registered_account?.account_holder == oldname)
+					ID.registered_account.account_holder = newname
 				if(!search_pda)
 					break
 				search_id = 0
@@ -875,7 +877,7 @@
 		if(E.mouse_pointer)
 			client.mouse_pointer_icon = E.mouse_pointer
 
-			
+
 
 /mob/proc/is_literate()
 	return 0


### PR DESCRIPTION
Closes #40655 
Fixes #40560

:cl: ShizCalev
fix: Clowns and mimes will no longer have the incorrect name on their ID's bank account.
/:cl:

also fixed an issue where clown ID's weren't being properly updated when assigned the outfit by  via robust quick dress shop