### PR TITLE
Changes revenant spell unlocks to only use stolen essence

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -56,6 +56,7 @@
 	var/essence_regenerating = TRUE //If the revenant regenerates essence or not
 	var/essence_regen_amount = 5 //How much essence regenerates
 	var/essence_accumulated = 0 //How much essence the revenant has stolen
+	var/essence_excess = 0 //How much stolen essence avilable for unlocks
 	var/revealed = FALSE //If the revenant can take damage from normal sources.
 	var/unreveal_time = 0 //How long the revenant is revealed for, is about 2 seconds times this var.
 	var/unstun_time = 0 //How long the revenant is stunned for, is about 2 seconds times this var.
@@ -128,6 +129,7 @@
 	if(statpanel("Status"))
 		stat(null, "Current essence: [essence]/[essence_regen_cap]E")
 		stat(null, "Stolen essence: [essence_accumulated]E")
+		stat(null, "Unused stolen essence: [essence_excess]E")
 		stat(null, "Stolen perfect souls: [perfectsouls]")
 
 /mob/living/simple_animal/revenant/update_health_hud()
@@ -294,16 +296,24 @@
 		return FALSE
 	return TRUE
 
+/mob/living/simple_animal/revenant/proc/unlock(essence_cost)
+	if(essence_excess < essence_cost)
+		return FALSE
+	essence_excess -= essence_cost
+	update_action_buttons_icon()
+	return TRUE
+
 /mob/living/simple_animal/revenant/proc/change_essence_amount(essence_amt, silent = FALSE, source = null)
 	if(!src)
 		return
-	if(essence + essence_amt <= 0)
+	if(essence + essence_amt < 0)
 		return
 	essence = max(0, essence+essence_amt)
-	update_action_buttons_icon()
 	update_health_hud()
 	if(essence_amt > 0)
 		essence_accumulated = max(0, essence_accumulated+essence_amt)
+		essence_excess = max(0, essence_excess+essence_amt)
+	update_action_buttons_icon()
 	if(!silent)
 		if(essence_amt > 0)
 			to_chat(src, "<span class='revennotice'>Gained [essence_amt]E[source ? " from [source]":""].</span>")

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -142,7 +142,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/New()
 	..()
 	if(locked)
-		name = "[initial(name)] ([unlock_amount]E)"
+		name = "[initial(name)] ([unlock_amount]SE)"
 	else
 		name = "[initial(name)] ([cast_amount]E)"
 
@@ -154,7 +154,7 @@
 	if(user.inhibited)
 		return FALSE
 	if(locked)
-		if(user.essence <= unlock_amount)
+		if(user.essence_excess <= unlock_amount)
 			return FALSE
 	if(user.essence <= cast_amount)
 		return FALSE
@@ -168,7 +168,7 @@
 			locked = FALSE
 		return TRUE
 	if(locked)
-		if(!user.castcheck(-unlock_amount))
+		if (!user.unlock(unlock_amount))
 			charge_counter = charge_max
 			return FALSE
 		name = "[initial(name)] ([cast_amount]E)"
@@ -194,6 +194,7 @@
 	charge_max = 200
 	range = 5
 	stun = 30
+	unlock_amount = 25
 	cast_amount = 40
 	var/shock_range = 2
 	var/shock_damage = 15
@@ -236,7 +237,7 @@
 	range = 4
 	stun = 20
 	reveal = 40
-	unlock_amount = 75
+	unlock_amount = 10
 	cast_amount = 30
 	action_icon_state = "defile"
 
@@ -287,7 +288,7 @@
 	charge_max = 200
 	range = 4
 	cast_amount = 60
-	unlock_amount = 200
+	unlock_amount = 125
 	action_icon_state = "malfunction"
 
 //A note to future coders: do not replace this with an EMP because it will wreck malf AIs and everyone will hate you.
@@ -334,7 +335,7 @@
 	charge_max = 200
 	range = 3
 	cast_amount = 50
-	unlock_amount = 200
+	unlock_amount = 75
 	action_icon_state = "blight"
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/blight/cast(list/targets, mob/living/simple_animal/revenant/user = usr)

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -51,6 +51,8 @@
 				to_chat(src, "<span class='revenminor'>You begin siphoning essence from [target]'s soul.</span>")
 				if(target.stat != DEAD)
 					to_chat(target, "<span class='warning'>You feel a horribly unpleasant draining sensation as your grip on life weakens...</span>")
+				if(target.stat == SOFT_CRIT)
+					target.stun(46)
 				reveal(46)
 				stun(46)
 				target.visible_message("<span class='warning'>[target] suddenly rises slightly into the air, [target.p_their()] skin turning an ashy gray.</span>")

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -1,20 +1,12 @@
 
 //Harvest; activated ly clicking the target, will try to drain their essence.
 /mob/living/simple_animal/revenant/ClickOn(atom/A, params) //revenants can't interact with the world directly.
-	var/list/modifiers = params2list(params)
-	if(modifiers["shift"])
-		ShiftClickOn(A)
-		return
-	if(modifiers["alt"])
-		AltClickOn(A)
-		return
-
+	A.examine(src)
 	if(ishuman(A))
 		if(A in drained_mobs)
 			to_chat(src, "<span class='revenwarning'>[A]'s soul is dead and empty.</span>" )
 		else if(in_range(src, A))
 			Harvest(A)
-	
 
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)
 	if(!castcheck(0))

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -1,12 +1,20 @@
 
 //Harvest; activated ly clicking the target, will try to drain their essence.
 /mob/living/simple_animal/revenant/ClickOn(atom/A, params) //revenants can't interact with the world directly.
-	A.examine(src)
+	var/list/modifiers = params2list(params)
+	if(modifiers["shift"])
+		ShiftClickOn(A)
+		return
+	if(modifiers["alt"])
+		AltClickOn(A)
+		return
+
 	if(ishuman(A))
 		if(A in drained_mobs)
 			to_chat(src, "<span class='revenwarning'>[A]'s soul is dead and empty.</span>" )
 		else if(in_range(src, A))
 			Harvest(A)
+	
 
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)
 	if(!castcheck(0))

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -52,7 +52,7 @@
 				if(target.stat != DEAD)
 					to_chat(target, "<span class='warning'>You feel a horribly unpleasant draining sensation as your grip on life weakens...</span>")
 				if(target.stat == SOFT_CRIT)
-					target.stun(46)
+					target.Stun(46)
 				reveal(46)
 				stun(46)
 				target.visible_message("<span class='warning'>[target] suddenly rises slightly into the air, [target.p_their()] skin turning an ashy gray.</span>")


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
tweak: Revenants now only use stolen essence to unlock new spells. No more counting corpses or waiting for regen before draining.
tweak: Spell unlock costs adjusted accordingly, defile upped from 0 to a cost of 10.
balance: Reduced blight cost to 75, more in line with its underwhelming nature.
tweak: Drain targets in soft-crit will be stunned, to prevent them crawling away.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Revenant spell unlocks always felt off to me. Currently, you use a combination of your capped essence plus stolen essence over the cap to unlock spells. Since the most expensive spells cost 200, this means you need to extract 125 essence on top of the 75 normal cap without using any spells in between draining and unlocking. In other words, worst case you need to have 8-9 corpses ready to drain in order to reach the 200. Better hope noone interrupts you. "Wasting" a corpse by draining before you regen to max cap is also a thing.

With this, you can use your unlocked spells to help you drain corpses. Spell costs have been reduced to be in line with not using the free 75 capped essence, ie malfunction reduced from 200 to 125. In addition, blight was reduced to 75, since effectively all it does is apply a small amount of toxin damage.