### PR TITLE
Borg malf/emag status is only shown on successful cover lock/unlock

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -501,8 +501,6 @@
 			to_chat(user, "<span class='warning'>Unable to locate a radio!</span>")
 
 	else if (istype(W, /obj/item/card/id)||istype(W, /obj/item/pda))			// trying to unlock the interface with an ID card
-		if(emagged)//still allow them to open the cover
-			to_chat(user, "<span class='notice'>The interface seems slightly damaged.</span>")
 		if(opened)
 			to_chat(user, "<span class='warning'>You must close the cover to swipe an ID card!</span>")
 		else
@@ -510,6 +508,8 @@
 				locked = !locked
 				to_chat(user, "<span class='notice'>You [ locked ? "lock" : "unlock"] [src]'s cover.</span>")
 				update_icons()
+				if(emagged)
+					to_chat(user, "<span class='notice'>The cover interface glitches out for a split second.</span>")
 			else
 				to_chat(user, "<span class='danger'>Access denied.</span>")
 


### PR DESCRIPTION
:cl: Denton
balance: Malfunctioning or emagged borgs now only give away their antag status if their interface is locked/unlocked successfully. The new message is: "The cover interface glitches out for a split second."
/:cl:

Right now, anyone can randomly swipe their ID on borgs - if "The interface seems slightly damaged." shows up, you know that either the AI is malf or that the borg got emagged. This works even if you have no Robotics access to actually unlock it.

This makes malf/emagged borgs extremely easy to discover, which (in my opinion) isn't in line with other antags. Malf AIs for example need to be carded, which is a huge leap in difficulty compared to just swiping an ID.