### PR TITLE
Reduces the amount of antags spawned by the Summon Guns and Summon Magic rituals

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -486,7 +486,7 @@
 
 /datum/spellbook_entry/summon/guns/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
 	SSblackbox.record_feedback("tally", "wizard_spell_learned", 1, name)
-	rightandwrong(SUMMON_GUNS, user, 25)
+	rightandwrong(SUMMON_GUNS, user, 10)
 	active = TRUE
 	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, 1)
 	to_chat(user, "<span class='notice'>You have cast summon guns!</span>")
@@ -503,7 +503,7 @@
 
 /datum/spellbook_entry/summon/magic/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
 	SSblackbox.record_feedback("tally", "wizard_spell_learned", 1, name)
-	rightandwrong(SUMMON_MAGIC, user, 25)
+	rightandwrong(SUMMON_MAGIC, user, 10)
 	active = TRUE
 	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, 1)
 	to_chat(user, "<span class='notice'>You have cast summon magic!</span>")


### PR DESCRIPTION
:cl:
balance: The Summon Guns and Summon Magic rituals will now only turn 10% of the crew each into antagonists, down from 25%.
/:cl:

This has frustrated people for a long time. The issue is that these rituals irrevocably destroy the round that they're in by turning one dangerous murderboning antag into literally half the station becoming dangerous murderboning antags. I reduced it to 10% each. I wanted to reduce it to zero so that they wouldn't delay the round for 30 minutes after the wizard teleports in and immediately dies, but I figured that simply reducing the amount of antags spawned would be better received. 