### PR TITLE
Fixes animals being stuck resting after being revived

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -328,7 +328,6 @@
 		health = 0
 		icon_state = icon_dead
 		density = FALSE
-		set_resting(TRUE)
 		..()
 
 /mob/living/simple_animal/proc/CanAttack(atom/the_target)


### PR DESCRIPTION
:cl:
fix: Simple mobs will no longer be stuck resting after being killed and then revived
/:cl:
Fixes #41408
Fixes #41242
Fixes #41120
Fixes #41048

Did a bit of testing and code diving, didn't see any reason for this line to exist. Animals still behave as expected when killed, becoming non-dense and using a dead sprite. All relevant `resting` checks I could find also checked `stat` and/or mobility.