### PR TITLE
[BOX] Added missing spawn point to detective's office

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -8774,6 +8774,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/start/detective,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "auh" = (


### PR DESCRIPTION
:cl: Thunder12345
fix: Boxstation's detective no longer starts the round undercover in a random job's spawn point
/:cl:
