### PR TITLE
Removes pre-scanning

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -79,7 +79,7 @@
 	if(in_range(user, src) || isobserver(user))
 		to_chat(user, "<span class='notice'>The status display reads: Cloning speed at <b>[speed_coeff*50]%</b>.<br>Predicted amount of cellular damage: <b>[100-heal_level]%</b>.<span>")
 		if(efficiency > 5)
-			to_chat(user, "<span class='notice'>Pod has been upgraded to support autoprocessing and apply beneficial mutations.<span>")
+			to_chat(user, "<span class='notice'>Pod has been upgraded to apply beneficial mutations.<span>")
 
 //The return of data disks?? Just for transferring between genetics machine/cloning machine.
 //TO-DO: Make the genetics machine accept them.

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -15,7 +15,6 @@
 	var/menu = 1 //Which menu screen to display
 	var/datum/data/record/active_record = null
 	var/loading = 0 // Nice loading text
-	var/autoprocess = 0
 
 	light_color = LIGHT_COLOR_BLUE
 
@@ -60,10 +59,6 @@
 	src.scanner = findscanner()
 	if(findfirstcloner && !LAZYLEN(pods))
 		findcloner()
-	if(!autoprocess)
-		STOP_PROCESSING(SSmachines, src)
-	else
-		START_PROCESSING(SSmachines, src)
 
 /obj/machinery/computer/cloning/proc/findscanner()
 	var/obj/machinery/dna_scannernew/scannerf = null

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -6,13 +6,11 @@
 	icon_screen = "dna"
 	icon_keyboard = "med_key"
 	circuit = /obj/item/circuitboard/computer/cloning
-	req_access = list(ACCESS_HEADS) //ONLY USED FOR RECORD DELETION RIGHT NOW.
 	var/obj/machinery/dna_scannernew/scanner = null //Linked scanner. For scanning.
 	var/list/pods //Linked cloning pods
 	var/temp = "Inactive"
 	var/scantemp_ckey
 	var/scantemp = "Ready to Scan"
-	var/menu = 1 //Which menu screen to display
 	var/datum/data/record/active_record = null
 	var/loading = 0 // Nice loading text
 
@@ -128,40 +126,38 @@
 	dat += "<h3>Cloning Pod Status</h3>"
 	dat += "<div class='statusDisplay'>[temp]&nbsp;</div>"
 
-	switch(src.menu)
-		if(1)
-			// Modules
-			if (isnull(src.scanner) || !LAZYLEN(pods))
-				dat += "<h3>Modules</h3>"
-				//dat += "<a href='byond://?src=[REF(src)];relmodules=1'>Reload Modules</a>"
-				if (isnull(src.scanner))
-					dat += "<font class='bad'>ERROR: No Scanner detected!</font><br>"
-				if (!LAZYLEN(pods))
-					dat += "<font class='bad'>ERROR: No Pod detected</font><br>"
+	// Modules
+	if (isnull(src.scanner) || !LAZYLEN(pods))
+		dat += "<h3>Modules</h3>"
+		//dat += "<a href='byond://?src=[REF(src)];relmodules=1'>Reload Modules</a>"
+		if (isnull(src.scanner))
+			dat += "<font class='bad'>ERROR: No Scanner detected!</font><br>"
+		if (!LAZYLEN(pods))
+			dat += "<font class='bad'>ERROR: No Pod detected</font><br>"
 
-			// Scanner
-			if (!isnull(src.scanner))
-				var/mob/living/scanner_occupant = get_mob_or_brainmob(scanner.occupant)
+	// Scanner
+	if (!isnull(src.scanner))
+		var/mob/living/scanner_occupant = get_mob_or_brainmob(scanner.occupant)
 
-				dat += "<h3>Scanner Functions</h3>"
+		dat += "<h3>Scanner Functions</h3>"
 
-				dat += "<div class='statusDisplay'>"
-				if(!scanner_occupant)
-					dat += "Scanner Unoccupied"
-				else if(loading)
-					dat += "[scanner_occupant] => Scanning..."
-				else
-					if(scanner_occupant.ckey != scantemp_ckey)
-						scantemp = "Ready to Scan"
-						scantemp_ckey = scanner_occupant.ckey
-					dat += "[scanner_occupant] => [scantemp]"
-				dat += "</div>"
+		dat += "<div class='statusDisplay'>"
+		if(!scanner_occupant)
+			dat += "Scanner Unoccupied"
+		else if(loading)
+			dat += "[scanner_occupant] => Scanning..."
+		else
+			if(scanner_occupant.ckey != scantemp_ckey)
+				scantemp = "Ready to Scan"
+				scantemp_ckey = scanner_occupant.ckey
+			dat += "[scanner_occupant] => [scantemp]"
+		dat += "</div>"
 
-				if(scanner_occupant)
-					dat += "<a href='byond://?src=[REF(src)];scan=1'>Start Scan</a>"
-					dat += "<br><a href='byond://?src=[REF(src)];lock=1'>[src.scanner.locked ? "Unlock Scanner" : "Lock Scanner"]</a>"
-				else
-					dat += "<span class='linkOff'>Start Scan</span>"
+		if(scanner_occupant)
+			dat += "<a href='byond://?src=[REF(src)];scan=1'>Start Scan</a>"
+			dat += "<br><a href='byond://?src=[REF(src)];lock=1'>[src.scanner.locked ? "Unlock Scanner" : "Lock Scanner"]</a>"
+		else
+			dat += "<span class='linkOff'>Start Scan</span>"
 
 
 	var/datum/browser/popup = new(user, "cloning", "Cloning System Control")
@@ -205,10 +201,6 @@
 		src.updateUsrDialog()
 		playsound(src, "terminal_type", 25, 0)
 
-
-	if (href_list["menu"])
-		src.menu = text2num(href_list["menu"])
-		playsound(src, "terminal_type", 25, 0)
 
 	src.add_fingerprint(usr)
 	src.updateUsrDialog()
@@ -286,7 +278,6 @@
 	else if(pod.growclone(mob_occupant.ckey, mob_occupant.real_name, dna.uni_identity, dna.struc_enzymes, mind, mrace, dna.features, mob_occupant.faction, quirks, has_bank_account))
 		temp = "[mob_occupant.real_name] => <font class='good'>Cloning cycle in progress...</font>"
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
-		menu = 1
 	else
 		temp = "[mob_occupant.real_name] => <font class='bad'>Initialisation failure.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -13,9 +13,7 @@
 	var/scantemp_ckey
 	var/scantemp = "Ready to Scan"
 	var/menu = 1 //Which menu screen to display
-	var/list/records = list()
 	var/datum/data/record/active_record = null
-	var/obj/item/disk/data/diskette = null //Mostly so the geneticist can steal everything.
 	var/loading = 0 // Nice loading text
 	var/autoprocess = 0
 
@@ -57,25 +55,6 @@
 			else if(!. && pod.is_operational() && !(pod.occupant || pod.mess) && pod.efficiency > 5)
 				. = pod
 
-/obj/machinery/computer/cloning/process()
-	if(!(scanner && LAZYLEN(pods) && autoprocess))
-		return
-
-	if(scanner.occupant && scanner.scan_level > 2)
-		scan_occupant(scanner.occupant)
-
-	for(var/datum/data/record/R in records)
-		var/obj/machinery/clonepod/pod = GetAvailableEfficientPod(R.fields["mind"])
-
-		if(!pod)
-			return
-
-		if(pod.occupant)
-			continue	//how though?
-
-		if(pod.growclone(R.fields["ckey"], R.fields["name"], R.fields["UI"], R.fields["SE"], R.fields["mind"], R.fields["mrace"], R.fields["features"], R.fields["factions"], R.fields["quirks"], R.fields["bank_account"]))
-			temp = "[R.fields["name"]] => <font class='good'>Cloning cycle in progress...</font>"
-			records -= R
 
 /obj/machinery/computer/cloning/proc/updatemodules(findfirstcloner)
 	src.scanner = findscanner()
@@ -121,15 +100,7 @@
 	LAZYREMOVE(pods, pod)
 
 /obj/machinery/computer/cloning/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/disk/data)) //INSERT SOME DISKETTES
-		if (!src.diskette)
-			if (!user.transferItemToLoc(W,src))
-				return
-			src.diskette = W
-			to_chat(user, "<span class='notice'>You insert [W].</span>")
-			playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
-			src.updateUsrDialog()
-	else if(W.tool_behaviour == TOOL_MULTITOOL)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
 		if(!multitool_check_buffer(user, W))
 			return
 		var/obj/item/multitool/P = W
@@ -159,13 +130,6 @@
 	var/dat = ""
 	dat += "<a href='byond://?src=[REF(src)];refresh=1'>Refresh</a>"
 
-	if(scanner && HasEfficientPod() && scanner.scan_level >= AUTOCLONING_MINIMAL_LEVEL)
-		if(!autoprocess)
-			dat += "<a href='byond://?src=[REF(src)];task=autoprocess'>Autoprocess</a>"
-		else
-			dat += "<a href='byond://?src=[REF(src)];task=stopautoprocess'>Stop autoprocess</a>"
-	else
-		dat += "<span class='linkOff'>Autoprocess</span>"
 	dat += "<h3>Cloning Pod Status</h3>"
 	dat += "<div class='statusDisplay'>[temp]&nbsp;</div>"
 
@@ -204,70 +168,6 @@
 				else
 					dat += "<span class='linkOff'>Start Scan</span>"
 
-			// Database
-			dat += "<h3>Database Functions</h3>"
-			if (src.records.len && src.records.len > 0)
-				dat += "<a href='byond://?src=[REF(src)];menu=2'>View Records ([src.records.len])</a><br>"
-			else
-				dat += "<span class='linkOff'>View Records (0)</span><br>"
-			if (src.diskette)
-				dat += "<a href='byond://?src=[REF(src)];disk=eject'>Eject Disk</a><br>"
-
-
-
-		if(2)
-			dat += "<h3>Current records</h3>"
-			dat += "<a href='byond://?src=[REF(src)];menu=1'><< Back</a><br><br>"
-			for(var/datum/data/record/R in records)
-				dat += "<h4>[R.fields["name"]]</h4>Scan ID [R.fields["id"]] <a href='byond://?src=[REF(src)];view_rec=[R.fields["id"]]'>View Record</a>"
-		if(3)
-			dat += "<h3>Selected Record</h3>"
-			dat += "<a href='byond://?src=[REF(src)];menu=2'><< Back</a><br>"
-
-			if (!src.active_record)
-				dat += "<font class='bad'>Record not found.</font>"
-			else
-				dat += "<h4>[src.active_record.fields["name"]]</h4>"
-				dat += "Scan ID [src.active_record.fields["id"]] <a href='byond://?src=[REF(src)];clone=[active_record.fields["id"]]'>Clone</a><br>"
-
-				var/obj/item/implant/health/H = locate(src.active_record.fields["imp"])
-
-				if ((H) && (istype(H)))
-					dat += "<b>Health Implant Data:</b><br />[H.sensehealth()]<br><br />"
-				else
-					dat += "<font class='bad'>Unable to locate Health Implant.</font><br /><br />"
-
-				dat += "<b>Unique Identifier:</b><br /><span class='highlight'>[src.active_record.fields["UI"]]</span><br>"
-				dat += "<b>Structural Enzymes:</b><br /><span class='highlight'>[src.active_record.fields["SE"]]</span><br>"
-
-				if(diskette && diskette.fields)
-					dat += "<div class='block'>"
-					dat += "<h4>Inserted Disk</h4>"
-					dat += "<b>Contents:</b> "
-					var/list/L = list()
-					if(diskette.fields["UI"])
-						L += "Unique Identifier"
-					if(diskette.fields["UE"] && diskette.fields["name"] && diskette.fields["blood_type"])
-						L += "Unique Enzymes"
-					if(diskette.fields["SE"])
-						L += "Structural Enzymes"
-					dat += english_list(L, "Empty", " + ", " + ")
-					dat += "<br /><a href='byond://?src=[REF(src)];disk=load'>Load from Disk</a>"
-
-					dat += "<br /><a href='byond://?src=[REF(src)];disk=save'>Save to Disk</a>"
-					dat += "</div>"
-
-				dat += "<font size=1><a href='byond://?src=[REF(src)];del_rec=1'>Delete Record</a></font>"
-
-		if(4)
-			if (!src.active_record)
-				src.menu = 2
-			dat = "[src.temp]<br>"
-			dat += "<h3>Confirm Record Deletion</h3>"
-
-			dat += "<b><a href='byond://?src=[REF(src)];del_rec=1'>Scan card to confirm.</a></b><br>"
-			dat += "<b><a href='byond://?src=[REF(src)];menu=3'>Cancel</a></b>"
-
 
 	var/datum/browser/popup = new(user, "cloning", "Cloning System Control")
 	popup.set_content(dat)
@@ -281,19 +181,7 @@
 	if(loading)
 		return
 
-	if(href_list["task"])
-		switch(href_list["task"])
-			if("autoprocess")
-				if(scanner && HasEfficientPod() && scanner.scan_level >= AUTOCLONING_MINIMAL_LEVEL)
-					autoprocess = TRUE
-					START_PROCESSING(SSmachines, src)
-					playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
-			if("stopautoprocess")
-				autoprocess = FALSE
-				STOP_PROCESSING(SSmachines, src)
-				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
-
-	else if ((href_list["scan"]) && !isnull(scanner) && scanner.is_operational())
+	if ((href_list["scan"]) && !isnull(scanner) && scanner.is_operational())
 		scantemp = ""
 
 		loading = 1
@@ -318,115 +206,12 @@
 			scanner.locked = FALSE
 			playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 
-	else if(href_list["view_rec"])
-		playsound(src, "terminal_type", 25, 0)
-		src.active_record = find_record("id", href_list["view_rec"], records)
-		if(active_record)
-			if(!active_record.fields["ckey"])
-				records -= active_record
-				active_record = null
-				src.temp = "<font class='bad'>Record Corrupt</font>"
-			else
-				src.menu = 3
-		else
-			src.temp = "Record missing."
-
-	else if (href_list["del_rec"])
-		if ((!src.active_record) || (src.menu < 3))
-			return
-		if (src.menu == 3) //If we are viewing a record, confirm deletion
-			src.temp = "Delete record?"
-			src.menu = 4
-			playsound(src, 'sound/machines/terminal_prompt.ogg', 50, 0)
-
-		else if (src.menu == 4)
-			var/obj/item/card/id/C = usr.get_active_held_item()
-			if (istype(C)||istype(C, /obj/item/pda))
-				if(src.check_access(C))
-					src.temp = "[src.active_record.fields["name"]] => Record deleted."
-					src.records.Remove(active_record)
-					active_record = null
-					playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
-					src.menu = 2
-				else
-					src.temp = "<font class='bad'>Access Denied.</font>"
-					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
-
-	else if (href_list["disk"]) //Load or eject.
-		switch(href_list["disk"])
-			if("load")
-				if (!diskette || !istype(diskette.fields) || !diskette.fields["name"] || !diskette.fields)
-					src.temp = "<font class='bad'>Load error.</font>"
-					src.updateUsrDialog()
-					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
-					return
-				if (!src.active_record)
-					src.temp = "<font class='bad'>Record error.</font>"
-					src.menu = 1
-					src.updateUsrDialog()
-					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
-					return
-
-				for(var/key in diskette.fields)
-					src.active_record.fields[key] = diskette.fields[key]
-				src.temp = "Load successful."
-				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
-
-			if("eject")
-				if(src.diskette)
-					src.diskette.forceMove(drop_location())
-					src.diskette = null
-					playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
-			if("save")
-				if(!diskette || diskette.read_only || !active_record || !active_record.fields)
-					src.temp = "<font class='bad'>Save error.</font>"
-					src.updateUsrDialog()
-					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
-					return
-
-				diskette.fields = active_record.fields.Copy()
-				diskette.name = "data disk - '[src.diskette.fields["name"]]'"
-				src.temp = "Save successful."
-				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
-
 	else if (href_list["refresh"])
 		src.updateUsrDialog()
 		playsound(src, "terminal_type", 25, 0)
 
-	else if (href_list["clone"])
-		var/datum/data/record/C = find_record("id", href_list["clone"], records)
-		//Look for that player! They better be dead!
-		if(C)
-			var/obj/machinery/clonepod/pod = GetAvailablePod()
-			//Can't clone without someone to clone.  Or a pod.  Or if the pod is busy. Or full of gibs.
-			if(!LAZYLEN(pods))
-				temp = "<font class='bad'>No Clonepods detected.</font>"
-				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
-			else if(!pod)
-				temp = "<font class='bad'>No Clonepods available.</font>"
-				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
-			else if(!CONFIG_GET(flag/revival_cloning))
-				temp = "<font class='bad'>Unable to initiate cloning cycle.</font>"
-				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
-			else if(pod.occupant)
-				temp = "<font class='bad'>Cloning cycle already in progress.</font>"
-				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
-			else if(pod.growclone(C.fields["ckey"], C.fields["name"], C.fields["UI"], C.fields["SE"], C.fields["mind"], C.fields["mrace"], C.fields["features"], C.fields["factions"], C.fields["quirks"], C.fields["bank_account"]))
-				temp = "[C.fields["name"]] => <font class='good'>Cloning cycle in progress...</font>"
-				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
-				records.Remove(C)
-				if(active_record == C)
-					active_record = null
-				menu = 1
-			else
-				temp = "[C.fields["name"]] => <font class='bad'>Initialisation failure.</font>"
-				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 
-		else
-			temp = "<font class='bad'>Data corruption.</font>"
-			playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
-
-	else if (href_list["menu"])
+	if (href_list["menu"])
 		src.menu = text2num(href_list["menu"])
 		playsound(src, "terminal_type", 25, 0)
 
@@ -464,54 +249,49 @@
 		scantemp = "<font class='bad'>Mental interface failure.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 		return
-	if (find_record("ckey", mob_occupant.ckey, records))
-		scantemp = "<font class='average'>Subject already in database.</font>"
-		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
-		return
 	if(SSeconomy.full_ancap)
 		if(!has_bank_account)
 			scantemp = "<font class='average'>Subject is either missing an ID card with a bank account on it, or does not have an account to begin with. Please ensure the ID card is on the body before attempting to scan.</font>"
 			playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 			return
-	var/datum/data/record/R = new()
+	var/mrace
 	if(dna.species)
 		// We store the instance rather than the path, because some
 		// species (abductors, slimepeople) store state in their
 		// species datums
 		dna.delete_species = FALSE
-		R.fields["mrace"] = dna.species
+		mrace = dna.species
 	else
 		var/datum/species/rando_race = pick(GLOB.roundstart_races)
-		R.fields["mrace"] = rando_race.type
+		mrace = rando_race.type
 
-	R.fields["ckey"] = mob_occupant.ckey
-	R.fields["name"] = mob_occupant.real_name
-	R.fields["id"] = copytext(md5(mob_occupant.real_name), 2, 6)
-	R.fields["UE"] = dna.unique_enzymes
-	R.fields["UI"] = dna.uni_identity
-	R.fields["SE"] = dna.struc_enzymes
-	R.fields["blood_type"] = dna.blood_type
-	R.fields["features"] = dna.features
-	R.fields["factions"] = mob_occupant.faction
-	R.fields["quirks"] = list()
-	R.fields["bank_account"] = has_bank_account
+	var/mind
+	if(mob_occupant.mind)
+		mind = "[REF(mob_occupant.mind)]"	
+
+	var/quirks = list()
 	for(var/V in mob_occupant.roundstart_quirks)
 		var/datum/quirk/T = V
-		R.fields["quirks"][T.type] = T.clone_data()
+		quirks[T.type] = T.clone_data()
 
-	if (!isnull(mob_occupant.mind)) //Save that mind so traitors can continue traitoring after cloning.
-		R.fields["mind"] = "[REF(mob_occupant.mind)]"
-
-   //Add an implant if needed
-	var/obj/item/implant/health/imp
-	for(var/obj/item/implant/health/HI in mob_occupant.implants)
-		imp = HI
-		break
-	if(!imp)
-		imp = new /obj/item/implant/health(mob_occupant)
-		imp.implant(mob_occupant)
-	R.fields["imp"] = "[REF(imp)]"
-
-	src.records += R
-	scantemp = "Subject successfully scanned."
-	playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
+	var/obj/machinery/clonepod/pod = GetAvailablePod()
+	//Can't clone without someone to clone.  Or a pod.  Or if the pod is busy. Or full of gibs.
+	if(!LAZYLEN(pods))
+		temp = "<font class='bad'>No Clonepods detected.</font>"
+		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
+	else if(!pod)
+		temp = "<font class='bad'>No Clonepods available.</font>"
+		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
+	else if(!CONFIG_GET(flag/revival_cloning))
+		temp = "<font class='bad'>Unable to initiate cloning cycle.</font>"
+		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
+	else if(pod.occupant)
+		temp = "<font class='bad'>Cloning cycle already in progress.</font>"
+		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
+	else if(pod.growclone(mob_occupant.ckey, mob_occupant.real_name, dna.uni_identity, dna.struc_enzymes, mind, mrace, dna.features, mob_occupant.faction, quirks, has_bank_account))
+		temp = "[mob_occupant.real_name] => <font class='good'>Cloning cycle in progress...</font>"
+		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
+		menu = 1
+	else
+		temp = "[mob_occupant.real_name] => <font class='bad'>Initialisation failure.</font>"
+		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)


### PR DESCRIPTION
:cl:
del: You can no longer pre-scan in the cloner
/:cl:

Edited:

Scanning reduces the consequences of death to a far more minor level than is reasonable. Its effect on the game is to reduce tension by making scanned crewmembers immortal while cloning still stands, thus making the game generally more boring.

Scanning also opens up the issue of post-scan knowledge, which is especially problematic given tgstation's usual stance on RP knowledge restriction. Post-scan knowledge cuts down the variety of stealth antag playstyles, and as such makes the game more boring yet again.

It makes the game more boring, so it should be removed. 