### PR TITLE
Fixes a rare case where the Malf law zero could be purged

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -419,17 +419,20 @@
 		to_chat(who,law)
 
 /datum/ai_laws/proc/clear_zeroth_law(force) //only removes zeroth from antag ai if force is 1
-	if(force)
+if(force)
 		zeroth = null
 		zeroth_borg = null
 		return
-	else
-		if(owner && owner.mind && owner.mind.special_role)
+	if(owner && owner.mind && owner.mind.special_role)
+		return
+	if (istype(owner, /mob/living/silicon/ai))
+		var/mob/living/silicon/ai/A=owner
+		if(A && A.deployed_shell && A.deployed_shell.mind && A.deployed_shell.mind.special_role)
+			message_admins("DEBUG ============ AI's shell is speical too")
 			return
-		else
-			zeroth = null
-			zeroth_borg = null
-			return
+	zeroth = null
+	zeroth_borg = null
+	return
 
 /datum/ai_laws/proc/clear_law_sixsixsix(force)
 	if(force || !is_devil(owner))

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -423,7 +423,7 @@
 		zeroth = null
 		zeroth_borg = null
 		return
-	if(owner && owner.mind && owner.mind.special_role)
+	if(owner?.mind?.special_role)
 		return
 	if (istype(owner, /mob/living/silicon/ai))
 		var/mob/living/silicon/ai/A=owner

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -428,7 +428,6 @@
 	if (istype(owner, /mob/living/silicon/ai))
 		var/mob/living/silicon/ai/A=owner
 		if(A && A.deployed_shell && A.deployed_shell.mind && A.deployed_shell.mind.special_role)
-			message_admins("DEBUG ============ AI's shell is speical too")
 			return
 	zeroth = null
 	zeroth_borg = null

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -419,7 +419,7 @@
 		to_chat(who,law)
 
 /datum/ai_laws/proc/clear_zeroth_law(force) //only removes zeroth from antag ai if force is 1
-if(force)
+	if(force)
 		zeroth = null
 		zeroth_borg = null
 		return

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -427,7 +427,7 @@
 		return
 	if (istype(owner, /mob/living/silicon/ai))
 		var/mob/living/silicon/ai/A=owner
-		if(A && A.deployed_shell && A.deployed_shell.mind && A.deployed_shell.mind.special_role)
+		if(A?.deployed_shell?.mind?.special_role)
 			return
 	zeroth = null
 	zeroth_borg = null

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -431,7 +431,6 @@
 			return
 	zeroth = null
 	zeroth_borg = null
-	return
 
 /datum/ai_laws/proc/clear_law_sixsixsix(force)
 	if(force || !is_devil(owner))


### PR DESCRIPTION
:cl: Zxaber
fix: It is no longer possible to purge a malfunctioning AI's Law zero if the AI is currently using a shell.
/:cl:

Fixes #41625

Issue was caused by the purge code being unable to reach the mind of an AI currently using a shell (since using a shell moves the player out of the core and into said shell), which caused it to skip to the AI not having antag status. This change adds a second check that will catch Malf AIs using shells. I also removed the else statements, since the returns will already stop execution of the function.