### PR TITLE
Makes cult structures not lose density when unanchored.

### DIFF
--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -57,7 +57,6 @@
 /obj/structure/destructible/cult/attackby(obj/I, mob/user, params)
 	if(istype(I, /obj/item/melee/cultblade/dagger) && iscultist(user))
 		anchored = !anchored
-		density = !density
 		to_chat(user, "<span class='notice'>You [anchored ? "":"un"]secure \the [src] [anchored ? "to":"from"] the floor.</span>")
 		if(!anchored)
 			icon_state = "[initial(icon_state)]_off"


### PR DESCRIPTION
fixes https://github.com/tgstation/tgstation/issues/41584
🆑 Eskjjlj
fix: Cult structures no longer become intangible when unanchored.
/🆑

You can't move through unanchored emitters or even chemical grinders so there should be no reason you can move through unanchored cult structures like the pylon or the forge.
