### PR TITLE
Fixes penguin butchering and makes babies drop one meat

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/penguin.dm
+++ b/code/modules/mob/living/simple_animal/friendly/penguin.dm
@@ -31,6 +31,7 @@
 	icon_dead = "penguin_dead"
 	butcher_results = list()
 	gold_core_spawnable = FRIENDLY_SPAWN
+	butcher_results = list(/obj/item/organ/ears/penguin = 1, /obj/item/reagent_containers/food/snacks/meat/slab/penguin = 3)
 
 /mob/living/simple_animal/pet/penguin/emperor/shamebrero
 	name = "Shamebrero penguin"
@@ -51,3 +52,4 @@
 	density = FALSE
 	pass_flags = PASSMOB
 	mob_size = MOB_SIZE_SMALL
+	butcher_results = list(/obj/item/organ/ears/penguin = 1, /obj/item/reagent_containers/food/snacks/meat/slab/penguin = 1)


### PR DESCRIPTION
Fixes #41026 
You sicko don't go killing babies for food
:cl: BebeYoshi
fix: Penguins drops their organs when butchered.
balance: Baby penguins only drop one meat instead of three.
/:cl:
