### PR TITLE
Fixes knives not embedding right (without rebalance stuff tacked on.)

### DIFF
--- a/code/datums/embedding_behavior.dm
+++ b/code/datums/embedding_behavior.dm
@@ -1,4 +1,4 @@
-#define EMBEDID "embed-[embed_chance]-[embedded_fall_chance]-[embedded_pain_chance]-[embedded_pain_multiplier]-[embedded_fall_pain_multiplier]-[embedded_impact_pain_multiplier]-[embedded_unsafe_removal_pain_multiplier]-[embedded_unsafe_removal_time]"
+#define EMBEDID "embed-[embed_chance]-[embedded_fall_chance]-[embedded_pain_chance]-[embedded_pain_multiplier]-[embedded_fall_pain_multiplier]-[embedded_impact_pain_multiplier]-[embedded_unsafe_removal_pain_multiplier]-[embedded_unsafe_removal_time]-[embedded_ignore_throwspeed_threshold]"
 
 /proc/getEmbeddingBehavior(embed_chance = EMBED_CHANCE,
                   embedded_fall_chance = EMBEDDED_ITEM_FALLOUT,
@@ -7,10 +7,11 @@
                   embedded_fall_pain_multiplier = EMBEDDED_FALL_PAIN_MULTIPLIER,
                   embedded_impact_pain_multiplier = EMBEDDED_IMPACT_PAIN_MULTIPLIER,
                   embedded_unsafe_removal_pain_multiplier = EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER,
-                  embedded_unsafe_removal_time = EMBEDDED_UNSAFE_REMOVAL_TIME)
+                  embedded_unsafe_removal_time = EMBEDDED_UNSAFE_REMOVAL_TIME,
+                  embedded_ignore_throwspeed_threshold = FALSE)
   . = locate(EMBEDID)
   if (!.)
-    . = new /datum/embedding_behavior(embed_chance, embedded_fall_chance, embedded_pain_chance, embedded_pain_multiplier, embedded_fall_pain_multiplier, embedded_impact_pain_multiplier, embedded_unsafe_removal_pain_multiplier, embedded_unsafe_removal_time)
+    . = new /datum/embedding_behavior(embed_chance, embedded_fall_chance, embedded_pain_chance, embedded_pain_multiplier, embedded_fall_pain_multiplier, embedded_impact_pain_multiplier, embedded_unsafe_removal_pain_multiplier, embedded_unsafe_removal_time, embedded_ignore_throwspeed_threshold)
 
 /datum/embedding_behavior
   var/embed_chance
@@ -21,6 +22,7 @@
   var/embedded_impact_pain_multiplier //The coefficient of multiplication for the damage this item does when first embedded (this*w_class)
   var/embedded_unsafe_removal_pain_multiplier //The coefficient of multiplication for the damage removing this without surgery causes (this*w_class)
   var/embedded_unsafe_removal_time //A time in ticks, multiplied by the w_class.
+  var/embedded_ignore_throwspeed_threshold //if we don't give a damn about EMBED_THROWSPEED_THRESHOLD
 
 /datum/embedding_behavior/New(embed_chance = EMBED_CHANCE,
                   embedded_fall_chance = EMBEDDED_ITEM_FALLOUT,
@@ -29,7 +31,8 @@
                   embedded_fall_pain_multiplier = EMBEDDED_FALL_PAIN_MULTIPLIER,
                   embedded_impact_pain_multiplier = EMBEDDED_IMPACT_PAIN_MULTIPLIER,
                   embedded_unsafe_removal_pain_multiplier = EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER,
-                  embedded_unsafe_removal_time = EMBEDDED_UNSAFE_REMOVAL_TIME)
+                  embedded_unsafe_removal_time = EMBEDDED_UNSAFE_REMOVAL_TIME,
+                  embedded_ignore_throwspeed_threshold = FALSE)
   src.embed_chance = embed_chance
   src.embedded_fall_chance = embedded_fall_chance
   src.embedded_pain_chance = embedded_pain_chance
@@ -38,9 +41,10 @@
   src.embedded_impact_pain_multiplier = embedded_impact_pain_multiplier
   src.embedded_unsafe_removal_pain_multiplier = embedded_unsafe_removal_pain_multiplier
   src.embedded_unsafe_removal_time = embedded_unsafe_removal_time
+  src.embedded_ignore_throwspeed_threshold = embedded_ignore_throwspeed_threshold
   tag = EMBEDID
 
-/datum/embedding_behavior/proc/setRating(embed_chance, embedded_fall_chance, embedded_pain_chance, embedded_pain_multiplier, embedded_fall_pain_multiplier, embedded_impact_pain_multiplier, embedded_unsafe_removal_pain_multiplier, embedded_unsafe_removal_time)
+/datum/embedding_behavior/proc/setRating(embed_chance, embedded_fall_chance, embedded_pain_chance, embedded_pain_multiplier, embedded_fall_pain_multiplier, embedded_impact_pain_multiplier, embedded_unsafe_removal_pain_multiplier, embedded_unsafe_removal_time, embedded_ignore_throwspeed_threshold)
   return getEmbeddingBehavior((isnull(embed_chance) ? src.embed_chance : embed_chance),\
                   (isnull(embedded_fall_chance) ? src.embedded_fall_chance : embedded_fall_chance),\
                   (isnull(embedded_pain_chance) ? src.embedded_pain_chance : embedded_pain_chance),\
@@ -48,6 +52,7 @@
                   (isnull(embedded_fall_pain_multiplier) ? src.embedded_fall_pain_multiplier : embedded_fall_pain_multiplier),\
                   (isnull(embedded_impact_pain_multiplier) ? src.embedded_impact_pain_multiplier : embedded_impact_pain_multiplier),\
                   (isnull(embedded_unsafe_removal_pain_multiplier) ? src.embedded_unsafe_removal_pain_multiplier : embedded_unsafe_removal_pain_multiplier),\
-                  (isnull(embedded_unsafe_removal_time) ? src.embedded_unsafe_removal_time : embedded_unsafe_removal_time))
+                  (isnull(embedded_unsafe_removal_time) ? src.embedded_unsafe_removal_time : embedded_unsafe_removal_time),\
+                  (isnull(embedded_ignore_throwspeed_threshold) ? src.embedded_ignore_throwspeed_threshold : embedded_ignore_throwspeed_threshold))
 
 #undef EMBEDID

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -119,7 +119,7 @@
 	name = "combat knife"
 	icon_state = "buckknife"
 	desc = "A military combat utility survival knife."
-	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 65, "embedded_fall_chance" = 10)
+	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 65, "embedded_fall_chance" = 10, "embedded_ignore_throwspeed_threshold" = TRUE)
 	force = 20
 	throwforce = 20
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "cut")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -134,7 +134,7 @@
 		skipcatch = TRUE
 		blocked = TRUE
 	else if(I)
-		if(I.throw_speed >= EMBED_THROWSPEED_THRESHOLD)
+		if((I.throw_speed >= EMBED_THROWSPEED_THRESHOLD) || I.embedding.embedded_ignore_throwspeed_threshold)
 			if(can_embed(I))
 				if(prob(I.embedding.embed_chance) && !has_trait(TRAIT_PIERCEIMMUNE))
 					throw_alert("embeddedobject", /obj/screen/alert/embeddedobject)


### PR DESCRIPTION
Noticed there was some commentary left from #8016 saying this was originally supposed to be a thing.

:cl: ShizCalev
fix: Combat knives can now get embedded in their victims again.
/:cl:

