### PR TITLE
Fix colorooc checking for R_ADMIN and byond

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -107,7 +107,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 	set name = "Set Your OOC Color"
 	set category = "Preferences"
 
-	if(!holder || check_rights_for(src, R_ADMIN))
+	if(!holder || !check_rights_for(src, R_ADMIN))
 		if(!is_content_unlocked())
 			return
 

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -123,7 +123,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 	set desc = "Returns your OOC Color to default"
 	set category = "Preferences"
 
-	if(!holder || check_rights_for(src, R_ADMIN))
+	if(!holder || !check_rights_for(src, R_ADMIN))
 		if(!is_content_unlocked())
 			return
 


### PR DESCRIPTION
> 
> steamport Today at 1:50 AM
> Hey
> can someone PR a change to /tg/?
> /client/verb/colorooc()
>     set name = "Set Your OOC Color"
>     set category = "Preferences"
> 
>     if(!holder || check_rights_for(src, R_ADMIN))
>         if(!is_content_unlocked())
>             return
> 
>     var/new_ooccolor = input(src, "Please select your OOC color.", "OOC color", prefs.ooccolor) as color|null
>     if(new_ooccolor)
>         prefs.ooccolor = sanitize_ooccolor(new_ooccolor)
>         prefs.save_preferences()
>     SSblackbox.record_feedback("tally", "admin_verb", 1, "Set OOC Color") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
> return
> change 
> if(!holder || check_rights_for(src, R_ADMIN))
>  to 
> if(!holder || !check_rights_for(src, R_ADMIN))
> (edited)
> because it'll check anyone with R_ADMIN for byond member for OOC color changing