### PR TITLE
"Floor is lava" no longer affects flying mobs, like say... artificers from a summon event wizard

### DIFF
--- a/code/datums/weather/weather_types/floor_is_lava.dm
+++ b/code/datums/weather/weather_types/floor_is_lava.dm
@@ -29,6 +29,6 @@
 		return
 	if(!L.client) //Only sentient people are going along with it!
 		return
-	if(L.movement_type == FLYING)
+	if(L.movement_type & FLYING)
 		return
 	L.adjustFireLoss(3)

--- a/code/datums/weather/weather_types/floor_is_lava.dm
+++ b/code/datums/weather/weather_types/floor_is_lava.dm
@@ -29,4 +29,6 @@
 		return
 	if(!L.client) //Only sentient people are going along with it!
 		return
+	if(L.movement_type == FLYING)
+		return
 	L.adjustFireLoss(3)


### PR DESCRIPTION
:cl: Robustin
fix: "Floor is lava" event no longer affects flying mobs
/:cl: