### PR TITLE
Cleans up some leftover circuitry stuff

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -32608,7 +32608,7 @@
 "bzD" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/computer/security/telescreen/circuitry,
+/obj/machinery/computer/security/telescreen/research,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -56598,7 +56598,7 @@
 /area/science/mixing)
 "lQm" = (
 /obj/machinery/camera{
-	c_tag = "Circuitry Lab";
+	c_tag = "Nanite Lab";
 	dir = 4;
 	network = list("ss13","rd")
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -102297,7 +102297,7 @@
 /area/science/misc_lab/range)
 "dqe" = (
 /obj/machinery/door/airlock/research{
-	name = "Circuitry Lab";
+	name = "Research Testing Range";
 	req_access_txt = "47"
 	},
 /obj/structure/disposalpipe/segment{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -83245,7 +83245,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/research/glass{
-	name = "Circuitry Lab";
+	name = "Research Testing Range";
 	req_access_txt = "47"
 	},
 /obj/machinery/door/firedoor,

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -70,10 +70,6 @@
 /area/ruin/unpowered/syndicate_lava_base/telecomms
 	name = "Syndicate Lavaland Telecommunications"
 
-/area/ruin/unpowered/syndicate_lava_base/circuits
-	name = "Syndicate Lavaland Circuit Lab"
-
-
 //Xeno Nest
 
 /area/ruin/unpowered/xenonest

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -178,7 +178,7 @@
 	circuit = /obj/item/circuitboard/computer/research
 
 /obj/machinery/computer/security/hos
-	name = "Head of Security's camera console"
+	name = "\improper Head of Security's camera console"
 	desc = "A custom security console with added access to the labor camp network."
 	network = list("ss13", "labor")
 	circuit = null
@@ -190,7 +190,7 @@
 	circuit = null
 
 /obj/machinery/computer/security/qm
-	name = "Quartermaster's camera console"
+	name = "\improper Quartermaster's camera console"
 	desc = "A console with access to the mining, auxillary base and vault camera networks."
 	network = list("mine", "auxbase", "vault")
 	circuit = null
@@ -223,32 +223,32 @@
 	network = list("thunder")
 
 /obj/machinery/computer/security/telescreen/rd
-	name = "Research Director's telescreen"
+	name = "\improper Research Director's telescreen"
 	desc = "Used for watching the AI and the RD's goons from the safety of his office."
 	network = list("rd", "aicore", "aiupload", "minisat", "xeno", "test")
 
-/obj/machinery/computer/security/telescreen/circuitry
-	name = "circuitry telescreen"
-	desc = "Used for watching the other eggheads from the safety of the circuitry lab."
+/obj/machinery/computer/security/telescreen/research
+	name = "research telescreen"
+	desc = "A telescreen with access to the research division's camera network."
 	network = list("rd")
 
 /obj/machinery/computer/security/telescreen/ce
-	name = "Chief Engineer's telescreen"
+	name = "\improper Chief Engineer's telescreen"
 	desc = "Used for watching the engine, telecommunications and the minisat."
 	network = list("engine", "singularity", "tcomms", "minisat")
 
 /obj/machinery/computer/security/telescreen/cmo
-	name = "Chief Medical Officer's telescreen"
+	name = "\improper Chief Medical Officer's telescreen"
 	desc = "A telescreen with access to the medbay's camera network."
 	network = list("medbay")
 
 /obj/machinery/computer/security/telescreen/vault
-	name = "Vault monitor"
+	name = "vault monitor"
 	desc = "A telescreen that connects to the vault's camera network."
 	network = list("vault")
 
 /obj/machinery/computer/security/telescreen/toxins
-	name = "Bomb test site monitor"
+	name = "bomb test site monitor"
 	desc = "A telescreen that connects to the bomb test site's camera."
 	network = list("toxin")
 
@@ -283,6 +283,6 @@
 	network = list("minisat")
 
 /obj/machinery/computer/security/telescreen/aiupload
-	name = "AI upload monitor"
+	name = "\improper AI upload monitor"
 	desc = "A telescreen that connects to the AI upload's camera network."
 	network = list("aiupload")

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -381,13 +381,6 @@
 	title = "To Serve Man"
 	page_link = "Guide_to_food_and_drinks"
 
-/obj/item/book/manual/wiki/circuitry
-	name = "Circuitry for Dummies"
-	icon_state = "book1"
-	author = "Dr. Hans Asperger"
-	title = "Circuitry for Dummies"
-	page_link = "Guide_to_circuits"
-
 /obj/item/book/manual/wiki/tcomms
 	name = "Subspace Telecommunications And You"
 	icon_state = "book3"


### PR DESCRIPTION
Closes #41479
Fixes #41290 

:cl: ShizCalev
fix: Corrected some doors still being called Circuitry Lab.
fix: Replaced the circuitry lab telescreen in the sci security checkpoint in science with a standard science telescreen.
fix: Corrected the Nanite lab's camera tags on Box.
/:cl:

