### PR TITLE
Moves the janitorial closet and adds the vacant commissary to Metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -29028,7 +29028,7 @@
 "bdA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "bdB" = (
 /obj/machinery/airalarm{
 	pixel_y = 28
@@ -29045,7 +29045,7 @@
 	},
 /obj/item/storage/secure/briefcase,
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "bdC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -29066,7 +29066,7 @@
 	},
 /obj/item/pen,
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "bdD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -29094,7 +29094,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "bdE" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -29907,13 +29907,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "bfk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "bfl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29923,7 +29923,7 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "bfm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -29937,7 +29937,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "bfn" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -30864,7 +30864,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "bhb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool,
@@ -30875,12 +30875,12 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "bhc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "bhd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -30902,7 +30902,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "bhe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -31867,7 +31867,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "biU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -31877,10 +31877,10 @@
 	pixel_y = -30
 	},
 /turf/open/floor/plating,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "biV" = (
 /obj/machinery/power/apc{
-	areastring = "/area/security/vacantcommissary";
+	areastring = "/area/vacant_room/commissary";
 	dir = 4;
 	name = "Vacant Commissary APC";
 	pixel_x = 27;
@@ -31902,7 +31902,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "biW" = (
 /obj/item/storage/box/lights/mixed,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -77690,7 +77690,7 @@
 "cXT" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "cXZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/window/reinforced{
@@ -81767,7 +81767,7 @@
 "dtM" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "dtP" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -83971,7 +83971,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "pvA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -84111,7 +84111,7 @@
 "qBS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "qJZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -84184,7 +84184,7 @@
 /area/library)
 "rrB" = (
 /turf/closed/wall,
-/area/security/vacantcommissary)
+/area/vacant_room/commissary)
 "rxn" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -26

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -29030,10 +29030,6 @@
 /turf/closed/wall,
 /area/security/vacantcommissary)
 "bdB" = (
-/obj/machinery/camera{
-	c_tag = "Custodial Closet";
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	pixel_y = 28
 	},
@@ -31903,6 +31899,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/camera{
+	c_tag = "Vacant Commissary";
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/vacantcommissary)
 "biW" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18,9 +18,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aae" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -284,7 +282,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -335,33 +333,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aaU" = (
-/obj/machinery/light_switch,
-/turf/closed/wall,
-/area/maintenance/disposal/incinerator)
 "aaV" = (
-/obj/machinery/atmospherics/components/unary/tank/toxins{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
+/turf/closed/wall,
+/area/janitor)
 "aaW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aaX" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
 	name = "old sink";
 	pixel_y = 28
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aaY" = (
@@ -403,16 +390,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/disposal/incinerator";
+	dir = 1;
+	name = "Incinerator APC";
+	pixel_y = 25
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "abe" = (
@@ -560,13 +547,37 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "abt" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/storage/box/lights/mixed,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/box/lights/mixed{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/storage/box/lights/mixed{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/grenade/chem_grenade/cleaner{
+	pixel_x = -7;
+	pixel_y = 12
+	},
+/obj/item/grenade/chem_grenade/cleaner{
+	pixel_x = -7;
+	pixel_y = 12
+	},
+/obj/item/grenade/chem_grenade/cleaner{
+	pixel_x = -7;
+	pixel_y = 12
+	},
+/obj/machinery/requests_console{
+	department = "Janitorial";
+	departmentType = 1;
+	pixel_x = 0;
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "abu" = (
 /obj/docking_port/stationary{
 	dir = 1;
@@ -862,18 +873,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acd" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/portable_atmospherics/canister,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
+/turf/closed/wall,
+/area/janitor)
 "ace" = (
 /obj/machinery/vending/sustenance{
 	desc = "A vending machine normally reserved for work camps.";
@@ -1561,9 +1563,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -1761,19 +1760,16 @@
 /turf/open/space,
 /area/space/nearstation)
 "adH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/janitor)
 "adI" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/janitor)
 "adJ" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -2248,13 +2244,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
-"aeD" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "aeE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3114,9 +3103,6 @@
 /area/security/prison)
 "afQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -5000,11 +4986,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ajk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
-/area/maintenance/starboard)
+/mob/living/simple_animal/hostile/lizard{
+	name = "Wags-His-Tail";
+	real_name = "Wags-His-Tail"
+	},
+/turf/open/floor/plating,
+/area/janitor)
 "ajl" = (
 /obj/item/soap/deluxe,
 /obj/item/storage/secure/safe{
@@ -7057,15 +7047,14 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "amB" = (
-/obj/structure/closet,
-/obj/item/flashlight,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/plasteel,
+/area/janitor)
 "amC" = (
 /obj/structure/chair{
 	dir = 4
@@ -7250,11 +7239,11 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/extinguisher,
 /obj/machinery/light/small,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "amW" = (
@@ -8819,10 +8808,6 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/plasteel,
 /area/security/main)
-"apX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
 "apY" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -8907,7 +8892,7 @@
 /obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/syringe,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -27478,21 +27463,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"baI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 2
 	},
@@ -27501,9 +27471,6 @@
 "baJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 2
@@ -27521,9 +27488,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 2
 	},
@@ -27534,12 +27498,6 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 2
 	},
@@ -27553,23 +27511,20 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "baN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 2
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -27580,9 +27535,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 2
@@ -28346,9 +28298,6 @@
 /area/hallway/primary/port)
 "bcb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/radio/intercom{
-	pixel_x = -29
-	},
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
@@ -28357,24 +28306,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bcc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bcd" = (
 /turf/closed/wall,
-/area/janitor)
-"bce" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Custodial Closet";
-	req_access_txt = "26"
-	},
-/turf/open/floor/plasteel,
 /area/janitor)
 "bcf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -28387,7 +28320,6 @@
 /obj/machinery/door/airlock{
 	name = "Central Emergency Storage"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -29093,68 +29025,85 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bdy" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	sortType = 22
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bdz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bdA" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/light_switch{
-	pixel_x = 8;
-	pixel_y = 30
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/janitor)
+/turf/closed/wall,
+/area/security/vacantcommissary)
 "bdB" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/janitor)
-"bdC" = (
-/obj/structure/closet/l3closet/janitor,
+/obj/machinery/camera{
+	c_tag = "Custodial Closet";
+	dir = 4
+	},
 /obj/machinery/airalarm{
 	pixel_y = 28
 	},
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/item/storage/secure/briefcase,
+/turf/open/floor/plasteel,
+/area/security/vacantcommissary)
+"bdC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen,
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/security/vacantcommissary)
 "bdD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/machinery/vending/wardrobe/jani_wardrobe,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch{
+	pixel_x = 28;
+	pixel_y = -6
+	},
+/obj/structure/table,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/obj/item/stack/sheet/metal/five,
+/obj/item/radio/intercom{
+	pixel_x = 28;
+	pixel_y = 5
+	},
+/obj/item/circuitboard/machine/paystand,
+/obj/item/stack/cable_coil/random/five,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/security/vacantcommissary)
 "bdE" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bdF" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -29945,80 +29894,79 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bfj" = (
-/obj/item/restraints/legcuffs/beartrap,
-/obj/item/restraints/legcuffs/beartrap,
-/obj/structure/table,
-/obj/machinery/requests_console{
-	department = "Janitorial";
-	departmentType = 1;
-	pixel_x = -29
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutter";
+	name = "Vacant Commissary Shutter"
 	},
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/camera{
-	c_tag = "Custodial Closet";
-	dir = 4
+/obj/structure/noticeboard{
+	desc = "A board for pinning important notices upon.";
+	name = "notice board";
+	pixel_y = 31
 	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/security/vacantcommissary)
 "bfk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/janitor)
+/area/security/vacantcommissary)
 "bfl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/security/vacantcommissary)
 "bfm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/janitor)
-"bfn" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Custodial Maintenance";
-	req_access_txt = "26"
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/security/vacantcommissary)
+"bfn" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/door/airlock/maintenance{
+	id_tag = "commissarydoor";
+	req_one_access_txt = "12;63;48;50"
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bfo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -30026,9 +29974,6 @@
 /obj/item/flashlight{
 	pixel_x = 1;
 	pixel_y = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -30911,58 +30856,59 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bha" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Custodial Closet APC";
-	areastring = "/area/janitor";
-	pixel_x = -24
-	},
-/obj/structure/table,
-/obj/item/clothing/gloves/color/orange,
-/obj/item/storage/box/mousetraps,
-/obj/item/storage/box/mousetraps,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutter";
+	name = "Vacant Commissary Shutter"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/security/vacantcommissary)
 "bhb" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/lizard{
-	name = "Wags-His-Tail";
-	real_name = "Wags-His-Tail"
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/security/vacantcommissary)
 "bhc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/landmark/start/janitor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/security/vacantcommissary)
 "bhd" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	id = "commissarydoor";
+	name = "Commissary Door Lock";
+	normaldoorcontrol = 1;
+	pixel_x = 26;
+	pixel_y = 6;
+	specialfunctions = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/security/vacantcommissary)
 "bhe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -31907,41 +31853,58 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"biS" = (
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed,
-/obj/item/storage/box/lights/mixed,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/janitor)
 "biT" = (
-/obj/structure/janitorialcart,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "commissaryshutter";
+	name = "Commissary Shutter Control";
+	pixel_x = -26;
+	pixel_y = 6;
+	req_access_txt = "19"
+	},
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/security/vacantcommissary)
 "biU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/light/small,
-/obj/item/radio/intercom{
-	pixel_y = -28
+/obj/item/storage/secure/safe{
+	pixel_x = 6;
+	pixel_y = -30
 	},
-/obj/vehicle/ridden/janicart,
-/obj/item/key/janitor,
 /turf/open/floor/plating,
-/area/janitor)
+/area/security/vacantcommissary)
 "biV" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/power/apc{
+	areastring = "/area/security/vacantcommissary";
+	dir = 4;
+	name = "Vacant Commissary APC";
+	pixel_x = 27;
+	pixel_y = 2
 	},
-/obj/machinery/disposal/bin,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow,
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/screwdriver,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/security/vacantcommissary)
 "biW" = (
 /obj/item/storage/box/lights/mixed,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -53304,8 +53267,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/closed/wall,
+/area/janitor)
 "bZC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -54133,6 +54096,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "caZ" = (
@@ -55670,20 +55637,26 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
-"cdW" = (
-/obj/item/flashlight,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "cdX" = (
-/obj/structure/closet/crate,
-/obj/item/coin/silver,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/mousetraps{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/structure/table,
+/obj/item/storage/box/mousetraps{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/clothing/gloves/color/orange{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/radio/intercom{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "ced" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56300,11 +56273,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -56312,11 +56285,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 2
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	sortType = 22
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -56324,21 +56301,36 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/door/airlock{
+	name = "Custodial Closet";
+	req_access_txt = "26"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"cfl" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Storage Room";
-	req_access_txt = "12"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/janitor)
+"cfl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = 26
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "cfq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -56924,32 +56916,15 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard/aft)
-"cgt" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Incinerator APC";
-	areastring = "/area/maintenance/disposal/incinerator";
-	pixel_x = -24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "cgu" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cgv" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
 	},
@@ -57642,21 +57617,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "chE" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"chG" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/item/storage/toolbox/emergency,
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/janitorialcart,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
+/area/janitor)
 "chM" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -59007,9 +58972,6 @@
 "ckz" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ckD" = (
@@ -77727,6 +77689,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"cXT" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/security/vacantcommissary)
 "cXZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/window/reinforced{
@@ -81800,6 +81766,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"dtM" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/security/vacantcommissary)
 "dtP" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -82724,9 +82694,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -82957,6 +82924,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"enV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = -29
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eoK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -83285,6 +83262,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"ieW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "ifN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -83344,12 +83326,33 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"iAj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	areastring = "/area/janitor";
+	dir = 8;
+	name = "Custodial Closet APC";
+	pixel_x = -25
+	},
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/structure/cable/yellow,
+/turf/open/floor/plasteel,
+/area/janitor)
 "iHl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"iKA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/starboard)
 "iLj" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -83434,6 +83437,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"kcI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/janitor,
+/turf/open/floor/plasteel,
+/area/janitor)
 "kfu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -83448,6 +83456,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"kjh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/vehicle/ridden/janicart,
+/obj/item/key/janitor,
+/turf/open/floor/plasteel,
+/area/janitor)
 "krD" = (
 /turf/closed/wall,
 /area/science/circuit)
@@ -83459,6 +83473,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"kwL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/turf/open/floor/plasteel,
+/area/janitor)
 "kxk" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -83533,6 +83553,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"kSB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/machinery/camera{
+	c_tag = "Custodial Closet";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "kVo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83611,6 +83644,15 @@
 	},
 /turf/open/floor/plating,
 /area/science/nanite)
+"lUZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/l3closet/janitor,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "lWY" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Server Room"
@@ -83686,6 +83728,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"mGS" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"mKO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/tank/toxins{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "mWg" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -83832,6 +83891,15 @@
 "owR" = (
 /turf/closed/wall,
 /area/engine/storage_shared)
+"oxX" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/closet,
+/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "oJW" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Foyer - Shared Storage";
@@ -83901,6 +83969,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"pqy" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel,
+/area/security/vacantcommissary)
 "pvA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -83927,9 +84000,6 @@
 "pCV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -83978,6 +84048,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"qbK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "qcZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -84030,6 +84110,10 @@
 "qBq" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/hallway/secondary/entry)
+"qBS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/security/vacantcommissary)
 "qJZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -84100,6 +84184,9 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"rrB" = (
+/turf/closed/wall,
+/area/security/vacantcommissary)
 "rxn" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -26
@@ -84126,6 +84213,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"rBU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "rCu" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -84487,6 +84580,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"wgP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wiZ" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -84567,6 +84672,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"xdW" = (
+/obj/machinery/vending/wardrobe/jani_wardrobe,
+/turf/open/floor/plasteel,
+/area/janitor)
 "xkG" = (
 /obj/item/integrated_electronics/wirer,
 /obj/structure/table/reinforced,
@@ -84576,6 +84685,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"xop" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "xse" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -106906,7 +107031,7 @@ aTb
 aUp
 aJO
 aXv
-aYU
+enV
 baF
 bcb
 bdx
@@ -107166,7 +107291,7 @@ aXw
 aYV
 baG
 baG
-bdy
+baG
 baG
 baG
 baG
@@ -107422,12 +107547,12 @@ aVR
 aXx
 aYW
 baH
-bcc
-bdz
 bfi
 bfi
 bfi
-bky
+bfi
+bfi
+wgP
 bmn
 bfi
 bqA
@@ -107678,12 +107803,12 @@ aUs
 aJR
 aXy
 dCE
-baI
-bcd
-bcd
-bcd
-bcd
-bcd
+baQ
+rrB
+pqy
+cXT
+cXT
+dtM
 bkz
 bkz
 bol
@@ -107935,12 +108060,12 @@ aUt
 aVS
 aXz
 aYY
-baI
-bcd
+baQ
+rrB
 bdA
 bfj
 bha
-biS
+bdA
 bkz
 bmo
 bom
@@ -108193,7 +108318,7 @@ aVT
 aXA
 aYZ
 baJ
-bce
+rrB
 bdB
 bfk
 bhb
@@ -108450,7 +108575,7 @@ aJR
 aXB
 aZa
 baK
-bcd
+rrB
 bdC
 bfl
 bhc
@@ -108707,7 +108832,7 @@ aVU
 aXC
 aYX
 baL
-bcf
+qBS
 bdD
 bfm
 bhd
@@ -108964,11 +109089,11 @@ aVV
 aXD
 aZb
 baM
-bcd
-bcd
+rrB
+rrB
 bfn
-bcd
-bcd
+rrB
+rrB
 bcg
 bmr
 bkz
@@ -121335,7 +121460,7 @@ caS
 ccB
 bST
 cfi
-aqr
+iKA
 chB
 dvY
 cku
@@ -121592,8 +121717,8 @@ caT
 ccC
 bST
 dDs
-apc
-apb
+rBU
+chD
 dvY
 ckv
 clZ
@@ -121849,7 +121974,7 @@ caU
 ccD
 cdV
 cfj
-apc
+mGS
 chC
 dvY
 dvY
@@ -122104,11 +122229,11 @@ bYp
 bZy
 tsx
 bZB
-cdW
+bcd
 cfk
-apc
-chD
-dvY
+bcd
+bcd
+bcd
 ckw
 cma
 cna
@@ -122360,12 +122485,12 @@ kys
 cow
 xVl
 dLK
-alq
-alq
+bcd
+kSB
 cfl
-alq
-alq
-dvY
+iAj
+kjh
+bcd
 ckx
 ciL
 dwQ
@@ -122617,12 +122742,12 @@ xVl
 mvj
 xVl
 dLK
-alq
+bcd
 cdX
 adH
-apc
+kcI
 chE
-dvY
+bcd
 cky
 ciL
 dwX
@@ -122874,12 +122999,12 @@ bVC
 nAG
 pCV
 aaM
-bmR
+bcd
 abt
 adI
 ajk
 amB
-apX
+bcd
 ckz
 ciL
 dwY
@@ -123130,13 +123255,13 @@ uJU
 uJU
 pvA
 aae
-bZE
-bZE
-bZE
-bZE
-bZE
-bZE
-bZE
+oxX
+bcf
+xdW
+lUZ
+xop
+kwL
+bcf
 aqe
 dwQ
 cnb
@@ -123390,10 +123515,10 @@ apc
 bZE
 aaV
 acd
-aeD
-cgt
-chG
-bZE
+acd
+acd
+acd
+bcd
 arh
 cmb
 cnc
@@ -123643,11 +123768,11 @@ alq
 bVC
 bWY
 bYr
-apc
+avs
 bZE
-aaW
-aaW
-aaW
+mKO
+qbK
+ieW
 cgu
 amV
 bZC
@@ -123900,7 +124025,7 @@ alq
 diu
 bWZ
 aad
-apc
+bcs
 bZE
 aaX
 adk
@@ -124158,7 +124283,7 @@ bVE
 bXa
 apc
 bZE
-aaU
+bZE
 abd
 adl
 ahT
@@ -125436,7 +125561,7 @@ atm
 cTw
 bPn
 bQR
-apc
+bSd
 anM
 bxc
 bVF

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -29898,8 +29898,6 @@
 	name = "Vacant Commissary Shutter"
 	},
 /obj/structure/noticeboard{
-	desc = "A board for pinning important notices upon.";
-	name = "notice board";
 	pixel_y = 31
 	},
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -31854,7 +31854,7 @@
 	name = "Commissary Shutter Control";
 	pixel_x = -26;
 	pixel_y = 6;
-	req_access_txt = "19"
+	req_access_txt = "0"
 	},
 /obj/structure/table,
 /obj/item/stack/packageWrap,


### PR DESCRIPTION
:cl: Mickyan
tweak: Metastation: The janitorial closet has been moved in the maintenance section of the service wing
add: Metastation: Added the vacant commissary where the janitorial closet used to be
/:cl:
Killing two birds with one stone in my opinion, now the janitor resides in its department's wing instead of on the opposite side of the station. 
It was also done out of necessity as it was the only suitable room that could be moved without causing too many changes to make space for the commissary. 
You usually stop by the janitor closet once or twice during the entire shift, so it being a bit out of the way isn't really an issue.

Meanwhile I've also rearranged the closet itself so you no longer have to move equipment around to reach everything as well as moved an intercom by the cargo hallway that appeared on top of a display screen

![meta_comm](https://user-images.githubusercontent.com/38563876/47190569-7e981b00-d342-11e8-8829-be21749dc46e.png)
