### PR TITLE
Prevents holy melons from defending against magic

### DIFF
--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -57,7 +57,3 @@
 	dried_type = null
 	wine_power = 70 //Water to wine, baby.
 	wine_flavor = "divinity"
-
-/obj/item/reagent_containers/food/snacks/grown/holymelon/Initialize()
-	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE) //deliver us from evil o melon god


### PR DESCRIPTION
:cl:
balance: holy melons are no longer anti-magic
/:cl:

Antimagic is a ridiculously strong ability to be able to mass-produce as easily as botany can mass-produce holymelons.