### PR TITLE
Fixes posibrains becoming unusable if the old mob suicided.

### DIFF
--- a/code/modules/antagonists/clockcult/clock_items/soul_vessel.dm
+++ b/code/modules/antagonists/clockcult/clock_items/soul_vessel.dm
@@ -65,6 +65,9 @@
 	if(is_servant_of_ratvar(target))
 		to_chat(user, "<span class='nezbere'>\"It would be more wise to revive your allies, friend.\"</span>")
 		return
+	if(target.suiciding)
+		to_chat(user, "<span class='nezbere'>\"This ally isn't able to be revived.\"</span>")
+		return
 	var/mob/living/carbon/human/H = target
 	if(H.stat == CONSCIOUS)
 		to_chat(user, "<span class='warning'>[H] must be dead or unconscious for you to claim [H.p_their()] mind!</span>")
@@ -87,9 +90,14 @@
 	if(!B) //either somebody already got to them or robotics did
 		to_chat(user, "<span class='warning'>[H] has no brain, and thus no mind to claim!</span>")
 		return
+	if(B.suicided || B.brainmob?.suiciding)
+		to_chat(user, "<span class='nezbere'>\"This ally isn't able to be revived.\"</span>")
+		return
 	if(!H.key) //nobody's home
 		to_chat(user, "<span class='warning'>[H] has no mind to claim!</span>")
 		return
+	if(brainmob.suiciding)
+		brainmob.set_suicide(FALSE)
 	playsound(H, 'sound/misc/splort.ogg', 60, 1, -1)
 	playsound(H, 'sound/magic/clockwork/anima_fragment_attack.ogg', 40, 1, -1)
 	H.fakedeath("soul_vessel") //we want to make sure they don't deathgasp and maybe possibly explode

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -36,7 +36,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 
 /obj/item/mmi/posibrain/proc/ping_ghosts(msg, newlymade)
 	if(newlymade || GLOB.posibrain_notify_cooldown <= world.time)
-		notify_ghosts("[name] [msg] in [get_area(src)]!", ghost_sound = !newlymade ? 'sound/effects/ghost2.ogg':null, enter_link = "<a href=?src=[REF(src)];activate=1>(Click to enter)</a>", source = src, action = NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_POSIBRAIN)
+		notify_ghosts("[name] [msg] in [get_area(src)]!", ghost_sound = !newlymade ? 'sound/effects/ghost2.ogg':null, enter_link = "<a href=?src=[REF(src)];activate=1>(Click to enter)</a>", source = src, action = NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_POSIBRAIN, notify_suiciders = FALSE)
 		if(!newlymade)
 			GLOB.posibrain_notify_cooldown = world.time + askDelay
 
@@ -87,10 +87,14 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 		return
 	if(is_occupied() || jobban_isbanned(user,"posibrain") || QDELETED(brainmob) || QDELETED(src) || QDELETED(user))
 		return
-
+	if(user.suiciding) //if they suicided, they're out forever.
+		to_chat(user, "<span class='warning'>[src] fizzles slightly. Sadly it doesn't take those who suicided!</span>")
+		return
 	var/posi_ask = alert("Become a [name]? (Warning, You can no longer be cloned, and all past lives will be forgotten!)","Are you positive?","Yes","No")
 	if(posi_ask == "No" || QDELETED(src))
 		return
+	if(brainmob.suiciding) //clear suicide status if the old occupant suicided.
+		brainmob.set_suicide(FALSE)
 	transfer_personality(user)
 
 /obj/item/mmi/posibrain/transfer_identity(mob/living/carbon/C)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -368,11 +368,13 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 /mob/proc/reagent_check(datum/reagent/R) // utilized in the species code
 	return 1
 
-/proc/notify_ghosts(var/message, var/ghost_sound = null, var/enter_link = null, var/atom/source = null, var/mutable_appearance/alert_overlay = null, var/action = NOTIFY_JUMP, flashwindow = TRUE, ignore_mapload = TRUE, ignore_key, header = null,) //Easy notification of ghosts.
+/proc/notify_ghosts(var/message, var/ghost_sound = null, var/enter_link = null, var/atom/source = null, var/mutable_appearance/alert_overlay = null, var/action = NOTIFY_JUMP, flashwindow = TRUE, ignore_mapload = TRUE, ignore_key, header = null, notify_suiciders = TRUE) //Easy notification of ghosts.
 	if(ignore_mapload && SSatoms.initialized != INITIALIZATION_INNEW_REGULAR)	//don't notify for objects created during a map load
 		return
 	for(var/mob/dead/observer/O in GLOB.player_list)
 		if(O.client)
+			if(!notify_suiciders && (O in GLOB.suicided_mob_list))
+				continue
 			if (ignore_key && O.ckey in GLOB.poll_ignore[ignore_key])
 				continue
 			to_chat(O, "<span class='ghostalert'>[message][(enter_link) ? " [enter_link]" : ""]</span>")


### PR DESCRIPTION
Fixes #41333

:cl: ShizCalev
fix: Posibrains will no longer become unusable if a mob suicides in them.
fix: Suiciding is now even MORE permanent... again.
/:cl:

