### PR TITLE
Rework of admin rank loading to support punctuation

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -20,7 +20,7 @@
 #define BANTYPE_ANY_JOB		9 //used to remove jobbans
 
 //Admin Permissions
-#define R_BUILDMODE		(1<<0)
+#define R_BUILD		(1<<0)
 #define R_ADMIN			(1<<1)
 #define R_BAN			(1<<2)
 #define R_FUN			(1<<3)
@@ -31,12 +31,12 @@
 #define R_STEALTH		(1<<8)
 #define R_POLL			(1<<9)
 #define R_VAREDIT		(1<<10)
-#define R_SOUNDS		(1<<11)
+#define R_SOUND		(1<<11)
 #define R_SPAWN			(1<<12)
-#define R_AUTOLOGIN		(1<<13)
+#define R_AUTOADMIN		(1<<13)
 #define R_DBRANKS		(1<<14)
 
-#define R_DEFAULT R_AUTOLOGIN
+#define R_DEFAULT R_AUTOADMIN
 
 #define R_EVERYTHING (1<<15)-1 //the sum of all other rank permissions, used for +EVERYTHING
 

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -195,7 +195,7 @@
 //Converts a rights bitfield into a string
 /proc/rights2text(rights, seperator="", prefix = "+")
 	seperator += prefix
-	if(rights & R_BUILDMODE)
+	if(rights & R_BUILD)
 		. += "[seperator]BUILDMODE"
 	if(rights & R_ADMIN)
 		. += "[seperator]ADMIN"
@@ -217,11 +217,11 @@
 		. += "[seperator]POLL"
 	if(rights & R_VAREDIT)
 		. += "[seperator]VAREDIT"
-	if(rights & R_SOUNDS)
+	if(rights & R_SOUND)
 		. += "[seperator]SOUND"
 	if(rights & R_SPAWN)
 		. += "[seperator]SPAWN"
-	if(rights & R_AUTOLOGIN)
+	if(rights & R_AUTOADMIN)
 		. += "[seperator]AUTOLOGIN"
 	if(rights & R_DBRANKS)
 		. += "[seperator]DBRANKS"

--- a/code/_globalvars/bitfields.dm
+++ b/code/_globalvars/bitfields.dm
@@ -51,7 +51,7 @@ GLOBAL_LIST_INIT(bitfields, list(
 		"ABSTRACT" = ABSTRACT,
 		),
 	"admin_flags" = list(
-		"BUILDMODE" = R_BUILDMODE,
+		"BUILDMODE" = R_BUILD,
 		"ADMIN" = R_ADMIN,
 		"BAN" = R_BAN,
 		"FUN" = R_FUN,
@@ -62,9 +62,9 @@ GLOBAL_LIST_INIT(bitfields, list(
 		"STEALTH" = R_STEALTH,
 		"POLL" = R_POLL,
 		"VAREDIT" = R_VAREDIT,
-		"SOUNDS" = R_SOUNDS,
+		"SOUNDS" = R_SOUND,
 		"SPAWN" = R_SPAWN,
-		"AUTOLOGIN" = R_AUTOLOGIN,
+		"AUTOLOGIN" = R_AUTOADMIN,
 		"DBRANKS" = R_DBRANKS
 		),
 	"interaction_flags_atom" = list(

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -795,7 +795,7 @@
 			src.cmd_admin_gib(M)
 
 		else if(href_list["build_mode"])
-			if(!check_rights(R_BUILDMODE))
+			if(!check_rights(R_BUILD))
 				return
 
 			var/mob/M = locate(href_list["build_mode"]) in GLOB.mob_list

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -135,7 +135,7 @@ GLOBAL_PROTECT(protected_ranks)
 	//load text from file and process each entry
 	var/ranks_text = file2text("[global.config.directory]/admin_ranks.txt")
 	var/datum/admin_rank/previous_rank
-	var/regex/admin_ranks_regex = new("^Name\\s*=\\s*(.+?)\\s*\n+Include\\s*=\\s*(\[\\l @\]*?)\\s*\n+Exclude\\s*=\\s*(\[\\l @\]*?)\\s*\n+Edit\\s*=\\s*(\[\\l @\]*?)\\s*\n*$", "gm")
+	var/regex/admin_ranks_regex = new(@"^Name\s*=\s*(.+?)\s*\n+Include\s*=\s*([\l @]*?)\s*\n+Exclude\s*=\s*([\l @]*?)\s*\n+Edit\s*=\s*([\l @]*?)\s*\n*$", "gm")
 	while(admin_ranks_regex.Find(ranks_text))
 		var/datum/admin_rank/R = new(admin_ranks_regex.group[1])
 		if(!R)
@@ -228,7 +228,7 @@ GLOBAL_PROTECT(protected_ranks)
 		rank_names[R.name] = R
 	//ckeys listed in admins.txt are always made admins before sql loading is attempted
 	var/admins_text = file2text("[global.config.directory]/admins.txt")
-	var/regex/admins_regex = new("^(?!#)(.+?)\\s+=\\s+(.+)", "gm")
+	var/regex/admins_regex = new(@"^(?!#)(.+?)\s+=\s+(.+)", "gm")
 	while(admins_regex.Find(admins_text))
 		new /datum/admins(rank_names[admins_regex.group[2]], ckey(admins_regex.group[1]), FALSE, TRUE)
 	if(!CONFIG_GET(flag/admin_legacy_system) || dbfail)

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -45,69 +45,69 @@ GLOBAL_PROTECT(protected_ranks)
 /datum/admin_rank/vv_edit_var(var_name, var_value)
 	return FALSE
 
-/proc/admin_keyword_to_flag(word, previous_rights=0)
-	var/flag = 0
-	switch(ckey(word))
-		if("buildmode","build")
-			flag = R_BUILDMODE
-		if("admin")
-			flag = R_ADMIN
-		if("ban")
-			flag = R_BAN
-		if("fun")
-			flag = R_FUN
-		if("server")
-			flag = R_SERVER
-		if("debug")
-			flag = R_DEBUG
-		if("permissions","rights")
-			flag = R_PERMISSIONS
-		if("possess")
-			flag = R_POSSESS
-		if("stealth")
-			flag = R_STEALTH
-		if("poll")
-			flag = R_POLL
-		if("varedit")
-			flag = R_VAREDIT
-		if("everything","host","all")
-			flag = R_EVERYTHING
-		if("sound","sounds")
-			flag = R_SOUNDS
-		if("spawn","create")
-			flag = R_SPAWN
-		if("autologin", "autoadmin")
-			flag = R_AUTOLOGIN
-		if("dbranks")
-			flag = R_DBRANKS
-		if("@","prev")
-			flag = previous_rights
-	return flag
-
 // Adds/removes rights to this admin_rank
-/datum/admin_rank/proc/process_keyword(word, previous_rights=0)
+/datum/admin_rank/proc/process_keyword(group, group_count, datum/admin_rank/previous_rank)
 	if(IsAdminAdvancedProcCall())
 		var/msg = " has tried to elevate permissions!"
 		message_admins("[key_name_admin(usr)][msg]")
 		log_admin("[key_name(usr)][msg]")
 		return
-	var/flag = admin_keyword_to_flag(word, previous_rights)
-	if(flag)
-		switch(text2ascii(word,1))
-			if(43)
-				rights |= flag	//+
+	var/list/keywords = splittext(group, " ")
+	var/flag = 0
+	for(var/k in keywords)
+		switch(k)
+			if("BUILD")
+				flag = R_BUILD
+			if("ADMIN")
+				flag = R_ADMIN
+			if("BAN")
+				flag = R_BAN
+			if("FUN")
+				flag = R_FUN
+			if("SERVER")
+				flag = R_SERVER
+			if("DEBUG")
+				flag = R_DEBUG
+			if("PERMISSIONS")
+				flag = R_PERMISSIONS
+			if("POSSESS")
+				flag = R_POSSESS
+			if("STEALTH")
+				flag = R_STEALTH
+			if("POLL")
+				flag = R_POLL
+			if("VAREDIT")
+				flag = R_VAREDIT
+			if("EVERYTHING")
+				flag = R_EVERYTHING
+			if("SOUND")
+				flag = R_SOUND
+			if("SPAWN")
+				flag = R_SPAWN
+			if("AUTOADMIN")
+				flag = R_AUTOADMIN
+			if("DBRANKS")
+				flag = R_DBRANKS
+			if("@")
+				if(previous_rank)
+					switch(group_count)
+						if(1)
+							flag = previous_rank.include_rights
+						if(2)
+							flag = previous_rank.exclude_rights
+						if(3)
+							flag = previous_rank.can_edit_rights
+				else
+					continue
+		switch(group_count)
+			if(1)
+				rights |= flag
 				include_rights	|= flag
-			if(45)
-				rights &= ~flag	//-
+			if(2)
+				rights &= ~flag
 				exclude_rights	|= flag
-			if(42)
-				can_edit_rights |= flag	//*
-
-// Checks for (keyword-formatted) rights on this admin
-/datum/admins/proc/check_keyword(word)
-	var/flag = admin_keyword_to_flag(word)
-	if(flag)
-		return ((rank.rights & flag) == flag) //true only if right has everything in flag
+			if(3)
+				can_edit_rights |= flag
 
 /proc/sync_ranks_with_db()
 	set waitfor = FALSE
@@ -132,23 +132,22 @@ GLOBAL_PROTECT(protected_ranks)
 		return
 	GLOB.admin_ranks.Cut()
 	GLOB.protected_ranks.Cut()
-	var/previous_rights = 0
-	//load text from file and process each line separately
-	for(var/line in world.file2list("[global.config.directory]/admin_ranks.txt"))
-		if(!line || findtextEx(line,"#",1,2))
-			continue
-		var/next = findtext(line, "=")
-		var/datum/admin_rank/R = new(ckeyEx(copytext(line, 1, next)))
+	//load text from file and process each entry
+	var/ranks_text = file2text("[global.config.directory]/admin_ranks.txt")
+	var/datum/admin_rank/previous_rank
+	var/regex/admin_ranks_regex = new("^Name\\s*=\\s*(.+?)\\s*\n+Include\\s*=\\s*(\[\\l @\]*?)\\s*\n+Exclude\\s*=\\s*(\[\\l @\]*?)\\s*\n+Edit\\s*=\\s*(\[\\l @\]*?)\\s*\n*$", "gm")
+	while(admin_ranks_regex.Find(ranks_text))
+		var/datum/admin_rank/R = new(admin_ranks_regex.group[1])
 		if(!R)
 			continue
+		var/count = 1
+		for(var/i in admin_ranks_regex.group - admin_ranks_regex.group[1])
+			if(i)
+				R.process_keyword(i, count, previous_rank)
+			count++
 		GLOB.admin_ranks += R
 		GLOB.protected_ranks += R
-		var/prev = findchar(line, "+-*", next, 0)
-		while(prev)
-			next = findchar(line, "+-*", prev + 1, 0)
-			R.process_keyword(copytext(line, prev, next), previous_rights)
-			prev = next
-		previous_rights = R.rights
+		previous_rank = R
 	if(!CONFIG_GET(flag/admin_legacy_system) || dbfail)
 		if(CONFIG_GET(flag/load_legacy_ranks_only))
 			if(!no_update)
@@ -162,7 +161,7 @@ GLOBAL_PROTECT(protected_ranks)
 			else
 				while(query_load_admin_ranks.NextRow())
 					var/skip
-					var/rank_name = ckeyEx(query_load_admin_ranks.item[1])
+					var/rank_name = query_load_admin_ranks.item[1]
 					for(var/datum/admin_rank/R in GLOB.admin_ranks)
 						if(R.name == rank_name) //this rank was already loaded from txt override
 							skip = 1
@@ -228,18 +227,10 @@ GLOBAL_PROTECT(protected_ranks)
 	for(var/datum/admin_rank/R in GLOB.admin_ranks)
 		rank_names[R.name] = R
 	//ckeys listed in admins.txt are always made admins before sql loading is attempted
-	var/list/lines = world.file2list("[global.config.directory]/admins.txt")
-	for(var/line in lines)
-		if(!length(line) || findtextEx(line, "#", 1, 2))
-			continue
-		var/list/entry = splittext(line, "=")
-		if(entry.len < 2)
-			continue
-		var/ckey = ckey(entry[1])
-		var/rank = ckeyEx(entry[2])
-		if(!ckey || !rank)
-			continue
-		new /datum/admins(rank_names[rank], ckey, 0, 1)
+	var/admins_text = file2text("[global.config.directory]/admins.txt")
+	var/regex/admins_regex = new("^(?!#)(.+?)\\s+=\\s+(.+)", "gm")
+	while(admins_regex.Find(admins_text))
+		new /datum/admins(rank_names[admins_regex.group[2]], ckey(admins_regex.group[1]), FALSE, TRUE)
 	if(!CONFIG_GET(flag/admin_legacy_system) || dbfail)
 		var/datum/DBQuery/query_load_admins = SSdbcore.NewQuery("SELECT ckey, rank FROM [format_table_name("admin")] ORDER BY rank")
 		if(!query_load_admins.Execute())
@@ -249,7 +240,7 @@ GLOBAL_PROTECT(protected_ranks)
 		else
 			while(query_load_admins.NextRow())
 				var/admin_ckey = ckey(query_load_admins.item[1])
-				var/admin_rank = ckeyEx(query_load_admins.item[2])
+				var/admin_rank = query_load_admins.item[2]
 				var/skip
 				if(rank_names[admin_rank] == null)
 					message_admins("[admin_ckey] loaded with invalid admin rank [admin_rank].")
@@ -277,7 +268,7 @@ GLOBAL_PROTECT(protected_ranks)
 					skip = TRUE
 			if(skip)
 				continue
-			new /datum/admins(rank_names[ckeyEx(backup_file_json["admins"]["[J]"])], ckey("[J]"))
+			new /datum/admins(rank_names[backup_file_json["admins"]["[J]"]], ckey("[J]"))
 	#ifdef TESTING
 	var/msg = "Admins Built:\n"
 	for(var/ckey in GLOB.admin_datums)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -244,7 +244,7 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 
 		var/rights = holder.rank.rights
 		verbs += GLOB.admin_verbs_default
-		if(rights & R_BUILDMODE)
+		if(rights & R_BUILD)
 			verbs += /client/proc/togglebuildmodeself
 		if(rights & R_ADMIN)
 			verbs += GLOB.admin_verbs_admin
@@ -264,7 +264,7 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 			verbs += /client/proc/stealth
 		if(rights & R_ADMIN)
 			verbs += GLOB.admin_verbs_poll
-		if(rights & R_SOUNDS)
+		if(rights & R_SOUND)
 			verbs += GLOB.admin_verbs_sounds
 			if(CONFIG_GET(string/invoke_youtubedl))
 				verbs += /client/proc/play_web_sound
@@ -611,7 +611,7 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 /client/proc/togglebuildmodeself()
 	set name = "Toggle Build Mode Self"
 	set category = "Special Verbs"
-	if (!(holder.rank.rights & R_BUILDMODE))
+	if (!(holder.rank.rights & R_BUILD))
 		return
 	if(src.mob)
 		togglebuildmode(src.mob)

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -55,7 +55,7 @@ GLOBAL_PROTECT(href_token)
 	//only admins with +ADMIN start admined
 	if(protected)
 		GLOB.protected_admins[target] = src
-	if (force_active || (R.rights & R_AUTOLOGIN))
+	if (force_active || (R.rights & R_AUTOADMIN))
 		activate()
 	else
 		deactivate()

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -279,7 +279,7 @@
 			rank_names[R.name] = R
 	var/new_rank = input("Please select a rank", "New rank") as null|anything in rank_names
 	if(new_rank == "*New Rank*")
-		new_rank = ckeyEx(input("Please input a new rank", "New custom rank") as text|null)
+		new_rank = input("Please input a new rank", "New custom rank") as text|null
 	if(!new_rank)
 		return
 	R = rank_names[new_rank]
@@ -356,10 +356,11 @@
 	var/m1 = "[key_name_admin(usr)] edited the permissions of [use_db ? " rank [D.rank.name] permanently" : "[admin_key] temporarily"]"
 	var/m2 = "[key_name(usr)] edited the permissions of [use_db ? " rank [D.rank.name] permanently" : "[admin_key] temporarily"]"
 	if(use_db || legacy_only)
+		var/rank_name = sanitizeSQL(D.rank.name)
 		var/old_flags
 		var/old_exclude_flags
 		var/old_can_edit_flags
-		var/datum/DBQuery/query_get_rank_flags = SSdbcore.NewQuery("SELECT flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")] WHERE rank = '[D.rank.name]'")
+		var/datum/DBQuery/query_get_rank_flags = SSdbcore.NewQuery("SELECT flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")] WHERE rank = '[rank_name]'")
 		if(!query_get_rank_flags.warn_execute())
 			qdel(query_get_rank_flags)
 			return
@@ -368,12 +369,12 @@
 			old_exclude_flags = text2num(query_get_rank_flags.item[2])
 			old_can_edit_flags = text2num(query_get_rank_flags.item[3])
 		qdel(query_get_rank_flags)
-		var/datum/DBQuery/query_change_rank_flags = SSdbcore.NewQuery("UPDATE [format_table_name("admin_ranks")] SET flags = '[new_flags]', exclude_flags = '[new_exclude_flags]', can_edit_flags = '[new_can_edit_flags]' WHERE rank = '[D.rank.name]'")
+		var/datum/DBQuery/query_change_rank_flags = SSdbcore.NewQuery("UPDATE [format_table_name("admin_ranks")] SET flags = '[new_flags]', exclude_flags = '[new_exclude_flags]', can_edit_flags = '[new_can_edit_flags]' WHERE rank = '[rank_name]'")
 		if(!query_change_rank_flags.warn_execute())
 			qdel(query_change_rank_flags)
 			return
 		qdel(query_change_rank_flags)
-		var/datum/DBQuery/query_change_rank_flags_log = SSdbcore.NewQuery("INSERT INTO [format_table_name("admin_log")] (datetime, round_id, adminckey, adminip, operation, target, log) VALUES ('[SQLtime()]', '[GLOB.round_id]', '[sanitizeSQL(usr.ckey)]', INET_ATON('[sanitizeSQL(usr.client.address)]'), 'change rank flags', '[D.rank.name]', 'Permissions of [D.rank.name] changed from[rights2text(old_flags," ")][rights2text(old_exclude_flags," ", "-")][rights2text(old_can_edit_flags," ", "*")] to[rights2text(new_flags," ")][rights2text(new_exclude_flags," ", "-")][rights2text(new_can_edit_flags," ", "*")]')")
+		var/datum/DBQuery/query_change_rank_flags_log = SSdbcore.NewQuery("INSERT INTO [format_table_name("admin_log")] (datetime, round_id, adminckey, adminip, operation, target, log) VALUES ('[SQLtime()]', '[GLOB.round_id]', '[sanitizeSQL(usr.ckey)]', INET_ATON('[sanitizeSQL(usr.client.address)]'), 'change rank flags', '[rank_name]', 'Permissions of [rank_name] changed from[rights2text(old_flags," ")][rights2text(old_exclude_flags," ", "-")][rights2text(old_can_edit_flags," ", "*")] to[rights2text(new_flags," ")][rights2text(new_exclude_flags," ", "-")][rights2text(new_can_edit_flags," ", "*")]')")
 		if(!query_change_rank_flags_log.warn_execute())
 			qdel(query_change_rank_flags_log)
 			return

--- a/code/modules/admin/sound_emitter.dm
+++ b/code/modules/admin/sound_emitter.dm
@@ -46,13 +46,13 @@
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
 /obj/effect/sound_emitter/attack_ghost(mob/user)
-	if(!check_rights_for(user.client, R_SOUNDS))
+	if(!check_rights_for(user.client, R_SOUND))
 		examine(user)
 		return
 	edit_emitter(user)
 
 /obj/effect/sound_emitter/AltClick(mob/user)
-	if(check_rights_for(user.client, R_SOUNDS))
+	if(check_rights_for(user.client, R_SOUND))
 		activate(user)
 		to_chat(user, "<span class='notice'>Sound emitter activated.</span>")
 
@@ -74,7 +74,7 @@
 
 /obj/effect/sound_emitter/Topic(href, href_list)
 	..()
-	if(!ismob(usr) || !usr.client || !check_rights_for(usr.client, R_SOUNDS))
+	if(!ismob(usr) || !usr.client || !check_rights_for(usr.client, R_SOUND))
 		return
 	var/mob/user = usr
 	if(href_list["edit_label"])

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -1,7 +1,7 @@
 /client/proc/play_sound(S as sound)
 	set category = "Fun"
 	set name = "Play Global Sound"
-	if(!check_rights(R_SOUNDS))
+	if(!check_rights(R_SOUND))
 		return
 
 	var/freq = 1
@@ -44,7 +44,7 @@
 /client/proc/play_local_sound(S as sound)
 	set category = "Fun"
 	set name = "Play Local Sound"
-	if(!check_rights(R_SOUNDS))
+	if(!check_rights(R_SOUND))
 		return
 
 	log_admin("[key_name(src)] played a local sound [S]")
@@ -55,7 +55,7 @@
 /client/proc/play_web_sound()
 	set category = "Fun"
 	set name = "Play Internet Sound"
-	if(!check_rights(R_SOUNDS))
+	if(!check_rights(R_SOUND))
 		return
 
 	var/ytdl = CONFIG_GET(string/invoke_youtubedl)
@@ -135,7 +135,7 @@
 /client/proc/set_round_end_sound(S as sound)
 	set category = "Fun"
 	set name = "Set Round End Sound"
-	if(!check_rights(R_SOUNDS))
+	if(!check_rights(R_SOUND))
 		return
 
 	SSticker.SetRoundEndSound(S)

--- a/config/admin_ranks.txt
+++ b/config/admin_ranks.txt
@@ -1,7 +1,7 @@
 #Admin Rank format is as follows:
 #
 #Name = Game Admin
-#Include = @ ADMIN BAN SOUNDS
+#Include = @ ADMIN BAN SOUND
 #Exclude = FUN
 #Edit =
 #
@@ -27,16 +27,16 @@
 #DEBUG = debug tools used for diagnosing and fixing problems. It's useful to give this to coders so they can investigate problems on a live server.
 #VAREDIT = everyone may view viewvars/debugvars/whatever you call it. This keyword allows you to actually EDIT those variables.
 #PERMISSIONS = allows you to promote and/or demote people.
-#SOUNDS = allows you to upload and play sounds.
+#SOUND = allows you to upload and play SOUND.
 #SPAWN = mob transformations, spawning of most atoms including mobs (high-risk atoms, e.g. blackholes, will require the +FUN flag too).
-#AUTOLOGIN = admin gains powers upon connect. This defaults to on, you can exclude AUTOLOGIN to make a role require using the readmin verb to gain powers (this does not effect the admin's ability to walk past bans or other on-connect limitations like panic bunker or pop limit).
+#AUTOADMIN = admin gains powers upon connect. This defaults to on, you can exclude AUTOADMIN to make a role require using the readmin verb to gain powers (this does not effect the admin's ability to walk past bans or other on-connect limitations like panic bunker or pop limit).
 #DBRANKS = when sql-based admin loading is enabled, allows for non-temporary changes in the permissions panel to be saved (requires DB).
 #EVERYTHING = Simply gives you everything without having to type every flag.
 #@ = special keyword for the current permission type that adds all the keywords that the preceding rank has of the same type.
 
 Name = Admin Observer
 Include =
-Exclude = AUTOLOGIN
+Exclude = AUTOADMIN
 Edit =
 
 Name = Moderator
@@ -60,7 +60,7 @@ Exclude =
 Edit =
 
 Name = Game Admin
-Include = @ STEALTH SOUNDS DEBUG
+Include = @ STEALTH SOUND DEBUG
 Exclude =
 Edit =
 
@@ -71,7 +71,7 @@ Edit = EVERYTHING
 
 Name = Lazy Master
 Include = EVERYTHING
-Exclude = AUTOLOGIN
+Exclude = AUTOADMIN
 Edit = EVERYTHING
 
 Name = Host
@@ -81,5 +81,5 @@ Edit = EVERYTHING
 
 Name = Coder
 Include = DEBUG VAREDIT SERVER SPAWN POLL
-Exclude = AUTOLOGIN
+Exclude = AUTOADMIN
 Edit =

--- a/config/admin_ranks.txt
+++ b/config/admin_ranks.txt
@@ -1,47 +1,85 @@
-##############################################################################################################
-# ADMIN RANK DEFINES                                                                                         #
-# The format of this is very simple. Rank name goes first.                                                   #
-# Rank is CASE-SENSITIVE, all punctuation save for '-', '_' and '@' will be stripped so spaces don't matter. #
-# You can then define permissions for each rank by adding a '=' followed by keywords                         #
-# These keywords represent groups of verbs and abilities.                                                    #
-# keywords are preceded by a '+', '-' or '*' + adds permissions, - takes them away.							 #
-# * is used only with SQL-based admin loading to denote what permissions the rank is allowed to edit		 #
-# +@ (or +prev) is a special shorthand which adds all the rights of the rank above it.                       #
-# Ranks with no keywords will just be given the most basic verbs and abilities                ~Carn          #
-##############################################################################################################
-# PLEASE NOTE: depending on config options, some abilities will be unavailable regardless if you have permission to use them!
-# If SQL-based admin loading is enabled, ranks and their keywords listed here will be loaded first and override any with the same name loaded from the database.
+#Admin Rank format is as follows:
+#
+#Name = Game Admin
+#Include = @ ADMIN BAN SOUNDS
+#Exclude = FUN
+#Edit =
+#
+#Name will match anything after '=' and must be identical to an admin's rank in admins.txt to be linked but otherwise has no formatting restrictions.
+#A rank's permissions are defined with keywords that control access to groups of verbs and abilities, they are case-sensitive and separated by a space with no prefix.
+#To define no permissions for a type, leave it empty.
+#There are three types of permissions:
+#Include will give a keyword to a rank.
+#Exclude removes a keyword and takes precedence over Include.
+#Edit will allow an admin to edit these permissions on other ranks or change an admin's rank to another if they can edit all the permissions it has.
+#Edit is only used when SQL-based admin loading is enabled.
+#If SQL-based admin loading is enabled, ranks and their keywords listed here will be loaded first and override any with the same name loaded from the database.
+#
+#The following are valid permission keywords:
+#ADMIN = general admin tools, verbs etc.
+#FUN = events, other event-orientated actions. Access to the fun secrets in the secrets panel.
+#BAN = the ability to ban and unban.
+#STEALTH = the ability to stealthmin (make yourself appear with a fake name to everyone but other admins.
+#POSSESS = the ability to possess objects.
+#POLL = the ability to create in game server polls (requires DB).
+#BUILD = the ability to use buildmode.
+#SERVER = the ability to restart the server, change the game mode or force a round to start/end.
+#DEBUG = debug tools used for diagnosing and fixing problems. It's useful to give this to coders so they can investigate problems on a live server.
+#VAREDIT = everyone may view viewvars/debugvars/whatever you call it. This keyword allows you to actually EDIT those variables.
+#PERMISSIONS = allows you to promote and/or demote people.
+#SOUNDS = allows you to upload and play sounds.
+#SPAWN = mob transformations, spawning of most atoms including mobs (high-risk atoms, e.g. blackholes, will require the +FUN flag too).
+#AUTOLOGIN = admin gains powers upon connect. This defaults to on, you can exclude AUTOLOGIN to make a role require using the readmin verb to gain powers (this does not effect the admin's ability to walk past bans or other on-connect limitations like panic bunker or pop limit).
+#DBRANKS = when sql-based admin loading is enabled, allows for non-temporary changes in the permissions panel to be saved (requires DB).
+#EVERYTHING = Simply gives you everything without having to type every flag.
+#@ = special keyword for the current permission type that adds all the keywords that the preceding rank has of the same type.
 
-# Follow the format below when documenting new keywords so the server tools may parse it
+Name = Admin Observer
+Include =
+Exclude = AUTOLOGIN
+Edit =
 
-# BEGIN_KEYWORDS
-# +ADMIN = general admin tools, verbs etc
-# +FUN = events, other event-orientated actions. Access to the fun secrets in the secrets panel.
-# +BAN = the ability to ban, jobban and fullban
-# +STEALTH = the ability to stealthmin (make yourself appear with a fake name to everyone but other admins
-# +POSSESS = the ability to possess objects
-# +POLL (or +POLL) = the ability to create in game server polls (requires DB)
-# +BUILD (or +BUILDMODE) = the ability to use buildmode
-# +SERVER = higher-risk admin verbs and abilities, such as those which affect the server configuration.
-# +DEBUG = debug tools used for diagnosing and fixing problems. It's useful to give this to coders so they can investigate problems on a live server.
-# +VAREDIT = everyone may view viewvars/debugvars/whatever you call it. This keyword allows you to actually EDIT those variables.
-# +RIGHTS (or +PERMISSIONS) = allows you to promote and/or demote people.
-# +SOUND (or +SOUNDS) = allows you to upload and play sounds
-# +SPAWN (or +CREATE) = mob transformations, spawning of most atoms including mobs (high-risk atoms, e.g. blackholes, will require the +FUN flag too)
-# +AUTOLOGIN = admin gains powers upon connect. This defaults to on, you can use -AUTOLOGIN to make a role require using the readmin verb to gain powers. (this does not effect the admin's ability to walk past bans or other on-connect limitations like panic bunker or pop limit.)
-# +DBRANKS = when sql-based admin loading is enabled, allows for non-temporary changes in the permissions panel to be saved (requires DB)
-# +EVERYTHING (or +HOST or +ALL) = Simply gives you everything without having to type every flag
-# END_KEYWORDS
+Name = Moderator
+Include = ADMIN
+Exclude =
+Edit =
 
-Admin Observer	= -AUTOLOGIN
-Moderator		= +ADMIN
-Admin Candidate	= +@
-Trial Admin		= +@ +SPAWN +VAREDIT +BAN
-Badmin			= +@ +POSSESS +POLL +BUILDMODE +SERVER +FUN
-Game Admin		= +@ +STEALTH +SOUNDS +DEBUG
-Game Master		= +EVERYTHING *EVERYTHING
-Lazy Master 	= +EVERYTHING -AUTOLOGIN *EVERYTHING
+Name = Admin Candidate
+Include = @
+Exclude =
+Edit =
 
-Host			= +EVERYTHING *EVERYTHING
+Name = Trial Admin
+Include = @ SPAWN VAREDIT BAN
+Exclude =
+Edit =
 
-Coder			= +DEBUG +VAREDIT +SERVER +SPAWN +POLL -AUTOLOGIN
+Name = Badmin
+Include = @ POSSESS POLL BUILD SERVER FUN
+Exclude =
+Edit =
+
+Name = Game Admin
+Include = @ STEALTH SOUNDS DEBUG
+Exclude =
+Edit =
+
+Name = Game Master
+Include = EVERYTHING
+Exclude =
+Edit = EVERYTHING
+
+Name = Lazy Master
+Include = EVERYTHING
+Exclude = AUTOLOGIN
+Edit = EVERYTHING
+
+Name = Host
+Include = EVERYTHING
+Exclude =
+Edit = EVERYTHING
+
+Name = Coder
+Include = DEBUG VAREDIT SERVER SPAWN POLL
+Exclude = AUTOLOGIN
+Edit =

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -1,14 +1,9 @@
-###############################################################################################
-# Basically, ckey goes first. Rank goes after the "="                                         #
-# Case is not important for ckey.                                                             #
-# Case IS important for the rank.                                                             #
-# All punctuation (spaces etc) EXCEPT '-', '_' and '@' will be stripped from rank names.      #
-# Ranks can be anything defined in admin_ranks.txt                                            #
-# NOTE: if the rank-name cannot be found in admin_ranks.txt, they will not be adminned! ~Carn #
-# NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
-# If SQL-based admin loading is enabled, admins listed here will always be loaded first		  #
-# and will override any duplicate entries in the database.									  #
-###############################################################################################
+#List users here to be made admins with the format: ckey = rank name.
+#Ckey will be converted to ckey format, lowercase with no punctuation except '@'.
+#Rank name will match anything after ' = ' and has not format requirements.
+#Ranks will match to those with the same name in admin_ranks.txt, if a match isn't found the user won't be adminned.
+#If SQL-based admin loading is enabled, admins listed here will always be loaded first and will override any duplicate entries in the database.
+
 Optimumtact = Host
 CitrusGender = Game Master
 NewSta = Game Master


### PR DESCRIPTION
:cl:
config: Admin ranks now support punctuation.
/:cl:

Change loading of admin ranks and admins to use regex and not be run through `ckeyEx` so they now support punctuation and special characters. `admin_ranks.txt` has a new format for rank entries, partly to make parsing easier and partly because I prefer it like this so the assignment of keywords is more clear. There is now only one permission keyword for each flag instead of 2 or 3 for a few.

Old rank format: `RankName = +FLAG1 +FLAG2 -FLAG3 *FLAG2`
New rank format:
```
Name = Rank Name
Include = FLAG1 FLAG2
Exclude = FLAG3
Edit = FLAG2
```
Renamed `R_BUILDMODE`, `R_SOUNDS` and `R_AUTOLOGIN` to `R_BUILD`, `R_SOUND` and `R_AUTOADMIN` so they are consistent with the keywords used in TG's config.

As this changes the format for ranks it's technically a config breaking change, but since both admins and ranks are mirrored to the DB they still get loaded correctly as different ranks even if `admin_ranks.txt` isn't updated for this code thus the only functional change is legacy admins and ranks won't be protected like they should be.

Here is the `admin_ranks.txt` from TG updated for new format [tg ranks new.txt](https://github.com/tgstation/tgstation/files/2705688/tg.ranks.new.txt)
`admins.txt` doesn't require a change.

@MrStonedOne @nfreader 