### PR TITLE
Fixes anti-magic not actually protecting against tesla blast spell

### DIFF
--- a/code/modules/spells/spell_types/lightning.dm
+++ b/code/modules/spells/spell_types/lightning.dm
@@ -68,7 +68,7 @@
 	if(current.anti_magic_check())
 		playsound(get_turf(current), 'sound/magic/lightningshock.ogg', 50, 1, -1)
 		current.visible_message("<span class='warning'>[current] absorbs the spell, remaining unharmed!</span>", "<span class='userdanger'>You absorb the spell, remaining unharmed!</span>")
-	if(bounces < 1)
+	else if(bounces < 1)
 		current.electrocute_act(bolt_energy,"Lightning Bolt",safety=1)
 		playsound(get_turf(current), 'sound/magic/lightningshock.ogg', 50, 1, -1)
 	else


### PR DESCRIPTION
:cl:
fix: Anti-magic items will now properly protect you from the tesla blast spell
/:cl:

Fixes #40956