### PR TITLE
Fixed heart attack disease

### DIFF
--- a/code/datums/diseases/heart_failure.dm
+++ b/code/datums/diseases/heart_failure.dm
@@ -57,9 +57,8 @@
 				if(H.stat == CONSCIOUS)
 					H.visible_message("<span class='userdanger'>[H] clutches at [H.p_their()] chest as if [H.p_their()] heart is stopping!</span>")
 				H.adjustStaminaLoss(60)
-				H.reagents.add_reagent("corazone", 3) // To give the victim a final chance to shock their heart before losing consciousness
 				H.set_heartattack(TRUE)
+				H.reagents.add_reagent("corazone", 3) // To give the victim a final chance to shock their heart before losing consciousness
 				cure()
-
 	else
 		cure()


### PR DESCRIPTION
:cl: Robustin
fix: The heart attack disease will now actually stop your heart (again)
/:cl:

1) Cool coderbro adds an ancient cloning lab ruin, somehow that requires him to fuck with Corazone and ends up breaking the chem
2) Another suave codefellah fixes the chem by having it add/remove a stable heart trait instead of having the chem function like it did before (prevent symptoms of a stopped heart).
3) The heart disease now gives you a chem that makes you immune to heart failure right before attempting to induce heart failure, nice! 

All I had to do was flip the order so that the person's heart stops, THEN they get a brief reprieve before they feel the full effect. 
