### PR TITLE
Abductor tongue fixes and tweaks

### DIFF
--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -64,6 +64,9 @@
 	//Equip
 	var/mob/living/carbon/human/H = owner.current
 	H.set_species(/datum/species/abductor)
+	var/obj/item/organ/tongue/abductor/T = H.getorganslot(ORGAN_SLOT_TONGUE)
+	T.mothership = "[team.name]"
+
 	H.real_name = "[team.name] [sub_role]"
 	H.equipOutfit(outfit)
 

--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -43,12 +43,13 @@
 		dat += "Collected Samples : [points] <br>"
 		dat += "Gear Credits: [credits] <br>"
 		dat += "<b>Transfer data in exchange for supplies:</b><br>"
-		dat += "<a href='?src=[REF(src)];dispense=baton'>Advanced Baton</A><br>"
+		dat += "<a href='?src=[REF(src)];dispense=baton'>Advanced Baton (2 Credits)</A><br>"
+		dat += "<a href='?src=[REF(src)];dispense=mind_device'>Mental Interface Device (2 Credits)</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=helmet'>Agent Helmet</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=vest'>Agent Vest</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=silencer'>Radio Silencer</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=tool'>Science Tool</A><br>"
-		dat += "<a href='?src=[REF(src)];dispense=mind_device'>Mental Interface Device</A><br>"
+		dat += "<a href='?src=[REF(src)];dispense=tongue'>Superlingual Matrix</a><br>"
 	else
 		dat += "<span class='bad'>NO EXPERIMENT MACHINE DETECTED</span> <br>"
 
@@ -112,6 +113,8 @@
 				Dispense(/obj/item/clothing/suit/armor/abductor/vest)
 			if("mind_device")
 				Dispense(/obj/item/abductor/mind_device,cost=2)
+			if("tongue")
+				Dispense(/obj/item/organ/tongue/abductor)
 	updateUsrDialog()
 
 /obj/machinery/abductor/console/proc/TeleporterRetrieve()

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -79,24 +79,48 @@
 	icon_state = "tongueayylmao"
 	say_mod = "gibbers"
 	taste_sensitivity = 101 // ayys cannot taste anything.
+	var/mothership
+
+/obj/item/organ/tongue/abductor/attack_self(mob/living/carbon/human/H)
+	if(!istype(H))
+		return
+
+	var/obj/item/organ/tongue/abductor/T = H.getorganslot(ORGAN_SLOT_TONGUE)
+	if(!istype(T))
+		return
+
+	if(T.mothership == mothership)
+		to_chat(H, "<span class='notice'>[src] is already attuned to the same channel as your own.</span>")
+
+	H.visible_message("<span class='notice'>[H] holds [src] in their hands, and concentrates for a moment.</span>", "<span class='notice'>You attempt to modify the attunation of [src].</span>")
+	if(do_after(H, delay=15, target=src))
+		to_chat(H, "<span class='notice'>You attune [src] to your own channel.</span>")
+		mothership = T.mothership
+
+/obj/item/organ/tongue/abductor/examine(mob/M)
+	. = ..()
+	if(M.has_trait(TRAIT_ABDUCTOR_TRAINING) || isobserver(M))
+		if(!mothership)
+			to_chat(M, "<span class='notice'>It is not attuned to a specific mothership.</span>")
+		else
+			to_chat(M, "<span class='notice'>It is attuned to [mothership].</span>")
 
 /obj/item/organ/tongue/abductor/TongueSpeech(var/message)
 	//Hacks
 	var/mob/living/carbon/human/user = usr
-	var/rendered = "<span class='abductor'><b>[user.name]:</b> [message]</span>"
+	var/rendered = "<span class='abductor'><b>[user.real_name]:</b> [message]</span>"
 	user.log_talk(message, LOG_SAY, tag="abductor")
 	for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)
-		var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
-		if(!T || T.type != type)
+		var/obj/item/organ/tongue/abductor/T = H.getorganslot(ORGAN_SLOT_TONGUE)
+		if(!istype(T))
 			continue
-		if(H.dna && H.dna.species.id == "abductor" && user.dna && user.dna.species.id == "abductor")
-			var/datum/antagonist/abductor/A = user.mind.has_antag_datum(/datum/antagonist/abductor)
-			if(!A || !(H.mind in A.team.members))
-				continue
-		to_chat(H, rendered)
+		if(mothership == T.mothership)
+			to_chat(H, rendered)
+
 	for(var/mob/M in GLOB.dead_mob_list)
 		var/link = FOLLOW_LINK(M, user)
 		to_chat(M, "[link] [rendered]")
+
 	return ""
 
 /obj/item/organ/tongue/zombie


### PR DESCRIPTION
:cl: coiax
fix: Abductors created by abductor mutation toxin will be able to talk
to themselves and to other abductors.
tweak: Abductor tongues now have distinct "channels". A person with an
abductor tongue will be able to attune another tongue to the same
channel as their own.
tweak: Speaking on the abductor channel will always use your mob's
"real name".
add: Abductor teams can now purchase additional superlingual matricies
from their abductor console.
/:cl:

Essentially, non-antagonist abductors couldn't hear themselves or each
other because of special case handling when the tongue was present
inside someone with the abductor species, in order so mothership teams
could hear only their team.

Now: All abductor speech is only heard by people with the same
"mothership" var as the speech originator. People can attack_self() with
the tongues to attune them to their channel, in case mothership teams
want to buy additional tongues, attune them to their team, and put them
in their abductee victims. It also means that if you kill the Agent,
stick his tongue in your mouth, you'll be able to talk to the Scientist.

Mobs with abductor training (or observers) can identify which channel the tongue is
attuned to.

I also marked the items in the abductor shop that cost two credits.