### PR TITLE
Adds zombies to the Magic Mirror blacklist

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -97,7 +97,7 @@
 	name = "magic mirror"
 	desc = "Turn and face the strange... face."
 	icon_state = "magic_mirror"
-	var/list/races_blacklist = list("skeleton", "agent", "angel", "military_synth", "memezombies", "clockwork golem servant", "android", "synth", "mush")
+	var/list/races_blacklist = list("skeleton", "agent", "angel", "military_synth", "memezombies", "clockwork golem servant", "android", "synth", "mush", "zombie")
 	var/list/choosable_races = list()
 
 /obj/structure/mirror/magic/New()


### PR DESCRIPTION
:cl:
balance: You can no longer choose the zombie race in the Wizard's Magic Mirror. This is the future you chose.
/:cl:

Coming back at you with another HOT balance PR. Was asked by @Arianya to do this. There has been a trend as of late of choosing the zombie race and a dextrous holoparasite with a staff of healing. This is a very challenging strat to counter, and it has exhausted any entertainment to be had from it, so now it will leave us forever.