### PR TITLE
Streamlines beacon types

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -68,7 +68,7 @@
 
 /datum/quirk/musician/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/musicbeacon/B = new(get_turf(H))
+	var/obj/item/choice_beacon/music/B = new(get_turf(H))
 	H.put_in_hands(B)
 	H.equip_to_slot(B, SLOT_IN_BACKPACK)
 	var/obj/item/musicaltuner/musicaltuner = new(get_turf(H))

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -267,7 +267,7 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 
 /obj/item/choice_beacon/music
-	name = "express delivery beacon"
+	name = "instrument delivery beacon"
 	desc = "Summon your tool of art."
 	icon_state = "gangtool-red"
 

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -266,51 +266,28 @@
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 
-/obj/item/musicbeacon
+/obj/item/choice_beacon/music
 	name = "express delivery beacon"
 	desc = "Summon your tool of art."
-	icon = 'icons/obj/device.dmi'
 	icon_state = "gangtool-red"
-	item_state = "radio"
-	var/static/list/display_names
 
-/obj/item/musicbeacon/attack_self(mob/user)
-	if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
-		beacon_music(user)
-
-/obj/item/musicbeacon/proc/beacon_music(mob/living/M)
-	if(!display_names)
-		display_names = list()
-		var/static/list/instruments = list(
-								/obj/item/instrument/violin,
-								/obj/item/instrument/piano_synth,
-								/obj/item/instrument/guitar,
-								/obj/item/instrument/eguitar,
-								/obj/item/instrument/glockenspiel,
-								/obj/item/instrument/accordion,
-								/obj/item/instrument/trumpet,
-								/obj/item/instrument/saxophone,
-								/obj/item/instrument/trombone,
-								/obj/item/instrument/recorder,
-								/obj/item/instrument/harmonica
-								)
-		for(var/V in instruments)
+/obj/item/choice_beacon/music/generate_display_names()
+	var/static/list/instruments
+	if(!instruments)
+		instruments = list()
+		var/list/templist = list(/obj/item/instrument/violin,
+							/obj/item/instrument/piano_synth,
+							/obj/item/instrument/guitar,
+							/obj/item/instrument/eguitar,
+							/obj/item/instrument/glockenspiel,
+							/obj/item/instrument/accordion,
+							/obj/item/instrument/trumpet,
+							/obj/item/instrument/saxophone,
+							/obj/item/instrument/trombone,
+							/obj/item/instrument/recorder,
+							/obj/item/instrument/harmonica
+							)
+		for(var/V in templist)
 			var/atom/A = V
-			display_names[initial(A.name)] = A
-	var/choice = input(M,"What instrument would you like to order?","Jazz Express") as null|anything in display_names
-	if(!choice || !M.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
-		return
-	choice = display_names[choice]
-	var/obj/instrument = new choice
-	var/obj/structure/closet/supplypod/bluespacepod/pod = new()
-	pod.explosionSize = list(0,0,0,2)
-	instrument.forceMove(pod)
-	var/msg = "<span class = danger>After making your selection, you notice a strange target on the ground. It might be best to step back!</span>"
-	if (ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(istype(H.ears, /obj/item/radio/headset))
-			msg = "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: <span class='bold'>Instrument request received. Your package is inbound, please stand back from the landing site.</span> Message ends.\""
-	to_chat(M, msg)
-
-	new /obj/effect/DPtarget(get_turf(src), pod)
-	qdel(src)
+			instruments[initial(A.name)] = A
+	return instruments

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -42,6 +42,7 @@
 /obj/item/choice_beacon/holy/spawn_option(obj/choice,mob/living/M)
 	if(!SSreligion.holy_armor_type)
 		..()
+		playsound(src, 'sound/effects/pray-chaplain.ogg', 40, 1)
 		SSblackbox.record_feedback("tally", "chaplain_armor", 1, "[choice]")
 		SSreligion.holy_armor_type = choice
 	else

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -18,43 +18,36 @@
 	item_state = "knight_templar"
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/food/drinks/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 
-/obj/item/holybeacon
+/obj/item/choice_beacon/holy
 	name = "armaments beacon"
 	desc = "Contains a set of armaments for the chaplain."
-	icon = 'icons/obj/device.dmi'
-	icon_state = "gangtool-red"
-	item_state = "radio"
 
-/obj/item/holybeacon/attack_self(mob/user)
-	if(user.mind && (user.mind.isholy) && !SSreligion.holy_armor_type)
-		beacon_armor(user)
+/obj/item/choice_beacon/holy/canUseBeacon(mob/living/user)
+	if(user.mind && user.mind.isholy)
+		return ..()
 	else
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 40, 1)
+		return FALSE
 
-/obj/item/holybeacon/proc/beacon_armor(mob/living/M)
-	if(!istype(M))
+/obj/item/choice_beacon/holy/generate_display_names()
+	var/static/list/holy_item_list
+	if(!holy_item_list)
+		holy_item_list = list()
+		var/list/templist = typesof(/obj/item/storage/box/holy)
+		for(var/V in templist)
+			var/atom/A = V
+			holy_item_list[initial(A.name)] = A
+	return holy_item_list
+
+/obj/item/choice_beacon/holy/spawn_option(obj/choice,mob/living/M)
+	if(!SSreligion.holy_armor_type)
+		..()
+		SSblackbox.record_feedback("tally", "chaplain_armor", 1, "[choice]")
+		SSreligion.holy_armor_type = choice
+	else
+		to_chat(M, "<span class='warning'>A selection has already been made. Self-Destructing...</span>")
 		return
-	var/list/holy_armor_list = typesof(/obj/item/storage/box/holy)
-	var/list/display_names = list()
-	for(var/V in holy_armor_list)
-		var/atom/A = V
-		display_names += list(initial(A.name) = A)
 
-	var/choice = input(M,"What holy armor kit would you like to order?","Holy Armor Theme") as null|anything in display_names
-	if(QDELETED(src) || !choice || M.stat || !in_range(M, src) || M.restrained() || !(M.mobility_flags & MOBILITY_USE) || SSreligion.holy_armor_type)
-		return
-
-	var/index = display_names.Find(choice)
-	var/A = holy_armor_list[index]
-
-	SSreligion.holy_armor_type = A
-	var/holy_armor_box = new A
-
-	SSblackbox.record_feedback("tally", "chaplain_armor", 1, "[choice]")
-
-	if(holy_armor_box)
-		qdel(src)
-		M.put_in_active_hand(holy_armor_box)///YOU COMPILED
 
 /obj/item/storage/box/holy
 	name = "Templar Kit"

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -42,7 +42,7 @@
 /obj/item/choice_beacon/holy/spawn_option(obj/choice,mob/living/M)
 	if(!SSreligion.holy_armor_type)
 		..()
-		playsound(src, 'sound/effects/pray-chaplain.ogg', 40, 1)
+		playsound(src, 'sound/effects/pray_chaplain.ogg', 40, 1)
 		SSblackbox.record_feedback("tally", "chaplain_armor", 1, "[choice]")
 		SSreligion.holy_armor_type = choice
 	else

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -12,33 +12,66 @@
 	w_class = WEIGHT_CLASS_SMALL
 	attack_verb = list("warned", "cautioned", "smashed")
 
-/obj/item/herobeacon
-	name = "heroic beacon"
-	desc = "To summon heroes from the past to protect the future."
+/obj/item/choice_beacon
+	name = "choice beacon"
+	desc = "Hey, why are you viewing this?!!"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "gangtool-blue"
 	item_state = "radio"
-	var/static/list/display_names = list()
 
-/obj/item/herobeacon/attack_self(mob/user)
+/obj/item/choice_beacon/attack_self(mob/user)
+	if(canUseBeacon(user))
+		generate_options(user)
+
+/obj/item/choice_beacon/proc/generate_display_names()
+	return list()
+
+/obj/item/choice_beacon/proc/canUseBeacon(mob/living/user)
 	if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
-		beacon_hero(user)
+		return TRUE
+	else
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 40, 1)
+		return FALSE
 
-/obj/item/herobeacon/proc/beacon_hero(mob/M)
+/obj/item/choice_beacon/proc/generate_options(mob/living/M)
+	var/list/display_names = generate_display_names()
 	if(!display_names.len)
-		var/static/list/herobox = typesof(/obj/item/storage/box/hero)
-		for(var/V in herobox)
-			var/atom/A = V
-			display_names[initial(A.name)] = A
-
-	var/choice = input(M,"What heroic outfit would you like to order?","Historic Heroes") as null|anything in display_names
+		return
+	var/choice = input(M,"Which item would you like to order?","Select an Item") as null|anything in display_names
 	if(!choice || !M.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		return
 
-	var/poseheroicallyuntilthisworks = display_names[choice]
-	var/herobox = new poseheroicallyuntilthisworks()
-	M.put_in_hands(herobox)
+	spawn_option(display_names[choice],M)
 	qdel(src)
+
+/obj/item/choice_beacon/proc/spawn_option(obj/choice,mob/living/M)
+	var/obj/new_item = new choice()
+	var/obj/structure/closet/supplypod/bluespacepod/pod = new()
+	pod.explosionSize = list(0,0,0,2)
+	new_item.forceMove(pod)
+	var/msg = "<span class = danger>After making your selection, you notice a strange target on the ground. It might be best to step back!</span>"
+	if (ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(istype(H.ears, /obj/item/radio/headset))
+			msg = "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: <span class='bold'>Item request received. Your package is inbound, please stand back from the landing site.</span> Message ends.\""
+	to_chat(M, msg)
+
+	new /obj/effect/DPtarget(get_turf(src), pod)
+
+/obj/item/choice_beacon/hero
+	name = "heroic beacon"
+	desc = "To summon heroes from the past to protect the future."
+
+/obj/item/choice_beacon/hero/generate_display_names()
+	var/static/list/hero_item_list
+	if(!hero_item_list)
+		hero_item_list = list()
+		var/list/templist = typesof(/obj/item/storage/box/hero) //we have to convert type = name to name = type, how lovely!
+		for(var/V in templist)
+			var/atom/A = V
+			hero_item_list[initial(A.name)] = A
+	return hero_item_list
+
 
 /obj/item/storage/box/hero
 	name = "Courageous Tomb Raider - 1940's."

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -14,7 +14,7 @@
 
 /obj/item/choice_beacon
 	name = "choice beacon"
-	desc = "Hey, why are you viewing this?!!"
+	desc = "Hey, why are you viewing this?!! Please let Centcom know about this odd occurance."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "gangtool-blue"
 	item_state = "radio"

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -23,7 +23,7 @@
 	if(canUseBeacon(user))
 		generate_options(user)
 
-/obj/item/choice_beacon/proc/generate_display_names()
+/obj/item/choice_beacon/proc/generate_display_names() // return the list that will be used in the choice selection. entries should be in (type.name = type) fashion. see choice_beacon/hero for how this is done.
 	return list()
 
 /obj/item/choice_beacon/proc/canUseBeacon(mob/living/user)

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -97,7 +97,7 @@
 	icon_door = "black"
 
 /obj/structure/closet/wardrobe/chaplain_black/PopulateContents()
-	new /obj/item/holybeacon(src)
+	new /obj/item/choice_beacon/holy(src)
 	new /obj/item/clothing/accessory/pocketprotector/cosmetology(src)
 	new /obj/item/clothing/under/rank/chaplain(src)
 	new /obj/item/clothing/shoes/sneakers/black(src)

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -143,7 +143,7 @@ Curator
 	l_pocket = /obj/item/laser_pointer
 	accessory = /obj/item/clothing/accessory/pocketprotector/full
 	backpack_contents = list(
-		/obj/item/herobeacon = 1,
+		/obj/item/choice_beacon/hero = 1,
 		/obj/item/soapstone = 1,
 		/obj/item/barcodescanner = 1
 	)

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -300,7 +300,7 @@
 	icon_state = "chapdrobe"
 	product_ads = "Are you being bothered by cultists or pesky revenants? Then come and dress like the holy man!;Clothes for men of the cloth!"
 	vend_reply = "Thank you for using the ChapDrobe!"
-	products = list(/obj/item/holybeacon = 1,
+	products = list(/obj/item/choice_beacon/holy = 1,
 					/obj/item/storage/backpack/cultpack = 1,
 					/obj/item/clothing/accessory/pocketprotector/cosmetology = 1,
 					/obj/item/clothing/under/rank/chaplain = 1,


### PR DESCRIPTION
### Purpose: 
Streamlines the beacons since they do the same thing. As you can see if you want to add a beacon all you have to do now is define it and change `generate_display_names()`. Compare old `herobeacon` to new `choice_beacon/hero`!

### Features: 
All beacon variants now use the droppod feature. It's more realistic than poofing items and tbh cute.
All beacon variants now buzz if you fail to use the item.
The Holy Beacon now praises the gods when you spawn something in.
Fixes #40991

### Performance/Maintainability:
- Much easier to add these types of beacons now without needless copy-paste.
- `display_names` was removed from the object and is now temporarily kept in the proc that called them. since it now is a list shared by all choice_beacon types it has lost its static nature.
- Slightly more procs than previously but this is mainly due to holybeacon having the extra checks and post-spawning feedback tally. Hopefully this modularity can be exploited more. If there's a better way let me know.


