### PR TITLE
Fixes solo changelings getting kill other changeling objectives

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -12,6 +12,7 @@
 	var/you_are_greet = TRUE
 	var/give_objectives = TRUE
 	var/team_mode = FALSE //Should assign team objectives ?
+	var/competitive_objectives = FALSE //Should we assign objectives in competition with other lings?
 
 	//Changeling Stuff
 
@@ -27,6 +28,7 @@
 	var/sting_range = 2
 	var/changelingID = "Changeling"
 	var/geneticdamage = 0
+	var/was_absorbed = FALSE //if they were absorbed by another ling already.
 	var/isabsorbing = 0
 	var/islinking = 0
 	var/geneticpoints = 10
@@ -42,6 +44,15 @@
 	// wip stuff
 	var/static/list/all_powers = typecacheof(/obj/effect/proc_holder/changeling,TRUE)
 
+/datum/antagonist/changeling/New()
+	. = ..()
+	for(var/datum/antagonist/changeling/C in GLOB.antagonists)
+		if(!C.owner || C.owner == owner)
+			continue
+		if(C.was_absorbed) //make sure the other ling wasn't already killed by another one. only matters if the changeling that absorbed them was gibbed after.
+			continue
+		competitive_objectives = TRUE
+		break
 
 /datum/antagonist/changeling/Destroy()
 	QDEL_NULL(cellular_emporium)
@@ -371,19 +382,19 @@
 		if(!CTO.escape_objective_compatible)
 			escape_objective_possible = FALSE
 			break
-	var/changeling_objective = rand(1,3)
-	switch(changeling_objective)
+
+	switch(competitive_objectives ? (team_mode ? rand(1,2) : rand(1,3)) : 1)
 		if(1)
 			var/datum/objective/absorb/absorb_objective = new
 			absorb_objective.owner = owner
 			absorb_objective.gen_amount_goal(6, 8)
 			objectives += absorb_objective
 		if(2)
-			var/datum/objective/absorb_changeling/ac = new
+			var/datum/objective/absorb_most/ac = new
 			ac.owner = owner
 			objectives += ac
-		if(3)
-			var/datum/objective/absorb_most/ac = new
+		if(3) //only give the murder other changelings goal if they're not in a team.
+			var/datum/objective/absorb_changeling/ac = new
 			ac.owner = owner
 			objectives += ac
 

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -102,6 +102,7 @@
 			changeling.absorbedcount += (target_ling.absorbedcount)
 			target_ling.stored_profiles.len = 1
 			target_ling.absorbedcount = 0
+			target_ling.was_absorbed = TRUE
 
 
 	changeling.chem_charges=min(changeling.chem_charges+10, changeling.chem_storage)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -18,7 +18,7 @@
 /datum/antagonist/traitor/on_gain()
 	if(owner.current && isAI(owner.current))
 		traitor_kind = TRAITOR_AI
-	
+
 	SSticker.mode.traitors += owner
 	owner.special_role = special_role
 	if(give_objectives)
@@ -48,7 +48,7 @@
 		A.verbs -= /mob/living/silicon/ai/proc/choose_modules
 		A.malf_picker.remove_malf_verbs(A)
 		qdel(A.malf_picker)
-	
+
 	SSticker.mode.traitors -= owner
 	if(!silent && owner.current)
 		to_chat(owner.current,"<span class='userdanger'> You are no longer the [special_role]! </span>")


### PR DESCRIPTION
Fixes #38753

:cl: ShizCalev
fix: Changelings with a team objective will no longer get an objective to absorb their teammates.
fix: Solo changelings will no longer get an objective to absorb themselves.
fix: Fixed latejoin/admin created changelings being given an objective to absorb the only other changeling if that ling was already absorbed and the ling that absorbed them was gibbed, leaving the objective in an uncompletable state.
/:cl:

that last one was pretty edgecase.