### PR TITLE
Choice beacon explosion changes

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -23,6 +23,12 @@
 	if(canUseBeacon(user))
 		generate_options(user)
 
+/obj/item/choice_beacon/emag_act(mob/user)
+	if(!CHECK_BITFIELD(obj_flags, EMAGGED))
+		to_chat(user, "<span class='notice'>You modify [src] to connect to a Syndicate supplier. They have the same goods, they're just less careful when dropping them.</span>")
+		to_chat(user, "<span class='danger'>#@& CONNECTED TO: SYNDICATE SHOP(tm); HOW CAN WE TAKE YOUR ORDER &@#</span>")
+		ENABLE_BITFIELD(obj_flags, EMAGGED)
+
 /obj/item/choice_beacon/proc/generate_display_names() // return the list that will be used in the choice selection. entries should be in (type.name = type) fashion. see choice_beacon/hero for how this is done.
 	return list()
 
@@ -47,10 +53,14 @@
 /obj/item/choice_beacon/proc/spawn_option(obj/choice,mob/living/M)
 	var/obj/new_item = new choice()
 	var/obj/structure/closet/supplypod/bluespacepod/pod = new()
-	pod.explosionSize = list(0,0,0,2)
+	if(CHECK_BITFIELD(obj_flags, EMAGGED))
+		pod.explosionSize = list(0,1,3,3)
+		pod.setStyle(STYLE_SYNDICATE)
+	else
+		pod.explosionSize = list(0,0,0,0)
 	new_item.forceMove(pod)
-	var/msg = "<span class = danger>After making your selection, you notice a strange target on the ground. It might be best to step back!</span>"
-	if (ishuman(M))
+	var/msg = "<span class=danger>After making your selection, you notice a strange target on the ground. It might be best to step back!</span>"
+	if(ishuman(M) && !CHECK_BITFIELD(obj_flags, EMAGGED))
 		var/mob/living/carbon/human/H = M
 		if(istype(H.ears, /obj/item/radio/headset))
 			msg = "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: <span class='bold'>Item request received. Your package is inbound, please stand back from the landing site.</span> Message ends.\""

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -23,12 +23,6 @@
 	if(canUseBeacon(user))
 		generate_options(user)
 
-/obj/item/choice_beacon/emag_act(mob/user)
-	if(!CHECK_BITFIELD(obj_flags, EMAGGED))
-		to_chat(user, "<span class='notice'>You modify [src] to connect to a Syndicate supplier. They have the same goods, they're just less careful when dropping them.</span>")
-		to_chat(user, "<span class='danger'>#@& CONNECTED TO: SYNDICATE SHOP(tm); HOW CAN WE TAKE YOUR ORDER &@#</span>")
-		ENABLE_BITFIELD(obj_flags, EMAGGED)
-
 /obj/item/choice_beacon/proc/generate_display_names() // return the list that will be used in the choice selection. entries should be in (type.name = type) fashion. see choice_beacon/hero for how this is done.
 	return list()
 
@@ -53,14 +47,10 @@
 /obj/item/choice_beacon/proc/spawn_option(obj/choice,mob/living/M)
 	var/obj/new_item = new choice()
 	var/obj/structure/closet/supplypod/bluespacepod/pod = new()
-	if(CHECK_BITFIELD(obj_flags, EMAGGED))
-		pod.explosionSize = list(0,1,3,3)
-		pod.setStyle(STYLE_SYNDICATE)
-	else
-		pod.explosionSize = list(0,0,0,0)
+	pod.explosionSize = list(0,0,0,0)
 	new_item.forceMove(pod)
 	var/msg = "<span class=danger>After making your selection, you notice a strange target on the ground. It might be best to step back!</span>"
-	if(ishuman(M) && !CHECK_BITFIELD(obj_flags, EMAGGED))
+	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(istype(H.ears, /obj/item/radio/headset))
 			msg = "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: <span class='bold'>Item request received. Your package is inbound, please stand back from the landing site.</span> Message ends.\""

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -30,7 +30,7 @@
 	var/effectQuiet = FALSE //The female sniper. If true, the pod makes no noise (including related explosions, opening sounds, etc)
 	var/effectMissile = FALSE //If true, the pod deletes the second it lands. If you give it an explosion, it will act like a missile exploding as it hits the ground
 	var/effectCircle = FALSE //If true, allows the pod to come in at any angle. Bit of a weird feature but whatever its here
-	var/style = STYLE_STANDARD //Style is a variable that keeps track of what the pod is supposed to look like. It acts as an index to the POD_STYLES list in cargo.dm defines to get the proper icon/name/desc for the pod. 
+	var/style = STYLE_STANDARD //Style is a variable that keeps track of what the pod is supposed to look like. It acts as an index to the POD_STYLES list in cargo.dm defines to get the proper icon/name/desc for the pod.
 	var/reversing = FALSE //If true, the pod will not send any items. Instead, after opening, it will close again (picking up items/mobs) and fly back to centcom
 	var/fallDuration = 4
 	var/fallingSoundLength = 11
@@ -80,7 +80,7 @@
 
 /obj/structure/closet/supplypod/tool_interact(obj/item/W, mob/user)
 	if (bluespace) //We dont want to worry about interacting with bluespace pods, as they are due to delete themselves soon anyways.
-		return FALSE 
+		return FALSE
 	else
 		..()
 
@@ -121,9 +121,9 @@
 			for (var/obj/item/bodypart/bodypart in CM.bodyparts) //Look at the bodyparts in our poor mob beneath our pod as it lands
 				var/destination = get_edge_target_turf(T, pick(GLOB.alldirs))
 				if (bodypart.dismemberable)
-					bodypart.dismember() //Using the power of flextape i've sawed this man's bodypart in half!	
+					bodypart.dismember() //Using the power of flextape i've sawed this man's bodypart in half!
 					bodypart.throw_at(destination, 2, 3)
-					sleep(1)		
+					sleep(1)
 
 		if (effectGib) //effectGib is on, that means whatever's underneath us better be fucking oof'd on
 			M.adjustBruteLoss(5000) //THATS A LOT OF DAMAGE (called just in case gib() doesnt work on em)
@@ -169,10 +169,10 @@
 		playsound(get_turf(holder), leavingSound, soundVolume, 0, 0)
 	if (reversing) //If we're reversing, we call the close proc. This sends the pod back up to centcom
 		close(holder)
-	else if (bluespace) //If we're a bluespace pod, then delete ourselves (along with our holder, if a seperate holder exists) 
-		if (style != STYLE_INVISIBLE) 
+	else if (bluespace) //If we're a bluespace pod, then delete ourselves (along with our holder, if a seperate holder exists)
+		if (style != STYLE_INVISIBLE)
 			do_sparks(5, TRUE, holder) //Create some sparks right before closing
-		qdel(src) //Delete ourselves and the holder 
+		qdel(src) //Delete ourselves and the holder
 		if (holder != src)
 			qdel(holder)
 

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -56,7 +56,7 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/structure/closet/supplypod/Initialize()
-	..()
+	. = ..()
 	setStyle(style, TRUE) //Upon initialization, give the supplypod an iconstate, name, and description based on the "style" variable. This system is important for the centcom_podlauncher to function correctly
 
 /obj/structure/closet/supplypod/update_icon()
@@ -234,6 +234,7 @@
 	return
 
 /obj/effect/DPtarget/Initialize(mapload, podParam, var/single_order = null)
+	. = ..()
 	if (ispath(podParam)) //We can pass either a path for a pod (as expressconsoles do), or a reference to an instantiated pod (as the centcom_podlauncher does)
 		podParam = new podParam() //If its just a path, instantiate it
 	pod = podParam


### PR DESCRIPTION
:cl: coiax
balance: Choice beacons (such as the one the curator, chaplain and people
with the Musican trait have access to) will no longer have pods that
have minor explosive effects.
/:cl:

Choice beacons are supposed to be just methods of spawning in a choice
of items, rather than weapons. I've seen traitors use the choice beacon
as a free way of instantly detonating a syndicate bomb they just
deployed, which is cute, but is probably just too powerful for a free
item.

The mild fire/knockback explosion from a choice beacon currently is
enough to set people on fire, burn up items, and throw items around in
your workplace. The focus should be on the items you get, not on the
destructive effects of their delivery.

Closes #41395