### PR TITLE
[READY] Restricts the cook's CQC to the kitchen and kitchen backroom

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -10,8 +10,7 @@
 	block_chance = 75
 	var/just_a_cook = FALSE
 	var/static/list/areas_under_siege = typecacheof(list(/area/crew_quarters/kitchen,
-														/area/crew_quarters/cafeteria,
-														/area/crew_quarters/bar))
+														/area/crew_quarters/kitchen/backroom))
 
 /datum/martial_art/cqc/under_siege
 	name = "Close Quarters Cooking"

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -9,8 +9,6 @@
 	help_verb = /mob/living/carbon/human/proc/CQC_help
 	block_chance = 75
 	var/just_a_cook = FALSE
-	var/static/list/areas_under_siege = typecacheof(list(/area/crew_quarters/kitchen,
-														/area/crew_quarters/kitchen/backroom))
 
 /datum/martial_art/cqc/under_siege
 	name = "Close Quarters Cooking"
@@ -21,7 +19,7 @@
 
 /datum/martial_art/cqc/can_use(mob/living/carbon/human/H)
 	var/area/A = get_area(H)
-	if(just_a_cook && !(is_type_in_typecache(A, areas_under_siege)))
+	if(just_a_cook && !(istype(A, /area/crew_quarters/kitchen)))
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
:cl: Nervere and subject217
balance: The cook's CQC now only works when in the kitchen or the kitchen backroom.
/:cl:

[why]: The reason why the cook got CQC, other than it being a meme, was that people would often break into the kitchen and the cook would have a hard time defending himself. There's really no problem with this, except when the cook can also use CQC in the bar, which tends to be a pretty big area that the cook doesn't even need to defend. The bartender has a shotgun for the purpose of defending his bar, after all. 

I removed CQC working in the cafeteria for the same reason, but `/area/crew_quarters/cafeteria` isn't even used as an area in any of the maps so it doesn't even have an effect. Kitchen backroom isn't used as an area, either, but @81Denton plans to change that soon, so I've added it to the list of areas where CQC is able to be used.