### PR TITLE
Spawners are now anchored

### DIFF
--- a/code/modules/mob/living/simple_animal/spawner.dm
+++ b/code/modules/mob/living/simple_animal/spawner.dm
@@ -11,7 +11,7 @@
 	var/mob_types = list(/mob/living/simple_animal/hostile/carp)
 	var/spawn_text = "emerges from"
 	status_flags = 0
-	move_resist = MOVE_FORCE_VERY_STRONG
+	move_resist = MOVE_FORCE_OVERWHELMING
 	anchored = TRUE
 	AIStatus = AI_OFF
 	a_intent = INTENT_HARM

--- a/code/modules/mob/living/simple_animal/spawner.dm
+++ b/code/modules/mob/living/simple_animal/spawner.dm
@@ -12,6 +12,7 @@
 	var/spawn_text = "emerges from"
 	status_flags = 0
 	move_resist = MOVE_FORCE_VERY_STRONG
+	anchored = TRUE
 	AIStatus = AI_OFF
 	a_intent = INTENT_HARM
 	stop_automated_movement = 1

--- a/code/modules/mob/living/simple_animal/spawner.dm
+++ b/code/modules/mob/living/simple_animal/spawner.dm
@@ -12,7 +12,6 @@
 	var/spawn_text = "emerges from"
 	status_flags = 0
 	move_resist = MOVE_FORCE_OVERWHELMING
-	anchored = TRUE
 	AIStatus = AI_OFF
 	a_intent = INTENT_HARM
 	stop_automated_movement = 1

--- a/code/modules/mob/living/simple_animal/spawner.dm
+++ b/code/modules/mob/living/simple_animal/spawner.dm
@@ -11,7 +11,7 @@
 	var/mob_types = list(/mob/living/simple_animal/hostile/carp)
 	var/spawn_text = "emerges from"
 	status_flags = 0
-	move_resist = MOVE_FORCE_OVERWHELMING
+	move_resist = INFINITY
 	AIStatus = AI_OFF
 	a_intent = INTENT_HARM
 	stop_automated_movement = 1


### PR DESCRIPTION
[Changelogs]:

:cl:
fix: spawners such as lavaland tendrils can't be moved around
/:cl:

[why]: Tendrils literally grow from the ground, you shouldn't be able to chuck them about just by throwing corpses into them
