### PR TITLE
Alters Sketchin Uplink Description

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -429,8 +429,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/ammo/pistol
 	name = "10mm Handgun Magazine"
-	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol. These rounds \
-			are dirt cheap but are half as effective as .357 rounds."
+	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol."
 	item = /obj/item/ammo_box/magazine/m10mm
 	cost = 1
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)


### PR DESCRIPTION
Alter the Sketchin desc in the Syndicate Uplink menu slightly, it now says "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol.", instead of further having the words "These rounds are dirt cheap but are half as effective as .357 rounds.".

Main reason being I find that line redundant, and that I got slightly confused when I saw the desc and thought it implied there was a better magazine type I can buy that deals double the damage for more TC. 