### PR TITLE
Open storage by alt clicking

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -732,16 +732,30 @@
 	return hide_from(target)
 
 /datum/component/storage/proc/on_alt_click(datum/source, mob/user)
-	if(!isliving(user) || user.incapacitated() || !quickdraw || locked || !user.CanReach(parent))
+	if(!isliving(user) || !user.CanReach(parent))
 		return
-	var/obj/item/I = locate() in real_location()
-	if(!I)
+	if(locked)
+		to_chat(user, "<span class='warning'>[parent] seems to be locked!</span>")
 		return
-	remove_from_storage(I, get_turf(user))
-	if(!user.put_in_hands(I))
-		to_chat(user, "<span class='notice'>You fumble for [I] and it falls on the floor.</span>")
+
+	var/atom/A = parent
+	if(!quickdraw)
+		A.add_fingerprint(user)
+		user_show_to_mob(user)
+		playsound(A, "rustle", 50, 1, -5)
 		return
-	user.visible_message("<span class='warning'>[user] draws [I] from [parent]!</span>", "<span class='notice'>You draw [I] from [parent].</span>")
+
+	if(!user.incapacitated())
+		var/obj/item/I = locate() in real_location()
+		if(!I)
+			return
+		A.add_fingerprint(user)
+		remove_from_storage(I, get_turf(user))
+		if(!user.put_in_hands(I))
+			to_chat(user, "<span class='notice'>You fumble for [I] and it falls on the floor.</span>")
+			return
+		user.visible_message("<span class='warning'>[user] draws [I] from [parent]!</span>", "<span class='notice'>You draw [I] from [parent].</span>")
+		return
 
 /datum/component/storage/proc/action_trigger(datum/signal_source, datum/action/source)
 	gather_mode_switch(source.owner)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
add: You can now alt click storage (bags, boxes, etc) to open it.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
Provides an alternative to click-dragging. 

The on_alt_click() proc wasn't ever used, but seemed to be ready for replacing the AltClick() overload from sabre sheath. I kept that part and added fingerprints to it as well, and it is still good to go (if it really was) whenever someone bothers.