### PR TITLE
Fixes inventory panel not updating after adding or removing an object from a non-human mob.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -704,6 +704,11 @@
 				if(who.dropItemToGround(what))
 					log_combat(src, who, "stripped [what] off")
 
+	if(Adjacent(who)) //update inventory window
+		who.show_inv(src)
+	else
+		src << browse(null,"window=mob[REF(who)]")
+
 // The src mob is trying to place an item on someone
 // Override if a certain mob should be behave differently when placing items (can't, for example)
 /mob/living/stripPanelEquip(obj/item/what, mob/who, where)
@@ -734,6 +739,11 @@
 							what.forceMove(get_turf(who))
 					else
 						who.equip_to_slot(what, where, TRUE)
+
+		if(Adjacent(who)) //update inventory window
+			who.show_inv(src)
+		else
+			src << browse(null,"window=mob[REF(who)]")
 
 /mob/living/singularity_pull(S, current_size)
 	..()


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed the inventory panel not updating when stripping an object from non-human mobs.
/:cl: