### PR TITLE
Blacklists tesla miniballs from the tesla bounty

### DIFF
--- a/code/modules/cargo/bounties/engineering.dm
+++ b/code/modules/cargo/bounties/engineering.dm
@@ -29,3 +29,9 @@
 	description = "Station 24 is being overrun by hordes of angry Mothpeople. They are requesting the ultimate bug zapper."
 	reward = 75000 //requires 14k credits of purchases, not to mention cooperation with engineering/heads of staff to set up inside the cramped shuttle
 	wanted_types = list(/obj/singularity/energy_ball)
+
+/datum/bounty/item/engineering/energy_ball/applies_to(obj/O)
+	if(!..())
+		return FALSE
+	var/obj/singularity/energy_ball/T = O
+	return !T.miniball


### PR DESCRIPTION
:cl:
fix: Fixed an issue that could cause a tesla ball submitted for the tesla ball bounty to not be deleted
/:cl:

This is necessary or the bounty can claim and qdel one of the miniballs orbiting the tesla instead of the tesla itself.