### PR TITLE
Adds the Plasma Fist scroll for plasmaman traitors

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1435,6 +1435,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/flashlight/lantern/syndicate
 	restricted_species = list("moth")
 
+/datum/uplink_item/race_restricted/plasmafist
+	name = "Frayed Scroll"
+	desc = "Reading this scroll will teach you the forbidden secrets of the Plasma Fist. With enough proficiency, \
+			you will be able to make people explode violently."
+	cost = 12
+	item = /obj/item/book/granter/martial/plasma_fist
+	restricted_species = list("plasmaman")
+
 // Role-specific items
 /datum/uplink_item/role_restricted
 	category = "Role-Restricted"


### PR DESCRIPTION
:cl: Denton
add: Added the Plasma Fist scroll for plasmaman traitors. They can purchase it for 12 TC.
/:cl:

This PR adds the plasma fist scroll for 12 TC - only plasmamen can buy it. While 12TC sounds low, keep in mind that A) plasma fist doesn't give you ranged immunity like carp does and B) plasmamen are slow as shit.

If you're not familiar with plasma fist:
```
	to_chat(usr, "<b><i>You clench your fists and have a flashback of knowledge...</i></b>")
	to_chat(usr, "<span class='notice'>Tornado Sweep</span>: Harm Harm Disarm. Repulses target and everyone back.")
	to_chat(usr, "<span class='notice'>Throwback</span>: Disarm Harm Disarm. Throws the target and an item at them.")
	to_chat(usr, "<span class='notice'>The Plasma Fist</span>: Harm Disarm Disarm Disarm Harm. Knocks the brain out of the opponent and gibs their body.")
```