### PR TITLE
Fixes hivemind mind-linking working on targets that have moved.

### DIFF
--- a/code/modules/spells/spell_types/hivemind.dm
+++ b/code/modules/spells/spell_types/hivemind.dm
@@ -61,7 +61,7 @@
 				to_chat(user, "<span class='notice'>We bruteforce our way past the mental barriers of [target.name] and begin linking our minds!</span>")
 			else
 				to_chat(user, "<span class='notice'>We begin linking our mind with [target.name]!</span>")
-			if(do_mob(user,user,50))
+			if(do_mob(user,target,50))
 				if((target in view(range)))
 					to_chat(user, "<span class='notice'>[target.name] was added to the Hive!</span>")
 					success = TRUE


### PR DESCRIPTION
:cl: ShizCalev
fix: The hivemind mind-link ability now properly checks if the target has moved or not.
/:cl:

https://github.com/tgstation/tgstation/blob/58f014c2efce7bf56dace32d910b8e95b100515a/code/modules/antagonists/hivemind/hivemind.dm#L179-L180
only supposed to work on stationary targets, likely just a copypasta error considering the rest of the do_mob checks in the file.