### PR TITLE
Select equipment only asks to empty pockets if there are things in your pockets

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -740,8 +740,9 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 		H = M.change_mob_type(/mob/living/carbon/human, null, null, TRUE)
 	else
 		H = M
-		if(alert("Drop Items in Pockets? No will delete them.", "Robust quick dress shop", "Yes", "No") == "No")
-			delete_pocket = TRUE
+		if(H.l_store || H.r_store || H.s_store) //saves a lot of time for admins and coders alike
+			if(alert("Drop Items in Pockets? No will delete them.", "Robust quick dress shop", "Yes", "No") == "No")
+				delete_pocket = TRUE
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Select Equipment") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	for (var/obj/item/I in H.get_equipped_items(delete_pocket))


### PR DESCRIPTION
:cl:
admin: select equipment no longer pesters you with alerts if it doesn't have to!
/:cl:

It'll save me some time, it'll save coders some time, it'll save admins some time, and honestly the alert is kind of confusing to read, I have to slowly read it to understand what it's asking me. Maybe i'm just dumb, but I don't care what happens to the pockets because almost every single time there is nothing IN THE POCKETS!