### PR TITLE
Ghetto surgery can now damage brains. Mannitol can heal damaged brains.

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -446,7 +446,7 @@
 	if(!H.getorgan(/obj/item/organ/heart))
 		return
 	var/obj/item/organ/brain/BR = H.getorgan(/obj/item/organ/brain)
-	if(QDELETED(BR) || BR.damaged_brain || BR.suicided)
+	if(QDELETED(BR) || BR.brain_death || BR.damaged_brain || BR.suicided)
 		return
 	return TRUE
 
@@ -585,6 +585,8 @@
 					var/obj/item/organ/brain/BR = H.getorgan(/obj/item/organ/brain)
 					if(BR)
 						if(BR.damaged_brain)
+							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's brain tissue is damaged making recovery of patient impossible via defibrillator. Further attempts futile.</span>"
+						if(BR.brain_death)
 							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's brain damaged beyond point of no return. Further attempts futile.</span>"
 						if(BR.suicided || BR.brainmob?.suiciding)
 							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - No intelligence pattern can be detected in patient's brain. Further attempts futile.</span>"

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -254,7 +254,7 @@
 				to_chat(user, "<span class='warning'>The MMI indicates that their mind is currently inactive; it might change!</span>")
 				return
 
-			if(BM.stat == DEAD || BM.suiciding || (M.brain && (M.brain.damaged_brain || M.brain.suicided)))
+			if(BM.stat == DEAD || BM.suiciding || (M.brain && (M.brain.brain_death || M.brain.damaged_brain || M.brain.suicided)))
 				to_chat(user, "<span class='warning'>Sticking a dead brain into the frame would sort of defeat the purpose!</span>")
 				return
 

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -57,7 +57,7 @@
 		newbrain.brainmob = null
 		brainmob.forceMove(src)
 		brainmob.container = src
-		if(!newbrain.damaged_brain && !newbrain.suicided && !brainmob.suiciding) // the brain organ hasn't been beaten to death, nor was from a suicider.
+		if(!newbrain.brain_death && !newbrain.damaged_brain && !newbrain.suicided && !brainmob.suiciding) // the brain organ hasn't been beaten to death, nor was from a suicider.
 			brainmob.stat = CONSCIOUS //we manually revive the brain mob
 			GLOB.dead_mob_list -= brainmob
 			GLOB.alive_mob_list += brainmob

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -11,8 +11,9 @@
 	attack_verb = list("attacked", "slapped", "whacked")
 	var/suicided = FALSE
 	var/mob/living/brain/brainmob = null
-	var/damaged_brain = FALSE //whether the brain organ is damaged.
-	var/decoy_override = FALSE	//I apologize to the security players, and myself, who abused this, but this is going to go.
+	var/brain_death = FALSE //if the brainmob was intentionally killed by attacking the brain after removal, or by severe braindamage
+	var/damaged_brain = FALSE //if the brain was injured after removal. Can be healed with mannitol.
+	var/decoy_override = FALSE	//if it's a fake brain with no brainmob assigned. Feedback messages will be faked as if it does have a brainmob. See changelings & dullahans.
 
 	var/list/datum/brain_trauma/traumas = list()
 
@@ -88,27 +89,58 @@
 
 /obj/item/organ/brain/attackby(obj/item/O, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
-	if(brainmob)
+
+	if(damaged_brain && O.is_drainable() && O.reagents.has_reagent("mannitol")) //attempt to heal the brain
+		. = TRUE //don't do attack animation.
+		if(brain_death || brainmob?.health <= HEALTH_THRESHOLD_DEAD) //if the brain is fucked anyway, do nothing
+			to_chat(user, "<span class='warning'>[src] is far too damaged, there's nothing else we can do for it!</span>")
+			return
+
+		if(!O.reagents.has_reagent("mannitol", 10))
+			to_chat(user, "<span class='warning'>There's not enough mannitol in [O] to restore [src]!</span>")
+			return
+
+		user.visible_message("[user] starts to pour the contents of [O] onto [src].", "<span class='notice'>You start to slowly pour the contents of [O] onto [src].</span>")
+		if(!do_after(user, 60, TRUE, src))
+			to_chat(user, "<span class='warning'>You failed to pour [O] onto [src]!</span>")
+			return
+
+		user.visible_message("[user] pours the contents of [O] onto [src], causing it to reform it's original shape and turn a slightly brighter shade of pink.", "<span class='notice'>You pour the contents of [O] onto [src], causing it to reform it's original shape and turn a slightly brighter shade of pink.</span>")
+		damaged_brain = FALSE //heal the superficial damage.
+
+		O.reagents.clear_reagents()
+		return
+
+	if(brainmob) //if we aren't trying to heal the brain, pass the attack onto the brainmob.
 		O.attack(brainmob, user) //Oh noooeeeee
+
+	damaged_brain = TRUE //brain was attacked, they're pretty fragile.
 
 /obj/item/organ/brain/examine(mob/user)
 	..()
 
 	if(suicided)
-		to_chat(user, "It's started turning slightly grey. They must not have been able to handle the stress of it all.")
+		to_chat(user, "<span class='info'>It's started turning slightly grey. They must not have been able to handle the stress of it all.</span>")
 	else if(brainmob)
 		if(brainmob.client)
-			if(brainmob.health <= HEALTH_THRESHOLD_DEAD)
-				to_chat(user, "It's lifeless and severely damaged.")
+			if(brain_death || brainmob.health <= HEALTH_THRESHOLD_DEAD)
+				to_chat(user, "<span class='info'>It's lifeless and severely damaged.</span>")
+			else if(damaged_brain)
+				to_chat(user, "<span class='info'>It seems to still have a bit of energy within it, but it's rather damaged... You may be able to restore it with some <b>mannitol</b>.</span>")
 			else
-				to_chat(user, "You can feel the small spark of life still left in this one.")
+				to_chat(user, "<span class='info'>You can feel the small spark of life still left in this one.</span>")
+		else if(damaged_brain)
+			to_chat(user, "<span class='info'>It seems particularly lifeless and is rather damaged... You may be able to restore it with some <b>mannitol</b> incase it becomes functional again later.</span>")
 		else
-			to_chat(user, "This one seems particularly lifeless. Perhaps it will regain some of its luster later.")
+			to_chat(user, "<span class='info'>This one seems particularly lifeless. Perhaps it will regain some of its luster later.</span>")
 	else
 		if(decoy_override)
-			to_chat(user, "This one seems particularly lifeless. Perhaps it will regain some of its luster later.")
+			if(damaged_brain)
+				to_chat(user, "<span class='info'>It seems particularly lifeless and is rather damaged... You may be able to restore it with some <b>mannitol</b> incase it becomes functional again later.</span>")
+			else
+				to_chat(user, "<span class='info'>This one seems particularly lifeless. Perhaps it will regain some of its luster later.</span>")
 		else
-			to_chat(user, "This one is completely devoid of life.")
+			to_chat(user, "<span class='info'>This one is completely devoid of life.</span>")
 
 /obj/item/organ/brain/attack(mob/living/carbon/C, mob/user)
 	if(!istype(C))

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -20,7 +20,7 @@
 		else if(istype(loc, /obj/item/organ/brain))
 			BR = loc
 		if(BR)
-			BR.damaged_brain = TRUE //beaten to a pulp
+			BR.brain_death = TRUE //beaten to a pulp
 
 /mob/living/brain/proc/handle_emp_damage()
 	if(emp_damage)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -787,6 +787,7 @@
 		L.damage = 0
 	var/obj/item/organ/brain/B = getorgan(/obj/item/organ/brain)
 	if(B)
+		B.brain_death = FALSE
 		B.damaged_brain = FALSE
 	for(var/thing in diseases)
 		var/datum/disease/D = thing

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -262,12 +262,12 @@
 					vomit()
 			else
 				SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
-				
+
 
 	//Clear all moods if no miasma at all
 	else
 		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
-			
+
 
 
 
@@ -315,7 +315,7 @@
 		return
 
 	var/deceasedturf = get_turf(src)
-	
+
 	// Closed turfs don't have any air in them, so no gas building up
 	if(!istype(deceasedturf,/turf/open))
 		return
@@ -649,7 +649,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 		death()
 		var/obj/item/organ/brain/B = getorganslot(ORGAN_SLOT_BRAIN)
 		if(B)
-			B.damaged_brain = TRUE
+			B.brain_death = TRUE
 
 /////////////////////////////////////
 //MONKEYS WITH TOO MUCH CHOLOESTROL//

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -67,10 +67,15 @@
 	list_reagents = list("morphine" = 30)
 
 /obj/item/reagent_containers/glass/bottle/chloralhydrate
-	name = "Chloral Hydrate Bottle"
+	name = "chloral hydrate bottle"
 	desc = "A small bottle of Choral Hydrate. Mickey's Favorite!"
 	icon_state = "bottle20"
 	list_reagents = list("chloralhydrate" = 15)
+
+/obj/item/reagent_containers/glass/bottle/mannitol
+	name = "mannitol bottle"
+	desc = "A small bottle of Mannitol. Useful for healing brain damage."
+	list_reagents = list("mannitol" = 30)
 
 /obj/item/reagent_containers/glass/bottle/charcoal
 	name = "charcoal bottle"
@@ -240,7 +245,7 @@
 	name = "Rhinovirus culture bottle"
 	desc = "A small bottle. Contains XY-rhinovirus culture in synthblood medium."
 	spawned_disease = /datum/disease/advance/cold
-	
+
 /obj/item/reagent_containers/glass/bottle/flu_virion
 	name = "Flu virion culture bottle"
 	desc = "A small bottle. Contains H13N1 flu virion culture in synthblood medium."

--- a/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/code/modules/research/nanites/nanite_programs/healing.dm
@@ -224,7 +224,7 @@
 	if(!C.getorgan(/obj/item/organ/heart)) //what are we even shocking
 		return FALSE
 	var/obj/item/organ/brain/BR = C.getorgan(/obj/item/organ/brain)
-	if(QDELETED(BR) || BR.damaged_brain || BR.suicided)
+	if(QDELETED(BR) || BR.brain_death || BR.damaged_brain || BR.suicided)
 		return FALSE
 	if(C.get_ghost())
 		return FALSE

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -106,7 +106,7 @@
 		user.visible_message("<span class='warning'>[user] begins to cut open [src].</span>",\
 			"<span class='notice'>You begin to cut open [src]...</span>")
 		if(do_after(user, 54, target = src))
-			drop_organs(user)
+			drop_organs(user, TRUE)
 	else
 		return ..()
 
@@ -118,7 +118,7 @@
 	pixel_y = rand(-3, 3)
 
 //empties the bodypart from its organs and other things inside it
-/obj/item/bodypart/proc/drop_organs(mob/user)
+/obj/item/bodypart/proc/drop_organs(mob/user, violent_removal)
 	var/turf/T = get_turf(src)
 	if(status != BODYPART_ROBOTIC)
 		playsound(T, 'sound/misc/splort.ogg', 50, 1, -1)
@@ -439,7 +439,7 @@
 		qdel(cavity_item)
 	return ..()
 
-/obj/item/bodypart/chest/drop_organs(mob/user)
+/obj/item/bodypart/chest/drop_organs(mob/user, violent_removal)
 	if(cavity_item)
 		cavity_item.forceMove(user.loc)
 		cavity_item = null

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -38,7 +38,7 @@
 		return FALSE
 	return ..()
 
-/obj/item/bodypart/head/drop_organs(mob/user)
+/obj/item/bodypart/head/drop_organs(mob/user, violent_removal)
 	var/turf/T = get_turf(src)
 	if(status != BODYPART_ROBOTIC)
 		playsound(T, 'sound/misc/splort.ogg', 50, 1, -1)
@@ -51,6 +51,8 @@
 				brainmob.forceMove(brain)
 				brain.brainmob = brainmob
 				brainmob = null
+			if(violent_removal && prob(rand(80, 100))) //ghetto surgery can damage the brain.
+				brain.damaged_brain = TRUE
 			brain.forceMove(T)
 			brain = null
 			update_icon_dropped()

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -147,7 +147,7 @@
 	return ..()
 
 
-/obj/item/bodypart/chest/robot/drop_organs(mob/user)
+/obj/item/bodypart/chest/robot/drop_organs(mob/user, violent_removal)
 	if(wired)
 		new /obj/item/stack/cable_coil(user.loc, 1)
 	if(cell)
@@ -224,7 +224,7 @@
 	return ..()
 
 
-/obj/item/bodypart/head/robot/drop_organs(mob/user)
+/obj/item/bodypart/head/robot/drop_organs(mob/user, violent_removal)
 	if(flash1)
 		flash1.forceMove(user.loc)
 		flash1 = null


### PR DESCRIPTION
:cl: ShizCalev
balance: Cutting someone's brain out via ghetto surgery (ie brutally chopping their skull to pieces with a fireaxe) now has a high probability of damaging the brain due to it's non-surgical nature.
balance: Likewise, attacking a brain will now cause minor brain damage. 
balance: With recent advancements in bluespace medical research, damaged (not braindead) brains can now be restored to a functional state by splashing them with 10u of mannitol.
/:cl:

This change is to give incentive to roboticists/MDs/ect to actually perform surgery to remove a patient's brain instead of just chopping their head off with a bonesaw and cutting the brain out. 

Also changed the `damaged_brain` var to be called `brain_death` to reflect it's actual usage. `damaged_brain` now corresponds to brains which were attacked (without outright killing it) or damaged during removal.