### PR TITLE
Fixes mobs with no legs getting stuck in the laying state

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -993,7 +993,7 @@
 		mobility_flags |= MOBILITY_MOVE
 	else
 		mobility_flags &= ~MOBILITY_MOVE
-	var/canstand_involuntary = conscious && !stat_softcrit && !knockdown && !chokehold && !paralyzed && has_legs && !(buckled && buckled.buckle_lying)
+	var/canstand_involuntary = conscious && !stat_softcrit && !knockdown && !chokehold && !paralyzed && (ignore_legs || has_legs) && !(buckled && buckled.buckle_lying)
 	var/canstand = canstand_involuntary && !resting
 
 	if(canstand)


### PR DESCRIPTION
:cl: ShizCalev
fix: Flying / floating humans will no longer get stuck laying down if they have no legs.
fix: Alien larva will no longer get stuck laying down after ventcrawling.
/:cl:
