### PR TITLE
Quantum deleter pads

### DIFF
--- a/code/game/machinery/quantum_deleter.dm
+++ b/code/game/machinery/quantum_deleter.dm
@@ -1,7 +1,7 @@
 /obj/machinery/quantumpad/deleter
 	name = "quantum deleter"
 	desc = "A quantum deleter (qdel for short) able to obliterate any object or entity standing above it when activated by only performing the first half of a quantum teleportation."
-	circuit = /obj/item/circuitboard/machine/quantum_deleter
+	circuit = /obj/item/circuitboard/machine/quantumpad/deleter
 
 /obj/machinery/quantumpad/deleter/interact(mob/user, obj/machinery/quantumpad/target_pad = linked_pad)
 	if(world.time < last_teleport + teleport_cooldown)

--- a/code/game/machinery/quantum_deleter.dm
+++ b/code/game/machinery/quantum_deleter.dm
@@ -52,6 +52,7 @@
 			//Don't delete ghosts
 			else if(!isobserver(ROI))
 				continue
-
+		if(isliving(ROI))
+			to_chat(ROI, "<span class='userdanger'>You don't feel so good...</span>")
 		qdel(ROI) //uh oh
 		CHECK_TICK

--- a/code/game/machinery/quantum_deleter.dm
+++ b/code/game/machinery/quantum_deleter.dm
@@ -34,7 +34,7 @@
 	sparks()
 	flick("qpad-beam", src)
 	playsound(get_turf(src), 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
-	if(target_pad)
+	if(target_pad && !QDELETED(target_pad) && !(target_pad.stat & NOPOWER))
 		target_pad.sparks()
 		flick("qpad-beam", target_pad)
 		playsound(get_turf(target_pad), 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
@@ -54,5 +54,7 @@
 				continue
 		if(isliving(ROI))
 			to_chat(ROI, "<span class='userdanger'>You don't feel so good...</span>")
+			if(target_pad && !QDELETED(target_pad) && !(target_pad.stat & NOPOWER) && prob(10))
+				new /obj/item/reagent_containers/food/snacks/store/bread/plain(get_turf(target_pad))
 		qdel(ROI) //uh oh
 		CHECK_TICK

--- a/code/game/machinery/quantum_deleter.dm
+++ b/code/game/machinery/quantum_deleter.dm
@@ -1,0 +1,57 @@
+/obj/machinery/quantumpad/deleter
+	name = "quantum deleter"
+	desc = "A quantum deleter (qdel for short) able to obliterate any object or entity standing above it when activated by only performing the first half of a quantum teleportation."
+	circuit = /obj/item/circuitboard/machine/quantum_deleter
+
+/obj/machinery/quantumpad/deleter/interact(mob/user, obj/machinery/quantumpad/target_pad = linked_pad)
+	if(world.time < last_teleport + teleport_cooldown)
+		to_chat(user, "<span class='warning'>[src] is recharging power. Please wait [DisplayTimeText(last_teleport + teleport_cooldown - world.time)].</span>")
+		return
+
+	if(teleporting)
+		to_chat(user, "<span class='warning'>[src] is charging up. Please wait.</span>")
+		return
+
+	add_fingerprint(user)
+	playsound(get_turf(src), 'sound/weapons/flash.ogg', 25, 1)
+	teleporting = TRUE
+	addtimer(CALLBACK(src, .proc/dodelete, user, target_pad), teleport_speed)
+
+/obj/machinery/quantumpad/deleter/proc/dodelete(mob/user, obj/machinery/quantumpad/target_pad = linked_pad)
+	if(!src || QDELETED(src))
+		teleporting = FALSE
+		return
+	if(stat & NOPOWER)
+		to_chat(user, "<span class='warning'>[src] is unpowered!</span>")
+		teleporting = FALSE
+		return
+
+	teleporting = FALSE
+	last_teleport = world.time
+
+	// use a lot of power
+	use_power(10000 / power_efficiency)
+	sparks()
+	flick("qpad-beam", src)
+	playsound(get_turf(src), 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
+	if(target_pad)
+		target_pad.sparks()
+		flick("qpad-beam", target_pad)
+		playsound(get_turf(target_pad), 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
+	for(var/atom/movable/ROI in get_turf(src))
+		if(QDELETED(ROI))
+			continue //sleeps in CHECK_TICK
+		   
+		// if is anchored, don't let through
+		if(ROI.anchored)
+			if(isliving(ROI))
+				var/mob/living/L = ROI
+				//only TP living mobs buckled to non anchored items
+				if(!L.buckled || L.buckled.anchored)
+					continue
+			//Don't delete ghosts
+			else if(!isobserver(ROI))
+				continue
+
+		qdel(ROI) //uh oh
+		CHECK_TICK

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -93,6 +93,10 @@
 		/obj/item/stock_parts/manipulator = 1,
 		/obj/item/stack/cable_coil = 1)
 	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)
+	
+/obj/item/circuitboard/machine/quantumpad/deleter
+	name = "Quantum Deleter (Machine Board)"
+	build_path = /obj/machinery/quantumpad/deleter
 
 /obj/item/circuitboard/machine/recharger
 	name = "Weapon Recharger (Machine Board)"

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -105,6 +105,14 @@
 	build_path = /obj/item/circuitboard/machine/quantumpad
 	category = list ("Teleportation Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	
+/datum/design/board/quantumdeleter
+	name = "Machine Design (Quantum Deleter Board)"
+	desc = "The circuit board for a quantum deleter."
+	id = "quantumdeleter"
+	build_path = /obj/item/circuitboard/machine/quantumpad/deleter
+	category = list ("Teleportation Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/board/launchpad
 	name = "Machine Design (Bluespace Launchpad Board)"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -180,7 +180,7 @@
 	display_name = "Bluespace Travel"
 	description = "Application of Bluespace for static teleportation technology."
 	prereq_ids = list("practical_bluespace")
-	design_ids = list("tele_station", "tele_hub", "teleconsole", "quantumpad", "quantumdeleter", "launchpad", "launchpad_console", "bluespace_pod")
+	design_ids = list("tele_station", "tele_hub", "teleconsole", "quantumpad", "launchpad", "launchpad_console", "bluespace_pod")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 
@@ -201,6 +201,15 @@
 	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "bluespacebodybag", "phasic_scanning", "roastingstick", "ore_silo")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
+	
+/datum/techweb_node/unregulated_bluespace
+	id = "unregulated_bluespace"
+	display_name = "Unregulated Bluespace Research"
+	description = "Bluespace technology using unstable or unbalanced procedures, prone to damaging the fabric of bluespace. Outlawed by galactic conventions."
+	prereq_ids = list("bluespace_travel", "syndicate_basic")
+	design_ids = list("quantumdeleter")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	export_price = 2500
 
 /datum/techweb_node/bluespace_power
 	id = "bluespace_power"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -180,7 +180,7 @@
 	display_name = "Bluespace Travel"
 	description = "Application of Bluespace for static teleportation technology."
 	prereq_ids = list("practical_bluespace")
-	design_ids = list("tele_station", "tele_hub", "teleconsole", "quantumpad", "launchpad", "launchpad_console", "bluespace_pod")
+	design_ids = list("tele_station", "tele_hub", "teleconsole", "quantumpad", "quantumdeleter", "launchpad", "launchpad_console", "bluespace_pod")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -584,6 +584,7 @@
 #include "code\game\machinery\newscaster.dm"
 #include "code\game\machinery\PDApainter.dm"
 #include "code\game\machinery\quantum_pad.dm"
+#include "code\game\machinery\quantum_deleter.dm"
 #include "code\game\machinery\recharger.dm"
 #include "code\game\machinery\rechargestation.dm"
 #include "code\game\machinery\recycler.dm"


### PR DESCRIPTION
:cl: XDTM
add: Added Quantum Deleters, special quantum pads that do not perform the second phase of a quantum teleportation, losing the cargo in the quantum aether.
add: Quantum Deleters are visually identical to quantum pads, and can also be linked to one to act as a harmless receiver. When sending to a normal quantum pad, instead, the destination will only get a few sparks.
add: Quantum Deleters require the new Unregulated Bluespace techweb node, which requires Bluespace Travel and Illegal Technology.
/:cl:

Can be used to dispose of unwanted trash, or to trick people into teleporting into your secret base in ghost town. Especially fun since it will seem like a perfectly normal teleportation to onlookers.