### PR TITLE
Non-emagged shuttles no longer throw atoms around

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -12,6 +12,8 @@
 	var/credit_cost = INFINITY
 	var/can_be_bought = TRUE
 
+	var/list/movement_force // If set, overrides default movement_force on shuttle
+
 	var/port_x_offset
 	var/port_y_offset
 
@@ -95,8 +97,9 @@
 					port.dheight = width - port_x_offset
 
 //Whatever special stuff you want
-/datum/map_template/shuttle/proc/on_bought()
-	return
+/datum/map_template/shuttle/proc/post_load(obj/docking_port/mobile/M)
+	if(movement_force)
+		M.movement_force = movement_force.Copy()
 
 /datum/map_template/shuttle/emergency
 	port_id = "emergency"
@@ -175,7 +178,8 @@
 	// first 10 minutes only
 	return world.time - SSticker.round_start_time < 6000
 
-/datum/map_template/shuttle/emergency/airless/on_bought()
+/datum/map_template/shuttle/emergency/airless/post_load()
+	. = ..()
 	//enable buying engines from cargo
 	var/datum/supply_pack/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shuttle_engine]
 	P.special_enabled = TRUE
@@ -208,6 +212,7 @@
 	description = "A hollowed out asteroid with engines strapped to it. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
 	credit_cost = -5000
+	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"
@@ -292,6 +297,7 @@
 	credit_cost = -1000
 	description = "Due to a lack of functional emergency shuttles, we bought this second hand from a scrapyard and pressed it into service. Please do not lean too heavily on the exterior windows, they are fragile."
 	admin_notes = "An abomination with no functional medbay, sections missing, and some very fragile windows. Surprisingly airtight."
+	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/narnar
 	suffix = "narnar"
@@ -327,6 +333,7 @@
 	It does, however, still dust anything on contact, emits high levels of radiation, and induce hallucinations in anyone looking at it without protective goggles. \
 	Emitters spawn powered on, expect admin notices, they are harmless."
 	credit_cost = 100000
+	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/imfedupwiththisworld
 	suffix = "imfedupwiththisworld"
@@ -335,6 +342,7 @@
 	Aw, come space on. Why not? No, I can't. Anyway, how is your space roleplay life?"
 	admin_notes = "Tiny, with a single airlock and wooden walls. What could go wrong?"
 	credit_cost = -5000
+	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/goon
 	suffix = "goon"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -94,16 +94,6 @@
 					port.dwidth = port_y_offset - 1
 					port.dheight = width - port_x_offset
 
-		for(var/obj/structure/closet/closet in place)
-			if(closet.anchorable)
-				closet.anchored = TRUE
-
-		for(var/obj/structure/table/table in place)
-			table.AddComponent(/datum/component/magnetic_catch)
-
-		for(var/obj/structure/rack/rack in place)
-			rack.AddComponent(/datum/component/magnetic_catch)
-
 //Whatever special stuff you want
 /datum/map_template/shuttle/proc/on_bought()
 	return

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -119,7 +119,7 @@
 
 	if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 		authorized.Cut()
-		obj_flags &= ~EMAGGED
+		DISABLE_BITFIELD(obj_flags, EMAGGED)
 
 	if(ENGINES_STARTED || (!IS_DOCKED))
 		return .
@@ -138,14 +138,15 @@
 	if(!IS_DOCKED)
 		return
 
-	if((obj_flags & EMAGGED) || ENGINES_STARTED)	//SYSTEM ERROR: THE SHUTTLE WILL LA-SYSTEM ERROR: THE SHUTTLE WILL LA-SYSTEM ERROR: THE SHUTTLE WILL LAUNCH IN 10 SECONDS
+	if(CHECK_BITFIELD(obj_flags, EMAGGED) || ENGINES_STARTED)	//SYSTEM ERROR: THE SHUTTLE WILL LA-SYSTEM ERROR: THE SHUTTLE WILL LA-SYSTEM ERROR: THE SHUTTLE WILL LAUNCH IN 10 SECONDS
 		to_chat(user, "<span class='warning'>The shuttle is already about to launch!</span>")
 		return
 
 	var/time = TIME_LEFT
 	message_admins("[ADMIN_LOOKUPFLW(user.client)] has emagged the emergency shuttle [time] seconds before launch.")
 	log_game("[key_name(user)] has emagged the emergency shuttle in [COORD(src)] [time] seconds before launch.")
-	obj_flags |= EMAGGED
+
+	ENABLE_BITFIELD(obj_flags, EMAGGED)
 	SSshuttle.emergency.movement_force = list("KNOCKDOWN" = 60, "THROW" = 20)//YOUR PUNY SEATBELTS can SAVE YOU NOW, MORTAL
 	var/datum/species/S = new
 	for(var/i in 1 to 10)
@@ -458,7 +459,7 @@
 /obj/machinery/computer/shuttle/pod/emag_act(mob/user)
 	if(obj_flags & EMAGGED)
 		return
-	obj_flags |= EMAGGED
+	ENABLE_BITFIELD(obj_flags, EMAGGED)
 	to_chat(user, "<span class='warning'>You fry the pod's alert level checking system.</span>")
 
 /obj/machinery/computer/shuttle/pod/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)

--- a/code/modules/shuttle/manipulator.dm
+++ b/code/modules/shuttle/manipulator.dm
@@ -299,7 +299,7 @@
 		WARNING(msg)
 		return
 	//Everything fine
-	S.on_bought()
+	S.post_load(preview_shuttle)
 	return TRUE
 
 /obj/machinery/shuttle_manipulator/proc/unload_preview()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -254,7 +254,7 @@
 
 	var/launch_status = NOLAUNCH
 
-	var/list/movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
+	var/list/movement_force = list("KNOCKDOWN" = 3, "THROW" = 0)
 
 	var/list/ripples = list()
 	var/engine_coeff = 1 //current engine coeff


### PR DESCRIPTION
:cl: coiax
del: Normal shuttles that are not emagged will no longer throw things around.
People will still be knocked down.
add: Emagged shuttles and poorly designed shuttles will also throw things
around on tables, as well as closets.
/:cl:

Shuttles were not mapped with the idea that their contents would be thrown
around violently every time they moved. This means that things like wheely chairs,
potted plants get chucked about the place. To get around this, the "magnetic_catch"
component was added, to partially bypass this effect in the first place.
But this component is only used in one place, in shuttle loading,
which means if a shuttle is custom built, suddenly and unexpectedly,
everything flies everywhere.

Instead, violent shuttle throwing should be limited to crappy shuttles,
(ie. asteroid with engines) and emagged shuttles. As such, I've removed
the magnetic component from tables and racks, to make shuttle throwing
more violent when it happens.