### PR TITLE
Fixes runtimes in manifolds on non station z-levels

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -17,7 +17,7 @@
 
 	var/mutable_appearance/center
 
-/obj/machinery/atmospherics/pipe/manifold/Initialize()
+/obj/machinery/atmospherics/pipe/manifold/New()
 	icon_state = ""
 	center = mutable_appearance(icon, "manifold_center")
 	return ..()

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
@@ -16,7 +16,7 @@
 
 	var/mutable_appearance/center
 
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/Initialize()
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/New()
 	icon_state = ""
 	center = mutable_appearance(icon, "manifold4w_center")
 	return ..()

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -17,7 +17,11 @@
 
 	var/mutable_appearance/center
 
-/obj/machinery/atmospherics/pipe/manifold/Initialize()
+/* We use New() instead of Initialize() because these values are used in update_icon()
+ * in the mapping subsystem init before Initialize() is called in the atoms subsystem init.
+ * This is true for the other manifolds (the 4 ways and the heat exchanges) too.
+ */
+/obj/machinery/atmospherics/pipe/manifold/New()
 	icon_state = ""
 	center = mutable_appearance(icon, "manifold_center")
 	return ..()

--- a/code/modules/atmospherics/machinery/pipes/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold4w.dm
@@ -16,7 +16,7 @@
 
 	var/mutable_appearance/center
 
-/obj/machinery/atmospherics/pipe/manifold4w/Initialize()
+/obj/machinery/atmospherics/pipe/manifold4w/New()
 	icon_state = ""
 	center = mutable_appearance(icon, "manifold4w_center")
 	return ..()


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Garen
fix: Fixes runtime spam in pipe manifolds on nonstation z-levels
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

The variable center was called in update_icon() which is called in atmos_init() which is called in the non station z-levels when the mapping subsystem is initialized. However center is set in Initialize() when the atoms subsystem is initialized(which occurs after the mapping subsystem). So this ensures its not null before it's called since new is called when the object is actually made.