### PR TITLE
Gives the Entertainers service headsets

### DIFF
--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -28,6 +28,7 @@ Clown
 	jobtype = /datum/job/clown
 
 	belt = /obj/item/pda/clown
+	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/clown
 	shoes = /obj/item/clothing/shoes/clown_shoes
 	mask = /obj/item/clothing/mask/gas/clown_hat
@@ -87,6 +88,7 @@ Mime
 	jobtype = /datum/job/mime
 
 	belt = /obj/item/pda/mime
+	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/mime
 	mask = /obj/item/clothing/mask/gas/mime
 	gloves = /obj/item/clothing/gloves/color/white


### PR DESCRIPTION
[Changelogs]: Gives the Clown and Mime the freedom of speech of the Service channel. Remember to beat the Mime if he uses it.

:cl: 
add: Years of campaigning for Clown rights may have failed, but Nanotrasen has given Clowns, and Mimes, service radios as compensation
/:cl:

[why]: I personally would like to have given all of the civilians, bar the assistants, a service radio but I'll test the waters with a small concession. As for the actual why, I feel like it would encourage a more cooperative frame of mind if the civilians started seeing themselves as their own department instead of a loose association of not belonging to a department. 