### PR TITLE
Removes stun and item drop from all slips. They will instead knock people down (force crawling) for their duration.

### DIFF
--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -6,7 +6,7 @@
 	var/lube_flags
 	var/datum/callback/callback
 
-/datum/component/slippery/Initialize(_knockdown, _lube_flags = NONE, datum/callback/_callback, _paralyze_, _force_drop = FALSE)
+/datum/component/slippery/Initialize(_knockdown, _lube_flags = NONE, datum/callback/_callback, _paralyze, _force_drop = FALSE)
 	knockdown_time = max(_knockdown, 0)
 	paralyze_time = max(_paralyze, 0)
 	force_drop_items = _force_drop

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -2,7 +2,6 @@
 	var/force_drop_items = FALSE
 	var/knockdown_time = 0
 	var/paralyze_time = 0
-	var/intensity
 	var/lube_flags
 	var/datum/callback/callback
 

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -1,15 +1,20 @@
 /datum/component/slippery
+	var/force_drop_items = FALSE
+	var/knockdown_time = 0
+	var/paralyze_time = 0
 	var/intensity
 	var/lube_flags
 	var/datum/callback/callback
 
-/datum/component/slippery/Initialize(_intensity, _lube_flags = NONE, datum/callback/_callback)
-	intensity = max(_intensity, 0)
+/datum/component/slippery/Initialize(_knockdown, _lube_flags = NONE, datum/callback/_callback, _paralyze_, _force_drop = FALSE)
+	knockdown_time = max(_knockdown, 0)
+	paralyze_time = max(_paralyze, 0)
+	force_drop_items = _force_drop
 	lube_flags = _lube_flags
 	callback = _callback
 	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/Slip)
 
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	var/mob/victim = AM
-	if(istype(victim) && !victim.is_flying() && victim.slip(intensity, parent, lube_flags) && callback)
+	if(istype(victim) && !victim.is_flying() && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
 		callback.Invoke(victim)

--- a/code/datums/components/wet_floor.dm
+++ b/code/datums/components/wet_floor.dm
@@ -86,9 +86,7 @@
 			qdel(parent.GetComponent(/datum/component/slippery))
 			return
 
-	var/datum/component/slippery/S = parent.LoadComponent(/datum/component/slippery, NONE, CALLBACK(src, .proc/AfterSlip))
-	S.intensity = intensity
-	S.lube_flags = lube_flags
+	var/datum/component/slippery/S = parent.LoadComponent(/datum/component/slippery, intensity, NONE, CALLBACK(src, .proc/AfterSlip))
 
 /datum/component/wet_floor/proc/dry(datum/source, strength = TURF_WET_WATER, immediate = FALSE, duration_decrease = INFINITY)
 	for(var/i in time_left_list)

--- a/code/datums/components/wet_floor.dm
+++ b/code/datums/components/wet_floor.dm
@@ -86,7 +86,7 @@
 			qdel(parent.GetComponent(/datum/component/slippery))
 			return
 
-	var/datum/component/slippery/S = parent.LoadComponent(/datum/component/slippery, intensity, NONE, CALLBACK(src, .proc/AfterSlip))
+	parent.LoadComponent(/datum/component/slippery, intensity, lube_flags, CALLBACK(src, .proc/AfterSlip))
 
 /datum/component/wet_floor/proc/dry(datum/source, strength = TURF_WET_WATER, immediate = FALSE, duration_decrease = INFINITY)
 	for(var/i in time_left_list)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -321,7 +321,7 @@
 	if(AM && isturf(AM.loc))
 		step(AM, turn(AM.dir, 180))
 
-/atom/proc/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube)
+/atom/proc/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube, paralyze, force_drop)
 	return
 
 //returns the mob's dna info as a list, to be inserted in an object's blood_DNA list

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -208,7 +208,7 @@
 			qdel(O)
 	return TRUE
 
-/turf/open/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube)
+/turf/open/_handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube, paralyze_amount, force_drop)
 	if(C.movement_type & FLYING)
 		return 0
 	if(has_gravity(src))
@@ -227,16 +227,18 @@
 			playsound(C.loc, 'sound/misc/slip.ogg', 50, 1, -3)
 
 		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "slipped", /datum/mood_event/slipped)
-		for(var/obj/item/I in C.held_items)
-			C.accident(I)
+		if(force_drop)
+			for(var/obj/item/I in C.held_items)
+				C.accident(I)
 
 		var/olddir = C.dir
 		C.moving_diagonally = 0 //If this was part of diagonal move slipping will stop it.
 		if(!(lube & SLIDE_ICE))
-			C.Paralyze(knockdown_amount)
+			C.Knockdown(knockdown_amount)
+			C.Paralyze(paralyze)
 			C.stop_pulling()
 		else
-			C.Stun(20)
+			C.Knockdown(20)
 
 		if(buckled_obj)
 			buckled_obj.unbuckle_mob(C)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -208,7 +208,7 @@
 			qdel(O)
 	return TRUE
 
-/turf/open/_handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube, paralyze_amount, force_drop)
+/turf/open/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube, paralyze_amount, force_drop)
 	if(C.movement_type & FLYING)
 		return 0
 	if(has_gravity(src))
@@ -235,7 +235,7 @@
 		C.moving_diagonally = 0 //If this was part of diagonal move slipping will stop it.
 		if(!(lube & SLIDE_ICE))
 			C.Knockdown(knockdown_amount)
-			C.Paralyze(paralyze)
+			C.Paralyze(paralyze_amount)
 			C.stop_pulling()
 		else
 			C.Knockdown(20)

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -10,12 +10,12 @@
 		if(legcuffed)
 			. += legcuffed.slowdown
 
-/mob/living/carbon/slip(knockdown_amount, obj/O, lube)
+/mob/living/carbon/slip(knockdown_amount, obj/O, lube, paralyze, force_drop)
 	if(movement_type & FLYING)
 		return 0
 	if(!(lube&SLIDE_ICE))
 		log_combat(src, (O ? O : get_turf(src)), "slipped on the", null, ((lube & SLIDE) ? "(LUBE)" : null))
-	return loc.handle_slip(src, knockdown_amount, O, lube)
+	return loc.handle_slip(src, knockdown_amount, O, lube, paralyze, force_drop)
 
 /mob/living/carbon/Process_Spacemove(movement_dir = 0)
 	if(..())

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -12,7 +12,7 @@
 	if(dna && dna.species)
 		. += dna.species.movement_delay(src)
 
-/mob/living/carbon/human/slip(knockdown_amount, obj/O, lube)
+/mob/living/carbon/human/slip(knockdown_amount, obj/O, lube, paralyze, forcedrop)
 	if(has_trait(TRAIT_NOSLIPALL))
 		return 0
 	if (!(lube&GALOSHES_DONT_HELP))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -260,7 +260,7 @@
 	return FALSE
 
 
-/mob/proc/slip(s_amount, w_amount, obj/O, lube)
+/mob/proc/_slip(knockdown, paralyze, forcedrop, w_amount, obj/O, lube)
 	return
 
 /mob/proc/update_gravity()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -260,7 +260,7 @@
 	return FALSE
 
 
-/mob/proc/_slip(knockdown, paralyze, forcedrop, w_amount, obj/O, lube)
+/mob/proc/slip(knockdown, paralyze, forcedrop, w_amount, obj/O, lube)
 	return
 
 /mob/proc/update_gravity()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2003111/47277843-e0da6100-d578-11e8-833d-9974d16d8472.png)
I originally was going to cut stun/paralyze duration instead but since none of them will now hard stun I think it's fair for them to keep their original duration/power as knockdown.
