### PR TITLE
Removes the antag spawn from Summon Guns/Magic and reduces the price to 0

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -477,7 +477,8 @@
 
 /datum/spellbook_entry/summon/guns
 	name = "Summon Guns"
-	desc = "Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill you. There is a good chance that they will shoot each other first."
+	desc = "Show your appreciation for the crew by giving them some impressive new armaments. You'll likely find yourself the target of them quickly, though. A choice for those with hair on their chest."
+	cost = 0
 
 /datum/spellbook_entry/summon/guns/IsAvailible()
 	if(!SSticker.mode) // In case spellbook is placed on map
@@ -486,7 +487,7 @@
 
 /datum/spellbook_entry/summon/guns/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
 	SSblackbox.record_feedback("tally", "wizard_spell_learned", 1, name)
-	rightandwrong(SUMMON_GUNS, user, 10)
+	rightandwrong(SUMMON_GUNS, user, 0)
 	active = TRUE
 	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, 1)
 	to_chat(user, "<span class='notice'>You have cast summon guns!</span>")
@@ -494,7 +495,8 @@
 
 /datum/spellbook_entry/summon/magic
 	name = "Summon Magic"
-	desc = "Share the wonders of magic with the crew and show them why they aren't to be trusted with it at the same time."
+	desc = "Share the wonders of magic with the crew, giving them magical artifacts and spellbooks. They'll probably try to use them on you too."
+	cost = 0
 
 /datum/spellbook_entry/summon/magic/IsAvailible()
 	if(!SSticker.mode) // In case spellbook is placed on map
@@ -503,7 +505,7 @@
 
 /datum/spellbook_entry/summon/magic/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
 	SSblackbox.record_feedback("tally", "wizard_spell_learned", 1, name)
-	rightandwrong(SUMMON_MAGIC, user, 10)
+	rightandwrong(SUMMON_MAGIC, user, 0)
 	active = TRUE
 	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, 1)
 	to_chat(user, "<span class='notice'>You have cast summon magic!</span>")


### PR DESCRIPTION
:cl: 
balance: Summon Guns and Magic no longer cost any spell points, but they also no longer spawn any survivalist antagonists. Activate them at your discretion, but an army of well armed crew probably won't end well for you.
/:cl:

A lot of people said that they'd prefer this sort of change over the other recent summon guns/magic change that I made, so I went ahead and threw it together to see what the response is like.