### PR TITLE
Makes Surgery Toolarm Preferred Choice instead of Powertools

### DIFF
--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -53,7 +53,7 @@
 	materials = list(MAT_METAL=70)
 	icon_state = "crowbar_large"
 	item_state = "crowbar"
-	toolspeed = 0.5
+	toolspeed = 0.7
 
 /obj/item/crowbar/cyborg
 	name = "hydraulic crowbar"
@@ -73,7 +73,7 @@
 
 	usesound = 'sound/items/jaws_pry.ogg'
 	force = 15
-	toolspeed = 0.25
+	toolspeed = 0.7
 
 /obj/item/crowbar/power/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is putting [user.p_their()] head in [src], it looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -120,7 +120,7 @@
 	attack_verb = list("drilled", "screwed", "jabbed","whacked")
 	hitsound = 'sound/items/drill_hit.ogg'
 	usesound = 'sound/items/drill_use.ogg'
-	toolspeed = 0.25
+	toolspeed = 0.7
 	random_color = FALSE
 
 /obj/item/screwdriver/power/suicide_act(mob/user)

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -91,7 +91,7 @@
 
 	materials = list(MAT_METAL=150,MAT_SILVER=50,MAT_TITANIUM=25)
 	usesound = 'sound/items/jaws_cut.ogg'
-	toolspeed = 0.25
+	toolspeed = 0.7
 	random_color = FALSE
 
 /obj/item/wirecutters/power/suicide_act(mob/user)

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -58,7 +58,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 8
 	attack_verb = list("drilled", "screwed", "jabbed")
-	toolspeed = 0.25
+	toolspeed = 0.7
 
 /obj/item/wrench/power/attack_self(mob/user)
 	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)


### PR DESCRIPTION
:cl: Toolby
balance: Power tools now perform construction slower than the toolarm implant (but still incredibly faster than normal tools)
balance: This is to promote trusting a player rather than safely printing off an item via techfab.
/:cl:

Reasoning: As said in the Advanced Surgery PR, The act of trusting an individual who could possibly be able to kill you should supercede the mineral cost difference (we do not balance those) and techweb cost difference (sorta balanced those) between powertools and toolarm implant. This will also mean that the CE now has a vested interest in Science/Medical efforts since he can get better tools, while still making powertools a considerably better item than normal tools (30% increase and less storage slots).

Also said in the Advanced Surgery PR, if construction is insufferable with both number-wise we can look at beefing down the numbers (with the implant still being preferred option).
