### PR TITLE
[READY]Ports yet another SDQL2 upgrade, refactors SDQL2 to a datum, adds SDQL2 options/more features

### DIFF
--- a/code/__DEFINES/_tick.dm
+++ b/code/__DEFINES/_tick.dm
@@ -8,3 +8,6 @@
 
 #define TICK_CHECK ( TICK_USAGE > Master.current_ticklimit )
 #define CHECK_TICK ( TICK_CHECK ? stoplag() : 0 )
+
+#define TICK_CHECK_HIGH_PRIORITY ( TICK_USAGE > 95 )
+#define CHECK_TICK_HIGH_PRIORITY ( TICK_CHECK_HIGH_PRIORITY? stoplag() : 0 )

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -64,13 +64,13 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 //Takes a value of time in deciseconds.
 //Returns a text value of that number in hours, minutes, or seconds.
 /proc/DisplayTimeText(time_value, round_seconds_to = 0.1)
-	var/second = round(time_value * 0.1, round_seconds_to)
+	var/second = FLOOR(time_value * 0.1, round_seconds_to)
 	if(!second)
 		return "right now"
 	if(second < 60)
 		return "[second] second[(second != 1)? "s":""]"
 	var/minute = FLOOR(second / 60, 1)
-	second = MODULUS(second, 60)
+	second = FLOOR(MODULUS(second, 60), round_seconds_to)
 	var/secondT
 	if(second)
 		secondT = " and [second] second[(second != 1)? "s":""]"

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -61,24 +61,31 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 		else
 			return 1
 
-#define DTT_SECONDS_TEXT "[second] second[(second != 1)? "s":""]"
-#define DTT_MINUTES_TEXT "[minute] minute[(minute != 1)? "s":""] and [DTT_SECONDS_TEXT]"
-#define DTT_HOURS_TEXT "[hour] hour[(hour != 1)? "s":""] and [DTT_MINUTES_TEXT]"
-#define DTT_DAYS_TEXT "[day] day[(day != 1)? "s":""] and [DTT_HOURS_TEXT]"
 //Takes a value of time in deciseconds.
 //Returns a text value of that number in hours, minutes, or seconds.
 /proc/DisplayTimeText(time_value, round_seconds_to = 0.1)
 	var/second = round(time_value * 0.1, round_seconds_to)
+	if(!second)
+		return "right now"
 	if(second < 60)
-		return DTT_SECONDS_TEXT
+		return "[second] second[(second != 1)? "s":""]"
 	var/minute = FLOOR(second / 60, 1)
 	second = MODULUS(second, 60)
+	var/secondT
+	if(second)
+		secondT = " and [second] second[(second != 1)? "s":""]"
 	if(minute < 60)
-		return DTT_MINUTES_TEXT
+		return "[minute] minute[(minute != 1)? "s":""][secondT]"
 	var/hour = FLOOR(minute / 60, 1)
 	minute = MODULUS(minute, 60)
+	var/minuteT
+	if(minute)
+		minuteT = " and [minute] minute[(minute != 1)? "s":""]"
 	if(hour < 24)
-		return DTT_HOURS_TEXT
+		return "[hour] hour[(hour != 1)? "s":""][minuteT][secondT]"
 	var/day = FLOOR(hour / 24, 1)
 	hour = MODULUS(hour, 24)
-	return DTT_DAYS_TEXT
+	var/hourT
+	if(hour)
+		hourT = " and [hour] hour[(hour != 1)? "s":""]"
+	return "[day] day[(day != 1)? "s":""][hourT][minuteT][secondT]"

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -61,98 +61,24 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 		else
 			return 1
 
+#define DTT_SECONDS_TEXT "[second] second[(second != 1)? "s":""]"
+#define DTT_MINUTES_TEXT "[minute] minute[(minute != 1)? "s":""] and [DTT_SECONDS_TEXT]"
+#define DTT_HOURS_TEXT "[hour] hour[(hour != 1)? "s":""] and [DTT_MINUTES_TEXT]"
+#define DTT_DAYS_TEXT "[day] day[(day != 1)? "s":""] and [DTT_HOURS_TEXT]"
 //Takes a value of time in deciseconds.
 //Returns a text value of that number in hours, minutes, or seconds.
-/proc/DisplayTimeText(time_value, truncate = FALSE)
-	var/second = (time_value)*0.1
-	var/second_adjusted = null
-	var/second_rounded = FALSE
-	var/minute = null
-	var/hour = null
-	var/day = null
-
-	if(!second)
-		return "0 seconds"
-	if(second >= 60)
-		minute = FLOOR(second/60, 1)
-		second = round(second - (minute*60), 0.1)
-		second_rounded = TRUE
-	if(second)	//check if we still have seconds remaining to format, or if everything went into minute.
-		second_adjusted = round(second)	//used to prevent '1 seconds' being shown
-		if(day || hour || minute)
-			if(second_adjusted == 1 && second >= 1)
-				second = " and 1 second"
-			else if(second > 1)
-				second = " and [second_adjusted] seconds"
-			else	//shows a fraction if seconds is < 1
-				if(second_rounded) //no sense rounding again if it's already done
-					second = " and [second] seconds"
-				else
-					second = " and [round(second, 0.1)] seconds"
-		else
-			if(second_adjusted == 1 && second >= 1)
-				second = "[truncate ? "second" : "1 second"]"
-			else if(second > 1)
-				second = "[second_adjusted] seconds"
-			else
-				if(second_rounded)
-					second = "[second] seconds"
-				else
-					second = "[round(second, 0.1)] seconds"
-	else
-		second = null
-
-	if(!minute)
-		return "[second]"
-	if(minute >= 60)
-		hour = FLOOR(minute/60, 1)
-		minute = (minute - (hour*60))
-	if(minute) //alot simpler from here since you don't have to worry about fractions
-		if(minute != 1)
-			if((day || hour) && second)
-				minute = ", [minute] minutes"
-			else if((day || hour) && !second)
-				minute = " and [minute] minutes"
-			else
-				minute = "[minute] minutes"
-		else
-			if((day || hour) && second)
-				minute = ", 1 minute"
-			else if((day || hour) && !second)
-				minute = " and 1 minute"
-			else
-				minute = "[truncate ? "minute" : "1 minute"]"
-	else
-		minute = null
-
-	if(!hour)
-		return "[minute][second]"
-	if(hour >= 24)
-		day = FLOOR(hour/24, 1)
-		hour = (hour - (day*24))
-	if(hour)
-		if(hour != 1)
-			if(day && (minute || second))
-				hour = ", [hour] hours"
-			else if(day && (!minute || !second))
-				hour = " and [hour] hours"
-			else
-				hour = "[hour] hours"
-		else
-			if(day && (minute || second))
-				hour = ", 1 hour"
-			else if(day && (!minute || !second))
-				hour = " and 1 hour"
-			else
-				hour = "[truncate ? "hour" : "1 hour"]"
-	else
-		hour = null
-
-	if(!day)
-		return "[hour][minute][second]"
-	if(day > 1)
-		day = "[day] days"
-	else
-		day = "[truncate ? "day" : "1 day"]"
-
-	return "[day][hour][minute][second]"
+/proc/DisplayTimeText(time_value, round_seconds_to = 0.1)
+	var/second = round(time_value * 0.1, round_seconds_to)
+	if(second < 60)
+		return DTT_SECONDS_TEXT
+	var/minute = FLOOR(second / 60, 1)
+	second = MODULUS(second, 60)
+	if(minute < 60)
+		return DTT_MINUTES_TEXT
+	var/hour = FLOOR(minute / 60, 1)
+	minute = MODULUS(minute, 60)
+	if(hour < 24)
+		return DTT_HOURS_TEXT
+	var/day = FLOOR(hour / 24, 1)
+	hour = MODULUS(hour, 24)
+	return DTT_DAYS_TEXT

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -486,12 +486,12 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 	if(show_next_to_key)
 		var/mob/showmob = GLOB.directory[show_next_to_key]
 		if(showmob)
-			to_chat(showmob, "<span class='admin'>SDQL query results: [query.get_query_text()]<br>\
-			SDQL query completed: [islist(query.obj_count_all)? length(query.obj_count_all) : query.obj_count_all] objects selected by path, and \
-			[query.where_switched? "[islist(query.obj_count_eligible)? length(query.obj_count_eligible) : query.obj_count_eligible] objects executed on after WHERE keyword selection." : ""]<br>\
-			SDQL query took [DisplayTimeText(query.end_time - query.start_time)] to complete.</span>")
-			if(length(query.select_text))
-				var/text = islist(query.select_text)? query.select_text.Join() : query.select_text
+			to_chat(showmob, "<span class='admin'>SDQL query results: [get_query_text()]<br>\
+			SDQL query completed: [islist(obj_count_all)? length(obj_count_all) : obj_count_all] objects selected by path, and \
+			[where_switched? "[islist(obj_count_eligible)? length(obj_count_eligible) : obj_count_eligible] objects executed on after WHERE keyword selection." : ""]<br>\
+			SDQL query took [DisplayTimeText(end_time - start_time)] to complete.</span>")
+			if(length(select_text))
+				var/text = islist(select_text)? select_text.Join() : select_text
 				var/static/result_offset = 0
 				showmob << browse(text, "window=SDQL-result-[result_offset++]")
 	show_next_to_key = null

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -396,7 +396,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 	stat("[id]		", delete_click.update("DELETE QUERY | STATE : [text_state()] | ALL/ELIG/FIN \
 	[islist(obj_count_all)? length(obj_count_all) : (isnull(obj_count_all)? "0" : obj_count_all)]/\
 	[islist(obj_count_eligible)? length(obj_count_eligible) : (isnull(obj_count_eligible)? "0" : obj_count_eligible)]/\
-	[islist(obj_count_finished)? length(obj_count_finished) : (isnull(obj_count_finished)? "0" : obj_count_finished)]"))
+	[islist(obj_count_finished)? length(obj_count_finished) : (isnull(obj_count_finished)? "0" : obj_count_finished)] - [get_query_text()]"))
 	stat("			", action_click.update("[SDQL2_IS_RUNNING? "HALT" : "RUN"]"))
 
 /datum/SDQL2_query/proc/delete_click()
@@ -416,13 +416,13 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 	log_admin(msg)
 	state = SDQL2_STATE_HALTING
 
-/datum/SDQL2_query/proc/admin_run(user = usr)
+/datum/SDQL2_query/proc/admin_run(mob/user = usr)
 	if(SDQL2_IS_RUNNING)
 		return
 	var/msg = "[key_name(user)] has (re)started query #[id]"
 	message_admins(msg)
 	log_admin(msg)
-	show_next_to_key = user
+	show_next_to_key = user.ckey
 	ARun()
 
 /datum/SDQL2_query/proc/admin_del(user = usr)
@@ -484,8 +484,9 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 	finished = TRUE
 	. = TRUE
 	if(show_next_to_key)
-		var/mob/showmob = GLOB.directory[show_next_to_key]
-		if(showmob)
+		var/client/C = GLOB.directory[show_next_to_key]
+		if(C)
+			var/mob/showmob = C.mob
 			to_chat(showmob, "<span class='admin'>SDQL query results: [get_query_text()]<br>\
 			SDQL query completed: [islist(obj_count_all)? length(obj_count_all) : obj_count_all] objects selected by path, and \
 			[where_switched? "[islist(obj_count_eligible)? length(obj_count_eligible) : obj_count_eligible] objects executed on after WHERE keyword selection." : ""]<br>\
@@ -664,7 +665,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 				select_refs[REF(i)] = TRUE
 				SDQL2_TICK_CHECK
 				SDQL2_HALT_CHECK
-			select_text = text_list.Join()
+			select_text = text_list
 
 		if("update")
 			if("set" in query_tree)
@@ -682,7 +683,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 
 /datum/SDQL2_query/proc/SDQL_print(object, list/text_list, print_nulls = TRUE)
 	if(is_proper_datum(object))
-		text_list += "<A HREF='?_src_=vars;[HrefToken()];Vars=[REF(object)]'>[REF(object)]</A> : [object]"
+		text_list += "<A HREF='?_src_=vars;[HrefToken(TRUE)];Vars=[REF(object)]'>[REF(object)]</A> : [object]"
 		if(istype(object, /atom))
 			var/atom/A = object
 			var/turf/T = A.loc

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -213,7 +213,6 @@
 				for(var/i in objs)
 					SDQL_print(i, text_list)
 					refs[REF(i)] = TRUE
-					text_list += "<br>"
 					CHECK_TICK
 				var/text = text_list.Join()
 				if (text)
@@ -329,8 +328,8 @@
 				out += d
 			CHECK_TICK
 		return out
-
-	type = text2path(type)
+	if(istext(type))
+		type = text2path(type)
 	var/typecache = typecacheof(type)
 
 	if(ispath(type, /mob))
@@ -715,7 +714,7 @@
 /proc/SDQL_is_proper_datum(thing)
 	return istype(thing, /datum) || istype(thing, /client)
 
-/proc/SDQL_print(object, list/text_list)
+/proc/SDQL_print(object, list/text_list, print_nulls = TRUE)
 	if(SDQL_is_proper_datum(object))
 		text_list += "<A HREF='?_src_=vars;[HrefToken()];Vars=[REF(object)]'>[REF(object)]</A> : [object]"
 		if(istype(object, /atom))
@@ -736,7 +735,7 @@
 				text_list += " <font color='gray'>in</font> area [a]"
 				if(T.loc != a)
 					text_list += " <font color='gray'>inside</font> [T]"
-
+		text_list += "<br>"
 	else if(islist(object))
 		var/list/L = object
 		var/first = TRUE
@@ -749,9 +748,9 @@
 			if (!isnull(x) && !isnum(x) && L[x] != null)
 				text_list += " -> "
 				SDQL_print(L[L[x]])
-		text_list += "]"
+		text_list += "]<br>"
 	else
-		if(isnull(object))
-			text_list += "NULL"
+		if(isnull(object) && print_nulls)
+			text_list += "NULL<br>"
 		else
-			text_list += "[object]"
+			text_list += "[object]<br>"

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -422,6 +422,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 	var/msg = "[key_name(user)] has (re)started query #[id]"
 	message_admins(msg)
 	log_admin(msg)
+	show_next_to_key = user
 	ARun()
 
 /datum/SDQL2_query/proc/admin_del(user = usr)
@@ -493,7 +494,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 				var/text = islist(query.select_text)? query.select_text.Join() : query.select_text
 				var/static/result_offset = 0
 				showmob << browse(text, "window=SDQL-result-[result_offset++]")
-
+	show_next_to_key = null
 	if(qdel_on_finish)
 		qdel(src)
 

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -282,8 +282,6 @@
 	qdel(parser)
 	return querys
 
-
-
 /proc/SDQL_testout(list/query_tree, indent = 0)
 	var/static/whitespace = "&nbsp;&nbsp;&nbsp; "
 	var/spaces = ""

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -224,6 +224,8 @@
 		var/datum/SDQL2_query/query = new /datum/SDQL2_query(query_tree)
 		if(QDELETED(query))
 			continue
+		if(usr)
+			query.show_next_to_key = usr.ckey
 		running += query
 		var/msg = "Starting query #[query.id] - [query.get_query_text()]."
 		if(usr)
@@ -251,19 +253,10 @@
 				running -= query
 			else
 				if(query.finished)
-					if(length(query.select_text))
-						var/text = islist(query.select_text)? query.select_text.Join() : query.select_text
-						var/static/result_offset = 0
-						usr << browse(text, "window=SDQL-result-[result_offset++]")
 					objs_all += islist(query.obj_count_all)? length(query.obj_count_all) : query.obj_count_all
 					objs_eligible += islist(query.obj_count_eligible)? length(query.obj_count_eligible) : query.obj_count_eligible
 					selectors_used |= query.where_switched
 					combined_refs |= query.select_refs
-					if(usr)
-						to_chat(usr, "<span class='admin'>SDQL query results: [query.get_query_text()]<br>\
-						SDQL query completed: [islist(query.obj_count_all)? length(query.obj_count_all) : query.obj_count_all] objects selected by path, and \
-						[query.where_switched? "[islist(query.obj_count_eligible)? length(query.obj_count_eligible) : query.obj_count_eligible] objects executed on after WHERE keyword selection." : ""]<br>\
-						SDQL query took [DisplayTimeText(query.end_time - query.start_time)] to complete.</span>")
 					running -= query
 					if(!CHECK_BITFIELD(query.options, SDQL2_OPTION_DO_NOT_AUTOGC))
 						QDEL_IN(query, 50)
@@ -298,6 +291,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 	var/start_time
 	var/end_time
 	var/where_switched = FALSE
+	var/show_next_to_key
 		//Select query only
 	var/list/select_refs
 	var/list/select_text
@@ -466,6 +460,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 			var/value = query_tree["options"][name]
 			set_option(name, value)
 	select_refs = list()
+	select_text = null
 	obj_count_all = 0
 	obj_count_eligible = 0
 	obj_count_finished = 0
@@ -487,6 +482,18 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 	state = SDQL2_STATE_IDLE
 	finished = TRUE
 	. = TRUE
+	if(show_next_to_key)
+		var/mob/showmob = GLOB.directory[show_next_to_key]
+		if(showmob)
+			to_chat(showmob, "<span class='admin'>SDQL query results: [query.get_query_text()]<br>\
+			SDQL query completed: [islist(query.obj_count_all)? length(query.obj_count_all) : query.obj_count_all] objects selected by path, and \
+			[query.where_switched? "[islist(query.obj_count_eligible)? length(query.obj_count_eligible) : query.obj_count_eligible] objects executed on after WHERE keyword selection." : ""]<br>\
+			SDQL query took [DisplayTimeText(query.end_time - query.start_time)] to complete.</span>")
+			if(length(query.select_text))
+				var/text = islist(query.select_text)? query.select_text.Join() : query.select_text
+				var/static/result_offset = 0
+				showmob << browse(text, "window=SDQL-result-[result_offset++]")
+
 	if(qdel_on_finish)
 		qdel(src)
 

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -635,7 +635,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 			for(var/i in found)
 				if(!is_proper_datum(i))
 					continue
-				world.SDQL_var(i, query_tree["call"][1], source = i, superuser = superuser, src)
+				world.SDQL_var(i, query_tree["call"][1], null, i, superuser, src)
 				obj_count_finished++
 				SDQL2_TICK_CHECK
 				SDQL2_HALT_CHECK
@@ -1031,7 +1031,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 		v = expression[start]
 	if(long)
 		if(expression[start + 1] == ".")
-			return SDQL_var(v, expression[start + 2], source = source, superuser = superuser, query = query)
+			return SDQL_var(v, expression[start + 2], null, source, superuser, query)
 		else if(expression[start + 1] == ":")
 			return (query.options & SDQL2_OPTION_BLOCKING_CALLS)? query.SDQL_function_async(object, v, expression[start + 2], source) : query.SDQL_function_blocking(object, v, expression[start + 2], source)
 		else if(expression[start + 1] == "\[" && islist(v))

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -148,12 +148,14 @@
 
 	TG ADDITIONS START:
 	Add USING keyword to the front of the query to use options system
+	The defaults aren't necessarily implemented, as there is no need to.
 	Available options: (D) means default
 	PROCCALL = (D)ASYNC, BLOCKING
 	SELECT = FORCE_NULLS, (D)SKIP_NULLS
 	PRIORITY = HIGH, (D) NORMAL
+	AUTOGC = (D) AUTOGC, KEEP_ALIVE
 
-	Example: USING PROCCALL = ASYNC, SELECT = FORCE_NULLS, PRIORITY = HIGH SELECT /mob FROM world WHERE z == 1
+	Example: USING PROCCALL = BLOCKING, SELECT = FORCE_NULLS, PRIORITY = HIGH SELECT /mob FROM world WHERE z == 1
 
 */
 

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -635,7 +635,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 			for(var/i in found)
 				if(!is_proper_datum(i))
 					continue
-				world.SDQL_var(i, query_tree["call"][1], source = i, superuser)
+				world.SDQL_var(i, query_tree["call"][1], source = i, superuser = superuser, src)
 				obj_count_finished++
 				SDQL2_TICK_CHECK
 				SDQL2_HALT_CHECK
@@ -871,7 +871,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 				result = dummy
 			val += result
 	else
-		val = world.SDQL_var(object, expression, i, object, superuser)
+		val = world.SDQL_var(object, expression, i, object, superuser, src)
 		i = expression.len
 
 	return list("val" = val, "i" = i)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -2,7 +2,8 @@
 
 /*
 	Welcome admins, badmins and coders alike, to Structured Datum Query Language.
-	SDQL allows you to powerfully run code on batches of objects (or single objects, it's still unmatched even there.)
+	SDQL allows you to powerfully run code on batches of objects (or single objects, it's still unmatched
+	even there.)
 	When I say "powerfully" I mean it you're in for a ride.
 
 	Ok so say you want to get a list of every mob. How does one do this?
@@ -20,7 +21,8 @@
 	These expressions can also do variable access and proc calls (yes, both on-object and globals!)
 	Keep reading!
 
-	Ok. What if you want to get every machine in the SSmachine process list? Looping through world is kinda slow.
+	Ok. What if you want to get every machine in the SSmachine process list? Looping through world is kinda
+	slow.
 
 	"SELECT * IN SSmachines.machinery"
 
@@ -48,15 +50,18 @@
 
 	This will give you a list of all the APCs, their charge AND RCon tag. Useful eh?
 
-	[] being a list here. Yeah you can write out lists directly without > lol lists in VV. Color matrix shenanigans inbound.
+	[] being a list here. Yeah you can write out lists directly without > lol lists in VV. Color matrix
+	shenanigans inbound.
 
-	After the "MAP" segment is executed, the rest of the query executes as if it's THAT object you just made (here the list).
+	After the "MAP" segment is executed, the rest of the query executes as if it's THAT object you just made
+	(here the list).
 	Yeah, by the way, you can chain these MAP / WHERE things FOREVER!
 
 	"SELECT /mob WHERE client MAP client WHERE holder MAP holder"
 
 	What if some dumbass admin spawned a bajillion spiders and you need to kill them all?
-	Oh yeah you'd rather not delete all the spiders in maintenace. Only that one room the spiders were spawned in.
+	Oh yeah you'd rather not delete all the spiders in maintenace. Only that one room the spiders were
+	spawned in.
 
 	"DELETE /mob/living/carbon/superior_animal/giant_spider WHERE loc.loc == marked"
 
@@ -79,7 +84,8 @@
 
 	You can also run multiple queries sequentially:
 
-	"CALL forceMove(marked) ON /mob/living/carbon/superior_animal; CALL gib() ON /mob/living/carbon/superior_animal"
+	"CALL forceMove(marked) ON /mob/living/carbon/superior_animal; CALL gib() ON
+	/mob/living/carbon/superior_animal"
 
 	And finally, you can directly modify variables on objects.
 
@@ -87,7 +93,8 @@
 
 	Don't crash the server, OK?
 
-	A quick recommendation: before you run something like a DELETE or another query.. Run it through SELECT first.
+	A quick recommendation: before you run something like a DELETE or another query.. Run it through SELECT
+	first.
 	You'd rather not gib every player on accident.
 	Or crash the server.
 
@@ -113,7 +120,8 @@
 	All names inside the IN block are global scope, so you can do living_mob_list (a global var) easily.
 	You can also run it on a single object. Because SDQL is that convenient even for single operations.
 
-	<type> filters out objects of, well, that type easily. "*" is a wildcard and just takes everything in the source list.
+	<type> filters out objects of, well, that type easily. "*" is a wildcard and just takes everything in
+	the source list.
 
 	And then there's the MAP/WHERE chain.
 	These operate on each individual object being ran through the query.
@@ -133,7 +141,8 @@
 	* \ref referencing: {0x30000cc} grabs the object with \ref [0x30000cc]
 	* Lists: [a, b, c] or [a: b, c: d]
 	* Math and stuff.
-	* A few special variables: src (the object currently scoped on), usr (your mob), marked (your marked datum), global(global scope)
+	* A few special variables: src (the object currently scoped on), usr (your mob),
+		marked (your marked datum), global(global scope)
 */
 
 /client/proc/SDQL2_query(query_text as message)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -91,7 +91,7 @@
 /datum/SDQL_parser/proc/query_options(i, list/node)
 	var/list/options = list()
 	if(tokenl(i) == "using")
-		i = option_assignment(i + 1, node, options)
+		i = option_assignments(i + 1, node, options)
 	query(i, node)
 	node["options"] = options
 

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -97,7 +97,7 @@
 		node["options"] = options
 
 //option_assignment:	query_option '=' define
-/datum/SDQL_parser/proc/option_assignment(var/i, var/list/node, var/list/assignment_list = list())
+/datum/SDQL_parser/proc/option_assignment(i, list/node, list/assignment_list = list())
 	var/type = tokenl(i)
 	if(!(type in SDQL2_VALID_OPTION_TYPES))
 		parse_error("Invalid option type: [type]")
@@ -110,11 +110,11 @@
 	return (i + 3)
 
 //option_assignments: option_assignment, [',' option_assignments]
-/datum/SDQL_parser/proc/option_assignments(i, list/node)
-	i = option_assignment(i, node)
+/datum/SDQL_parser/proc/option_assignments(i, list/node, list/store)
+	i = option_assignment(i, node, store)
 
 	if(token(i) == ",")
-		i = option_assignments(i + 1, node)
+		i = option_assignments(i + 1, node, store)
 
 	return i
 

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -93,7 +93,8 @@
 	if(tokenl(i) == "using")
 		i = option_assignments(i + 1, node, options)
 	query(i, node)
-	node["options"] = options
+	if(length(options))
+		node["options"] = options
 
 //option_assignment:	query_option '=' define
 /datum/SDQL_parser/proc/option_assignment(var/i, var/list/node, var/list/assignment_list = list())

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -7,36 +7,34 @@
 //
 //	query				:	select_query | delete_query | update_query | call_query | explain
 //	explain				:	'EXPLAIN' query
+//	select_query		:	'SELECT' object_selectors
+//	delete_query		:	'DELETE' object_selectors
+//	update_query		:	'UPDATE' object_selectors 'SET' assignments
+//	call_query			:	'CALL' variable 'ON' object_selectors // Note here: 'variable' does function calls. This simplifies parsing.
 //
-//	select_query		:	'SELECT' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]
-//	delete_query		:	'DELETE' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]
-//	update_query		:	'UPDATE' select_list [('FROM' | 'IN') from_list] 'SET' assignments ['WHERE' bool_expression]
-//	call_query			:	'CALL' variable ['ON' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]]
+//	select_item			:	'*' | object_type
 //
-//	select_list			:	select_item [',' select_list]
-//	select_item			:	'*' | select_function | object_type
-//	select_function		:	count_function
-//	count_function		:	'COUNT' '(' '*' ')' | 'COUNT' '(' object_types ')'
+//  object_selectors    :   select_item [('FROM' | 'IN') from_item] [modifier_list]
+//  modifier_list       :   ('WHERE' bool_expression | 'MAP' expression) [modifier_list]
 //
-//	from_list			:	from_item [',' from_list]
-//	from_item			:	'world' | object_type
+//	from_item			:	'world' | expression
 //
-//	call_function		:	<function name> ['(' [arguments] ')']
+//	call_function		:	<function name> '(' [arguments] ')'
 //	arguments			:	expression [',' arguments]
 //
-//	object_type			:	<type path> | string
+//	object_type			:	<type path>
 //
-//	assignments			:	assignment, [',' assignments]
+//	assignments			:	assignment [',' assignments]
 //	assignment			:	<variable name> '=' expression
-//	variable			:	<variable name> | <variable name> '.' variable | call_function
+//	variable			:	<variable name> | <variable name> '.' variable | '[' <hex number> ']' | '[' <hex number> ']' '.' variable
 //
 //	bool_expression		:	expression comparitor expression  [bool_operator bool_expression]
 //	expression			:	( unary_expression | '(' expression ')' | value ) [binary_operator expression]
 //	unary_expression	:	unary_operator ( unary_expression | value | '(' expression ')' )
 //	comparitor			:	'=' | '==' | '!=' | '<>' | '<' | '<=' | '>' | '>='
-//	value				:	variable | string | number | 'null'
+//	value				:	variable | string | number | 'null' | object_type
 //	unary_operator		:	'!' | '-' | '~'
-//	binary_operator		:	comparitor | '+' | '-' | '/' | '*' | '&' | '|' | '^'
+//	binary_operator		:	comparitor | '+' | '-' | '/' | '*' | '&' | '|' | '^' | '%'
 //	bool_operator		:	'AND' | '&&' | 'OR' | '||'
 //
 //	string				:	''' <some text> ''' | '"' <some text > '"'
@@ -51,18 +49,21 @@
 	var/list/query
 	var/list/tree
 
-	var/list/select_functions = list("count")
 	var/list/boolean_operators = list("and", "or", "&&", "||")
 	var/list/unary_operators = list("!", "-", "~")
-	var/list/binary_operators = list("+", "-", "/", "*", "&", "|", "^")
+	var/list/binary_operators = list("+", "-", "/", "*", "&", "|", "^", "%")
 	var/list/comparitors = list("=", "==", "!=", "<>", "<", "<=", ">", ">=")
+
+
 
 /datum/SDQL_parser/New(query_list)
 	query = query_list
 
+
+
 /datum/SDQL_parser/proc/parse_error(error_message)
 	error = 1
-	to_chat(usr, "<span class='danger'>SDQL2 Parsing Error: [error_message]</span>")
+	to_chat(usr, "<span class='warning'>SQDL2 Parsing Error: [error_message]</span>")
 	return query.len + 1
 
 /datum/SDQL_parser/proc/parse()
@@ -91,354 +92,517 @@
 /datum/SDQL_parser/proc/tokenl(i)
 	return lowertext(token(i))
 
-
 //query:	select_query | delete_query | update_query
 /datum/SDQL_parser/proc/query(i, list/node)
 	query_type = tokenl(i)
+
 	switch(query_type)
 		if("select")
 			select_query(i, node)
+
 		if("delete")
 			delete_query(i, node)
+
 		if("update")
 			update_query(i, node)
+
 		if("call")
 			call_query(i, node)
+
 		if("explain")
 			node += "explain"
 			node["explain"] = list()
 			query(i + 1, node["explain"])
 
 
-//	select_query:	'SELECT' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]
+//	select_query:	'SELECT' object_selectors
 /datum/SDQL_parser/proc/select_query(i, list/node)
 	var/list/select = list()
-	i = select_list(i + 1, select)
-	node += "select"
+	i = object_selectors(i + 1, select)
+
 	node["select"] = select
-	selectors(i, node)
 	return i
 
-//delete_query:	'DELETE' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]
+
+//delete_query:	'DELETE' object_selectors
 /datum/SDQL_parser/proc/delete_query(i, list/node)
 	var/list/select = list()
-	i = select_list(i + 1, select)
-	node += "delete"
+	i = object_selectors(i + 1, select)
+
 	node["delete"] = select
-	selectors(i, node)
+
 	return i
 
-//update_query:	'UPDATE' select_list [('FROM' | 'IN') from_list] 'SET' assignments ['WHERE' bool_expression]
+
+//update_query:	'UPDATE' object_selectors 'SET' assignments
 /datum/SDQL_parser/proc/update_query(i, list/node)
 	var/list/select = list()
-	i = select_list(i + 1, select)
-	node += "update"
+	i = object_selectors(i + 1, select)
+
 	node["update"] = select
+
 	if(tokenl(i) != "set")
 		i = parse_error("UPDATE has misplaced SET")
+
 	var/list/set_assignments = list()
 	i = assignments(i + 1, set_assignments)
-	node += "set"
+
 	node["set"] = set_assignments
-	selectors(i, node)
+
 	return i
 
-//call_query:	'CALL' call_function ['ON' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]]
+
+//call_query:	'CALL' call_function ['ON' object_selectors]
 /datum/SDQL_parser/proc/call_query(i, list/node)
 	var/list/func = list()
 	i = variable(i + 1, func) // Yes technically does anything variable() matches but I don't care, if admins fuck up this badly then they shouldn't be allowed near SDQL.
-	node += "call"
+
 	node["call"] = func
+
 	if(tokenl(i) != "on")
-		return i
+		return parse_error("You need to specify what to call ON.")
+
 	var/list/select = list()
-	i = select_list(i + 1, select)
-	node += "on"
+	i = object_selectors(i + 1, select)
+
 	node["on"] = select
-	selectors(i, node)
+
 	return i
 
-//select_list:	select_item [',' select_list]
+// object_selectors: select_item [('FROM' | 'IN') from_item] [modifier_list]
+/datum/SDQL_parser/proc/object_selectors(i, list/node)
+	i = select_item(i, node)
+
+	if (tokenl(i) == "from" || tokenl(i) == "in")
+		i++
+		var/list/from = list()
+		i = from_item(i, from)
+		node[++node.len] = from
+
+	else
+		node[++node.len] = list("world")
+
+	i = modifier_list(i, node)
+	return i
+
+// modifier_list: ('WHERE' bool_expression | 'MAP' expression) [modifier_list]
+/datum/SDQL_parser/proc/modifier_list(i, list/node)
+	while (TRUE)
+		if (tokenl(i) == "where")
+			i++
+			node += "where"
+			var/list/expr = list()
+			i = bool_expression(i, expr)
+			node[++node.len] = expr
+
+		else if (tokenl(i) == "map")
+			i++
+			node += "map"
+			var/list/expr = list()
+			i = expression(i, expr)
+			node[++node.len] = expr
+
+		else
+			return i
+
+//select_list:select_item [',' select_list]
 /datum/SDQL_parser/proc/select_list(i, list/node)
 	i = select_item(i, node)
+
 	if(token(i) == ",")
 		i = select_list(i + 1, node)
+
 	return i
 
 //assignments:	assignment, [',' assignments]
 /datum/SDQL_parser/proc/assignments(i, list/node)
 	i = assignment(i, node)
+
 	if(token(i) == ",")
 		i = assignments(i + 1, node)
+
 	return i
+
 
 //select_item:	'*' | select_function | object_type
 /datum/SDQL_parser/proc/select_item(i, list/node)
-	if(token(i) == "*")
+	if (token(i) == "*")
 		node += "*"
 		i++
-	else if(tokenl(i) in select_functions)
-		i = select_function(i, node)
-	else
+
+	else if (copytext(token(i), 1, 2) == "/")
 		i = object_type(i, node)
+
+	else
+		i = parse_error("Expected '*' or type path for select item")
+
 	return i
 
 // Standardized method for handling the IN/FROM and WHERE options.
 /datum/SDQL_parser/proc/selectors(i, list/node)
 	while (token(i))
 		var/tok = tokenl(i)
-		if(tok in list("from", "in"))
+		if (tok in list("from", "in"))
 			var/list/from = list()
 			i = from_item(i + 1, from)
+
 			node["from"] = from
 			continue
-		if(tok == "where")
+
+		if (tok == "where")
 			var/list/where = list()
 			i = bool_expression(i + 1, where)
+
 			node["where"] = where
 			continue
+
 		parse_error("Expected either FROM, IN or WHERE token, found [token(i)] instead.")
 		return i + 1
-	if(!node.Find("from"))
+
+	if (!node.Find("from"))
 		node["from"] = list("world")
+
 	return i
 
-//from_item:	'world' | object_type
+//from_item:	'world' | expression
 /datum/SDQL_parser/proc/from_item(i, list/node)
 	if(token(i) == "world")
 		node += "world"
 		i++
+
 	else
 		i = expression(i, node)
+
 	return i
+
 
 //bool_expression:	expression [bool_operator bool_expression]
 /datum/SDQL_parser/proc/bool_expression(i, list/node)
+
 	var/list/bool = list()
 	i = expression(i, bool)
+
 	node[++node.len] = bool
+
 	if(tokenl(i) in boolean_operators)
 		i = bool_operator(i, node)
 		i = bool_expression(i, node)
+
 	return i
+
 
 //assignment:	<variable name> '=' expression
 /datum/SDQL_parser/proc/assignment(var/i, var/list/node, var/list/assignment_list = list())
 	assignment_list += token(i)
+
 	if(token(i + 1) == ".")
 		i = assignment(i + 2, node, assignment_list)
+
 	else if(token(i + 1) == "=")
 		var/exp_list = list()
 		node[assignment_list] = exp_list
+
 		i = expression(i + 2, exp_list)
+
 	else
 		parse_error("Assignment expected, but no = found")
+
 	return i
 
-//variable:	<variable name> | <variable name> '.' variable
+
+//variable:	<variable name> | <variable name> '.' variable | '[' <hex number> ']' | '[' <hex number> ']' '.' variable
 /datum/SDQL_parser/proc/variable(i, list/node)
 	var/list/L = list(token(i))
 	node[++node.len] = L
+
 	if(token(i) == "{")
-		L += token(i+1)
+		L += token(i + 1)
 		i += 2
+
 		if(token(i) != "}")
 			parse_error("Missing } at end of pointer.")
+
 	if(token(i + 1) == ".")
 		L += "."
 		i = variable(i + 2, L)
-	else if(token(i + 1) == "(") // OH BOY PROC
+
+	else if (token(i + 1) == "(") // OH BOY PROC
 		var/list/arguments = list()
 		i = call_function(i, null, arguments)
 		L += ":"
 		L[++L.len] = arguments
-	else if(token(i + 1) == "\[")
+
+	else if (token(i + 1) == "\[")
 		var/list/expression = list()
 		i = expression(i + 2, expression)
 		if (token(i) != "]")
 			parse_error("Missing ] at the end of list access.")
+
 		L += "\["
 		L[++L.len] = expression
 		i++
+
 	else
 		i++
+
 	return i
 
+
+//object_type:	<type path>
+/datum/SDQL_parser/proc/object_type(i, list/node)
+
+	if (copytext(token(i), 1, 2) != "/")
+		return parse_error("Expected type, but it didn't begin with /")
+
+	var/path = text2path(token(i))
+	if (path == null)
+		return parse_error("Nonexistant type path: [token(i)]")
+
+	node += path
+
+	return i + 1
+
+
+//comparitor:	'=' | '==' | '!=' | '<>' | '<' | '<=' | '>' | '>='
+/datum/SDQL_parser/proc/comparitor(i, list/node)
+
+	if(token(i) in list("=", "==", "!=", "<>", "<", "<=", ">", ">="))
+		node += token(i)
+
+	else
+		parse_error("Unknown comparitor [token(i)]")
+
+	return i + 1
+
+
+//bool_operator:	'AND' | '&&' | 'OR' | '||'
+/datum/SDQL_parser/proc/bool_operator(i, list/node)
+
+	if(tokenl(i) in list("and", "or", "&&", "||"))
+		node += token(i)
+
+	else
+		parse_error("Unknown comparitor [token(i)]")
+
+	return i + 1
+
+
+//string:	''' <some text> ''' | '"' <some text > '"'
+/datum/SDQL_parser/proc/string(i, list/node)
+
+	if(copytext(token(i), 1, 2) in list("'", "\""))
+		node += token(i)
+
+	else
+		parse_error("Expected string but found '[token(i)]'")
+
+	return i + 1
+
 //array:	'[' expression, expression, ... ']'
-/datum/SDQL_parser/proc/array(i, list/node)
+/datum/SDQL_parser/proc/array(var/i, var/list/node)
+	// Arrays get turned into this: list("[", list(exp_1a = exp_1b, ...), ...), "[" is to mark the next node as an array.
 	if(copytext(token(i), 1, 2) != "\[")
 		parse_error("Expected an array but found '[token(i)]'")
 		return i + 1
-	node += token(i)
+
+	node += token(i) // Add the "["
+
 	var/list/expression_list = list()
+
 	i++
 	if(token(i) != "]")
 		var/list/temp_expression_list = list()
 		var/tok
 		do
 			tok = token(i)
-			if(tok == "," || tok == ":")
-				if(temp_expression_list == null)
+			if (tok == "," || tok == ":")
+				if (temp_expression_list == null)
 					parse_error("Found ',' or ':' without expression in an array.")
 					return i + 1
+
 				expression_list[++expression_list.len] = temp_expression_list
 				temp_expression_list = null
-				if(tok == ":")
+				if (tok == ":")
 					temp_expression_list = list()
 					i = expression(i + 1, temp_expression_list)
 					expression_list[expression_list[expression_list.len]] = temp_expression_list
 					temp_expression_list = null
 					tok = token(i)
-					if(tok != ",")
-						if(tok == "]")
+					if (tok != ",")
+						if (tok == "]")
 							break
+
 						parse_error("Expected ',' or ']' after array assoc value, but found '[token(i)]'")
 						return i
+
+
 				i++
 				continue
+
 			temp_expression_list = list()
 			i = expression(i, temp_expression_list)
+
+			// Ok, what the fuck BYOND?
+			// Not having these lines here causes the parser to die
+			// on an error saying that list/token() doesn't exist as a proc.
+			// These lines prevent that.
+			// I assume the compiler/VM is shitting itself and swapping out some variables internally?
+			// While throwing in debug logging it disappeared
+			// And these 3 lines prevent it from happening while being quiet.
+			// So.. it works.
+			// Don't touch it.
+			var/whatthefuck = i
+			whatthefuck = src.type
+			whatthefuck = whatthefuck
+
 		while(token(i) && token(i) != "]")
-		if(temp_expression_list)
+
+		if (temp_expression_list)
 			expression_list[++expression_list.len] = temp_expression_list
+
 	node[++node.len] = expression_list
-	return i + 1
 
-//object_type:	<type path> | string
-/datum/SDQL_parser/proc/object_type(i, list/node)
-	if(copytext(token(i), 1, 2) == "/")
-		node += token(i)
-	else
-		i = string(i, node)
-	return i + 1
-
-//comparitor:	'=' | '==' | '!=' | '<>' | '<' | '<=' | '>' | '>='
-/datum/SDQL_parser/proc/comparitor(i, list/node)
-	if(token(i) in list("=", "==", "!=", "<>", "<", "<=", ">", ">="))
-		node += token(i)
-	else
-		parse_error("Unknown comparitor [token(i)]")
-	return i + 1
-
-//bool_operator:	'AND' | '&&' | 'OR' | '||'
-/datum/SDQL_parser/proc/bool_operator(i, list/node)
-	if(tokenl(i) in list("and", "or", "&&", "||"))
-		node += token(i)
-	else
-		parse_error("Unknown comparitor [token(i)]")
-	return i + 1
-
-//string:	''' <some text> ''' | '"' <some text > '"'
-/datum/SDQL_parser/proc/string(i, list/node)
-	if(copytext(token(i), 1, 2) in list("'", "\""))
-		node += token(i)
-	else
-		parse_error("Expected string but found '[token(i)]'")
 	return i + 1
 
 //call_function:	<function name> ['(' [arguments] ')']
 /datum/SDQL_parser/proc/call_function(i, list/node, list/arguments)
 	if(length(tokenl(i)))
 		var/procname = ""
-		if(token(i) == "global" && token(i+1) == ".")
+		if(tokenl(i) == "global" && token(i + 1) == ".") // Global proc.
 			i += 2
 			procname = "global."
 		node += procname + token(i++)
 		if(token(i) != "(")
 			parse_error("Expected ( but found '[token(i)]'")
+
 		else if(token(i + 1) != ")")
-			var/list/expression_list_temp = list()
+			var/list/temp_expression_list = list()
 			do
-				i = expression(i + 1, expression_list_temp)
+				i = expression(i + 1, temp_expression_list)
 				if(token(i) == ",")
-					arguments[++arguments.len] = expression_list_temp
-					expression_list_temp = list()
+					arguments[++arguments.len] = temp_expression_list
+					temp_expression_list = list()
 					continue
+
 			while(token(i) && token(i) != ")")
-			arguments[++arguments.len] = expression_list_temp
+
+			arguments[++arguments.len] = temp_expression_list // The code this is copy pasted from won't be executed when it's the last param, this fixes that.
 		else
 			i++
 	else
 		parse_error("Expected a function but found nothing")
 	return i + 1
 
-//select_function:	count_function
-/datum/SDQL_parser/proc/select_function(i, list/node)
-	parse_error("Sorry, function calls aren't available yet")
-	return i
 
 //expression:	( unary_expression | '(' expression ')' | value ) [binary_operator expression]
 /datum/SDQL_parser/proc/expression(i, list/node)
+
 	if(token(i) in unary_operators)
 		i = unary_expression(i, node)
+
 	else if(token(i) == "(")
 		var/list/expr = list()
+
 		i = expression(i + 1, expr)
+
 		if(token(i) != ")")
 			parse_error("Missing ) at end of expression.")
+
 		else
 			i++
+
 		node[++node.len] = expr
+
 	else
 		i = value(i, node)
+
 	if(token(i) in binary_operators)
 		i = binary_operator(i, node)
 		i = expression(i, node)
+
 	else if(token(i) in comparitors)
 		i = binary_operator(i, node)
+
 		var/list/rhs = list()
 		i = expression(i, rhs)
+
 		node[++node.len] = rhs
+
+
 	return i
+
 
 //unary_expression:	unary_operator ( unary_expression | value | '(' expression ')' )
 /datum/SDQL_parser/proc/unary_expression(i, list/node)
+
 	if(token(i) in unary_operators)
 		var/list/unary_exp = list()
+
 		unary_exp += token(i)
 		i++
+
 		if(token(i) in unary_operators)
 			i = unary_expression(i, unary_exp)
+
 		else if(token(i) == "(")
 			var/list/expr = list()
+
 			i = expression(i + 1, expr)
+
 			if(token(i) != ")")
 				parse_error("Missing ) at end of expression.")
+
 			else
 				i++
+
 			unary_exp[++unary_exp.len] = expr
+
 		else
 			i = value(i, unary_exp)
+
 		node[++node.len] = unary_exp
+
+
 	else
 		parse_error("Expected unary operator but found '[token(i)]'")
+
 	return i
 
-//binary_operator:	comparitor | '+' | '-' | '/' | '*' | '&' | '|' | '^'
+
+//binary_operator:	comparitor | '+' | '-' | '/' | '*' | '&' | '|' | '^' | '%'
 /datum/SDQL_parser/proc/binary_operator(i, list/node)
+
 	if(token(i) in (binary_operators + comparitors))
 		node += token(i)
+
 	else
 		parse_error("Unknown binary operator [token(i)]")
+
 	return i + 1
 
-//value:	variable | string | number | 'null'
+
+//value:	variable | string | number | 'null' | object_type
 /datum/SDQL_parser/proc/value(i, list/node)
 	if(token(i) == "null")
 		node += "null"
 		i++
-	else if(lowertext(copytext(token(i),1,3)) == "0x" && isnum(hex2num(copytext(token(i),3))))
-		node += hex2num(copytext(token(i),3))
+
+	else if(lowertext(copytext(token(i), 1, 3)) == "0x" && isnum(hex2num(copytext(token(i), 3))))
+		node += hex2num(copytext(token(i), 3))
 		i++
+
 	else if(isnum(text2num(token(i))))
 		node += text2num(token(i))
 		i++
+
 	else if(copytext(token(i), 1, 2) in list("'", "\""))
 		i = string(i, node)
+
 	else if(copytext(token(i), 1, 2) == "\[") // Start a list.
 		i = array(i, node)
+	else if(copytext(token(i), 1, 2) == "/")
+		i = object_type(i, node)
 	else
 		i = variable(i, node)
-	return i
 
-/*EXPLAIN SELECT * WHERE 42 = 6 * 9 OR val = - 5 == 7*/
+	return i

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -48,6 +48,12 @@
 /proc/_image(icon, loc, icon_state, layer, dir)
 	return image(icon, loc, icon_state, layer, dir)
 
+/proc/_istype(object, type)
+	return istype(object, type)
+
+/proc/_ispath(path, type)
+	return ispath(path, type)
+
 /proc/_length(E)
 	return length(E)
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -31,7 +31,7 @@
 	message_admins("[key_name_admin(src)] has started answering [ADMIN_LOOKUPFLW(M)]'s prayer.")
 	var/msg = input("Message:", text("Subtle PM to [M.key]")) as text|null
 
-	if (!msg)
+	if(!msg)
 		message_admins("[key_name_admin(src)] decided not to answer [ADMIN_LOOKUPFLW(M)]'s prayer")
 		return
 	if(usr)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -556,7 +556,7 @@
 			GLOB.ahelp_tickets.stat_entry()
 		if(length(GLOB.sdql2_queries))
 			if(statpanel("SDQL2"))
-				stat("Access Global SDQL2 List", GLOB.sdql2_vv_statclick)
+				stat("Access Global SDQL2 List", GLOB.sdql2_vv_statobj)
 				for(var/i in GLOB.sdql2_queries)
 					var/datum/SDQL2_query/Q = i
 					Q.generate_stat()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -554,6 +554,12 @@
 			GLOB.cameranet.stat_entry()
 		if(statpanel("Tickets"))
 			GLOB.ahelp_tickets.stat_entry()
+		if(length(GLOB.sdql2_queries))
+			if(statpanel("SDQL2"))
+				stat("Access Global SDQL2 List", GLOB.sdql2_vv_statclick)
+				for(var/i in GLOB.sdql2_queries)
+					var/datum/SDQL2_query/Q = i
+					Q.generate_stat()
 
 	if(listed_turf && client)
 		if(!TurfAdjacent(listed_turf))


### PR DESCRIPTION
Thanks @PJB3005 
:cl:
experimental: SDQL2 has been refactored to a datum!
rscadd: A new SDQL2 panel has been added to admin tabs, for tracking, VVing, and halting SDQL2 queries.
rscadd: SDQL2 documentation is now available in SDQL_2.dm
rscadd: SDQL2 now has MAP added. MAP will cause the query to execute on whatever is specified in MAP, whether it's a variable or a procedure call (which will grab the return results), etc etc.
rscadd: SDQL2 now has a superuser mode, for uses outside of admin button pressing. This causes it to operate without admin protection wrapping.
rscadd: SDQL2 now supports options, including ignoring nulls in select or forcing it to operate in high priority mode, which lets it use 95% of the tick instead of obeying the Master Controller's tick limit. USE WITH CAUTION. Also includes a mode for blocking proccalls
rscadd: SDQL2 now supports TRUE/FALSE.
rscadd: To use options, append OPTIONS to the query. Available are "PRIORITY" = HIGH/NORMAL, "SELECT" = FORCE_NULLS/DISABLE or 0/FALSE, "PROCCALL" = ASYNC/BLOCKING.
/:cl:

Also displaytimetext is refactored.