### PR TITLE
Fixes dried blood decals showing up as normal blood

### DIFF
--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -20,9 +20,9 @@
 	bloodiness = 0
 
 /obj/effect/decal/cleanable/blood/old/Initialize(mapload, list/datum/disease/diseases)
-	icon_state += "-old" //This IS necessary because the parent /blood type uses icon randomization.
 	add_blood_DNA(list("Non-human DNA" = random_blood_type())) // Needs to happen before ..()
-	return ..()
+	. = ..()
+	icon_state = "[icon_state]-old" //change from the normal blood icon selected from random_icon_states in the parent's Initialize to the old dried up blood.
 
 /obj/effect/decal/cleanable/blood/splatter
 	random_icon_states = list("gibbl1", "gibbl2", "gibbl3", "gibbl4", "gibbl5")


### PR DESCRIPTION
Caused by #35183

:cl: ShizCalev
fix: Fixed dried blood decals showing up as normal blood.
/:cl:

This is supposed to override the decal set by the parent's initialize. 