### PR TITLE
Removes public autolathes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -24440,6 +24440,7 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bgv" = (
@@ -28689,7 +28690,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -27
 	},
-/obj/machinery/rnd/production/techfab/department/cargo,
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bqp" = (
@@ -30446,14 +30447,6 @@
 "buI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"buJ" = (
-/obj/effect/turf_decal/loading_area,
-/obj/machinery/door/poddoor/shutters{
-	id = "public_autolathe";
-	name = "public autolathe shutters"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -56623,16 +56616,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"nEa" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "public_autolathe";
-	name = "public autolathe shutters"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "nEP" = (
 /obj/structure/closet/l3closet/scientist{
 	pixel_x = -2
@@ -56745,12 +56728,6 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"oEF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "oHU" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -56838,7 +56815,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "psy" = (
@@ -80870,7 +80849,7 @@ bfm
 bNK
 bkN
 bfm
-oEF
+bfm
 bwe
 bwd
 bwY
@@ -81126,8 +81105,8 @@ boR
 bqs
 bbR
 bkM
-nEa
-bqs
+bbR
+bbR
 bwd
 bvL
 byI
@@ -81383,8 +81362,8 @@ boT
 bbR
 bbR
 buI
-bfm
-bqs
+bbR
+bbR
 bwd
 ccR
 byK
@@ -81640,8 +81619,8 @@ bbR
 bqt
 cBq
 bbR
-bfm
-bqs
+bbR
+bbR
 bwd
 bxC
 byL
@@ -81896,8 +81875,8 @@ bnJ
 bty
 bbR
 bbR
-bbR
-buJ
+bty
+bty
 pqP
 bwd
 byM

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -127043,11 +127043,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hor)
-"kwx" = (
-/obj/effect/turf_decal/loading_area,
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "kyo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -127160,21 +127155,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "loI" = (
-/obj/machinery/autolathe,
-/obj/machinery/door/window/southleft{
-	name = "Research Lab Desk";
-	req_one_access_txt = "7;29"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rndlab1";
 	name = "Research and Development Shutter"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/science/lab)
 "lti" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped,
@@ -166625,7 +166611,7 @@ cQQ
 cSw
 cUl
 cQP
-kwx
+cXA
 loI
 daV
 dcJ

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -83243,32 +83243,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"izu" = (
-/obj/machinery/autolathe{
-	name = "public autolathe"
-	},
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Research and Development Desk";
-	req_one_access_txt = "7;29"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "research_shutters";
-	name = "research shutters"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "iAj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -114090,7 +114064,7 @@ cay
 cci
 cdM
 ceR
-izu
+cge
 chm
 ciG
 ckc

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -20832,11 +20832,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"aXu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/dark,
-/area/quartermaster/office)
 "aXv" = (
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -22390,6 +22385,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "baz" = (
@@ -98494,7 +98490,7 @@ aTb
 aOT
 aVp
 aWu
-aXu
+aPW
 aYq
 aPY
 bav


### PR DESCRIPTION
:cl: Powercreep Balance Committee
del: Public autolathes have been removed. Please ask (or break into) cargo if you need something.
/:cl:

I think this change should be fairly apparent why it would be beneficial, but if not:

Public autolathes are part of the large amount of resource-creep which became popular with the rise of multiple maps and map rotation. Having an over-abundance of resources, tools, and gear available to the crew stifles meaningful player interaction and conflict. 

Autolathe goods being locked behind cargo's doors would require players, once again, to interact with their fellow crew on cargo duty in order to receive what they want (or to break in and evade security). We survived for years with this mechanically being the case, and I believe it would only be logical to return to it.

Cobby: Closes #41938 