### PR TITLE
Adds multitool examine message for clone pods

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -76,6 +76,7 @@
 
 /obj/machinery/clonepod/examine(mob/user)
 	..()
+	to_chat(user, "<span class='notice'>The <i>linking</i> device can be <i>scanned<i> with a multitool.</span>")
 	if(in_range(user, src) || isobserver(user))
 		to_chat(user, "<span class='notice'>The status display reads: Cloning speed at <b>[speed_coeff*50]%</b>.<br>Predicted amount of cellular damage: <b>[100-heal_level]%</b>.<span>")
 		if(efficiency > 5)


### PR DESCRIPTION
:cl: Denton
spellcheck: Added an examine message to clone pods which shows that you can link them via multitool.
/:cl:

Just copy pasted this message so that players can actually find out how to link clone pods to cloning computers.
