### PR TITLE
Adds minimum to space pirate payoff event

### DIFF
--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -17,6 +17,7 @@
 	startWhen = 60 //2 minutes to answer
 	var/datum/comm_message/threat
 	var/payoff = 0
+	var/payoff_min = 20000
 	var/paid_off = FALSE
 	var/ship_name = "Space Privateers Association"
 	var/shuttle_spawned = FALSE
@@ -31,7 +32,7 @@
 	threat = new
 	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	if(D)
-		payoff = round(D.account_balance * 0.80)
+		payoff = D.account_balance < payoff_min ? payoff_min : round(D.account_balance * 0.80)
 	threat.title = "Business proposition"
 	threat.content = "This is [ship_name]. Pay up [payoff] credits or you'll walk the plank."
 	threat.possible_answers = list("We'll pay.","No way.")

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -32,7 +32,7 @@
 	threat = new
 	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	if(D)
-		payoff = D.account_balance < payoff_min ? payoff_min : round(D.account_balance * 0.80)
+		payoff = D.account_balance < payoff_min ? payoff_min : floor(D.account_balance * 0.80, 1000)
 	threat.title = "Business proposition"
 	threat.content = "This is [ship_name]. Pay up [payoff] credits or you'll walk the plank."
 	threat.possible_answers = list("We'll pay.","No way.")

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -32,7 +32,7 @@
 	threat = new
 	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	if(D)
-		payoff = D.account_balance < payoff_min ? payoff_min : FLOOR(D.account_balance * 0.80, 1000)
+		payoff = max(payoff_min, FLOOR(D.account_balance * 0.80, 1000))
 	threat.title = "Business proposition"
 	threat.content = "This is [ship_name]. Pay up [payoff] credits or you'll walk the plank."
 	threat.possible_answers = list("We'll pay.","No way.")

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -32,7 +32,7 @@
 	threat = new
 	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	if(D)
-		payoff = D.account_balance < payoff_min ? payoff_min : floor(D.account_balance * 0.80, 1000)
+		payoff = D.account_balance < payoff_min ? payoff_min : FLOOR(D.account_balance * 0.80, 1000)
 	threat.title = "Business proposition"
 	threat.content = "This is [ship_name]. Pay up [payoff] credits or you'll walk the plank."
 	threat.possible_answers = list("We'll pay.","No way.")


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
tweak: The space pirates will no longer ask for pocket change.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

The space pirates event can currently ask for a very low amounts of credits, which will almost always lead to them being paid off by the crew. There is no lower limitation, so when cargo buys guns for all the cash you get offers like 4 credits or you'll walk the plank. This sets it to 20 000 credits. 

Feedback on the minimum amount appreciated.