### PR TITLE
Moves wormholes to the RIPPLE_LAYER

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -33,6 +33,7 @@
 	name = "wormhole"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "anom"
+	layer = RIPPLE_LAYER
 	mech_sized = TRUE
 
 /obj/effect/portal/Move(newloc)


### PR DESCRIPTION
Puts them above all "real" stuff.

Seems weird that they were being layered beneath windows tbh.