### PR TITLE
Allows lethal turrets to target blobs

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -409,6 +409,10 @@
 				if(assess_perp(Mech.occupant) >= 4)
 					targets += Mech
 
+	if(mode == TURRET_LETHAL)
+		for(var/obj/structure/blob/B in view(scan_range, base))
+			targets += B
+
 	if(targets.len)
 		tryToShootAt(targets)
 	else if(!always_up)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -409,7 +409,7 @@
 				if(assess_perp(Mech.occupant) >= 4)
 					targets += Mech
 
-	if(check_anomalies && (mode == TURRET_LETHAL))
+	if(check_anomalies && GLOB.blobs.len && (mode == TURRET_LETHAL))
 		for(var/obj/structure/blob/B in view(scan_range, base))
 			targets += B
 

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -409,7 +409,7 @@
 				if(assess_perp(Mech.occupant) >= 4)
 					targets += Mech
 
-	if(mode == TURRET_LETHAL)
+	if(check_anomalies && (mode == TURRET_LETHAL))
 		for(var/obj/structure/blob/B in view(scan_range, base))
 			targets += B
 


### PR DESCRIPTION
:cl: ShizCalev
balance: Lethal turrets can now target blobs.
/:cl:

Gives an AI a way to defend itself if a blob decides to plop itself down in it's core or the AI upload. 

Likewise, this also allows the crew to build laser gun turrets to help fight against it, providing a little more challenge to the blob if the crew gets smart.

Downside is that turrets are still very weak again blob (they die in a single hit by a blob), so it's not a be-all and end-all defensive strat.