### PR TITLE
Reduces **default** run speed

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -32,7 +32,7 @@ EMOJIS
 ## To speed things up make the number negative, to slow things down, make the number positive.
 
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
-RUN_DELAY 1
+RUN_DELAY 2
 WALK_DELAY 4
 
 ## The variables below affect the movement of specific mob types. THIS AFFECTS ALL SUBTYPES OF THE TYPE YOU CHOOSE!


### PR DESCRIPTION
[Changelogs]: #
:cl:
balance: Default run speed has been reduced.
/:cl:

The current run speed is too fast - much faster than it used to be, maybe because of less lag and increased tickrate.

As a result of reduced run speed, combat feels more interesting - smashing random arrow keys is less of a game changing factor. Also "pixel hunting" when moving is easier. This makes combat more strategic and less "click, move and hope".

Also note that this changes the default run speed in the config, so it may be overriden if some server feels like it.