### PR TITLE
Prevents an incorrect ghost examine

### DIFF
--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -74,3 +74,6 @@
 			machinery_computer.verbs -= /obj/machinery/modular_computer/proc/eject_disk
 		if(MC_AI)
 			machinery_computer.verbs -= /obj/machinery/modular_computer/proc/eject_card
+
+/obj/item/modular_computer/processor/attack_ghost(mob/user)
+	ui_interact(user)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
fix: Ghosts can no longer examine the inner workings of modular computers.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Fixes #41251 
Both the console and the processor handling the interaction reached /atom/proc/attack_ghost(), which caused the ghost to examine the processor. This moves the ui_interact one step down, and prevents processor from calling the parent proc.