### PR TITLE
Prevents nulls in playerlist from preventing speaking 

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -244,6 +244,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	var/list/the_dead = list()
 	for(var/_M in GLOB.player_list)
 		var/mob/M = _M
+		if(!M)
+			continue
 		if(M.stat != DEAD) //not dead, not important
 			continue
 		if(!M.client || !client) //client is so that ghosts don't have to listen to mice


### PR DESCRIPTION
:cl: karma
fix: Prevents nulls in playerlist from preventing speaking 
/:cl:

[why]: sometimes a null gets into the playerlist and fucks up speech and  the admins wont know how to clear nulls