### PR TITLE
Altered miasma stats

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -148,7 +148,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 
 /datum/gas/miasma
 	id = "miasma"
-	specific_heat = 20
+	specific_heat = 100
 	name = "Miasma"
 	gas_overlay = "miasma"
 	moles_visible = MOLES_GAS_VISIBLE * 60


### PR DESCRIPTION
:cl:
balance: Increased miasma's specific heat.
/:cl:
Altered Miasma Stats

Miasma seemed to be lacking useful non-antag applications outside of being something for atmos techs to deal with, so I increased the specific heat to make it more useful for engineers as a coolant for example.