### PR TITLE
Fixes grenades not adjusting their detonation timer when attacked by a screwdriver

### DIFF
--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -89,16 +89,16 @@
 /obj/item/grenade/attackby(obj/item/W, mob/user, params)
 	if(W.tool_behaviour == TOOL_SCREWDRIVER)
 		switch(det_time)
-			if ("1")
+			if (1)
 				det_time = 10
 				to_chat(user, "<span class='notice'>You set the [name] for 1 second detonation time.</span>")
-			if ("10")
+			if (10)
 				det_time = 30
 				to_chat(user, "<span class='notice'>You set the [name] for 3 second detonation time.</span>")
-			if ("30")
+			if (30)
 				det_time = 50
 				to_chat(user, "<span class='notice'>You set the [name] for 5 second detonation time.</span>")
-			if ("50")
+			if (50)
 				det_time = 1
 				to_chat(user, "<span class='notice'>You set the [name] for instant detonation.</span>")
 		add_fingerprint(user)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: TheDracheX
fix: Fixes grenades not changing their detonation timer when attacked by a screwdriver.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

As far as I can tell this has been broken for 6-ish years. `chem_grenade.dm` already implements its own `attackby` to change detonation time. This fix would enable all other grenades that do not implement their own `attackby` to have timers based on 1, 3, 5 seconds and instant detonation.

![itwerks](https://user-images.githubusercontent.com/5410619/49002901-6c21b600-f126-11e8-8e39-8c13771f6a15.PNG)
