### PR TITLE
Reduces the sound volume of gorillas and migos

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -94,7 +94,7 @@
 
 /mob/living/simple_animal/hostile/gorilla/handle_automated_speech(override)
 	if(speak_chance && (override || prob(speak_chance)))
-		playsound(src, 'sound/creatures/gorilla.ogg', 200)
+		playsound(src, 'sound/creatures/gorilla.ogg', 50)
 	..()
 
 /mob/living/simple_animal/hostile/gorilla/can_use_guns(obj/item/G)
@@ -105,6 +105,6 @@
 /mob/living/simple_animal/hostile/gorilla/proc/oogaooga()
 	oogas++
 	if(oogas >= rand(2,6))
-		playsound(src, 'sound/creatures/gorilla.ogg', 200)
+		playsound(src, 'sound/creatures/gorilla.ogg', 50)
 		oogas = 0
 

--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -41,7 +41,7 @@
 	if(stat)
 		return
 	var/chosen_sound = pick(migo_sounds)
-	playsound(src, chosen_sound, 100, TRUE)
+	playsound(src, chosen_sound, 50, TRUE)
 
 /mob/living/simple_animal/hostile/netherworld/migo/Life()
 	..()
@@ -49,7 +49,7 @@
 		return
 	if(prob(10))
 		var/chosen_sound = pick(migo_sounds)
-		playsound(src, chosen_sound, 100, TRUE)
+		playsound(src, chosen_sound, 50, TRUE)
 
 /mob/living/simple_animal/hostile/netherworld/blankbody
 	name = "blank body"


### PR DESCRIPTION
:cl:
tweak: Gorillas and migos will hurt your ears less now.
/:cl:

If you think this is "too low" and the "uniqueness of these mobs is ruined" this is the same sound level that frogs use. I assure you, this is still plenty obnoxious, and it doesn't force you to turn down your volume or suffer ear damage anymore.

also as a side note attack_sound plays at 50, so for gorillas this brings it in line with the volume when they attack.