### PR TITLE
fixes medkit in runtime station

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1306,7 +1306,7 @@
 "dO" = (
 /obj/structure/table,
 /obj/machinery/light,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "dP" = (


### PR DESCRIPTION
~~:cl:
fix: runtime medkits is no longer empty
/:cl:~~

Fixes #41963