### PR TITLE
Transparent protection for clothing [READY]

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -48,6 +48,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	//Since any item can now be a piece of clothing, this has to be put here so all items share it.
 	var/flags_inv //This flag is used to determine when items in someone's inventory cover others. IE helmets making it so you can't see glasses, etc.
+	var/transparent_protection = 0 //you can see someone's mask through their transparent visor, but you can't reach it
 
 	var/interaction_flags_item = INTERACT_ITEM_ATTACK_HAND_PICKUP
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -48,7 +48,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	//Since any item can now be a piece of clothing, this has to be put here so all items share it.
 	var/flags_inv //This flag is used to determine when items in someone's inventory cover others. IE helmets making it so you can't see glasses, etc.
-	var/transparent_protection = 0 //you can see someone's mask through their transparent visor, but you can't reach it
+	var/transparent_protection = NONE //you can see someone's mask through their transparent visor, but you can't reach it
 
 	var/interaction_flags_item = INTERACT_ITEM_ATTACK_HAND_PICKUP
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -353,7 +353,7 @@
 		if(M.back && wash_obj(M.back))
 			M.update_inv_back(0)
 
-		var/list/obscured = M.check_obscured_slots()
+		var/list/obscured = M.check_obscured_slots(TRUE) //can't wash a gas mask through a visor
 
 		if(M.head && wash_obj(M.head))
 			M.update_inv_head()

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -537,6 +537,7 @@
 	armor = list("melee" = 40, "bullet" = 50, "laser" = 50, "energy" = 25, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR //we want to see the mask
+	transparent_protection = HIDEMASK
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	actions_types = list()

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -537,7 +537,6 @@
 	armor = list("melee" = 40, "bullet" = 50, "laser" = 50, "energy" = 25, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR //we want to see the mask
-	transparent_protection = HIDEMASK
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	actions_types = list()

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -72,6 +72,7 @@
 	desc = "A protective & concealing hood."
 	armor = list("melee" = 35, "bullet" = 10, "laser" = 25, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR
+	transparent_protection = HIDEMASK
 
 /obj/item/clothing/suit/hooded/cloak/drake
 	name = "drake armour"
@@ -84,6 +85,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	transparent_protection = HIDEGLOVES|HIDESUITSTORAGE|HIDEJUMPSUIT|HIDESHOES
 
 /obj/item/clothing/head/hooded/cloakhood/drake
 	name = "drake helm"

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -385,12 +385,14 @@
 	drop_all_held_items()
 
 
-/mob/living/carbon/proc/check_obscured_slots()
+/mob/living/carbon/proc/check_obscured_slots(transparent_protection)
 	var/list/obscured = list()
 	var/hidden_slots = NONE
 
 	for(var/obj/item/I in get_equipped_items())
 		hidden_slots |= I.flags_inv
+		if(transparent_protection)
+			hidden_slots |= I.transparent_protection
 
 	if(hidden_slots & HIDENECK)
 		obscured |= SLOT_NECK

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -238,7 +238,7 @@
 
 	if(href_list["item"]) //canUseTopic check for this is handled by mob/Topic()
 		var/slot = text2num(href_list["item"])
-		if(slot in check_obscured_slots())
+		if(slot in check_obscured_slots(TRUE))
 			to_chat(usr, "<span class='warning'>You can't reach that! Something is covering it.</span>")
 			return
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -492,7 +492,7 @@
 					L.receive_damage(0,5)
 					Paralyze(100)
 
-/mob/living/carbon/human/acid_act(acidpwr, acid_volume, bodyzone_hit) //todo: update this to utilize check_obscured_slots()
+/mob/living/carbon/human/acid_act(acidpwr, acid_volume, bodyzone_hit) //todo: update this to utilize check_obscured_slots() //and make sure it's check_obscured_slots(TRUE) to stop aciding through visors etc
 	var/list/damaged = list()
 	var/list/inventory_items_to_kill = list()
 	var/acidity = acidpwr * min(acid_volume*0.005, 0.1)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1577,7 +1577,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	if(H.on_fire)
 		//the fire tries to damage the exposed clothes and items
 		var/list/burning_items = list()
-		var/list/obscured = H.check_obscured_slots()
+		var/list/obscured = H.check_obscured_slots(TRUE)
 		//HEAD//
 
 		if(H.glasses && !(SLOT_GLASSES in obscured))

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -151,7 +151,7 @@
 	//the fire tries to damage the exposed clothes and items
 	var/list/burning_items = list()
 	//HEAD//
-	var/list/obscured = check_obscured_slots()
+	var/list/obscured = check_obscured_slots(TRUE)
 	if(wear_mask && !(SLOT_WEAR_MASK in obscured))
 		burning_items += wear_mask
 	if(wear_neck && !(SLOT_NECK in obscured))


### PR DESCRIPTION
:cl: 
fix: Some items cover equipment while still letting you see it
fix: in particular, this stops clothes burning off underneath drake armor
/:cl:

Allows you to fashionably wear drake armor and be on fire without all your clothes burning off.

This can't just be done by flags_inv as drake armour has visible holes, but still protects from fire totally. More generally, I believe this makes sense for helmets with glass transparent enough to look into and so forth, so I think it's worth adding a seperate set of flags for. 

This could apply to captain's, but I don't think it really makes sense. Adding it would just be fixing a gameplay issue with a bug, which would be lame.

closes #42094