### PR TITLE
Bugfixes usage of variable ssshuttle.points for cargo

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -537,9 +537,10 @@ SUBSYSTEM_DEF(shuttle)
 	if (istype(SSshuttle.shuttle_purchase_requirements_met))
 		shuttle_purchase_requirements_met = SSshuttle.shuttle_purchase_requirements_met
 
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	centcom_message = SSshuttle.centcom_message
 	ordernum = SSshuttle.ordernum
-	points = SSshuttle.points
+	points = D.account_balance
 	emergencyNoEscape = SSshuttle.emergencyNoEscape
 	emergencyCallAmount = SSshuttle.emergencyCallAmount
 	shuttle_purchased = SSshuttle.shuttle_purchased

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -562,7 +562,8 @@
 				dat += "<BR>Lift access restrictions on maintenance and external airlocks? <BR>\[ <A HREF='?src=[REF(src)];operation=enableemergency'>OK</A> | <A HREF='?src=[REF(src)];operation=viewmessage'>Cancel</A> \]"
 
 		if(STATE_PURCHASE)
-			dat += "Budget: [SSshuttle.points] Credits.<BR>"
+			var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
+			dat += "Budget: [D.account_balance] Credits.<BR>"
 			dat += "<BR>"
 			dat += "<b>Caution: Purchasing dangerous shuttles may lead to mutiny and/or death.</b><br>"
 			dat += "<BR>"

--- a/code/modules/cargo/bounty_console.dm
+++ b/code/modules/cargo/bounty_console.dm
@@ -35,9 +35,10 @@
 		setup_bounties()
 
 	var/dat = ""
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	dat += "<a href='?src=[REF(src)];refresh=1'>Refresh</a>"
 	dat += "<a href='?src=[REF(src)];refresh=1;choice=Print'>Print Paper</a>"
-	dat += "<p>Credits: <b>[SSshuttle.points]</b></p>"
+	dat += "<p>Credits: <b>[D.account_balance]</b></p>"
 	dat += {"<table style="text-align:center;" border="1" cellspacing="0" width="100%">"}
 	dat += "<tr><th>Name</th><th>Description</th><th>Reward</th><th>Completion</th><th>Status</th></tr>"
 	for(var/datum/bounty/B in GLOB.bounties_list)

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -90,10 +90,10 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 	var/value = 0
 	var/purchases = 0
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	for(var/datum/supply_order/SO in SSshuttle.shoppinglist)
 		if(!empty_turfs.len)
 			break
-		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 		if(D)
 			if(!D.adjust_money(-SO.pack.cost))
 				continue
@@ -108,7 +108,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			message_admins("\A [SO.pack.name] ordered by [ADMIN_LOOKUPFLW(SO.orderer_ckey)] has shipped.")
 		purchases++
 
-	investigate_log("[purchases] orders in this shipment, worth [value] credits. [SSshuttle.points] credits left.", INVESTIGATE_CARGO)
+	investigate_log("[purchases] orders in this shipment, worth [value] credits. [D.account_balance] credits left.", INVESTIGATE_CARGO)
 
 /obj/docking_port/mobile/supply/proc/sell()
 	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)


### PR DESCRIPTION
The economy overhaul left behind a few errors relating to Cargo, namely the variable 'ssshuttle.points', now obsolete, being used on the bounty console, for the purchasing of a shuttle, and for assessing how many credits were left after a shipment purchase.

This pull request fixes these errors. I initially created this for Yogstation, but since it relies on code from /tg/, I thought it'd be beneficial to bugfix it here as well.

I've done some testing in-game and it works as expected. It's just a few variable changes, so no issues are expected to pop up.