### PR TITLE
Adds hydroponics guard armbands to hydro clothes vendors

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -169,7 +169,8 @@
 					/obj/item/clothing/suit/apron = 2,
 					/obj/item/clothing/suit/apron/overalls = 3,
 					/obj/item/clothing/under/rank/hydroponics = 3,
-					/obj/item/clothing/mask/bandana = 3)
+					/obj/item/clothing/mask/bandana = 3,
+					/obj/item/clothing/accessory/armband/hydro = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/hydro_wardrobe
 	payment_department = ACCOUNT_SRV
 /obj/item/vending_refill/wardrobe/hydro_wardrobe


### PR DESCRIPTION
:cl: Denton
tweak: Added hydroponics guard armbands to Hydrobe clothes vendors.
/:cl:

So far the hydro guard armbands are only available on Metastation. I added them to Hydrobes so that sec officers <s>on weed patrol</s> who hang around hydroponics can put them on.