### PR TITLE
Tweaks faux lavaland tile crafting amounts back to normal levels

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -31,7 +31,7 @@ Mineral Sheets
 GLOBAL_LIST_INIT(sandstone_recipes, list ( \
 	new/datum/stack_recipe("pile of dirt", /obj/machinery/hydroponics/soil, 3, time = 10, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("sandstone door", /obj/structure/mineral_door/sandstone, 10, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("aesthetic volcanic floor tile", /obj/item/stack/tile/basalt, 2, 2, 4, 20), \
+	new/datum/stack_recipe("aesthetic volcanic floor tile", /obj/item/stack/tile/basalt, 1, 4, 20), \
 	new/datum/stack_recipe("Assistant Statue", /obj/structure/statue/sandstone/assistant, 5, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("Breakdown into sand", /obj/item/stack/ore/glass, 1, one_per_turf = 0, on_floor = 1) \
 	))


### PR DESCRIPTION
:cl: landscaping moonman
tweak: Due to resolved manufacturer complaints, more aesthetic basalt tiles will be yielded in crafting than previously, in line with the results of other floortile products.
/:cl:

Some code maintenance on #26808 to make them more compliant with contempary code, especially since placing turfs on lavaland changed to no longer require a stack of 2 to place down one tile, therefore making the original design choices redundant. 

It follows the same formulae as everything else numerically: 1, 4, 20 which should give you a significant boost of floortiles to play with without being particularly outside of the norm.

- Complimentary picture of a suggestion on how to spend your newly found time not crafting ineffective ratios of sandstone floortiles. :man_artist: :woman_artist: :paintbrush: 
![dusty in here](https://puu.sh/BMAFs/39b0aef5f4.jpg)