### PR TITLE
Nuclear bombs in rifts spawn a singulo on the station and count as a syndie victory

### DIFF
--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -27,6 +27,9 @@
 					M.visible_message("<span class='danger'>The bluespace collapse crushes the air towards it, pulling [M] towards the ground...</span>")
 					M.Paralyze(5, TRUE, TRUE)		//Overrides stun absorbs.
 			T.TerraformTurf(/turf/open/chasm/magic, /turf/open/chasm/magic)
+		for(var/fabricarea in get_areas(/area/fabric_of_reality))
+			var/area/fabric_of_reality/R = fabricarea
+			R.origin = loccheck
 		for (var/obj/structure/ladder/unbreakable/binary/ladder in GLOB.ladders)
 			ladder.ActivateAlmonds()
 		message_admins("[ADMIN_LOOKUPFLW(user)] detonated a bag of holding at [ADMIN_VERBOSEJMP(loccheck)].")

--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -137,6 +137,7 @@
 	has_gravity = TRUE
 	noteleport = TRUE
 	blob_allowed = FALSE
+	var/turf/origin
 
 //CAPTURE THE FLAG
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -3,8 +3,8 @@
 	config_tag = "nuclear"
 	report_type = "nuclear"
 	false_report_weight = 10
-	required_players = 30 // 30 players - 3 players to be the nuke ops = 27 players remaining
-	required_enemies = 2
+	required_players = 0 // 30 players - 3 players to be the nuke ops = 27 players remaining
+	required_enemies = 1
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE
 	enemy_minimum_age = 14

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -3,8 +3,8 @@
 	config_tag = "nuclear"
 	report_type = "nuclear"
 	false_report_weight = 10
-	required_players = 0 // 30 players - 3 players to be the nuke ops = 27 players remaining
-	required_enemies = 1
+	required_players = 30 // 30 players - 3 players to be the nuke ops = 27 players remaining
+	required_enemies = 2
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE
 	enemy_minimum_age = 14

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -424,7 +424,10 @@
 	var/off_station = 0
 	var/turf/bomb_location = get_turf(src)
 	var/area/A = get_area(bomb_location)
-	if(bomb_location && is_station_level(bomb_location.z))
+	if(istype(A, /area/fabric_of_reality))
+		var/area/fabric_of_reality/fabric = A
+		new /obj/singularity(fabric.origin, 2000) // Stage five singulo back on the station, as a gift
+	else if(bomb_location && is_station_level(bomb_location.z))
 		if(istype(A, /area/space))
 			off_station = NUKE_NEAR_MISS
 		if((bomb_location.x < (128-NUKERANGE)) || (bomb_location.x > (128+NUKERANGE)) || (bomb_location.y < (128-NUKERANGE)) || (bomb_location.y > (128+NUKERANGE)))
@@ -445,7 +448,13 @@
 
 /obj/machinery/nuclearbomb/proc/really_actually_explode(off_station)
 	Cinematic(get_cinematic_type(off_station),world,CALLBACK(SSticker,/datum/controller/subsystem/ticker/proc/station_explosion_detonation,src))
-	INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnZLevel, z)
+	var/area/A = get_area(src)
+	if(istype(A, /area/fabric_of_reality))
+		var/area/fabric_of_reality/fabric = A
+		var/turf/T = fabric.origin
+		INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnZLevel, T.z)
+	else
+		INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnZLevel, z)
 
 /obj/machinery/nuclearbomb/proc/get_cinematic_type(off_station)
 	if(off_station < 2)


### PR DESCRIPTION
A nuclear bomb in a rift in spacetime will now count as a syndie major victory, and spawn a singulo back at the station rift origin turf.

:cl:
tweak: A nuclear bomb in a rift in spacetime will now count as a syndie major victory, and spawn a singulo back at the station rift origin turf.
/:cl:

[why]: Bounty.
With this implementation, if the nuke lands on a tile of the rift when entering a magic chasm, it'll continue ticking and eventually blow up, causing a syndicate major victory,and killing all the mobs on the station, as if it was on the station. But if it lands in the central part of the rift, where the singularity is, it gets destroyed. Waiting for oranges to choose whether to leave this or to make it completely indestructible.