### PR TITLE
Makes atmos tank control consoles rebuildable

### DIFF
--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -180,48 +180,56 @@ GLOBAL_LIST_EMPTY(atmos_air_controllers)
 	input_tag = ATMOS_GAS_MONITOR_INPUT_O2
 	output_tag = ATMOS_GAS_MONITOR_OUTPUT_O2
 	sensors = list(ATMOS_GAS_MONITOR_SENSOR_O2 = "Oxygen Tank")
+	circuit = /obj/item/circuitboard/computer/atmos_control/tank/oxygen_tank
 
 /obj/machinery/computer/atmos_control/tank/toxin_tank
 	name = "Plasma Supply Control"
 	input_tag = ATMOS_GAS_MONITOR_INPUT_TOX
 	output_tag = ATMOS_GAS_MONITOR_OUTPUT_TOX
 	sensors = list(ATMOS_GAS_MONITOR_SENSOR_TOX = "Plasma Tank")
+	circuit = /obj/item/circuitboard/computer/atmos_control/tank/toxin_tank
 
 /obj/machinery/computer/atmos_control/tank/air_tank
 	name = "Mixed Air Supply Control"
 	input_tag = ATMOS_GAS_MONITOR_INPUT_AIR
 	output_tag = ATMOS_GAS_MONITOR_OUTPUT_AIR
 	sensors = list(ATMOS_GAS_MONITOR_SENSOR_AIR = "Air Mix Tank")
+	circuit = /obj/item/circuitboard/computer/atmos_control/tank/air_tank
 
 /obj/machinery/computer/atmos_control/tank/mix_tank
 	name = "Gas Mix Tank Control"
 	input_tag = ATMOS_GAS_MONITOR_INPUT_MIX
 	output_tag = ATMOS_GAS_MONITOR_OUTPUT_MIX
 	sensors = list(ATMOS_GAS_MONITOR_SENSOR_MIX = "Gas Mix Tank")
+	circuit = /obj/item/circuitboard/computer/atmos_control/tank/mix_tank
 
 /obj/machinery/computer/atmos_control/tank/nitrous_tank
 	name = "Nitrous Oxide Supply Control"
 	input_tag = ATMOS_GAS_MONITOR_INPUT_N2O
 	output_tag = ATMOS_GAS_MONITOR_OUTPUT_N2O
 	sensors = list(ATMOS_GAS_MONITOR_SENSOR_N2O = "Nitrous Oxide Tank")
+	circuit = /obj/item/circuitboard/computer/atmos_control/tank/nitrous_tank
 
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank
 	name = "Nitrogen Supply Control"
 	input_tag = ATMOS_GAS_MONITOR_INPUT_N2
 	output_tag = ATMOS_GAS_MONITOR_OUTPUT_N2
 	sensors = list(ATMOS_GAS_MONITOR_SENSOR_N2 = "Nitrogen Tank")
+	circuit = /obj/item/circuitboard/computer/atmos_control/tank/nitrogen_tank
 
 /obj/machinery/computer/atmos_control/tank/carbon_tank
 	name = "Carbon Dioxide Supply Control"
 	input_tag = ATMOS_GAS_MONITOR_INPUT_CO2
 	output_tag = ATMOS_GAS_MONITOR_OUTPUT_CO2
 	sensors = list(ATMOS_GAS_MONITOR_SENSOR_CO2 = "Carbon Dioxide Tank")
+	circuit = /obj/item/circuitboard/computer/atmos_control/tank/carbon_tank
 
 /obj/machinery/computer/atmos_control/tank/incinerator
 	name = "Incinerator Air Control"
 	input_tag = ATMOS_GAS_MONITOR_INPUT_INCINERATOR
 	output_tag = ATMOS_GAS_MONITOR_OUTPUT_INCINERATOR
 	sensors = list(ATMOS_GAS_MONITOR_SENSOR_INCINERATOR = "Incinerator Chamber")
+	circuit = /obj/item/circuitboard/computer/atmos_control/tank/incinerator
 
 // This hacky madness is the evidence of the fact that a lot of machines were never meant to be constructable, im so sorry you had to see this
 /obj/machinery/computer/atmos_control/tank/proc/reconnect(mob/user)

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -95,6 +95,38 @@
 	name = "Tank Control (Computer Board)"
 	build_path = /obj/machinery/computer/atmos_control/tank
 
+/obj/item/circuitboard/computer/atmos_control/tank/oxygen_tank
+	name = "Oxygen Supply Control (Computer Board)"
+	build_path = /obj/machinery/computer/atmos_control/tank/oxygen_tank
+
+/obj/item/circuitboard/computer/atmos_control/tank/toxin_tank
+	name = "Plasma Supply Control (Computer Board)"
+	build_path = /obj/machinery/computer/atmos_control/tank/toxin_tank
+
+/obj/item/circuitboard/computer/atmos_control/tank/air_tank
+	name = "Mixed Air Supply Control (Computer Board)"
+	build_path = /obj/machinery/computer/atmos_control/tank/air_tank
+
+/obj/item/circuitboard/computer/atmos_control/tank/mix_tank
+	name = "Gas Mix Supply Control (Computer Board)"
+	build_path = /obj/machinery/computer/atmos_control/tank/mix_tank
+
+/obj/item/circuitboard/computer/atmos_control/tank/nitrous_tank
+	name = "Nitrous Oxide Supply Control (Computer Board)"
+	build_path = /obj/machinery/computer/atmos_control/tank/nitrous_tank
+
+/obj/item/circuitboard/computer/atmos_control/tank/nitrogen_tank
+	name = "Nitrogen Supply Control (Computer Board)"
+	build_path = /obj/machinery/computer/atmos_control/tank/nitrogen_tank
+
+/obj/item/circuitboard/computer/atmos_control/tank/carbon_tank
+	name = "Carbon Dioxide Supply Control (Computer Board)"
+	build_path = /obj/machinery/computer/atmos_control/tank/carbon_tank
+
+/obj/item/circuitboard/computer/atmos_control/tank/incinerator
+	name = "Incinerator Air Control (Computer Board)"
+	build_path = /obj/machinery/computer/atmos_control/tank/incinerator
+
 /obj/item/circuitboard/computer/atmos_alert
 	name = "Atmospheric Alert (Computer Board)"
 	build_path = /obj/machinery/computer/atmos_alert


### PR DESCRIPTION
:cl: Denton
fix: Atmos gas tank computers can now be properly rebuilt with their own circuit boards.
/:cl:

Fixes: #40858
