### PR TITLE
Makes Romerol Buyable for Nuke Ops

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -777,7 +777,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/romerol
 	cost = 25
 	cant_discount = TRUE
-	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/dart_pistol
 	name = "Dart Pistol"


### PR DESCRIPTION
🆑 Fluffe9911
add: Nuke Ops can now buy romerol!
/🆑
I mean it makes sense when you think about it its a weapon of mass destruction that generally ends in the station being all flesh eating zombies which at worst backfires horribly and at best can lead to a quick in and out grab the disk or a distraction. plus this has the potential to lead to some interesting situations with how the nukies and crew handle it so why not. then again this may be a bad idea only time will tell *shrug*