### PR TITLE
Fixes delta cargo conveyors

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -126688,7 +126688,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
 	dir = 9;
-	id = "cargoload"
+	id = "cargounload"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -76,6 +76,10 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	else
 		return ..()
 
+/obj/machinery/conveyor/setDir(newdir)
+	. = ..()
+	update_move_direction()
+
 /obj/machinery/conveyor/proc/update_move_direction()
 	switch(dir)
 		if(NORTH)


### PR DESCRIPTION
Fixes #41368

Surprised this one took so long to catch.

:cl: ShizCalev
fix: Delta's cargo shuttle's conveyor belts will no longer move the wrong direction if turned on while the shuttle is at CentCom.
/:cl:
