### PR TITLE
Updates mineral doors a bit

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -698,6 +698,11 @@
 	. = ..()
 	update_icon()
 
+/obj/structure/window/paperframe/examine(mob/user)
+	. = ..()
+	if(obj_integrity < max_integrity)
+		to_chat(user, "<span class='info'>It looks a bit damaged, you may be able to fix it with some <b>paper</b>.</span>")
+
 /obj/structure/window/paperframe/spawnDebris(location)
 	. = list(new /obj/item/stack/sheet/mineral/wood(location))
 	for (var/i in 1 to rand(1,4))


### PR DESCRIPTION
Fixes #40971 

:cl: ShizCalev
tweak: Mineral (and wood/paper) doors can now be unsecured from the ground with a wrench (the wiki is finally accurate after like 10 years.)
tweak: Mineral doors can now be deconstructed with a welder. In the case of paper/wood doors, use a crowbar instead.
fix: Paper / wood doors can no longer be dug by a pickaxe.
fix: Attacking a paper or wood door with a lit welder will now set it alight.
tweak: Damaged paper doors can now be repaired by hitting them with paper (wasn't consistent with paper windows.)
tweak: Paper windows will now inform you that they can be repaired when damaged.
/:cl:

