### PR TITLE
Fixes wizards being unable to talk smack

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -10731,6 +10731,10 @@
 	},
 /turf/open/floor/grass,
 /area/centcom/holding)
+"ye" = (
+/obj/machinery/telecomms/allinone/indestructable,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
 "yf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -24822,7 +24826,7 @@ qE
 qE
 qE
 qE
-qZ
+ye
 qZ
 FT
 Gr


### PR DESCRIPTION
:cl: optional name here
fix: Added a telecomms mainframe to the wizard shuttle so that wizards can use their intercoms.
/:cl:

fixes: #41128

I added an all-in-one tcomms machine so that the wiz shuttle intercoms work properly.