### PR TITLE
Revert "Clowns and Mimes acts no longer get ruined when you examine their ID cards (#40655)"

### DIFF
--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -9,8 +9,7 @@
 /datum/bank_account/New(newname, job)
 	if(add_to_accounts)
 		SSeconomy.bank_accounts += src
-	if(newname)
-		account_holder = newname
+	account_holder = newname
 	account_job = job
 	account_id = rand(111111,999999)
 

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -81,12 +81,10 @@
 	if(!H)
 		return FALSE
 	if(!visualsOnly)
-		var/obj/item/card/id/I = H.wear_id ? H.wear_id.GetID() : null
-		var/datum/bank_account/bank_account
-		if(I)
-			bank_account = new(I.registered_name, src)
-		else
-			bank_account = new(H.real_name, src)
+		var/datum/bank_account/bank_account = new(H.real_name, src)
+		bank_account.account_holder = H.real_name
+		bank_account.account_job = src
+		bank_account.account_id = rand(111111,999999)
 		bank_account.payday(STARTING_PAYCHECKS, TRUE)
 		H.account_id = bank_account.account_id
 	if(CONFIG_GET(flag/enforce_human_authority) && (title in GLOB.command_positions))

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -82,9 +82,6 @@
 		return FALSE
 	if(!visualsOnly)
 		var/datum/bank_account/bank_account = new(H.real_name, src)
-		bank_account.account_holder = H.real_name
-		bank_account.account_job = src
-		bank_account.account_id = rand(111111,999999)
 		bank_account.payday(STARTING_PAYCHECKS, TRUE)
 		H.account_id = bank_account.account_id
 	if(CONFIG_GET(flag/enforce_human_authority) && (title in GLOB.command_positions))


### PR DESCRIPTION
This reverts commit 81d452d69729fa0a7fafc1b8f370214d8be47afa / #40655

This was fixed properly by #40951.

This also introduced a bug where ERT personnel (and anyone who spawns in with a non-standard ID card in their outfit datum) get bank accounts assigned to "Emergency Response Team Commander", "Security Response Officer", ect.
