### PR TITLE
 Scrying orb now grants sixth sense (and xray) to whoever possesses it

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -55,7 +55,7 @@
 #define TRAIT_PARALYSIS_R_ARM	"para-r-arm"
 #define TRAIT_PARALYSIS_L_LEG	"para-l-leg"
 #define TRAIT_PARALYSIS_R_LEG	"para-r-leg"
-#define TRAIT_XRAY_VISION       "xray-vision"
+#define TRAIT_XRAY_VISION       "xray_vision"
 
 //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -55,6 +55,7 @@
 #define TRAIT_PARALYSIS_R_ARM	"para-r-arm"
 #define TRAIT_PARALYSIS_L_LEG	"para-l-leg"
 #define TRAIT_PARALYSIS_R_LEG	"para-r-leg"
+#define TRAIT_XRAY_VISION       "xray-vision"
 
 //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it
@@ -99,3 +100,4 @@
 #define GENETICS_SPELL "genetics_spell"
 #define EYES_COVERED "eyes_covered"
 #define CULT_EYES "cult_eyes"
+#define SCRYING_ORB "scrying-orb"

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -45,11 +45,13 @@
 	if(..())
 		return
 
+	owner.add_trait(TRAIT_XRAY_VISION, GENETIC_MUTATION)
 	owner.update_sight()
 
 /datum/mutation/human/x_ray/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
+	owner.remove_trait(TRAIT_XRAY_VISION, GENETIC_MUTATION)
 	owner.update_sight()
 
 

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -146,15 +146,29 @@
 	force = 15
 	hitsound = 'sound/items/welder2.ogg'
 
-	var/xray_granted = FALSE
+	var/mob/current_owner
 
-/obj/item/scrying/equipped(mob/user)
-	if(!xray_granted && ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(!(H.dna.check_mutation(XRAY)))
-			H.dna.add_mutation(XRAY)
-			xray_granted = TRUE
+/obj/item/scrying/Initialize(mapload)
 	. = ..()
+	START_PROCESSING(SSobj, src)
+
+/obj/item/scrying/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	. = ..()
+
+/obj/item/scrying/process()
+	var/mob/holder = get(loc, /mob)
+	if(current_owner && current_owner != holder)
+		current_owner.remove_trait(TRAIT_SIXTHSENSE, SCRYING_ORB)
+		current_owner.remove_trait(TRAIT_XRAY_VISION, SCRYING_ORB)
+
+		current_owner = null
+
+	if(!current_owner)
+		current_owner = holder
+
+		current_owner.add_trait(TRAIT_SIXTHSENSE, SCRYING_ORB)
+		current_owner.add_trait(TRAIT_XRAY_VISION, SCRYING_ORB)
 
 /obj/item/scrying/attack_self(mob/user)
 	to_chat(user, "<span class='notice'>You can see...everything!</span>")

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -136,7 +136,7 @@
 
 /obj/item/scrying
 	name = "scrying orb"
-	desc = "An incandescent orb of otherworldly energy, staring into it gives you vision beyond mortal means."
+	desc = "An incandescent orb of otherworldly energy, merely holding it gives you vision and hearing beyond mortal means, and staring into it lets you see the entire universe."
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state ="bluespace"
 	throw_speed = 3
@@ -159,19 +159,25 @@
 /obj/item/scrying/process()
 	var/mob/holder = get(loc, /mob)
 	if(current_owner && current_owner != holder)
+
+		to_chat(current_owner, "<span class='notice'>Your otherworldly vision fades...</span>")
+
 		current_owner.remove_trait(TRAIT_SIXTHSENSE, SCRYING_ORB)
 		current_owner.remove_trait(TRAIT_XRAY_VISION, SCRYING_ORB)
+		current_owner.update_sight()
 
 		current_owner = null
 
 	if(!current_owner)
 		current_owner = holder
 
+		to_chat(current_owner, "<span class='notice'>You can see...everything!</span>")
+
 		current_owner.add_trait(TRAIT_SIXTHSENSE, SCRYING_ORB)
 		current_owner.add_trait(TRAIT_XRAY_VISION, SCRYING_ORB)
+		current_owner.update_sight()
 
 /obj/item/scrying/attack_self(mob/user)
-	to_chat(user, "<span class='notice'>You can see...everything!</span>")
 	visible_message("<span class='danger'>[user] stares into [src], their eyes glazing over.</span>")
 	user.ghostize(1)
 
@@ -202,12 +208,12 @@
 	if(M.stat != DEAD)
 		to_chat(user, "<span class='warning'>This artifact can only affect the dead!</span>")
 		return
-	
+
 	for(var/mob/dead/observer/ghost in GLOB.dead_mob_list) //excludes new players
 		if(ghost.mind && ghost.mind.current == M && ghost.client)  //the dead mobs list can contain clientless mobs
 			ghost.reenter_corpse()
 			break
-	
+
 	if(!M.mind || !M.client)
 		to_chat(user, "<span class='warning'>There is no soul connected to this body...</span>")
 		return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -590,12 +590,18 @@
 			see_invisible = min(G.invis_view, see_invisible)
 		if(!isnull(G.lighting_alpha))
 			lighting_alpha = min(lighting_alpha, G.lighting_alpha)
-	if(dna)
+
+	var/has_xray = has_trait(TRAIT_XRAY_VISION)
+
+	if(dna && !has_xray)
 		for(var/X in dna.mutations)
 			var/datum/mutation/M = X
 			if(M.name == XRAY)
-				sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
-				see_in_dark = max(see_in_dark, 8)
+				has_xray = TRUE
+
+	if(has_xray)
+		sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
+		see_in_dark = max(see_in_dark, 8)
 
 	if(see_override)
 		see_invisible = see_override

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -591,15 +591,7 @@
 		if(!isnull(G.lighting_alpha))
 			lighting_alpha = min(lighting_alpha, G.lighting_alpha)
 
-	var/has_xray = has_trait(TRAIT_XRAY_VISION)
-
-	if(dna && !has_xray)
-		for(var/X in dna.mutations)
-			var/datum/mutation/M = X
-			if(M.name == XRAY)
-				has_xray = TRUE
-
-	if(has_xray)
+	if(has_trait(TRAIT_XRAY_VISION))
 		sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		see_in_dark = max(see_in_dark, 8)
 


### PR DESCRIPTION
:cl:
add: A wizard's scrying orb now grants both xray vision, and the ability to hear the dead to whoever possesses it.
balance: However, as soon as the orb is no longer in your possession, these abilities fade.
/:cl:

This was @XDTM's idea, when he implemented near death experiences.

It works even when in your backpack.

This also adds the TRAIT_XRAY_VISION, for non-genetic, non-eyeball sources of xray.

Why? Having a wizard talking to ghosts means it looks like he's talking to thin air. Also, this makes scrying orb a little more active in its knowledge gathering. Ghosts will have the chance to mislead the wizard with whatever they're talking about.