### PR TITLE
honkbots can be fixed with a welder

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -120,9 +120,7 @@ Maintenance panel panel is [open ? "opened" : "closed"]"},
 
 
 /mob/living/simple_animal/bot/honkbot/attackby(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_WELDER && user.a_intent != INTENT_HARM)
-		return
-	if(!W.tool_behaviour == TOOL_SCREWDRIVER && (W.force) && (!target) && (W.damtype != STAMINA) ) // Check for welding tool to fix #2432.
+	if(!W.tool_behaviour == TOOL_SCREWDRIVER && (W.force) && (!target) && (W.damtype != STAMINA) )
 		retaliate(user)
 		addtimer(CALLBACK(src, .proc/react_buzz), 5)
 	..()


### PR DESCRIPTION
this fix is really weird, and here's the 411 on why:

https://github.com/tgstation/tgstation/blob/a9ca93b60dbf7b9f0fc5cbe94c406a2126312fee/code/modules/mob/living/simple_animal/bot/honkbot.dm#L122-L125

whoever made honkbots purposely disabled welding because welding would make the bot mad, arresting you. that got fixed a very long time ago, and it doesn't really make sense for this bot not to be able to be fixed, so I undid it.

If this is intended for a reason I missed, I can change the pr to at least let the owner know so things like
#41882 from popping up

(fixes #41882)