### PR TITLE
Adds separate MMI/borg messages for damaged brains

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -254,8 +254,12 @@
 				to_chat(user, "<span class='warning'>The MMI indicates that their mind is currently inactive; it might change!</span>")
 				return
 
-			if(BM.stat == DEAD || BM.suiciding || (M.brain && (M.brain.brain_death || M.brain.damaged_brain || M.brain.suicided)))
+			if(BM.stat == DEAD || BM.suiciding || (M.brain && (M.brain.brain_death || M.brain.suicided)))
 				to_chat(user, "<span class='warning'>Sticking a dead brain into the frame would sort of defeat the purpose!</span>")
+				return
+
+			if(M.brain && M.brain.damaged_brain)
+				to_chat(user, "<span class='warning'>The MMI indicates that the brain is damaged!</span>")
 				return
 
 			if(jobban_isbanned(BM, "Cyborg") || QDELETED(src) || QDELETED(BM) || QDELETED(user) || QDELETED(M) || !Adjacent(user))

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -258,7 +258,7 @@
 				to_chat(user, "<span class='warning'>Sticking a dead brain into the frame would sort of defeat the purpose!</span>")
 				return
 
-			if(M.brain && M.brain.damaged_brain)
+			if(M.brain?.damaged_brain)
 				to_chat(user, "<span class='warning'>The MMI indicates that the brain is damaged!</span>")
 				return
 

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -193,7 +193,7 @@
 
 /obj/item/mmi/examine(mob/user)
 	..()
-	to_chat(user, "<span class='notice'>There is a switch to toggle the radio system [radio.on ? "off" : "on"].[brain ? " It is currently being covered by the brain." : ""]</span>")
+	to_chat(user, "<span class='notice'>There is a switch to toggle the radio system [radio.on ? "off" : "on"].[brain ? " It is currently being covered by [brain]." : null]</span>")
 	if(brainmob)
 		var/mob/living/brain/B = brainmob
 		if(!B.key || !B.mind || B.stat == DEAD)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -57,11 +57,12 @@
 		newbrain.brainmob = null
 		brainmob.forceMove(src)
 		brainmob.container = src
-		if(!newbrain.brain_death && !newbrain.damaged_brain && !newbrain.suicided && !brainmob.suiciding) // the brain organ hasn't been beaten to death, nor was from a suicider.
+		var/fubar_brain = newbrain.brain_death && newbrain.suicided && brainmob.suiciding //brain is damaged beyond repair or from a suicider
+		if(!fubar_brain && !newbrain.damaged_brain) // the brain organ hasn't been beaten to death, nor was from a suicider.
 			brainmob.stat = CONSCIOUS //we manually revive the brain mob
 			GLOB.dead_mob_list -= brainmob
 			GLOB.alive_mob_list += brainmob
-		if(!newbrain.brain_death && newbrain.damaged_brain && !newbrain.suicided && !brainmob.suiciding) // the brain is damaged, but not from a suicider
+		else if(!fubar_brain && newbrain.damaged_brain) // the brain is damaged, but not from a suicider
 			to_chat(user, "<span class='warning'>[src]'s indicator light turns yellow and its brain integrity alarm beeps softly. Perhaps you should check [newbrain] for damage.</span>")
 			playsound(src, "sound/machines/synth_no.ogg", 5, TRUE)
 		else

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -61,6 +61,9 @@
 			brainmob.stat = CONSCIOUS //we manually revive the brain mob
 			GLOB.dead_mob_list -= brainmob
 			GLOB.alive_mob_list += brainmob
+		if(!newbrain.brain_death && newbrain.damaged_brain && !newbrain.suicided && !brainmob.suiciding) // the brain is damaged, but not from a suicider
+			to_chat(user, "<span class='warning'>[src]'s indicator light turns yellow and its brain integrity alarm beeps softly. Perhaps you should check [newbrain] for damage.</span>")
+			playsound(src, "sound/machines/synth_no.ogg", 5, TRUE)
 		else
 			to_chat(user, "<span class='warning'>[src]'s indicator light turns red and its brainwave activity alarm beeps softly. Perhaps you should check [newbrain] again.</span>")
 			playsound(src, "sound/weapons/smg_empty_alarm.ogg", 5, TRUE)
@@ -190,6 +193,7 @@
 
 /obj/item/mmi/examine(mob/user)
 	..()
+	to_chat(user, "<span class='notice'>There is a switch to toggle the radio system.</span>")
 	if(brainmob)
 		var/mob/living/brain/B = brainmob
 		if(!B.key || !B.mind || B.stat == DEAD)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -193,7 +193,8 @@
 
 /obj/item/mmi/examine(mob/user)
 	..()
-	to_chat(user, "<span class='notice'>There is a switch to toggle the radio system.</span>")
+	if(!brain)
+    	to_chat(user, "<span class='notice'>There is a switch to toggle the radio system [radio.on ? "off" : "on"].</span>")
 	if(brainmob)
 		var/mob/living/brain/B = brainmob
 		if(!B.key || !B.mind || B.stat == DEAD)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -193,8 +193,7 @@
 
 /obj/item/mmi/examine(mob/user)
 	..()
-	if(!brain)
-		to_chat(user, "<span class='notice'>There is a switch to toggle the radio system [radio.on ? "off" : "on"].</span>")
+	to_chat(user, "<span class='notice'>There is a switch to toggle the radio system [radio.on ? "off" : "on"].[brain ? " that is currently being covered by the brain." : ""]</span>")
 	if(brainmob)
 		var/mob/living/brain/B = brainmob
 		if(!B.key || !B.mind || B.stat == DEAD)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -194,7 +194,7 @@
 /obj/item/mmi/examine(mob/user)
 	..()
 	if(!brain)
-    	to_chat(user, "<span class='notice'>There is a switch to toggle the radio system [radio.on ? "off" : "on"].</span>")
+		to_chat(user, "<span class='notice'>There is a switch to toggle the radio system [radio.on ? "off" : "on"].</span>")
 	if(brainmob)
 		var/mob/living/brain/B = brainmob
 		if(!B.key || !B.mind || B.stat == DEAD)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -193,7 +193,7 @@
 
 /obj/item/mmi/examine(mob/user)
 	..()
-	to_chat(user, "<span class='notice'>There is a switch to toggle the radio system [radio.on ? "off" : "on"].[brain ? " that is currently being covered by the brain." : ""]</span>")
+	to_chat(user, "<span class='notice'>There is a switch to toggle the radio system [radio.on ? "off" : "on"].[brain ? " It is currently being covered by the brain." : ""]</span>")
 	if(brainmob)
 		var/mob/living/brain/B = brainmob
 		if(!B.key || !B.mind || B.stat == DEAD)


### PR DESCRIPTION
:cl: Denton
spellcheck: Added separate MMI/cyborg shell messages for when players try to insert damaged brains or MMIs that contain damaged brains.
spellcheck: Added an MMI examine message that mentions their radio toggle.
/:cl: