### PR TITLE
Fixes accidental buff from switching deconstruction R&D to techwebs by NERFING protolathes to match autolathe scaling ( 100%-40% T1-T4 from 50%-12.5% T1-T4 construction efficiency)

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -68,11 +68,12 @@
 		for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 			total_storage += M.rating * 75000
 		materials.set_local_size(total_storage)
-	var/total_rating = 0
+	var/total_rating = 1.2
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
-		total_rating += M.rating
-	total_rating = max(1, total_rating)
-	efficiency_coeff = total_rating
+		total_rating = CLAMP(total_rating - (M.rating * 0.1), 0, 1)
+	if(total_rating == 0)
+		efficiency_coeff = INFINITY
+	efficiency_coeff = 1/total_rating
 
 //we eject the materials upon deconstruction.
 /obj/machinery/rnd/production/on_deconstruction()


### PR DESCRIPTION
Closes #41975 

As of right now autolathes are by default 2x less efficient than protolathes and more than 2x less efficient than protolathes when fully upgraded, leading to high consistencies and unexpected behavior when designs are transferred between the two, due to me accidently buffing the fuck out of protolathes when I first added techwebs.