### PR TITLE
Adds access requirement to cargo direct purchases

### DIFF
--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -180,6 +180,11 @@
 				if(!istype(account))
 					say("Invalid bank account.")
 					return
+				var/required_access = pack.get_access()
+				var/list/useraccess = H.wear_id.GetAccess()
+				if(required_access && !(required_access in useraccess))
+					say("Your ID does not have the required access.")
+					return
 
 			var/reason = ""
 			if(requestonly && !self_paid)

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -180,9 +180,8 @@
 				if(!istype(account))
 					say("Invalid bank account.")
 					return
-				var/required_access = pack.get_access()
 				var/list/useraccess = H.wear_id.GetAccess()
-				if(required_access && !(required_access in useraccess))
+				if(pack.access && !(pack.access in useraccess))
 					say("Your ID does not have the required access.")
 					return
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -41,6 +41,9 @@
 		for(var/item in contains)
 			new item(C)
 
+/datum/supply_pack/proc/get_access()
+	return access
+
 // If you add something to this list, please group it by type and sort it alphabetically instead of just jamming it in like an animal
 
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -41,9 +41,6 @@
 		for(var/item in contains)
 			new item(C)
 
-/datum/supply_pack/proc/get_access()
-	return access
-
 // If you add something to this list, please group it by type and sort it alphabetically instead of just jamming it in like an animal
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
tweak: Buying crates from cargo with your own money now requires you to have access to open said crate.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

There is currently a trend of the RD rushing to cargo to buy a few armories worth of gear on the research budget a few minutes into the round. This change makes the RD have to ask the relevant people before buying his epic gamer gear. Also assistants can't just order crates of combat shotguns.

To be specific, this will only let you buy a crate if the ID you are buying it with has the required access to open said crate.