### PR TITLE
Fixes curse of normality alerts on hypnosis

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -88,6 +88,7 @@
 	status_type = STATUS_EFFECT_REPLACE
 	tick_interval = 1
 	duration = 100
+	alert_type = null
 	
 /datum/status_effect/pacify/on_creation(mob/living/new_owner, set_duration)
 	if(isnum(set_duration))
@@ -553,6 +554,12 @@
 	tick_interval = 10
 	examine_text = "<span class='warning'>SUBJECTPRONOUN seems slow and unfocused.</span>"
 	var/stun = TRUE
+	alert_type = /obj/screen/alert/status_effect/trance
+	
+/obj/screen/alert/status_effect/trance
+	name = "Trance"
+	desc = "Everything feels so distant, and you can feel your thoughts forming loops inside your head..."
+	icon_state = "high"
 
 /datum/status_effect/trance/tick()
 	if(stun)


### PR DESCRIPTION
:cl: XDTM
fix: Hypnosis now shows the proper alert instead of Curse of Normality.
/:cl:

Also removed the alert for pacification, since it would be inconsistent with other sources of pacification.

Fixes #41805