### PR TITLE
Fixes Box disposals

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -22652,8 +22652,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/disposalpipe/junction{
-	dir = 4
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)


### PR DESCRIPTION
:cl: Denton
fix: Boxstation disposal pipes no longer empty themselves in the Vacant Commissary.
/:cl:

Fixes: #41952