### PR TITLE
Rocket launcher fixes, adds suicide_act

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/grenade.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/grenade.dm
@@ -12,11 +12,16 @@
 
 /obj/item/ammo_box/magazine/rocket
 	name = "84mm HE rocket"
+	desc = "A 84mm rocket."
 	icon_state = "srm-8"
 	ammo_type = /obj/item/ammo_casing/caseless/srm8
 	caliber = "84mm"
 	max_ammo = 1
 	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/ammo_box/magazine/rocket/update_icon()
+	..()
+	desc = initial(desc)
 
 /obj/item/ammo_box/magazine/rocket/hedp
 	name = "84mm HEDP rocket"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -481,7 +481,7 @@
 	if(zoomed)
 		zoom(user,FALSE)
 
-/obj/item/gun/proc/handle_suicide(mob/living/carbon/human/user, mob/living/carbon/human/target, params)
+/obj/item/gun/proc/handle_suicide(mob/living/carbon/human/user, mob/living/carbon/human/target, params, bypass_timer)
 	if(!ishuman(user) || !ishuman(target))
 		return
 
@@ -497,7 +497,7 @@
 
 	semicd = TRUE
 
-	if(!do_mob(user, target, 120) || user.zone_selected != BODY_ZONE_PRECISE_MOUTH)
+	if(!bypass_timer && (!do_mob(user, target, 120) || user.zone_selected != BODY_ZONE_PRECISE_MOUTH))
 		if(user)
 			if(user == target)
 				user.visible_message("<span class='notice'>[user] decided not to shoot.</span>")

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -74,7 +74,7 @@
 		update_icon()
 		chamber_round()
 
-/obj/item/gun/ballistic/automatic/rocketlauncher
+/obj/item/gun/ballistic/rocketlauncher
 	name = "rocket propelled grenade launcher"
 	desc = "A reusable rocket propelled grenade launcher."
 	icon_state = "rocketlauncher"
@@ -86,23 +86,39 @@
 	pin = /obj/item/firing_pin/implant/pindicate
 	burst_size = 1
 	fire_delay = 0
-	select = 0
-	actions_types = list()
 	casing_ejector = FALSE
 	weapon_weight = WEAPON_HEAVY
 	magazine_wording = "rocket"
 
-/obj/item/gun/ballistic/automatic/rocketlauncher/unrestricted
+/obj/item/gun/ballistic/rocketlauncher/handle_atom_del(atom/A)
+	if(A == chambered)
+		chambered = null
+		if(!QDELETED(magazine))
+			QDEL_NULL(magazine)
+	if(A == magazine)
+		magazine = null
+		if(!QDELETED(chambered))
+			QDEL_NULL(chambered)
+	update_icon()
+	return ..()
+
+/obj/item/gun/ballistic/rocketlauncher/can_shoot()
+	return chambered?.BB
+
+/obj/item/gun/ballistic/rocketlauncher/unrestricted
 	pin = /obj/item/firing_pin
 
-/obj/item/gun/ballistic/automatic/rocketlauncher/process_chamber()
+/obj/item/gun/ballistic/rocketlauncher/process_chamber()
 	if(chambered)
 		chambered = null
 	if(magazine)
 		QDEL_NULL(magazine)
 	update_icon()
 
-/obj/item/gun/ballistic/automatic/rocketlauncher/attack_self(mob/living/user)
+/obj/item/gun/ballistic/rocketlauncher/attack_self_tk(mob/user)
+	return //too difficult to remove the rocket with TK
+
+/obj/item/gun/ballistic/rocketlauncher/attack_self(mob/living/user)
 	if(magazine)
 		if(chambered)
 			chambered.forceMove(magazine)
@@ -111,15 +127,31 @@
 		else
 			stack_trace("Removed [magazine] from [src] without a chambered round")
 		magazine.forceMove(drop_location())
-		user.put_in_hands(magazine)
+		if(user.is_holding(src))
+			user.put_in_hands(magazine)
 		playsound(src, 'sound/weapons/gun_magazine_remove_full.ogg', 70, TRUE)
 		to_chat(user, "<span class='notice'>You work the [magazine] out from [src].</span>")
 		magazine = null
 	else
 		to_chat(user, "<span class='notice'>There's no rocket in [src].</span>")
 	update_icon()
-	return
 
-/obj/item/gun/ballistic/automatic/rocketlauncher/update_icon()
-	..()
-	icon_state = "rocketlauncher[magazine ? "-[get_ammo(TRUE)]" : ""]"
+/obj/item/gun/ballistic/rocketlauncher/update_icon()
+	icon_state = "[initial(icon_state)]-[chambered ? "1" : "0"]"
+
+/obj/item/gun/ballistic/rocketlauncher/suicide_act(mob/user)
+	if(can_shoot())
+		handle_suicide(user, user, null, TRUE)
+		if(!QDELETED(user)) //if they weren't gibbed by the explosion, take care of them for good.
+			user.gib()
+		return MANUAL_SUICIDE
+	else
+		user.visible_message("<span class='warning'>[user] sticks [src] in [user.p_their()] mouth, ready to pull the trigger...</span>", \
+			"<span class='userdanger'>You stick [src] in your mouth, ready to pull the trigger...</span>")
+		sleep(5)
+		shoot_with_empty_chamber(user)
+		sleep(20)
+		user.visible_message("<span class='warning'>[user]'s looks about the room realizing [user.p_theyre()] still there. [user.p_they(TRUE)] proceed to shove [src] further down their throat and choke [user.p_them()]self with it!</span>", \
+			"<span class='userdanger'>You look around after realizing you're still here, then proceed to choke yourself with [src]!</span>")
+		sleep(20)
+		return OXYLOSS

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -42,7 +42,7 @@ GLOBAL_LIST_INIT(summoned_guns, list(
 	/obj/item/gun/ballistic/revolver/grenadelauncher,
 	/obj/item/gun/ballistic/revolver/golden,
 	/obj/item/gun/ballistic/automatic/sniper_rifle,
-	/obj/item/gun/ballistic/automatic/rocketlauncher,
+	/obj/item/gun/ballistic/rocketlauncher,
 	/obj/item/gun/medbeam,
 	/obj/item/gun/energy/laser/scatter,
 	/obj/item/gun/energy/gravity_gun))

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -224,7 +224,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "84mm Rocket Propelled Grenade Launcher"
 	desc = "A reusable rocket propelled grenade launcher preloaded with a low-yield 84mm HE round. \
 		Guaranteed to send your target out with a bang or your money back!"
-	item = /obj/item/gun/ballistic/automatic/rocketlauncher
+	item = /obj/item/gun/ballistic/rocketlauncher
 	cost = 8
 	surplus = 30
 	include_modes = list(/datum/game_mode/nuclear)


### PR DESCRIPTION
:cl: ShizCalev
fix: You can no longer try to tactically reload rocket launchers, making it become invisible and breaking it's rocket.
fix: You can no longer unload a rocket with TK
tweak: Suiciding while holding a rocket launcher will now cause you to blow yourself up with it.
/:cl:

Fixes #41215