### PR TITLE
Adds recycler check on xenobio console interaction

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -33,6 +33,7 @@
 	var/datum/component/redirect/listener
 
 	var/obj/machinery/monkey_recycler/connected_recycler
+	var/initialized_recycler = FALSE
 	var/list/stored_slimes
 	var/obj/item/slimepotion/slime/current_potion
 	var/max_slimes = 5
@@ -58,6 +59,7 @@
 		if(get_area(recycler.loc) == get_area(loc))
 			connected_recycler = recycler
 			connected_recycler.connected += src
+			initialized_recycler = TRUE
 
 /obj/machinery/computer/camera_advanced/xenobio/Destroy()
 	stored_slimes = null
@@ -118,7 +120,14 @@
 	RegisterSignal(user, COMSIG_XENO_SLIME_CLICK_SHIFT, .proc/XenoSlimeClickShift)	
 	RegisterSignal(user, COMSIG_XENO_TURF_CLICK_SHIFT, .proc/XenoTurfClickShift)	
 	RegisterSignal(user, COMSIG_XENO_TURF_CLICK_CTRL, .proc/XenoTurfClickCtrl)	
-	RegisterSignal(user, COMSIG_XENO_MONKEY_CLICK_CTRL, .proc/XenoMonkeyClickCtrl)	
+	RegisterSignal(user, COMSIG_XENO_MONKEY_CLICK_CTRL, .proc/XenoMonkeyClickCtrl)
+
+	if(!initialized_recycler)
+		for(var/obj/machinery/monkey_recycler/recycler in GLOB.monkey_recyclers)
+			if(get_area(recycler.loc) == get_area(loc))
+				connected_recycler = recycler
+				connected_recycler.connected += src
+				initialized_recycler = TRUE
 
 
 /obj/machinery/computer/camera_advanced/xenobio/remove_eye_control(mob/living/user)

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -33,7 +33,6 @@
 	var/datum/component/redirect/listener
 
 	var/obj/machinery/monkey_recycler/connected_recycler
-	var/initialized_recycler = FALSE
 	var/list/stored_slimes
 	var/obj/item/slimepotion/slime/current_potion
 	var/max_slimes = 5
@@ -59,7 +58,6 @@
 		if(get_area(recycler.loc) == get_area(loc))
 			connected_recycler = recycler
 			connected_recycler.connected += src
-			initialized_recycler = TRUE
 
 /obj/machinery/computer/camera_advanced/xenobio/Destroy()
 	stored_slimes = null
@@ -122,13 +120,11 @@
 	RegisterSignal(user, COMSIG_XENO_TURF_CLICK_CTRL, .proc/XenoTurfClickCtrl)	
 	RegisterSignal(user, COMSIG_XENO_MONKEY_CLICK_CTRL, .proc/XenoMonkeyClickCtrl)
 
-	if(!initialized_recycler)
+	if(!connected_recycler)
 		for(var/obj/machinery/monkey_recycler/recycler in GLOB.monkey_recyclers)
 			if(get_area(recycler.loc) == get_area(loc))
 				connected_recycler = recycler
 				connected_recycler.connected += src
-				initialized_recycler = TRUE
-
 
 /obj/machinery/computer/camera_advanced/xenobio/remove_eye_control(mob/living/user)
 	UnregisterSignal(user, COMSIG_XENO_SLIME_CLICK_CTRL)	

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -120,6 +120,7 @@
 	RegisterSignal(user, COMSIG_XENO_TURF_CLICK_CTRL, .proc/XenoTurfClickCtrl)	
 	RegisterSignal(user, COMSIG_XENO_MONKEY_CLICK_CTRL, .proc/XenoMonkeyClickCtrl)
 
+	//Checks for recycler on every interact, prevents issues with load order on certain maps. 
 	if(!connected_recycler)
 		for(var/obj/machinery/monkey_recycler/recycler in GLOB.monkey_recyclers)
 			if(get_area(recycler.loc) == get_area(loc))


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
fix: Xenobio consoles that didn't connect to recycler in the xenobio lab should now do so.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
Now actually fixes #41792
Camera consoles without a recycler connected will try to connect to one in the same area when interacted with.