### PR TITLE
adds tooltips to radials

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -17,10 +17,12 @@ GLOBAL_LIST_EMPTY(radial_menus)
 /obj/screen/radial/slice/MouseEntered(location, control, params)
 	. = ..()
 	icon_state = "radial_slice_focus"
+	openToolTip(usr, src, params, title = name)
 
 /obj/screen/radial/slice/MouseExited(location, control, params)
 	. = ..()
 	icon_state = "radial_slice"
+	closeToolTip(usr)
 
 /obj/screen/radial/slice/Click(location, control, params)
 	if(usr.client == parent.current_user)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20558591/49342652-682df080-f65e-11e8-8c1e-a3d4830dbc64.png)

Shamelessly stolen from https://github.com/ParadiseSS13/Paradise/pull/10074


:cl: Nich
rscadd: Radials now have tooltips on hover
/:cl:

[why]: # Because previously both here and downstream when I tried to add radials for Borg-modules or for the admin-smite menu, people asked for tooltips, this adds them for all radials.
