### PR TITLE
Modifies the electrocution damage cap and scaling

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -155,7 +155,7 @@
 
 /obj/item/stock_parts/cell/proc/get_electrocute_damage()
 	if(charge >= 1000)
-		return CLAMP(round(charge/10000), 10, 90) + rand(-5,5)
+		return CLAMP(20 + round(avail/25000), 20, 90) + rand(-5,5)
 	else
 		return 0
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -155,7 +155,7 @@
 
 /obj/item/stock_parts/cell/proc/get_electrocute_damage()
 	if(charge >= 1000)
-		return CLAMP(20 + round(avail/25000), 20, 90) + rand(-5,5)
+		return CLAMP(20 + round(charge/25000), 20, 90) + rand(-5,5)
 	else
 		return 0
 

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -96,6 +96,6 @@
 
 /datum/powernet/proc/get_electrocute_damage()
 	if(avail >= 1000)
-		return CLAMP(round(avail/10000), 10, 90) + rand(-5,5)
+		return CLAMP(20 + round(avail/25000), 20, 90) + rand(-5,5)
 	else
 		return 0


### PR DESCRIPTION
zippity zappity get off my praperty

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Kierany9
tweak: Electric shocks are no longer capped at a measly 90(+-5) damage, with a proper engine setup and hotwiring, electric shocks can now do up to 195(+-5). However, for the most part, shocks do less damage than before at charges under 2 MW.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Gives rogue engineers, CEs and AIs more to do with the engine other than immediately cause a delamination or plasma flood and actually engage with the mechanics of their department beyond "open all the plasma valves" or "close all the coolant valves". The old cap is now reached at exactly 2 MW (Up from 900 KW), and the new cap is 195 damage(with a +- 5 modifier, meaning that there's 1/11 chance to instantly die at the new cap) at around 4.3 MW. The minimum shock damage has been upped to 20 and at very low wattages it deals more than before to keep the formulas simple(sorry greytide), but with the safest possible engine setup, the damage is more or less the same than it used to be.

~~It's a web edit, sue me~~