### PR TITLE
AI upgrade logging/hints

### DIFF
--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -4,7 +4,7 @@
 //Malf Picker
 /obj/item/malf_upgrade
 	name = "combat software upgrade"
-	desc = "A highly illegal, highly dangerous upgrade for artificial intelligence units, granting them a variety of powers as well as the ability to hack APCs.<br> This upgrade is certified malfunction-free and must be applied directly to an active AI core."
+	desc = "A highly illegal, highly dangerous upgrade for artificial intelligence units, granting them a variety of powers as well as the ability to hack APCs.<br> This upgrade does not override any active laws, and must be applied directly to an active AI core."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "datadisk3"
 

--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -4,7 +4,8 @@
 //Malf Picker
 /obj/item/malf_upgrade
 	name = "combat software upgrade"
-	desc = "A highly illegal, highly dangerous upgrade for artificial intelligence units, granting them a variety of powers as well as the ability to hack APCs."
+	desc = "A highly illegal, highly dangerous upgrade for artificial intelligence units, granting them a variety of powers as well as the ability to hack APCs. <br>
+			This upgrade is certified malfunction-free and must be applied directly to an active AI core."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "datadisk3"
 
@@ -18,7 +19,10 @@
 		to_chat(AI, "<span class='userdanger'>[user] has attempted to upgrade you with combat software that you already possess. You gain 50 points to spend on Malfunction Modules instead.</span>")
 	else
 		to_chat(AI, "<span class='userdanger'>[user] has upgraded you with combat software!</span>")
+		to_chat(AI, "<span class='userdanger'>Your current laws and objectives remain unchanged.</span>") //this unlocks malf powers, but does not give the license to plasma flood
 		AI.add_malf_picker()
+		log_game("[key_name(user)] has upgraded [key_name(AI)] with a [src].")
+		message_admins("[ADMIN_LOOKUPFLW(user)] has upgraded [ADMIN_LOOKUPFLW(AI)] with a [src].")
 	to_chat(user, "<span class='notice'>You upgrade [AI]. [src] is consumed in the process.</span>")
 	qdel(src)
 
@@ -26,7 +30,7 @@
 //Lipreading
 /obj/item/surveillance_upgrade
 	name = "surveillance software upgrade"
-	desc = "A software package that will allow an artificial intelligence to 'hear' from its cameras via lip reading."
+	desc = "An illegal software package that will allow an artificial intelligence to 'hear' from its cameras via lip reading and hidden microphones."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "datadisk3"
 
@@ -39,4 +43,6 @@
 		to_chat(AI, "<span class='userdanger'>[user] has upgraded you with surveillance software!</span>")
 		to_chat(AI, "Via a combination of hidden microphones and lip reading software, you are able to use your cameras to listen in on conversations.")
 	to_chat(user, "<span class='notice'>You upgrade [AI]. [src] is consumed in the process.</span>")
+	log_game("[key_name(user)] has upgraded [key_name(AI)] with a [src].")
+	message_admins("[ADMIN_LOOKUPFLW(user)] has upgraded [ADMIN_LOOKUPFLW(AI)] with a [src].")
 	qdel(src)

--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -4,7 +4,7 @@
 //Malf Picker
 /obj/item/malf_upgrade
 	name = "combat software upgrade"
-	desc = "A highly illegal, highly dangerous upgrade for artificial intelligence units, granting them a variety of powers as well as the ability to hack APCs.<br> This upgrade does not override any active laws, and must be applied directly to an active AI core."
+	desc = "A highly illegal, highly dangerous upgrade for artificial intelligence units, granting them a variety of powers as well as the ability to hack APCs.<br>This upgrade does not override any active laws, and must be applied directly to an active AI core."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "datadisk3"
 

--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -4,8 +4,7 @@
 //Malf Picker
 /obj/item/malf_upgrade
 	name = "combat software upgrade"
-	desc = "A highly illegal, highly dangerous upgrade for artificial intelligence units, granting them a variety of powers as well as the ability to hack APCs. <br>
-			This upgrade is certified malfunction-free and must be applied directly to an active AI core."
+	desc = "A highly illegal, highly dangerous upgrade for artificial intelligence units, granting them a variety of powers as well as the ability to hack APCs.<br> This upgrade is certified malfunction-free and must be applied directly to an active AI core."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "datadisk3"
 


### PR DESCRIPTION
:cl: Denton
tweak: AIs that get upgraded with a combat software upgrade now see a reminder that this doesn't change their laws or antagonist status.
admin: Added logging and an admin follow message to AI combat/surveillance software upgrades.
/:cl:

I've heard complaints about the AI combat upgrade: 
1) No logging
2) Players assume that this makes them an antag and start plasma flooding, which in return makes admins drink when they have to deal with this
3) Players don't know how to upgrade their harmyeller

This PR adds logging plus an admin alert to both upgrades, displays a little "hey, this upgrade doesn't make you an antag" hint and lets players know how to install the upgrade.