### PR TITLE
[READY]Bubblegum Buffs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -5,12 +5,13 @@ BUBBLEGUM
 Bubblegum spawns randomly wherever a lavaland creature is able to spawn. It is the most powerful slaughter demon in existence.
 Bubblegum's footsteps are heralded by shaking booms, proving its tremendous size.
 
-It acts as a melee creature, chasing down and attacking its target while also using different attacks to augment its power that increase as it takes damage.
+It acts as a melee creature, chasing down and attacking its target while also using different attacks to augment its power
 
 It tries to strike at its target through any bloodpools under them; if it fails to do that, it will spray blood and then attempt to warp to a bloodpool near the target.
-If it fails to warp to a target, it may summon up to 6 slaughterlings from the blood around it.
-If it does not summon all 6 slaughterlings, it will instead charge at its target, dealing massive damage to anything it hits and spraying a stream of blood.
-At half health, it will either charge three times or warp, then charge, instead of doing a single charge.
+If it does warp it will enter an enraged state, becoming immune to all projectiles, becoming much faster, and dealing damage and knockback to anything that gets in the cloud around it.
+It may summon clones charging from all sides, one of these charges being bubblegum himself.
+It can charge at its target leaving lots of damaging spaces behind if he's enraged, and also heavily damaging anything directly hit in the charge.
+If at half health it will start to charge from all sides with clones.
 
 When Bubblegum dies, it leaves behind a H.E.C.K. mining suit as well as a chest that can contain three things:
  1. A bottle that, when activated, drives everyone nearby into a frenzy
@@ -38,7 +39,7 @@ Difficulty: Hard
 	melee_damage_lower = 40
 	melee_damage_upper = 40
 	speed = 1
-	move_to_delay = 7.5
+	move_to_delay = 5
 	retreat_distance = 5
 	minimum_distance = 5
 	rapid_melee = 8 // every 1/4 second
@@ -193,8 +194,6 @@ Difficulty: Hard
 	sleep(get_dist(src, T) * movespeed)
 	try_bloodattack()
 	charging = 0
-	if(target)
-		MoveToTarget(target) // get moving nerd
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Bump(atom/A)
 	if(charging)
@@ -382,7 +381,7 @@ Difficulty: Hard
 	enrage_till = world.time + boost_time
 	retreat_distance = null
 	minimum_distance = 1
-	change_move_delay(initial(move_to_delay) / 2) // double move speed
+	change_move_delay(3.75)
 	var/newcolor = rgb(149, 10, 10)
 	add_atom_colour(newcolor, TEMPORARY_COLOUR_PRIORITY)
 	var/datum/callback/cb = CALLBACK(src, .proc/blood_enrage_end)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -38,7 +38,7 @@ Difficulty: Hard
 	melee_damage_lower = 40
 	melee_damage_upper = 40
 	speed = 1
-	move_to_delay = 6
+	move_to_delay = 7.5
 	retreat_distance = 5
 	minimum_distance = 5
 	rapid_melee = 8 // every 1/4 second
@@ -188,7 +188,7 @@ Difficulty: Hard
 	var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(loc,src)
 	animate(D, alpha = 0, color = "#FF0000", transform = matrix()*2, time = 3)
 	sleep(delay)
-	var/movespeed = is_enraged() ? 0.5 : 0.7
+	var/movespeed = 0.7
 	walk_towards(src, T, movespeed)
 	sleep(get_dist(src, T) * movespeed)
 	try_bloodattack()
@@ -333,7 +333,7 @@ Difficulty: Hard
 					continue
 				hitby += L
 				to_chat(L, "<span class='userdanger'>[src]'s ground slam shockwave sends you flying!</span>")
-				var/turf/thrownat = get_ranged_target_turf(L, get_dir(orgin, L), 10)
+				var/turf/thrownat = get_ranged_target_turf(L, get_dir(orgin, L), 4)
 				L.throw_at(thrownat, get_dist(L, thrownat), 2, L, 1)
 				L.apply_damage(20, BRUTE)
 				shake_camera(L, 2, 1)
@@ -443,16 +443,17 @@ Difficulty: Hard
 	var/distance = directions.len
 	var/realspawn = pick(directions)
 	var/tocharge = list()
+	var/waittime = 6 + directions.len * 0.4
 	for(var/dir in (directions - realspawn))
 		var/turf/place = get_ranged_target_turf(chargeat, dir, distance)
 		var/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/B = new /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination(src.loc)
 		B.forceMove(place)
 		tocharge += B
 	for(var/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/B in tocharge)
-		INVOKE_ASYNC(B, .proc/charge, chargeat, 6)
+		INVOKE_ASYNC(B, .proc/charge, chargeat, waittime)
 	var/turf/place = get_ranged_target_turf(chargeat, realspawn, distance)
 	forceMove(place)
-	charge(chargeat, 6)
+	charge(chargeat, waittime)
 	charging = 0
 
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -100,7 +100,7 @@ Difficulty: Hard
 			hallucination_charge_around(times = 6, delay = 10 - anger_modifier / 5)
 			SetRecoveryTime(10)
 	else
-		if(prob(50))
+		if(prob(50 - anger_modifier))
 			hallucination_charge_around(times = 4, delay = 9)
 			hallucination_charge_around(times = 4, delay = 8)
 			hallucination_charge_around(times = 4, delay = 7)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -38,7 +38,7 @@ Difficulty: Hard
 	melee_damage_lower = 40
 	melee_damage_upper = 40
 	speed = 1
-	move_to_delay = 5
+	move_to_delay = 6
 	retreat_distance = 5
 	minimum_distance = 5
 	rapid_melee = 8 // every 1/4 second

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -37,8 +37,12 @@ Difficulty: Hard
 	armour_penetration = 40
 	melee_damage_lower = 40
 	melee_damage_upper = 40
-	speed = 2
+	speed = 1
 	move_to_delay = 10
+	vision_range = 20
+	aggro_vision_range = 20
+	rapid_melee = 8 // every quarter second
+	melee_queue_distance = 20 // as far as the aggro vision range is
 	ranged = 1
 	pixel_x = -32
 	del_on_death = 1
@@ -89,9 +93,6 @@ Difficulty: Hard
 		warped = blood_warp()
 		if(warped && prob(100 - anger_modifier))
 			return
-		else
-			if(prob(25))
-				INVOKE_ASYNC(src, .proc/blood_ball, max(5, anger_modifier))
 
 	if(prob(90) || slaughterlings())
 		if(health > maxHealth * 0.5)
@@ -127,7 +128,10 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/AttackingTarget()
 	if(!charging)
-		return ..()
+		. = ..()
+		if(.)
+			recovery_time = world.time + 20 // can only attack melee once every 2 seconds but rapid_melee gives higher priority
+
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Goto(target, delay, minimum_distance)
 	if(!charging)
@@ -173,11 +177,10 @@ Difficulty: Hard
 		DestroySurroundings()
 		if(isliving(A))
 			var/mob/living/L = A
-			L.visible_message("<span class='danger'>[src] slams into [L]!</span>", "<span class='userdanger'>[src] slams into you and forces you to the side!</span>")
-			var/move_dir = turn(dir, pick(-90, 90)) // to the left or right of bubblegum
+			L.visible_message("<span class='danger'>[src] slams into [L]!</span>", "<span class='userdanger'>[src] tramples you into the ground!</span>")
 			src.forceMove(get_turf(L))
-			L.forceMove(get_step(src, move_dir))
 			L.apply_damage(40, BRUTE)
+			L.Stun(10)
 			playsound(get_turf(L), 'sound/effects/meteorimpact.ogg', 100, 1)
 			shake_camera(L, 4, 3)
 			shake_camera(src, 2, 3)
@@ -341,75 +344,6 @@ Difficulty: Hard
 	for(var/obj/effect/decal/cleanable/nearby in view(T, range))
 		if(nearby.can_bloodcrawl_in())
 			. += nearby
-
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/blood_ball(var/count = 5, var/atom/shootat = target)
-	var/cooldown = max(10 - count, 1)
-	var/directions = GLOB.cardinals + GLOB.diagonals
-	SetRecoveryTime(count * cooldown + 10)
-	for(var/i = 1 to count)
-		if(!shootat || !isliving(shootat))
-			return
-		var/turf/endturf = get_turf(shootat)
-		for(var/j = 1 to 3)
-			var/turf/check = get_step(endturf, pick(directions))
-			if(check)
-				endturf = check
-		var/obj/item/projectile/P = new /obj/item/projectile/blood_ball(src.loc)
-		P.firer = src
-		P.preparePixelProjectile(endturf, src)
-		P.range = get_dist(endturf, get_turf(src))
-		P.speed = 20 / P.range
-		P.fire()
-		new /obj/effect/temp_visual/blood_ball_target(endturf)
-		sleep(cooldown)
-
-/obj/effect/temp_visual/blood_ball_target
-	icon = 'icons/mob/actions/actions_items.dmi'
-	icon_state = "sniper_zoom"
-	layer = BELOW_MOB_LAYER
-	light_range = 2
-	duration = 20
-
-/obj/effect/temp_visual/blood_ball_target/ex_act()
-	return
-
-/obj/item/projectile/blood_ball
-	name = "bloodball"
-	desc = "You should probably get moving!"
-	icon_state = "mini_leaper"
-	layer = FLY_LAYER
-	forcedodge = 1
-	light_range = 2
-	light_color = LIGHT_COLOR_RED
-
-/obj/item/projectile/blood_ball/ex_act()
-	return
-
-/obj/item/projectile/blood_ball/on_hit(atom/target, blocked = FALSE)
-	return
-
-/obj/item/projectile/blood_ball/Bump(atom/A)
-	return
-
-/obj/item/projectile/blood_ball/on_range()
-	var/turf/T = get_turf(src)
-	playsound(T,'sound/effects/splat.ogg', 100, 1, -1)
-
-	// damage to living targets
-	for(var/mob/living/L in T.contents)
-		if(istype(L, /mob/living/simple_animal/hostile/megafauna/bubblegum))
-			continue
-		L.adjustBruteLoss(10)
-		to_chat(L, "<span class='userdanger'>You're hit directly by the blood ball!</span>")
-
-	// deals damage to mechs
-	for(var/obj/mecha/M in T.contents)
-		M.take_damage(45, BRUTE, "melee", 1)
-
-	// spawns blood around the end location
-	new /obj/effect/decal/cleanable/blood(T)
-
-	return ..()
 
 /obj/effect/decal/cleanable/blood/bubblegum
 	bloodiness = 0

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -97,16 +97,16 @@ Difficulty: Hard
 		if(prob(75))
 			charge()
 		else
-			hallucination_charge()
+			hallucination_charge_around()
 	else
 		if(prob(50))
 			charge()
 		else
-			hallucination_charge(GLOB.cardinals + GLOB.diagonals)
+			hallucination_charge_around(GLOB.cardinals + GLOB.diagonals)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Initialize()
 	. = ..()
-	if(!istype(src, /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination))
+	if(ispath(src, /mob/living/simple_animal/hostile/megafauna/bubblegum))
 		for(var/mob/living/simple_animal/hostile/megafauna/bubblegum/B in GLOB.mob_living_list)
 			if(B != src)
 				return INITIALIZE_HINT_QDEL //There can be only one
@@ -163,7 +163,7 @@ Difficulty: Hard
 		playsound(src, 'sound/effects/meteorimpact.ogg', 200, 1, 2, 1)
 	return ..()
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge(var/atom/chargeat = target)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge(var/atom/chargeat = target, var/delay = 3)
 	if(!chargeat)
 		return
 	var/dir = get_dir(src, chargeat)
@@ -177,7 +177,7 @@ Difficulty: Hard
 	setDir(dir)
 	var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(loc,src)
 	animate(D, alpha = 0, color = "#FF0000", transform = matrix()*2, time = 3)
-	sleep(3)
+	sleep(delay)
 	var/movespeed = is_enraged() ? 0.5 : 0.7
 	walk_towards(src, T, movespeed)
 	sleep(get_dist(src, T) * movespeed)
@@ -420,22 +420,22 @@ Difficulty: Hard
 /obj/effect/decal/cleanable/blood/bubblegum/can_bloodcrawl_in()
 	return TRUE
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/hallucination_charge(var/list/directions = GLOB.cardinals)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/hallucination_charge_around(var/list/directions = GLOB.cardinals)
 	if(!target || !directions.len)
 		return
 	var/turf/chargeat = get_turf(target)
-	var/distance = directions.len + 2
+	var/distance = directions.len
 	var/realspawn = pick(directions)
 	for(var/dir in directions)
 		var/turf/place = get_ranged_target_turf(target, dir, distance)
 		if(dir == realspawn)
 			forceMove(place)
-			INVOKE_ASYNC(src, .proc/charge, chargeat)
+			INVOKE_ASYNC(src, .proc/charge, chargeat, 6)
 			continue
 		var/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/B = new /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination(src.loc)
 		B.forceMove(place)
 		B.target = target
-		INVOKE_ASYNC(B, .proc/charge, chargeat)
+		INVOKE_ASYNC(B, .proc/charge, chargeat, 6)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination
 	name = "bubblegum's hallucination"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -1,5 +1,3 @@
-#define MEDAL_PREFIX "Bubblegum"
-
 /*
 
 BUBBLEGUM
@@ -9,15 +7,15 @@ Bubblegum's footsteps are heralded by shaking booms, proving its tremendous size
 
 It acts as a melee creature, chasing down and attacking its target while also using different attacks to augment its power that increase as it takes damage.
 
-It often charges, dealing massive damage to anything unfortunate enough to be standing where it's aiming.
-Whenever it isn't chasing something down, it will sink into nearby blood pools (if possible) and springs out of the closest one to its target.
-To make this possible, it sprays streams of blood at random.
-From these blood pools Bubblegum may summon slaughterlings - weak, low-damage minions designed to impede the target's progress.
+It tries to strike at its target through any bloodpools under them; if it fails to do that, it will spray blood and then attempt to warp to a bloodpool near the target.
+If it fails to warp to a target, it may summon up to 6 slaughterlings from the blood around it.
+If it does not summon all 6 slaughterlings, it will instead charge at its target, dealing massive damage to anything it hits and spraying a stream of blood.
+At half health, it will either charge three times or warp, then charge, instead of doing a single charge.
 
-When Bubblegum dies, it leaves behind a H.E.C.K. suit+helmet as well as a chest that can contain three things:
- 1. A spellblade that can slice off limbs at range
- 2. A bottle that, when activated, drives everyone nearby into a frenzy
- 3. A contract that marks for death the chosen target
+When Bubblegum dies, it leaves behind a H.E.C.K. mining suit as well as a chest that can contain three things:
+ 1. A bottle that, when activated, drives everyone nearby into a frenzy
+ 2. A contract that marks for death the chosen target
+ 3. A spellblade that can slice off limbs at range
 
 Difficulty: Hard
 
@@ -46,13 +44,12 @@ Difficulty: Hard
 	del_on_death = 1
 	crusher_loot = list(/obj/structure/closet/crate/necropolis/bubblegum/crusher)
 	loot = list(/obj/structure/closet/crate/necropolis/bubblegum)
-	var/charging = 0
+	blood_volume = BLOOD_VOLUME_MAXIMUM //BLEED FOR ME
+	var/charging = FALSE
 	medal_type = BOSS_MEDAL_BUBBLEGUM
 	score_type = BUBBLEGUM_SCORE
 	deathmessage = "sinks into a pool of blood, fleeing the battle. You've won, for now... "
 	deathsound = 'sound/magic/enter_blood.ogg'
-
-	do_footstep = TRUE
 
 /obj/item/gps/internal/bubblegum
 	icon_state = null
@@ -60,33 +57,54 @@ Difficulty: Hard
 	desc = "You're not quite sure how a signal can be bloody."
 	invisibility = 100
 
+/mob/living/simple_animal/hostile/megafauna/bubblegum/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE)
+	. = ..()
+	if(. > 0 && prob(25))
+		var/obj/effect/decal/cleanable/blood/gibs/bubblegum/B = new /obj/effect/decal/cleanable/blood/gibs/bubblegum(loc)
+		if(prob(40))
+			step(B, pick(GLOB.cardinals))
+		else
+			B.setDir(pick(GLOB.cardinals))
+
+/obj/effect/decal/cleanable/blood/gibs/bubblegum
+	name = "thick blood"
+	desc = "Thick, splattered blood."
+	random_icon_states = list("gib3", "gib5", "gib6")
+	bloodiness = 20
+
+/obj/effect/decal/cleanable/blood/gibs/bubblegum/can_bloodcrawl_in()
+	return TRUE
+
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Life()
 	..()
-	move_to_delay = CLAMP(round((health/maxHealth) * 10), 5, 10)
+	move_to_delay = CLAMP((health/maxHealth) * 10, 5, 10)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/OpenFire()
-	anger_modifier = CLAMP(((maxHealth - health)/50),0,20)
+	anger_modifier = CLAMP(((maxHealth - health)/60),0,20)
 	if(charging)
 		return
 	ranged_cooldown = world.time + ranged_cooldown_time
 
-	blood_warp()
-
-	if(prob(25))
+	var/warped = FALSE
+	if(!try_bloodattack())
 		INVOKE_ASYNC(src, .proc/blood_spray)
+		warped = blood_warp()
+		if(warped && prob(100 - anger_modifier))
+			return
 
-	else if(prob(5+anger_modifier/2))
-		slaughterlings()
-	else
-		if(health > maxHealth/2 && !client)
-			INVOKE_ASYNC(src, .proc/charge)
+	if(prob(90 - anger_modifier) || slaughterlings())
+		if(health > maxHealth * 0.5)
+			charge()
 		else
-			INVOKE_ASYNC(src, .proc/triple_charge)
+			if(prob(70) || warped)
+				charge(3)
+			else
+				warp_charge()
 
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Initialize()
 	. = ..()
-	for(var/mob/living/simple_animal/hostile/megafauna/bubblegum/B in GLOB.mob_list)
+	for(var/mob/living/simple_animal/hostile/megafauna/bubblegum/B in GLOB.mob_living_list)
 		if(B != src)
 			return INITIALIZE_HINT_QDEL //There can be only one
 	var/obj/effect/proc_holder/spell/bloodcrawl/bloodspell = new
@@ -100,54 +118,51 @@ Difficulty: Hard
 	if(.)
 		SSshuttle.shuttle_purchase_requirements_met |= "bubblegum"
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/do_attack_animation(atom/A)
-	if(charging)
-		return
-	..()
+/mob/living/simple_animal/hostile/megafauna/bubblegum/do_attack_animation(atom/A, visual_effect_icon)
+	if(!charging)
+		..()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/AttackingTarget()
-	if(charging)
-		return
-	..()
+	if(!charging)
+		return ..()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Goto(target, delay, minimum_distance)
-	if(charging)
-		return
-	..()
+	if(!charging)
+		..()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Move()
-	if(!stat)
-		playsound(src.loc, 'sound/effects/meteorimpact.ogg', 200, 1, 2, 1)
 	if(charging)
-		new/obj/effect/temp_visual/decoy/fading(loc,src)
+		new /obj/effect/temp_visual/decoy/fading(loc,src)
 		DestroySurroundings()
 	. = ..()
+	if(!stat && .)
+		playsound(src, 'sound/effects/meteorimpact.ogg', 200, 1, 2, 1)
 	if(charging)
 		DestroySurroundings()
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/triple_charge()
-	charge()
-	sleep(10)
-	charge()
-	sleep(10)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/warp_charge()
+	blood_warp()
 	charge()
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge()
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge(charges = 1)
 	var/turf/T = get_turf(target)
 	if(!T || T == loc)
 		return
-	new /obj/effect/temp_visual/dragon_swoop(T)
-	charging = 1
+	new /obj/effect/temp_visual/dragon_swoop/bubblegum(T)
+	charging = TRUE
 	DestroySurroundings()
 	walk(src, 0)
 	setDir(get_dir(src, T))
 	var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(loc,src)
-	animate(D, alpha = 0, color = "#FF0000", transform = matrix()*2, time = 5)
-	sleep(5)
+	animate(D, alpha = 0, color = "#FF0000", transform = matrix()*2, time = 3)
+	sleep(3)
 	throw_at(T, get_dist(src, T), 1, src, 0)
-	charging = 0
-	Goto(target, move_to_delay, minimum_distance)
-
+	sleep(7)
+	if(charges <= 1)
+		charging = FALSE
+		SetRecoveryTime(5)
+		return
+	charge(charges - 1)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Bump(atom/A)
 	if(charging)
@@ -156,12 +171,12 @@ Difficulty: Hard
 		DestroySurroundings()
 	..()
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/throw_impact(atom/A)
 	if(!charging)
 		return ..()
 
-	else if(isliving(hit_atom))
-		var/mob/living/L = hit_atom
+	else if(isliving(A))
+		var/mob/living/L = A
 		L.visible_message("<span class='danger'>[src] slams into [L]!</span>", "<span class='userdanger'>[src] slams into you!</span>")
 		L.apply_damage(40, BRUTE)
 		playsound(get_turf(L), 'sound/effects/meteorimpact.ogg', 100, 1)
@@ -170,20 +185,142 @@ Difficulty: Hard
 		var/throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(L, src)))
 		L.throw_at(throwtarget, 3)
 
-	charging = 0
+	charging = FALSE
 
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/get_mobs_on_blood()
+	var/list/targets = ListTargets()
+	. = list()
+	for(var/mob/living/L in targets)
+		var/list/bloodpool = get_pools(get_turf(L), 0)
+		if(bloodpool.len && (!faction_check_mob(L) || L.stat == DEAD))
+			. += L
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/try_bloodattack()
+	var/list/targets = get_mobs_on_blood()
+	if(targets.len)
+		INVOKE_ASYNC(src, .proc/bloodattack, targets, prob(50))
+
+		return TRUE
+	return FALSE
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/bloodattack(list/targets, handedness)
+	var/mob/living/target_one = pick_n_take(targets)
+	var/turf/target_one_turf = get_turf(target_one)
+	var/mob/living/target_two
+	if(targets.len)
+		target_two = pick_n_take(targets)
+		var/turf/target_two_turf = get_turf(target_two)
+		if(target_two.stat != CONSCIOUS || prob(10))
+			bloodgrab(target_two_turf, handedness)
+		else
+			bloodsmack(target_two_turf, handedness)
+
+	if(target_one)
+		var/list/pools = get_pools(get_turf(target_one), 0)
+		if(pools.len)
+			target_one_turf = get_turf(target_one)
+			if(target_one_turf)
+				if(target_one.stat != CONSCIOUS || prob(10))
+					bloodgrab(target_one_turf, !handedness)
+				else
+					bloodsmack(target_one_turf, !handedness)
+
+	if(!target_two && target_one)
+		var/list/poolstwo = get_pools(get_turf(target_one), 0)
+		if(poolstwo.len)
+			target_one_turf = get_turf(target_one)
+			if(target_one_turf)
+				if(target_one.stat != CONSCIOUS || prob(10))
+					bloodgrab(target_one_turf, handedness)
+				else
+					bloodsmack(target_one_turf, handedness)
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/bloodsmack(turf/T, handedness)
+	if(handedness)
+		new /obj/effect/temp_visual/bubblegum_hands/rightsmack(T)
+	else
+		new /obj/effect/temp_visual/bubblegum_hands/leftsmack(T)
+	sleep(2.5)
+	for(var/mob/living/L in T)
+		if(!faction_check_mob(L))
+			to_chat(L, "<span class='userdanger'>[src] rends you!</span>")
+			playsound(T, attack_sound, 100, 1, -1)
+			var/limb_to_hit = L.get_bodypart(pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
+			L.apply_damage(25, BRUTE, limb_to_hit, L.run_armor_check(limb_to_hit, "melee", null, null, armour_penetration))
+	sleep(3)
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/bloodgrab(turf/T, handedness)
+	if(handedness)
+		new /obj/effect/temp_visual/bubblegum_hands/rightpaw(T)
+		new /obj/effect/temp_visual/bubblegum_hands/rightthumb(T)
+	else
+		new /obj/effect/temp_visual/bubblegum_hands/leftpaw(T)
+		new /obj/effect/temp_visual/bubblegum_hands/leftthumb(T)
+	sleep(6)
+	for(var/mob/living/L in T)
+		if(!faction_check_mob(L))
+			to_chat(L, "<span class='userdanger'>[src] drags you through the blood!</span>")
+			playsound(T, 'sound/magic/enter_blood.ogg', 100, 1, -1)
+			var/turf/targetturf = get_step(src, dir)
+			L.forceMove(targetturf)
+			playsound(targetturf, 'sound/magic/exit_blood.ogg', 100, 1, -1)
+			if(L.stat != CONSCIOUS)
+				addtimer(CALLBACK(src, .proc/devour, L), 2)
+	sleep(1)
+
+/obj/effect/temp_visual/dragon_swoop/bubblegum
+	duration = 10
+
+/obj/effect/temp_visual/bubblegum_hands
+	icon = 'icons/effects/bubblegum.dmi'
+	duration = 9
+
+/obj/effect/temp_visual/bubblegum_hands/rightthumb
+	icon_state = "rightthumbgrab"
+
+/obj/effect/temp_visual/bubblegum_hands/leftthumb
+	icon_state = "leftthumbgrab"
+
+/obj/effect/temp_visual/bubblegum_hands/rightpaw
+	icon_state = "rightpawgrab"
+	layer = BELOW_MOB_LAYER
+
+/obj/effect/temp_visual/bubblegum_hands/leftpaw
+	icon_state = "leftpawgrab"
+	layer = BELOW_MOB_LAYER
+
+/obj/effect/temp_visual/bubblegum_hands/rightsmack
+	icon_state = "rightsmack"
+
+/obj/effect/temp_visual/bubblegum_hands/leftsmack
+	icon_state = "leftsmack"
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/blood_warp()
+	if(Adjacent(target))
+		return FALSE
+	var/list/can_jaunt = get_pools(get_turf(src), 1)
+	if(!can_jaunt.len)
+		return FALSE
+
+	var/list/pools = get_pools(get_turf(target), 2)
+	var/list/pools_to_remove = get_pools(get_turf(target), 1)
+	pools -= pools_to_remove
+	if(!pools.len)
+		return FALSE
+
+	var/obj/effect/temp_visual/decoy/DA = new /obj/effect/temp_visual/decoy(loc,src)
+	DA.color = "#FF0000"
+	var/oldtransform = DA.transform
+	DA.transform = matrix()*2
+	animate(DA, alpha = 255, color = initial(DA.color), transform = oldtransform, time = 3)
+	sleep(3)
+	qdel(DA)
+
 	var/obj/effect/decal/cleanable/blood/found_bloodpool
-	var/list/pools = list()
-	var/can_jaunt = FALSE
-	for(var/obj/effect/decal/cleanable/blood/nearby in view(src,2))
-		can_jaunt = TRUE
-		break
-	if(!can_jaunt)
-		return
-	for(var/obj/effect/decal/cleanable/blood/nearby in view(get_turf(target),2))
-		pools += nearby
+	pools = get_pools(get_turf(target), 2)
+	pools_to_remove = get_pools(get_turf(target), 1)
+	pools -= pools_to_remove
 	if(pools.len)
 		shuffle_inplace(pools)
 		found_bloodpool = pick(pools)
@@ -193,30 +330,53 @@ Difficulty: Hard
 		forceMove(get_turf(found_bloodpool))
 		playsound(get_turf(src), 'sound/magic/exit_blood.ogg', 100, 1, -1)
 		visible_message("<span class='danger'>And springs back out!</span>")
+		return TRUE
+	return FALSE
 
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/get_pools(turf/T, range)
+	. = list()
+	for(var/obj/effect/decal/cleanable/nearby in view(T, range))
+		if(nearby.can_bloodcrawl_in())
+			. += nearby
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/blood_spray()
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/blood_spray(var/range = 10, var/atom/shootat = target)
+	if(!shootat)
+		return
+	var/angle = ATAN2(shootat.x - src.x, shootat.y - src.y) // angle to the target
+	var/turf/end = get_turf(src)
+	for(var/i = 1 to range)
+		var/turf/check = locate(src.x + cos(angle) * i, src.y + sin(angle) * i, src.z)
+		if(!check || !end.CanAtmosPass(check))
+			break
+		end = check
+	var/list/toaffect = getline(src, end)
+	if(!toaffect.len || toaffect.len < 2)
+		return
 	visible_message("<span class='danger'>[src] sprays a stream of gore!</span>")
-	var/turf/E = get_edge_target_turf(src, src.dir)
-	var/range = 10
-	var/turf/previousturf = get_turf(src)
-	for(var/turf/J in getline(src,E))
-		if(!range)
-			break
+	for(var/i = 2 to toaffect.len)
+		var/turf/J = toaffect[i]
+		var/turf/previousturf = toaffect[i - 1]
 		new /obj/effect/temp_visual/dir_setting/bloodsplatter(previousturf, get_dir(previousturf, J))
-		if(!previousturf.CanAtmosPass(J))
-			break
 		playsound(J,'sound/effects/splat.ogg', 100, 1, -1)
 		new /obj/effect/decal/cleanable/blood(J)
-		range--
-		previousturf = J
-		sleep(1)
+		sleep((previousturf.x - J.x == 0 || previousturf.y - J.y == 0) ? 1 : 2) // diagonals take longer
+
+/obj/effect/decal/cleanable/blood/bubblegum
+	bloodiness = 0
+
+/obj/effect/decal/cleanable/blood/bubblegum/can_bloodcrawl_in()
+	return TRUE
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/slaughterlings()
 	visible_message("<span class='danger'>[src] summons a shoal of slaughterlings!</span>")
-	for(var/obj/effect/decal/cleanable/blood/H in range(src, 10))
-		if(prob(25))
-			new /mob/living/simple_animal/hostile/asteroid/hivelordbrood/slaughter(H.loc)
+	var/max_amount = 6
+	for(var/H in get_pools(get_turf(src), 1))
+		if(!max_amount)
+			break
+		max_amount--
+		var/obj/effect/decal/cleanable/blood/B = H
+		new /mob/living/simple_animal/hostile/asteroid/hivelordbrood/slaughter(B.loc)
+	return max_amount
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/slaughter
 	name = "slaughterling"
@@ -234,5 +394,3 @@ Difficulty: Hard
 	if(istype(mover, /mob/living/simple_animal/hostile/megafauna/bubblegum))
 		return 1
 	return 0
-
-#undef MEDAL_PREFIX


### PR DESCRIPTION
:cl: Joe Berry
add: Reverts back to the bubblegum before [#38306](https://github.com/tgstation/tgstation/pull/38306), was an unfinished pr and generally this bubblegum has more stuff to work with.

add: Enrage mode, while in this mode bubblegum is colored a deep red, moves faster, doesn't retreat, and is immune to projectiles. All while throwing out ground slam attacks around him that throw people around.

add: Clones, basically fake bubblegums that do one attack and disappear afterwards.

add: Ground slam attack, only happens when bubblegum is enraged, throws enemies around. Beware being thrown into a wall or you might be stunned because this is how throws work in this game.

add: Bubblegum can now continue to charge through enemies without stopping.

del: Bubblegum's anger modifier no longer determines his movement speed, instead having a constant speed and changing on enragement.

tweak: Blood spray is now a directional move and can move diagonally towards its target

tweak: Bubblegums charge no longer uses throws to calculate being hit.

balance: Bubblegum now retreats in his standard phase while not using moves, generally he was hard to get hit by in this phase anyways so this is a much smarter play on his part.

balance: Blood spray can now move through walls and goes further, this was pretty easily cheesed because it couldn't move through walls with just hugging the edges of walls and just made him too hard to balance.

balance: Bubblegum now procs melee checks much more often, though he has the same cooldown for his melee attacks. This means you're much less likely to stand next to him and not get hit.

balance: Bubblegum now charges 2 tiles past you, makes it slightly more difficult to predict where he's going to go and makes it so he can catch up to you easier.

balance: Bubblegum now moves faster during his charge.

balance: Bubblegum now only takes 50 damage from explosions, taking many bombs to kill him instead of just 10.
/:cl:

[why]: # Because bubblegum is, to be fair, a boring boss at the moment. He also has some of the best, and even borderline overpowered loot. Another thing to consider is that lore-wise he's meant to be the king of the slaughter demons and only one of them is allowed to spawn per round. For all of these things he should really just be stronger and more of a challenge to take down.

Current version video : (Note that this is using a move speed of 1.5 as will be the standard in the near future) - [Bubblegum v6](https://youtu.be/uXtZ3Un2hV4?t=43)