### PR TITLE
Nanite brainwashing no longer spams the brainwashee and dchat

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -142,6 +142,8 @@
 #define COMSIG_LIVING_EXTINGUISHED "living_extinguished"		//from base of mob/living/ExtinguishMob() (/mob/living)
 #define COMSIG_LIVING_ELECTROCUTE_ACT "living_electrocute_act"		//from base of mob/living/electrocute_act(): (shock_damage)
 #define COMSIG_LIVING_MINOR_SHOCK "living_minor_shock"			//sent by stuff like stunbatons and tasers: ()
+#define COMSIG_LIVING_BRAINWASHED "living_brainwashed"          // mob/living has the brainwashed antagonist datum added
+#define COMSIG_LIVING_UNBRAINWASHED "living_unbrainwashed"          // mob/living has the brainwashed antagonist datum added
 
 //ALL OF THESE DO NOT TAKE INTO ACCOUNT WHETHER AMOUNT IS 0 OR LOWER AND ARE SENT REGARDLESS!
 #define COMSIG_LIVING_STATUS_STUN "living_stun"					//from base of mob/living/Stun() (amount, update, ignore)

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -16,7 +16,6 @@
 			var/datum/objective/brainwashing/objective = new(O)
 			B.objectives += objective
 		M.add_antag_datum(B)
-
 	var/begin_message = "<span class='deadsay'><b>[L]</b> has been brainwashed with the following objectives: "
 	var/obj_message = english_list(directives)
 	var/end_message = "</b>.</span>"
@@ -30,6 +29,14 @@
 	show_in_antagpanel = TRUE
 	antagpanel_category = "Other"
 	show_name_in_check_antagonists = TRUE
+
+/datum/antagonist/brainwashed/on_gain()
+	. = ..()
+	SEND_SIGNAL(owner, COMSIG_LIVING_BRAINWASHED)
+
+/datum/antagonist/brainwashed/on_removal()
+	. = ..()
+	SEND_SIGNAL(owner, COMSIG_LIVING_UNBRAINWASHED)
 
 /datum/antagonist/brainwashed/greet()
 	to_chat(owner, "<span class='warning'>Your mind reels as it begins focusing on a single purpose...</span>")

--- a/code/modules/research/nanites/nanite_programs/weapon.dm
+++ b/code/modules/research/nanites/nanite_programs/weapon.dm
@@ -170,6 +170,12 @@
 	extra_settings = list("Directive")
 	var/cooldown = 0 //avoids spam when nanites are running low
 	var/directive = "..."
+	var/brainwashed = FALSE
+
+/datum/nanite_program/mind_control/on_mob_add()
+	. = ..()
+	//Register to signal when they get unbrainwashed, so if we're passively rewashing we can do it
+	RegisterSignal(nanites.host_mob, COMSIG_LIVING_UNBRAINWASHED, .proc/host_mob_unbrainwashed)
 
 /datum/nanite_program/mind_control/set_extra_setting(user, setting)
 	if(setting == "Directive")
@@ -182,15 +188,20 @@
 	if(setting == "Directive")
 		return directive
 
+/datum/nanite_program/mind_control/proc/host_mob_unbrainwashed()
+	//Host mob is unbrainwashed, let the passive effect rebrainwash them
+	brainwashed=FALSE
+
 /datum/nanite_program/mind_control/copy_extra_settings_to(datum/nanite_program/mind_control/target)
 	target.directive = directive
 
 /datum/nanite_program/mind_control/enable_passive_effect()
-	if(world.time < cooldown)
+	if( ( world.time < cooldown ) || brainwashed)
 		return
 	. = ..()
 	brainwash(host_mob, directive)
 	log_game("A mind control nanite program brainwashed [key_name(host_mob)] with the objective '[directive]'.")
+	brainwashed = TRUE//stop brainwashing until done
 
 /datum/nanite_program/mind_control/disable_passive_effect()
 	. = ..()


### PR DESCRIPTION
We simply set a var when we brainwash someone and then unset it when
they get unbrainwashed by some means, so we can reapply it

This prevents the deadchat and brainwashee spam that happens, while
still allowing brainwashing to reapply if the user is unbrainwashed

I'm not 100% happy about this, since it still ticks needlessly on the
nanites timer but I didn't see any on_passive_effect toggle on/ toggle
off procs that I could hook to do the brainwash/unbrainwash and remove
the ticking proc all together (in favour of just brainwashing on effect
start, end and unbrainwash while effect in progress)

@XDTM please review as I am not familiar with the nanites programs subsystem