### PR TITLE
Grinder won't show you reagents if you can't see reagents

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -65,15 +65,15 @@
 	to_chat(user, "<span class='notice'>It contains:</span>")
 	for(var/i in holdingitems)
 		var/obj/item/O = i
-		to_chat(user, "<span class='notice'>- \A [O.name]</span>")
+		to_chat(user, "<span class='notice'>- \A [O.name].</span>")
 
 	if(beaker)
 		if(!length(beaker.reagents.reagent_list))
-			to_chat(user, "<span class='notice'>- An empty [beaker]</span>")
+			to_chat(user, "<span class='notice'>- An empty [beaker].</span>")
 		else if(user.can_see_reagents() || issilicon(user) || isobserver(user))
 			to_chat(user, "<span class='notice'>- \A [beaker] containing:</span>")
 			for(var/datum/reagent/R in beaker.reagents.reagent_list)
-				to_chat(user, "<span class='notice'>&nbsp;&nbsp;- [R.volume] units of [R.name]</span>")
+				to_chat(user, "<span class='notice'>&nbsp;&nbsp;- [R.volume] units of [R.name].</span>")
 		else
 			var/volume = 0
 			for(var/datum/reagent/R in beaker.reagents.reagent_list)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -56,6 +56,26 @@
 	if(in_range(user, src) || isobserver(user))
 		to_chat(user, "<span class='notice'>The status display reads: Grinding reagents at <b>[speed*100]%</b>.<span>")
 
+	if(!beaker && !length(holdingitems))
+		return
+	to_chat(user, "It contains:")
+	for(var/i in holdingitems)
+		var/obj/item/O = i
+		to_chat(user, "\A [O.name]")
+	if(beaker)
+		if(!length(beaker.reagents.reagent_list))
+			to_chat(user, "An empty [beaker]")
+		else if(user.can_see_reagents() || issilicon(user))
+			to_chat(user, "\A [beaker] containing:<ul>")
+			for(var/datum/reagent/R in beaker.reagents.reagent_list)
+				to_chat(user, "<li>[R.volume] units of [R.name]</li>")
+			to_chat(user, "</ul>")
+		else
+			var/volume = 0
+			for(var/datum/reagent/R in beaker.reagents.reagent_list)
+				volume += R.volume
+			to_chat(user, "\A [beaker] containing [volume] units of something.")
+
 /obj/machinery/reagentgrinder/handle_atom_del(atom/A)
 	. = ..()
 	if(A == beaker)
@@ -181,21 +201,6 @@
 			mix(user)
 		if("examine")
 			examine(user)
-
-/obj/machinery/reagentgrinder/examine(mob/user)
-	. = ..()
-	if(!beaker && !length(holdingitems))
-		return
-	to_chat(user, "It contains:")
-	for(var/i in holdingitems)
-		var/obj/item/O = i
-		to_chat(user, "\A [O.name]")
-	if(beaker)
-		to_chat(user, "\A [beaker]")
-		if(!(stat & (NOPOWER|BROKEN)))
-			to_chat(user, "The screen reads:")
-			for(var/datum/reagent/R in beaker.reagents.reagent_list)
-				to_chat(user, "[R.volume] units of [R.name]")
 
 /obj/machinery/reagentgrinder/proc/eject(mob/user)
 	for(var/i in holdingitems)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -53,28 +53,33 @@
 
 /obj/machinery/reagentgrinder/examine(mob/user)
 	..()
-	if(in_range(user, src) || isobserver(user))
-		to_chat(user, "<span class='notice'>The status display reads: Grinding reagents at <b>[speed*100]%</b>.<span>")
+	if(!in_range(user, src) && !issilicon(user) && !isobserver(user))
+		to_chat(user, "<span class='warning'>You're too far away to examine its contents!</span>")
+		return
+
+	to_chat(user, "<span class='notice'>The status display reads: Grinding reagents at <b>[speed*100]%</b>.<span>")
 
 	if(!beaker && !length(holdingitems))
 		return
-	to_chat(user, "It contains:")
+
+	to_chat(user, "<span class='notice'>It contains:</span>")
 	for(var/i in holdingitems)
 		var/obj/item/O = i
-		to_chat(user, "\A [O.name]")
+		to_chat(user, "<span class='notice'>- \A [O.name]</span>")
+
 	if(beaker)
 		if(!length(beaker.reagents.reagent_list))
-			to_chat(user, "An empty [beaker]")
-		else if(user.can_see_reagents() || issilicon(user))
-			to_chat(user, "\A [beaker] containing:<ul>")
+			to_chat(user, "<span class='notice'>- An empty [beaker]</span>")
+		else if(user.can_see_reagents() || issilicon(user) || isobserver(user))
+			to_chat(user, "<span class='notice'>- \A [beaker] containing:</span>")
 			for(var/datum/reagent/R in beaker.reagents.reagent_list)
-				to_chat(user, "<li>[R.volume] units of [R.name]</li>")
-			to_chat(user, "</ul>")
+				to_chat(user, "<span class='notice'>&nbsp;&nbsp;- [R.volume] units of [R.name]</span>")
 		else
 			var/volume = 0
 			for(var/datum/reagent/R in beaker.reagents.reagent_list)
 				volume += R.volume
-			to_chat(user, "\A [beaker] containing [volume] units of something.")
+			to_chat(user, "<span class='notice'>- \A [beaker] containing:</span>")
+			to_chat(user, "<span class='notice'>&nbsp;&nbsp;- [volume] units of something.</span>")
 
 /obj/machinery/reagentgrinder/handle_atom_del(atom/A)
 	. = ..()


### PR DESCRIPTION
[Changelogs]: #
:cl:
balance: If you aren't wearing googles that allow you to check reagents in a beaker, you can't see reagents inside a grinder. AIs, borgs and observers and can always see the reagents.
balance: You need to be next to the grinder to see its contents, unless you are AI, borg or observer.
/:cl:

Shouldn't matter for bartenders and chemistry as they spawn with googles.
Makes googles have the utility they should have (seeing reagents you couldn't see with naked eye).
