### PR TITLE
Fixes Pubby monastery fridge access

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -51458,7 +51458,9 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
 "cuG" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
+	},
 /obj/machinery/light/small{
 	dir = 2
 	},


### PR DESCRIPTION
:cl: Denton
fix: The fridge in Pubbystation's public monastery kitchen is no longer locked by default.
/:cl:

This was overlooked in the recent PR that added access reqs to kitchen closets