### PR TITLE
Fixes 4-way H/E manifold icon

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
@@ -2,7 +2,7 @@
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w
 	icon = 'icons/obj/atmospherics/pipes/he-manifold.dmi'
-	icon_state = "manifold4w"
+	icon_state = "manifold4w-2"
 
 	name = "4-way pipe manifold"
 	desc = "A manifold composed of heat-exchanging pipes."


### PR DESCRIPTION
The icon state "manifold4w" doesn't exist for 4-way H/E manifolds, which is why their icon doesn't show up in Dream Maker. This PR fixes that.