### PR TITLE
[s] Gun TK fixes

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -105,10 +105,11 @@
 /obj/item/ammo_box/attack_self(mob/user)
 	var/obj/item/ammo_casing/A = get_round()
 	if(A)
-		if(!user.put_in_hands(A))
+		A.forceMove(drop_location())
+		if(!user.is_holding(src) || !user.put_in_hands(A))	//incase they're using TK
 			A.bounce_away(FALSE, NONE)
-		playsound(src, 'sound/weapons/bulletinsert.ogg', 60, 1)
-		to_chat(user, "<span class='notice'>You remove a round from \the [src]!</span>")
+		playsound(src, 'sound/weapons/bulletinsert.ogg', 60, TRUE)
+		to_chat(user, "<span class='notice'>You remove a round from [src]!</span>")
 		update_icon()
 
 /obj/item/ammo_box/update_icon()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -43,7 +43,7 @@
 				else
 					to_chat(user, "<span class='notice'>You insert the magazine into \the [src].</span>")
 
-				playsound(user, 'sound/weapons/autoguninsert.ogg', 60, 1)
+				playsound(src, 'sound/weapons/autoguninsert.ogg', 60, TRUE)
 				chamber_round()
 				A.update_icon()
 				update_icon()


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed an exploit allowing you to teleport ammo out of a magazine.
fix: Fixed magazine loading sounds playing at the incorrect location if you load the magazine via TK.
/:cl:
