### PR TITLE
Adds a config option to automatically reopen job positions of folks who suicide at roundstart

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_EMPTY(player_list)				//all mobs **with clients attached**.
 GLOBAL_LIST_EMPTY(mob_list)					//all mobs, including clientless
 GLOBAL_LIST_EMPTY(mob_directory)			//mob_id -> mob
 GLOBAL_LIST_EMPTY(alive_mob_list)			//all alive mobs, including clientless. Excludes /mob/dead/new_player
+GLOBAL_LIST_EMPTY(suicided_mob_list)		//contains a list of all mobs that suicided, including their associated ghosts.
 GLOBAL_LIST_EMPTY(drones_list)
 GLOBAL_LIST_EMPTY(dead_mob_list)			//all dead mobs, including clientless. Excludes /mob/dead/new_player
 GLOBAL_LIST_EMPTY(joined_player_list)		//all clients that have joined the game at round-start or as a latejoin.

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -423,7 +423,7 @@
 /datum/config_entry/flag/reopen_roundstart_suicide_roles_command_positions
 
 /datum/config_entry/number/reopen_roundstart_suicide_roles_delay
-	min_val = 300
+	min_val = 30
 
 /datum/config_entry/flag/reopen_roundstart_suicide_roles_command_report
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -416,3 +416,14 @@
 /datum/config_entry/flag/log_pictures
 
 /datum/config_entry/flag/picture_logging_camera
+
+
+/datum/config_entry/flag/reopen_roundstart_suicide_roles
+
+/datum/config_entry/flag/reopen_roundstart_suicide_roles_command_positions
+
+/datum/config_entry/number/reopen_roundstart_suicide_roles_delay
+	min_val = 300
+
+/datum/config_entry/flag/reopen_roundstart_suicide_roles_command_report
+

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -84,6 +84,12 @@
 		report = !CONFIG_GET(flag/no_intercept_report)
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/display_roundstart_logout_report), ROUNDSTART_LOGOUT_REPORT_TIME)
 
+	if(CONFIG_GET(flag/reopen_roundstart_suicide_roles))
+		var/delay = CONFIG_GET(number/reopen_roundstart_suicide_roles_delay)
+		if(!delay)
+			delay = 4 MINUTES
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/reopen_roundstart_suicide_roles), delay)
+
 	if(SSdbcore.Connect())
 		var/sql
 		if(SSticker.mode)
@@ -424,6 +430,53 @@
 	for(var/mob/dead/new_player/P in GLOB.player_list)
 		if(P.client && P.ready == PLAYER_READY_TO_PLAY)
 			. ++
+
+/proc/reopen_roundstart_suicide_roles()
+	var/list/valid_positions = list()
+	valid_positions += GLOB.engineering_positions
+	valid_positions += GLOB.medical_positions
+	valid_positions += GLOB.science_positions
+	valid_positions += GLOB.supply_positions
+	valid_positions += GLOB.civilian_positions
+	valid_positions += GLOB.security_positions
+	if(CONFIG_GET(flag/reopen_roundstart_suicide_roles_command_positions))
+		valid_positions += GLOB.command_positions //add any remaining command positions
+	else
+		valid_positions -= GLOB.command_positions //remove all command positions that were added from their respective department positions lists.
+
+	var/list/reopened_jobs = list()
+	for(var/X in GLOB.suicided_mob_list)
+		if(!isliving(X))
+			continue
+		var/mob/living/L = X
+		if(L.job in valid_positions)
+			var/datum/job/J = SSjob.GetJob(L.job)
+			if(!J)
+				continue
+			J.current_positions = max(J.current_positions-1, 0)
+			reopened_jobs += L.job
+
+	if(CONFIG_GET(flag/reopen_roundstart_suicide_roles_command_report))
+		if(reopened_jobs.len)
+			var/reopened_job_report_positions
+			for(var/dead_dudes_job in reopened_jobs)
+				reopened_job_report_positions = "[reopened_job_report_positions ? "[reopened_job_report_positions]\n":""][dead_dudes_job]"
+
+			var/suicide_command_report = "<font size = 3><b>Central Command Human Resources Board</b><br>\
+								Notice of Personnel Change</font><hr>\
+								To personnel management staff aboard [station_name()]:<br><br>\
+								Our medical staff have detected a series of anomalies in the vital sensors \
+								of some of the staff aboard your station.<br><br>\
+								Further investigation into the situation on our end resulted in us discovering \
+								a series of rather... unforturnate decisions that were made on the part of said staff.<br><br>\
+								As such, we have taken the liberty to automatically reopen employment opportunities for the positions of the crew members \
+								who have decided not to partake in our research. We will be forwarding their cases to our employment review board \
+								to determine their eligibility for continued service with the company (and of course the \
+								continued storage of cloning records within the central medical backup server.)<br><br>\
+								<i>The following positions have been reopened on our behalf:<br><br>\
+								[reopened_job_report_positions]</i>"
+
+			print_command_report(suicide_command_report, "Central Command Personnel Update")
 
 //////////////////////////
 //Reports player logouts//

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -86,8 +86,10 @@
 
 	if(CONFIG_GET(flag/reopen_roundstart_suicide_roles))
 		var/delay = CONFIG_GET(number/reopen_roundstart_suicide_roles_delay)
-		if(!delay)
-			delay = 4 MINUTES
+		if(delay)
+			delay = (delay SECONDS)
+		else
+			delay = (4 MINUTES) //default to 4 minutes if the delay isn't defined.
 		addtimer(CALLBACK(GLOBAL_PROC, .proc/reopen_roundstart_suicide_roles), delay)
 
 	if(SSdbcore.Connect())

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -2,6 +2,10 @@
 
 /mob/proc/set_suicide(suicide_state)
 	suiciding = suicide_state
+	if(suicide_state)
+		GLOB.suicided_mob_list += src
+	else
+		GLOB.suicided_mob_list -= src
 
 /mob/living/carbon/set_suicide(suicide_state) //you thought that box trick was pretty clever, didn't you? well now hardmode is on, boyo.
 	. = ..()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -60,10 +60,10 @@ MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal 1
 ## Unhash to enable reopening of command level positions
 #REOPEN_ROUNDSTART_SUICIDE_ROLES_COMMAND_POSITIONS
 
-## Define the delay for roles to be reopened after the round starts in deciseconds.
-## Has a minimum delay of 30 seconds (300ds), though it's suggested to keep over 1 min (600ds)
-## If undefined, the delay defaults to 4 minutes (2400 deciseconds).
-#REOPEN_ROUNDSTART_SUICIDE_ROLES_DELAY 2400
+## Define the delay for roles to be reopened after the round starts in seconds.
+## Has a minimum delay of 30 seconds, though it's suggested to keep over 1 min
+## If undefined, the delay defaults to 4 minutes.
+#REOPEN_ROUNDSTART_SUICIDE_ROLES_DELAY 240
 
 ## Unhash to enable a printed command report for reopened roles listing what roles were reopened.
 #REOPEN_ROUNDSTART_SUICIDE_ROLES_COMMAND_REPORT

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -37,7 +37,7 @@ WALK_DELAY 4
 
 ## The variables below affect the movement of specific mob types. THIS AFFECTS ALL SUBTYPES OF THE TYPE YOU CHOOSE!
 ## Entries completely override all subtypes. Later entries have precedence over earlier entries.
-## This means if you put /mob 0 on the last entry, it will null out all changes, while if you put /mob as the first entry and 
+## This means if you put /mob 0 on the last entry, it will null out all changes, while if you put /mob as the first entry and
 ## /mob/living/carbon/human on the last entry, the last entry will override the first.
 ##MULTIPLICATIVE_MOVESPEED /mob/living/carbon/human 0
 ##MULTIPLICATIVE_MOVESPEED /mob/living/silicon/robot 0
@@ -53,6 +53,20 @@ MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal 1
 
 ## If uncommented, this forces all players to use random names !and appearances!.
 #FORCE_RANDOM_NAMES
+
+## Unhash this to turn on automatic reopening of a player's job if they suicide at roundstart
+#REOPEN_ROUNDSTART_SUICIDE_ROLES
+
+## Unhash to enable reopening of command level positions
+#REOPEN_ROUNDSTART_SUICIDE_ROLES_COMMAND_POSITIONS
+
+## Define the delay for roles to be reopened after the round starts in deciseconds.
+## Has a minimum delay of 30 seconds (300ds), though it's suggested to keep over 1 min (600ds)
+## If undefined, the delay defaults to 4 minutes (2400 deciseconds).
+#REOPEN_ROUNDSTART_SUICIDE_ROLES_DELAY 2400
+
+## Unhash to enable a printed command report for reopened roles listing what roles were reopened.
+#REOPEN_ROUNDSTART_SUICIDE_ROLES_COMMAND_REPORT
 
 
 ## ALERT LEVELS ###
@@ -136,10 +150,10 @@ MIDROUND_ANTAG CHANGELING
 MIDROUND_ANTAG WIZARD
 #MIDROUND_ANTAG  MONKEY
 
-## Uncomment these for overrides of the minimum / maximum number of players in a round type. 
+## Uncomment these for overrides of the minimum / maximum number of players in a round type.
 ## If you set any of these occasionally check to see if you still need them as the modes
 ## will still be actively rebalanced around the SUGGESTED populations, not your overrides.
-## Notes: For maximum number of players a value of -1 means no maximum. Setting minimums to 
+## Notes: For maximum number of players a value of -1 means no maximum. Setting minimums to
 ## VERY low numbers (< 5) can lead to errors if the roundtypes were not designed for that.
 
 #MIN_POP TRAITOR 0


### PR DESCRIPTION
Config option, defaults to off.

Mostly to help counter mass-suicides at the HOP due to folks not liking a map leaving tons of jobs walled off. If 10 folks suicide at the start you'll be spending the next 10~ minutes just sitting at the console to reopen their slots (that is if you even have a HOP, and have enough player **connected** to the server to allow you to increase the number of slots.)

:cl: ShizCalev
add: Added a config option to automatically reopen the job positions of players who have suicided at roundstart.
/:cl:
