### PR TITLE
Fixes heat sources not igniting things

### DIFF
--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -40,7 +40,7 @@
 	if (src.on && !(stat & NOPOWER) )
 		var/turf/location = src.loc
 		if (isturf(location))
-			location.hotspot_expose(700,10,1)
+			location.hotspot_expose(1000,500,1)
 	return 1
 
 /obj/machinery/igniter/Initialize()

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -30,20 +30,20 @@
 	playsound(src, "sparks", 100, TRUE)
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(300,5)
+		T.hotspot_expose(1000,100)
 	QDEL_IN(src, 20)
 
 /obj/effect/particle_effect/sparks/Destroy()
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(300,1)
+		T.hotspot_expose(1000,100)
 	return ..()
 
 /obj/effect/particle_effect/sparks/Move()
 	..()
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(300,1)
+		T.hotspot_expose(1000,100)
 
 /datum/effect_system/spark_spread
 	effect_type = /obj/effect/particle_effect/sparks

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -603,7 +603,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(success)
 			location = get_turf(M)
 	if(isturf(location))
-		location.hotspot_expose(flame_heat, 1)
+		location.hotspot_expose(flame_heat, 5)
 
 /obj/item/proc/ignition_effect(atom/A, mob/user)
 	if(is_hot())

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -130,7 +130,7 @@
 	if(isOn())
 		use(1)
 		var/turf/location = get_turf(user)
-		location.hotspot_expose(550, 10, 1)
+		location.hotspot_expose(700, 50, 1)
 		if(get_fuel() <= 0)
 			set_light(0)
 

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -111,7 +111,7 @@
 
 	playsound(src, 'sound/effects/comfyfire.ogg',50,0, 0, 1)
 	var/turf/T = get_turf(src)
-	T.hotspot_expose(500, 5)
+	T.hotspot_expose(700, 5)
 	update_icon()
 	adjust_light()
 

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -26,7 +26,7 @@
 		return FALSE//Cooldown check
 	var/turf/location = get_turf(loc)
 	if(location)
-		location.hotspot_expose(700,10)
+		location.hotspot_expose(1000,1000)
 	sparks.start()
 	return TRUE
 

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -136,7 +136,7 @@
 			if(prob(30))
 				do_sparks(2, 1, T)
 			T.ex_act(EXPLODE_LIGHT)
-			T.hotspot_expose(700,25,1)
+			T.hotspot_expose(1000,500,1)
 
 	if(!(obj_flags & EMAGGED))
 		for(var/item in spawned)

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -208,7 +208,7 @@
 
 /obj/structure/bonfire/proc/Burn()
 	var/turf/current_location = get_turf(src)
-	current_location.hotspot_expose(1000,100,1)
+	current_location.hotspot_expose(1000,500,1)
 	for(var/A in current_location)
 		if(A == src)
 			continue

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -113,7 +113,7 @@
 		ExtinguishMob() //If there's no oxygen in the tile we're on, put out the fire
 		return TRUE
 	var/turf/location = get_turf(src)
-	location.hotspot_expose(700, 10, 1)
+	location.hotspot_expose(700, 50, 1)
 
 /mob/living/proc/handle_stomach()
 	return

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -14,4 +14,4 @@
 	var/turf/location = get_turf(src)
 	if(location)
 		new /obj/effect/hotspot(location)
-		location.hotspot_expose(700, 5, 1)
+		location.hotspot_expose(700, 50, 1)


### PR DESCRIPTION
:cl: Denton
fix: Fixed sparks and igniters not properly igniting plasma.
/:cl:

Since #41679 got merged, we can safely crank up hotspot_expose() values that were reduced in #38232 again. 
This should fix pretty much all issues where heat sources like sparks fail to ignite plasma.

Fixes: #37829
Fixes: #41247
Fixes: #41647