### PR TITLE
Makes cloaks obscure suit storage items

### DIFF
--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -8,6 +8,7 @@
 	item_state = "qmcloak"
 	w_class = WEIGHT_CLASS_SMALL
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
+	flags_inv = HIDESUITSTORAGE
 
 /obj/item/clothing/head/cloakhood
 	name = "cloak hood"


### PR DESCRIPTION
:cl: ShizCalev
balance: Cloaks now obscure suit storage items.
/:cl:

Gives them a benefit to wearing them. You can now hide the fact you're wearing a taser on your armor by putting a cloak over it!