### PR TITLE
Makes mild traumas a bit less trivial to cure

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -832,7 +832,6 @@
 	color = "#EEFF8F"
 
 /datum/reagent/medicine/neurine/on_mob_life(mob/living/carbon/C)
-	C.adjustBrainLoss(-3*REM)
 	if(prob(15))
 		C.cure_trauma_type(resilience = TRAUMA_RESILIENCE_BASIC)
 	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -823,7 +823,17 @@
 
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/C)
 	C.adjustBrainLoss(-2*REM)
-	if(prob(10))
+	..()
+	
+/datum/reagent/medicine/neurine
+	name = "Neurine"
+	id = "neurine"
+	description = "Reacts with neural tissue, helping reform damaged connections. Can cure minor traumas."
+	color = "#EEFF8F"
+
+/datum/reagent/medicine/neurine/on_mob_life(mob/living/carbon/C)
+	C.adjustBrainLoss(-3*REM)
+	if(prob(15))
 		C.cure_trauma_type(resilience = TRAUMA_RESILIENCE_BASIC)
 	..()
 

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -165,6 +165,12 @@
 	results = list("mannitol" = 3)
 	required_reagents = list("sugar" = 1, "hydrogen" = 1, "water" = 1)
 	mix_message = "The solution slightly bubbles, becoming thicker."
+	
+/datum/chemical_reaction/neurine
+	name = "Neurine"
+	id = "neurine"
+	results = list("neurine" = 3)
+	required_reagents = list("mannitol" = 1, "acetone" = 1, "oxygen" = 1)
 
 /datum/chemical_reaction/mutadone
 	name = "Mutadone"


### PR DESCRIPTION
:cl: XDTM
balance: Mannitol no longer cures mild traumas.
balance: Added a new reagent, Neurine, made with Mannitol, Acetone and Oxygen. Neurine can cure mild traumas in the same way Mannitol did, but does not heal brain damage.
/:cl:

With mannitol being extremely easy to produce, mild traumas mean nothing more than a quick trip to medbay instead of being, y'know, lasting traumas. Increasing the difficulty of producing the reagent a bit should make these traumas a little more meaningful if there aren't proper chemists around.
