### PR TITLE
Slime consoles say the number of monkeys when you recycle a monkey

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -222,6 +222,7 @@
 			if(M.stat)
 				M.visible_message("[M] vanishes as [M.p_theyre()] reclaimed for recycling!")
 				X.monkeys = round(X.monkeys + 0.2,0.1)
+				to_chat(owner, "[X] now has [X.monkeys] monkeys available.")
 				qdel(M)
 	else
 		to_chat(owner, "<span class='notice'>Target is not near a camera. Cannot proceed.</span>")


### PR DESCRIPTION
It always annoyed me that slime consoles would display the number of monkeys left when feeding slimes, but not when recycling monkeys. One line change, now it does both.

:cl: actioninja
tweak: Slime Management Consoles now state the number of monkeys available when you recycle a monkey.
/:cl:
