### PR TITLE
[Ready] Makes nicotine and cigar(ettes) much slower acting. Cigars now contain more nicotine.

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -112,7 +112,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/icon_off = "cigoff"
 	var/type_butt = /obj/item/cigbutt
 	var/lastHolder = null
-	var/smoketime = 300
+	var/smoketime = 150
 	var/chem_volume = 30
 	var/list/list_reagents = list("nicotine" = 15)
 	heat = 1000
@@ -212,7 +212,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				return
 		reagents.remove_any(REAGENTS_METABOLISM)
 
-
+var/counter = 0 // There is no way this is the best way of doing this
 /obj/item/clothing/mask/cigarette/process()
 	var/turf/location = get_turf(src)
 	var/mob/living/M = loc
@@ -227,7 +227,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return
 	open_flame()
 	if(reagents && reagents.total_volume)
-		handle_reagents()
+		counter++
+		if (counter == 6)
+			handle_reagents()
+			counter = 0
 
 /obj/item/clothing/mask/cigarette/attack_self(mob/user)
 	if(lit)
@@ -350,8 +353,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	type_butt = /obj/item/cigbutt/cigarbutt
 	throw_speed = 0.5
 	item_state = "cigaroff"
-	smoketime = 1500
+	smoketime = 325
 	chem_volume = 40
+	list_reagents = list("nicotine" = 30)
 
 /obj/item/clothing/mask/cigarette/cigar/cohiba
 	name = "\improper Cohiba Robusto cigar"
@@ -359,9 +363,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "cigar2off"
 	icon_on = "cigar2on"
 	icon_off = "cigar2off"
-	smoketime = 2000
+	smoketime = 500
 	chem_volume = 80
-
+	list_reagents =list("nicotine" = 50)
 
 /obj/item/clothing/mask/cigarette/cigar/havana
 	name = "premium Havanian cigar"
@@ -369,8 +373,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "cigar2off"
 	icon_on = "cigar2on"
 	icon_off = "cigar2off"
-	smoketime = 7200
+	smoketime = 1000
 	chem_volume = 50
+	list_reagents =list("nicotine" = 40)
 
 /obj/item/cigbutt
 	name = "cigarette butt"

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -115,6 +115,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/smoketime = 150
 	var/chem_volume = 30
 	var/list/list_reagents = list("nicotine" = 15)
+	var/dragtime = 100
 	var/nextdragtime = 0
 	heat = 1000
 
@@ -226,11 +227,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		qdel(src)
 		return
 	open_flame()
-	if(reagents && reagents.total_volume)
-		nextdragtime++
-		if (nextdragtime == 6)
-			handle_reagents()
-			nextdragtime = 0
+	if((reagents && reagents.total_volume) && (nextdragtime <= world.time))
+		nextdragtime = world.time + dragtime
+		handle_reagents()
 
 /obj/item/clothing/mask/cigarette/attack_self(mob/user)
 	if(lit)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -115,6 +115,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/smoketime = 150
 	var/chem_volume = 30
 	var/list/list_reagents = list("nicotine" = 15)
+	var/nextdragtime = 0
 	heat = 1000
 
 /obj/item/clothing/mask/cigarette/suicide_act(mob/user)
@@ -212,7 +213,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				return
 		reagents.remove_any(REAGENTS_METABOLISM)
 
-var/counter = 0 // There is no way this is the best way of doing this
 /obj/item/clothing/mask/cigarette/process()
 	var/turf/location = get_turf(src)
 	var/mob/living/M = loc
@@ -227,10 +227,10 @@ var/counter = 0 // There is no way this is the best way of doing this
 		return
 	open_flame()
 	if(reagents && reagents.total_volume)
-		counter++
-		if (counter == 6)
+		nextdragtime++
+		if (nextdragtime == 6)
 			handle_reagents()
-			counter = 0
+			nextdragtime = 0
 
 /obj/item/clothing/mask/cigarette/attack_self(mob/user)
 	if(lit)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -22,7 +22,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "match_unlit"
 	var/lit = FALSE
 	var/burnt = FALSE
-	var/smoketime = 5
+	var/smoketime = 5 // 10 seconds
 	w_class = WEIGHT_CLASS_TINY
 	heat = 1000
 	grind_results = list("phosphorus" = 2)
@@ -106,17 +106,17 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	w_class = WEIGHT_CLASS_TINY
 	body_parts_covered = null
 	grind_results = list()
+	var/dragtime = 100
+	var/nextdragtime = 0
 	var/lit = FALSE
 	var/starts_lit = FALSE
 	var/icon_on = "cigon"  //Note - these are in masks.dmi not in cigarette.dmi
 	var/icon_off = "cigoff"
 	var/type_butt = /obj/item/cigbutt
 	var/lastHolder = null
-	var/smoketime = 150
+	var/smoketime = 180 // 1 is 2 seconds, so a single cigarette will last 6 minutes.
 	var/chem_volume = 30
 	var/list/list_reagents = list("nicotine" = 15)
-	var/dragtime = 100
-	var/nextdragtime = 0
 	heat = 1000
 
 /obj/item/clothing/mask/cigarette/suicide_act(mob/user)
@@ -307,7 +307,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	type_butt = /obj/item/cigbutt/roach
 	throw_speed = 0.5
 	item_state = "spliffoff"
-	smoketime = 180
+	smoketime = 120 // four minutes
 	chem_volume = 50
 	list_reagents = null
 
@@ -352,7 +352,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	type_butt = /obj/item/cigbutt/cigarbutt
 	throw_speed = 0.5
 	item_state = "cigaroff"
-	smoketime = 325
+	smoketime = 300 // 11 minutes
 	chem_volume = 40
 	list_reagents = list("nicotine" = 30)
 
@@ -362,7 +362,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "cigar2off"
 	icon_on = "cigar2on"
 	icon_off = "cigar2off"
-	smoketime = 500
+	smoketime = 600 // 20 minutes
 	chem_volume = 80
 	list_reagents =list("nicotine" = 50)
 
@@ -372,7 +372,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "cigar2off"
 	icon_on = "cigar2on"
 	icon_off = "cigar2off"
-	smoketime = 1000
+	smoketime = 900 // 30 minutes
 	chem_volume = 50
 	list_reagents =list("nicotine" = 40)
 

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -106,6 +106,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	w_class = WEIGHT_CLASS_TINY
 	body_parts_covered = null
 	grind_results = list()
+	heat = 1000
 	var/dragtime = 100
 	var/nextdragtime = 0
 	var/lit = FALSE
@@ -117,7 +118,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/smoketime = 180 // 1 is 2 seconds, so a single cigarette will last 6 minutes.
 	var/chem_volume = 30
 	var/list/list_reagents = list("nicotine" = 15)
-	heat = 1000
 
 /obj/item/clothing/mask/cigarette/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is huffing [src] as quickly as [user.p_they()] can! It looks like [user.p_theyre()] trying to give [user.p_them()]self cancer.</span>")

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -354,7 +354,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	item_state = "cigaroff"
 	smoketime = 300 // 11 minutes
 	chem_volume = 40
-	list_reagents = list("nicotine" = 30)
+	list_reagents = list("nicotine" = 25)
 
 /obj/item/clothing/mask/cigarette/cigar/cohiba
 	name = "\improper Cohiba Robusto cigar"
@@ -364,7 +364,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_off = "cigar2off"
 	smoketime = 600 // 20 minutes
 	chem_volume = 80
-	list_reagents =list("nicotine" = 50)
+	list_reagents =list("nicotine" = 40)
 
 /obj/item/clothing/mask/cigarette/cigar/havana
 	name = "premium Havanian cigar"
@@ -374,7 +374,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_off = "cigar2off"
 	smoketime = 900 // 30 minutes
 	chem_volume = 50
-	list_reagents =list("nicotine" = 40)
+	list_reagents =list("nicotine" = 15)
 
 /obj/item/cigbutt
 	name = "cigarette butt"

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -41,9 +41,11 @@
 	description = "Slightly reduces stun times. If overdosed it will deal toxin and oxygen damage."
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
-	addiction_threshold = 30
+	addiction_threshold = 5
 	taste_description = "smoke"
 	trippy = FALSE
+	overdose_threshold=10
+	metabolization_rate = 0.115 * REAGENTS_METABOLISM
 
 /datum/reagent/drug/nicotine/on_mob_life(mob/living/carbon/M)
 	if(prob(1))
@@ -56,6 +58,12 @@
 	M.AdjustParalyzed(-20, FALSE)
 	M.AdjustImmobilized(-20, FALSE)
 	M.adjustStaminaLoss(-0.5*REM, 0)
+	..()
+	. = 1
+
+/datum/reagent/drug/nicotine/overdose_process(mob/living/M)
+	M.adjustToxLoss(0.05*REM, 0)
+	M.adjustOxyLoss(0.2*REM, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -41,10 +41,10 @@
 	description = "Slightly reduces stun times. If overdosed it will deal toxin and oxygen damage."
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
-	addiction_threshold = 5
+	addiction_threshold = 10
 	taste_description = "smoke"
 	trippy = FALSE
-	overdose_threshold=10
+	overdose_threshold=15
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 
 /datum/reagent/drug/nicotine/on_mob_life(mob/living/carbon/M)
@@ -62,8 +62,8 @@
 	. = 1
 
 /datum/reagent/drug/nicotine/overdose_process(mob/living/M)
-	M.adjustToxLoss(0.05*REM, 0)
-	M.adjustOxyLoss(0.2*REM, 0)
+	M.adjustToxLoss(0.1*REM, 0)
+	M.adjustOxyLoss(1.1*REM, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -45,7 +45,7 @@
 	taste_description = "smoke"
 	trippy = FALSE
 	overdose_threshold=10
-	metabolization_rate = 0.115 * REAGENTS_METABOLISM
+	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 
 /datum/reagent/drug/nicotine/on_mob_life(mob/living/carbon/M)
 	if(prob(1))


### PR DESCRIPTION

:cl:
tweak: nicotine now metabolizes far slower, but is actually dangerous at high doses. Try actually smoking!
tweak: cigarettes don't last as long, but more slowly inject reagents to hopefully last its entire lifetime. if you need it to burn fast, try a pipe or vape.
bugfix: overdosing on nicotine now causes oxygen and toxin damage, as the description said it did.
/:cl:

[why]: cigarettes always bugged me because they give you 15 nicotine in 30 seconds and then go out 9 minutes later, while cigars contained the exact same amount of nicotine. Previously, if you wanted the perks of nicotine, you were best off putting an entire pack in a grinder and sipping it. Overdosing on nicotine is now very slowly but steadily lethal, and actually possible. you'd have to smoke nonstop for a long long time to overdose by accident, and it should take 2 or 3 cigarettes with this to cause the addiction (which still does nothing, not the concern of this pr) maybe some crazy people will dropper 9 units of nicotine into their eyeballs, but this is far better than carp classic smoothies being free and easy shorter stuns.