### PR TITLE
Removes some unneeded variable specification with circuitboard spawners

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -215,16 +215,15 @@
 				)
 
 // Tech storage circuit board spawners
-// For these, make sure that lootcount equals the number of list items
 
 /obj/effect/spawner/lootdrop/techstorage
 	name = "generic circuit board spawner"
 	lootdoubles = FALSE
 	fan_out_items = TRUE
+	lootcount = INFINITY
 
 /obj/effect/spawner/lootdrop/techstorage/service
 	name = "service circuit board spawner"
-	lootcount = 10
 	loot = list(
 				/obj/item/circuitboard/computer/arcade/battle,
 				/obj/item/circuitboard/computer/arcade/orion_trail,
@@ -240,7 +239,6 @@
 
 /obj/effect/spawner/lootdrop/techstorage/rnd
 	name = "RnD circuit board spawner"
-	lootcount = 12
 	loot = list(
 				/obj/item/circuitboard/computer/aifixer,
 				/obj/item/circuitboard/machine/rdserver,
@@ -258,7 +256,6 @@
 
 /obj/effect/spawner/lootdrop/techstorage/security
 	name = "security circuit board spawner"
-	lootcount = 3
 	loot = list(
 				/obj/item/circuitboard/computer/secure_data,
 				/obj/item/circuitboard/computer/security,
@@ -267,7 +264,6 @@
 
 /obj/effect/spawner/lootdrop/techstorage/engineering
 	name = "engineering circuit board spawner"
-	lootcount = 3
 	loot = list(
 				/obj/item/circuitboard/computer/atmos_alert,
 				/obj/item/circuitboard/computer/stationalert,
@@ -276,7 +272,6 @@
 
 /obj/effect/spawner/lootdrop/techstorage/tcomms
 	name = "tcomms circuit board spawner"
-	lootcount = 9
 	loot = list(
 				/obj/item/circuitboard/computer/message_monitor,
 				/obj/item/circuitboard/machine/telecomms/broadcaster,
@@ -291,7 +286,6 @@
 
 /obj/effect/spawner/lootdrop/techstorage/medical
 	name = "medical circuit board spawner"
-	lootcount = 9
 	loot = list(
 				/obj/item/circuitboard/computer/cloning,
 				/obj/item/circuitboard/machine/clonepod,
@@ -306,7 +300,6 @@
 
 /obj/effect/spawner/lootdrop/techstorage/AI
 	name = "secure AI circuit board spawner"
-	lootcount = 3
 	loot = list(
 				/obj/item/circuitboard/computer/aiupload,
 				/obj/item/circuitboard/computer/borgupload,
@@ -315,7 +308,6 @@
 
 /obj/effect/spawner/lootdrop/techstorage/command
 	name = "secure command circuit board spawner"
-	lootcount = 3
 	loot = list(
 				/obj/item/circuitboard/computer/crew,
 				/obj/item/circuitboard/computer/communications,
@@ -324,7 +316,6 @@
 
 /obj/effect/spawner/lootdrop/techstorage/RnD_secure
 	name = "secure RnD circuit board spawner"
-	lootcount = 3
 	loot = list(
 				/obj/item/circuitboard/computer/mecha_control,
 				/obj/item/circuitboard/computer/apc_control,


### PR DESCRIPTION
Code improvement, I spotted this, and it bugged me.

No need to count how many items there are, if you want to spawn them all. No infinite loop because lootdoubles = FALSE means that the loot list empties.