### PR TITLE
[review would be kinda sweet] reduces the maximum capacity of small oxygen tanks, while retaining their base volume.

### DIFF
--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -169,21 +169,21 @@
 	w_class = WEIGHT_CLASS_SMALL
 	force = 4
 	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
-	volume = 3 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
+	volume = 1 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
 
 
 /obj/item/tank/internals/emergency_oxygen/New()
 	..()
 	air_contents.assert_gas(/datum/gas/oxygen)
-	air_contents.gases[/datum/gas/oxygen][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
+	air_contents.gases[/datum/gas/oxygen][MOLES] = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
 /obj/item/tank/internals/emergency_oxygen/engi
 	name = "extended-capacity emergency oxygen tank"
 	icon_state = "emergency_engi"
-	volume = 6
+	volume = 2 // should last a bit over 30 minutes if full
 
 /obj/item/tank/internals/emergency_oxygen/double
 	name = "double emergency oxygen tank"
 	icon_state = "emergency_double"
-	volume = 10
+	volume = 8


### PR DESCRIPTION
:cl:
tweak: Nanotrasen has saved materials on emergency oxygen tanks by decreasing the size of the tanks while increasing the pressure- they still hold the same amount of oxygen, but it'll be hard to fit more in.
/:cl:
why: It bothers me that one oxygen canister can make an emergency tank last the whole round, and any role with access to them like miner or engineer just does it as busywork. now oxygen tanks are a third the size, but carry the same amount of gas overall. A small emergency tank will still last for _around 16 minutes,_ so this isn't anything to be worried about. This gives reason to use large sized oxygen tanks for things besides internal jetpacks as well-miners can definitely use those, as their suits can store them. or roles could just carry spare tanks or refill every 30 minutes. If more oxygen is absolutely essential, you can also cram much more oxygen into a tank by using pumps. I think this change is for the better, and might also give slight advantage to chems like salbutamol, and the upgraded lungs science can produce.