### PR TITLE
makes extract surgeries more reasonable and expedient

### DIFF
--- a/code/modules/surgery/remove_embedded_object.dm
+++ b/code/modules/surgery/remove_embedded_object.dm
@@ -1,6 +1,6 @@
 /datum/surgery/embedded_removal
 	name = "removal of embedded objects"
-	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/remove_object)
+	steps = list(/datum/surgery_step/incise, /datum/surgery_step/remove_object)
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
 
 


### PR DESCRIPTION
:cl:
tweak: "remove embedded object" surgery is now only two steps, instead of four.
/:cl:

[why]: extract surgeries require FOUR steps, while whatever is embedded continues to fuck up the person and make them lose all their blood. It's always MUCH more reasonable to heal the person first and make them violently pull the shuriken or whatever out of themselves. Now it should be possible to consider doing the slow-ass surgery.