### PR TITLE
Adds empty oxygen and plasma tanks to techwebs

### DIFF
--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -38,7 +38,6 @@
 
 /obj/item/tank/internals/oxygen/empty/New()
 	..()
-	air_contents.assert_gas(/datum/gas/oxygen)
 	air_contents.gases[/datum/gas/oxygen][MOLES] = 0
 	return
 

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -36,6 +36,11 @@
 	icon_state = "oxygen_fr"
 	dog_fashion = null
 
+/obj/item/tank/internals/oxygen/empty/New()
+	..()
+	air_contents.assert_gas(/datum/gas/oxygen)
+	air_contents.gases[/datum/gas/oxygen][MOLES] = 0
+	return
 
 /*
  * Anesthetic
@@ -109,6 +114,10 @@
 	air_contents.gases[/datum/gas/plasma][MOLES] = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
+/obj/item/tank/internals/plasma/empty/New()
+	..()
+	air_contents.gases[/datum/gas/plasma][MOLES] = 0
+	return
 
 /*
  * Plasmaman Plasma Tank

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -236,6 +236,26 @@
 	build_path = /obj/item/vending_refill/donksoft
 	category = list("Equipment")
 
+/datum/design/oxygen_tank
+	name = "Oxygen Tank"
+	desc = "An empty oxygen tank."
+	id = "oxygen_tank"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 2000)
+	build_path = /obj/item/tank/internals/oxygen/empty
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/plasma_tank
+	name = "Plasma Tank"
+	desc = "An empty oxygen tank."
+	id = "plasma_tank"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 2000)
+	build_path = /obj/item/tank/internals/plasma/empty
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+
 /////////////////////////////////////////
 ////////////Janitor Designs//////////////
 /////////////////////////////////////////

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -125,7 +125,8 @@
 	prereq_ids = list("base")
 	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin", "scanner_gate",
 	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
-	"apc_control", "cell_charger", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics", "cell_charger", "stack_console", "stack_machine")
+	"apc_control", "cell_charger", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics", "cell_charger", "stack_console", "stack_machine", 
+	"oxygen_tank", "plasma_tank")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	export_price = 5000
 


### PR DESCRIPTION
:cl: Denton
add: The 'Industrial Engineering' research node now includes empty oxygen and plasma tanks.
/:cl:

This PR lets players print empty oxygen and plasma tanks from the RnD and engineering protolathes once they have Industrial Engineering researched.

Turns out that such a basic thing as tank dispensers can't be built or ordered once they're gone. It might be worth adding that in a separate PR.