### PR TITLE
Enables Color matrix for getFlatIcon operations

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -712,7 +712,7 @@ world
 	var/static/icon/flat_template = icon('icons/effects/effects.dmi', "nothing")
 
 	#define BLANK icon(flat_template)
-	#define SET_SELF(SETVAR) \
+	#define SET_SELF(SETVAR) do { \
 		var/icon/SELF_ICON=icon(icon(curicon, curstate, base_icon_dir),"",SOUTH,no_anim?1:null); \
 		if(A.alpha<255) { \
 			SELF_ICON.Blend(rgb(255,255,255,A.alpha),ICON_MULTIPLY);\
@@ -723,7 +723,8 @@ world
 			else{ \
 				SELF_ICON.Blend(A.color,ICON_MULTIPLY)} \
 		} \
-		##SETVAR=SELF_ICON;
+		##SETVAR=SELF_ICON;\
+		} while (0)
 	#define INDEX_X_LOW 1
 	#define INDEX_X_HIGH 2
 	#define INDEX_Y_LOW 3

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -712,8 +712,18 @@ world
 	var/static/icon/flat_template = icon('icons/effects/effects.dmi', "nothing")
 
 	#define BLANK icon(flat_template)
-	#define SET_SELF(SETVAR) var/icon/SELF_ICON=icon(icon(curicon, curstate, base_icon_dir),"",SOUTH,no_anim?1:null);if(A.alpha<255)SELF_ICON.Blend(rgb(255,255,255,A.alpha),ICON_MULTIPLY);if(A.color)SELF_ICON.Blend(A.color,ICON_MULTIPLY);;##SETVAR=SELF_ICON;
-
+	#define SET_SELF(SETVAR) \
+		var/icon/SELF_ICON=icon(icon(curicon, curstate, base_icon_dir),"",SOUTH,no_anim?1:null); \
+		if(A.alpha<255) { \
+			SELF_ICON.Blend(rgb(255,255,255,A.alpha),ICON_MULTIPLY);\
+		} \
+		if(A.color) { \
+			if(islist(A.color)){ \
+				SELF_ICON.MapColors(arglist(A.color))} \
+			else{ \
+				SELF_ICON.Blend(A.color,ICON_MULTIPLY)} \
+		} \
+		##SETVAR=SELF_ICON;
 	#define INDEX_X_LOW 1
 	#define INDEX_X_HIGH 2
 	#define INDEX_Y_LOW 3
@@ -860,7 +870,11 @@ world
 			flat.Blend(add, blendMode2iconMode(curblend), I.pixel_x + 2 - flatX1, I.pixel_y + 2 - flatY1)
 
 		if(A.color)
-			flat.Blend(A.color, ICON_MULTIPLY)
+			if(islist(A.color))
+				flat.MapColors(arglist(A.color))
+			else
+				flat.Blend(A.color, ICON_MULTIPLY)
+		
 		if(A.alpha < 255)
 			flat.Blend(rgb(255, 255, 255, A.alpha), ICON_MULTIPLY)
 


### PR DESCRIPTION
:cl: Poojawa
fix: fixes getFlatIcon breaking if an overlay was a color matrix
/:cl:

Color Matrix allows for making one overlay layer have up to three different color channels depending on the sprite having Red Green and Blue pixels. e.g.


![](https://i.gyazo.com/081f52c0215cfb10db9a82e91f3d7460.png)
base


![](https://i.gyazo.com/da4259a336229457149987d972715b6f.png)
color matrix shifted

On a related project, I was constantly running into overlay errors, specifically encountering Blend when I didn't want it to blend for the character setup picture. This resolves that issue. 

Based PBJ3005 pointed out the fate flaw introduced by Kev. 

