### PR TITLE
New admin only wand, wand of safety, plus buffed other admin wands

### DIFF
--- a/code/modules/projectiles/ammunition/special/magic.dm
+++ b/code/modules/projectiles/ammunition/special/magic.dm
@@ -22,6 +22,10 @@
 	projectile_type = /obj/item/projectile/magic/teleport
 	harmful = FALSE
 
+/obj/item/ammo_casing/magic/safety
+	projectile_type = /obj/item/projectile/magic/safety
+	harmful = FALSE
+
 /obj/item/ammo_casing/magic/door
 	projectile_type = /obj/item/projectile/magic/door
 	harmful = FALSE

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -7,7 +7,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	can_charge = 0
 	max_charges = 100 //100, 50, 50, 34 (max charge distribution by 25%ths)
-	var/variable_charges = 1
+	var/variable_charges = TRUE
 
 /obj/item/gun/magic/wand/Initialize()
 	if(prob(75) && variable_charges) //25% chance of listed max charges, 50% chance of 1/2 max charges, 25% chance of 1/3 max charges
@@ -73,6 +73,13 @@
 	user.adjustOxyLoss(500)
 	charges--
 
+/obj/item/gun/magic/wand/death/debug
+	desc = "In some obscure circles, this is known as the 'cloning tester's friend'."
+	max_charges = 500
+	variable_charges = FALSE
+	can_charge = TRUE
+	recharge_rate = 1
+
 
 /////////////////////////////////////
 //WAND OF HEALING
@@ -97,8 +104,11 @@
 	..()
 
 /obj/item/gun/magic/wand/resurrection/debug //for testing
-	name = "debug wand of healing"
+	desc = "Is it possible for something to be even more powerful than regular magic? This wand is."
 	max_charges = 500
+	variable_charges = FALSE
+	can_charge = TRUE
+	recharge_rate = 1
 
 /////////////////////////////////////
 //WAND OF POLYMORPH
@@ -128,7 +138,7 @@
 	fire_sound = 'sound/magic/wand_teleport.ogg'
 	icon_state = "telewand"
 	max_charges = 10 //10, 5, 5, 4
-	no_den_usage = 1
+	no_den_usage = TRUE
 
 /obj/item/gun/magic/wand/teleport/zap_self(mob/living/user)
 	if(do_teleport(user, user, 10, channel = TELEPORT_CHANNEL_MAGIC))
@@ -137,6 +147,34 @@
 		smoke.start()
 		charges--
 	..()
+
+/obj/item/gun/magic/wand/safety
+	name = "wand of safety"
+	desc = "This wand will use the lightest of bluespace currents to gently place the target somewhere safe."
+	ammo_type = /obj/item/ammo_casing/magic/safety
+	fire_sound = 'sound/magic/wand_teleport.ogg'
+	icon_state = "telewand"
+	max_charges = 10 //10, 5, 5, 4
+	no_den_usage = FALSE
+
+/obj/item/gun/magic/wand/safety/zap_self(mob/living/user)
+	var/turf/origin = get_turf(user)
+	var/turf/destination = find_safe_turf()
+
+	if(do_teleport(user, destination, channel=TELEPORT_CHANNEL_MAGIC))
+		for(var/t in list(origin, destination))
+			var/datum/effect_system/smoke_spread/smoke = new
+			smoke.set_up(0, t)
+			smoke.start()
+	..()
+
+/obj/item/gun/magic/wand/safety/debug
+	desc = "This wand has 'find_safe_turf()' engraved into its blue wood. Perhaps it's a secret message?"
+	max_charges = 500
+	variable_charges = FALSE
+	can_charge = TRUE
+	recharge_rate = 1
+
 
 /////////////////////////////////////
 //WAND OF DOOR CREATION

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -50,7 +50,7 @@
 	icon_state = "bluespace"
 	damage = 0
 	damage_type = OXY
-	nodamage = 1
+	nodamage = TRUE
 	var/inner_tele_radius = 0
 	var/outer_tele_radius = 6
 
@@ -72,6 +72,32 @@
 				var/datum/effect_system/smoke_spread/smoke = new
 				smoke.set_up(max(round(4 - teleammount),0), stuff.loc) //Smoke drops off if a lot of stuff is moved for the sake of sanity
 				smoke.start()
+
+/obj/item/projectile/magic/safety
+	name = "bolt of safety"
+	icon_state = "bluespace"
+	damage = 0
+	damage_type = OXY
+	nodamage = TRUE
+
+/obj/item/projectile/magic/safety/on_hit(atom/target)
+	. = ..()
+	if(ismob(target))
+		var/mob/M = target
+		if(M.anti_magic_check())
+			M.visible_message("<span class='warning'>[src] fizzles on contact with [target]!</span>")
+			return
+	if(isturf(target))
+		return
+
+	var/turf/origin_turf = get_turf(target)
+	var/turf/destination_turf = find_safe_turf()
+
+	if(do_teleport(target, destination_turf, channel=TELEPORT_CHANNEL_MAGIC))
+		for(var/t in list(origin_turf, destination_turf))
+			var/datum/effect_system/smoke_spread/smoke = new
+			smoke.set_up(0, t)
+			smoke.start()
 
 /obj/item/projectile/magic/door
 	name = "bolt of door creation"


### PR DESCRIPTION
:cl: coiax
admin: Admins now have access to a "wand of safety", a supercharged teleportation
wand that moves people to a safe turf, like a swarmer teleport without the cuffing.
/:cl:

I also changed the description of the debug healing wands, and added
a debug safety, and debug death wands. Debug wands also charge
every (other?) tick.

I specifically coded this because I would have liked to have something like it
for the Winter Ball, in clearing people who were trying to break into the Brig.
And I'm sure that other admins can do probably bad stuff with attaching the
projectile to those rapid fire turrets.