### PR TITLE
[s] Fixes changeling decapitation, for real this time

### DIFF
--- a/code/modules/antagonists/changeling/powers/regenerate.dm
+++ b/code/modules/antagonists/changeling/powers/regenerate.dm
@@ -26,7 +26,6 @@
 				and tearing!</span>")
 			C.emote("scream")
 			C.regenerate_limbs(1)
-		C.regenerate_organs()
 		if(!user.getorganslot(ORGAN_SLOT_BRAIN))
 			var/obj/item/organ/brain/B
 			if(C.has_dna() && C.dna.species.mutant_brain)
@@ -36,6 +35,7 @@
 			B.vital = FALSE
 			B.decoy_override = TRUE
 			B.Insert(C)
+		C.regenerate_organs()
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.restore_blood()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -152,14 +152,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/should_have_stomach = !(NOSTOMACH in species_traits)
 	var/should_have_tail = mutanttail
 
-	if(brain && (replace_current || !should_have_brain))
-		if(!brain.decoy_override)//Just keep it if it's fake
-			brain.Remove(C,TRUE,TRUE)
-			QDEL_NULL(brain)
-	if(should_have_brain && !brain)
-		brain = new mutant_brain()
-		brain.Insert(C, TRUE, TRUE)
-
 	if(heart && (!should_have_heart || replace_current))
 		heart.Remove(C,1)
 		QDEL_NULL(heart)
@@ -212,6 +204,14 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		tail.Insert(C)
 
 	if(C.get_bodypart(BODY_ZONE_HEAD))
+		if(brain && (replace_current || !should_have_brain))
+			if(!brain.decoy_override)//Just keep it if it's fake
+				brain.Remove(C,TRUE,TRUE)
+				QDEL_NULL(brain)
+		if(should_have_brain && !brain)
+			brain = new mutant_brain()
+			brain.Insert(C, TRUE, TRUE)
+
 		if(eyes && (replace_current || !should_have_eyes))
 			eyes.Remove(C,1)
 			QDEL_NULL(eyes)


### PR DESCRIPTION
The Revive power was calling regenerate_organs(), which did not check for the presence of a head before inserting a (non-fake) brain.
Additionally, the Regenerate power would call regenerate_organs() before the fake brain insertion, which was also inserting a non-fake brain, even with the above fixed.

Fixes #41435 