### PR TITLE
Clumsy clowns are bad at velcro

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -81,6 +81,16 @@
 	. = ..()
 	AddComponent(/datum/component/squeak, list('sound/effects/clownstep1.ogg'=1,'sound/effects/clownstep2.ogg'=1), 50)
 
+/obj/item/clothing/shoes/clown_shoes/attack_hand(mob/user)
+	if(iscarbon(user))
+		var/mob/living/carbon/C = user
+		if(src == C.shoes)
+			if(user.has_trait(TRAIT_CLUMSY))
+				to_chat(user, "<span class='notice'>You clumsily fiddle with the velcro straps. (This will take around one minute and you need to stay still.)</span>")
+				if (!do_after(user, 600, target = user))
+					return
+	..()
+
 /obj/item/clothing/shoes/clown_shoes/equipped(mob/user, slot)
 	. = ..()
 	if(user.mind && user.mind.assigned_role == "Clown")


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
balance: If you are clumsy, removing clown shoes now take a minute.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Good clowns wear their shoes. Bad ones take them off when convenient. This makes removing them inconvenient, but not impossible. 
Antag clowns shouldn't be clumsy, and should not be affected. Persistent non-antags can also get around this.