### PR TITLE
Fixes hilbertshoteltestingsite.dmm roundstart atmos

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
@@ -197,13 +197,9 @@
 /turf/closed/mineral/random,
 /area/ruin/unpowered/no_grav)
 "K" = (
-/turf/open/floor/plasteel/stairs/left,
-/area/ruin/unpowered/no_grav)
-"L" = (
-/turf/open/floor/plasteel/stairs/medium,
-/area/ruin/unpowered/no_grav)
-"M" = (
-/turf/open/floor/plasteel/stairs/right,
+/turf/open/floor/plasteel/stairs/right{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/ruin/unpowered/no_grav)
 
 (1,1,1) = {"
@@ -816,7 +812,7 @@ B
 B
 B
 I
-L
+K
 b
 b
 b
@@ -844,7 +840,7 @@ c
 d
 c
 d
-M
+K
 b
 b
 b

--- a/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
@@ -201,6 +201,14 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/unpowered/no_grav)
+"U" = (
+/turf/open/floor/plasteel/stairs/medium{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered/no_grav)
+"X" = (
+/turf/open/floor/plasteel/stairs/left,
+/area/ruin/unpowered/no_grav)
 
 (1,1,1) = {"
 a
@@ -784,7 +792,7 @@ B
 B
 B
 d
-K
+X
 b
 b
 b
@@ -812,7 +820,7 @@ B
 B
 B
 I
-K
+U
 b
 b
 b


### PR DESCRIPTION
Fixes atmos being different between adjacent tiles at roundstart in hilbertshoteltestingsite.dmm