### PR TITLE
fixes 2 minor blindness quirk bugs (thank u cyberboss)

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -320,7 +320,7 @@
 /datum/quirk/blindness/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/clothing/glasses/sunglasses/blindfold/white/glasses = new(get_turf(H))
-	if(!H.equip_to_slot_if_possible(glasses, SLOT_GLASSES)) //if you can't put it on the user's eyes, put it in their hands, otherwise put it on their eyes
+	if(!H.equip_to_slot_if_possible(glasses, SLOT_GLASSES, bypass_equip_delay_self = TRUE)) //if you can't put it on the user's eyes, put it in their hands, otherwise put it on their eyes
 		H.put_in_hands(glasses)
 	H.regenerate_icons()
 

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -320,6 +320,6 @@
 /datum/quirk/blindness/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/clothing/glasses/sunglasses/blindfold/white/glasses = new(get_turf(H))
-	if(!H.equip_to_slot(glasses, SLOT_GLASSES)) //if you can't put it on the user's eyes, put it in their hands, otherwise put it on their eyes
-		H.put_in_hands(glasses)
+	H.put_in_hands(glasses)
+	H.equip_to_slot(glasses, SLOT_GLASSES) //if you can't put it on the user's eyes, put it in their hands, otherwise put it on their eyes
 	H.regenerate_icons()

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -320,6 +320,7 @@
 /datum/quirk/blindness/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/clothing/glasses/sunglasses/blindfold/white/glasses = new(get_turf(H))
-	H.put_in_hands(glasses) //try to put it in the user's hands, then on the user's eyes
-	H.equip_to_slot(glasses, SLOT_GLASSES)
+	if(!H.equip_to_slot_if_possible(glasses, SLOT_GLASSES)) //if you can't put it on the user's eyes, put it in their hands, otherwise put it on their eyes
+		H.put_in_hands(glasses)
 	H.regenerate_icons()
+

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -320,6 +320,6 @@
 /datum/quirk/blindness/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/clothing/glasses/sunglasses/blindfold/white/glasses = new(get_turf(H))
-	H.put_in_hands(glasses)
-	H.equip_to_slot(glasses, SLOT_GLASSES) //if you can't put it on the user's eyes, put it in their hands, otherwise put it on their eyes
+	H.put_in_hands(glasses) //try to put it in the user's hands, then on the user's eyes
+	H.equip_to_slot(glasses, SLOT_GLASSES)
 	H.regenerate_icons()

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -284,7 +284,7 @@
 	..()
 
 /obj/item/clothing/glasses/sunglasses/blindfold/white/update_icon(mob/living/carbon/human/user)
-	if(ishuman(user))
+	if(ishuman(user) && !colored_before)
 		add_atom_colour("#[user.eye_color]", FIXED_COLOUR_PRIORITY)
 		colored_before = TRUE
 

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -290,7 +290,7 @@
 
 /obj/item/clothing/glasses/sunglasses/blindfold/white/worn_overlays(isinhands = FALSE, file2use)
 	. = list()
-	if(!isinhands && ishuman(loc))
+	if(!isinhands && ishuman(loc) && !colored_before)
 		var/mob/living/carbon/human/H = loc
 		var/mutable_appearance/M = mutable_appearance('icons/mob/eyes.dmi', "blindfoldwhite")
 		M.appearance_flags |= RESET_COLOR


### PR DESCRIPTION
when i added the check cyberboss asked for, it'd do this weird thing where it splits the icon of the blindfold between your eyes and hands, but the true item would be in your hands

also fixed the blindfold changing color more than once (my bad)
:cl: Basilman
fix: fixed blindness identification blindfold changing color more than once
fix: fixed blindfold item being split in your inventory
/:cl:

