### PR TITLE
Lowers the amount of miasma required to display a warning

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -243,7 +243,7 @@
 
 		//Miasma side effects
 		switch(miasma_partialpressure)
-			if(1 to 5)
+			if(0.25 to 5)
 				// At lower pp, give out a little warning
 				SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
 				if(prob(5))

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -294,7 +294,7 @@
 
 			// Miasma side effects
 			switch(miasma_pp)
-				if(1 to 5)
+				if(0.25 to 5)
 					// At lower pp, give out a little warning
 					SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "smell")
 					if(prob(5))


### PR DESCRIPTION
:cl: Mickyan
tweak: lowered the concentration of miasma required to display a warning message
/:cl:
An early warning to properly store those bodies if you don't want to catch a disease, previous amount was unlikely to be reached in normal conditions

From testing it took about 10 minutes for two bodies to produce enough miasma in the delta station genetics room (assuming the room remains sealed)