### PR TITLE
Bandaid for the TGS4 Linux trusted mode bug

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -1,7 +1,8 @@
 #define RESTART_COUNTER_PATH "data/round_counter.txt"
 
 GLOBAL_VAR(restart_counter)
-GLOBAL_VAR_INIT(bypass_tgs_reboot)
+//TODO: Replace INFINITY with the version that fixes http://www.byond.com/forum/?post=2407430
+GLOBAL_VAR_INIT(bypass_tgs_reboot, world.system_type == UNIX && world.byond_build < INFINITY)
 
 //This happens after the Master subsystem new(s) (it's a global datum)
 //So subsystems globals exist, but are not initialised
@@ -16,9 +17,6 @@ GLOBAL_VAR_INIT(bypass_tgs_reboot)
 	make_datum_references_lists()	//initialises global lists for referencing frequently used datums (so that we only ever do it once)
 
 	TgsNew(new /datum/tgs_event_handler/tg, minimum_required_security_level = TGS_SECURITY_TRUSTED)
-
-	//TODO: Replace INFINITY with the version that fixes http://www.byond.com/forum/?post=2407430
-	GLOB.bypass_tgs_reboot = world.system_type == UNIX && world.byond_build < INFINITY
 
 	GLOB.revdata = new
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -1,6 +1,7 @@
 #define RESTART_COUNTER_PATH "data/round_counter.txt"
 
 GLOBAL_VAR(restart_counter)
+GLOBAL_VAR_INIT(bypass_tgs_reboot)
 
 //This happens after the Master subsystem new(s) (it's a global datum)
 //So subsystems globals exist, but are not initialised
@@ -14,7 +15,10 @@ GLOBAL_VAR(restart_counter)
 
 	make_datum_references_lists()	//initialises global lists for referencing frequently used datums (so that we only ever do it once)
 
-	TgsNew(minimum_required_security_level = TGS_SECURITY_TRUSTED)
+	TgsNew(new /datum/tgs_event_handler/tg, minimum_required_security_level = TGS_SECURITY_TRUSTED)
+
+	//TODO: Replace INFINITY with the version that fixes http://www.byond.com/forum/?post=2407430
+	GLOB.bypass_tgs_reboot = world.system_type == UNIX && world.byond_build < INFINITY
 
 	GLOB.revdata = new
 
@@ -202,7 +206,8 @@ GLOBAL_VAR(restart_counter)
 		to_chat(world, "<span class='boldannounce'>Rebooting world...</span>")
 		Master.Shutdown()	//run SS shutdowns
 	
-	TgsReboot()
+	if(!GLOB.bypass_tgs_reboot)
+		TgsReboot()
 
 	if(TEST_RUN_PARAMETER in params)
 		FinishTestRun()

--- a/code/modules/tgs/event_handler.dm
+++ b/code/modules/tgs/event_handler.dm
@@ -1,0 +1,4 @@
+/datum/tgs_event_handler/tg/HandleEvent(event_code, ...)
+    switch(event_code)
+        if(TGS_EVENT_COMPILE_COMPLETE)
+            GLOB.bypass_tgs_reboot = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2640,6 +2640,7 @@
 #include "code\modules\surgery\organs\tails.dm"
 #include "code\modules\surgery\organs\tongue.dm"
 #include "code\modules\surgery\organs\vocal_cords.dm"
+#include "code\modules\tgs\event_handler.dm"
 #include "code\modules\tgs\includes.dm"
 #include "code\modules\tgui\external.dm"
 #include "code\modules\tgui\states.dm"


### PR DESCRIPTION
Simple skip calling `TgsReboot()` if there is no reason to (no new deployment)

This will cause issues if TGS decides there is another reason to reboot the world (like if DD settings change, or the message that a deployment finished isn't received). It can be overridden by VVing the GLOB var, using the "Service Restart" admin command, or the `ROUNDS_UNTIL_HARD_RESTART` config option

Workaround for https://github.com/tgstation/tgstation-server/issues/798