### PR TITLE
mobs on centcom are no longer valid for midround antags

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -160,7 +160,7 @@
 	var/list/antag_candidates = list()
 
 	for(var/mob/living/carbon/human/H in living_crew)
-		if(H.client && H.client.prefs.allow_midround_antag)
+		if(H.client && H.client.prefs.allow_midround_antag && !is_centcom_level(H.z))
 			antag_candidates += H
 
 	if(!antag_candidates)


### PR DESCRIPTION
fixes #41885 

the problems with picking centcom antags are in the issue post. if this isn't a good idea, i can just make it check for the thunderdome arena area instead.