### PR TITLE
Succumb is only possible below -70% health

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -41,6 +41,7 @@
 //Health Defines
 #define HEALTH_THRESHOLD_CRIT 0
 #define HEALTH_THRESHOLD_FULLCRIT -30
+#define HEALTH_THRESHOLD_SUCCUMB -70
 #define HEALTH_THRESHOLD_DEAD -100
 
 #define HEALTH_THRESHOLD_NEARDEATH -90 //Not used mechanically, but to determine if someone is so close to death they hear the other side

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -310,13 +310,15 @@
 
 /mob/living/verb/succumb(whispered as null)
 	set hidden = TRUE
-	if (InCritical())
+	if (CanSuccumb())
 		log_message("Has [whispered ? "whispered his final words" : "succumbed to death"] while in [InFullCritical() ? "hard":"soft"] critical with [round(health, 0.1)] points of health!", LOG_ATTACK)
 		adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)
 		updatehealth()
 		if(!whispered)
 			to_chat(src, "<span class='notice'>You have given up life and succumbed to death.</span>")
 		death()
+	else
+		to_chat(src, "<span class='notice'>You don't feel like giving up yet.</span>")
 
 /mob/living/incapacitated(ignore_restraints = FALSE, ignore_grab = FALSE, check_immobilized = FALSE)
 	if(stat || IsUnconscious() || IsStun() || IsParalyzed() || (check_immobilized && IsImmobilized()) || (!ignore_restraints && restrained(ignore_grab)))
@@ -332,6 +334,9 @@
 
 /mob/living/proc/InFullCritical()
 	return (health <= HEALTH_THRESHOLD_FULLCRIT && stat == UNCONSCIOUS)
+
+/mob/living/proc/CanSuccumb()
+	return (health <= HEALTH_THRESHOLD_SUCCUMB && stat == UNCONSCIOUS)
 
 //This proc is used for mobs which are affected by pressure to calculate the amount of pressure that actually
 //affects them once clothing is factored in. ~Errorage

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -159,12 +159,12 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	var/succumbed = FALSE
 
-	var/fullcrit = InFullCritical()
-	if((InCritical() && !fullcrit) || message_mode == MODE_WHISPER)
+	var/cansuccumb = CanSuccumb()
+	if((InCritical() && !cansuccumb) || message_mode == MODE_WHISPER)
 		message_range = 1
 		message_mode = MODE_WHISPER
 		src.log_talk(message, LOG_WHISPER)
-		if(fullcrit)
+		if(cansuccumb)
 			var/health_diff = round(-HEALTH_THRESHOLD_DEAD + health)
 			// If we cut our message short, abruptly end it with a-..
 			var/message_len = length(message)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
tweak: You cannot succumb above -70% health. Down from -1% via verb, -30% via whisper.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
I see a lot of abuse of the succumb verb lately, ranging from people denying slimes feeding on them to people just succumbing out of being converted/deconverted during those modes. It's an easy out of #fun and great for cucking antags. I dont think full removal is in order, but being able to succumb at -1% health is getting silly. 

This changes both the verb and succumbing by whispering to only work under -70% health (down from -1% and -30% respectively) , which I think is a much more reasonable treshold for giving up on life. It does let you whisper for longer, but you still lose hearing at the old treshold so you can only really keep the monologue going.

If you refuse to wait the few minutes dying usually takes if left alone, then you can ghost instead but take the permanent round removal choice.