### PR TITLE
Near-death experiences

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -43,6 +43,8 @@
 #define HEALTH_THRESHOLD_FULLCRIT -30
 #define HEALTH_THRESHOLD_DEAD -100
 
+#define HEALTH_THRESHOLD_NEARDEATH -90 //Not used mechanically, but to determine if someone is so close to death they hear the other side
+
 //Actual combat defines
 
 //click cooldowns, in tenths of a second, used for various combat actions

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -51,6 +51,7 @@
 #define TRAIT_NOSOFTCRIT		"nosoftcrit"
 #define TRAIT_MINDSHIELD		"mindshield"
 #define TRAIT_DISSECTED			"dissected"
+#define TRAIT_SIXTHSENSE		"sixth_sense" //I can hear dead people
 
 
 #define TRAIT_ALCOHOL_TOLERANCE	"alcohol_tolerance"

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -391,12 +391,14 @@ GLOBAL_LIST_EMPTY(species_list)
 		else
 			prefs = new
 
-		var/adminoverride = 0
+		var/override = FALSE
 		if(M.client && M.client.holder && (prefs.chat_toggles & CHAT_DEAD))
-			adminoverride = 1
-		if(isnewplayer(M) && !adminoverride)
+			override = TRUE
+		if(M.has_trait(TRAIT_SIXTHSENSE))
+			override = TRUE
+		if(isnewplayer(M) && !override)
 			continue
-		if(M.stat != DEAD && !adminoverride)
+		if(M.stat != DEAD && !override)
 			continue
 		if(speaker_key && speaker_key in prefs.ignoring)
 			continue

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -262,6 +262,8 @@
 
 /datum/config_entry/flag/ghost_interaction
 
+/datum/config_entry/flag/near_death_experience //If carbons can hear ghosts when unconscious and very close to death
+
 /datum/config_entry/flag/silent_ai
 /datum/config_entry/flag/silent_borg
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -754,7 +754,7 @@
 		if(IsUnconscious() || IsSleeping() || getOxyLoss() > 50 || (has_trait(TRAIT_DEATHCOMA)) || (health <= HEALTH_THRESHOLD_FULLCRIT && !has_trait(TRAIT_NOHARDCRIT)))
 			stat = UNCONSCIOUS
 			blind_eyes(1)
-			if(health <= HEALTH_THRESHOLD_NEARDEATH)
+			if(health <= HEALTH_THRESHOLD_NEARDEATH && !has_trait(TRAIT_NODEATH))
 				add_trait(TRAIT_SIXTHSENSE, "near-death")
 			else
 				remove_trait(TRAIT_SIXTHSENSE, "near-death")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -754,12 +754,17 @@
 		if(IsUnconscious() || IsSleeping() || getOxyLoss() > 50 || (has_trait(TRAIT_DEATHCOMA)) || (health <= HEALTH_THRESHOLD_FULLCRIT && !has_trait(TRAIT_NOHARDCRIT)))
 			stat = UNCONSCIOUS
 			blind_eyes(1)
+			if(health <= HEALTH_THRESHOLD_NEARDEATH)
+				add_trait(TRAIT_SIXTHSENSE, "near-death")
+			else
+				remove_trait(TRAIT_SIXTHSENSE, "near-death")
 		else
 			if(health <= crit_threshold && !has_trait(TRAIT_NOSOFTCRIT))
 				stat = SOFT_CRIT
 			else
 				stat = CONSCIOUS
 			adjust_blindness(-1)
+			remove_trait(TRAIT_SIXTHSENSE, "near-death")
 		update_mobility()
 	update_damage_hud()
 	update_health_hud()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -754,7 +754,7 @@
 		if(IsUnconscious() || IsSleeping() || getOxyLoss() > 50 || (has_trait(TRAIT_DEATHCOMA)) || (health <= HEALTH_THRESHOLD_FULLCRIT && !has_trait(TRAIT_NOHARDCRIT)))
 			stat = UNCONSCIOUS
 			blind_eyes(1)
-			if(health <= HEALTH_THRESHOLD_NEARDEATH && !has_trait(TRAIT_NODEATH))
+			if(CONFIG_GET(flag/near_death_experience) && health <= HEALTH_THRESHOLD_NEARDEATH && !has_trait(TRAIT_NODEATH))
 				add_trait(TRAIT_SIXTHSENSE, "near-death")
 			else
 				remove_trait(TRAIT_SIXTHSENSE, "near-death")

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -324,6 +324,10 @@ SEC_START_BRIG
 ## Uncomment to let ghosts spin chairs. You may be wondering why this is a config option. Don't ask.
 #GHOST_INTERACTION
 
+## NEAR-DEATH EXPERIENCE ###
+## Comment this out to disable mobs hearing ghosts when unconscious and very close to death
+NEAR_DEATH_EXPERIENCE
+
 ## NON-VOCAL SILICONS ###
 ## Uncomment these to stop the AI, or cyborgs, from having vocal communication.
 #SILENT_AI


### PR DESCRIPTION
:cl: XDTM
add: Being really close to death might cause surreal experiences, almost as if you could hear the other side of the veil.
/:cl:

Someone falling under -90 health crit will hear deadchat. This _is_ potentially exploitable, but i personally think that someone torturing some poor bastard one inch away from death and then bringing them back is hilarious, especially if ghosts don't feel like being helpful.

You need to be unconscious for this, and death-immune mobs like zombies and memento-mori wearing people cannot have, by definition, near-death experiences.
