### PR TITLE
Syndicate balloons can be used to unlock illegal tech once again

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1625,7 +1625,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/toy/syndicateballoon
 	cost = 20
 	cant_discount = TRUE
-	illegal_tech = FALSE
 
 /datum/uplink_item/badass/costumes
 	surplus = 0


### PR DESCRIPTION
:cl: Evsey9
tweak: You can now use syndicate balloons to unlock illegal tech node once again.
/:cl:

This shouldn't be an issue now that you cant find syndi balloons in delta maint.
Also gives an incentive for sec officers to chase down that traitor clown that wasted all his TC on a syndicate balloon ( other than valids )