### PR TITLE
Fixes camera tag in Delta commissary

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -81919,7 +81919,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Vacant Office";
+	c_tag = "Vacant Commissary";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{


### PR DESCRIPTION
:cl: Mickyan
fix: Deltastation: the vacant commissary camera can now correctly be accessed from the camera console
/:cl:

I double checked everything like five times and I still missed this
