### PR TITLE
Update the SDQL grammar comment

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -11,7 +11,7 @@
 //	select_query		:	'SELECT' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]
 //	delete_query		:	'DELETE' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]
 //	update_query		:	'UPDATE' select_list [('FROM' | 'IN') from_list] 'SET' assignments ['WHERE' bool_expression]
-//	call_query			:	'CALL' call_function ['ON' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]]
+//	call_query			:	'CALL' variable ['ON' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]]
 //
 //	select_list			:	select_item [',' select_list]
 //	select_item			:	'*' | select_function | object_type
@@ -28,7 +28,7 @@
 //
 //	assignments			:	assignment, [',' assignments]
 //	assignment			:	<variable name> '=' expression
-//	variable			:	<variable name> | <variable name> '.' variable
+//	variable			:	<variable name> | <variable name> '.' variable | call_function
 //
 //	bool_expression		:	expression comparitor expression  [bool_operator bool_expression]
 //	expression			:	( unary_expression | '(' expression ')' | value ) [binary_operator expression]


### PR DESCRIPTION
variable allows for proc calls and technically the call option just uses variable to parse out it's function (even if you provide something that makes no sense)
