### PR TITLE
Drops Dragnet Stun And Reduces Dragnet Trap Break-Out Time

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -297,6 +297,7 @@
 	armed = 1
 	icon_state = "e_snare"
 	trap_damage = 0
+	breakouttime = 30
 	item_flags = DROPDEL
 	flags_1 = NONE
 

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -59,7 +59,6 @@
 	name = "energy snare"
 	icon_state = "e_snare"
 	nodamage = 1
-	paralyze = 20
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 4
 


### PR DESCRIPTION

:cl: 
balance: dragnet no longer stuns on hit
balance: dragnet traps are removed 10x faster than previously.
/:cl:
why: its a better taser, the bear trapping is already enough to make it a good gun doesnt need to have fucking stun and 30s beartraps