### PR TITLE
Adds three new .38 ammo types

### DIFF
--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -124,12 +124,12 @@
 				L[avoid_assoc_duplicate_keys(A.name, areaindex)] = R
 
 		for(var/obj/item/implant/tracking/I in GLOB.tracked_implants)
-			if(!I.imp_in || !isliving(I.loc))
+			if(!I.imp_in || !isliving(I.loc) || !I.allow_teleport)
 				continue
 			else
 				var/mob/living/M = I.loc
 				if(M.stat == DEAD)
-					if(M.timeofdeath + 6000 < world.time)
+					if(M.timeofdeath + I.lifespan_postmortem < world.time)
 						continue
 				if(is_eligible(I))
 					L[avoid_assoc_duplicate_keys(M.real_name, areaindex)] = I

--- a/code/game/objects/items/implants/implant_track.dm
+++ b/code/game/objects/items/implants/implant_track.dm
@@ -1,7 +1,19 @@
 /obj/item/implant/tracking
 	name = "tracking implant"
 	desc = "Track with this."
-	activated = 0
+	activated = FALSE
+	var/lifespan_postmortem = 6000 //for how many deciseconds after user death will the implant work?
+	var/allow_teleport = TRUE //will people implanted with this act as teleporter beacons?
+
+/obj/item/implant/tracking/c38
+	name = "TRAC implant"
+	desc = "A smaller tracking implant that supplies power for only a few minutes."
+	var/lifespan = 3000 //how many deciseconds does the implant last?
+	allow_teleport = FALSE
+
+/obj/item/implant/tracking/c38/Initialize()
+	. = ..()
+	QDEL_IN(src, lifespan)
 
 /obj/item/implant/tracking/New()
 	..()
@@ -20,8 +32,8 @@
 /obj/item/implant/tracking/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
 				<b>Name:</b> Tracking Beacon<BR>
-				<b>Life:</b> 10 minutes after death of host<BR>
-				<b>Important Notes:</b> None<BR>
+				<b>Life:</b> 10 minutes after death of host.<BR>
+				<b>Important Notes:</b> Implant also works as a teleporter beacon.<BR>
 				<HR>
 				<b>Implant Details:</b> <BR>
 				<b>Function:</b> Continuously transmits low power signal. Useful for tracking.<BR>

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -80,7 +80,7 @@
 					else
 						var/mob/living/M = W.loc
 						if (M.stat == DEAD)
-							if (M.timeofdeath + 6000 < world.time)
+							if (M.timeofdeath + W.lifespan_postmortem < world.time)
 								continue
 
 					var/turf/tr = get_turf(W)

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -21,3 +21,20 @@
 	desc = "A .38 bullet casing."
 	caliber = "38"
 	projectile_type = /obj/item/projectile/bullet/c38
+
+/obj/item/ammo_casing/c38/trac
+	name = ".38 TRAC bullet casing"
+	desc = "A .38 \"TRAC\" bullet casing."
+	projectile_type = /obj/item/projectile/bullet/c38/trac
+
+/obj/item/ammo_casing/c38/hotshot
+	name = ".38 Hot Shot bullet casing"
+	desc = "A .38 Hot Shot bullet casing."
+	caliber = "38"
+	projectile_type = /obj/item/projectile/bullet/c38/hotshot
+
+/obj/item/ammo_casing/c38/iceblox
+	name = ".38 Iceblox bullet casing"
+	desc = "A .38 Iceblox bullet casing."
+	caliber = "38"
+	projectile_type = /obj/item/projectile/bullet/c38/iceblox

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -15,6 +15,21 @@
 	multiple_sprites = 1
 	materials = list(MAT_METAL = 20000)
 
+/obj/item/ammo_box/c38/trac
+	name = "speed loader (.38 TRAC)"
+	desc = "Designed to quickly reload revolvers. TRAC bullets embed a tracking implant within the target's body."
+	ammo_type = /obj/item/ammo_casing/c38/trac
+
+/obj/item/ammo_box/c38/hotshot
+	name = "speed loader (.38 Hot Shot)"
+	desc = "Designed to quickly reload revolvers. Hot Shot bullets contain an incendiary payload."
+	ammo_type = /obj/item/ammo_casing/c38/hotshot
+
+/obj/item/ammo_box/c38/iceblox
+	name = "speed loader (.38 Iceblox)"
+	desc = "Designed to quickly reload revolvers. Iceblox bullets contain a cryogenic payload."
+	ammo_type = /obj/item/ammo_casing/c38/iceblox
+
 /obj/item/ammo_box/c9mm
 	name = "ammo box (9mm)"
 	icon_state = "9mmbox"

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -16,6 +16,43 @@
 	name = ".38 bullet"
 	damage = 25
 
+/obj/item/projectile/bullet/c38/trac
+	name = ".38 TRAC bullet"
+	damage = 10
+
+/obj/item/projectile/bullet/c38/trac/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	var/mob/living/carbon/M = target
+	var/obj/item/implant/tracking/imp
+	for(var/obj/item/implant/tracking/TI in M.implants) //checks if the target already contains a tracking implant
+		imp = TI
+		break
+	if(!imp)
+		imp = new /obj/item/implant/tracking(M)
+		imp.implant(M)
+
+/obj/item/projectile/bullet/c38/hotshot //similar to incendiary bullets, but do not leave a flaming trail
+	name = ".38 Hot Shot bullet"
+	damage = 20
+
+/obj/item/projectile/bullet/c38/hotshot/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/M = target
+		M.adjust_fire_stacks(6)
+		M.IgniteMob()
+
+/obj/item/projectile/bullet/c38/iceblox //see /obj/item/projectile/temp for the original code
+	name = ".38 Iceblox bullet"
+	damage = 20
+	var/temperature = 100
+
+/obj/item/projectile/bullet/c38/iceblox/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(isliving(target))
+		var/mob/living/M = target
+		M.adjust_bodytemperature(((100-blocked)/100)*(temperature - M.bodytemperature))
+
 // .357 (Syndie Revolver)
 
 /obj/item/projectile/bullet/a357

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -23,12 +23,12 @@
 /obj/item/projectile/bullet/c38/trac/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	var/mob/living/carbon/M = target
-	var/obj/item/implant/tracking/imp
-	for(var/obj/item/implant/tracking/TI in M.implants) //checks if the target already contains a tracking implant
+	var/obj/item/implant/tracking/c38/imp
+	for(var/obj/item/implant/tracking/c38/TI in M.implants) //checks if the target already contains a tracking implant
 		imp = TI
-		break
+		return
 	if(!imp)
-		imp = new /obj/item/implant/tracking(M)
+		imp = new /obj/item/implant/tracking/c38(M)
 		imp.implant(M)
 
 /obj/item/projectile/bullet/c38/hotshot //similar to incendiary bullets, but do not leave a flaming trail

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -432,3 +432,33 @@
 	build_path = /obj/item/evidencebag
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/c38_trac
+	name = "Speed Loader (.38 TRAC)"
+	desc = "Designed to quickly reload revolvers. TRAC bullets embed a tracking implant within the target's body."
+	id = "c38_trac"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 20000, MAT_SILVER = 5000, MAT_GOLD = 1000)
+	build_path = /obj/item/ammo_box/c38/trac
+	category = list("Security")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/c38_hotshot
+	name = "Speed Loader (.38 Hot Shot)"
+	desc = "Designed to quickly reload revolvers. Hot Shot bullets contain an incendiary payload."
+	id = "c38_hotshot"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 20000, MAT_PLASMA = 5000)
+	build_path = /obj/item/ammo_box/c38/hotshot
+	category = list("Security")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/c38_iceblox
+	name = "Speed Loader (.38 Iceblox)"
+	desc = "Designed to quickly reload revolvers. Iceblox bullets contain a cryogenic payload."
+	id = "c38_iceblox"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 20000, MAT_PLASMA = 5000)
+	build_path = /obj/item/ammo_box/c38/iceblox
+	category = list("Security")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -435,7 +435,7 @@
 	display_name = "Subdermal Implants"
 	description = "Electronic implants buried beneath the skin."
 	prereq_ids = list("biotech")
-	design_ids = list("implanter", "implantcase", "implant_chem", "implant_tracking", "locator")
+	design_ids = list("implanter", "implantcase", "implant_chem", "implant_tracking", "locator", "c38_trac")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -631,12 +631,12 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
-/datum/techweb_node/tech_shell
-	id = "tech_shell"
-	display_name = "Technological Shells"
-	description = "They're more technological than regular shot."
+/datum/techweb_node/exotic_ammo
+	id = "exotic_ammo"
+	display_name = "Exotic Ammunition"
+	description = "They won't know what hit em."
 	prereq_ids = list("adv_weaponry")
-	design_ids = list("techshotshell")
+	design_ids = list("techshotshell", "c38_hotshot", "c38_iceblox")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
:cl: Denton
add: Added three new .38 ammo types. TRAC bullets, which embed a tracking implant inside the target's body. The implant only lasts for five minutes and doesn't work as a teleport beacon. Hot Shot bullets set targets on fire; Iceblox bullets drastically lower the target's body temperature. They are available after researching the Subdermal Implants node (TRAC) or Exotic Ammunition node (Hot Shot/Iceblox).
tweak: Renamed the Technological Shells research node to Exotic Ammunition. 
code: The "lifespan_postmortem" var now determines how long tracking implants work after death.
/:cl:

Flavor aside, the detective's revolver is little more than a weak Stechkin. I figured that some ammo variety might make it more fun to use:
- TRAC: Only deals 10 damage, but implants a tracking implant once it hits someone. Security can then track the perp with a bluespace locator. It will delete itself after 5 minutes and doesn't work as a teleport beacon.
- Hot Shot: 20 damage and hits the target with 6 fire stacks.
- Iceblox: 20 damage, lowers the target's body temp similar to the temp gun.

Let me know if you think that Hot Shot/Iceblox are too strong - they won't be available early during most rounds because they're gated behind the tech shells node and require plasma to print. 