### PR TITLE
Revert "Makes Romerol Buyable for Nuke Ops"

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -776,6 +776,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/romerol
 	cost = 25
 	cant_discount = TRUE
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/dart_pistol
 	name = "Dart Pistol"


### PR DESCRIPTION
Reverts tgstation/tgstation#41033
This PR was made by a yogs player who all commonly have hardons for romerol, xenos and other stuff like crew V. threat. It should be kept to their upstream only. Clown Ops already have romerol as apart of their gimmick and frankly romerol + biochem sprayer is bullshit as I learnt from being a clown op