### PR TITLE
Removes syndie balloon from Delta

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5234,7 +5234,6 @@
 "aoD" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
-/obj/item/toy/syndicateballoon,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
 	dir = 1

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1589,7 +1589,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/toy/syndicateballoon
 	cost = 20
 	cant_discount = TRUE
-	illegal_tech = FALSE
 
 /datum/uplink_item/badass/costumes
 	surplus = 0

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1589,6 +1589,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/toy/syndicateballoon
 	cost = 20
 	cant_discount = TRUE
+	illegal_tech = FALSE
 
 /datum/uplink_item/badass/costumes
 	surplus = 0


### PR DESCRIPTION
:cl: Denton
tweak: Removed the syndicate balloon from Deltastation maintenance.
/:cl:

I'm not a fan of placing a free roundstart balloon on Delta - seeing one is supposed to be a "damn, this badass spent all his TC on a balloon" moment and not "oh, Dave went into maint and found this".