### PR TITLE
Snowdin fixes, VR tweak

### DIFF
--- a/_maps/RandomZLevels/VR/snowdin_VR.dmm
+++ b/_maps/RandomZLevels/VR/snowdin_VR.dmm
@@ -7822,15 +7822,12 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
 "qX" = (
-/obj/machinery/computer/atmos_control/tank{
-	dir = 1;
-	frequency = 1442;
-	name = "Toxins Supply Control";
-	output_tag = "snowdin_toxins_out";
-	sensors = list("snowdin_toxins" = "Tank")
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/frame/computer{
+	dir = 1;
+	name = "Toxins Supply Control"
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -7858,13 +7855,6 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
 "ra" = (
-/obj/machinery/computer/atmos_control/tank{
-	dir = 1;
-	frequency = 1442;
-	name = "Oxygen Supply Control";
-	output_tag = "snowdin_oxygen_out";
-	sensors = list("snowdin_oxygen" = "Tank")
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -7872,22 +7862,23 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/frame/computer{
+	dir = 1;
+	name = "Oxygen Supply Control"
+	},
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
 "rb" = (
-/obj/machinery/computer/atmos_control/tank{
-	dir = 1;
-	frequency = 1442;
-	name = "Nitrogen Supply Control";
-	output_tag = "snowdin_nitrogen_out";
-	sensors = list("snowdin_nitrogen" = "Tank")
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/structure/frame/computer{
+	dir = 1;
+	name = "Nitrogen Supply Control"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
@@ -8002,17 +7993,12 @@
 /turf/closed/wall/r_wall,
 /area/awaymission/snowdin/post/engineering)
 "rs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating,
-/area/awaymission/snowdin/post/engineering)
-"rt" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/window/reinforced/fulltile/ice,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/engineering)
 "ru" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible,
+/obj/structure/window/reinforced/fulltile/ice,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/engineering)
 "rv" = (
@@ -8119,7 +8105,7 @@
 "rI" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
 	dir = 1;
-	id = "syndie_lavaland_inc_in";
+	piping_layer = 3;
 	pixel_x = 5;
 	pixel_y = 5
 	},
@@ -8171,55 +8157,28 @@
 /turf/open/floor/engine,
 /area/awaymission/snowdin/post/engineering)
 "rM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon{
 	dir = 1;
-	frequency = 1442;
-	id_tag = "snowdin_toxins_out";
 	name = "toxin out"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating/snowed/smoothed,
 /area/awaymission/snowdin/post/engineering)
 "rN" = (
-/obj/machinery/air_sensor{
-	frequency = 1442;
-	id_tag = "snowdin_toxins";
-	name = "gas sensor (toxins)"
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating/snowed/smoothed,
 /area/awaymission/snowdin/post/engineering)
 "rO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon{
 	dir = 1;
-	frequency = 1442;
-	id_tag = "snowdin_oxygen_out";
 	name = "oxygen out"
 	},
-/turf/open/floor/plating/airless,
-/area/awaymission/snowdin/post/engineering)
-"rP" = (
-/obj/machinery/air_sensor{
-	frequency = 1442;
-	id_tag = "snowdin_oxygen";
-	name = "gas sensor (oxygen)"
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating/snowed/smoothed,
 /area/awaymission/snowdin/post/engineering)
 "rQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon{
 	dir = 1;
-	frequency = 1442;
-	id_tag = "snowdin_nitrogen_out";
 	name = "nitrogen out"
 	},
-/turf/open/floor/plating/airless,
-/area/awaymission/snowdin/post/engineering)
-"rR" = (
-/obj/machinery/air_sensor{
-	frequency = 1442;
-	id_tag = "snowdin_nitrogen";
-	name = "gas sensor (nitrogen)"
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating/snowed/smoothed,
 /area/awaymission/snowdin/post/engineering)
 "rS" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -8323,12 +8282,9 @@
 	},
 /turf/open/floor/engine,
 /area/awaymission/snowdin/post/engineering)
-"sh" = (
-/turf/open/floor/plating/airless,
-/area/awaymission/snowdin/post/engineering)
 "si" = (
 /obj/machinery/light/small,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating/snowed/smoothed,
 /area/awaymission/snowdin/post/engineering)
 "sl" = (
 /obj/effect/turf_decal/stripes/line{
@@ -10264,13 +10220,13 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
 "xA" = (
-/mob/living/simple_animal/hostile/netherworld/migo,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/mob/living/simple_animal/hostile/netherworld/migo,
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/mining_dock)
 "xB" = (
@@ -15757,6 +15713,9 @@
 	},
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
+"Zj" = (
+/turf/open/floor/plating/asteroid/snow,
+/area/awaymission/snowdin/post/engineering)
 
 (1,1,1) = {"
 aa
@@ -29682,8 +29641,8 @@ qv
 qW
 rs
 rM
-sh
-oW
+Zj
+Zj
 af
 fq
 af
@@ -29937,7 +29896,7 @@ nt
 pX
 qw
 qX
-rt
+rs
 rN
 si
 oW
@@ -30194,9 +30153,9 @@ nt
 pY
 pV
 qY
-nN
-nN
-nN
+oW
+oW
+oW
 oW
 ag
 af
@@ -30453,8 +30412,8 @@ qx
 qZ
 ru
 rO
-sh
-oW
+rN
+Zj
 am
 am
 af
@@ -30708,10 +30667,10 @@ nN
 qa
 qy
 ra
-rt
-rP
-si
-oW
+rs
+rN
+rN
+Zj
 am
 am
 af
@@ -30965,10 +30924,10 @@ nN
 qb
 qz
 qY
-nN
-nN
-nN
 oW
+oW
+rN
+Zj
 am
 am
 af
@@ -31224,8 +31183,8 @@ qA
 qZ
 ru
 rQ
-sh
-oW
+rN
+Zj
 af
 af
 af
@@ -31479,10 +31438,10 @@ nN
 qd
 qB
 rb
-rt
-rR
-si
-oW
+rs
+rN
+rN
+Zj
 ag
 af
 af
@@ -31738,8 +31697,8 @@ qC
 oW
 oW
 oW
-oW
-oW
+Zj
+Zj
 af
 af
 dX

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -8169,9 +8169,9 @@
 "rI" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
 	dir = 1;
-	id = "syndie_lavaland_inc_in";
 	pixel_x = 5;
-	pixel_y = 5
+	pixel_y = 5;
+	piping_layer = 3
 	},
 /obj/effect/light_emitter{
 	name = "cave light";


### PR DESCRIPTION
:cl: Denton
fix: The Snowdin waste loop air injector is now on the correct piping layer.
tweak: Tweaked the Snowdin VR atmos area so it looks properly broken.
/:cl:

Closes: #39593

Apart from the piping_layer fixes, I tweaked the Snowdin VR atmos area - the gas miners were removed for performance reasons, so I figured that I might as well remap the area a little so it looks properly broken.

![snowdin-vr-atmos](https://user-images.githubusercontent.com/32391752/48658530-c85c4a00-ea43-11e8-985f-7ec193f2d3af.PNG)