### PR TITLE
Restores mech plasma cutter damage

### DIFF
--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -32,6 +32,11 @@
 	range = 9
 	mine_range = 3
 
+/obj/item/projectile/plasma/adv/mech/Initialize()
+	if(!lavaland_equipment_pressure_check(get_turf(src)))
+		damage = 10
+		name = "weakened [name]"
+
 /obj/item/projectile/plasma/turret
 	//Between normal and advanced for damage, made a beam so not the turret does not destroy glass
 	name = "plasma beam"

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -28,7 +28,7 @@
 	mine_range = 5
 
 /obj/item/projectile/plasma/adv/mech
-	damage = 10
+	damage = 40
 	range = 9
 	mine_range = 3
 


### PR DESCRIPTION
:cl: Zxaber
balance: Restored mech-mounted plasma cutter damage to their former glory. However, like before, this glory is only applicable in low-atmospheric conditions.
/:cl:

The reasoning for the plasma cutter nerf (easily mass producible, too good compared to alternatives) doesn't really apply to mech cutters.
- In order to use the cutter itself, you have to build the mech too(50 metal sheets and some glass for the frame, 10 more metal and five plasteel for the outer shell, actual assembly time, and time to charge whatever cell you want). While you could conceivably hammer out a few Ripleys with cutters to combat whatever emergency is happening, having the materials to do so means you most likely have the ability to make something better anyway. 
- A Durand with actual combat weapons isn't terribly more difficult to make than a Ripley, but is vastly more powerful.

Several people have expressed a desire for mechs to have a P-KA, but no one has actually stepped up to the plate. Meanwhile, mechs that are generally only made for mining deserve to have some method at fighting off lavaland enemies.