### PR TITLE
Alien infestation event not limited to once per round, but will not fire while existing aliens are alive

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -4,7 +4,15 @@
 	weight = 5
 
 	min_players = 10
-	max_occurrences = 1
+
+/datum/round_event_control/alien_infestation/canSpawnEvent()
+	. = ..()
+	if(!.)
+		return .
+
+	for(var/mob/living/carbon/alien/A in GLOB.player_list)
+		if(A.stat != DEAD)
+			return FALSE
 
 /datum/round_event/ghost_role/alien_infestation
 	announceWhen	= 400
@@ -14,7 +22,6 @@
 
 	// 50% chance of being incremented by one
 	var/spawncount = 1
-	var/successSpawn = 0	//So we don't make a command report if nothing gets spawned.
 	fakeable = TRUE
 
 
@@ -23,15 +30,13 @@
 	if(prob(50))
 		spawncount++
 
-/datum/round_event/ghost_role/alien_infestation/kill()
-	if(!successSpawn && control)
-		// This never happened, so let's not deny the future of this round
-		// some xenolovin
-		control.occurrences--
-	return ..()
-
 /datum/round_event/ghost_role/alien_infestation/announce(fake)
-	if(successSpawn || fake)
+	var/living_aliens = FALSE
+	for(var/mob/living/carbon/alien/A in GLOB.player_list)
+		if(A.stat != DEAD)
+			living_aliens = TRUE
+
+	if(living_aliens || fake)
 		priority_announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", 'sound/ai/aliens.ogg')
 
 
@@ -64,13 +69,8 @@
 		new_xeno.key = C.key
 
 		spawncount--
-		successSpawn = TRUE
 		message_admins("[ADMIN_LOOKUPFLW(new_xeno)] has been made into an alien by an event.")
 		log_game("[key_name(new_xeno)] was spawned as an alien by an event.")
 		spawned_mobs += new_xeno
 
-	if(successSpawn)
-		return SUCCESSFUL_SPAWN
-	else
-		// Like how did we get here?
-		return FALSE
+	return SUCCESSFUL_SPAWN


### PR DESCRIPTION
:cl: coiax
tweak: Alien infestations are not limited to once per round only, but will never
happen while existing aliens are alive.
/:cl:

Essentially, it's really disheartening when a larva is spawned, and it dies quickly
because the player makes a mistake or is unlucky. So, aliens MAY happen again, but
it's still a weight 5 event, so don't get your hopes up.