### PR TITLE
Low grade clone pods can leave people with brain traumas

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -176,10 +176,13 @@
 		H.dna.remove_mutation_group(unclean_mutations)
 	if(efficiency > 5 && prob(20))
 		H.randmutvg()
-	if(efficiency < 3 && prob(50))
-		var/mob/M = H.randmutb()
-		if(ismob(M))
-			H = M
+	if(efficiency < 3)
+		if(prob(50))
+			H.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_BASIC)
+		if(prob(50))
+			var/mob/M = H.randmutb()
+			if(ismob(M))
+				H = M
 
 	H.silent = 20 //Prevents an extreme edge case where clones could speak if they said something at exactly the right moment.
 	occupant = H


### PR DESCRIPTION
:cl: coiax
add: Sometimes a low level cloning pod will make errors in replicating your brain,
leaving you with a mild brain trauma.
/:cl:

Same threshold as negative mutations, (efficiency < 3), same chance (50%).

It's the easiest level to cure, just requiring neurine, which can be made
from mannitol.

Why? Because people came out brain damaged, but that never translated
into "real" traumas anymore. Now people can come out dumb like they used to.
Or afraid of cats.