### PR TITLE
Fixed organ bags killing brains

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -90,6 +90,9 @@
 /obj/item/organ/brain/attackby(obj/item/O, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
 
+	if(istype(O, /obj/item/organ_storage))
+		return //Borg organ bags shouldn't be killing brains
+
 	if(damaged_brain && O.is_drainable() && O.reagents.has_reagent("mannitol")) //attempt to heal the brain
 		. = TRUE //don't do attack animation.
 		if(brain_death || brainmob?.health <= HEALTH_THRESHOLD_DEAD) //if the brain is fucked anyway, do nothing


### PR DESCRIPTION
:cl: Zxaber
fix: Fixed borg organ bags causing brain damage when picking up brains.
/:cl:

Since the organ bag is specifically designed to handle organs, it's weird that it would cause damage to them. Presumably, this was just an oversight from a missing exception.
