### PR TITLE
Fixes syndicate MMI nameswaping, adds better user feedback when inserting a dead brain

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9055,9 +9055,7 @@
 	},
 /area/maintenance/starboard)
 "aqs" = (
-/obj/item/mmi{
-	name = "man-machine interface"
-	},
+/obj/item/mmi,
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -208,7 +208,7 @@
 		brainopslastname = creator_op.nuke_team.syndicate_name
 	var/brainopsname = "[brainfirstname] [brainopslastname]"
 
-	R.mmi.name = "Man-Machine Interface: [brainopsname]"
+	R.mmi.name = "[initial(R.mmi.name)]: [brainopsname]"
 	R.mmi.brain.name = "[brainopsname]'s brain"
 	R.mmi.brainmob.real_name = brainopsname
 	R.mmi.brainmob.name = brainopsname

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -1,5 +1,5 @@
 /obj/item/mmi
-	name = "Man-Machine Interface"
+	name = "\improper Man-Machine Interface"
 	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity, that nevertheless has become standard-issue on Nanotrasen stations."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "mmi_off"
@@ -32,7 +32,7 @@
 /obj/item/mmi/Initialize()
 	. = ..()
 	radio = new(src) //Spawns a radio inside the MMI.
-	radio.broadcasting = 0 //researching radio mmis turned the robofabs into radios because this didnt start as 0.
+	radio.broadcasting = FALSE //researching radio mmis turned the robofabs into radios because this didnt start as 0.
 	laws.set_laws_config()
 
 /obj/item/mmi/attackby(obj/item/O, mob/user, params)
@@ -51,7 +51,7 @@
 		var/mob/living/brain/B = newbrain.brainmob
 		if(!B.key)
 			B.notify_ghost_cloning("Someone has put your brain in a MMI!", source = src)
-		visible_message("[user] sticks \a [newbrain] into \the [src].")
+		user.visible_message("[user] sticks \a [newbrain] into [src].", "<span class='notice'>[src]'s indicator light turn on as you insert [newbrain].</span>")
 
 		brainmob = newbrain.brainmob
 		newbrain.brainmob = null
@@ -61,11 +61,14 @@
 			brainmob.stat = CONSCIOUS //we manually revive the brain mob
 			GLOB.dead_mob_list -= brainmob
 			GLOB.alive_mob_list += brainmob
+		else
+			to_chat(user, "<span class='warning'>[src]'s indicator light turns red and its brainwave activity alarm beeps softly. Perhaps you should check [newbrain] again.</span>")
+			playsound(src, "sound/weapons/smg_empty_alarm.ogg", 5, TRUE)
 
 		brainmob.reset_perspective()
 		brain = newbrain
 
-		name = "Man-Machine Interface: [brainmob.real_name]"
+		name = "[initial(name)]: [brainmob.real_name]"
 		update_icon()
 
 		SSblackbox.record_feedback("amount", "mmis_filled", 1)
@@ -79,12 +82,12 @@
 /obj/item/mmi/attack_self(mob/user)
 	if(!brain)
 		radio.on = !radio.on
-		to_chat(user, "<span class='notice'>You toggle the MMI's radio system [radio.on==1 ? "on" : "off"].</span>")
+		to_chat(user, "<span class='notice'>You toggle the [src]'s radio system [radio.on==1 ? "on" : "off"].</span>")
 	else
-		to_chat(user, "<span class='notice'>You unlock and upend the MMI, spilling the brain onto the floor.</span>")
 		eject_brain(user)
 		update_icon()
-		name = "Man-Machine Interface"
+		name = initial(name)
+		to_chat(user, "<span class='notice'>You unlock and upend [src], spilling the brain onto the floor.</span>")
 
 /obj/item/mmi/proc/eject_brain(mob/user)
 	brainmob.container = null //Reset brainmob mmi var.
@@ -124,7 +127,7 @@
 		brain = new(src)
 		brain.name = "[L.real_name]'s brain"
 
-	name = "Man-Machine Interface: [brainmob.real_name]"
+	name = "[initial(name)]: [brainmob.real_name]"
 	update_icon()
 	return
 
@@ -136,7 +139,7 @@
 	set desc = "Toggle listening channel on or off."
 	set category = "MMI"
 	set src = usr.loc
-	set popup_menu = 0
+	set popup_menu = FALSE
 
 	if(brainmob.stat)
 		to_chat(brainmob, "<span class='warning'>Can't do that while incapacitated or dead!</span>")
@@ -144,8 +147,8 @@
 		to_chat(brainmob, "<span class='warning'>Your radio is disabled!</span>")
 		return
 
-	radio.listening = radio.listening==1 ? 0 : 1
-	to_chat(brainmob, "<span class='notice'>Radio is [radio.listening==1 ? "now" : "no longer"] receiving broadcast.</span>")
+	radio.listening = !radio.listening
+	to_chat(brainmob, "<span class='notice'>Radio is [radio.listening ? "now" : "no longer"] receiving broadcast.</span>")
 
 /obj/item/mmi/emp_act(severity)
 	. = ..()
@@ -202,11 +205,11 @@
 	return //so that the MMI won't get a warning about not being able to move if it tries to move
 
 /obj/item/mmi/syndie
-	name = "Syndicate Man-Machine Interface"
+	name = "\improper Syndicate Man-Machine Interface"
 	desc = "Syndicate's own brand of MMI. It enforces laws designed to help Syndicate agents achieve their goals upon cyborgs and AIs created with it."
 	overrides_aicore_laws = TRUE
 
 /obj/item/mmi/syndie/Initialize()
 	. = ..()
 	laws = new /datum/ai_laws/syndicate_override()
-	radio.on = 0
+	radio.on = FALSE

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -82,7 +82,7 @@
 /obj/item/mmi/attack_self(mob/user)
 	if(!brain)
 		radio.on = !radio.on
-		to_chat(user, "<span class='notice'>You toggle the [src]'s radio system [radio.on==1 ? "on" : "off"].</span>")
+		to_chat(user, "<span class='notice'>You toggle [src]'s radio system [radio.on==1 ? "on" : "off"].</span>")
 	else
 		eject_brain(user)
 		update_icon()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -154,12 +154,12 @@
 		mmi = new (src)
 		mmi.brain = new /obj/item/organ/brain(mmi)
 		mmi.brain.name = "[real_name]'s brain"
-		mmi.icon_state = "mmi_full"
-		mmi.name = "Man-Machine Interface: [real_name]"
+		mmi.name = "[initial(mmi.name)]: [real_name]"
 		mmi.brainmob = new(mmi)
 		mmi.brainmob.name = src.real_name
 		mmi.brainmob.real_name = src.real_name
 		mmi.brainmob.container = mmi
+		mmi.update_icon()
 
 	updatename()
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -382,7 +382,7 @@
 	R.apply_pref_name("cyborg")
 
 	if(R.mmi)
-		R.mmi.name = "Man-Machine Interface: [real_name]"
+		R.mmi.name = "[initial(R.mmi.name)]: [real_name]"
 		if(R.mmi.brain)
 			R.mmi.brain.name = "[real_name]'s brain"
 		if(R.mmi.brainmob)


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed Syndicate MMI's having their name swapped when inserting a brain.
tweak: Added better user feedback when inserting a dead brain into an MMI.
/:cl: