### PR TITLE
reduces electrical storm chance

### DIFF
--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/electrical_storm
 	earliest_start = 10 MINUTES
 	min_players = 5
-	weight = 40
+	weight = 20
 	alertadmins = 0
 
 /datum/round_event/electrical_storm


### PR DESCRIPTION
This PR simply reduces the electrical storm weight from 40 to 20. The fact that nobody really takes the time to replace those lights except a rare few, if any makes this event frustrating when it happens.

:cl: davethwave
tweak: reduces electrical storm chance by half
/:cl:
