### PR TITLE
Vareditting the dir var now calls setDir()

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -524,9 +524,9 @@
 			add_atom_colour(color, ADMIN_COLOUR_PRIORITY)
 
 		if("dir")
-			if(isnull(var_value) || !(var_value in GLOB.alldirs))
-				return FALSE
-			setDir(var_value)
+			var/do_setdir = alert(usr, "use setDir?", "[src]", "Yes", "No")
+			if(do_setdir == "Yes")
+				setDir(var_value)
 			return TRUE
 
 /atom/vv_get_dropdown()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -523,6 +523,12 @@
 		if("color")
 			add_atom_colour(color, ADMIN_COLOUR_PRIORITY)
 
+		if("dir")
+			if(isnull(var_value) || !(var_value in GLOB.alldirs))
+				return FALSE
+			setDir(var_value)
+			return TRUE
+
 /atom/vv_get_dropdown()
 	. = ..()
 	. += "---"


### PR DESCRIPTION
Fixes stuff getting out of sync in the case of things like chairs, infrared sensors, conveyor belts, ect.

Shouldn't have any issues, though for some reason I think there's probably a different proc up the atom movement chain that this should be calling instead.