### PR TITLE
Prevents megafauna signal gps getting exploded.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -43,6 +43,9 @@
 	QDEL_NULL(internal)
 	. = ..()
 
+/mob/living/simple_animal/hostile/megafauna/prevent_content_explosion()
+	return TRUE
+
 /mob/living/simple_animal/hostile/megafauna/death(gibbed)
 	if(health > 0)
 		return


### PR DESCRIPTION
What it says on the tin. Alternative fix is to make these unexplodable gps but eh.

GPS signal component is better idea