### PR TITLE
Medbay Item Respriting

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -248,3 +248,6 @@
 		current_skin = choice
 		icon_state = unique_reskin[choice]
 		to_chat(M, "[src] is now skinned as '[choice].'")
+//called when objects are renamed
+/obj/proc/changed_name(newname)
+     name = newname

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -136,7 +136,7 @@
 			if(oldname == input)
 				to_chat(user, "You changed \the [O.name] to... well... \the [O.name].")
 			else
-				O.name = input
+				O.changed_name(input)
 				to_chat(user, "\The [oldname] has been successfully been renamed to \the [input].")
 				O.renamedByPlayer = TRUE
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -266,6 +266,7 @@
 				P.name = trim("[name] patch")
 				adjust_item_drop_location(P)
 				reagents.trans_to(P,vol_each, transfered_by = usr)
+				P.changed_name(P.name)
 			. = TRUE
 
 		if("createBottle")

--- a/code/modules/reagents/reagent_containers/medspray.dm
+++ b/code/modules/reagents/reagent_containers/medspray.dm
@@ -91,3 +91,15 @@
 	name = "sterilizer spray"
 	desc = "Spray bottle loaded with non-toxic sterilizer. Useful in preparation for surgery."
 	list_reagents = list("sterilizine" = 60)
+/obj/item/reagent_containers/medspray/changed_name(newname)
+	var/compare = lowertext(newname)
+	if (compare == ("styptic powder"))
+		icon_state = "brutespray"
+	if (compare == ("silver sulfadiazine"))			// Renamed sprays have their icon changed to fit their new name when appropriate.
+		icon_state = "burnspray"
+	if (compare == ("synthflesh"))
+		icon_state = "synthspray"
+	else
+		icon_state = "medspray"
+	update_icon()
+	return ..()

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -38,3 +38,12 @@
 	desc = "Helps with burn injuries."
 	list_reagents = list("silver_sulfadiazine" = 20)
 	icon_state = "bandaid_burn"
+
+/obj/item/reagent_containers/pill/patch/changed_name(newname)
+	var/compare = lowertext(newname)
+	if (compare == "brute patch")
+		icon_state = "bandaid_brute"
+	if (compare == "burn patch")
+		icon_state = "bandaid_burn"
+	update_icon()
+	return ..()


### PR DESCRIPTION
🆑
tweak: If you rename medical sprays to styptic powder, silver sulfadiazine, or synthflesh updates the icon to the appropriate spray type. Also when making patches in the chem master if they are named "brute" or "burn" they have their icon changed to the brute/burn patches.
/🆑
Naming sprays/patches these specific names should change their sprite.
