### PR TITLE
shift E & B keybinding stuff

### DIFF
--- a/code/modules/keybindings/bindings_human.dm
+++ b/code/modules/keybindings/bindings_human.dm
@@ -3,16 +3,17 @@
 		switch(_key)
 			if("E") // Put held thing in belt or take out most recent thing from belt
 				var/obj/item/thing = get_active_held_item()
-				var/obj/item/storage/equipped_belt = get_item_by_slot(SLOT_BELT)
+				var/obj/item/equipped_belt = get_item_by_slot(SLOT_BELT)
 				if(!equipped_belt) // We also let you equip a belt like this
 					if(!thing)
 						to_chat(user, "<span class='notice'>You have no belt to take something out of.</span>")
 						return
-					equip_to_slot_if_possible(thing, SLOT_BELT)
+					if(equip_to_slot_if_possible(thing, SLOT_BELT))
+						update_inv_hands()
 					return
-				if(!istype(equipped_belt)) // not a storage item
+				if(!SEND_SIGNAL(equipped_belt, COMSIG_CONTAINS_STORAGE)) // not a storage item
 					if(!thing)
-						to_chat(user, "<span class='notice'>You have no belt to take something out of.</span>")
+						equipped_belt.attack_hand(src)
 					else
 						to_chat(user, "<span class='notice'>You can't fit anything in.</span>")
 					return
@@ -31,27 +32,28 @@
 
 			if("B") // Put held thing in backpack or take out most recent thing from backpack
 				var/obj/item/thing = get_active_held_item()
-				var/obj/item/storage/equipped_backpack = get_item_by_slot(SLOT_BACK)
-				if(!equipped_backpack) // We also let you equip a backpack like this
+				var/obj/item/equipped_back = get_item_by_slot(SLOT_BACK)
+				if(!equipped_back) // We also let you equip a backpack like this
 					if(!thing)
 						to_chat(user, "<span class='notice'>You have no backpack to take something out of.</span>")
 						return
-					equip_to_slot_if_possible(thing, SLOT_BACK)
+					if(equip_to_slot_if_possible(thing, SLOT_BACK))
+						update_inv_hands()
 					return
-				if(!istype(equipped_backpack)) // not a storage item
+				if(!SEND_SIGNAL(equipped_back, COMSIG_CONTAINS_STORAGE)) // not a storage item
 					if(!thing)
-						to_chat(user, "<span class='notice'>You have no backpack to take something out of.</span>")
+						equipped_back.attack_hand(src)
 					else
 						to_chat(user, "<span class='notice'>You can't fit anything in.</span>")
 					return
 				if(thing) // put thing in backpack
-					if(!SEND_SIGNAL(equipped_backpack, COMSIG_TRY_STORAGE_INSERT, thing, user.mob))
+					if(!SEND_SIGNAL(equipped_back, COMSIG_TRY_STORAGE_INSERT, thing, user.mob))
 						to_chat(user, "<span class='notice'>You can't fit anything in.</span>")
 					return
-				if(!equipped_backpack.contents.len) // nothing to take out
+				if(!equipped_back.contents.len) // nothing to take out
 					to_chat(user, "<span class='notice'>There's nothing in your backpack to take out.</span>")
 					return
-				var/obj/item/stored = equipped_backpack.contents[equipped_backpack.contents.len]
+				var/obj/item/stored = equipped_back.contents[equipped_back.contents.len]
 				if(!stored || stored.on_found(src))
 					return
 				stored.attack_hand(src) // take out thing from backpack

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -124,8 +124,8 @@ Hotkey-Mode: (hotkey-mode must be on)
 \t<B></B>h = stop pulling
 \tx = swap-hand
 \tz = activate held object (or y)
-\tShift+e = Put held item into belt or take out most recent item added to belt.
-\tShift+b = Put held item into backpack or take out most recent item added to backpack.
+\tShift+e = Put held item into belt(or belt slot) or take out most recent item added.
+\tShift+b = Put held item into backpack(or back slot) or take out most recent item added.
 \tf = cycle-intents-left
 \tg = cycle-intents-right
 \t1 = help-intent


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Garen
tweak: The shift E & B keybindings now take the item in the slot if it is not a storage item. The hotkey help has been updated accordingly.
fix: Fixed shift E & B not updating hands when it was used to put an item directly into the slot(not into a storage item but the actual equip slot)
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I added that functionality to the keybinding since it was weird that you could put say a crowbar on the belt slot via the keybinding if there was no belt but couldn't remove it with the same input(despite being able to do that if you were putting it in an actual belt).

As for the bug fix I didn't make it so that the equip_to_slot_if_possible proc updates hands since that proc is meant to only put an item in the slot, not handle anything with hands. The equip from hands proc doesn't target a specific slot so its not used here.