### PR TITLE
Makes ventcrawl much easier on the client

### DIFF
--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -98,7 +98,9 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 			A.pipe_vision_img.plane = ABOVE_HUD_PLANE
 		pipes_shown += A.pipe_vision_img
 		if(client)
-			client.images += A.pipe_vision_img
+			if(A.loc.x >= starting_machine.loc.x - 7 && A.loc.x <= starting_machine.loc.x + 7)
+				if(A.loc.y >= starting_machine.loc.y - 7 && A.loc.y <= starting_machine.loc.y + 7)
+					client.images += A.pipe_vision_img
 	setMovetype(movement_type | VENTCRAWLING)
 
 

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -97,10 +97,8 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 			A.pipe_vision_img = image(A, A.loc, layer = ABOVE_HUD_LAYER, dir = A.dir)
 			A.pipe_vision_img.plane = ABOVE_HUD_PLANE
 		pipes_shown += A.pipe_vision_img
-		if(client)
-			if(A.loc.x >= starting_machine.loc.x - 8 && A.loc.x <= starting_machine.loc.x + 8)
-				if(A.loc.y >= starting_machine.loc.y - 8 && A.loc.y <= starting_machine.loc.y + 8)
-					client.images += A.pipe_vision_img
+		if(client && A.loc.x >= starting_machine.loc.x - 8 && A.loc.x <= starting_machine.loc.x + 8 && A.loc.y >= starting_machine.loc.y - 8 && A.loc.y <= starting_machine.loc.y + 8)
+			client.images += A.pipe_vision_img
 	setMovetype(movement_type | VENTCRAWLING)
 
 

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -91,14 +91,15 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 	if(!totalMembers.len)
 		return
 
-	for(var/X in totalMembers)
-		var/obj/machinery/atmospherics/A = X //all elements in totalMembers are necessarily of this type.
-		if(!A.pipe_vision_img)
-			A.pipe_vision_img = image(A, A.loc, layer = ABOVE_HUD_LAYER, dir = A.dir)
-			A.pipe_vision_img.plane = ABOVE_HUD_PLANE
-		pipes_shown += A.pipe_vision_img
-		if(client && A.loc.x >= starting_machine.loc.x - 8 && A.loc.x <= starting_machine.loc.x + 8 && A.loc.y >= starting_machine.loc.y - 8 && A.loc.y <= starting_machine.loc.y + 8)
-			client.images += A.pipe_vision_img
+	if(client)
+		for(var/X in totalMembers)
+			var/obj/machinery/atmospherics/A = X //all elements in totalMembers are necessarily of this type.
+			if(in_view_range(client.mob, A))
+				if(!A.pipe_vision_img)
+					A.pipe_vision_img = image(A, A.loc, layer = ABOVE_HUD_LAYER, dir = A.dir)
+					A.pipe_vision_img.plane = ABOVE_HUD_PLANE
+				client.images += A.pipe_vision_img
+				pipes_shown += A.pipe_vision_img
 	setMovetype(movement_type | VENTCRAWLING)
 
 

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -98,8 +98,8 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 			A.pipe_vision_img.plane = ABOVE_HUD_PLANE
 		pipes_shown += A.pipe_vision_img
 		if(client)
-			if(A.loc.x >= starting_machine.loc.x - 7 && A.loc.x <= starting_machine.loc.x + 7)
-				if(A.loc.y >= starting_machine.loc.y - 7 && A.loc.y <= starting_machine.loc.y + 7)
+			if(A.loc.x >= starting_machine.loc.x - 8 && A.loc.x <= starting_machine.loc.x + 8)
+				if(A.loc.y >= starting_machine.loc.y - 8 && A.loc.y <= starting_machine.loc.y + 8)
 					client.images += A.pipe_vision_img
 	setMovetype(movement_type | VENTCRAWLING)
 


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
fix: Reduced ventcrawl lag greatly.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
Basically prevents adding pipe images to client if they are outside view range. I don't know of any situations where the view range while vent crawling is higher than the standard 7, if there are let me know so I can up it.

Partial fix of #41433 as vent crawling is still fairly expensive for the server, but at least alleviates the client lag. See the short videos below for a comparison.

[Before](https://i.imgur.com/9a8d2zw.mp4)
[After](https://i.imgur.com/9J0SWMN.mp4)
