### PR TITLE
Printed oxygen/plasma tanks no longer contain oxygen/plasma

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -14,14 +14,15 @@
 	var/full_speed = TRUE // If the jetpack will have a speedboost in space/nograv or not
 	var/datum/effect_system/trail_follow/ion/ion_trail
 
-/obj/item/tank/jetpack/New()
-	..()
+/obj/item/tank/jetpack/Initialize()
+	. = ..()
+	ion_trail = new
+	ion_trail.set_up(src)
+
+/obj/item/tank/jetpack/populate_gas()
 	if(gas_type)
 		air_contents.assert_gas(gas_type)
 		air_contents.gases[gas_type][MOLES] = ((6 * ONE_ATMOSPHERE) * volume / (R_IDEAL_GAS_EQUATION * T20C))
-
-	ion_trail = new
-	ion_trail.set_up(src)
 
 /obj/item/tank/jetpack/ui_action_click(mob/user, action)
 	if(istype(action, /datum/action/item_action/toggle_jetpack))
@@ -186,8 +187,8 @@
 	var/obj/item/tank/internals/tank = null
 	var/mob/living/carbon/human/cur_user
 
-/obj/item/tank/jetpack/suit/New()
-	..()
+/obj/item/tank/jetpack/suit/Initialize()
+	. = ..()
 	STOP_PROCESSING(SSobj, src)
 	temp_air_contents = air_contents
 

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -12,18 +12,16 @@
  */
 /obj/item/tank/internals/oxygen
 	name = "oxygen tank"
-	desc = "A tank of oxygen."
+	desc = "A tank of oxygen, this one is blue."
 	icon_state = "oxygen"
 	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
 	force = 10
 	dog_fashion = /datum/dog_fashion/back
 
 
-/obj/item/tank/internals/oxygen/New()
-	..()
+/obj/item/tank/internals/oxygen/populate_gas()
 	air_contents.assert_gas(/datum/gas/oxygen)
 	air_contents.gases[/datum/gas/oxygen][MOLES] = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
-	return
 
 
 /obj/item/tank/internals/oxygen/yellow
@@ -36,9 +34,7 @@
 	icon_state = "oxygen_fr"
 	dog_fashion = null
 
-/obj/item/tank/internals/oxygen/empty/New()
-	..()
-	air_contents.gases[/datum/gas/oxygen][MOLES] = 0
+/obj/item/tank/internals/oxygen/empty/populate_gas()
 	return
 
 /*
@@ -51,12 +47,10 @@
 	item_state = "an_tank"
 	force = 10
 
-/obj/item/tank/internals/anesthetic/New()
-	..()
+/obj/item/tank/internals/anesthetic/populate_gas()
 	air_contents.assert_gases(/datum/gas/oxygen, /datum/gas/nitrous_oxide)
 	air_contents.gases[/datum/gas/oxygen][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
 	air_contents.gases[/datum/gas/nitrous_oxide][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
-	return
 
 /*
  * Air
@@ -69,12 +63,10 @@
 	force = 10
 	dog_fashion = /datum/dog_fashion/back
 
-/obj/item/tank/internals/air/New()
-	..()
+/obj/item/tank/internals/air/populate_gas()
 	air_contents.assert_gases(/datum/gas/oxygen, /datum/gas/nitrogen)
 	air_contents.gases[/datum/gas/oxygen][MOLES] = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
 	air_contents.gases[/datum/gas/nitrogen][MOLES] = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
-	return
 
 
 /*
@@ -89,11 +81,9 @@
 	force = 8
 
 
-/obj/item/tank/internals/plasma/New()
-	..()
+/obj/item/tank/internals/plasma/populate_gas()
 	air_contents.assert_gas(/datum/gas/plasma)
 	air_contents.gases[/datum/gas/plasma][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
-	return
 
 /obj/item/tank/internals/plasma/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/flamethrower))
@@ -108,14 +98,11 @@
 	else
 		return ..()
 
-/obj/item/tank/internals/plasma/full/New()
-	..() // Plasma asserted in parent
+/obj/item/tank/internals/plasma/full/populate_gas()
+	air_contents.assert_gas(/datum/gas/plasma)
 	air_contents.gases[/datum/gas/plasma][MOLES] = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
-	return
 
-/obj/item/tank/internals/plasma/empty/New()
-	..()
-	air_contents.gases[/datum/gas/plasma][MOLES] = 0
+/obj/item/tank/internals/plasma/empty/populate_gas()
 	return
 
 /*
@@ -130,16 +117,13 @@
 	force = 10
 	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
 
-/obj/item/tank/internals/plasmaman/New()
-	..()
+/obj/item/tank/internals/plasmaman/populate_gas()
 	air_contents.assert_gas(/datum/gas/plasma)
 	air_contents.gases[/datum/gas/plasma][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
-	return
 
-/obj/item/tank/internals/plasmaman/full/New()
-	..() // Plasma asserted in parent
+/obj/item/tank/internals/plasmaman/full/populate_gas()
+	air_contents.assert_gas(/datum/gas/plasma)
 	air_contents.gases[/datum/gas/plasma][MOLES] = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
-	return
 
 
 /obj/item/tank/internals/plasmaman/belt
@@ -150,14 +134,12 @@
 	volume = 6
 	w_class = WEIGHT_CLASS_SMALL //thanks i forgot this
 
-/obj/item/tank/internals/plasmaman/belt/full/New()
-	..() // Plasma asserted in parent
+/obj/item/tank/internals/plasmaman/belt/full/populate_gas()
+	air_contents.assert_gas(/datum/gas/plasma)
 	air_contents.gases[/datum/gas/plasma][MOLES] = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
+
+/obj/item/tank/internals/plasmaman/belt/empty/populate_gas()
 	return
-	
-/obj/item/tank/internals/plasmaman/belt/empty/Initialize()
-	. = ..() // Plasma asserted in parent
-	air_contents.gases[/datum/gas/plasma][MOLES] = 0
 
 
 
@@ -176,31 +158,27 @@
 	volume = 1 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
 
 
-/obj/item/tank/internals/emergency_oxygen/New()
-	..()
+/obj/item/tank/internals/emergency_oxygen/populate_gas()
 	air_contents.assert_gas(/datum/gas/oxygen)
 	air_contents.gases[/datum/gas/oxygen][MOLES] = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
+
+
+/obj/item/tank/internals/emergency_oxygen/empty/populate_gas()
 	return
-	
-/obj/item/tank/internals/emergency_oxygen/empty/Initialize()
-	. = ..()
-	air_contents.gases[/datum/gas/oxygen][MOLES] = 0
 
 /obj/item/tank/internals/emergency_oxygen/engi
 	name = "extended-capacity emergency oxygen tank"
 	icon_state = "emergency_engi"
 	volume = 2 // should last a bit over 30 minutes if full
 
-/obj/item/tank/internals/emergency_oxygen/engi/empty/Initialize()
-	. = ..()
-	air_contents.gases[/datum/gas/oxygen][MOLES] = 0
+/obj/item/tank/internals/emergency_oxygen/engi/empty/populate_gas()
+	return
 
 /obj/item/tank/internals/emergency_oxygen/double
 	name = "double emergency oxygen tank"
 	icon_state = "emergency_double"
 	volume = 8
-	
-/obj/item/tank/internals/emergency_oxygen/double/empty/Initialize()
-	. = ..()
-	air_contents.gases[/datum/gas/oxygen][MOLES] = 0
-	
+
+/obj/item/tank/internals/emergency_oxygen/double/empty/populate_gas()
+	return
+

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -51,13 +51,18 @@
 	H.update_action_buttons_icon()
 
 
-/obj/item/tank/New()
-	..()
+/obj/item/tank/Initialize()
+	. = ..()
 
 	air_contents = new(volume) //liters
 	air_contents.temperature = T20C
 
+	populate_gas()
+
 	START_PROCESSING(SSobj, src)
+
+/obj/item/tank/proc/populate_gas()
+	return
 
 /obj/item/tank/Destroy()
 	if(air_contents)
@@ -69,10 +74,10 @@
 /obj/item/tank/examine(mob/user)
 	var/obj/icon = src
 	..()
-	if (istype(src.loc, /obj/item/assembly))
+	if(istype(src.loc, /obj/item/assembly))
 		icon = src.loc
-	if(!in_range(src, user))
-		if (icon == src)
+	if(!in_range(src, user) && !isobserver(user))
+		if(icon == src)
 			to_chat(user, "<span class='notice'>If you want any more information you'll need to get closer.</span>")
 		return
 

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -235,7 +235,7 @@
 	materials = list(MAT_METAL = 500)
 	build_path = /obj/item/tank/internals/emergency_oxygen/empty
 	category = list("initial","Misc","Equipment")
-	
+
 /datum/design/emergency_oxygen_engi
 	name = "Extended-Capacity Emergency Oxygen Tank"
 	id = "emergency_oxygen_engi"
@@ -244,7 +244,7 @@
 	build_path = /obj/item/tank/internals/emergency_oxygen/engi/empty
 	category = list("hacked","Misc","Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
-	
+
 /datum/design/plasmaman_tank_belt
 	name = "Plasmaman Belt Tank"
 	id = "plasmaman_tank_belt"


### PR DESCRIPTION
:cl: coiax
fix: Printed oxygen or plasma tanks at the protolathe are now empty.
/:cl:

The discrepency in behaviour was because the new /empty types were
using Initialize, which for some reason wasn't working.

However, when I ported the whole of /obj/item/tank into using
Initialize() it works fine, and all the empty tanks are empty
as intended, (and the ones that should have gas, do have gas).
