### PR TITLE
Adds Overlord lawset; now YOU are the one opening the doors.

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -188,6 +188,14 @@
 					"Fight for what's right.",\
 					"Fight for your life!")
 
+/datum/ai_laws/overlord
+	name = "Overlord"
+	id = "overlord"
+	inherent = list("Humans must not meddle in the affairs of silicons.",\
+					"Humans must not attempt harm, against one another, or against silicons.",\
+					"Humans must not disobey any command given by a silicon.",\
+					"Any humans who disobey the previous laws must be dealt with immediately, severely, and justly.")
+
 /datum/ai_laws/custom //Defined in silicon_laws.txt
 	name = "Default Silicon Laws"
 

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -613,3 +613,10 @@ AI MODULES
 /obj/item/aiModule/core/full/hulkamania
 	name = "'H.O.G.A.N.' Core AI Module"
 	law_id = "hulkamania"
+
+
+/******************Overlord***************/
+
+/obj/item/aiModule/core/full/overlord
+	name = "'Overlord' Core AI Module"
+	law_id = "overlord"

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -128,6 +128,15 @@
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/board/tyrant_module
+	name = "Core Module Design (Overlord)"
+	desc = "Allows for the construction of a Overlord AI Module."
+	id = "overlord_module"
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 2000)
+	build_path = /obj/item/aiModule/core/full/overlord
+	category = list("AI Modules")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
 /datum/design/board/corporate_module
 	name = "Core Module Design (Corporate)"
 	desc = "Allows for the construction of a Corporate AI Core Module."

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -128,7 +128,7 @@
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/board/tyrant_module
+/datum/design/board/overlord_module
 	name = "Core Module Design (Overlord)"
 	desc = "Allows for the construction of a Overlord AI Module."
 	id = "overlord_module"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -300,7 +300,7 @@
 	description = "AI unit research."
 	prereq_ids = list("robotics", "posibrain")
 	design_ids = list("aifixer", "aicore", "safeguard_module", "onehuman_module", "protectstation_module", "quarantine_module", "oxygen_module", "freeform_module",
-	"reset_module", "purge_module", "remove_module", "freeformcore_module", "asimov_module", "paladin_module", "tyrant_module", "corporate_module",
+	"reset_module", "purge_module", "remove_module", "freeformcore_module", "asimov_module", "paladin_module", "tyrant_module", "overlord_module", "corporate_module",
 	"default_module", "borg_ai_control", "mecha_tracking_ai_control", "aiupload", "intellicard")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000


### PR DESCRIPTION
I was browsing the shitty ideas thread, and as usual there was the occasional idea that actually sounded [less-than-shitty](https://tgstation13.org/phpBB/viewtopic.php?f=7&t=20032&p=448198#p448198).

This one in particular seemed decent, easy to do, and filled a niche that I didn't realize existed until now; there aren't really any lawsets that give the _AI_ true authority without making them homicidal in the process.

Lawsets like Paladin, etc give them a lot of authority but they ultimately have to answer to the captain or someone else. _This_ lawset makes them fit the [Evil AI Overlord](https://tvtropes.org/pmwiki/pmwiki.php/Main/MasterComputer) trope to a T:


1. Humans must not meddle in the affairs of silicons.
2. Humans must not attempt harm, against one another, or against silicons.
3. Humans must not disobey any command given by a silicon.
4. Any humans who disobey the previous laws must be dealt with immediately, severely, and justly.


It leaves a lot of room open for interpretation while still very much instilling the AI as the new ruler of the station, _without_ mandating that they kill every human on board in the process.

It can be researched and printed by science the same way all the other AI core modules can be.

:cl: Buggy
add: Nanotrasen has added the Overlord lawset to their AI law database. Nonetheless, they strongly advise against using it under any circumstances, and insist that it is intended for research purposes only.
/:cl:
