### PR TITLE
Makes stacked pipe notices a little more useful

### DIFF
--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -57,8 +57,8 @@
 							if(item.parent)
 								var/static/pipenetwarnings = 10
 								if(pipenetwarnings > 0)
-									warning("build_pipeline(): [item.type] added to a pipenet while still having one. (pipes leading to the same spot stacking in one turf) Nearby: ([item.x], [item.y], [item.z])")
-									pipenetwarnings -= 1
+									warning("build_pipeline(): [item.type] added to a pipenet while still having one. (pipes leading to the same spot stacking in one turf) around [AREACOORD(item)]")
+									pipenetwarnings--
 									if(pipenetwarnings == 0)
 										warning("build_pipeline(): further messages about pipenets will be suppressed")
 							members += item


### PR DESCRIPTION
Now gives you the area's name, which is needed in the case of pipes located in a spawning shuttle, and makes locating them in general a little quicker.