### PR TITLE
Admin only: Pair pinpointers, come in matched pairs, and always point to the other one

### DIFF
--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -26,6 +26,7 @@
 /obj/item/pinpointer/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)
 	GLOB.pinpointer_list -= src
+	target = null
 	return ..()
 
 /obj/item/pinpointer/attack_self(mob/living/user)
@@ -140,3 +141,35 @@
 				target = null
 	if(!target) //target can be set to null from above code, or elsewhere
 		active = FALSE
+
+
+/obj/item/pinpointer/pair
+	name = "pair pinpointer"
+	desc = "A handheld tracking device that locks onto its other half of the matching pair."
+	var/other_pair
+
+/obj/item/pinpointer/pair/Destroy()
+	other_pair = null
+	. = ..()
+
+/obj/item/pinpointer/pair/scan_for_target()
+	target = other_pair
+
+/obj/item/pinpointer/pair/examine(mob/user)
+	. = ..()
+	if(!active || !target)
+		return
+	var/mob/mob_holder = get(target, /mob)
+	if(istype(mob_holder))
+		to_chat(user, "Its pair is being held by [mob_holder].")
+		return
+
+/obj/item/storage/box/pinpointer_pairs
+	name = "pinpointer pair box"
+
+/obj/item/storage/box/pinpointer_pairs/PopulateContents()
+	var/obj/item/pinpointer/pair/A = new(src)
+	var/obj/item/pinpointer/pair/B = new(src)
+
+	A.other_pair = B
+	B.other_pair = A


### PR DESCRIPTION
:cl: coiax
add: Admin and event only pair pinpointers! They come in a box of two, and each pinpointer will always point at its corresponding pair. Aww.
/:cl:

Would come in handy in tracking your date for the Winter Ball.

The key item path here is `/obj/item/storage/box/pinpointer_pairs`, which makes a box containing
two pinpointers that are paired with each other.