### PR TITLE
Smuggler satchels now only show up once

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -63,11 +63,11 @@ SUBSYSTEM_DEF(persistence)
 	if(old_secret_satchels && old_secret_satchels.len >= 10) //guards against low drop pools assuring that one player cannot reliably find his own gear.
 		var/pos = rand(1, old_secret_satchels.len)
 		F = new()
-		old_secret_satchels.Cut(pos, pos+1 % old_secret_satchels.len)
 		F.x = old_secret_satchels[pos]["x"]
 		F.y = old_secret_satchels[pos]["y"]
 		F.z = SSmapping.station_start
 		path = text2path(old_secret_satchels[pos]["saved_obj"])
+		old_secret_satchels.Cut(pos, pos+1 % old_secret_satchels.len)
 
 	if(F)
 		if(isfloorturf(F.loc) && !isplatingturf(F.loc))


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
fix: Smuggler satchels should now properly be removed from the pool upon spawn.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Order matters. Upon spawn the old ordering removed the chosen satchel from the list, then got the data from what used to be the next list entry. This caused the next entry to potentially show up several times, while the chosen satchel never did. 