### PR TITLE
Fixes fire alarms being unable to be activated

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -119,7 +119,7 @@
 	..()
 
 /obj/machinery/firealarm/proc/alarm(mob/user)
-	if(!is_operational() || (last_alarm+FIREALARM_COOLDOWN < world.time))
+	if(!is_operational() || (last_alarm+FIREALARM_COOLDOWN > world.time))
 		return
 	last_alarm = world.time
 	var/area/A = get_area(src)


### PR DESCRIPTION
Fixes #41190

67 (last_alarm inits to 0) is always less than world_time kevinz, this is why you should actually test your PRs

The check in question was erroneous (and looks like copypasted from few lines above, but few lines above test the _opposite_ condition), but it was never run before #41077.