### PR TITLE
Makes Catgirls sound different than humans

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -2,6 +2,7 @@
 /datum/species/human/felinid
 	name = "Felinid"
 	id = "felinid"
+	say_mod = "yowls"
 	limbs_id = "human"
 
 	mutant_bodyparts = list("ears", "tail_human")


### PR DESCRIPTION
[Changelogs]: # "felinids" now "yowl" as opposed to sounding exactly like humans. 
For reference: Garlic Bread yowls, "I hope cats get removed"
       

:cl: 
Adds: Cats now yowl
/:cl:

[why]: # Numerous times I have seen silicons take needless precautions because they couldn't tell if someone was a human. Giving cats their own sound will help them obey law 2 orders more accurately, along with law 1 orders. 
Also, yowls seemed the best suggestion, its a mix between actually sounding like a cat, but not being a snowflake noise like nyas or mews. 
Based off this thread: https://tgstation13.org/phpBB/viewtopic.php?f=9&t=19934