### PR TITLE
teleporter computer now shows renamed beacons

### DIFF
--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -120,7 +120,7 @@
 	if(regime_set == "Teleporter")
 		for(var/obj/item/beacon/R in GLOB.teleportbeacons)
 			if(is_eligible(R))
-				if(R.renamed == TRUE)
+				if(R.renamed)
 					L[avoid_assoc_duplicate_keys(R.name, areaindex)] = R
 				else
 					var/area/A = get_area(R)

--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -121,7 +121,7 @@
 		for(var/obj/item/beacon/R in GLOB.teleportbeacons)
 			if(is_eligible(R))
 				if(R.renamed)
-					L[avoid_assoc_duplicate_keys(R.name, areaindex)] = R
+					L[avoid_assoc_duplicate_keys("[R.name] ([get_area(R)])", areaindex)] = R
 				else
 					var/area/A = get_area(R)
 					L[avoid_assoc_duplicate_keys(A.name, areaindex)] = R
@@ -135,7 +135,7 @@
 					if(M.timeofdeath + 6000 < world.time)
 						continue
 				if(is_eligible(I))
-					L[avoid_assoc_duplicate_keys(M.real_name, areaindex)] = I
+					L[avoid_assoc_duplicate_keys("[M.real_name] ([get_area(M)])", areaindex)] = I
 
 		var/desc = input("Please select a location to lock in.", "Locking Computer") as null|anything in L
 		target = L[desc]

--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -120,8 +120,11 @@
 	if(regime_set == "Teleporter")
 		for(var/obj/item/beacon/R in GLOB.teleportbeacons)
 			if(is_eligible(R))
-				var/area/A = get_area(R)
-				L[avoid_assoc_duplicate_keys(A.name, areaindex)] = R
+				if(R.renamed == TRUE)
+					L[avoid_assoc_duplicate_keys(R.name, areaindex)] = R
+				else
+					var/area/A = get_area(R)
+					L[avoid_assoc_duplicate_keys(A.name, areaindex)] = R
 
 		for(var/obj/item/implant/tracking/I in GLOB.tracked_implants)
 			if(!I.imp_in || !isliving(I.loc))


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Zxaber
add: The teleporter computers's selection window now shows the name of renamed beacons, as well as their location
tweak: For consistency's sake, tracking implants now show the carrier's location as well as name.
/:cl:

I suspect this was intended, since the beacon already has code for renaming it via pen and a "renamed" variable that gets updated when the beacon is renamed. In any case, it's now consistent with tracking implants, which already show the name of the person implanted.

![image](https://user-images.githubusercontent.com/37497534/48307834-7d55aa80-e50a-11e8-8478-755139223c28.png)

This change only affects the list popup. Once the beacon is selected, the TGUI window shows the actual destination  (also just like tracking implants)