### PR TITLE
The cyborg reset module wire is always marked with a star

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -98,6 +98,12 @@
 /datum/wires/proc/get_wire(color)
 	return colors[color]
 
+/datum/wires/proc/get_color_of_wire(wire_type)
+	for(var/color in colors)
+		var/other_type = colors[color]
+		if(wire_type == other_type)
+			return color
+
 /datum/wires/proc/get_attached(color)
 	if(assemblies[color])
 		return assemblies[color]

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -23,7 +23,7 @@
 	status += "The intelligence link display shows [R.connected_ai ? R.connected_ai.name : "NULL"]."
 	status += "The camera light is [!isnull(R.builtInCamera) && R.builtInCamera.status ? "on" : "off"]."
 	status += "The lockdown indicator is [R.lockcharge ? "on" : "off"]."
-	status += "The reset module hardware light is [R.has_module() ? "on" : "off"]."
+	status += "There is a star symbol above the [get_color_of_wire(WIRE_RESET_MODULE)] wire."
 	return status
 
 /datum/wires/robot/on_pulse(wire, user)


### PR DESCRIPTION
:cl: coiax
add: The cyborg reset module wire has a star symbol marking, allowing a trained Roboticist to easily provide resets without altering any other cyborg settings.
/:cl:

When I removed cyborg module reset modules, it was pulse-to-reset, which
when applied to all the wires on a cyborg, had no real side effects
if there was only one AI.

Now that it's a cut-to-reset wire, cutting all the wires will invariably
desync the cyborg from its parent AI, given that all cyborg wires are
randomised.

My intention was never for the reset wire to be "found" just like door
wires, just to make it cheaper and possible to reset a borg module
"in the field".

Someone who hasn't read the wiki or knows what a "star symbol" means,
will have to be told what to look for, so I chose this method of signaling
rather than just "the module reset wire is X".

Also, it's a Keep Talking And No One Explodes reference.