### PR TITLE
Unnests turret silicon check

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -372,17 +372,20 @@
 				if(SA.stat || in_faction(SA)) //don't target if dead or in faction
 					continue
 				targets += SA
-			if(issilicon(A))
-				var/mob/living/silicon/sillycone = A
-				if(sillycone.stat || in_faction(sillycone))
+				continue
+
+		if(issilicon(A))
+			var/mob/living/silicon/sillycone = A
+			if(sillycone.stat || in_faction(sillycone))
+				continue
+
+			if(iscyborg(sillycone))
+				var/mob/living/silicon/robot/sillyconerobot = A
+				if(LAZYLEN(faction) && (ROLE_SYNDICATE in faction) && sillyconerobot.emagged == TRUE)
 					continue
 
-				if(iscyborg(sillycone))
-					var/mob/living/silicon/robot/sillyconerobot = A
-					if(LAZYLEN(faction) && (ROLE_SYNDICATE in faction) && sillyconerobot.emagged == TRUE)
-						continue
-
-				targets += sillycone
+			targets += sillycone
+			continue
 
 		if(iscarbon(A))
 			var/mob/living/carbon/C = A


### PR DESCRIPTION
@ExcessiveUseOfCobblestone

Was apparently a mistake to have it under check_anomalies. 

Also added a couple more continues after a mob was added to targets since it continued to go through unnecessary checks.

:cl: ShizCalev
fix: Turrets will now correctly target silicon mobs when check anomalies is disabled.
/:cl:

