### PR TITLE
Raises cult minimum pop to match scaling.

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -38,7 +38,7 @@
 	false_report_weight = 10
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
 	protected_jobs = list()
-	required_players = 24
+	required_players = 29
 	required_enemies = 4
 	recommended_enemies = 4
 	enemy_minimum_age = 14


### PR DESCRIPTION
Cult scales recommenced below required so it fail if the addition member chance didn't hit.
Alternative solution is to just bump it up to required but personally i'd rather see less of it.

Fixes #41053