### PR TITLE
Boxstation Mapping Changes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -103,7 +103,6 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "aan" = (
-/obj/machinery/hydroponics/soil,
 /obj/item/seeds/ambrosia,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -114,6 +113,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aao" = (
@@ -123,7 +123,6 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "aap" = (
-/obj/machinery/hydroponics/soil,
 /obj/item/seeds/carrot,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -131,13 +130,13 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaq" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/obj/machinery/hydroponics/soil,
 /obj/item/plant_analyzer,
 /obj/machinery/camera{
 	c_tag = "Prison Common Room";
@@ -150,10 +149,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aar" = (
-/obj/machinery/hydroponics/soil,
 /obj/item/seeds/glowshroom,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -161,6 +160,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aas" = (
@@ -209,7 +209,6 @@
 /area/security/prison)
 "aaB" = (
 /obj/structure/window/reinforced,
-/obj/machinery/hydroponics/soil,
 /obj/item/seeds/potato,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -218,6 +217,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaC" = (
@@ -226,17 +226,16 @@
 /area/security/prison)
 "aaD" = (
 /obj/structure/window/reinforced,
-/obj/machinery/hydroponics/soil,
 /obj/item/seeds/grass,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaE" = (
 /obj/structure/window/reinforced,
-/obj/machinery/hydroponics/soil,
 /obj/item/cultivator,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -245,16 +244,17 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaF" = (
 /obj/structure/window/reinforced,
-/obj/machinery/hydroponics/soil,
 /obj/item/cultivator,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaG" = (
@@ -530,6 +530,13 @@
 /area/crew_quarters/heads/hos)
 "abr" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "abs" = (
@@ -735,7 +742,7 @@
 	pixel_y = -3
 	},
 /obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor";
+	c_tag = "Armory - Internal";
 	dir = 2
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -853,10 +860,19 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/deputy,
+/obj/machinery/button/door{
+	id = "hosspace";
+	name = "Space Shutters Control";
+	pixel_x = -26;
+	pixel_y = 34
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "abU" = (
 /obj/machinery/computer/card/minor/hos,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "abV" = (
@@ -1046,6 +1062,9 @@
 /area/crew_quarters/heads/hos)
 "act" = (
 /obj/machinery/holopad,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "acu" = (
@@ -1053,6 +1072,11 @@
 /area/crew_quarters/heads/hos)
 "acv" = (
 /obj/structure/closet/secure_closet/contraband/armory,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/obj/effect/spawner/lootdrop/armory_contraband/metastation,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acw" = (
@@ -1264,6 +1288,9 @@
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/stamp/hos,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "acR" = (
@@ -1276,6 +1303,9 @@
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -1402,6 +1432,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/button/door{
+	id = "armory";
+	name = "Armory Shutters";
+	pixel_x = 26;
+	pixel_y = -26;
+	req_access_txt = "3"
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "adh" = (
@@ -1478,23 +1515,23 @@
 	id = "armory";
 	name = "Armoury Shutter"
 	},
-/obj/machinery/button/door{
-	id = "armory";
-	name = "Armory Shutters";
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "adm" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "adn" = (
 /obj/structure/chair{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -1610,14 +1647,12 @@
 "adC" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/scalpel{
-	pixel_y = 12
+/obj/item/storage/backpack/duffelbag/sec/surgery{
+	pixel_y = 5
 	},
-/obj/item/circular_saw,
-/obj/item/hemostat,
-/obj/item/retractor,
-/obj/item/surgical_drapes,
-/obj/item/razor,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "adD" = (
@@ -1718,6 +1753,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "adN" = (
@@ -1744,6 +1782,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "adQ" = (
@@ -2098,6 +2139,9 @@
 "aex" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "aey" = (
@@ -2109,6 +2153,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "aez" = (
@@ -5081,11 +5131,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door_timer{
-	id = "Cell 4";
-	name = "Cell 4";
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -5099,6 +5144,12 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/button/flasher{
+	id = "holdingflash";
+	pixel_x = 26;
+	pixel_y = 0;
+	req_access_txt = "1"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5360,12 +5411,15 @@
 /area/security/brig)
 "akY" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/security/brig)
 "akZ" = (
@@ -5631,14 +5685,20 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/flasher{
-	id = "Cell 4";
-	pixel_x = 28
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/machinery/flasher{
+	id = "holdingflash";
+	pixel_x = 25
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alF" = (
@@ -5918,17 +5978,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"amp" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 4";
-	name = "Cell 4 Locker"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "amq" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
@@ -5938,6 +5988,9 @@
 	prison_radio = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amr" = (
@@ -8486,10 +8539,10 @@
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "ato" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "atp" = (
@@ -10566,11 +10619,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ayv" = (
+/obj/structure/table,
+/obj/item/clothing/head/welding,
+/obj/item/screwdriver{
+	pixel_y = 16
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/item/radio/off,
-/obj/item/assembly/timer,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayw" = (
@@ -10669,47 +10729,41 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ayK" = (
-/obj/structure/closet/crate/rcd,
 /obj/machinery/camera/motion{
 	c_tag = "EVA Motion Sensor"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayL" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "ayM" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/extinguisher,
+/obj/item/extinguisher,
 /obj/machinery/firealarm{
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/item/clothing/head/welding,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayN" = (
-/obj/structure/rack,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/hand_labeler,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
-"ayO" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
 	},
-/obj/item/screwdriver{
-	pixel_y = 16
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayP" = (
+/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "EVA Storage APC";
@@ -10722,14 +10776,11 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayQ" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/crate/rcd,
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayR" = (
 /obj/structure/table,
@@ -10956,14 +11007,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "azs" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -11044,11 +11092,12 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "azE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -11191,14 +11240,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "azU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -11623,13 +11672,18 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aAR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
 	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aAS" = (
@@ -11660,13 +11714,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aAW" = (
-/obj/structure/rack,
-/obj/item/tank/jetpack/carbondioxide,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -11781,18 +11833,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aBj" = (
-/obj/structure/rack,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/tank/jetpack/carbondioxide,
+/obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "aBk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11815,37 +11860,42 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aBn" = (
+/obj/structure/table,
+/obj/item/stack/sheet/rglass{
+	amount = 50
+	},
+/obj/item/stack/sheet/rglass{
+	amount = 50
+	},
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aBo" = (
-/obj/machinery/holopad,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
-"aBp" = (
-/obj/structure/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aBq" = (
-/obj/structure/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -11997,22 +12047,12 @@
 /turf/closed/wall,
 /area/storage/primary)
 "aBO" = (
-/obj/machinery/requests_console{
-	department = "EVA";
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "aBP" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -12137,19 +12177,15 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "aCa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aCb" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/item/pen{
-	desc = "Writes upside down!";
-	name = "astronaut pen"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -12195,12 +12231,6 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
-"aCg" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
 "aCh" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel/white/side{
@@ -12762,51 +12792,72 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aDA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Magboot Storage";
+	pixel_x = -1;
+	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "aDB" = (
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/stripes/line{
-	dir = 2
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aDC" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "aDD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
-"aDE" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "EVA Storage";
+/obj/structure/rack,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
-"aDF" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/item/tank/jetpack/carbondioxide{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Jetpack Storage";
+	pixel_x = -1;
+	req_access_txt = "19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "aDG" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -13332,25 +13383,27 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aEW" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aEX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "EVA Storage";
-	req_access_txt = "18"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aEY" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aEZ" = (
 /turf/open/floor/plasteel/dark,
@@ -13372,8 +13425,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "aFc" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aFd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13858,12 +13916,30 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aGi" = (
+/obj/structure/table,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/multitool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aGj" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aGk" = (
 /obj/structure/sink{
@@ -13899,24 +13975,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"aGo" = (
-/obj/structure/table,
-/obj/item/stack/sheet/rglass{
-	amount = 50
-	},
-/obj/item/stack/sheet/rglass{
-	amount = 50
-	},
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
 "aGp" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -13924,16 +13982,6 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"aGq" = (
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
 "aGr" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/clown,
@@ -14492,16 +14540,16 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aHB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aHC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aHD" = (
 /obj/structure/chair/stool{
@@ -14604,22 +14652,11 @@
 	},
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"aHN" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/crowbar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
 "aHO" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "aHP" = (
 /obj/machinery/door/firedoor,
@@ -15193,6 +15230,9 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "aJf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/camera{
 	c_tag = "EVA South";
 	dir = 1
@@ -15226,32 +15266,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"aJj" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/extinguisher,
-/obj/item/extinguisher,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
 "aJk" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -15259,16 +15273,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"aJl" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
 "aJm" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -22058,16 +22062,12 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bal" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/hydroponics)
 "bam" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -22567,10 +22567,13 @@
 	},
 /area/hallway/primary/starboard)
 "bbB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Hydroponics";
-	req_access_txt = "35"
+/obj/machinery/vending/hydronutrients,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -26226,6 +26229,15 @@
 /area/maintenance/disposal)
 "bkA" = (
 /obj/effect/landmark/event_spawn,
+/mob/living/simple_animal/bot/secbot{
+	arrest_type = 1;
+	health = 45;
+	icon_state = "secbot1";
+	idcheck = 1;
+	name = "Sergeant-at-Armsky";
+	on = 1;
+	weaponscheck = 1
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bkB" = (
@@ -55541,6 +55553,16 @@
 "cVb" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"cWK" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "cYY" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/landmark/xeno_spawn,
@@ -55670,6 +55692,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"eje" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "elq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -55683,6 +55717,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"euG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "eyF" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -55761,6 +55800,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"ffx" = (
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "flc" = (
 /obj/item/assembly/prox_sensor{
 	pixel_x = -4;
@@ -55929,6 +55978,14 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard)
+"gCX" = (
+/obj/structure/tank_dispenser/oxygen{
+	layer = 2.9;
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "gES" = (
 /obj/item/radio/intercom{
 	pixel_x = 28;
@@ -56126,6 +56183,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"iHz" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "iHT" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light{
@@ -56521,6 +56582,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"lfn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "lhu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -56644,6 +56714,15 @@
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"mtU" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "evashutter";
+	name = "E.V.A. Storage Shutter"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "mBm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -56694,6 +56773,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"mQw" = (
+/obj/machinery/camera/motion{
+	c_tag = "Armory - External";
+	dir = 1
+	},
+/turf/open/space,
+/area/space)
 "mSf" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -56707,6 +56793,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"mXi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "nbv" = (
 /turf/closed/wall,
 /area/science/explab)
@@ -56947,11 +57043,30 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"pwf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "pDu" = (
 /obj/machinery/computer/nanite_cloud_controller,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"pEf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "pHl" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -57006,6 +57121,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"pRV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "pUr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/wood,
@@ -57016,6 +57137,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"pXN" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd";
+	name = "research lab shutters"
+	},
+/obj/machinery/autolathe{
+	name = "public autolathe"
+	},
+/obj/machinery/door/window/southleft{
+	name = "Research and Development Desk";
+	req_one_access_txt = "7;29"
+	},
+/turf/open/floor/plating,
+/area/science/lab)
 "qae" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/junction/flip{
@@ -57135,6 +57270,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"riE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rmX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -57182,6 +57323,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"sai" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/hos)
 "sjr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/loading_area,
@@ -57259,6 +57406,12 @@
 /obj/item/shovel/spade,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"sDM" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sHk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -57266,6 +57419,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"sIG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "sLv" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -57391,6 +57553,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"tBl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tDw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57453,6 +57622,21 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"uiL" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "evashutter";
+	name = "E.V.A. Storage Shutter"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/button/door{
+	id = "evashutter";
+	name = "E.V.A. Storage Shutter Control";
+	pixel_x = 30;
+	req_access_txt = "19"
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "ulo" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -57507,6 +57691,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"uGU" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uHA" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -57559,17 +57749,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"vbD" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "EVA Storage";
-	req_access_txt = "18"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
 "vdl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57696,6 +57875,14 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"vOx" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Hydroponics";
+	req_access_txt = "35"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "vPE" = (
 /obj/item/assembly/signaler{
 	pixel_y = 8
@@ -57732,6 +57919,20 @@
 	},
 /turf/open/floor/plating,
 /area/science/nanite)
+"woN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "wph" = (
 /obj/docking_port/stationary{
 	area_type = /area/construction/mining/aux_base;
@@ -57801,6 +58002,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"wQS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "wUs" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -82982,10 +83197,10 @@ aBk
 ayL
 ayL
 ayL
-ayW
-ayW
-ayW
-ayW
+ayL
+ayL
+ayL
+ayL
 aLW
 aNs
 aJq
@@ -83238,11 +83453,11 @@ azE
 aBj
 aBO
 aDC
+aEZ
+aDC
+aBO
+aDC
 ayL
-aGo
-aHN
-aJj
-ayW
 aLV
 aJq
 aOE
@@ -83491,16 +83706,16 @@ aph
 awg
 axy
 ayN
-azE
+eje
 aAW
 aCa
 aDB
-aDI
-azW
-azW
-azW
-ayW
-aLX
+lfn
+aDB
+aCa
+pRV
+ayL
+uGU
 aJq
 aOE
 aJn
@@ -83755,9 +83970,9 @@ aDA
 aEW
 aGi
 aHB
-aEZ
-aBt
-aJs
+iHz
+mtU
+riE
 aJq
 aOE
 aJn
@@ -84007,14 +84222,14 @@ axz
 ayP
 azU
 aBo
-aCg
+azW
 azW
 aEX
-aEZ
-aEZ
-aEZ
-vbD
-aJs
+gCX
+azW
+iHz
+mtU
+riE
 aJq
 bJx
 aJn
@@ -84262,16 +84477,16 @@ aph
 awg
 axy
 ayv
-azE
+pwf
 aBn
 aCb
 aDD
 aEY
 aGj
 aHC
-aEZ
-aBt
-aJs
+iHz
+uiL
+riE
 aJq
 aOE
 aJn
@@ -84519,16 +84734,16 @@ aph
 awg
 axy
 ayQ
-azE
+cWK
 aBq
-aBr
-aDE
+sIG
+aCc
 aFc
-azW
-azW
+aCc
+sIG
 aJf
-ayW
-aJr
+ayL
+sDM
 aJq
 aOE
 aJn
@@ -84775,16 +84990,16 @@ vsa
 avh
 awh
 axz
-ayO
+azW
 azE
-aBp
-aCc
-aDF
-ayL
-aGq
+aBj
+aEZ
+aDC
+aEZ
+aDC
 aHO
-aJl
-ayW
+aDC
+ayL
 aJq
 aJq
 aOE
@@ -85037,11 +85252,11 @@ azS
 aBs
 aCi
 aDI
+ayW
+ayW
+ayW
+ayW
 ayL
-ayW
-ayW
-ayW
-ayW
 aJq
 aJq
 aOE
@@ -88339,7 +88554,7 @@ aaf
 aaf
 aaf
 aaf
-aaa
+mQw
 adR
 abo
 aaZ
@@ -88872,8 +89087,8 @@ ajf
 ajK
 aks
 akY
-alx
-amp
+tBl
+tBl
 aiX
 anA
 anz
@@ -89885,8 +90100,8 @@ aaf
 abq
 abq
 abq
-abr
-abr
+pEf
+euG
 abq
 abq
 aff
@@ -90402,7 +90617,7 @@ acr
 acQ
 adn
 adM
-abq
+mXi
 afg
 afU
 afU
@@ -90653,7 +90868,7 @@ aaa
 aaa
 aaa
 aaf
-abr
+woN
 abV
 acu
 acS
@@ -90910,13 +91125,13 @@ aaf
 aaf
 aaf
 aaf
-abr
+wQS
 abU
 act
-acu
-acu
+sai
+sai
 ato
-abq
+mXi
 afi
 afW
 afW
@@ -97903,7 +98118,7 @@ aVJ
 aOX
 aYP
 bal
-bam
+ffx
 aYV
 aYV
 aYV
@@ -98159,7 +98374,7 @@ aVI
 aVI
 aVI
 aYO
-aRJ
+bam
 bbB
 aYV
 aYV
@@ -98416,8 +98631,8 @@ aRJ
 aVK
 aRJ
 aRJ
+vOx
 aRJ
-bbB
 aYV
 aYV
 aYV
@@ -103561,7 +103776,7 @@ aCR
 bcs
 aXq
 aYV
-bfX
+aYV
 bfV
 bfV
 bfV
@@ -105361,7 +105576,7 @@ aYV
 bdv
 aYV
 bgb
-bhC
+pXN
 biU
 biW
 blJ

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -11603,6 +11603,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aAI" = (
@@ -15278,6 +15279,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aJn" = (
@@ -16357,7 +16359,11 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe";
+	pixel_x = -4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aLV" = (
@@ -16749,16 +16755,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"aNc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aNd" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/grimy,
@@ -17151,6 +17147,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aOf" = (
@@ -17316,26 +17313,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aOz" = (
-/obj/structure/sign/directions/security{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = -24
-	},
-/obj/structure/sign/directions/evac{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/structure/sign/directions/engineering{
-	pixel_x = 32;
-	pixel_y = -40
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "aOA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17343,16 +17320,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aOB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aOC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17750,11 +17717,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aPN" = (
-/obj/structure/table,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aPO" = (
@@ -18263,21 +18226,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aRe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/storage/tools)
-"aRf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Auxiliary Tool Storage";
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
+/area/storage/tools)
+"aRf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
 /area/storage/tools)
 "aRg" = (
 /obj/machinery/vending/boozeomat,
@@ -18610,13 +18572,10 @@
 /turf/open/floor/carpet,
 /area/chapel/main)
 "aRT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/rack,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/electronics/apc,
-/obj/item/electronics/airlock,
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aRU" = (
@@ -18667,7 +18626,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"aSa" = (
+"aSb" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"aSc" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
@@ -18679,16 +18645,6 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/storage/box/lights/mixed,
-/turf/open/floor/plasteel,
-/area/storage/tools)
-"aSb" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"aSc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/storage/tools)
@@ -18734,17 +18690,10 @@
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aSl" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "aSm" = (
-/turf/open/floor/plating,
-/area/storage/emergency/port)
-"aSn" = (
-/obj/item/extinguisher,
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "aSo" = (
@@ -18786,9 +18735,7 @@
 /turf/open/floor/plating,
 /area/storage/tools)
 "aSt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aSu" = (
@@ -19274,19 +19221,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/storage/emergency/port)
-"aTJ" = (
-/obj/machinery/light/small,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/storage/emergency/port)
-"aTK" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/turf/open/floor/plating,
-/area/storage/emergency/port)
 "aTL" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -19555,13 +19489,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aUw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel,
-/area/storage/tools)
 "aUx" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -24350,6 +24277,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit)
 "bge" = (
@@ -24388,6 +24316,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bgj" = (
@@ -29152,6 +29081,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"brl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/storage/tools)
 "brm" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -55711,6 +55646,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"emL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space/nearstation)
+"enQ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "epI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -55966,6 +55915,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"guW" = (
+/obj/machinery/light,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "gwd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -56130,6 +56084,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hLt" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/dark/corner,
+/area/hallway/primary/aft)
 "hYR" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plating,
@@ -56218,6 +56179,13 @@
 /obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"jqp" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "jrH" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd2";
@@ -56572,6 +56540,18 @@
 	dir = 8
 	},
 /area/science/research)
+"kXV" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/extinguisher,
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating,
+/area/storage/emergency/port)
 "lcg" = (
 /obj/machinery/light{
 	dir = 4
@@ -57237,6 +57217,30 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/detectives_office)
+"qPk" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
+"qPN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "qQC" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot{
@@ -57281,6 +57285,14 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"rAc" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/storage/emergency/port)
+"rHJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
 "rHZ" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -57323,6 +57335,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"rYZ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "sai" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57569,6 +57588,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"tHT" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "tKG" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -57749,6 +57775,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"uXE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "vdl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57868,6 +57908,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"vHu" = (
+/obj/structure/rack,
+/obj/item/electronics/apc,
+/obj/item/electronics/airlock,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/storage/tools)
 "vIU" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light{
@@ -57970,6 +58019,9 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"wHd" = (
+/turf/closed/wall,
+/area/hallway/primary/port)
 "wHy" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 1;
@@ -58093,6 +58145,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"xtj" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/storage/tools)
 "xEu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -80123,7 +80182,7 @@ aOi
 aLE
 aRc
 aSm
-aTJ
+aTI
 aPK
 cCl
 aYh
@@ -80379,8 +80438,8 @@ aMT
 aOi
 aPL
 aPK
-aSm
-aTI
+kXV
+rAc
 aPK
 aWB
 cCj
@@ -80636,8 +80695,8 @@ aMU
 aOw
 aPN
 aPK
-aSn
-aTK
+aPK
+aPK
 aPK
 tav
 yeu
@@ -80893,9 +80952,9 @@ aMS
 aOv
 aPM
 aPQ
-aPQ
-aPQ
-aPQ
+aRV
+aSW
+aVa
 tav
 aYi
 aYZ
@@ -81149,10 +81208,10 @@ aLp
 aMV
 aOy
 aLE
-aPQ
-aRV
-aSW
-aVa
+aSs
+vHu
+aSr
+aWF
 tav
 aWE
 aYZ
@@ -81409,7 +81468,7 @@ aPc
 aRe
 aRT
 aSt
-aWF
+xtj
 tav
 aWG
 aYZ
@@ -81665,8 +81724,8 @@ aOA
 aPO
 aRf
 aSc
-aSc
-aUw
+brl
+aSr
 tav
 hqp
 avr
@@ -81916,14 +81975,14 @@ aJh
 aHv
 aJh
 aKA
-aLN
-aMS
-aOz
-aLE
+aLT
+aNp
+aOC
+wHd
 aPQ
-aSa
-aSr
-aSr
+aTL
+aTP
+aWD
 tav
 aYZ
 gES
@@ -82173,14 +82232,14 @@ aGf
 aHL
 aJi
 aKB
-aLT
-aNp
-aOC
+rYZ
+qPk
+enQ
+aJw
 aPQ
-aPQ
-aTL
-aTP
-aWD
+aSs
+aSs
+aSs
 tav
 aYj
 tav
@@ -82430,14 +82489,14 @@ ayG
 ayG
 ayG
 ayG
-aHP
-aNc
-aOB
-aPQ
-aPQ
-aSs
-aSs
-aSs
+aJq
+aNr
+bBo
+aJw
+aJw
+uXE
+qPN
+qPN
 tav
 tav
 tav
@@ -85798,8 +85857,8 @@ aaa
 aaf
 aaa
 aaa
-aaa
-aJn
+rHJ
+qPN
 aXf
 aJq
 byV
@@ -86055,8 +86114,8 @@ aaa
 aaf
 aaa
 aaa
-aaa
-aJn
+rHJ
+qPN
 aXf
 aJq
 byU
@@ -86312,8 +86371,8 @@ bgO
 bsb
 aaf
 aaf
-aaf
-aJn
+emL
+uXE
 aXf
 aJq
 aJq
@@ -87610,7 +87669,7 @@ bCv
 bJq
 bKw
 bLH
-bRq
+hLt
 bNO
 bOQ
 bQf
@@ -87854,8 +87913,8 @@ bij
 bsg
 aaf
 aaf
-aaf
-aJn
+emL
+uXE
 aJq
 aJq
 bBu
@@ -88111,8 +88170,8 @@ aaa
 aaf
 aaa
 aaa
-aaa
-aJn
+rHJ
+qPN
 aJq
 aJq
 bBt
@@ -88368,8 +88427,8 @@ aaa
 aaf
 aaa
 aaa
-aaa
-aJn
+rHJ
+qPN
 aJq
 aJq
 aXf
@@ -89347,7 +89406,7 @@ ala
 akz
 alf
 aiX
-anA
+jqp
 anz
 aoF
 apo
@@ -89604,7 +89663,7 @@ akZ
 alE
 amq
 aiX
-anA
+tHT
 anz
 aoE
 aod
@@ -99150,7 +99209,7 @@ aYV
 aYV
 aYV
 aYV
-beE
+guW
 bfS
 biE
 bkf

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -17086,7 +17086,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aOe" = (
-/obj/item/beacon,
 /obj/machinery/camera{
 	c_tag = "Arrivals Bay 1 South"
 	},
@@ -24119,6 +24118,7 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bfQ" = (
@@ -26900,7 +26900,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 8;
-	output_dir = 1
+	output_dir = 4
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
@@ -55876,11 +55876,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"guW" = (
-/obj/machinery/light,
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "gwd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -56271,6 +56266,10 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"kcH" = (
+/obj/item/beacon,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "keW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/sorting/mail{
@@ -68627,7 +68626,7 @@ aaa
 aaa
 awW
 aOe
-ayl
+kcH
 ayl
 aRY
 awW
@@ -99222,7 +99221,7 @@ aYV
 aYV
 aYV
 aYV
-guW
+beE
 bfS
 biE
 bkf

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -4342,26 +4342,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/security/main)
-"aiQ" = (
-/obj/machinery/camera{
-	c_tag = "Brig East"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aiR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aiS" = (
@@ -4457,15 +4445,18 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/camera{
+	c_tag = "Brig East"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4760,12 +4751,12 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4785,17 +4776,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"ajN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Brig";
-	req_access_txt = "63; 42"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ajO" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -4846,8 +4826,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"ajS" = (
-/obj/structure/window/reinforced,
+"ajT" = (
+/obj/structure/chair{
+	dir = 8;
+	name = "Defense"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
+"ajU" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -4864,23 +4857,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
-"ajT" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/courtroom)
-"ajU" = (
 /obj/machinery/door/window/southleft{
 	name = "Court Cell";
 	req_access_txt = "2"
@@ -5117,23 +5093,14 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aks" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"akt" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5166,12 +5133,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"akx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/security/brig)
 "aky" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6890,13 +6851,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aoE" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aoF" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/tile/red{
@@ -6904,14 +6858,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aoG" = (
-/obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
 "aoH" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law{
@@ -26951,8 +26897,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bml" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 8;
+	output_dir = 1
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bmm" = (
@@ -29291,17 +29241,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "brO" = (
-/obj/structure/table,
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
 	pixel_x = -30
 	},
-/obj/item/multitool,
 /obj/machinery/camera{
 	c_tag = "Cargo Office";
 	dir = 4
 	},
+/obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "brP" = (
@@ -30189,9 +30138,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bud" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -30385,6 +30331,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/item/multitool,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "buF" = (
@@ -47375,6 +47322,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "ckb" = (
@@ -55620,6 +55568,17 @@
 "dYq" = (
 /turf/closed/wall,
 /area/science/nanite)
+"efj" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "63; 42"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "eja" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/nanite_chamber_control{
@@ -55678,14 +55637,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"eyM" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 2;
-	output_dir = 1
-	},
-/obj/machinery/door/firedoor,
+"ezt" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/area/security/brig)
 "eAi" = (
 /obj/machinery/button/door{
 	id = "commissaryshutter";
@@ -55808,6 +55763,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"fuz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/security/courtroom)
 "fvi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -56175,10 +56136,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"jlm" = (
-/obj/machinery/rnd/production/techfab/department/cargo,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "jqp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -56395,6 +56352,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"kxs" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "kxC" = (
 /obj/machinery/computer/rdconsole/experiment{
 	dir = 1
@@ -56527,10 +56491,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"kSb" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "kXt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -56577,6 +56537,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"ljF" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "ltd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -56612,6 +56578,9 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"lxl" = (
+/turf/closed/wall/r_wall,
+/area/security/courtroom)
 "lAB" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
@@ -56794,6 +56763,18 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"nuw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nvb" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/cigarette,
@@ -56921,6 +56902,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"oCK" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oDF" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
@@ -57032,6 +57025,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"pwk" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "pDu" = (
 /obj/machinery/computer/nanite_cloud_controller,
 /obj/effect/turf_decal/bot,
@@ -57101,6 +57100,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"pQg" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "pRV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -57227,6 +57233,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"qPr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "qPN" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -57534,6 +57545,7 @@
 	pixel_x = 2;
 	pixel_y = 3
 	},
+/obj/item/hand_labeler,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "tfg" = (
@@ -57566,12 +57578,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"trb" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/courtroom)
 "tBl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -57588,13 +57594,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"tHT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "tKG" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -57834,6 +57833,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"vrZ" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "vsa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/power/apc{
@@ -80973,10 +80986,10 @@ bnz
 bpA
 bbR
 sWR
-jlm
+bqs
 bud
-eyM
-kSb
+bxy
+byE
 bAZ
 bGm
 bzF
@@ -81487,7 +81500,7 @@ boR
 bqs
 bbR
 bkM
-bbR
+ljF
 bwd
 bxB
 bvL
@@ -88628,13 +88641,13 @@ agW
 ahE
 aii
 agn
-ajd
+ajc
 ajI
 ahY
-akW
-aiG
-amo
-amW
+vrZ
+nuw
+nuw
+qPr
 anz
 anz
 aoz
@@ -88885,16 +88898,16 @@ agY
 ahA
 ahZ
 adR
-aiQ
+ajd
 ajI
-akt
-akQ
-agj
-agj
-aiX
-anB
+ahY
+akW
+aiG
+amo
+amW
 anz
-aoD
+anz
+aoz
 aod
 aqe
 arf
@@ -89145,13 +89158,13 @@ cBV
 ajf
 ajK
 aks
-akY
-tBl
-tBl
+akQ
+agj
+agj
 aiX
-anA
+anB
 anz
-aoC
+aoD
 aod
 aqe
 arf
@@ -89400,15 +89413,15 @@ ahC
 aia
 aiP
 aiR
-ajB
-akv
-ala
-akz
-alf
+ezt
+oCK
+akY
+tBl
+tBl
 aiX
-jqp
+anA
 anz
-aoF
+aoC
 apo
 aqh
 arh
@@ -89656,16 +89669,16 @@ agZ
 ahI
 aim
 adR
-aiG
-ajL
-aku
-akZ
-alE
-amq
+ajc
+pwk
+akv
+ala
+akz
+alf
 aiX
-tHT
+jqp
 anz
-aoE
+aoF
 aod
 aqg
 aun
@@ -89913,16 +89926,16 @@ afU
 ahF
 aip
 adR
+aiG
+ajL
+aku
+akZ
+alE
+amq
 aiX
-ajN
-akx
-aiX
-aiX
-aiX
-aiX
-anC
-anU
-anC
+kxs
+ajn
+pQg
 cSA
 aqe
 arf
@@ -90170,16 +90183,16 @@ ahb
 ahF
 clI
 abp
-ajh
-ajM
-akw
-alb
-alG
-amr
-amY
-amY
-ajp
-aoG
+lxl
+efj
+fuz
+lxl
+lxl
+lxl
+lxl
+anC
+anU
+anC
 cSA
 aqe
 arf
@@ -90427,15 +90440,15 @@ ahd
 ahI
 clS
 abp
-ajj
-ajP
-aky
-alc
-alI
-ams
-amZ
-amZ
-anW
+ajh
+ajM
+akw
+alb
+alG
+amr
+amY
+amY
+ajp
 aoH
 cSA
 aqe
@@ -90684,15 +90697,15 @@ ahc
 ahH
 aiq
 abp
-aji
-ajO
-akw
-ajn
-alH
-amr
-amY
-amY
-anV
+ajj
+ajP
+aky
+alc
+alI
+ams
+amZ
+amZ
+anW
 ajo
 cSA
 aqe
@@ -90941,15 +90954,15 @@ ahf
 ahK
 ait
 abp
-ajl
-ajR
+aji
+ajO
 akw
-ald
-alJ
-amt
-ajp
-ajp
-anY
+ajn
+alH
+amr
+amY
+amY
+anV
 ajo
 apq
 aqe
@@ -91198,15 +91211,15 @@ ahe
 ahJ
 ais
 abp
-ajk
-ajQ
+ajl
+ajR
 akw
-ajn
-alH
-amr
-amY
-amY
-anX
+ald
+alJ
+amt
+ajp
+ajp
+anY
 ajo
 app
 aqi
@@ -91455,15 +91468,15 @@ ahh
 ahM
 aiv
 abp
-aiY
-ajE
-ajH
-akn
-ale
-alD
-ana
-ana
-amu
+ajk
+ajQ
+akw
+ajn
+alH
+amr
+amY
+amY
+anX
 ajo
 aps
 aqk
@@ -91712,15 +91725,15 @@ ahg
 ahL
 aiu
 abp
-ajm
-ajS
-ajn
-ajT
-akA
-amr
-amY
-amY
-anV
+aiY
+ajE
+ajH
+akn
+ale
+alD
+ana
+ana
+amu
 ajo
 apr
 aqj
@@ -91969,15 +91982,15 @@ ahi
 ahN
 aix
 abp
-ajp
+ajm
 ajU
 ajn
-trb
-ajn
+ajT
+akA
 amr
-ajp
-ajp
-ajp
+amY
+amY
+anV
 ajo
 apt
 aqm
@@ -98948,7 +98961,7 @@ aRJ
 aRJ
 aYQ
 cBg
-bam
+aRJ
 aYV
 aYV
 aYV


### PR DESCRIPTION
This PR is intended as larger series of minor, and maybe major, changes to Boxstation. In the hope of improving it and warming up reception to this somewhat neglected map. 

(This PR is a WIP)

**I HIGHLY** welcome any **feedback** and **suggestions** for future changes or tweaks to the map in any capacity, one thing I've been told is that Box maint could be enlarged but I'm still thinking about how I'd approach that, if at all.

Below I'll list every single change I've effected, for transparency sake as well since its not unheard of minor things to be swinged through. Pictures will be included at the end of the more bigger changes.

I've currently gone through Security and some civilian areas. I'm now working my way around Engineering, Medical and Science. Maintenance is also on my agenda.

----------------

* Hydro dirt mounds in the Perma Brig have been replaced with proper hydro trays.
* Surgical tools in the 'prisoner transfer centre' are now inside a surgical dufflebag.
* Sergeant-at-Armsky has been posted to the armoury.
* External armoury now has a security camera placed there.
* HoS Office has been electrified and now has privacy shutters
* The oft unused 'cell 4' is now a communal holding cell (pic below)
* EVA has been reworked to be far more accessible in a emergency and now has additional space suits, eight up from four. Other misc supply count is akin to how it was prior. 


* Botany now has two public facing vendors for public use, a MegaSeed and NutriMax vendor.
* Science now has a public autolathe via the 'RnD' window.


* New fire safety closets and a few extra emergency lockers have been sprinkled around the main halls.
* Bar backroom now has a new Hooch Master Deluxe for mixing.


* Security entrance now has a window in between the doors.
* ORM is now public facing
* Two hand labblers were placed in science.

----------------

![screenshot 2018-11-21 00 03 51](https://user-images.githubusercontent.com/6595389/48787185-4447e200-ed23-11e8-86b4-bbb399251cd1.png)
EVA

![screenshot 2018-11-21 09 06 18](https://user-images.githubusercontent.com/6595389/48812426-446ccf80-ed6d-11e8-9538-78bc86aa5f08.png)
Botany

![screenshot 2018-11-21 00 04 25](https://user-images.githubusercontent.com/6595389/48787194-47db6900-ed23-11e8-95c6-26fe0f61444d.png)
Public Autolathe

![screenshot 2018-11-21 09 05 44](https://user-images.githubusercontent.com/6595389/48812406-2a32f180-ed6d-11e8-828f-d2fbd42f8133.png)
Security Entrance and Common Cell

![screenshot 2018-11-21 09 06 04](https://user-images.githubusercontent.com/6595389/48812413-374fe080-ed6d-11e8-8ba2-5b374afc654e.png)
ORM


:cl: Steelpoint
add: NTSS Boxstation has undergone several large and minor scale retrofits and refits by the Nanotrasen Corps of Engineers. 
tweak: Changes of note include a reworked EVA Storage, improved permanent confinement living area and a public autolathe. A full list of changes can be found on your local NT Git page.
/:cl:
