### PR TITLE
Magic Survivalists can have spellbooks count if they did not use them

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -844,7 +844,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		for(var/obj/I in all_items) //Check for wanted items
 			if(is_type(I, /obj/item/book/granter/spell))
 				var/obj/item/book/granter/spell/spellbook = I
-				if(!I.used || !I.oneuse) //if the book still has powers...
+				if(!spellbook.used || !spellbook.oneuse) //if the book still has powers...
 					stolen_count++ //it counts. nice.
 			else if(is_type_in_typecache(I, wanted_items))
 				stolen_count++

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -842,7 +842,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 			continue
 		var/list/all_items = M.current.GetAllContents()	//this should get things in cheesewheels, books, etc.
 		for(var/obj/I in all_items) //Check for wanted items
-			if(is_type(I, /obj/item/book/granter/spell))
+			if(istype(I, /obj/item/book/granter/spell))
 				var/obj/item/book/granter/spell/spellbook = I
 				if(!spellbook.used || !spellbook.oneuse) //if the book still has powers...
 					stolen_count++ //it counts. nice.

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -808,6 +808,18 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	..()
 	wanted_items = typecacheof(wanted_items)
 
+/datum/objective/steal_five_of_type/check_completion()
+	var/list/datum/mind/owners = get_owners()
+	var/stolen_count = 0
+	for(var/datum/mind/M in owners)
+		if(!isliving(M.current))
+			continue
+		var/list/all_items = M.current.GetAllContents()	//this should get things in cheesewheels, books, etc.
+		for(var/obj/I in all_items) //Check for wanted items
+			if(is_type_in_typecache(I, wanted_items))
+				stolen_count++
+	return stolen_count >= 5
+
 /datum/objective/steal_five_of_type/summon_guns
 	name = "steal guns"
 	explanation_text = "Steal at least five guns!"
@@ -822,7 +834,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	wanted_items = GLOB.summoned_magic_objectives
 	..()
 
-/datum/objective/steal_five_of_type/check_completion()
+/datum/objective/steal_five_of_type/summon_magic/check_completion()
 	var/list/datum/mind/owners = get_owners()
 	var/stolen_count = 0
 	for(var/datum/mind/M in owners)
@@ -830,7 +842,11 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 			continue
 		var/list/all_items = M.current.GetAllContents()	//this should get things in cheesewheels, books, etc.
 		for(var/obj/I in all_items) //Check for wanted items
-			if(is_type_in_typecache(I, wanted_items))
+			if(is_type(I, /obj/item/book/granter/spell))
+				var/obj/item/book/granter/spell/spellbook = I
+				if(!I.used || !I.oneuse) //if the book still has powers...
+					stolen_count++ //it counts. nice.
+			else if(is_type_in_typecache(I, wanted_items))
 				stolen_count++
 	return stolen_count >= 5
 

--- a/code/modules/antagonists/survivalist/survivalist.dm
+++ b/code/modules/antagonists/survivalist/survivalist.dm
@@ -31,6 +31,10 @@
 	name = "Amateur Magician"
 	greet_message = "Grow your newfound talent! Grab as many magical artefacts as possible, by any means necessary. Kill anyone who gets in your way."
 
+/datum/antagonist/survivalist/greet()
+	..()
+	to_chat(owner, "<span class='notice'>As a wonderful magician, you should remember that spellbooks don't mean anything if they are used up.</span>")
+
 /datum/antagonist/survivalist/magic/forge_objectives()
 	var/datum/objective/steal_five_of_type/summon_magic/magic = new
 	magic.owner = owner

--- a/code/modules/antagonists/survivalist/survivalist.dm
+++ b/code/modules/antagonists/survivalist/survivalist.dm
@@ -31,7 +31,7 @@
 	name = "Amateur Magician"
 	greet_message = "Grow your newfound talent! Grab as many magical artefacts as possible, by any means necessary. Kill anyone who gets in your way."
 
-/datum/antagonist/survivalist/greet()
+/datum/antagonist/survivalist/magic/greet()
 	..()
 	to_chat(owner, "<span class='notice'>As a wonderful magician, you should remember that spellbooks don't mean anything if they are used up.</span>")
 

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(summoned_special_magic, list(
 	/obj/item/necromantic_stone,
 	/obj/item/blood_contract))
 
-//everything above except for single use spellbooks, because those are for basic bitches
+//everything above except for single use spellbooks, because they are counted separately (and are for basic bitches anyways)
 GLOBAL_LIST_INIT(summoned_magic_objectives, list(
 	/obj/item/antag_spawner/contract,
 	/obj/item/blood_contract,


### PR DESCRIPTION
:cl:
tweak: spellbooks now count towards the survivalist objective if they were not used.
/:cl:

fixes #40857

It feels like shit if you don't know spellbooks don't count and you just lose out of nowhere. It also doesn't make sense for them to count if they still have magic powers.