### PR TITLE
Fixes CentCom AT warnings

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -121,6 +121,7 @@
 /turf/open/indestructible/binary
 	name = "tear in the fabric of reality"
 	CanAtmosPass = ATMOS_PASS_NO
+	blocks_air = TRUE
 	baseturfs = /turf/open/indestructible/binary
 	icon_state = "binary"
 	footstep = null
@@ -131,6 +132,7 @@
 /turf/open/indestructible/airblock
 	icon_state = "bluespace"
 	CanAtmosPass = ATMOS_PASS_NO
+	blocks_air = TRUE
 	baseturfs = /turf/open/indestructible/airblock
 
 /turf/open/indestructible/clock_spawn_room


### PR DESCRIPTION
:cl: Denton
fix: The "tear in the fabric of reality" area no longer throws "HEY! LISTEN!" active turf warnings.
/:cl:

Those two were missing `blocks_air = TRUE` which prevents AT processing.