### PR TITLE
Adds the hypnotic flash to the uplink

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -48,6 +48,8 @@
 
 #define STATUS_EFFECT_SLEEPING /datum/status_effect/incapacitating/sleeping //the affected is asleep
 
+#define STATUS_EFFECT_PACIFY /datum/status_effect/pacify //the affected is pacified, preventing direct hostile actions
+
 #define STATUS_EFFECT_BELLIGERENT /datum/status_effect/belligerent //forces the affected to walk, doing damage if they try to run
 
 #define STATUS_EFFECT_GEISTRACKER /datum/status_effect/geis_tracker //if you're using geis, this tracks that and keeps you from using scripture

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -573,7 +573,7 @@
 /datum/status_effect/trance/on_creation(mob/living/new_owner, _duration, _stun = TRUE)
 	duration = _duration
 	stun = _stun
-	. = ..()
+	return ..()
 
 /datum/status_effect/trance/on_remove()
 	UnregisterSignal(owner, COMSIG_MOVABLE_HEAR)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -83,6 +83,24 @@
 	icon_state = "asleep"
 
 //OTHER DEBUFFS
+/datum/status_effect/pacify
+	id = "pacify"
+	status_type = STATUS_EFFECT_REPLACE
+	tick_interval = 1
+	duration = 100
+	
+/datum/status_effect/pacify/on_creation(mob/living/new_owner, set_duration)
+	if(isnum(set_duration))
+		duration = set_duration
+	. = ..()	
+
+/datum/status_effect/pacify/on_apply()
+	owner.add_trait(TRAIT_PACIFISM, "status_effect")
+	return ..()
+
+/datum/status_effect/pacify/on_remove()
+	owner.remove_trait(TRAIT_PACIFISM, "status_effect")
+
 /datum/status_effect/his_wrath //does minor damage over time unless holding His Grace
 	id = "his_wrath"
 	duration = -1

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -338,7 +338,7 @@
 	if(targeted)
 		if(M.flash_act(1, 1))
 			var/hypnosis = FALSE
-			if(M.hypnosis_vulnerable)
+			if(M.hypnosis_vulnerable())
 				hypnosis = TRUE
 			if(user)
 				visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")
@@ -353,7 +353,7 @@
 			else
 				M.confused += min(M.confused + 10, 20)
 				M.dizziness += min(M.dizziness + 10, 20)
-				M.drowsiness += min(M.drowsiness + 10, 20)
+				M.drowsyness += min(M.drowsyness + 10, 20)
 				M.apply_status_effect(STATUS_EFFECT_PACIFY, 100)
 				
 		else if(user)
@@ -367,5 +367,5 @@
 			to_chat(M, "<span class='notice'>Such a pretty light...</span>")
 			M.confused += min(M.confused + 4, 20)
 			M.dizziness += min(M.dizziness + 4, 20)
-			M.drowsiness += min(M.drowsiness + 4, 20)
+			M.drowsyness += min(M.drowsyness + 4, 20)
 			M.apply_status_effect(STATUS_EFFECT_PACIFY, 40)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -354,8 +354,8 @@
 			to_chat(M, "<span class='danger'>[src] fails to blind you!</span>")
 			
 	else if(M.flash_act())
-			to_chat(M, "<span class='notice'>Such a pretty light...</span>")
-			M.confused += min(M.confused + 4, 20)
-			M.dizziness += min(M.dizziness + 4, 20)
-			M.drowsyness += min(M.drowsyness + 4, 20)
-			M.apply_status_effect(STATUS_EFFECT_PACIFY, 40)
+		to_chat(M, "<span class='notice'>Such a pretty light...</span>")
+		M.confused += min(M.confused + 4, 20)
+		M.dizziness += min(M.dizziness + 4, 20)
+		M.drowsyness += min(M.drowsyness + 4, 20)
+		M.apply_status_effect(STATUS_EFFECT_PACIFY, 40)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -321,10 +321,6 @@
 	
 /obj/item/assembly/flash/hypnotic/burn_out()
 	return
-
-/obj/item/assembly/flash/hypnotic/proc/check_vulnerable(mob/living/carbon/C)
-	if(C.hallucinating())
-		return TRUE
 	
 /obj/item/assembly/flash/hypnotic/flash_carbon(mob/living/carbon/M, mob/user, power = 15, targeted = TRUE, generic_message = FALSE)
 	if(!istype(M))

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -337,29 +337,23 @@
 			if(M.hypnosis_vulnerable())
 				hypnosis = TRUE
 			if(user)
-				visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")
-				to_chat(user, "<span class='danger'>You hypno-flash [M]!</span>")
-				if(!hypnosis)
-					to_chat(M, "<span class='notice'>The light makes you feel oddly relaxed...</span>")
-			else if(!hypnosis)
-				to_chat(M, "<span class='notice'>The light makes you feel oddly relaxed...</span>")
+				user.visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>", "<span class='danger'>You hypno-flash [M]!</span>")	
 				
-			if(hypnosis) //Placed here so the trance message does not appear before the flash message
-				M.apply_status_effect(/datum/status_effect/trance, 200, TRUE)
-			else
+			if(!hypnosis)
+				to_chat(M, "<span class='notice'>The light makes you feel oddly relaxed...</span>")
 				M.confused += min(M.confused + 10, 20)
 				M.dizziness += min(M.dizziness + 10, 20)
 				M.drowsyness += min(M.drowsyness + 10, 20)
-				M.apply_status_effect(STATUS_EFFECT_PACIFY, 100)
+				M.apply_status_effect(STATUS_EFFECT_PACIFY, 100)			
+			else
+				M.apply_status_effect(/datum/status_effect/trance, 200, TRUE)				
 				
 		else if(user)
-			visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")
-			to_chat(user, "<span class='warning'>You fail to hypno-flash [M]!</span>")
-			to_chat(M, "<span class='danger'>[user] fails to blind you with the flash!</span>")
+			user.visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>", "<span class='warning'>You fail to hypno-flash [M]!</span>")
 		else
 			to_chat(M, "<span class='danger'>[src] fails to blind you!</span>")
-	else
-		if(M.flash_act())
+			
+	else if(M.flash_act())
 			to_chat(M, "<span class='notice'>Such a pretty light...</span>")
 			M.confused += min(M.confused + 4, 20)
 			M.dizziness += min(M.dizziness + 4, 20)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -12,6 +12,7 @@
 	crit_fail = FALSE     //Is the flash burnt out?
 	light_color = LIGHT_COLOR_WHITE
 	light_power = FLASH_LIGHT_POWER
+	var/flashing_overlay = "flash-f"
 	var/times_used = 0 //Number of times it's been used.
 	var/burnout_resistance = 0
 	var/last_used = 0 //last world.time it was used.
@@ -36,8 +37,8 @@
 		add_overlay("flashburnt")
 		attached_overlays += "flashburnt"
 	if(flash)
-		add_overlay("flash-f")
-		attached_overlays += "flash-f"
+		add_overlay(flashing_overlay)
+		attached_overlays += flashing_overlay
 		addtimer(CALLBACK(src, .proc/update_icon), 5)
 	if(holder)
 		holder.update_icon()
@@ -311,3 +312,60 @@
 /obj/item/assembly/flash/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	activate()
 	return ..()
+	
+/obj/item/assembly/flash/hypnotic
+	desc = "A modified flash device, programmed to emit a sequence of subliminal flashes that can send a vulnerable target into a hypnotic trance."
+	flashing_overlay = "flash-hypno"
+	light_color = LIGHT_COLOR_PINK
+	cooldown = 20
+	
+/obj/item/assembly/flash/hypnotic/burn_out()
+	return
+
+/obj/item/assembly/flash/hypnotic/proc/check_vulnerable(mob/living/carbon/C)
+	if(C.hallucinating())
+		return TRUE
+	
+/obj/item/assembly/flash/hypnotic/flash_carbon(mob/living/carbon/M, mob/user, power = 15, targeted = TRUE, generic_message = FALSE)
+	if(!istype(M))
+		return
+	if(user)
+		log_combat(user, M, "[targeted? "hypno-flashed(targeted)" : "hypno-flashed(AOE)"]", src)
+	else //caused by emp/remote signal
+		M.log_message("was [targeted? "hypno-flashed(targeted)" : "hypno-flashed(AOE)"]",LOG_ATTACK)
+	if(generic_message && M != user)
+		to_chat(M, "<span class='disarm'>[src] emits a soothing light...</span>")
+	if(targeted)
+		if(M.flash_act(1, 1))
+			var/hypnosis = FALSE
+			if(M.hypnosis_vulnerable)
+				hypnosis = TRUE
+			if(user)
+				visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")
+				to_chat(user, "<span class='danger'>You hypno-flash [M]!</span>")
+				if(!hypnosis)
+					to_chat(M, "<span class='notice'>The light makes you feel oddly relaxed...</span>")
+			else if(!hypnosis)
+				to_chat(M, "<span class='notice'>The light makes you feel oddly relaxed...</span>")
+				
+			if(hypnosis) //Placed here so the trance message does not appear before the flash message
+				M.apply_status_effect(/datum/status_effect/trance, 200, TRUE)
+			else
+				M.confused += min(M.confused + 10, 20)
+				M.dizziness += min(M.dizziness + 10, 20)
+				M.drowsiness += min(M.drowsiness + 10, 20)
+				M.apply_status_effect(STATUS_EFFECT_PACIFY, 100)
+				
+		else if(user)
+			visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")
+			to_chat(user, "<span class='warning'>You fail to hypno-flash [M]!</span>")
+			to_chat(M, "<span class='danger'>[user] fails to blind you with the flash!</span>")
+		else
+			to_chat(M, "<span class='danger'>[src] fails to blind you!</span>")
+	else
+		if(M.flash_act())
+			to_chat(M, "<span class='notice'>Such a pretty light...</span>")
+			M.confused += min(M.confused + 4, 20)
+			M.dizziness += min(M.dizziness + 4, 20)
+			M.drowsiness += min(M.drowsiness + 4, 20)
+			M.apply_status_effect(STATUS_EFFECT_PACIFY, 40)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -923,3 +923,17 @@
 
 /mob/living/carbon/can_resist()
 	return bodyparts.len > 2 && ..()
+	
+/mob/living/carbon/proc/hypnosis_vulnerable()
+	if(has_trait(TRAIT_MINDSHIELD))
+		return FALSE
+	if(hallucinating())
+		return TRUE
+	if(IsSleeping())
+		return TRUE
+	if(has_trait(TRAIT_DUMB))
+		return TRUE
+	GET_COMPONENT_FROM(mood, /datum/component/mood, src)
+	if(mood)
+		if(mood.sanity < SANITY_UNSTABLE)
+			return TRUE

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1513,6 +1513,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/disk/surgery/brainwashing
 	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Roboticist")
 	cost = 5
+	
+/datum/uplink_item/role_restricted/hypnotic_flash
+	name = "Hypnotic Flash"
+	desc = "A modified flash able to hypnotize targets. If the target is not in a mentally vulnerable state, it will only confuse and pacify them temporarily."
+	item = /obj/item/assembly/flash/hypnotic
+	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Roboticist")
+	cost = 6
 
 /datum/uplink_item/role_restricted/haunted_magic_eightball
 	name = "Haunted Magic Eightball"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1134,6 +1134,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 	item = /obj/item/storage/briefcase/launchpad
 	cost = 6
+	
+/datum/uplink_item/device_tools/hypnotic_flash
+	name = "Hypnotic Flash"
+	desc = "A modified flash able to hypnotize targets. If the target is not in a mentally vulnerable state, it will only confuse and pacify them temporarily."
+	item = /obj/item/assembly/flash/hypnotic
+	cost = 7
 
 /datum/uplink_item/device_tools/magboots
 	name = "Blood-Red Magboots"
@@ -1513,13 +1519,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/disk/surgery/brainwashing
 	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Roboticist")
 	cost = 5
-	
-/datum/uplink_item/role_restricted/hypnotic_flash
-	name = "Hypnotic Flash"
-	desc = "A modified flash able to hypnotize targets. If the target is not in a mentally vulnerable state, it will only confuse and pacify them temporarily."
-	item = /obj/item/assembly/flash/hypnotic
-	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Roboticist")
-	cost = 6
 
 /datum/uplink_item/role_restricted/haunted_magic_eightball
 	name = "Haunted Magic Eightball"


### PR DESCRIPTION
:cl: XDTM
add: Added the Hypnotic Flash to the uplink for 7 TC.
add: The Hypnotic Flash temporarily confuses and pacifies those it's used on.
add: If the victim is in a mentally vulnerable state (hallucinating, insane, reduced mental activity) they will instead fall into a trance, and will be hypnotized by the next words they hear.
/:cl:

Controlled hypnosis for traitors. Usual caveats apply: Mindshield prevents the trance effect (but not the confusion/pacification) and it can still deconvert from hypnosis; a new hypnosis will override the previous one; and most importantly for any ambiguity the interpretation is mostly up to the victim, so it's not a 100% sure conversion (i'm _hoping_ people won't use this clause to just ignore it).
