### PR TITLE
Adds infinite closets, admin-only utility spawns

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/infinite.dm
+++ b/code/game/objects/structures/crates_lockers/closets/infinite.dm
@@ -1,0 +1,33 @@
+/obj/structure/closet/infinite
+	name = "infinite closet"
+	desc = "It's closets, all the way down."
+	var/replicating_type
+	var/stop_replicating_at = 4
+	var/auto_close_time = 15 SECONDS // Set to 0 to disable auto-closing.
+
+/obj/structure/closet/infinite/Initialize()
+	. = ..()
+	START_PROCESSING(SSobj, src)
+
+/obj/structure/closet/infinite/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	. = ..()
+
+/obj/structure/closet/infinite/process()
+	if(!replicating_type)
+		if(!length(contents))
+			return
+		else
+			replicating_type = contents[1].type
+
+	if(replicating_type && !opened && (length(contents) < stop_replicating_at))
+		new replicating_type(src)
+
+/obj/structure/closet/infinite/open()
+	. = ..()
+	if(. && auto_close_time)
+		addtimer(CALLBACK(src, .proc/close_on_my_own), auto_close_time, TIMER_OVERRIDE)
+
+/obj/structure/closet/infinite/proc/close_on_my_own()
+	if(close())
+		visible_message("<span class='notice'>\The [src] closes on its own.</span>")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1019,6 +1019,7 @@
 #include "code\game\objects\structures\crates_lockers\closets\cardboardbox.dm"
 #include "code\game\objects\structures\crates_lockers\closets\fitness.dm"
 #include "code\game\objects\structures\crates_lockers\closets\gimmick.dm"
+#include "code\game\objects\structures\crates_lockers\closets\infinite.dm"
 #include "code\game\objects\structures\crates_lockers\closets\job_closets.dm"
 #include "code\game\objects\structures\crates_lockers\closets\l3closet.dm"
 #include "code\game\objects\structures\crates_lockers\closets\syndicate.dm"


### PR DESCRIPTION
:cl: coiax
admin: Added the infinite closet, a closet that replicates the first thing that's put into it.
/:cl:

This works on types, so usual caveats apply. Admins could use this during building events, and fill the closets with stacks of metal (provided the /fifty) type exists, could use it when handing out boxes of pinpoint pairs, etc.

Mappers can use this like any other closet, it'll automatically absorb items on top of it, and will bond to the first one inserted.