### PR TITLE
Fixes signaler not working on paystand

### DIFF
--- a/code/modules/economy/pay_stand.dm
+++ b/code/modules/economy/pay_stand.dm
@@ -61,7 +61,8 @@
 		to_chat(user, "What is this, the 1800s? We only take card here.")
 		return
 	if(istype(W, /obj/item/assembly/signaler))
-		if(signaler.secured)
+		var/obj/item/assembly/signaler/S = W
+		if(S.secured)
 			to_chat(user, "<span class='warning'>The signaler needs to be in attachable mode to add it to the paystand!</span>")
 			return
 		if(!my_card)
@@ -73,8 +74,8 @@
 				to_chat(user, "<span class='warning'>ERROR: Invalid amount designated.</span>")
 				return
 			if(cash_limit)
-				W.forceMove(src)
-				signaler = W
+				S.forceMove(src)
+				signaler = S
 				signaler_threshold = cash_limit
 				to_chat(user, "You attach the signaler to the paystand.")
 				desc += " A signaler appears to be attached to the scanner."


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl:  MMMiracles
fix: Fixes signalers not working properly on paystands
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

checking if the non-existent paystand signaler is secured instead of the signaler you're trying to attach is ni bueno.
