### PR TITLE
Adds light eater interaction to marker beacons

### DIFF
--- a/code/modules/mining/equipment/marker_beacons.dm
+++ b/code/modules/mining/equipment/marker_beacons.dm
@@ -124,8 +124,16 @@ GLOBAL_LIST_INIT(marker_beacon_colors, list(
 			M.add(1)
 			playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
 			qdel(src)
-	else
-		return ..()
+			return
+	if(istype(I, /obj/item/light_eater))
+		var/ash_type = /obj/effect/decal/cleanable/ash
+		var/obj/effect/decal/cleanable/ash/A = new ash_type(loc)
+		A.desc += "\nLooks like this used to be \an [name] some time ago."
+		visible_message("<span class='danger'>[src] is disintegrated by [I]!</span>")
+		playsound(src, 'sound/items/welder.ogg', 50, 1)
+		qdel(src)
+		return
+	return ..()
 
 /obj/structure/marker_beacon/AltClick(mob/living/user)
 	..()

--- a/code/modules/mining/equipment/marker_beacons.dm
+++ b/code/modules/mining/equipment/marker_beacons.dm
@@ -126,9 +126,8 @@ GLOBAL_LIST_INIT(marker_beacon_colors, list(
 			qdel(src)
 			return
 	if(istype(I, /obj/item/light_eater))
-		var/ash_type = /obj/effect/decal/cleanable/ash
-		var/obj/effect/decal/cleanable/ash/A = new ash_type(loc)
-		A.desc += "\nLooks like this used to be \an [name] some time ago."
+		var/obj/effect/decal/cleanable/ash/A = new /obj/effect/decal/cleanable/ash(drop_location())
+		A.desc += "\nLooks like this used to be \a [src] some time ago."
 		visible_message("<span class='danger'>[src] is disintegrated by [I]!</span>")
 		playsound(src, 'sound/items/welder.ogg', 50, 1)
 		qdel(src)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
fix: Marker beacons are now disintegrated by nightmares light eater
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
Fixes #40957 and #40601
Bring the marker beacons in line with other lights, destroying them in the first hit by light eater.