### PR TITLE
Fixes items worn by a burning mob not getting burning overlays while taking damage.

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1617,8 +1617,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 		for(var/X in burning_items)
 			var/obj/item/I = X
-			if(!(I.resistance_flags & FIRE_PROOF))
-				I.take_damage(H.fire_stacks, BURN, "fire", 0)
+			I.fire_act((H.fire_stacks * 50)) //damage taken is reduced to 2% of this value by fire_act()
 
 		var/thermal_protection = H.get_thermal_protection()
 

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -166,8 +166,7 @@
 
 	for(var/X in burning_items)
 		var/obj/item/I = X
-		if(!(I.resistance_flags & FIRE_PROOF))
-			I.take_damage(fire_stacks, BURN, "fire", 0)
+		I.fire_act((fire_stacks * 50)) //damage taken is reduced to 2% of this value by fire_act()
 
 	adjust_bodytemperature(BODYTEMP_HEATING_MAX)
 	SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "on_fire", /datum/mood_event/on_fire)


### PR DESCRIPTION
:cl:
fix: Fixed items worn by a burning mob not getting burning overlays while taking damage.
fix: Fixed items with special effects when lit on fire not having the effect triggered when worn by a mob.
/:cl: