### PR TITLE
Fixes fire extinguishers sometimes failing to extinguish people

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -171,7 +171,7 @@
 			W.reagents = R
 			R.my_atom = W
 			reagents.trans_to(W,1)
-	
+
 		//Make em move dat ass, hun
 		addtimer(CALLBACK(src, /obj/item/extinguisher/proc/move_particles, water_particles), 2)
 
@@ -192,7 +192,7 @@
 		for(var/A in get_turf(W))
 			W.reagents.reaction(A)
 		if(W.loc == my_target)
-			break
+			particles -= W
 	if(repetition < power)
 		repetition++
 		addtimer(CALLBACK(src, /obj/item/extinguisher/proc/move_particles, particles, repetition), 2)


### PR DESCRIPTION
:cl:
fix: Fixed a bug that caused fire extinguishers to often fail to extinguish people
/:cl:
Fixes #40361 

This was an oversight from the refactor in #39860. Before the refactor, each particle had it's own concurrently-running loop and `break`-ing to end the loop when one particle reached it's destination wouldn't stop the other particles.