### PR TITLE
Allows floats on all config entries that have no valid reason to disallow them

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -74,22 +74,27 @@
 
 /datum/config_entry/number/traitor_scaling_coeff	//how much does the amount of players get divided by to determine traitors
 	config_entry_value = 6
+	integer = FALSE
 	min_val = 1
 
 /datum/config_entry/number/brother_scaling_coeff	//how many players per brother team
 	config_entry_value = 25
+	integer = FALSE
 	min_val = 1
 
 /datum/config_entry/number/changeling_scaling_coeff	//how much does the amount of players get divided by to determine changelings
 	config_entry_value = 6
+	integer = FALSE
 	min_val = 1
 
 /datum/config_entry/number/security_scaling_coeff	//how much does the amount of players get divided by to determine open security officer positions
 	config_entry_value = 8
+	integer = FALSE
 	min_val = 1
 
 /datum/config_entry/number/abductor_scaling_coeff	//how many players per abductor team
 	config_entry_value = 15
+	integer = FALSE
 	min_val = 1
 
 /datum/config_entry/number/traitor_objectives_amount
@@ -114,18 +119,22 @@
 
 /datum/config_entry/number/antag_rep_maximum
 	config_entry_value = 200
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/default_antag_tickets
 	config_entry_value = 100
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/max_tickets_per_roll
 	config_entry_value = 100
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/midround_antag_time_check	// How late (in minutes you want the midround antag system to stay on, setting this to 0 will disable the system)
 	config_entry_value = 60
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/midround_antag_life_check	// A ratio of how many people need to be alive in order for the round not to immediately end in midround antagonist
@@ -136,6 +145,7 @@
 
 /datum/config_entry/number/shuttle_refuel_delay
 	config_entry_value = 12000
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/flag/show_game_type_odds	//if set this allows players to see the odds of each roundtype on the get revision screen
@@ -156,6 +166,7 @@
 
 /datum/config_entry/number/arrivals_shuttle_dock_window	//Time from when a player late joins on the arrivals shuttle to when the shuttle docks on the station
 	config_entry_value = 55
+	integer = FALSE
 	min_val = 30
 
 /datum/config_entry/flag/arrivals_shuttle_require_undocked	//Require the arrivals shuttle to be undocked before latejoiners can join
@@ -186,6 +197,7 @@
 
 /datum/config_entry/number/revival_brain_life
 	config_entry_value = -1
+	integer = FALSE
 	min_val = -1
 
 /datum/config_entry/flag/ooc_during_round
@@ -227,14 +239,16 @@
 		update_mob_config_movespeeds()
 
 /datum/config_entry/number/movedelay/run_delay
+	integer = FALSE
 
 /datum/config_entry/number/movedelay/walk_delay
+	integer = FALSE
 
 /////////////////////////////////////////////////Outdated move delay
 /datum/config_entry/number/outdated_movedelay
 	deprecated_by = /datum/config_entry/keyed_list/multiplicative_movespeed
 	abstract_type = /datum/config_entry/number/outdated_movedelay
-
+	integer = FALSE
 	var/movedelay_type
 
 /datum/config_entry/number/outdated_movedelay/DeprecationUpdate(value)
@@ -258,6 +272,7 @@
 
 /datum/config_entry/number/gateway_delay	//How long the gateway takes before it activates. Default is half an hour. Only matters if roundstart_away is enabled.
 	config_entry_value = 18000
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/flag/ghost_interaction
@@ -299,10 +314,12 @@
 
 /datum/config_entry/number/lavaland_budget
 	config_entry_value = 60
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/space_budget
 	config_entry_value = 16
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/flag/allow_random_events	// Enables random events mid-round when set

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -13,10 +13,12 @@
 
 /datum/config_entry/number/lobby_countdown	// In between round countdown.
 	config_entry_value = 120
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/round_end_countdown	// Post round murder death kill countdown
 	config_entry_value = 25
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/flag/hub	// if the game appears on the hub or not
@@ -71,10 +73,12 @@
 
 /datum/config_entry/number/vote_delay	// minimum time between voting sessions (deciseconds, 10 minute default)
 	config_entry_value = 6000
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/vote_period  // length of voting period (deciseconds, default 1 minute)
 	config_entry_value = 600
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/flag/default_no_vote	// vote does not default to nochange/norestart
@@ -87,6 +91,7 @@
 
 /datum/config_entry/number/fps
 	config_entry_value = 20
+	integer = FALSE
 	min_val = 1
 	max_val = 100   //byond will start crapping out at 50, so this is just ridic
 	var/sync_validate = FALSE
@@ -161,6 +166,7 @@
 
 /datum/config_entry/number/use_exp_restrictions_heads_hours
 	config_entry_value = 0
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/flag/use_exp_restrictions_heads_department
@@ -197,10 +203,12 @@
 
 /datum/config_entry/number/id_console_jobslot_delay
 	config_entry_value = 30
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/inactivity_period	//time in ds until a player is considered inactive
 	config_entry_value = 3000
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/inactivity_period/ValidateAndSet(str_val)
@@ -210,6 +218,7 @@
 
 /datum/config_entry/number/afk_period	//time in ds until a player is considered inactive
 	config_entry_value = 3000
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/afk_period/ValidateAndSet(str_val)
@@ -306,10 +315,12 @@
 
 /datum/config_entry/number/ipintel_save_good
 	config_entry_value = 12
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/ipintel_save_bad
 	config_entry_value = 1
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/string/ipintel_domain
@@ -364,6 +375,7 @@
 
 /datum/config_entry/number/error_cooldown	// The "cooldown" time for each occurrence of a unique error
 	config_entry_value = 600
+	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/error_limit	// How many occurrences before the next will silence them
@@ -371,9 +383,11 @@
 
 /datum/config_entry/number/error_silence_time	// How long a unique error will be silenced for
 	config_entry_value = 6000
+	integer = FALSE
 
 /datum/config_entry/number/error_msg_delay	// How long to wait between messaging admins about occurrences of a unique error
 	config_entry_value = 50
+	integer = FALSE
 
 /datum/config_entry/flag/irc_announce_new_game
 


### PR DESCRIPTION
Needed for run speed changes we are planning, but I'm allowing them on any config that has no bonafide reason to disallow them.

The criteria used was "Is there a technical reason why floats should not be allowed or is there a technical/logical reason why floats would never mean anything more compared to a integer".

For instance: The cloning timer was made to allow floats because 0.5 ds increments are valid at our current fps and more would be valid at other fpses. Yes, from a practical standpoint nobody would ever want to have cloning be valid for 30 minutes and 50 milliseconds after death, but from a technical standpoint there is no reason not to let them.
