### PR TITLE
Fixes Aiming Beam/Reflect Blob Interaction

### DIFF
--- a/code/modules/antagonists/blob/blob/blobs/shield.dm
+++ b/code/modules/antagonists/blob/blob/blobs/shield.dm
@@ -45,6 +45,8 @@
 	explosion_block = 2
 
 /obj/structure/blob/shield/reflective/handle_ricochet(obj/item/projectile/P)
+	if(istype(P,/obj/item/projectile/beam/beam_rifle/hitscan/aiming_beam))
+		return
 	var/turf/p_turf = get_turf(P)
 	var/face_direction = get_dir(src, p_turf)
 	var/face_angle = dir2angle(face_direction)

--- a/code/modules/antagonists/blob/blob/blobs/shield.dm
+++ b/code/modules/antagonists/blob/blob/blobs/shield.dm
@@ -46,7 +46,7 @@
 
 /obj/structure/blob/shield/reflective/handle_ricochet(obj/item/projectile/P)
 	if(istype(P,/obj/item/projectile/beam/beam_rifle/hitscan/aiming_beam))
-		return
+		return FALSE
 	var/turf/p_turf = get_turf(P)
 	var/face_direction = get_dir(src, p_turf)
 	var/face_angle = dir2angle(face_direction)


### PR DESCRIPTION
Only you can prevent chat spam!

FYI because the aiming beam is a projectile type the reflector blob spams "the aiming beam reflects off the blob"