### PR TITLE
makes the abductor console use radials

### DIFF
--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -134,7 +134,12 @@
 		dummy.overlays = snap.overlays
 		disguises2[name] = dummy
 
-	var/entry_name = show_radial_menu(usr, src, disguises2)
+	var/entry_name
+	if(remote)
+		entry_name = show_radial_menu(usr, camera.eyeobj, disguises2)
+	else
+		entry_name = show_radial_menu(usr, src, disguises2)
+
 	var/datum/icon_snapshot/chosen = disguises[entry_name]
 	if(chosen && vest && (remote || in_range(usr,src)))
 		vest.SetDisguise(chosen)

--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -126,8 +126,15 @@
 	if(vest)
 		vest.flip_mode()
 
-/obj/machinery/abductor/console/proc/SelectDisguise(remote = 0)
-	var/entry_name = input( "Choose Disguise", "Disguise") as null|anything in disguises
+/obj/machinery/abductor/console/proc/SelectDisguise(remote = FALSE)
+	var/list/disguises2 = list()
+	for(var/name in disguises)
+		var/datum/icon_snapshot/snap = disguises[name]
+		var/image/dummy = image(snap.icon, src, snap.icon_state)
+		dummy.overlays = snap.overlays
+		disguises2[name] = dummy
+
+	var/entry_name = show_radial_menu(usr, src, disguises2)
 	var/datum/icon_snapshot/chosen = disguises[entry_name]
 	if(chosen && vest && (remote || in_range(usr,src)))
 		vest.SetDisguise(chosen)


### PR DESCRIPTION
:cl: Nicjh
add: Abductor console's select disguise option now uses a radial
/:cl:

![image](https://user-images.githubusercontent.com/20558591/49895717-78f61780-fe51-11e8-829e-7d0bd49f3b1f.png)

Definitely much better as a visual interface
