### PR TITLE
Replaces the single line text prompt in Admin PMs with a multiline one

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -55,7 +55,7 @@
 
 	if(AH)
 		message_admins("[key_name_admin(src)] has started replying to [key_name_admin(C, 0, 0)]'s admin help.")
-	var/msg = input(src,"Message:", "Private message to [key_name(C, 0, 0)]") as text|null
+	var/msg = input(src,"Message:", "Private message to [key_name(C, 0, 0)]") as message|null
 	if (!msg)
 		message_admins("[key_name_admin(src)] has cancelled their reply to [key_name_admin(C, 0, 0)]'s admin help.")
 		return
@@ -90,7 +90,7 @@
 		if(!ircreplyamount)	//to prevent people from spamming irc
 			return
 		if(!msg)
-			msg = input(src,"Message:", "Private message to Administrator") as text|null
+			msg = input(src,"Message:", "Private message to Administrator") as message|null
 
 		if(!msg)
 			return
@@ -112,7 +112,7 @@
 
 		//get message text, limit it's length.and clean/escape html
 		if(!msg)
-			msg = input(src,"Message:", "Private message to [key_name(recipient, 0, 0)]") as text|null
+			msg = input(src,"Message:", "Private message to [key_name(recipient, 0, 0)]") as message|null
 			msg = trim(msg)
 			if(!msg)
 				return
@@ -191,7 +191,7 @@
 					spawn()	//so we don't hold the caller proc up
 						var/sender = src
 						var/sendername = key
-						var/reply = input(recipient, msg,"Admin PM from-[sendername]", "") as text|null		//show message and await a reply
+						var/reply = input(recipient, msg,"Admin PM from-[sendername]", "") as message|null		//show message and await a reply
 						if(recipient && reply)
 							if(sender)
 								recipient.cmd_admin_pm(sender,reply)										//sender is still about, let's reply to them


### PR DESCRIPTION

:cl: 
admin: Admin PMs are now multi-line text prompts, making it easier to write big admin PMs.
/:cl:

There are a number of reasons why I consider this desirable over the current behavior.
1. It allows you to freely and easily copy/paste logs (since logs are multiline, before you couldn't just copy paste them into a single admin PM)
2. It makes it much easier to organize a long admin PM with line breaks instead of a single span of uninterrupted text.
3. More of a personal issue, but you can't accidentally press enter and send an admin PM anymore. If you want to send it via keyboard still, you can press tab and then press enter.

I made a short demonstration.
https://streamable.com/m1erw
I could also add this to ahelps, which isn't a bad idea. But I wanted to PR this separately first.