### PR TITLE
Adds a new combat drug, Last Wish

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -477,10 +477,10 @@
 		M.vomit(20, TRUE) //blood vomit
 	if(stage = 3 && current_cycle == 150)
 		to_chat(M, "<span class='warning'>You can't feel your body anymore.</span>")
-		L.add_trait(TRAIT_PARALYSIS_L_ARM, id)
-		L.add_trait(TRAIT_PARALYSIS_R_ARM, id)
-		L.add_trait(TRAIT_PARALYSIS_L_LEG, id)
-		L.add_trait(TRAIT_PARALYSIS_R_LEG, id)
+		M.add_trait(TRAIT_PARALYSIS_L_ARM, id)
+		M.add_trait(TRAIT_PARALYSIS_R_ARM, id)
+		M.add_trait(TRAIT_PARALYSIS_L_LEG, id)
+		M.add_trait(TRAIT_PARALYSIS_R_LEG, id)
 		stage++
 	..()
 	. = 1

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -453,6 +453,7 @@
 	description = "A byproduct of romerol testing, this combat drug can keep the user alive far beyond human standards, but will kill them as soon as it runs out."
 	reagent_state = LIQUID
 	color = "#BF4095"
+	self_consuming = TRUE
 	var/stage = 0 //Used for message tracking
 	overdose_threshold = 30
 	//No addiction threshold, if you run out you're too dead to want more

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -475,7 +475,7 @@
 		stage++
 	if(prob(5 + (current_cycle / 25)) && current_cycle > 60)
 		M.vomit(20, TRUE) //blood vomit
-	if(stage = 3 && current_cycle == 150)
+	if(stage == 3 && current_cycle == 150)
 		to_chat(M, "<span class='warning'>You can't feel your body anymore.</span>")
 		M.add_trait(TRAIT_PARALYSIS_L_ARM, id)
 		M.add_trait(TRAIT_PARALYSIS_R_ARM, id)

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -47,3 +47,10 @@
 	results = list("happiness" = 4)
 	required_reagents = list("nitrous_oxide" = 2, "epinephrine" = 1, "ethanol" = 1)
 	required_catalysts = list("plasma" = 5)
+	
+/datum/chemical_reaction/last_wish
+	name = "Last Wish"
+	id = "last_wish"
+	results = list("last_wish" = 3)
+	required_reagents = list("ghoulpowder" = 1, "ephedrine" = 1, "corazone" = 1)
+	required_catalysts = list("strange_reagent" = 5)


### PR DESCRIPTION
:cl: XDTM
add: Added Last Wish, a new combat drug made from ghoul powder, ephedrine, and corazone, with strange reagent as catalyst.
add: This drug makes the user immune to crit and death, effectively making them shrug off any amount of damage. However, if it runs out (after it's been in the system for a bit) the user will instantly die. Prolonged use may result in unclonability or the body outright exploding into gore. Use with caution.
add: Prolonged use may also result in side effects of ramping severity due to the body's internal decay.
/:cl:

This drug can keep you up and running through anything (except gibbing, dusting, or other instakills) for up to five minutes before complete paralysis (and also beyond, if you have someone else keeping you supplied). It does not prevent conventional stuns and restraints, so all you have to do in return is keep them locked up until the drug expires.

Has potential uses for last-minute survival, blackmail, or a roaring rampage of revenge, especially if paired with bath salts or hulk for the antistun. The ingredients are fairly hard to obtain, so it shouldn't be abused easily, but it might make for some cool moments if someone manages to do so.
