### PR TITLE
Makes the Heavy Sleeper quirk description mention that it also affects being unconscious

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -140,7 +140,7 @@
 
 /datum/quirk/heavy_sleeper
 	name = "Heavy Sleeper"
-	desc = "You sleep like a rock! Whenever you're put to sleep or knocked unconscious, you a little bit longer to wake up."
+	desc = "You sleep like a rock! Whenever you're put to sleep or knocked unconscious, you take a little bit longer to wake up."
 	value = -1
 	mob_trait = TRAIT_HEAVY_SLEEPER
 	gain_text = "<span class='danger'>You feel sleepy.</span>"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -140,7 +140,7 @@
 
 /datum/quirk/heavy_sleeper
 	name = "Heavy Sleeper"
-	desc = "You sleep like a rock! Whenever you're put to sleep, you sleep for a little bit longer."
+	desc = "You sleep like a rock! Whenever you're put to sleep or knocked unconscious, you a little bit longer to wake up."
 	value = -1
 	mob_trait = TRAIT_HEAVY_SLEEPER
 	gain_text = "<span class='danger'>You feel sleepy.</span>"


### PR DESCRIPTION
:cl: Mickyan
spellcheck: the description for the Heavy Sleeper quirk now mentions that it also affects being unconscious. Some (not all) of the most common sources of being knocked unconscious are: explosions, CO2 overload, seizures, low blood count
/:cl:

Seems like most people don't realize this and it's kind of important