### PR TITLE
BoH bombing logs now include ckey in admin logs/messages

### DIFF
--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -18,6 +18,10 @@
 		to_chat(user, "<span class='danger'>The Bluespace interfaces of the two devices catastrophically malfunction!</span>")
 		qdel(W)
 		playsound(loccheck,'sound/effects/supermatter.ogg', 200, 1)
+
+		message_admins("[ADMIN_LOOKUPFLW(user)] detonated a bag of holding at [ADMIN_VERBOSEJMP(loccheck)].")
+		log_game("[key_name(user)] detonated a bag of holding at [loc_name(loccheck)].")
+
 		user.gib(TRUE, TRUE, TRUE)
 		for(var/turf/T in range(6,loccheck))
 			if(istype(T, /turf/open/space/transit))
@@ -29,8 +33,6 @@
 			T.TerraformTurf(/turf/open/chasm/magic, /turf/open/chasm/magic)
 		for (var/obj/structure/ladder/unbreakable/binary/ladder in GLOB.ladders)
 			ladder.ActivateAlmonds()
-		message_admins("[ADMIN_LOOKUPFLW(user)] detonated a bag of holding at [ADMIN_VERBOSEJMP(loccheck)].")
-		log_game("[key_name(user)] detonated a bag of holding at [loc_name(loccheck)].")
 		qdel(A)
 		return
 	. = ..()


### PR DESCRIPTION
:cl: coiax
fix: A player who bag of holding bombs now correctly has their
ckey entered in the admin log, and admin messages.
/:cl:

The mob was gibbed (and thus destroyed) before the message
was being sent.