### PR TITLE
Fixes manually inserting sheets into a gulag stacker not adding points

### DIFF
--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -142,6 +142,11 @@ GLOBAL_LIST(labor_sheet_values)
 	points += inp.point_value * inp.amount
 	..()
 
+/obj/machinery/mineral/stacking_machine/laborstacker/attackby(obj/item/I, mob/living/user)
+	if(istype(I, /obj/item/stack/sheet) && user.canUnEquip(I))
+		var/obj/item/stack/sheet/inp = I
+		points += inp.point_value * inp.amount
+	return ..()
 
 /**********************Point Lookup Console**************************/
 /obj/machinery/mineral/labor_points_checker


### PR DESCRIPTION
Fixes #41150

:cl: ShizCalev
fix: Manually inserting sheets into the gulag stacking machine will now properly add points to the console.
/:cl:
