### PR TITLE
Lisa will no longer mate with corgi puppies. (Fixes istype checks in make_babies)

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -377,12 +377,12 @@
 	for(var/mob/M in view(7, src))
 		if(M.stat != CONSCIOUS) //Check if it's conscious FIRST.
 			continue
-		else if(istype(M, childtype)) //Check for children SECOND.
+		else if(is_type_in_typecache(M, childtype)) //Check for children SECOND.
 			children++
 		else if(istype(M, animal_species))
 			if(M.ckey)
 				continue
-			else if(!istype(M, childtype) && M.gender == MALE) //Better safe than sorry ;_;
+			else if(!is_type_in_typecache(M, childtype) && M.gender == MALE) //Better safe than sorry ;_;
 				partner = M
 
 		else if(isliving(M) && !faction_check_mob(M)) //shyness check. we're not shy in front of things that share a faction with us.


### PR DESCRIPTION
morality has been restored to the world

The reason is actually relatively boring: whenever childtype was turned into lists, that fucked up the istype checks. Lisa and all simple animals were actually being prevented from mating with BYOND lists, not with their children.

The other thing affected by this is the max children in view of mob check, which also used istype incorrectly, which incorrectly allowed for the return of the petsplosion bug. Please do not bitch (no pun intended) about this. 

Fixes https://github.com/tgstation/tgstation/issues/41044.
Fixes https://github.com/tgstation/tgstation/issues/27550 for real.