### PR TITLE
Increases clown impact on singularities

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -633,7 +633,7 @@
 		if((mind.assigned_role == "Station Engineer") || (mind.assigned_role == "Chief Engineer") )
 			gain = 100
 		if(mind.assigned_role == "Clown")
-			gain = rand(-300, 300)
+			gain = rand(-1000, 1000)
 	investigate_log("([key_name(src)]) has been consumed by the singularity.", INVESTIGATE_SINGULO) //Oh that's where the clown ended up!
 	gib()
 	return(gain)


### PR DESCRIPTION
:cl: Denton
tweak: Clowns that are consumed by singularities now either add or remove a much larger amount of energy.
/:cl:

This PR increases the impact clowns have when they consumed by singularities, from -300 or +300 pts. to -1000/+1000 pts.

I really like the idea of desperate crew ganging up to throw the clown into the loose singularity, like in those old movies where people would toss a virgin into an active volcano to placate it.

With this change, a clown that's tossed into an early stage 4 singularity (1300 pts) could either shrink it down to a stage 2 (200-499 pts), or increase the power enough for it to become a stage 5 (2000+ pts).