### PR TITLE
Fixes pipe underlays

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -228,7 +228,7 @@
 		pressures = int_air.return_pressure() - env_air.return_pressure()
 
 	user.visible_message("<span class='danger'>[user] is sent flying by pressure!</span>","<span class='userdanger'>The pressure sends you flying!</span>")
-	
+
 	// if get_dir(src, user) is not 0, target is the edge_target_turf on that dir
 	// otherwise, edge_target_turf uses a random cardinal direction
 	// range is pressures / 250
@@ -245,19 +245,20 @@
 			transfer_fingerprints_to(stored)
 	..()
 
-/obj/machinery/atmospherics/proc/getpipeimage(iconset, iconstate, direction, col=rgb(255,255,255))
+/obj/machinery/atmospherics/proc/getpipeimage(iconset, iconstate, direction, col=rgb(255,255,255), piping_layer=2)
 
 	//Add identifiers for the iconset
 	if(iconsetids[iconset] == null)
 		iconsetids[iconset] = num2text(iconsetids.len + 1)
 
 	//Generate a unique identifier for this image combination
-	var/identifier = iconsetids[iconset] + "_[iconstate]_[direction]_[col]"
+	var/identifier = iconsetids[iconset] + "_[iconstate]_[direction]_[col]_[piping_layer]"
 
 	if((!(. = pipeimages[identifier])))
 		var/image/pipe_overlay
 		pipe_overlay = . = pipeimages[identifier] = image(iconset, iconstate, dir = direction)
 		pipe_overlay.color = col
+		PIPING_LAYER_SHIFT(pipe_overlay, piping_layer)
 
 /obj/machinery/atmospherics/on_construction(obj_color, set_layer)
 	if(can_unwrench)

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -38,8 +38,7 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/update_icon_nopipes()
 	cut_overlays()
 	if(showpipe)
-		var/image/cap = getpipeimage(icon, "dpvent_cap", dir)
-		PIPING_LAYER_SHIFT(cap, piping_layer)
+		var/image/cap = getpipeimage(icon, "dpvent_cap", dir, piping_layer = piping_layer)
 		add_overlay(cap)
 
 	if(!on || !is_operational())

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -59,13 +59,9 @@
 
 /obj/machinery/atmospherics/components/proc/get_pipe_underlay(state, dir, color = null)
 	if(color)
-		. = getpipeimage('icons/obj/atmospherics/components/binary_devices.dmi', state, dir, color)
+		. = getpipeimage('icons/obj/atmospherics/components/binary_devices.dmi', state, dir, color, piping_layer = shift_underlay_only ? piping_layer : 2)
 	else
-		. = getpipeimage('icons/obj/atmospherics/components/binary_devices.dmi', state, dir)
-
-	if(shift_underlay_only)
-		var/image/I = .
-		PIPING_LAYER_SHIFT(I, piping_layer)
+		. = getpipeimage('icons/obj/atmospherics/components/binary_devices.dmi', state, dir, piping_layer = shift_underlay_only ? piping_layer : 2)
 
 // Pipenet stuff; housekeeping
 

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -34,11 +34,10 @@
 
 		var/image/cap
 		if(node)
-			cap = getpipeimage(icon, "cap", direction, node.pipe_color)
+			cap = getpipeimage(icon, "cap", direction, node.pipe_color, piping_layer = piping_layer)
 		else
-			cap = getpipeimage(icon, "cap", direction)
+			cap = getpipeimage(icon, "cap", direction, piping_layer = piping_layer)
 
-		PIPING_LAYER_SHIFT(cap, piping_layer)
 		add_overlay(cap)
 
 	return ..()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -25,11 +25,10 @@
 
 		var/image/cap
 		if(node)
-			cap = getpipeimage(icon, "cap", direction, node.pipe_color)
+			cap = getpipeimage(icon, "cap", direction, node.pipe_color, piping_layer = piping_layer)
 		else
-			cap = getpipeimage(icon, "cap", direction)
+			cap = getpipeimage(icon, "cap", direction, piping_layer = piping_layer)
 
-		PIPING_LAYER_SHIFT(cap, piping_layer)
 		add_overlay(cap)
 
 	return ..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -28,8 +28,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/update_icon_nopipes()
 	icon_state = "connector"
 	if(showpipe)
-		var/image/cap = getpipeimage(icon, "connector_cap", initialize_directions)
-		PIPING_LAYER_SHIFT(cap, piping_layer)
+		var/image/cap = getpipeimage(icon, "connector_cap", initialize_directions, piping_layer = piping_layer)
 		add_overlay(cap)
 
 /obj/machinery/atmospherics/components/unary/portables_connector/process_atmos()

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -52,8 +52,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/update_icon_nopipes()
 	cut_overlays()
 	if(showpipe)
-		var/image/cap = getpipeimage(icon, "vent_cap", initialize_directions)
-		PIPING_LAYER_SHIFT(cap, piping_layer)
+		var/image/cap = getpipeimage(icon, "vent_cap", initialize_directions, piping_layer = piping_layer)
 		add_overlay(cap)
 
 	if(welded)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -69,8 +69,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/update_icon_nopipes()
 	cut_overlays()
 	if(showpipe)
-		var/image/cap = getpipeimage(icon, "scrub_cap", initialize_directions)
-		PIPING_LAYER_SHIFT(cap, piping_layer)
+		var/image/cap = getpipeimage(icon, "scrub_cap", initialize_directions, piping_layer = piping_layer)
 		add_overlay(cap)
 
 	if(welded)
@@ -97,7 +96,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/proc/broadcast_status()
 	if(!radio_connection)
 		return FALSE
-	
+
 	var/list/f_types = list()
 	for(var/path in GLOB.meta_gas_info)
 		var/list/gas = GLOB.meta_gas_info[path]
@@ -186,7 +185,7 @@
 			air_contents.merge(filtered_out)
 			tile.assume_air(removed)
 			tile.air_update_turf()
-	
+
 	else //Just siphoning all air
 
 		var/transfer_moles = environment.total_moles()*(volume_rate/environment.volume)
@@ -284,7 +283,7 @@
 	if(. && on && is_operational())
 		to_chat(user, "<span class='warning'>You cannot unwrench [src], turn it off first!</span>")
 		return FALSE
-		
+
 /obj/machinery/atmospherics/components/unary/vent_scrubber/examine(mob/user)
 	..()
 	if(welded)

--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -61,12 +61,11 @@
 	var/image/I
 
 	if(p_color)
-		I = getpipeimage(icon, "pipe", p_dir, p_color)
+		I = getpipeimage(icon, "pipe", p_dir, p_color, piping_layer = piping_layer)
 	else
-		I = getpipeimage(icon, "pipe", p_dir)
+		I = getpipeimage(icon, "pipe", p_dir, piping_layer = piping_layer)
 
 	I.layer = layer - 0.01
-	PIPING_LAYER_SHIFT(I, p_layer)
 	add_overlay(I)
 
 /obj/machinery/atmospherics/pipe/layer_manifold/SetInitDirections()


### PR DESCRIPTION
Yet another instance of tgcoders writing shitty code that screws over downstreams, yay!

so at yogstation we were having a small problem. The pipes in atmos had weird underlay shifting problems. 

![image](https://cdn.discordapp.com/attachments/134722107190935552/524995533685784586/unknown.png)

it only happened with certain pipe colors: cyan, red, blue, white. And it didn't happen on tgstation. Only on yogs. So I did some code diving and found out that you tg fucks modified the pixel_x/y returned values of the appearance cache, which means subsequent requests resulted in the pipe underlay being shifted slightly even if it shouldn't be. But this only happens if you use pipes that have shift_underlay_only with pipe layers. It doesn't happen if you don't use other pipe layers, which tg's maps don't but yogs maps do. Except donutstation.

so moral of the story, don't modify the return value of getpipeimage lest you inadvertantly break something on a downstream

:cl: monster860
fix: Fixes pumps and valves appearing super broken on maps that make heavy use of pipe layers.
/:cl: