### PR TITLE
Removes a redundant fix for preventing message spam

### DIFF
--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -57,9 +57,6 @@
 		if (!isturf(T))
 			return
 
-		if(last_act + (40 * I.toolspeed) > world.time)//prevents message spam
-			return
-		last_act = world.time
 		to_chat(user, "<span class='notice'>You start picking...</span>")
 
 		if(I.use_tool(src, user, 40, volume=50))


### PR DESCRIPTION
This is a few lines of code that was intended to 'prevent message spam' while mining (see the string 'You start picking...'). Since messages of the same type are now collapsed into eachother, this code is no longer necessary.
