### PR TITLE
Restores some melee stuns

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -72,7 +72,7 @@
 	if((D.stat != DEAD) && damage >= A.dna.species.punchstunthreshold)
 		D.visible_message("<span class='danger'>[A] has knocked [D] down!!</span>", \
 								"<span class='userdanger'>[A] has knocked [D] down!</span>")
-		D.apply_effect(40, EFFECT_KNOCKDOWN, armor_block)
+		D.apply_effect(40, EFFECT_PARALYZE, armor_block)
 		D.forcesay(GLOB.hit_appends)
 	else if(!(D.mobility_flags & MOBILITY_STAND))
 		D.forcesay(GLOB.hit_appends)

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -39,7 +39,7 @@
 		if((D.stat != DEAD) && prob(knockout_prob))
 			D.visible_message("<span class='danger'>[A] has knocked [D] out with a haymaker!</span>", \
 								"<span class='userdanger'>[A] has knocked [D] out with a haymaker!</span>")
-			D.apply_effect(200,EFFECT_KNOCKDOWN,armor_block)
+			D.apply_effect(200, EFFECT_PARALYZE, armor_block)
 			D.SetSleeping(100)
 			D.forcesay(GLOB.hit_appends)
 			log_combat(A, D, "knocked out (boxing) ")

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1212,9 +1212,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		target.apply_damage(damage, BRUTE, affecting, armor_block)
 		log_combat(user, target, "punched")
 		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold)
-			target.visible_message("<span class='danger'>[user] has knocked  [target] down!</span>", \
+			target.visible_message("<span class='danger'>[user] has knocked [target] down!</span>", \
 							"<span class='userdanger'>[user] has knocked [target] down!</span>", null, COMBAT_MESSAGE_RANGE)
-			target.apply_effect(80, EFFECT_KNOCKDOWN, armor_block)
+			target.apply_effect(80, EFFECT_PARALYZE, armor_block)
 			target.forcesay(GLOB.hit_appends)
 		else if(!(target.mobility_flags & MOBILITY_STAND))
 			target.forcesay(GLOB.hit_appends)
@@ -1380,7 +1380,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					if(prob(I.force))
 						H.visible_message("<span class='danger'>[H] has been knocked down!</span>", \
 									"<span class='userdanger'>[H] has been knocked down!</span>")
-						H.apply_effect(60, EFFECT_KNOCKDOWN, armor_block)
+						H.apply_effect(60, EFFECT_PARALYZE, armor_block)
 
 				if(bloody)
 					if(H.wear_suit)


### PR DESCRIPTION
:cl: ShizCalev
balance: Punching someone to the point where they fall to the ground will now temporarily stun them, as it used to.
/:cl:

This trivialized hand to hand combat a bit. Pushes are currently more powerful than punches since they stun, while knocking someone out cold with your bare fists doesn't?

`EFFECT_KNOCKDOWN` doesn't restrict movement, doesn't restrict item usage (IE you can just pick up an esword while crawling around on the ground after being beaten silly and continue to murderize people as if you were a terminator during the entire duration of it), nor does it restrict any other actions such as hand to hand combat (so if you're knocked to the ground, you can just keep punching & kicking whoever did it to you without any penalty.)