### PR TITLE
Makes teleports use forceMove by default

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -8,7 +8,7 @@
 // forceMove: if false, teleport will use Move() proc (dense objects will prevent teleportation)
 // no_effects: disable the default effectin/effectout of sparks
 // forced: whether or not to ignore no_teleport
-/proc/do_teleport(atom/movable/teleatom, atom/destination, precision=null, forceMove = FALSE, datum/effect_system/effectin=null, datum/effect_system/effectout=null, asoundin=null, asoundout=null, no_effects=FALSE, channel=TELEPORT_CHANNEL_BLUESPACE, forced = FALSE)
+/proc/do_teleport(atom/movable/teleatom, atom/destination, precision=null, forceMove = TRUE, datum/effect_system/effectin=null, datum/effect_system/effectout=null, asoundin=null, asoundout=null, no_effects=FALSE, channel=TELEPORT_CHANNEL_BLUESPACE, forced = FALSE)
 	// teleporting most effects just deletes them
 	var/static/list/delete_atoms = typecacheof(list(
 		/obj/effect,


### PR DESCRIPTION
Making teleports use Move() was the most retarded decision tg coders have ever made in the history of coding. It literally broke so many things. Here's a list:

- bluespace wormhole projector (causes an infinite fucking loop, which results in massive fucking lag)
- Regime: Gate setting on normal teleporter (causes an infinite fucking loop, which results in massive fucking lag)
- hand tele (causes an infinite fucking loop, which results in massive fucking lag)

learn to code, fuckos.

:cl: monster860
fix: Teleports now go back to force-moving you instead of Move()
/:cl: