### PR TITLE
Paystand Modifications

### DIFF
--- a/code/modules/economy/pay_stand.dm
+++ b/code/modules/economy/pay_stand.dm
@@ -7,7 +7,7 @@
 	anchored = TRUE
 	var/locked = FALSE
 	var/obj/item/card/id/my_card
-	var/obj/item/assembly/signaler/signaler = null //attached signaler, let people attach signalers that get activated if the user's transaction limit is achieved.
+	var/obj/item/assembly/signaler/signaler //attached signaler, let people attach signalers that get activated if the user's transaction limit is achieved.
 	var/signaler_threshold = 0 //signaler threshold amount
 	var/amount_deposited = 0 //keep track of the amount deposited over time so you can pay multiple times to reach the signaler threshold
 
@@ -23,7 +23,7 @@
 				var/msg = stripped_input(user, "Name of pay stand:", "Paystand Naming", "[user]'s Awesome Paystand")
 				if(!msg)
 					return
-				name = "[msg]"
+				name = msg
 				desc = "Owned by [assistant_mains_need_to_die.registered_account.account_holder], pays directly into [user.p_their()] account."
 				my_card = assistant_mains_need_to_die
 				to_chat(user, "You link the stand to your account.")
@@ -52,7 +52,7 @@
 			to_chat(user, "Thanks for purchasing! The vendor has been informed.")
 			return
 		else
-			to_chat(user, "<span class='warning'>ERROR: Account has insufficient funds to make transaction.</span>")
+			to_chat(user, "<span class='warning'>ERROR: Insufficient funds to make transaction.</span>")
 			return
 	if(istype(W, /obj/item/stack/spacecash))
 		to_chat(user, "What is this, the 2000s? We only take card here.")
@@ -68,7 +68,7 @@
 			to_chat(user, "<span class='warning'>ERROR: No identification card has been assigned to this paystand yet!</span>")
 			return
 		if(!signaler)
-			var/cash_limit = input(user, "Enter the minium amount of cash needed to deposit before the signaler is activated.", "Signaler Activation Threshold") as null|num
+			var/cash_limit = input(user, "Enter the minimum amount of cash needed to deposit before the signaler is activated.", "Signaler Activation Threshold") as null|num
 			if(cash_limit < 1)
 				to_chat(user, "<span class='warning'>ERROR: Invalid amount designated.</span>")
 				return

--- a/code/modules/economy/pay_stand.dm
+++ b/code/modules/economy/pay_stand.dm
@@ -5,6 +5,7 @@
 	icon_state = "card_scanner"
 	density = TRUE
 	anchored = TRUE
+	var/locked = FALSE
 	var/obj/item/card/id/my_card
 	var/obj/item/assembly/signaler/signaler = null //attached signaler, let people attach signalers that get activated if the user's transaction limit is achieved.
 	var/signaler_threshold = 0 //signaler threshold amount
@@ -12,6 +13,10 @@
 
 /obj/machinery/paystand/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/card/id))
+		if(W == my_card)
+			locked = !locked
+			to_chat(user, "<span class='notice'>You [src.locked ? "lock" : "unlock"] the bolts on the paystand.</span>")
+			return
 		if(!my_card)
 			var/obj/item/card/id/assistant_mains_need_to_die = W
 			if(assistant_mains_need_to_die.registered_account)
@@ -97,4 +102,10 @@
 	if(signaler && amount_deposited >= signaler_threshold)
 		signaler.activate()
 		amount_deposited = 0
+
+/obj/machinery/paystand/default_unfasten_wrench(mob/user, obj/item/I, time = 20)
+	if(locked)
+		to_chat(user, "<span class='warning'>The anchored bolts on this paystand are currently locked!</span>")
+		return
+	. = ..()
 	


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: MMMiracles
add: Signalers can now be attached to active paystands to send a signal when a certain amount of money is deposited.
add: Swiping your card on a paystand you own will let you lock it down, preventing it from being unbolted from the ground.
tweak: Paystands now ask for how much you want to deposit when interacting instead of a static price.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I thought it was pretty dumb the paystands designed to encourage shops was also forced to a single static price instead of allowing the person to put in how much they actually wanted to pay.

The signaler attaching lets you hook up a signaler to any active paystand and set up a threshold. Any amount of money deposited after this will start counting up to the threshold and reset when said threshold is hit, activating the signaler in the process.