### PR TITLE
Fixes Swedish mutation language

### DIFF
--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -139,9 +139,9 @@
 	if(message)
 		message = replacetext(message,"w","v")
 		message = replacetext(message,"j","y")
-		message = replacetext(message,"a",pick("�","�","�","a"))
+		message = replacetext(message,"a",pick("å","ä","æ","a"))
 		message = replacetext(message,"bo","bjo")
-		message = replacetext(message,"o",pick("�","�","o"))
+		message = replacetext(message,"o",pick("ö","ø","o"))
 		if(prob(30))
 			message += " Bork[pick("",", bork",", bork, bork")]!"
 	return message


### PR DESCRIPTION
Caused by #25325
Fixes #41453

:cl: ShizCalev
fix: The Swedish language now works again.
/:cl:
