### PR TITLE
Changes disabler beams from 36 stamina damage to 40

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -69,7 +69,7 @@
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 36
+	damage = 40
 	damage_type = STAMINA
 	flag = "energy"
 	hitsound = 'sound/weapons/tap.ogg'


### PR DESCRIPTION

:cl: 
tweak: Disabler beams now deal 40 stamina damage, so they should be a bit more consistent in knocking people down in 3 hits.
/:cl:

This is mostly to try and help get them back in line with how they used to be in terms of knock down power before the stamina damage reworks. Effectively, all it does is increase the consistency of getting the 3 hit knockdown instead of the 4 hit or 5 hit knockdown.
