### PR TITLE
Changes "free" to "servant" when trying to spawn as servant golem

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -182,6 +182,7 @@
 /obj/effect/mob_spawn/human/golem/servant
 	has_owner = TRUE
 	name = "inert servant golem shell"
+	mob_name = "a servant golem"
 
 
 /obj/effect/mob_spawn/human/golem/adamantine


### PR DESCRIPTION
Can be confusing sometimes.

Before: "Become a free golem?"
Now: "Become a servant golem?"