### PR TITLE
Fixes gulag reclaimer breaking when a prisoner is gibbed

### DIFF
--- a/code/game/machinery/gulag_item_reclaimer.dm
+++ b/code/game/machinery/gulag_item_reclaimer.dm
@@ -64,6 +64,10 @@
 	var/list/mobs = list()
 	for(var/i in stored_items)
 		var/mob/thismob = i
+		if(QDELETED(thismob))
+			say("Alert! Unable to locate vital signals of a previously processed prisoner. Ejecting equipment!")
+			drop_items(thismob)
+			continue
 		var/list/mob_info = list()
 		mob_info["name"] = thismob.real_name
 		mob_info["mob"] = "[REF(thismob)]"


### PR DESCRIPTION
Fixes first part of #41150

:cl: ShizCalev
fix: The gulag reclaimer will no longer break when a mob is gibbed, and will instead dump the mob's equipment on the ground when the console is next used.
/:cl: