### PR TITLE
Relating to issue #39395, the ratvarian spear now breaks when it is used as opposed to never breaking.

### DIFF
--- a/code/modules/antagonists/clockcult/clock_items/clock_weapons/ratvarian_spear.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clock_weapons/ratvarian_spear.dm
@@ -72,5 +72,6 @@
 		if(T) //make sure we're not in null or something
 			T.visible_message("<span class='warning'>[src] [pick("cracks in two and fades away", "snaps in two and dematerializes")]!</span>")
 			new /obj/effect/temp_visual/ratvar/spearbreak(T)
+			qdel(src)
 		action.weapon_reset(RATVARIAN_SPEAR_COOLDOWN)
 


### PR DESCRIPTION
[Changelogs]: # This addresses the issue in #39395 where the ratvarian spear would never break when it was thrown and hit someone, now it breaks properly.

[Why]: # So, if the slim chance the ratvarian spear is used, it can be used properly and break like it was intended to.
