### PR TITLE
Prevents stacking projected forcefields

### DIFF
--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -27,6 +27,10 @@
 			qdel(F)
 			return
 	var/turf/T = get_turf(target)
+	var/obj/structure/projected_forcefield/found_field = locate() in T
+	if(found_field)
+		to_chat(user, "<span class='warning'>There is already a forcefield in that location!</span>")
+		return
 	if(T.density)
 		return
 	if(get_dist(T,src) > field_distance_limit)


### PR DESCRIPTION
:cl: XDTM
fix: Projected forcefields can no longer be stacked onto the same tile.
/:cl:

Fixes #41840
Fixes #41839
