### PR TITLE
Readd zooming action to zoomable guns 

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -476,8 +476,15 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
+/obj/item/gun/pickup(mob/user)
+	..()
+	if(azoom)
+		azoom.Grant(user)
+
 /obj/item/gun/dropped(mob/user)
 	. = ..()
+	if(azoom)
+		azoom.Remove(user)
 	if(zoomed)
 		zoom(user,FALSE)
 


### PR DESCRIPTION
[Changelogs]: It seems the proc that grant it was accidentally deleted alongside the gunlight action one (Which should stayed deleted) when it was refactored in #40998

Fixes #41403

This readd the zooming action to syndicate sniper rifle (and any other gun that have it)

:cl:
fix: You can zoom your zoomable guns again.
/:cl: