### PR TITLE
Fixes AI law changes to no longer be restricted by z-level. AKA, kills powergaming antags out of AI subversion

### DIFF
--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -16,11 +16,6 @@
 			to_chat(user, "<span class='caution'>Upload failed!</span> Check to make sure [current.name] is functioning properly.")
 			current = null
 			return
-		var/turf/currentloc = get_turf(current)
-		if(currentloc && user.z != currentloc.z)
-			to_chat(user, "<span class='caution'>Upload failed!</span> Unable to establish a connection to [current.name]. You're too far away!")
-			current = null
-			return
 		M.install(current.laws, user)
 	else
 		return ..()


### PR DESCRIPTION
If you're about to whine in the PR comments about how golems will ruin everything, go buy guns and kill the golems. Duh.
https://tgstation13.org/phpBB/viewtopic.php?f=23&t=20354#p454667
oranges declared this a bug in the admin exchange, and so it's being fixed.
:cl: Iamgoofball
fix: AI laws are no longer only changeable on the same z-level as the AI.
/:cl: