### PR TITLE
Heavily Buffs voice of god

### DIFF
--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -1,7 +1,7 @@
-#define COOLDOWN_STUN 1200
-#define COOLDOWN_DAMAGE 600
-#define COOLDOWN_MEME 300
-#define COOLDOWN_NONE 100
+#define COOLDOWN_STUN 200
+#define COOLDOWN_DAMAGE 100
+#define COOLDOWN_MEME 50
+#define COOLDOWN_NONE 10
 
 /obj/item/organ/vocal_cords //organs that are activated through speech with the :x/MODE_KEY_VOCALCORDS channel
 	name = "vocal cords"


### PR DESCRIPTION
:cl:
balance: voice of god cooldown heavily reduced
/:cl:

Colossus is the hardest boss to fight, but voice of god is mediocre loot. I feel it'd be a lot more suited to the difficulty of the fight if you didn't have to wait TWO MINUTES between each use. These changes would make it powerful, but I don't think it would be insanely powerful compared to other top-tier megafauna loot (such as drake bottle).
