### PR TITLE
Fixes exosuit console issues

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_random_ripley.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_random_ripley.dmm
@@ -9,7 +9,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "d" = (
-/obj/mecha/working/ripley/mining,
+/obj/mecha/working/ripley/mining{
+	ruin_mecha = 1
+	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "e" = (

--- a/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -101,7 +101,9 @@
 /turf/open/floor/mineral/titanium/yellow/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
 "A" = (
-/obj/mecha/working/ripley,
+/obj/mecha/working/ripley{
+	ruin_mecha = 1
+	},
 /turf/open/floor/mineral/titanium/yellow/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
 "B" = (

--- a/_maps/RandomZLevels/VR/snowdin_VR.dmm
+++ b/_maps/RandomZLevels/VR/snowdin_VR.dmm
@@ -14459,7 +14459,8 @@
 /area/awaymission/snowdin/post/mining_main/mechbay)
 "In" = (
 /obj/mecha/working/ripley/mining{
-	dir = 1
+	dir = 1;
+	ruin_mecha = 1
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/mech_bay_recharge_floor,

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -2127,7 +2127,9 @@
 	},
 /area/awaymission/caves/BMP_asteroid)
 "gC" = (
-/obj/mecha/working/ripley/mining,
+/obj/mecha/working/ripley/mining{
+	ruin_mecha = 1
+	},
 /turf/open/floor/plasteel/recharge_floor,
 /area/awaymission/caves/BMP_asteroid)
 "gD" = (

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -14564,7 +14564,8 @@
 /area/awaymission/snowdin/post/mining_main/mechbay)
 "In" = (
 /obj/mecha/working/ripley/mining{
-	dir = 1
+	dir = 1;
+	ruin_mecha = 1
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/mech_bay_recharge_floor,

--- a/_maps/RandomZLevels/spacebattle.dmm
+++ b/_maps/RandomZLevels/spacebattle.dmm
@@ -844,7 +844,9 @@
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "dL" = (
-/obj/mecha/working/ripley/firefighter,
+/obj/mecha/working/ripley/firefighter{
+	ruin_mecha = 1
+	},
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "dM" = (

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -24,6 +24,7 @@
 	infra_luminosity = 15 //byond implementation is bugged.
 	force = 5
 	flags_1 = HEAR_1
+	var/ruin_mecha = FALSE //if the mecha starts on a ruin, don't automatically give it a tracking beacon to prevent metagaming.
 	var/can_move = 0 //time of next allowed movement
 	var/mob/living/carbon/occupant = null
 	var/step_in = 10 //make a step in step_in/10 sec.

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -6,28 +6,21 @@
 	req_access = list(ACCESS_ROBOTICS)
 	circuit = /obj/item/circuitboard/computer/mecha_control
 	var/list/located = list()
-	var/screen = 0
-	var/stored_data
 
 /obj/machinery/computer/mecha/ui_interact(mob/user)
 	. = ..()
-	var/dat = "<html><head><title>[src.name]</title><style>h3 {margin: 0px; padding: 0px;}</style></head><body>"
-	if(screen == 0)
-		dat += "<h3>Tracking beacons data</h3>"
-		var/list/trackerlist = list()
-		for(var/obj/mecha/MC in GLOB.mechas_list)
-			trackerlist += MC.trackers
-		for(var/obj/item/mecha_parts/mecha_tracking/TR in trackerlist)
-			var/answer = TR.get_mecha_info()
-			if(answer)
-				dat += {"<hr>[answer]<br/>
-						  <a href='?src=[REF(src)];send_message=[REF(TR)]'>Send message</a><br/>
+	var/dat = {"<html><head><title>[src.name]</title><style>h3 {margin: 0px; padding: 0px;}</style></head><body><br>
+				<h3>Tracking beacons data</h3>"}
+	var/list/trackerlist = list()
+	for(var/obj/mecha/MC in GLOB.mechas_list)
+		trackerlist += MC.trackers
+	for(var/obj/item/mecha_parts/mecha_tracking/TR in trackerlist)
+		var/answer = TR.get_mecha_info()
+		if(answer)
+			dat += {"<hr>[answer]<br/><br>
+						<a href='?src=[REF(src)];send_message=[REF(TR)]'>Send Message</a> | <a style='color: #f00;' href='?src=[REF(src)];shock=[REF(TR)]'>(EMP Pulse)</a><br>"}
 
-	if(screen==1)
-		dat += {"<h3>Log contents</h3>"
-		<a href='?src=[REF(src)];return=1'>Return</a><hr>"
-		[stored_data]"}
-
+	dat += "<hr>"
 	dat += "<A href='?src=[REF(src)];refresh=1'>(Refresh)</A><BR>"
 	dat += "</body></html>"
 
@@ -48,8 +41,7 @@
 	if(href_list["shock"])
 		var/obj/item/mecha_parts/mecha_tracking/MT = afilter.getObj("shock")
 		MT.shock()
-	if(href_list["return"])
-		screen = 0
+
 	updateUsrDialog()
 	return
 
@@ -66,16 +58,16 @@
 		return 0
 	var/obj/mecha/M = src.loc
 	var/cell_charge = M.get_charge()
-	var/answer = {"<b>Name:</b> [M.name]
-<b>Integrity:</b> [M.obj_integrity/M.max_integrity*100]%
-<b>Cell charge:</b> [isnull(cell_charge)?"Not found":"[M.cell.percent()]%"]
-<b>Airtank:</b> [M.return_pressure()]kPa
-<b>Pilot:</b> [M.occupant||"None"]
-<b>Location:</b> [get_area(M)||"Unknown"]
-<b>Active equipment:</b> [M.selected||"None"] "}
+	var/answer = {"<b>Name:</b> [M.name]<br>
+<b>Integrity:</b> [round((M.obj_integrity/M.max_integrity*100), 0.01)]%<br>
+<b>Cell Charge:</b> [isnull(cell_charge)?"Not Found":"[M.cell.percent()]%"]<br>
+<b>Airtank:</b> [round(M.return_pressure(), 0.01)] kPa<br>
+<b>Pilot:</b> [M.occupant||"None"]<br>
+<b>Location:</b> [get_area(M)||"Unknown"]<br>
+<b>Active Equipment:</b> [M.selected||"None"]"}
 	if(istype(M, /obj/mecha/working/ripley))
 		var/obj/mecha/working/ripley/RM = M
-		answer += "<b>Used cargo space:</b> [RM.cargo.len/RM.cargo_capacity*100]%<br>"
+		answer += "<br><b>Used Cargo Space:</b> [round((RM.cargo.len/RM.cargo_capacity*100), 0.01)]%"
 
 	return answer
 

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -63,7 +63,7 @@
 <b>Cell Charge:</b> [isnull(cell_charge)?"Not Found":"[M.cell.percent()]%"]<br>
 <b>Airtank:</b> [round(M.return_pressure(), 0.01)] kPa<br>
 <b>Pilot:</b> [M.occupant||"None"]<br>
-<b>Location:</b> [get_area(M)||"Unknown"]<br>
+<b>Location:</b> [get_area_name(M, TRUE)||"Unknown"]<br>
 <b>Active Equipment:</b> [M.selected||"None"]"}
 	if(istype(M, /obj/mecha/working/ripley))
 		var/obj/mecha/working/ripley/RM = M

--- a/code/game/mecha/working/working.dm
+++ b/code/game/mecha/working/working.dm
@@ -3,4 +3,5 @@
 
 /obj/mecha/working/Initialize()
 	. = ..()
-	trackers += new /obj/item/mecha_parts/mecha_tracking(src)
+	if(!ruin_mecha)
+		trackers += new /obj/item/mecha_parts/mecha_tracking(src)


### PR DESCRIPTION
Fixes #41299

:cl: ShizCalev
fix: Fixed exosuit console showing some code by accident.
fix: Restored the ability to send EMP pulses via the exosuit console
fix: Fixed tracking beacons being added to mechas located at ruins allowing you to metagame their spawning.
fix: Fixed exosuit consoles presenting some values via scientific notation (ie pressure being 3.258e-5)
/:cl:

Also cleaned up the output a bit since it was all presented as a single line wall of text.
![image](https://user-images.githubusercontent.com/6209658/47965871-39e6d200-e01a-11e8-952b-79194dba511e.png)

