### PR TITLE
Retarded TG Coder Teleport Debacle Fix - Bonus PR

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -399,12 +399,12 @@ structure_check() searches for nearby cultist structures required for the invoca
 			continue
 		if(!A.anchored)
 			movedsomething = TRUE
-			if(do_teleport(A, T, forceMove = TRUE, channel = TELEPORT_CHANNEL_CULT))
+			if(do_teleport(A, target, forceMove = TRUE, channel = TELEPORT_CHANNEL_CULT))
 				movesuccess = TRUE
 	if(movedsomething)
 		..()
 		if(moveuserlater)
-			if(do_teleport(user, T, channel = TELEPORT_CHANNEL_CULT))
+			if(do_teleport(user, target, channel = TELEPORT_CHANNEL_CULT))
 				movesuccess = TRUE
 		if(movesuccess)
 			visible_message("<span class='warning'>There is a sharp crack of inrushing air, and everything above the rune disappears!</span>", null, "<i>You hear a sharp crack.</i>")


### PR DESCRIPTION
IT TELEPORTS YOU

FROM THE SOURCE TURF

TO THE FUCKING SOURCE TURF


IDIOTS!!!!

you fuckers fucked my cult round today.

thanks for ruining yogstation. not.

:cl: monster860
fix: Fixes teleport runes not working, at all.
/:cl: