### PR TITLE
Fixes fires [READY]

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -35,7 +35,7 @@
 		if(oxy < 0.5)
 			return 0
 
-		active_hotspot = new /obj/effect/hotspot(src, exposed_temperature, exposed_volume*25)
+		active_hotspot = new /obj/effect/hotspot(src, exposed_volume*25, exposed_temperature)
 
 		active_hotspot.just_spawned = (current_cycle < SSair.times_fired)
 			//remove just_spawned protection if no longer processing this cell

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -35,9 +35,7 @@
 		if(oxy < 0.5)
 			return 0
 
-		active_hotspot = new /obj/effect/hotspot(src)
-		active_hotspot.temperature = exposed_temperature
-		active_hotspot.volume = exposed_volume*25
+		active_hotspot = new /obj/effect/hotspot(src, exposed_temperature, exposed_volume*25)
 
 		active_hotspot.just_spawned = (current_cycle < SSair.times_fired)
 			//remove just_spawned protection if no longer processing this cell
@@ -61,9 +59,13 @@
 	var/bypassing = FALSE
 	var/visual_update_tick = 0
 
-/obj/effect/hotspot/Initialize()
+/obj/effect/hotspot/Initialize(mapload, starting_volume, starting_temperature)
 	. = ..()
 	SSair.hotspots += src
+	if(!isnull(starting_volume))
+		volume = starting_volume
+	if(!isnull(starting_temperature))
+		temperature = starting_temperature
 	perform_exposure()
 	setDir(pick(GLOB.cardinals))
 	air_update_turf()
@@ -75,24 +77,19 @@
 
 	location.active_hotspot = src
 
-	if(volume > CELL_VOLUME*0.95)
-		bypassing = TRUE
-	else
-		bypassing = FALSE
+	bypassing = !just_spawned && (volume > CELL_VOLUME*0.95)
 
 	if(bypassing)
-		if(!just_spawned)
-			location.air.temperature = max(temperature, location.air.temperature)
-			location.air.react(src)
-			temperature = location.air.temperature
-			volume = location.air.reaction_results["fire"]*FIRE_GROWTH_RATE
+		volume = location.air.reaction_results["fire"]*FIRE_GROWTH_RATE
+		temperature = location.air.temperature
 	else
 		var/datum/gas_mixture/affected = location.air.remove_ratio(volume/location.air.volume)
-		affected.temperature = temperature
-		affected.react(src)
-		temperature = affected.temperature
-		volume = affected.reaction_results["fire"]*FIRE_GROWTH_RATE
-		location.assume_air(affected)
+		if(affected) //in case volume is 0
+			affected.temperature = temperature
+			affected.react(src)
+			temperature = affected.temperature
+			volume = affected.reaction_results["fire"]*FIRE_GROWTH_RATE
+			location.assume_air(affected)
 
 	for(var/A in location)
 		var/atom/AT = A


### PR DESCRIPTION
:cl:
fix: fires will no longer burn quite so hot
fix: the first spark of a hotspot is no longer always the same temperature
/:cl:

I misunderstood the atmos code and fucked up. The part I used was for starting off small fires, and so was inappropriate for the big fires it was then applied to. This should fix it.
fixes #42038 

The effects of this pr **compared to just a revert** are:

A: a hotspot's initial burn will have its temperature set if created by hotspot_expose. Previously the first hit was always at the same temperature.
B: the initial burn is never bypassed. Bypassing meant that large volume hotspots like those created by igniters never actually increased the heat of the tile by more than the initial spark (which was weak due to A).

So if you used an igniter on some gas, it would
originally: weak burn, bypass, go out
broken pr: weak burn, strong burn, grow, grow....
This one: strong burn, bypass, spread fires to nearby tiles if necessary