### PR TITLE
Reverts "hotspot_expose() will now heat the turf's air if it fails to create a hotspot"

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -42,11 +42,6 @@
 		active_hotspot.just_spawned = (current_cycle < SSair.times_fired)
 			//remove just_spawned protection if no longer processing this cell
 		SSair.add_to_active(src, 0)
-	else
-		var/datum/gas_mixture/heating = air_contents.remove_ratio(exposed_volume/air_contents.volume)
-		heating.temperature = exposed_temperature
-		heating.react()
-		assume_air(heating)
 	return igniting
 
 //This is the icon for fire on turfs, also helps for nurturing small fires until they are full tile


### PR DESCRIPTION
So far, this change has caused constant issues while having practically zero gameplay impact.

This is especially bad with sparks, which are easily spammable cosmetic effects. With this change, they are stuck in one of two states:

A) High temperature: They ignite plasma, but quickly heat up rooms until they are uninhabitable and kill players.
B) Low temperature: They no longer have the issue of killing people, but don't properly ignite plasma. For example, this messes with the malf AI overload ability, holo deck plasma flood and toxins igniters.

These issues keep appearing, even after four merged PRs that attempted to fix them. 

If you compare the downsides (broken overload/holodeck flood/toxins igniters) with the potential benefits (tools heat up air by miniscule amounts and bonfires might eventually kill people), it is clear to me that the game is better off without this feature.

