### PR TITLE
Borg ion thrusters no longer drain charge in gravity.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -1,7 +1,10 @@
 /mob/living/silicon/robot/Process_Spacemove(movement_dir = 0)
+	. = ..()
+	if(.)
+		return TRUE
 	if(ionpulse())
-		return 1
-	return ..()
+		return TRUE
+	return FALSE
 
 /mob/living/silicon/robot/mob_negates_gravity()
 	return magpulse


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
fix: Borg ion thrusters now stop draining charge when you can move without them. 
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Partial fix of #39893
If jetpacks are smart enough to disengage in gravity, borg thrusters should be able to do so too.