### PR TITLE
mixers work on 0% and 100%

### DIFF
--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -40,7 +40,7 @@
 
 /obj/machinery/atmospherics/components/trinary/mixer/power_change()
 	var/old_stat = stat
-	..(1
+	..()
 	if(stat != old_stat)
 		update_icon()
 

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -129,8 +129,8 @@
 	data["on"] = on
 	data["set_pressure"] = round(target_pressure)
 	data["max_pressure"] = round(MAX_OUTPUT_PRESSURE)
-	data["node1_concentration"] = round(node1_concentration*100)
-	data["node2_concentration"] = round(node2_concentration*100)
+	data["node1_concentration"] = round(node1_concentration*100, 1)
+	data["node2_concentration"] = round(node2_concentration*100, 1)
 	return data
 
 /obj/machinery/atmospherics/components/trinary/mixer/ui_act(action, params)

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -169,7 +169,7 @@
 	update_icon()
 
 /obj/machinery/atmospherics/components/trinary/mixer/proc/adjust_node1_value(delta)
-	node1_concentration = round(max(0, min(1, node1_concentration + delta))*100)/100
+	node1_concentration = round(max(0, min(1, node1_concentration + delta), 0.01)
 	node2_concentration = 1 - node1_concentration
 
 /obj/machinery/atmospherics/components/trinary/mixer/can_unwrench(mob/user)

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -169,7 +169,7 @@
 	update_icon()
 
 /obj/machinery/atmospherics/components/trinary/mixer/proc/adjust_node1_value(delta)
-	node1_concentration = round(max(0, min(1, node1_concentration + delta), 0.01)
+	node1_concentration = round(max(0, min(1, node1_concentration + delta)), 0.01)
 	node2_concentration = 1 - node1_concentration
 
 /obj/machinery/atmospherics/components/trinary/mixer/can_unwrench(mob/user)

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -59,7 +59,7 @@
 	var/datum/gas_mixture/air1 = airs[1]
 	var/datum/gas_mixture/air2 = airs[2]
 
-	if(!air1 || !air2 || (node1_concentration && air1.temperature <= 0) || (node2_concentration &&  air2.temperature <= 0))
+	if(!air1 || !air2)
 		return
 
 	var/datum/gas_mixture/air3 = airs[3]
@@ -71,27 +71,34 @@
 		return
 
 	//Calculate necessary moles to transfer using PV=nRT
-
 	var/general_transfer = (target_pressure - output_starting_pressure) * air3.volume / R_IDEAL_GAS_EQUATION
 
-	var/transfer_moles1 = node1_concentration ? node1_concentration * general_transfer / air1.temperature : 0
-
-	var/transfer_moles2 = node2_concentration ? node2_concentration * general_transfer / air2.temperature : 0
-
-
-	if((transfer_moles2 < 0) || (transfer_moles1 < 0))
-		return
-
+	var/transfer_moles1 = air1.temperature ? node1_concentration * general_transfer / air1.temperature : 0
+	var/transfer_moles2 = air2.temperature ? node2_concentration * general_transfer / air2.temperature : 0
 
 	var/air1_moles = air1.total_moles()
 	var/air2_moles = air2.total_moles()
 
-	if((air1_moles < transfer_moles1) || (air2_moles < transfer_moles2))
-		var/ratio1 = transfer_moles1 ? air1_moles / transfer_moles1 : 1
-		var/ratio2 = transfer_moles2 ? air2_moles / transfer_moles2 : 1
-		var/ratio = min(ratio1,ratio2)
-		transfer_moles1 *= ratio
-		transfer_moles2 *= ratio
+	if(!node2_concentration)
+		if(air1.temperature <= 0)
+			return	
+		transfer_moles1 = min(transfer_moles1, air1_moles)
+		transfer_moles2 = 0
+	else if(!node1_concentration)
+		if(air2.temperature <= 0)
+			return	
+		transfer_moles2 = min(transfer_moles2, air2_moles)
+		transfer_moles1 = 0
+	else
+		if(air1.temperature <= 0 || air2.temperature <= 0)
+			return
+		if((transfer_moles2 <= 0) || (transfer_moles1 <= 0))
+			return
+		if((air1_moles < transfer_moles1) || (air2_moles < transfer_moles2))
+			var/ratio = 0
+			ratio = min(air1_moles / transfer_moles1, air2_moles / transfer_moles2)
+			transfer_moles1 *= ratio
+			transfer_moles2 *= ratio
 
 	//Actually transfer the gas
 
@@ -151,18 +158,21 @@
 				investigate_log("was set to [target_pressure] kPa by [key_name(usr)]", INVESTIGATE_ATMOS)
 		if("node1")
 			var/value = text2num(params["concentration"])
-			node1_concentration = max(0, min(1, node1_concentration + value))
-			node2_concentration = max(0, min(1, node2_concentration - value))
+			adjust_node1_value(value)
 			investigate_log("was set to [node1_concentration] % on node 1 by [key_name(usr)]", INVESTIGATE_ATMOS)
 			. = TRUE
 		if("node2")
 			var/value = text2num(params["concentration"])
+			adjust_node1_value(-value)
 			node2_concentration = round(max(0, min(1, node2_concentration + value))*100)/100
 			node1_concentration = round(max(0, min(1, node1_concentration - value))*100)/100
 			investigate_log("was set to [node2_concentration] % on node 2 by [key_name(usr)]", INVESTIGATE_ATMOS)
 			. = TRUE
 	update_icon()
 
+/obj/machinery/atmospherics/components/trinary/mixer/proc/adjust_node1_value(delta)
+	node1_concentration = round(max(0, min(1, node1_concentration + delta))*100)/100
+	node2_concentration = 1 - node1_concentration
 
 /obj/machinery/atmospherics/components/trinary/mixer/can_unwrench(mob/user)
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -40,7 +40,7 @@
 
 /obj/machinery/atmospherics/components/trinary/mixer/power_change()
 	var/old_stat = stat
-	..()
+	..(1
 	if(stat != old_stat)
 		update_icon()
 
@@ -164,8 +164,6 @@
 		if("node2")
 			var/value = text2num(params["concentration"])
 			adjust_node1_value(-value)
-			node2_concentration = round(max(0, min(1, node2_concentration + value))*100)/100
-			node1_concentration = round(max(0, min(1, node1_concentration - value))*100)/100
 			investigate_log("was set to [node2_concentration] % on node 2 by [key_name(usr)]", INVESTIGATE_ATMOS)
 			. = TRUE
 	update_icon()


### PR DESCRIPTION
:cl:
fix: Mixers now work on 0% and 100% settings as pumps
fix: Mixers display rounded percentages, not floored. As such numbers should always add up to 100%
/:cl:
fixes #40960