### PR TITLE
Adds sound to all whetstones

### DIFF
--- a/code/game/objects/items/sharpener.dm
+++ b/code/game/objects/items/sharpener.dm
@@ -40,6 +40,7 @@
 		to_chat(user, "<span class='warning'>[I] has already been refined before. It cannot be sharpened further!</span>")
 		return
 	user.visible_message("<span class='notice'>[user] sharpens [I] with [src]!</span>", "<span class='notice'>You sharpen [I], making it much more deadly than before.</span>")
+	playsound(get_turf(src), 'sound/items/unsheath.ogg', 25, 1)
 	I.sharpness = IS_SHARP_ACCURATE
 	I.force = CLAMP(I.force + increment, 0, max)
 	I.throwforce = CLAMP(I.throwforce + increment, 0, max)

--- a/code/game/objects/items/sharpener.dm
+++ b/code/game/objects/items/sharpener.dm
@@ -40,7 +40,7 @@
 		to_chat(user, "<span class='warning'>[I] has already been refined before. It cannot be sharpened further!</span>")
 		return
 	user.visible_message("<span class='notice'>[user] sharpens [I] with [src]!</span>", "<span class='notice'>You sharpen [I], making it much more deadly than before.</span>")
-	playsound(get_turf(src), 'sound/items/unsheath.ogg', 25, 1)
+	playsound(src, 'sound/items/unsheath.ogg', 25, 1)
 	I.sharpness = IS_SHARP_ACCURATE
 	I.force = CLAMP(I.force + increment, 0, max)
 	I.throwforce = CLAMP(I.throwforce + increment, 0, max)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -362,10 +362,7 @@
 	prefix = "darkened"
 
 /obj/item/sharpener/cult/update_icon()
-	var/old_state = icon_state
 	icon_state = "cult_sharpener[used ? "_used" : ""]"
-	if(old_state != icon_state)
-		playsound(get_turf(src), 'sound/items/unsheath.ogg', 25, 1)
 
 /obj/item/clothing/suit/hooded/cultrobes/cult_shield
 	name = "empowered cultist armor"


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
add: Kitchen whetstones now have a sound when used.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
Cult sharpeners already had this sound, moved it to the parent so we can enjoy it on all of them instead.