### PR TITLE
Fixes repair droids with short circuit

### DIFF
--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -251,8 +251,8 @@
 				chassis.clearInternalDamage(int_dam_flag)
 				repaired = 1
 				break
-	if(health_boost<0 || chassis.obj_integrity < chassis.max_integrity)
-		chassis.obj_integrity += min(health_boost, chassis.max_integrity-chassis.obj_integrity)
+	if(h_boost<0 || chassis.obj_integrity < chassis.max_integrity)
+		chassis.obj_integrity += min(h_boost, chassis.max_integrity-chassis.obj_integrity)
 		repaired = 1
 	if(repaired)
 		if(!chassis.use_power(energy_drain))


### PR DESCRIPTION
:cl: Swindly
fix: Fixed repair droids not damaging mechs when the mech has a short circuit.
/:cl:

Processing uses a temporary h_boost variable based on the repair droid's health_boost variable and modified when the mech has a short circuit, but the h_boost variable was unused while the health_boost variable was instead used to check repairs.