### PR TITLE
Fixes Supermatter Shard being hidden behind objects

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -653,7 +653,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	anchored = FALSE
 	gasefficency = 0.125
 	explosion_power = 12
-	layer = 3.1
+	layer = 4.1
 	moveable = TRUE
 
 /obj/machinery/power/supermatter_crystal/shard/engine

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -55,7 +55,6 @@
 #define SUPERMATTER_WARNING_PERCENT 100
 
 #define SUPERMATTER_COUNTDOWN_TIME 30 SECONDS
-#define SUPERMATTER_SHARD_LAYER_MODIFIER 4.1
 
 GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
@@ -654,7 +653,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	anchored = FALSE
 	gasefficency = 0.125
 	explosion_power = 12
-	layer = SUPERMATTER_SHARD_LAYER_MODIFIER
+	layer = ABOVE_MOB_LAYER
 	moveable = TRUE
 
 /obj/machinery/power/supermatter_crystal/shard/engine

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -56,6 +56,8 @@
 
 #define SUPERMATTER_COUNTDOWN_TIME 30 SECONDS
 
+#define SUPERMATTER_SHARD_LAYER_MODIFIER 4.1
+
 GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 /obj/machinery/power/supermatter_crystal
@@ -653,7 +655,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	anchored = FALSE
 	gasefficency = 0.125
 	explosion_power = 12
-	layer = 4.1
+	layer = SUPERMATTER_SHARD_LAYER_MODIFIER
 	moveable = TRUE
 
 /obj/machinery/power/supermatter_crystal/shard/engine

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -653,6 +653,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	anchored = FALSE
 	gasefficency = 0.125
 	explosion_power = 12
+	layer = 3.1
 	moveable = TRUE
 
 /obj/machinery/power/supermatter_crystal/shard/engine

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -55,7 +55,6 @@
 #define SUPERMATTER_WARNING_PERCENT 100
 
 #define SUPERMATTER_COUNTDOWN_TIME 30 SECONDS
-
 #define SUPERMATTER_SHARD_LAYER_MODIFIER 4.1
 
 GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)


### PR DESCRIPTION
:cl: Zaex
tweak: Supermatter Shard is now placed in front of other objects.
/:cl:

Issue ID https://github.com/tgstation/tgstation/issues/41043
Suppermatter Shard was being exploited and put under objects to hide it.
