### PR TITLE
[ready] Makes events ghost-announce their spawned atom much more consistently

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -130,9 +130,10 @@
 	return
 
 //Called after something followable has been spawned by an event
-//Lets the ghosts know that the event has started, and provides a follow link to a mob if possible
+//Provides ghosts a follow link to an atom if possible
 //Only called once.
-/datum/round_event/proc/announce_to_ghosts(var/atom/atom_of_interest)
+/datum/round_event/proc/announce_to_ghosts(atom/atom_of_interest)
+	message_admins("meme")
 	if(control.alert_observers)
 		if (atom_of_interest)
 			notify_ghosts("[atom_of_interest] has just been spawned from [control.name]!", enter_link="<a href=?src=[REF(atom_of_interest)];orbit=1>(Click to orbit)</a>", source=atom_of_interest, action=NOTIFY_ORBIT, header="Something Spawned")

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -133,7 +133,6 @@
 //Provides ghosts a follow link to an atom if possible
 //Only called once.
 /datum/round_event/proc/announce_to_ghosts(atom/atom_of_interest)
-	message_admins("meme")
 	if(control.alert_observers)
 		if (atom_of_interest)
 			notify_ghosts("[atom_of_interest] has just been spawned from [control.name]!", enter_link="<a href=?src=[REF(src)];orbit=1>(Click to orbit)</a>", source=atom_of_interest, action=NOTIFY_ORBIT, header="Something Spawned")

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -136,7 +136,7 @@
 	message_admins("meme")
 	if(control.alert_observers)
 		if (atom_of_interest)
-			notify_ghosts("[atom_of_interest] has just been spawned from [control.name]!", enter_link="<a href=?src=[REF(atom_of_interest)];orbit=1>(Click to orbit)</a>", source=atom_of_interest, action=NOTIFY_ORBIT, header="Something Spawned")
+			notify_ghosts("[atom_of_interest] has just been spawned from [control.name]!", enter_link="<a href=?src=[REF(src)];orbit=1>(Click to orbit)</a>", source=atom_of_interest, action=NOTIFY_ORBIT, header="Something Spawned")
 	return
 
 //Called when the tick is equal to the announceWhen variable.

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -94,7 +94,7 @@
 	testing("[time2text(world.time, "hh:mm:ss")] [E.type]")
 	if(random)
 		log_game("Random Event triggering: [name] ([typepath])")
-
+	deadchat_broadcast("<span class='deadsay'><b>[name]</b> has just been[random ? " randomly" : ""] triggered!</span>") //STOP ASSUMING IT'S BADMINS!
 	return E
 
 //Special admins setup
@@ -112,7 +112,6 @@
 	var/activeFor		= 0	//How long the event has existed. You don't need to change this.
 	var/current_players	= 0 //Amount of of alive, non-AFK human players on server at the time of event start
 	var/fakeable = TRUE		//Can be faked by fake news event.
-	var/atom/atom_of_interest = null //Used for ghosts to follow the event when it starts, if possible
 
 //Called first before processing.
 //Allows you to setup your event, such as randomly
@@ -130,15 +129,13 @@
 /datum/round_event/proc/start()
 	return
 
-//Called after start()
+//Called after something followable has been spawned by an event
 //Lets the ghosts know that the event has started, and provides a follow link to a mob if possible
 //Only called once.
-/datum/round_event/proc/announce_to_ghosts()
+/datum/round_event/proc/announce_to_ghosts(var/atom/atom_of_interest)
 	if(control.alert_observers)
 		if (atom_of_interest)
-			notify_ghosts("[control.name] has just been[control.random ? " randomly" : ""] triggered!", enter_link="<a href=?src=[REF(src)];orbit=1>(Click to orbit)</a>", source=atom_of_interest, action=NOTIFY_ORBIT, header="Event Triggered")
-		else 
-			notify_ghosts("[control.name] has just been[control.random ? " randomly" : ""] triggered!", header="Event Triggered")
+			notify_ghosts("[atom_of_interest] has just been spawned from [control.name]!", enter_link="<a href=?src=[REF(atom_of_interest)];orbit=1>(Click to orbit)</a>", source=atom_of_interest, action=NOTIFY_ORBIT, header="Something Spawned")
 	return
 
 //Called when the tick is equal to the announceWhen variable.
@@ -174,8 +171,6 @@
 	if(activeFor == startWhen)
 		processing = FALSE
 		start()
-		if (!istype(src, /datum/round_event/ghost_role))
-			announce_to_ghosts() //Ghost roles handle announcing after the roles have been properly spawned from the try_spawn() proc
 		processing = TRUE
 
 	if(activeFor == announceWhen)

--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -29,7 +29,7 @@
 
 	scientist.mind.add_antag_datum(/datum/antagonist/abductor/scientist, T)
 	agent.mind.add_antag_datum(/datum/antagonist/abductor/agent, T)
-	atom_of_interest = agent
+	announce_to_ghosts(agent)
 
 	spawned_mobs += list(agent, scientist)
 

--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -29,7 +29,6 @@
 
 	scientist.mind.add_antag_datum(/datum/antagonist/abductor/scientist, T)
 	agent.mind.add_antag_datum(/datum/antagonist/abductor/agent, T)
-	announce_to_ghosts(agent)
 
 	spawned_mobs += list(agent, scientist)
 

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -62,7 +62,7 @@
 
 		var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
 		new_xeno.key = C.key
-		atom_of_interest = new_xeno
+		announce_to_ghosts(new_xeno)
 
 		spawncount--
 		successSpawn = TRUE

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -62,7 +62,6 @@
 
 		var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
 		new_xeno.key = C.key
-		announce_to_ghosts(new_xeno)
 
 		spawncount--
 		successSpawn = TRUE

--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -49,4 +49,4 @@
 	if(T)
 		newAnomaly = new anomaly_path(T)
 	if (newAnomaly)
-		atom_of_interest = newAnomaly
+		announce_to_ghosts(newAnomaly)

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -24,7 +24,7 @@
 		return NOT_ENOUGH_PLAYERS
 	var/mob/dead/observer/new_blob = pick(candidates)
 	var/mob/camera/blob/BC = new_blob.become_overmind()
-	atom_of_interest = BC
+	announce_to_ghosts(BC)
 	spawned_mobs += BC
 	message_admins("[ADMIN_LOOKUPFLW(BC)] has been made into a blob overmind by an event.")
 	log_game("[key_name(BC)] was spawned as a blob overmind by an event.")

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -24,7 +24,6 @@
 		return NOT_ENOUGH_PLAYERS
 	var/mob/dead/observer/new_blob = pick(candidates)
 	var/mob/camera/blob/BC = new_blob.become_overmind()
-	announce_to_ghosts(BC)
 	spawned_mobs += BC
 	message_admins("[ADMIN_LOOKUPFLW(BC)] has been made into a blob overmind by an event.")
 	log_game("[key_name(BC)] was spawned as a blob overmind by an event.")

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -42,7 +42,7 @@
 	vendingMachines.Remove(originMachine)
 	originMachine.shut_up = 0
 	originMachine.shoot_inventory = 1
-	atom_of_interest = originMachine
+	announce_to_ghosts(originMachine)
 
 /datum/round_event/brand_intelligence/tick()
 	if(!originMachine || QDELETED(originMachine) || originMachine.shut_up || originMachine.wires.is_all_cut())	//if the original vending machine is missing or has it's voice switch flipped

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -5,11 +5,11 @@
 	min_players = 2
 	earliest_start = 10 MINUTES
 	max_occurrences = 6
-	var/hasAnnounced = FALSE
 
 /datum/round_event/carp_migration
 	announceWhen	= 3
 	startWhen = 50
+	var/hasAnnounced = FALSE
 
 /datum/round_event/carp_migration/setup()
 	startWhen = rand(40, 60)

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -5,6 +5,7 @@
 	min_players = 2
 	earliest_start = 10 MINUTES
 	max_occurrences = 6
+	var/hasAnnounced = FALSE
 
 /datum/round_event/carp_migration
 	announceWhen	= 3
@@ -18,11 +19,16 @@
 
 
 /datum/round_event/carp_migration/start()
+	var/mob/living/simple_animal/hostile/carp/fish
 	for(var/obj/effect/landmark/carpspawn/C in GLOB.landmarks_list)
-		var/mob/living/simple_animal/hostile/carp/fish
 		if(prob(95))
 			fish = new (C.loc)
 		else
 			fish = new /mob/living/simple_animal/hostile/carp/megacarp(C.loc)
+			fishannounce(fish) //Prefer to announce the megacarps over the regular fishies
+	fishannounce(fish)
 
-		announce_to_ghosts(fish) //Gonna be a lot of announcements kek
+/datum/round_event/carp_migration/proc/fishannounce(atom/fish)	
+	if (!hasAnnounced)
+		announce_to_ghosts(fish) //Only anounce the first fish
+		hasAnnounced = TRUE

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -25,5 +25,4 @@
 		else
 			fish = new /mob/living/simple_animal/hostile/carp/megacarp(C.loc)
 
-		if (!atom_of_interest)
-			atom_of_interest = fish //Assign the atom of interest to the first carp to spawn
+		announce_to_ghosts(fish) //Gonna be a lot of announcements kek

--- a/code/modules/events/devil.dm
+++ b/code/modules/events/devil.dm
@@ -32,7 +32,7 @@
 	var/mob/living/carbon/human/devil = create_event_devil()
 	Mind.transfer_to(devil)
 	add_devil(devil, ascendable = FALSE)
-	atom_of_interest = devil
+	announce_to_ghosts(devil)
 
 	spawned_mobs += devil
 	message_admins("[ADMIN_LOOKUPFLW(devil)] has been made into a devil by an event.")

--- a/code/modules/events/devil.dm
+++ b/code/modules/events/devil.dm
@@ -32,7 +32,6 @@
 	var/mob/living/carbon/human/devil = create_event_devil()
 	Mind.transfer_to(devil)
 	add_devil(devil, ascendable = FALSE)
-	announce_to_ghosts(devil)
 
 	spawned_mobs += devil
 	message_admins("[ADMIN_LOOKUPFLW(devil)] has been made into a devil by an event.")

--- a/code/modules/events/ghost_role.dm
+++ b/code/modules/events/ghost_role.dm
@@ -39,7 +39,8 @@
 	else if(status == SUCCESSFUL_SPAWN)
 		message_admins("[role_name] spawned successfully.")
 		if(spawned_mobs.len)
-			announce_to_ghosts()
+			for (var/mob/M in spawned_mobs)
+				announce_to_ghosts(M)
 		else
 			message_admins("No mobs found in the `spawned_mobs` list, this is \
 				a bug.")

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -19,4 +19,4 @@
 		var/mob/living/carbon/human/winner = pickweight(heart_attack_contestants)
 		var/datum/disease/D = new /datum/disease/heart_failure()
 		winner.ForceContractDisease(D, FALSE, TRUE)
-		atom_of_interest = winner
+		announce_to_ghosts(winner)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -36,7 +36,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/turf/startT = spaceDebrisStartLoc(startside, z)
 	var/turf/endT = spaceDebrisFinishLoc(startside, z)
 	var/atom/rod = new /obj/effect/immovablerod(startT, endT, C.special_target)
-	atom_of_interest = rod
+	announce_to_ghosts(rod)
 
 /obj/effect/immovablerod
 	name = "immovable rod"

--- a/code/modules/events/nightmare.dm
+++ b/code/modules/events/nightmare.dm
@@ -39,6 +39,6 @@
 	playsound(S, 'sound/magic/ethereal_exit.ogg', 50, 1, -1)
 	message_admins("[ADMIN_LOOKUPFLW(S)] has been made into a Nightmare by an event.")
 	log_game("[key_name(S)] was spawned as a Nightmare by an event.")
-	atom_of_interest = S
+	announce_to_ghosts(S)
 	spawned_mobs += S
 	return SUCCESSFUL_SPAWN

--- a/code/modules/events/nightmare.dm
+++ b/code/modules/events/nightmare.dm
@@ -39,6 +39,5 @@
 	playsound(S, 'sound/magic/ethereal_exit.ogg', 50, 1, -1)
 	message_admins("[ADMIN_LOOKUPFLW(S)] has been made into a Nightmare by an event.")
 	log_game("[key_name(S)] was spawned as a Nightmare by an event.")
-	announce_to_ghosts(S)
 	spawned_mobs += S
 	return SUCCESSFUL_SPAWN

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -32,7 +32,7 @@
 	Mind.active = 1
 	Mind.transfer_to(operative)
 	Mind.add_antag_datum(/datum/antagonist/nukeop/lone)
-	atom_of_interest = operative
+	announce_to_ghosts(operative)
 
 	message_admins("[ADMIN_LOOKUPFLW(operative)] has been made into lone operative by an event.")
 	log_game("[key_name(operative)] was spawned as a lone operative by an event.")

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -32,7 +32,6 @@
 	Mind.active = 1
 	Mind.transfer_to(operative)
 	Mind.add_antag_datum(/datum/antagonist/nukeop/lone)
-	announce_to_ghosts(operative)
 
 	message_admins("[ADMIN_LOOKUPFLW(operative)] has been made into lone operative by an event.")
 	log_game("[key_name(operative)] was spawned as a lone operative by an event.")

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -80,11 +80,9 @@
 				var/mob/M = candidates[1]
 				spawner.create(M.ckey)
 				candidates -= M
-				if (!atom_of_interest)
-					atom_of_interest = M
+				announce_to_ghosts(M)
 			else
-				if (!atom_of_interest)
-					atom_of_interest = spawner
+				announce_to_ghosts(spawner)
 
 	priority_announce("Unidentified armed ship detected near the station.")
 

--- a/code/modules/events/processor_overload.dm
+++ b/code/modules/events/processor_overload.dm
@@ -29,8 +29,7 @@
 /datum/round_event/processor_overload/start()
 	for(var/obj/machinery/telecomms/processor/P in GLOB.telecomms_list)
 		if(prob(10))
-			if (!atom_of_interest)
-				atom_of_interest = P //Set the atom of interest to the first processor to blow
+			announce_to_ghosts(P)
 			// Damage the surrounding area to indicate that it popped
 			explosion(get_turf(P), 0, 0, 2)
 			// Only a level 1 explosion actually damages the machine

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -22,7 +22,7 @@
 
 	if(turfs.len) //Pick a turf to spawn at if we can
 		var/turf/T = pick(turfs)
-		new /datum/spacevine_controller(T) //spawn a controller at turf
+		new /datum/spacevine_controller(T, src) //spawn a controller at turf
 
 
 /datum/spacevine_mutation
@@ -378,10 +378,11 @@
 	var/list/vine_mutations_list
 	var/mutativeness = 1
 
-/datum/spacevine_controller/New(turf/location, list/muts, potency, production, var/event = null)
+/datum/spacevine_controller/New(turf/location, list/muts, potency, production, var/datum/round_event/event = null)
 	vines = list()
 	growth_queue = list()
-	spawn_spacevine_piece(location, null, muts)
+	if (event)
+		event.announce_to_ghosts(spawn_spacevine_piece(location, null, muts))
 	START_PROCESSING(SSobj, src)
 	vine_mutations_list = list()
 	init_subtypes(/datum/spacevine_mutation/, vine_mutations_list)
@@ -432,6 +433,7 @@
 	for(var/datum/spacevine_mutation/SM in SV.mutations)
 		SM.on_birth(SV)
 	location.Entered(SV)
+	return SV
 
 /datum/spacevine_controller/proc/VineDestroyed(obj/structure/spacevine/S)
 	S.master = null

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -34,6 +34,6 @@
 		var/spawn_type = /obj/structure/spider/spiderling
 		if(prob(66))
 			spawn_type = /obj/structure/spider/spiderling/nurse
-		atom_of_interest = spawn_atom_to_turf(spawn_type, vent, 1, FALSE)
+		announce_to_ghosts(spawn_atom_to_turf(spawn_type, vent, 1, FALSE))
 		vents -= vent
 		spawncount--

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -26,5 +26,5 @@
 
 		var/datum/disease/D = new /datum/disease/appendicitis()
 		H.ForceContractDisease(D, FALSE, TRUE)
-		atom_of_interest = H
+		announce_to_ghosts(H)
 		break


### PR DESCRIPTION
Fixes #41217

:cl: MrDoomBringer
fix: Events now announce follow-able atoms to ghosts much more reliably
/:cl:

Implements @ShizCalev's suggestion to just have the event ghost-announce normally, then call a separate ghost announcement for the "atom of interest" as it is created.
