### PR TITLE
UTTERLY CATASTROPHIC pumpkin meteors will now only happen when it's catastrophic meteor wave, instead of 100% ending the round every time any kind of dust appears

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -21,8 +21,6 @@
 		determine_wave_type()
 
 /datum/round_event/meteor_wave/proc/determine_wave_type()
-	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
-		wave_name = "halloween"
 	if(!wave_name)
 		wave_name = pickweight(list(
 			"normal" = 50,
@@ -34,7 +32,10 @@
 		if("threatening")
 			wave_type = GLOB.meteors_threatening
 		if("catastrophic")
-			wave_type = GLOB.meteors_catastrophic
+			if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+				wave_type = GLOB.meteorsSPOOKY
+			else
+				wave_type = GLOB.meteors_catastrophic
 		if("meaty")
 			wave_type = GLOB.meteorsB
 		if("space dust")


### PR DESCRIPTION
:cl: Barhandar
fix: Pumpkin meteors on Halloween now replace catastrophic meteor waves, instead of ALL OF THEM.
/:cl:

[why]: any kind of dust event right now is a guaranteed, no save allowed, round ender because nobody is ever going to fix THAT kind of damage to entirety of outer side of the station, including nigh-guaranteed atmos venting. This fixes that by making sure the insane damage is contained in the all-year round-ender option.

Yes, this is ~~untested~~ _live-tested_ webedit.

Speedmerge pls.

Fixes #41202