### PR TITLE
Suiciding with a gun will now say "You pull the trigger", instead of referring to you in the third person.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -508,7 +508,7 @@
 
 	semicd = FALSE
 
-	target.visible_message("<span class='warning'>[user] pulls the trigger!</span>", "<span class='userdanger'>[user] pulls the trigger!</span>")
+	target.visible_message("<span class='warning'>[user] pulls the trigger!</span>", "<span class='userdanger'>[(user == target) ? "You pull" : "[user] pulls"] the trigger!</span>")
 
 	if(chambered && chambered.BB)
 		chambered.BB.damage *= 5


### PR DESCRIPTION
:cl: ShizCalev
spellcheck: Suiciding with a gun will now say 'You pull the trigger', instead of referring to you in the third person.
/:cl:
