### PR TITLE
Fixes chem dispenser macro granularity

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -84,8 +84,7 @@
 	if(panel_open)
 		to_chat(user, "<span class='notice'>[src]'s maintenance hatch is open!</span>")
 	if(in_range(user, src) || isobserver(user))
-		to_chat(user, "<span class='notice'>The status display reads: <br>Recharging <b>[recharge_amount]</b> power units per interval.<br>Power efficiency increased by <b>[(powerefficiency*1000)-100]%</b>.<span>")
-		to_chat(user, "<span class='notice'>Macro granularity at <b>[macroresolution]u</b>.<span>")
+		to_chat(user, "<span class='notice'>The status display reads: <br>Recharging <b>[recharge_amount]</b> power units per interval.<br>Power efficiency increased by <b>[round((powerefficiency*1000)-100, 1)]%</b>.<br>Macro granularity at <b>[macroresolution]u</b>.<span>")
 
 /obj/machinery/chem_dispenser/process()
 	if (recharge_counter >= 4)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -19,7 +19,7 @@
 	var/working_state = "dispenser_working"
 	var/nopower_state = "dispenser_nopower"
 	var/has_panel_overlay = TRUE
-	var/macrotier = 1
+	var/macroresolution = 1
 	var/obj/item/reagent_containers/beaker = null
 	var/list/dispensable_reagents = list(
 		"hydrogen",
@@ -85,15 +85,8 @@
 		to_chat(user, "<span class='notice'>[src]'s maintenance hatch is open!</span>")
 	if(in_range(user, src) || isobserver(user))
 		to_chat(user, "<span class='notice'>The status display reads: <br>Recharging <b>[recharge_amount]</b> power units per interval.<br>Power efficiency increased by <b>[(powerefficiency*1000)-100]%</b>.<span>")
-		switch(macrotier)
-			if(1)
-				to_chat(user, "<span class='notice'>Macro granularity at <b>5u</b>.<span>")
-			if(2)
-				to_chat(user, "<span class='notice'>Macro granularity at <b>3u</b>.<span>")
-			if(3)
-				to_chat(user, "<span class='notice'>Macro granularity at <b>2u</b>.<span>")
-			if(4)
-				to_chat(user, "<span class='notice'>Macro granularity at <b>1u</b>.<span>")
+		to_chat(user, "<span class='notice'>Macro granularity at <b>[macroresolution]u</b>.<span>")
+
 /obj/machinery/chem_dispenser/process()
 	if (recharge_counter >= 4)
 		if(!is_operational())
@@ -254,14 +247,14 @@
 				return
 			var/recipe_to_use = params["recipe"]
 			var/list/chemicals_to_dispense = process_recipe_list(recipe_to_use)
-			var/res = get_macro_resolution()
+			var/res = macroresolution
 			for(var/key in chemicals_to_dispense) // i suppose you could edit the list locally before passing it
 				var/list/keysplit = splittext(key," ")
 				var/r_id = keysplit[1]
 				if(beaker && dispensable_reagents.Find(r_id)) // but since we verify we have the reagent, it'll be fine
 					var/datum/reagents/R = beaker.reagents
 					var/free = R.maximum_volume - R.total_volume
-					var/actual = min(round(chemicals_to_dispense[key], res), (cell.charge * powerefficiency)*10, free)
+					var/actual = min(max(chemicals_to_dispense[key], res), (cell.charge * powerefficiency)*10, free)
 					if(actual)
 						if(!cell.use(actual / powerefficiency))
 							say("Not enough energy to complete operation!")
@@ -285,7 +278,7 @@
 				var/list/first_process = splittext(recipe, ";")
 				if(!LAZYLEN(first_process))
 					return
-				var/res = get_macro_resolution()
+				var/res = macroresolution
 				var/resmismatch = FALSE
 				for(var/reagents in first_process)
 					var/list/reagent = splittext(reagents, "=")
@@ -352,10 +345,10 @@
 	work_animation()
 	visible_message("<span class='danger'>[src] malfunctions, spraying chemicals everywhere!</span>")
 
-
 /obj/machinery/chem_dispenser/RefreshParts()
 	recharge_amount = initial(recharge_amount)
 	var/newpowereff = 0.0666666
+	macroresolution = 5
 	for(var/obj/item/stock_parts/cell/P in component_parts)
 		cell = P
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
@@ -363,13 +356,11 @@
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
 		recharge_amount *= C.rating
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
-		if (M.rating > macrotier)
-			macrotier = M.rating
+		if (M.rating > 1)
+			macroresolution -= M.rating		//5 for t1, 3 for t2, 2 for t3, 1 for t4
 		if (M.rating > 3)
 			dispensable_reagents |= upgrade_reagents
 	powerefficiency = round(newpowereff, 0.01)
-
-
 
 /obj/machinery/chem_dispenser/on_deconstruction()
 	cell = null
@@ -378,31 +369,26 @@
 		beaker = null
 	return ..()
 
-/obj/machinery/chem_dispenser/proc/get_macro_resolution()
-	. = 5
-	if (macrotier > 1)
-		. -= macrotier // 5 for tier1, 3 for 2, 2 for 3, 1 for 4.
-
 /obj/machinery/chem_dispenser/proc/check_macro(macro)
-	var/res = get_macro_resolution()
+	var/res = macroresolution
 	for (var/reagent in splittext(trim(macro), ";"))
 		if (!check_macro_part(reagent, res))
 			return FALSE
 	return TRUE
 
-/obj/machinery/chem_dispenser/proc/check_macro_part(var/part, var/res = get_macro_resolution())
+/obj/machinery/chem_dispenser/proc/check_macro_part(var/part, var/res = macroresolution)
 	var/detail = splittext(part, "=")
-	if (round(text2num(detail[2]), res) != text2num(detail[2]))
+	if (text2num(detail[2]) < res)
 		return FALSE
 	return TRUE
 
-/obj/machinery/chem_dispenser/proc/process_recipe_list(var/fucking_hell)
+/obj/machinery/chem_dispenser/proc/process_recipe_list(var/recipe)
 	var/list/key_list = list()
 	var/list/final_list = list()
-	var/list/first_process = splittext(fucking_hell, ";")
+	var/list/first_process = splittext(recipe, ";")
 	for(var/reagents in first_process)
-		var/list/fuck = splittext(reagents, "=")
-		final_list += list(avoid_assoc_duplicate_keys(fuck[1],key_list) = text2num(fuck[2]))
+		var/list/splitreagent = splittext(reagents, "=")
+		final_list += list(avoid_assoc_duplicate_keys(splitreagent[1],key_list) = text2num(splitreagent[2]))
 	return final_list
 
 /obj/machinery/chem_dispenser/drinks/Initialize()


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
fix: Chem dispenser macros now function properly with higher tier manipulator.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
Fixes #37706

Old system required the macros input numbers to be divisible by the macro resolution. This makes it use the resolution as a minimum instead. It never made sense for t2 and t3 to be unable to make a recipe a t1 could.
Also fixed a rounding error in the part status readout.