### PR TITLE
Buffs blob [READY]

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -15,7 +15,7 @@
 
 
 //Blob
-#define BLOB_REROLL_TIME 240 //blob gets a free reroll every X time
+#define BLOB_REROLL_TIME 2400 //blob gets a free reroll every X time
 #define BLOB_SPREAD_COST 4
 #define BLOB_ATTACK_REFUND 3 //blob refunds this much if it attacks and doesn't spread
 

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -18,6 +18,7 @@
 #define BLOB_REROLL_TIME 2400 //blob gets a free reroll every X time
 #define BLOB_SPREAD_COST 4
 #define BLOB_ATTACK_REFUND 2 //blob refunds this much if it attacks and doesn't spread
+#define BLOB_REFLECTOR_COST 15
 
 
 //ERT Types

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -14,6 +14,12 @@
 #define APPRENTICE_HEALING "healing"
 
 
+//Blob
+#define BLOB_REROLL_TIME 240 //blob gets a free reroll every X time
+#define BLOB_SPREAD_COST 4
+#define BLOB_ATTACK_REFUND 3 //blob refunds this much if it attacks and doesn't spread
+
+
 //ERT Types
 #define ERT_BLUE "Blue"
 #define ERT_RED  "Red"

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -17,7 +17,7 @@
 //Blob
 #define BLOB_REROLL_TIME 2400 //blob gets a free reroll every X time
 #define BLOB_SPREAD_COST 4
-#define BLOB_ATTACK_REFUND 3 //blob refunds this much if it attacks and doesn't spread
+#define BLOB_ATTACK_REFUND 2 //blob refunds this much if it attacks and doesn't spread
 
 
 //ERT Types

--- a/code/modules/antagonists/blob/blob/blobs/shield.dm
+++ b/code/modules/antagonists/blob/blob/blobs/shield.dm
@@ -40,8 +40,8 @@
 	icon_state = "blob_glow"
 	flags_1 = CHECK_RICOCHET_1
 	point_return = 8
-	max_integrity = 50
-	brute_resist = 1
+	max_integrity = 100
+	brute_resist = 0.5
 	explosion_block = 2
 
 /obj/structure/blob/shield/reflective/handle_ricochet(obj/item/projectile/P)

--- a/code/modules/antagonists/blob/blob/overmind.dm
+++ b/code/modules/antagonists/blob/blob/overmind.dm
@@ -30,6 +30,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	var/list/blob_mobs = list()
 	var/list/resource_blobs = list()
 	var/free_chem_rerolls = 1 //one free chemical reroll
+	var/last_reroll_time = 0 //time since we last rerolled, used to give free rerolls
 	var/nodes_required = 1 //if the blob needs nodes to place resource and factory blobs
 	var/placed = 0
 	var/base_point_rate = 2 //for blob core placement
@@ -94,6 +95,9 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 		max_blob_points = INFINITY
 		blob_points = INFINITY
 		addtimer(CALLBACK(src, .proc/victory), 450)
+	else if(!free_chem_rerolls && (last_reroll_time + BLOB_REROLL_TIME<world.time))
+		to_chat(src, "<b><span class='big'><font color=\"#EE4000\">You have gained another free chemical re-roll.</font></span></b>")
+		free_chem_rerolls = 1
 
 	if(!victory_in_progress && max_count < blobs_legit.len)
 		max_count = blobs_legit.len

--- a/code/modules/antagonists/blob/blob/powers.dm
+++ b/code/modules/antagonists/blob/blob/powers.dm
@@ -114,15 +114,16 @@
 /mob/camera/blob/verb/create_shield_power()
 	set category = "Blob"
 	set name = "Create/Upgrade Shield Blob (15)"
-	set desc = "Create a shield blob, which will block fire and is hard to kill. Using this on an existing shield blob turns it into a reflective blob, capable of reflecting most projectiles but making it much weaker than usual to brute attacks."
+	set desc = "Create a shield blob, which will block fire and is hard to kill. Using this on an existing shield blob turns it into a reflective blob, capable of reflecting most projectiles but making it twice as weak to brute attacks."
 	create_shield()
 
 /mob/camera/blob/proc/create_shield(turf/T)
 	var/obj/structure/blob/shield/S = locate(/obj/structure/blob/shield) in T
 	if(S)
-		if(!can_buy(15))
+		if(!can_buy(BLOB_REFLECTOR_COST))
 			return
 		if(S.obj_integrity < S.max_integrity * 0.5)
+			add_points(BLOB_REFLECTOR_COST)	
 			to_chat(src, "<span class='warning'>This shield blob is too damaged to be modified properly!</span>")
 			return
 		to_chat(src, "<span class='warning'>You secrete a reflective ooze over the shield blob, allowing it to reflect projectiles at the cost of reduced intregrity.</span>")

--- a/code/modules/antagonists/blob/blob/powers.dm
+++ b/code/modules/antagonists/blob/blob/powers.dm
@@ -126,7 +126,7 @@
 			add_points(BLOB_REFLECTOR_COST)	
 			to_chat(src, "<span class='warning'>This shield blob is too damaged to be modified properly!</span>")
 			return
-		to_chat(src, "<span class='warning'>You secrete a reflective ooze over the shield blob, allowing it to reflect projectiles at the cost of reduced intregrity.</span>")
+		to_chat(src, "<span class='warning'>You secrete a reflective ooze over the shield blob, allowing it to reflect projectiles at the cost of reduced integrity.</span>")
 		S.change_to(/obj/structure/blob/shield/reflective, src)
 	else
 		createSpecial(15, /obj/structure/blob/shield, 0, 0, T)


### PR DESCRIPTION
:cl:
balance: blobs now receive a 50% cost refund on attacks that don't spread
balance: blobs receive a free chemical re-roll every 4 minutes
balance: reflector blobs are considerably tougher
fix: attempting to turn a damaged strong blob into a reflector blob now refunds points
fix: fixed an intregrity
/:cl:

I think Blob is a great midround antag. It provides a threat that forces the station to work together as a whole, adds excellent drama, and has a cool design. However, it's currently very weak. I think it needs both a buff of the core antag, and then some buffs/nerfs to bring all the different variants into line. This PR deals only with the former.

One thing blob is currently lacking in is kill power. To actually attack someone, or smash through a wall, takes a crippling amount of chemicals (usually 16-20). This means that if the blob fights back through spreading instead of factories it cripples itself. I believe attacking should be cheap to make blob a more dangerous enemy to fight, while not allowing it to reach critical mass more quickly while not in combat.

Re-rolls are very cool and make fighting blob more dynamic. They also help combat the current terrible balance between blob variants so RNG doesn't force you to watch yourself die to fire extinguishers. However, you have to pass up 80 chemicals to get one after your first. In fact, I believe any chemical cost makes re-rolling clunky to use - re-rolls work best as an attempt to throw off a crew that's beating you too easily, and sinking yourself into low points plays actively against that. 

Reflector blobs are also rarely used. As they are now, you pay 15 points just to have a reflecting strong blob tile with 1/3rd health, and FOUR TIMES BRUTE DAMAGE. This means that the blob tile dies TWELVE TIMES quicker to brute than it did before! This buffs it to die a mere three times quicker to brute, and 1.5x quicker to burn.