### PR TITLE
Add cancel button to assault pod destination selector

### DIFF
--- a/code/modules/shuttle/assault_pod.dm
+++ b/code/modules/shuttle/assault_pod.dm
@@ -35,7 +35,9 @@
 
 /obj/item/assault_pod/attack_self(mob/living/user)
 	var/target_area
-	target_area = input("Area to land", "Select a Landing Zone", target_area) in GLOB.teleportlocs
+	target_area = input("Area to land", "Select a Landing Zone", target_area) as null|anything in GLOB.teleportlocs
+	if(!target_area)
+		return
 	var/area/picked_area = GLOB.teleportlocs[target_area]
 	if(!src || QDELETED(src))
 		return


### PR DESCRIPTION
[Changelogs]:
Fixes #41467
![image](https://user-images.githubusercontent.com/40092670/48551434-854d8a00-e910-11e8-8271-86a8c1e00b49.png)
This adds a cancel button to the assault pod destination selector.

:cl: 
add: Cancel button to assault pod destination selector.
/:cl:
