### PR TITLE
Chem Dispenser supports negative inputs on highest macrotier.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -263,10 +263,13 @@
 					var/free = R.maximum_volume - R.total_volume
 					var/actual = min(round(chemicals_to_dispense[key], res), (cell.charge * powerefficiency)*10, free)
 					if(actual)
-						if(!cell.use(actual / powerefficiency))
+						if(!cell.use(abs(actual) / powerefficiency))
 							say("Not enough energy to complete operation!")
 							return
-						R.add_reagent(r_id, actual)
+						if(actual > 0)
+							R.add_reagent(r_id, actual)
+						if(actual < 0 && macrotier == 4)
+							R.remove_reagent(r_id, abs(actual))
 						work_animation()
 		if("clear_recipes")
 			if(!is_operational())


### PR DESCRIPTION
[Changelogs]: Makes the chem_dispenser on the highest tier able to handle negative inputs from macros.

:cl: yorii
add: Chem dispenser supports negative inputs on highest macrotier.
/:cl:

[why]: For the simple quality of life improvement of not having to put the beaker in yet another machine once you actually get your machines upgraded.
