### PR TITLE
Netherworld portal interaction for zombies and skeletons

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -65,6 +65,7 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 #define isslimeperson(A) (is_species(A, /datum/species/jelly/slime))
 #define isluminescent(A) (is_species(A, /datum/species/jelly/luminescent))
 #define iszombie(A) (is_species(A, /datum/species/zombie))
+#define isskeleton(A) (is_species(A, /datum/species/skeleton))
 #define ismoth(A) (is_species(A, /datum/species/moth))
 #define ishumanbasic(A) (is_species(A, /datum/species/human))
 #define iscatperson(A) (ishumanbasic(A) && istype(A.dna.species, /datum/species/human/felinid) )

--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -66,7 +66,7 @@
 
 /obj/structure/spawner/nether
 	name = "netherworld link"
-	desc = "A direct link to another dimension full of creatures not very happy to see you. <span class='warning'>Entering the link would be a very bad idea.</span>"
+	desc = null //see examine()
 	icon_state = "nether"
 	max_integrity = 50
 	spawn_time = 600 //1 minute
@@ -80,9 +80,20 @@
 	.=..()
 	START_PROCESSING(SSprocessing, src)
 
+/obj/structure/spawner/nether/examine(mob/user)
+	..()
+	if(isskeleton(user) || iszombie(user))
+		to_chat(user, "A direct link to another dimension full of creatures very happy to see you. <span class='nicegreen'>You can see your house from here!</span>")
+	else
+		to_chat(user, "A direct link to another dimension full of creatures not very happy to see you. <span class='warning'>Entering the link would be a very bad idea.</span>")
+
 /obj/structure/spawner/nether/attack_hand(mob/user)
+	. = ..()
+	if(isskeleton(user) || iszombie(user))
+		to_chat(user, "<span class='notice'>You don't feel like going home yet...</span>")
+	else
 		user.visible_message("<span class='warning'>[user] is violently pulled into the link!</span>", \
-						  "<span class='userdanger'>Touching the portal, you are quickly pulled through into a world of unimaginable horror!</span>")
+							"<span class='userdanger'>Touching the portal, you are quickly pulled through into a world of unimaginable horror!</span>")
 		contents.Add(user)
 
 /obj/structure/spawner/nether/process()


### PR DESCRIPTION
This adds flavor text whenever zombies and skeletons examine the nether portal and click on it. You know, since they're clearly from a different place.