### PR TITLE
Makes shunted AI camera work

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -70,8 +70,6 @@
 
 /mob/camera/aiEye/proc/setLoc(T, force_update = FALSE)
 	if(ai)
-		if(!isturf(ai.loc))
-			return
 		T = get_turf(T)
 		if(!force_update && (T == get_turf(src)) )
 			return //we are already here!


### PR DESCRIPTION
:cl:
fix: shunted AI camera now actually works
/:cl:
 
Two excellent benefits.

One: shunting is not just paralyse yourself in a corner simulator
and 
two: stops the endless "ERROR: Eyeobj not found" spam.