### PR TITLE
Nuke Op Tactical Medkit Reshuffle

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -29,7 +29,7 @@
 /obj/item/storage/firstaid/regular/PopulateContents()
 	if(empty)
 		return
-	var/static/items_inside = list(	
+	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/stack/medical/bruise_pack = 2,
 		/obj/item/stack/medical/ointment = 2,
@@ -44,7 +44,7 @@
 /obj/item/storage/firstaid/ancient/PopulateContents()
 	if(empty)
 		return
-	var/static/items_inside = list(	
+	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/stack/medical/bruise_pack = 3,
 		/obj/item/stack/medical/ointment= 3)
@@ -67,7 +67,7 @@
 /obj/item/storage/firstaid/fire/PopulateContents()
 	if(empty)
 		return
-	var/static/items_inside = list(	
+	var/static/items_inside = list(
 		/obj/item/reagent_containers/pill/patch/silver_sulf = 3,
 		/obj/item/reagent_containers/pill/oxandrolone = 2,
 		/obj/item/reagent_containers/hypospray/medipen = 1,
@@ -91,7 +91,7 @@
 /obj/item/storage/firstaid/toxin/PopulateContents()
 	if(empty)
 		return
-	var/static/items_inside = list(	
+	var/static/items_inside = list(
 		/obj/item/reagent_containers/syringe/charcoal = 4,
 		/obj/item/storage/pill_bottle/charcoal = 2,
 		/obj/item/healthanalyzer = 1)
@@ -110,7 +110,7 @@
 /obj/item/storage/firstaid/o2/PopulateContents()
 	if(empty)
 		return
-	var/static/items_inside = list(	
+	var/static/items_inside = list(
 		/obj/item/reagent_containers/pill/salbutamol = 4,
 		/obj/item/reagent_containers/hypospray/medipen = 2,
 		/obj/item/healthanalyzer = 1)
@@ -129,7 +129,7 @@
 /obj/item/storage/firstaid/brute/PopulateContents()
 	if(empty)
 		return
-	var/static/items_inside = list(	
+	var/static/items_inside = list(
 		/obj/item/reagent_containers/pill/patch/styptic = 4,
 		/obj/item/stack/medical/gauze = 2,
 		/obj/item/healthanalyzer = 1)
@@ -152,8 +152,9 @@
 	new /obj/item/defibrillator/compact/combat/loaded(src)
 	new /obj/item/reagent_containers/hypospray/combat(src)
 	new /obj/item/reagent_containers/pill/patch/styptic(src)
+	new /obj/item/reagent_containers/pill/patch/styptic(src)
 	new /obj/item/reagent_containers/pill/patch/silver_sulf(src)
-	new /obj/item/reagent_containers/syringe/lethal/choral(src)
+	new /obj/item/reagent_containers/pill/patch/silver_sulf(src)
 	new /obj/item/clothing/glasses/hud/health/night(src)
 
 /*


### PR DESCRIPTION
This PR reworks the Tactical Medkit that Nuke Ops can purchase.

The medkit now spawns with.
* 2x Burn Patches
* 2x Brute Patches
* Gauze
* Combat Hypospray
* Combat Defib (functionally useless)
* Med NVGs.

Essentially, I added an extra burn/brute patch each and removed the lethal injection syringe.

I did this because I felt I was not getting much value out of the tac medkit. I feel this will increase the value of the medkit instead of me deciding to just empty out the free medkits and give myself the burn and brute patches from them instead.

:cl: Steelpoint
tweak: The Tactical Medkit that Nuke Ops can purchase now has extra medical supplies.
/:cl:

