### PR TITLE
Fixes glowsticks not running out of fuel

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -473,11 +473,6 @@
 	. = ..()
 	if(.)
 		user.visible_message("<span class='notice'>[user] cracks and shakes [src].</span>", "<span class='notice'>You crack and shake [src], turning it on!</span>")
-		activate()
-
-/obj/item/flashlight/glowstick/proc/activate()
-	if(!on)
-		on = TRUE
 		START_PROCESSING(SSobj, src)
 
 /obj/item/flashlight/glowstick/suicide_act(mob/living/carbon/human/user)


### PR DESCRIPTION
:cl: Swindly
fix: Fixed glowsticks not running out of fuel or turning off when they have no fuel
/:cl:

The activate proc only started fuel processing if the glowstick was on, but the glowstick was always on when activate() was called because the call to the parent's attack_self() turns the glowstick on and activate() would not have been called otherwise.