### PR TITLE
Malf camera network upgrade fixes

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -104,11 +104,11 @@
 
 /obj/machinery/camera/examine(mob/user)
 	..()
-	if(isEmpProof(assembly.malf_emp_firmware_active)) //don't reveal it's upgraded if was done via MALF AI Upgrade Camera Network ability
+	if(isEmpProof(TRUE)) //don't reveal it's upgraded if was done via MALF AI Upgrade Camera Network ability
 		to_chat(user, "It has electromagnetic interference shielding installed.")
 	else
 		to_chat(user, "<span class='info'>It can be shielded against electromagnetic interference with some <b>plasma</b>.</span>")
-	if(isXRay(assembly.malf_xray_firmware_active)) //don't reveal it's upgraded if was done via MALF AI Upgrade Camera Network ability
+	if(isXRay(TRUE)) //don't reveal it's upgraded if was done via MALF AI Upgrade Camera Network ability
 		to_chat(user, "It has an X-ray photodiode installed.")
 	else
 		to_chat(user, "<span class='info'>It can be upgraded with an X-ray photodiode with an <b>analyzer</b>.</span>")
@@ -223,10 +223,10 @@
 	// UPGRADES
 	if(panel_open)
 		if(I.tool_behaviour == TOOL_ANALYZER)
-			if(!isXRay(assembly.malf_xray_firmware_active)) //don't reveal it was already upgraded if was done via MALF AI Upgrade Camera Network ability
+			if(!isXRay(TRUE)) //don't reveal it was already upgraded if was done via MALF AI Upgrade Camera Network ability
 				if(!user.temporarilyRemoveItemFromInventory(I))
 					return
-				upgradeXRay(FALSE, assembly.malf_xray_firmware_active)
+				upgradeXRay(FALSE, TRUE)
 				to_chat(user, "<span class='notice'>You attach [I] into [assembly]'s inner circuits.</span>")
 				qdel(I)
 			else
@@ -234,9 +234,9 @@
 			return
 
 		else if(istype(I, /obj/item/stack/sheet/mineral/plasma))
-			if(!isEmpProof(assembly.malf_emp_firmware_active)) //don't reveal it was already upgraded if was done via MALF AI Upgrade Camera Network ability
+			if(!isEmpProof(TRUE)) //don't reveal it was already upgraded if was done via MALF AI Upgrade Camera Network ability
 				if(I.use_tool(src, user, 0, amount=1))
-					upgradeEmpProof(FALSE, assembly.malf_emp_firmware_active)
+					upgradeEmpProof(FALSE, TRUE)
 					to_chat(user, "<span class='notice'>You attach [I] into [assembly]'s inner circuits.</span>")
 			else
 				to_chat(user, "<span class='notice'>[src] already has that upgrade!</span>")
@@ -334,7 +334,7 @@
 
 /obj/machinery/camera/update_icon() //TO-DO: Make panel open states, xray camera, and indicator lights overlays instead.
 	var/xray_module
-	if(isXRay(assembly.malf_xray_firmware_active))
+	if(isXRay(TRUE))
 		xray_module = "xray"
 	if(!status)
 		icon_state = "[xray_module][default_camera_icon]_off"

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -60,9 +60,15 @@
 	if(CA)
 		assembly = CA
 		if(assembly.xray_module)
-			upgradeEmpProof()
-		if(assembly.emp_module)
 			upgradeXRay()
+		else if(assembly.malf_xray_firmware_present) //if it was secretly upgraded via the MALF AI Upgrade Camera Network ability
+			upgradeXRay(TRUE)
+
+		if(assembly.emp_module)
+			upgradeEmpProof()
+		else if(assembly.malf_xray_firmware_present) //if it was secretly upgraded via the MALF AI Upgrade Camera Network ability
+			upgradeEmpProof(TRUE)
+
 		if(assembly.proxy_module)
 			upgradeMotion()
 	else
@@ -98,11 +104,11 @@
 
 /obj/machinery/camera/examine(mob/user)
 	..()
-	if(isEmpProof())
+	if(isEmpProof(assembly.malf_emp_firmware_active)) //don't reveal it's upgraded if was done via MALF AI Upgrade Camera Network ability
 		to_chat(user, "It has electromagnetic interference shielding installed.")
 	else
 		to_chat(user, "<span class='info'>It can be shielded against electromagnetic interference with some <b>plasma</b>.</span>")
-	if(isXRay())
+	if(isXRay(assembly.malf_xray_firmware_active)) //don't reveal it's upgraded if was done via MALF AI Upgrade Camera Network ability
 		to_chat(user, "It has an X-ray photodiode installed.")
 	else
 		to_chat(user, "<span class='info'>It can be upgraded with an X-ray photodiode with an <b>analyzer</b>.</span>")
@@ -217,10 +223,10 @@
 	// UPGRADES
 	if(panel_open)
 		if(I.tool_behaviour == TOOL_ANALYZER)
-			if(!isXRay())
+			if(!isXRay(assembly.malf_xray_firmware_active)) //don't reveal it was already upgraded if was done via MALF AI Upgrade Camera Network ability
 				if(!user.temporarilyRemoveItemFromInventory(I))
 					return
-				upgradeXRay()
+				upgradeXRay(FALSE, assembly.malf_xray_firmware_active)
 				to_chat(user, "<span class='notice'>You attach [I] into [assembly]'s inner circuits.</span>")
 				qdel(I)
 			else
@@ -228,9 +234,9 @@
 			return
 
 		else if(istype(I, /obj/item/stack/sheet/mineral/plasma))
-			if(!isEmpProof())
+			if(!isEmpProof(assembly.malf_emp_firmware_active)) //don't reveal it was already upgraded if was done via MALF AI Upgrade Camera Network ability
 				if(I.use_tool(src, user, 0, amount=1))
-					upgradeEmpProof()
+					upgradeEmpProof(FALSE, assembly.malf_emp_firmware_active)
 					to_chat(user, "<span class='notice'>You attach [I] into [assembly]'s inner circuits.</span>")
 			else
 				to_chat(user, "<span class='notice'>[src] already has that upgrade!</span>")
@@ -328,7 +334,7 @@
 
 /obj/machinery/camera/update_icon() //TO-DO: Make panel open states, xray camera, and indicator lights overlays instead.
 	var/xray_module
-	if(isXRay())
+	if(isXRay(assembly.malf_xray_firmware_active))
 		xray_module = "xray"
 	if(!status)
 		icon_state = "[xray_module][default_camera_icon]_off"

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -78,7 +78,7 @@
 			malf_xray_firmware_active = malf_xray_firmware_present //re-enable firmware based upgrades after the part is removed.
 		if(istype(loc, /obj/machinery/camera))
 			var/obj/machinery/camera/contained_camera = loc
-			contained_camera.removeXRay(malf_xray_firmware_active) //make sure we don't remove MALF upgrades.
+			contained_camera.removeXRay(malf_xray_firmware_present) //make sure we don't remove MALF upgrades.
 
 	else if(A == emp_module)
 		emp_module = null

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -19,7 +19,13 @@
 	max_integrity = 150
 	//	Motion, EMP-Proof, X-ray
 	var/obj/item/analyzer/xray_module
+	var/malf_xray_firmware_active //used to keep from revealing malf AI upgrades for user facing isXRay() checks when they use Upgrade Camera Network ability
+								//will be false if the camera is upgraded with the proper parts.
+	var/malf_xray_firmware_present //so the malf upgrade is restored when the normal upgrade part is removed.
 	var/obj/item/stack/sheet/mineral/plasma/emp_module
+	var/malf_emp_firmware_active //used to keep from revealing malf AI upgrades for user facing isEmp() checks after they use Upgrade Camera Network ability
+								//will be false if the camera is upgraded with the proper parts.
+	var/malf_emp_firmware_present //so the malf upgrade is restored when the normal upgrade part is removed.
 	var/obj/item/assembly/prox_sensor/proxy_module
 	var/state = STATE_WRENCHED
 
@@ -68,15 +74,19 @@
 	if(A == xray_module)
 		xray_module = null
 		update_icon()
+		if(malf_xray_firmware_present)
+			malf_xray_firmware_active = malf_xray_firmware_present //re-enable firmware based upgrades after the part is removed.
 		if(istype(loc, /obj/machinery/camera))
 			var/obj/machinery/camera/contained_camera = loc
-			contained_camera.removeXRay()
+			contained_camera.removeXRay(malf_xray_firmware_active) //make sure we don't remove MALF upgrades.
 
 	else if(A == emp_module)
 		emp_module = null
+		if(malf_emp_firmware_present)
+			malf_emp_firmware_active = malf_emp_firmware_present //re-enable firmware based upgrades after the part is removed.
 		if(istype(loc, /obj/machinery/camera))
 			var/obj/machinery/camera/contained_camera = loc
-			contained_camera.removeEmpProof()
+			contained_camera.removeEmpProof(malf_emp_firmware_present) //make sure we don't remove MALF upgrades
 
 	else if(A == proxy_module)
 		emp_module = null
@@ -97,9 +107,15 @@
 	I.forceMove(drop_location())
 	if(I == xray_module)
 		xray_module = null
+		if(malf_xray_firmware_present)
+			malf_xray_firmware_active = malf_xray_firmware_present //re-enable firmware based upgrades after the part is removed.
 		update_icon()
+
 	else if(I == emp_module)
 		emp_module = null
+		if(malf_emp_firmware_present)
+			malf_emp_firmware_active = malf_emp_firmware_present //re-enable firmware based upgrades after the part is removed.
+
 	else if(I == proxy_module)
 		proxy_module = null
 
@@ -141,6 +157,9 @@
 				if(!W.use_tool(src, user, 0, amount=1)) //only use one sheet, otherwise the whole stack will be consumed.
 					return
 				emp_module = new(src)
+				if(malf_xray_firmware_active)
+					malf_xray_firmware_active = FALSE //flavor reason: MALF AI Upgrade Camera Network ability's firmware is incompatible with the new part
+														//real reason: make it a normal upgrade so the finished camera's icons and examine texts are restored.
 				to_chat(user, "<span class='notice'>You attach [W] into [src]'s inner circuits.</span>")
 				return
 
@@ -152,6 +171,9 @@
 					return
 				to_chat(user, "<span class='notice'>You attach [W] into [src]'s inner circuits.</span>")
 				xray_module = W
+				if(malf_xray_firmware_active)
+					malf_xray_firmware_active = FALSE //flavor reason: MALF AI Upgrade Camera Network ability's firmware is incompatible with the new part
+														//real reason: make it a normal upgrade so the finished camera's icons and examine texts are restored.
 				update_icon()
 				return
 

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -65,36 +65,53 @@
 
 // UPGRADE PROCS
 
-/obj/machinery/camera/proc/isEmpProof()
-	return upgrades & CAMERA_UPGRADE_EMP_PROOF
+/obj/machinery/camera/proc/isEmpProof(ignore_malf_upgrades)
+	return (upgrades & CAMERA_UPGRADE_EMP_PROOF) && (!ignore_malf_upgrades)
 
-/obj/machinery/camera/proc/upgradeEmpProof()
-	if(isEmpProof())
-		return
+/obj/machinery/camera/proc/upgradeEmpProof(malf_upgrade, ignore_malf_upgrades)
+	if(isEmpProof(ignore_malf_upgrades)) //pass a malf upgrade to ignore_malf_upgrades so we can replace the malf module with the normal one
+		return							//that way if someone tries to upgrade an already malf-upgraded camera, it'll just upgrade it to a normal version.
 	emp_component = AddComponent(/datum/component/empprotection, EMP_PROTECT_SELF | EMP_PROTECT_WIRES | EMP_PROTECT_CONTENTS)
-	if(!assembly.emp_module)
+	if(malf_upgrade)
+		assembly.malf_emp_firmware_active = TRUE //don't add parts to drop, update icon, ect. reconstructing it will also retain the upgrade.
+		assembly.malf_emp_firmware_present = TRUE //so the upgrade is retained after incompatible parts are removed.
+
+	else if(!assembly.emp_module) //only happens via upgrading in camera/attackby()
 		assembly.emp_module = new(assembly)
+		if(assembly.malf_emp_firmware_active)
+			assembly.malf_emp_firmware_active = FALSE //make it appear like it's just normally upgraded so the icons and examine texts are restored.
+
 	upgrades |= CAMERA_UPGRADE_EMP_PROOF
 
-/obj/machinery/camera/proc/removeEmpProof()
+/obj/machinery/camera/proc/removeEmpProof(ignore_malf_upgrades)
+	if(ignore_malf_upgrades) //don't downgrade it if malf software is forced onto it.
+		return
 	emp_component.RemoveComponent()
 	upgrades &= ~CAMERA_UPGRADE_EMP_PROOF
 
 
 
-/obj/machinery/camera/proc/isXRay()
-	return upgrades & CAMERA_UPGRADE_XRAY
+/obj/machinery/camera/proc/isXRay(ignore_malf_upgrades)
+	return (upgrades & CAMERA_UPGRADE_XRAY) && (!ignore_malf_upgrades)
 
-/obj/machinery/camera/proc/upgradeXRay()
-	if(isXRay())
-		return
-	if(!assembly.xray_module)
+/obj/machinery/camera/proc/upgradeXRay(malf_upgrade, ignore_malf_upgrades)
+	if(isXRay(ignore_malf_upgrades)) //pass a malf upgrade to ignore_malf_upgrades so we can replace the malf upgrade with the normal one
+		return						//that way if someone tries to upgrade an already malf-upgraded camera, it'll just upgrade it to a normal version.
+	if(malf_upgrade)
+		assembly.malf_xray_firmware_active = TRUE //don't add parts to drop, update icon, ect. reconstructing it will also retain the upgrade.
+		assembly.malf_xray_firmware_present = TRUE //so the upgrade is retained after incompatible parts are removed.
+
+	else if(!assembly.xray_module) //only happens via upgrading in camera/attackby()
 		assembly.xray_module = new(assembly)
+		if(assembly.malf_xray_firmware_active)
+			assembly.malf_xray_firmware_active = FALSE //make it appear like it's just normally upgraded so the icons and examine texts are restored.
+
 	upgrades |= CAMERA_UPGRADE_XRAY
 	update_icon()
 
-/obj/machinery/camera/proc/removeXRay()
-	upgrades &= ~CAMERA_UPGRADE_XRAY
+/obj/machinery/camera/proc/removeXRay(ignore_malf_upgrades)
+	if(!ignore_malf_upgrades) //don't downgrade it if malf software is forced onto it.
+		upgrades &= ~CAMERA_UPGRADE_XRAY
 	update_icon()
 
 

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -66,7 +66,7 @@
 // UPGRADE PROCS
 
 /obj/machinery/camera/proc/isEmpProof(ignore_malf_upgrades)
-	return (upgrades & CAMERA_UPGRADE_EMP_PROOF) && (!ignore_malf_upgrades)
+	return (upgrades & CAMERA_UPGRADE_EMP_PROOF) && (!(ignore_malf_upgrades && assembly.malf_emp_firmware_active))
 
 /obj/machinery/camera/proc/upgradeEmpProof(malf_upgrade, ignore_malf_upgrades)
 	if(isEmpProof(ignore_malf_upgrades)) //pass a malf upgrade to ignore_malf_upgrades so we can replace the malf module with the normal one
@@ -92,7 +92,7 @@
 
 
 /obj/machinery/camera/proc/isXRay(ignore_malf_upgrades)
-	return (upgrades & CAMERA_UPGRADE_XRAY) && (!ignore_malf_upgrades)
+	return (upgrades & CAMERA_UPGRADE_XRAY) && (!(ignore_malf_upgrades && assembly.malf_xray_firmware_active))
 
 /obj/machinery/camera/proc/upgradeXRay(malf_upgrade, ignore_malf_upgrades)
 	if(isXRay(ignore_malf_upgrades)) //pass a malf upgrade to ignore_malf_upgrades so we can replace the malf upgrade with the normal one

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -826,17 +826,17 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	for(var/V in GLOB.cameranet.cameras)
 		var/obj/machinery/camera/C = V
 		if(C.assembly)
-			var/upgraded = 0
+			var/upgraded = FALSE
 
 			if(!C.isXRay())
-				C.upgradeXRay()
+				C.upgradeXRay(TRUE) //if this is removed you can get rid of camera_assembly/var/malf_xray_firmware_active and clean up isxray()
 				//Update what it can see.
 				GLOB.cameranet.updateVisibility(C, 0)
-				upgraded = 1
+				upgraded = TRUE
 
 			if(!C.isEmpProof())
-				C.upgradeEmpProof()
-				upgraded = 1
+				C.upgradeEmpProof(TRUE) //if this is removed you can get rid of camera_assembly/var/malf_emp_firmware_active and clean up isemp()
+				upgraded = TRUE
 
 			if(upgraded)
 				upgraded_cameras++


### PR DESCRIPTION
Fixes #41436

:cl: ShizCalev
fix: Fixed building a new camera with EMP upgrades in it's assembly giving it the X-Ray upgrade, and vice versa.
fix: The AI Camera network firmware upgrade will no longer change the icon of the upgraded cameras, with made it very obvious the AI was rogue when the entire station suddenly had X-Ray cameras.
fix: You will no longer be able to detect the usage of the AI Camera network firmware upgrade by examining a camera to see if it has xray / emp upgrades.
fix: You will no longer be able to detect the usage of the AI Camera network firmware upgrade by trying to upgrade the camera (it's a software thing, not a hardware thing.)
fix: Cameras rebuilt after being upgraded by the AI Camera network firmware upgrade will now retain their upgrades.
/:cl: