### PR TITLE
Compatability for IE8's lack of css3 breaking banning panel checkboxes

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -87,7 +87,9 @@
 		panel_height = 240
 	var/datum/browser/panel = new(usr, "banpanel", "Banning Panel", 910, panel_height)
 	panel.add_stylesheet("banpanelcss", 'html/admin/banpanel.css')
-	panel.add_script("banpaneljs", 'html/admin/banpanel.js')
+	if(usr.client.prefs.tgui_fancy) //some browsers (IE8) have trouble with unsupported css3 elements and DOM methods that break the panel's functionality, so we won't load those if a user is in no frills tgui mode since that's for similar compatability support
+		panel.add_stylesheet("banpanelcss3", 'html/admin/banpanel_css3.css')
+		panel.add_script("banpaneljs", 'html/admin/banpanel.js')
 	var/list/output = list("<form method='get' action='?src=[REF(src)]'>[HrefTokenFormField()]")
 	output += {"<input type='hidden' name='src' value='[REF(src)]'>
 	<label class='inputlabel checkbox'>Key:
@@ -200,14 +202,14 @@
 				banned_from += query_get_banned_roles.item[1]
 			qdel(query_get_banned_roles)
 		var/break_counter = 0
-		output += "<div class='row'><div class='column'><label class='rolegroup command'><input type='checkbox' name='Command' class='hidden' onClick='toggle_checkboxes(this, \"_dep\")'>Command</label><div class='content'>"
+		output += "<div class='row'><div class='column'><label class='rolegroup command'><input type='checkbox' name='Command' class='hidden' [usr.client.prefs.tgui_fancy ? " onClick='toggle_checkboxes(this, \"_dep\")'" : ""]>Command</label><div class='content'>"
 		//all heads are listed twice so have a javascript call to toggle both their checkboxes when one is pressed
 		//for simplicity this also includes the captain even though it doesn't do anything
 		for(var/job in GLOB.command_positions)
 			if(break_counter > 0 && (break_counter % 3 == 0))
 				output += "<br>"
 			output += {"<label class='inputlabel checkbox'>[job]
-						<input type='checkbox' id='[job]_com' name='[job]' class='Command' onClick='toggle_head(this, \"_dep\")' value='1'>
+						<input type='checkbox' id='[job]_com' name='[job]' class='Command' value='1'[usr.client.prefs.tgui_fancy ? " onClick='toggle_head(this, \"_dep\")'" : ""]>
 						<div class='inputbox[(job in banned_from) ? " banned" : ""]'></div></label>
 			"}
 			break_counter++
@@ -221,9 +223,9 @@
 							"Silicon" = GLOB.nonhuman_positions) //another cheat for simplicity
 		for(var/department in job_lists)
 			//the first element is the department head so they need the same javascript call as above
-			output += "<div class='column'><label class='rolegroup [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' onClick='toggle_checkboxes(this, \"_com\")'>[department]</label><div class='content'>"
+			output += "<div class='column'><label class='rolegroup [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' [usr.client.prefs.tgui_fancy ? " onClick='toggle_checkboxes(this, \"_com\")'" : ""]>[department]</label><div class='content'>"
 			output += {"<label class='inputlabel checkbox'>[job_lists[department][1]]
-						<input type='checkbox' id='[job_lists[department][1]]_dep' name='[job_lists[department][1]]' class='[department]' onClick='toggle_head(this, \"_com\")' value='1'>
+						<input type='checkbox' id='[job_lists[department][1]]_dep' name='[job_lists[department][1]]' class='[department]' value='1'[usr.client.prefs.tgui_fancy ? " onClick='toggle_head(this, \"_com\")'" : ""]>
 						<div class='inputbox[(job_lists[department][1] in banned_from) ? " banned" : ""]'></div></label>
 			"}
 			break_counter = 1
@@ -246,7 +248,7 @@
 									ROLE_REV_HEAD, ROLE_SERVANT_OF_RATVAR, ROLE_SYNDICATE,
 									ROLE_TRAITOR, ROLE_WIZARD)) //ROLE_REV_HEAD is excluded from this because rev jobbans are handled by ROLE_REV
 		for(var/department in long_job_lists)
-			output += "<div class='column'><label class='rolegroup long [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' onClick='toggle_checkboxes(this, \"_com\")'>[department]</label><div class='content'>"
+			output += "<div class='column'><label class='rolegroup long [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' [usr.client.prefs.tgui_fancy ? " onClick='toggle_checkboxes(this, \"_com\")'" : ""]>[department]</label><div class='content'>"
 			break_counter = 0
 			for(var/job in long_job_lists[department])
 				if(break_counter > 0 && (break_counter % 10 == 0))

--- a/html/admin/banpanel.css
+++ b/html/admin/banpanel.css
@@ -15,7 +15,7 @@
     width: 150px;
 }
 
-.row:after {
+.row {
     content: '';
     display: table;
     clear: both;
@@ -84,19 +84,6 @@
     background-color: #6d3f40;
 }
 
-.inputlabel {
-    position: relative;
-    display: inline;
-    cursor: pointer;
-    padding-left: 20px;
-}
-
-.inputlabel input {
-    position: absolute;
-    z-index: -1;
-    opacity: 0;
-}
-
 .inputbox {
     position: absolute;
     top: 0px;
@@ -104,72 +91,6 @@
     width: 14px;
     height: 14px;
     background: #e6e6e6;
-}
-
-.radio .inputbox {
-    border-radius: 50%;
-}
-
-.inputlabel:hover input ~ .inputbox {
-    background: #b4b4b4;
-}
-
-.inputlabel input:checked ~ .inputbox {
-    background: #2196F3;
-}
-
-.inputlabel:hover input:not([disabled]):checked ~ .inputbox{
-    background: #0a6ebd;
-}
-
-.inputlabel input:disabled ~ .inputbox {
-    pointer-events: none;
-    background: #838383;
-}
-
-.banned {
-    background: #ff4e4e;
-}
-
-.inputlabel:hover input ~ .banned {
-    background: #ff0000;
-}
-
-.inputlabel input:checked ~ .banned {
-    background: #a80000;
-}
-
-.inputlabel:hover input:not([disabled]):checked ~ .banned{
-    background: #810000;
-}
-
-.inputbox:after {
-    position: absolute;
-    display: none;
-    content: '';
-}
-
-.inputlabel input:checked ~ .inputbox:after {
-    display: block;
-}
-
-.checkbox .inputbox:after {
-    top: 1px;
-    left: 5px;
-    width: 3px;
-    height: 9px;
-    transform: rotate(45deg);
-    border: solid #fff;
-    border-width: 0 2px 2px 0;
-}
-
-.radio .inputbox:after {
-    top: 4px;
-    left: 4px;
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: #fff;
 }
 
 .select {

--- a/html/admin/banpanel_css3.css
+++ b/html/admin/banpanel_css3.css
@@ -1,0 +1,78 @@
+.inputlabel {
+    position: relative;
+    display: inline;
+    cursor: pointer;
+    padding-left: 20px;
+}
+
+.inputlabel input {
+    position: absolute;
+    z-index: -1;
+    opacity: 0;
+}
+
+.radio .inputbox {
+    border-radius: 50%;
+}
+
+.inputlabel:hover input ~ .inputbox {
+    background: #b4b4b4;
+}
+
+.inputlabel input:checked ~ .inputbox {
+    background: #2196F3;
+}
+
+.inputlabel:hover input:not([disabled]):checked ~ .inputbox{
+    background: #0a6ebd;
+}
+
+.inputlabel input:disabled ~ .inputbox {
+    pointer-events: none;
+    background: #838383;
+}
+
+.banned {
+    background: #ff4e4e;
+}
+
+.inputlabel:hover input ~ .banned {
+    background: #ff0000;
+}
+
+.inputlabel input:checked ~ .banned {
+    background: #a80000;
+}
+
+.inputlabel:hover input:not([disabled]):checked ~ .banned{
+    background: #810000;
+}
+
+.inputbox:after {
+    position: absolute;
+    display: none;
+    content: '';
+}
+
+.inputlabel input:checked ~ .inputbox:after {
+    display: block;
+}
+
+.checkbox .inputbox:after {
+    top: 1px;
+    left: 5px;
+    width: 3px;
+    height: 9px;
+    transform: rotate(45deg);
+    border: solid #fff;
+    border-width: 0 2px 2px 0;
+}
+
+.radio .inputbox:after {
+    top: 4px;
+    left: 4px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #fff;
+}


### PR DESCRIPTION
Per https://github.com/tgstation/tgstation/pull/41176#issuecomment-445248098 css3 elements and javascript method `GetElementsByClassName` cause rendering issues on old browsers that breaks key functionality of the banning panel: being able to ban people. To avoid this if a user has tgui fancy mode off they won't load up any of the problematic css3 elements or javascript. I've used the tgui fancy mode preference because it has basically the same function and I didn't want to make another just for this.

There is actually still some css3 left, flexible box and resize elements, but I don't think they cause any problems beyond possibly some weird formatting.

The unbanning panel should be all fine since it doesn't have any input boxes.

@cyprex