### PR TITLE
Adds a loneop uplink, restricts reinforcements

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -14,6 +14,7 @@ GLOBAL_LIST_EMPTY(uplinks)
 	var/lockable = TRUE
 	var/locked = TRUE
 	var/allow_restricted = TRUE
+	var/allow_restricted_loneop = TRUE
 	var/telecrystals
 	var/selected_cat
 	var/owner = null
@@ -44,7 +45,7 @@ GLOBAL_LIST_EMPTY(uplinks)
 		RegisterSignal(parent, COMSIG_PEN_ROTATED, .proc/pen_rotation)
 
 	GLOB.uplinks += src
-	uplink_items = get_uplink_items(gamemode, TRUE, allow_restricted)
+	uplink_items = get_uplink_items(gamemode, TRUE, allow_restricted, allow_restricted_loneop)
 
 	if(_owner)
 		owner = _owner
@@ -85,7 +86,7 @@ GLOBAL_LIST_EMPTY(uplinks)
 
 /datum/component/uplink/proc/set_gamemode(_gamemode)
 	gamemode = _gamemode
-	uplink_items = get_uplink_items(gamemode, TRUE, allow_restricted)
+	uplink_items = get_uplink_items(gamemode, TRUE, allow_restricted, allow_restricted_loneop)
 
 /datum/component/uplink/proc/OnAttackBy(datum/source, obj/item/I, mob/user)
 	if(!active)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -170,3 +170,7 @@
 		/obj/item/tank/jetpack/oxygen/harness=1,\
 		/obj/item/gun/ballistic/automatic/pistol=1,\
 		/obj/item/kitchen/knife/combat/survival)
+
+/datum/outfit/syndicate/full/loneop
+	name = "Syndicate Lone Operative - Full Kit"
+	uplink_type = /obj/item/uplink/nuclear/loneop

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -209,7 +209,7 @@
 	name = "Lone Operative"
 	always_new_team = TRUE
 	send_to_spawnpoint = FALSE //Handled by event
-	nukeop_outfit = /datum/outfit/syndicate/full
+	nukeop_outfit = /datum/outfit/syndicate/full/loneop
 
 /datum/antagonist/nukeop/lone/assign_nuke()
 	if(nuke_team && !nuke_team.tracked_nuke)

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -43,7 +43,7 @@
 /mob/living/simple_animal/drone/syndrone/badass
 	name = "Badass Syndrone"
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi/elite
-	default_storage = /obj/item/uplink/nuclear
+	default_storage = /obj/item/uplink/nuclear/loneop
 
 /mob/living/simple_animal/drone/syndrone/badass/Initialize()
 	. = ..()

--- a/code/modules/uplink/uplink_devices.dm
+++ b/code/modules/uplink/uplink_devices.dm
@@ -45,6 +45,12 @@
 	hidden_uplink.set_gamemode(/datum/game_mode/nuclear)
 	hidden_uplink.name = "debug nuclear uplink"
 
+/obj/item/uplink/nuclear/loneop/Initialize()
+	. = ..()
+	GET_COMPONENT(hidden_uplink, /datum/component/uplink)
+	hidden_uplink.allow_restricted_loneop = FALSE
+	hidden_uplink.set_gamemode(/datum/game_mode/nuclear)
+
 /obj/item/uplink/nuclear_restricted/Initialize()
 	. = ..()
 	GET_COMPONENT(hidden_uplink, /datum/component/uplink)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1,6 +1,6 @@
 GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
-/proc/get_uplink_items(var/datum/game_mode/gamemode = null, allow_sales = TRUE, allow_restricted = TRUE)
+/proc/get_uplink_items(var/datum/game_mode/gamemode = null, allow_sales = TRUE, allow_restricted = TRUE, allow_restricted_loneop = TRUE)
 	var/list/filtered_uplink_items = list()
 	var/list/sale_items = list()
 
@@ -21,6 +21,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 		if(I.player_minimum && I.player_minimum > GLOB.joined_player_list.len)
 			continue
 		if (I.restricted && !allow_restricted)
+			continue
+		if (I.restricted_loneop && !allow_restricted_loneop)
 			continue
 
 		if(!filtered_uplink_items[I.category])
@@ -75,6 +77,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/player_minimum //The minimum crew size needed for this item to be added to uplinks.
 	var/purchase_log_vis = TRUE // Visible in the purchase log?
 	var/restricted = FALSE // Adds restrictions for VR/Events
+	var/restricted_loneop = FALSE //Adds restrictions for loneops. Some items cant be used off base.
 	var/list/restricted_species //Limits items to a specific species. Hopefully.
 	var/illegal_tech = TRUE // Can this item be deconstructed to unlock certain techweb research nodes?
 
@@ -870,6 +873,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	refundable = TRUE
 	include_modes = list(/datum/game_mode/nuclear)
 	restricted = TRUE
+	restricted_loneop = TRUE
 
 /datum/uplink_item/support/reinforcement/assault_borg
 	name = "Syndicate Assault Cyborg"
@@ -879,6 +883,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	refundable = TRUE
 	cost = 65
 	restricted = TRUE
+	restricted_loneop = TRUE
 
 /datum/uplink_item/support/reinforcement/medical_borg
 	name = "Syndicate Medical Cyborg"
@@ -889,6 +894,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	refundable = TRUE
 	cost = 35
 	restricted = TRUE
+	restricted_loneop = TRUE
 
 /datum/uplink_item/support/reinforcement/saboteur_borg
 	name = "Syndicate Saboteur Cyborg"
@@ -899,6 +905,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	refundable = TRUE
 	cost = 35
 	restricted = TRUE
+	restricted_loneop = TRUE
 
 /datum/uplink_item/support/gygax
 	name = "Dark Gygax Exosuit"


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
fix: Restricted lone operative uplink, can no longer buy reinforcement and borg beacons that cannot be used.
fix: Badass Syndrones can no longer generate infinite TC.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Fixes #42042

Adds a loneop uplink that can be restricted, removes the reinforcements beacons that could not be used anyway. A new outfit has been added for this.
Also made badass syndrones spawn with the new uplink instead, prevents an exploit allowing them to make infinite tc.