### PR TITLE
Cyborg modules now automatically turn off when deactivated

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -516,6 +516,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		overlay_state = pick(overlay_list)
 	update_icon()
 
+/obj/item/lighter/cyborg_unequip(mob/user)
+	if(!lit)
+		return
+	set_lit(FALSE)
+
 /obj/item/lighter/suicide_act(mob/living/carbon/user)
 	if (lit)
 		user.visible_message("<span class='suicide'>[user] begins holding \the [src]'s flame up to [user.p_their()] face! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -200,8 +200,16 @@
 	to_chat(user, "<span class='warning'>You override [src]'s radiation storing protocols. It will now generate small doses of radiation, and stored rads are now projected into creatures you scan.</span>")
 	obj_flags |= EMAGGED
 
+
+
 /obj/item/geiger_counter/cyborg
 	var/datum/component/mobhook
+
+/obj/item/geiger_counter/cyborg/cyborg_unequip(mob/user)
+	if(!scanning)
+		return
+	scanning = FALSE
+	update_icon()
 
 /obj/item/geiger_counter/cyborg/equipped(mob/user)
 	. = ..()

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -26,13 +26,21 @@ SLIME SCANNER
 	user.visible_message("<span class='suicide'>[user] begins to emit terahertz-rays into [user.p_their()] brain with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return TOXLOSS
 
-/obj/item/t_scanner/attack_self(mob/user)
-
+/obj/item/t_scanner/proc/toggle_on()
 	on = !on
 	icon_state = copytext(icon_state, 1, length(icon_state))+"[on]"
-
 	if(on)
 		START_PROCESSING(SSobj, src)
+	else
+		STOP_PROCESSING(SSobj, src)
+
+/obj/item/t_scanner/attack_self(mob/user)
+	toggle_on()
+
+/obj/item/t_scanner/cyborg_unequip(mob/user)
+	if(!on)
+		return
+	toggle_on()
 
 /obj/item/t_scanner/process()
 	if(!on)

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -139,6 +139,11 @@
 	sharpness = IS_SHARP
 	light_color = "#40ceff"
 
+/obj/item/melee/transforming/energy/sword/cyborg/saw/cyborg_unequip(mob/user)
+	if(!active)
+		return
+	transform_weapon(user, TRUE)
+
 /obj/item/melee/transforming/energy/sword/cyborg/saw/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	return 0
 

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -29,8 +29,11 @@
 	return ..()
 
 /obj/item/pinpointer/attack_self(mob/living/user)
-	active = !active
+	toggle_on()
 	user.visible_message("<span class='notice'>[user] [active ? "" : "de"]activates [user.p_their()] pinpointer.</span>", "<span class='notice'>You [active ? "" : "de"]activate your pinpointer.</span>")
+
+/obj/item/pinpointer/proc/toggle_on()
+	active = !active
 	playsound(src, 'sound/items/screwdriver2.ogg', 50, 1)
 	if(active)
 		START_PROCESSING(SSfastprocess, src)
@@ -94,12 +97,8 @@
 
 /obj/item/pinpointer/crew/attack_self(mob/living/user)
 	if(active)
-		active = FALSE
+		toggle_on()
 		user.visible_message("<span class='notice'>[user] deactivates [user.p_their()] pinpointer.</span>", "<span class='notice'>You deactivate your pinpointer.</span>")
-		playsound(src, 'sound/items/screwdriver2.ogg', 50, 1)
-		target = null //Restarting the pinpointer forces a target reset
-		STOP_PROCESSING(SSfastprocess, src)
-		update_icon()
 		return
 
 	var/list/name_counts = list()
@@ -130,11 +129,8 @@
 		return
 
 	target = names[A]
-	active = TRUE
+	toggle_on()
 	user.visible_message("<span class='notice'>[user] activates [user.p_their()] pinpointer.</span>", "<span class='notice'>You activate your pinpointer.</span>")
-	playsound(src, 'sound/items/screwdriver2.ogg', 50, 1)
-	START_PROCESSING(SSfastprocess, src)
-	update_icon()
 
 /obj/item/pinpointer/crew/scan_for_target()
 	if(target)

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -304,6 +304,11 @@
 	desc = "An advanced welder designed to be used in robotic systems."
 	toolspeed = 0.5
 
+/obj/item/weldingtool/largetank/cyborg/cyborg_unequip(mob/user)
+	if(!isOn())
+		return
+	switched_on(user)
+
 /obj/item/weldingtool/largetank/flamethrower_screwdriver()
 	return
 

--- a/code/modules/antagonists/nukeop/equipment/pinpointer.dm
+++ b/code/modules/antagonists/nukeop/equipment/pinpointer.dm
@@ -68,6 +68,11 @@
 	item_flags = NODROP
 	flags_1 = NONE
 
+/obj/item/pinpointer/syndicate_cyborg/cyborg_unequip(mob/user)
+	if(!active)
+		return
+	toggle_on()
+
 /obj/item/pinpointer/syndicate_cyborg/scan_for_target()
 	target = null
 	var/list/possible_targets = list()

--- a/code/modules/mining/equipment/mineral_scanner.dm
+++ b/code/modules/mining/equipment/mineral_scanner.dm
@@ -43,6 +43,10 @@
 	var/current_cooldown = 0
 	var/range = 7
 
+/obj/item/t_scanner/adv_mining_scanner/cyborg/Initialize()
+	. = ..()
+	toggle_on()
+
 /obj/item/t_scanner/adv_mining_scanner/lesser
 	name = "automatic mining scanner"
 	desc = "A scanner that automatically checks surrounding rock for useful minerals; it can also be used to stop gibtonite detonations."

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -5,7 +5,8 @@
 /mob/living/silicon/robot/get_active_held_item()
 	return module_active
 
-
+/obj/item/proc/cyborg_unequip(mob/user)
+	return
 
 /mob/living/silicon/robot/proc/uneq_module(obj/item/O)
 	if(!O)
@@ -37,6 +38,7 @@
 		O.item_flags &= ~DROPDEL //we shouldn't HAVE things with DROPDEL_1 in our modules, but better safe than runtiming horribly
 
 	O.forceMove(module) //Return item to module so it appears in its contents, so it can be taken out again.
+	O.cyborg_unequip(src)
 
 	hud_used.update_robot_modules_display()
 	return 1

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -525,7 +525,6 @@
 		/obj/item/weldingtool/mini,
 		/obj/item/extinguisher/mini,
 		/obj/item/storage/bag/sheetsnatcher/borg,
-		/obj/item/t_scanner/adv_mining_scanner,
 		/obj/item/gun/energy/kinetic_accelerator/cyborg,
 		/obj/item/gps/cyborg,
 		/obj/item/stack/marker_beacon)
@@ -537,6 +536,16 @@
 	cyborg_base_icon = "miner"
 	moduleselect_icon = "miner"
 	hat_offset = 0
+	var/obj/item/t_scanner/adv_mining_scanner/cyborg/mining_scanner //built in memes.
+
+/obj/item/robot_module/miner/rebuild_modules()
+	. = ..()
+	if(!mining_scanner)
+		mining_scanner = new(src)
+
+/obj/item/robot_module/miner/Destroy()
+	QDEL_NULL(mining_scanner)
+	return ..()
 
 /obj/item/robot_module/syndicate
 	name = "Syndicate Assault"


### PR DESCRIPTION
:cl: ShizCalev
balance: Putting an item back into your inventory as a cyborg will now automatically turn said item off (ie welders, lighters, ect.)
fix: Cyborgs can now longer conceal unconcealable energy saws (ie ones that are activated) inside themselves. They will now turn off automatically.
/:cl:
