### PR TITLE
Storage implant techweb design

### DIFF
--- a/code/game/objects/items/implants/implant_storage.dm
+++ b/code/game/objects/items/implants/implant_storage.dm
@@ -32,3 +32,10 @@
 /obj/item/implanter/storage
 	name = "implanter (storage)"
 	imp_type = /obj/item/implant/storage
+	
+/obj/item/implant/storage/replica
+	max_slot_stacking = 1
+
+/obj/item/implanter/storage/replica
+	name = "implanter (storage)"
+	imp_type = /obj/item/implant/storage/replica

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -53,3 +53,13 @@
 	build_path = /obj/item/storage/bag/ore/holding
 	category = list("Bluespace Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
+	
+/datum/design/implant_storage
+	name = "Storage Implant"
+	desc = "An implanter containing a storage implant, able to store items in a hidden bluespace pocket."
+	id = "implant_storage"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 500, MAT_GLASS = 500, MAT_PLASMA = 2000, MAT_BLUESPACE = 4000, MAT_DIAMOND = 2000)
+	build_path = /obj/item/implanter/storage
+	category = list("Bluespace Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -56,10 +56,10 @@
 	
 /datum/design/implant_storage
 	name = "Storage Implant"
-	desc = "An implanter containing a storage implant, able to store items in a hidden bluespace pocket."
+	desc = "An implanter containing a replica of a syndicate storage implant, able to store items in a hidden bluespace pocket."
 	id = "implant_storage"
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 500, MAT_GLASS = 500, MAT_PLASMA = 2000, MAT_BLUESPACE = 4000, MAT_DIAMOND = 2000)
-	build_path = /obj/item/implanter/storage
+	build_path = /obj/item/implanter/storage/replica
 	category = list("Bluespace Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE


### PR DESCRIPTION
:cl: XDTM
add: Storage implants can now be built in protolathes if the Unregulated Bluespace node has been researched.
/:cl:

Requires #41339 to be complete, since it has the aforementioned node.
