### PR TITLE
Fixes, improves multitool desc

### DIFF
--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -31,8 +31,8 @@
 	var/mode = 0
 
 /obj/item/multitool/examine(mob/user)
-	if(buffer)
-		to_chat(user, "<span class='notice'>Its buffer contains [buffer].</span>")
+	..()
+	to_chat(user, "<span class='notice'>Its buffer [buffer ? "contains [buffer]." : "is empty."]</span>")
 
 /obj/item/multitool/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] puts the [src] to [user.p_their()] chest. It looks like [user.p_theyre()] trying to pulse [user.p_their()] heart off!</span>")


### PR DESCRIPTION
:cl: Denton
fix: Multitools can now be properly examined again.
/:cl:

examine() was missing a ..()
The examine message now shows "Its buffer contains [buffer]/is empty." instead of hiding the message when the buffer is empty.