### PR TITLE
You can now throw hats onto people's heads

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -43,6 +43,7 @@ SUBSYSTEM_DEF(throwing)
 	var/atom/movable/thrownthing
 	var/atom/target
 	var/turf/target_turf
+	var/target_zone
 	var/init_dir
 	var/maxrange
 	var/speed

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -526,6 +526,8 @@
 	TT.diagonals_first = diagonals_first
 	TT.force = force
 	TT.callback = callback
+	if(!QDELETED(thrower))
+		TT.target_zone = thrower.zone_selected
 
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -30,8 +30,10 @@
 		var/mob/M = loc
 		M.update_inv_head()
 
-/obj/item/clothing/head/throw_impact(atom/hit_atom)
+/obj/item/clothing/head/throw_impact(atom/hit_atom, datum/thrownthing/thrownthing)
 	..()
+	if(thrownthing.target_zone && thrownthing.target_zone != BODY_ZONE_HEAD)
+		return
 	if(iscarbon(hit_atom))
 		var/mob/living/carbon/H = hit_atom
 		if(H.head)

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -7,6 +7,7 @@
 	slot_flags = ITEM_SLOT_HEAD
 	var/blockTracking = 0 //For AI tracking
 	var/can_toggle = null
+	var/snug_fit = FALSE //can the hat be knocked off?
 	dynamic_hair_suffix = "+generic"
 
 /obj/item/clothing/head/Initialize()
@@ -28,3 +29,20 @@
 	if(ismob(loc))
 		var/mob/M = loc
 		M.update_inv_head()
+
+/obj/item/clothing/head/throw_impact(atom/hit_atom)
+	..()
+	if(iscarbon(hit_atom))
+		var/mob/living/carbon/H = hit_atom
+		if(H.head)
+			var/obj/item/clothing/head/WH = H.head
+			if(!WH.snug_fit)
+				if(H.dropItemToGround(WH))
+					H.equip_to_slot_if_possible(src, SLOT_HEAD, 0, 1, 1)
+					H.visible_message("<span class='warning'>[src] knocks [WH] off [H]'s head!</span>", "<span class='warning'>[WH] is suddenly knocked off your head, replaced by [src]!</span>")
+			else
+				H.visible_message("<span class='warning'>[src] bounces off [H]'s [WH.name]!", "<span class='warning'>[src] bounces off your [WH.name], falling to the floor.</span>")
+				return
+		if(!H.head)
+			H.equip_to_slot_if_possible(src, SLOT_HEAD, 0, 1, 1)
+			H.visible_message("<span class='notice'>[src] lands neatly on [H]'s head!", "<span class='notice'>[src] lands perfectly onto your head!</span>")

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -7,7 +7,7 @@
 	slot_flags = ITEM_SLOT_HEAD
 	var/blockTracking = 0 //For AI tracking
 	var/can_toggle = null
-	var/snug_fit = FALSE //can the hat be knocked off?
+	var/snug_fit = FALSE //is the hat immune to being knocked off?
 	dynamic_hair_suffix = "+generic"
 
 /obj/item/clothing/head/Initialize()

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -32,12 +32,14 @@
 		M.update_inv_head()
 
 /obj/item/clothing/head/throw_impact(atom/hit_atom, datum/thrownthing/thrownthing)
-	..()
-	if(thrownthing.target_zone && thrownthing.target_zone != BODY_ZONE_HEAD)
+	. = ..()
+	if(!.)
+		return
+	if(thrownthing && thrownthing.target_zone && thrownthing.target_zone != BODY_ZONE_HEAD)
 		return
 	if(iscarbon(hit_atom))
 		var/mob/living/carbon/H = hit_atom
-		if(H.head)
+		if(H.head && istype(H.head, /obj/item/clothing/head))
 			var/obj/item/clothing/head/WH = H.head
 			if(istype(WH) && !WH.snug_fit && !anti_tinfoil_maneuver)
 				if(H.dropItemToGround(WH))

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -8,6 +8,7 @@
 	var/blockTracking = 0 //For AI tracking
 	var/can_toggle = null
 	var/snug_fit = FALSE //is the hat immune to being knocked off?
+	var/anti_tinfoil_maneuver = FALSE //if the hat does something negative when worn, this should probably be set to TRUE
 	dynamic_hair_suffix = "+generic"
 
 /obj/item/clothing/head/Initialize()
@@ -38,7 +39,7 @@
 		var/mob/living/carbon/H = hit_atom
 		if(H.head)
 			var/obj/item/clothing/head/WH = H.head
-			if(!WH.snug_fit)
+			if(!WH.snug_fit && !anti_tinfoil_maneuver)
 				if(H.dropItemToGround(WH))
 					H.equip_to_slot_if_possible(src, SLOT_HEAD, 0, 1, 1)
 					H.visible_message("<span class='warning'>[src] knocks [WH] off [H]'s head!</span>", "<span class='warning'>[WH] is suddenly knocked off your head, replaced by [src]!</span>")

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -39,7 +39,7 @@
 		var/mob/living/carbon/H = hit_atom
 		if(H.head)
 			var/obj/item/clothing/head/WH = H.head
-			if(!WH.snug_fit && !anti_tinfoil_maneuver)
+			if(istype(WH) && !WH.snug_fit && !anti_tinfoil_maneuver)
 				if(H.dropItemToGround(WH))
 					H.equip_to_slot_if_possible(src, SLOT_HEAD, 0, 1, 1)
 					H.visible_message("<span class='warning'>[src] knocks [WH] off [H]'s head!</span>", "<span class='warning'>[WH] is suddenly knocked off your head, replaced by [src]!</span>")

--- a/code/modules/clothing/head/collectable.dm
+++ b/code/modules/clothing/head/collectable.dm
@@ -123,6 +123,7 @@
 	desc = "WARNING! Offers no real protection, or luminosity, but damn, is it fancy!"
 	icon_state = "hardhat0_yellow"
 	item_state = "hardhat0_yellow"
+	snug_fit = TRUE
 
 	dog_fashion = /datum/dog_fashion/head
 
@@ -145,6 +146,7 @@
 	item_state = "thunderdome"
 	resistance_flags = NONE
 	flags_inv = HIDEHAIR
+	snug_fit = TRUE
 
 /obj/item/clothing/head/collectable/swat
 	name = "collectable SWAT helmet"
@@ -153,3 +155,4 @@
 	item_state = "swat"
 	resistance_flags = NONE
 	flags_inv = HIDEHAIR
+	snug_fit = TRUE

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -11,6 +11,7 @@
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	resistance_flags = FIRE_PROOF
 	dynamic_hair_suffix = "+generic"
+	snug_fit = TRUE
 
 	dog_fashion = /datum/dog_fashion/head
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -13,6 +13,7 @@
 	resistance_flags = NONE
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEHAIR
+	snug_fit = TRUE
 
 	dog_fashion = /datum/dog_fashion/head/helmet
 

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -82,6 +82,7 @@
 	item_state = "snowman_h"
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+	snug_fit = TRUE
 
 /obj/item/clothing/head/justice
 	name = "justice hat"
@@ -90,6 +91,7 @@
 	item_state = "justicered"
 	flags_inv = HIDEHAIR|HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR
 	flags_cover = HEADCOVERSEYES
+	snug_fit = TRUE
 
 /obj/item/clothing/head/justice/blue
 	icon_state = "justiceblue"
@@ -298,6 +300,7 @@
 	desc = "When everything's going to crab, protecting your head is the best choice."
 	icon_state = "lobster_hat"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+	snug_fit = TRUE
 
 /obj/item/clothing/head/drfreezehat
 	name = "doctor freeze's wig"

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -28,6 +28,7 @@
 	visor_flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	resistance_flags = FIRE_PROOF
+	snug_fit = TRUE
 
 /obj/item/clothing/head/welding/attack_self(mob/user)
 	weldingvisortoggle(user)

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -237,6 +237,7 @@
 	item_state = "foilhat"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = -5,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = -5, "fire" = 0, "acid" = 0)
 	equip_delay_other = 140
+	anti_tinfoil_maneuver = TRUE //ranged NODROP conspiracy spreading + c4 is bad for your health
 	var/datum/brain_trauma/mild/phobia/paranoia
 
 /obj/item/clothing/head/foilhat/equipped(mob/living/carbon/human/user, slot)

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -21,6 +21,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	resistance_flags = NONE
 	dog_fashion = null
+	snug_fit = TRUE
 
 /obj/item/clothing/suit/space
 	name = "space suit"

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -9,6 +9,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDEFACE
 	resistance_flags = ACID_PROOF
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	snug_fit = TRUE
 
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -71,6 +71,7 @@
 	desc = "A protective & concealing hood."
 	armor = list("melee" = 35, "bullet" = 10, "laser" = 25, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR
+	snug_fit = TRUE
 
 /obj/item/clothing/suit/hooded/cloak/drake
 	name = "drake armour"
@@ -92,3 +93,4 @@
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	snug_fit = TRUE

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -70,6 +70,7 @@
 	equip_delay_other = 70
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	resistance_flags = NONE
+	snug_fit = TRUE
 
 
 /obj/item/clothing/suit/bomb_suit
@@ -128,6 +129,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	resistance_flags = NONE
 	rad_flags = RAD_PROTECT_CONTENTS
+	snug_fit = TRUE
 
 /obj/item/clothing/suit/radiation
 	name = "radiation suit"

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -8,6 +8,7 @@
 	strip_delay = 50
 	equip_delay_other = 50
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	snug_fit = TRUE
 	dog_fashion = /datum/dog_fashion/head/blue_wizard
 
 /obj/item/clothing/head/wizard/red

--- a/code/modules/hydroponics/beekeeping/beekeeper_suit.dm
+++ b/code/modules/hydroponics/beekeeping/beekeeper_suit.dm
@@ -5,7 +5,7 @@
 	icon_state = "beekeeper"
 	item_state = "beekeeper"
 	clothing_flags = THICKMATERIAL
-
+	snug_fit = TRUE
 
 /obj/item/clothing/suit/beekeeper_suit
 	name = "beekeeper suit"


### PR DESCRIPTION
:cl: MMMiracles
add: You can now throw hats onto people's heads by targeting their head
add: Hats that aren't sufficiently snug on one's head can be knocked off by another incoming hat.
/:cl:

Throwing a hat at someone will now have it land on their head, or if they're wearing a hat, will knock it off and replace it if the worn hat isn't sufficiently snug enough. This excludes all helmets, wizard hats, hard hats, and space helmets. I don't know if security berets should be added to that since they're effectively helmets but the idea of having some mechanical difference between your regular helmet and the berets is funny to me.

'but what about c4???'

c4 takes away some throw speed and throw distance on any item you plant it on so cross-screen frisbeeing of explosive hats requires something like a pneumatic cannon to accomplish



