### PR TITLE
Fixes accidental buff from switching deconstruction R&D to techwebs by BUFFING autolathes to match protolathes (50%-12.5% T1-T4 from 100%-40% T1-T4 construction efficiency)

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -217,10 +217,10 @@
 		T += MB.rating*75000
 	GET_COMPONENT(materials, /datum/component/material_container)
 	materials.max_amount = T
-	T=1.2
+	T = 0
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
-		T -= M.rating*0.2
-	prod_coeff = min(1,max(0,T)) // Coeff going 1 -> 0,8 -> 0,6 -> 0,4
+		T += M.rating * 2
+	prod_coeff = round(1 / T, 0.01)
 
 /obj/machinery/autolathe/examine(mob/user)
 	..()


### PR DESCRIPTION
closes #41976

As of right now autolathes are by default 2x less efficient than protolathes and more than 2x less efficient than protolathes when fully upgraded, leading to high consistencies and unexpected behavior when designs are transferred between the two, due to me accidently buffing the fuck out of protolathes when I first added techwebs.