### PR TITLE
Improves strange reagent feedback/desc, fixes missing delay/ghost notification

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -782,7 +782,7 @@
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
 	id = "strange_reagent"
-	description = "A miracle drug capable of bringing the dead back to life. Only functions if the target has less than 100 brute and burn damage (independent of one another) and hasn't been husked. Causes slight damage to the living."
+	description = "A miracle drug capable of bringing the dead back to life. Only functions when applied by patch or spray, if the target has less than 100 brute and burn damage (independent of one another) and hasn't been husked. Causes slight damage to the living."
 	reagent_state = LIQUID
 	color = "#A0E85E"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -790,19 +790,16 @@
 
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/carbon/human/M, method=TOUCH, reac_volume)
 	if(M.stat == DEAD)
-		if(M.getBruteLoss() >= 100 || M.getFireLoss() >= 100 || M.has_trait(TRAIT_HUSK))
-			M.visible_message("<span class='warning'>[M]'s body convulses a bit, and then falls still once more.</span>")
-			return
-		if(M.suiciding || M.hellbound)
+		if(M.suiciding || M.hellbound || !M) //it's dead, Jim
 			M.visible_message("<span class='warning'>[M]'s body does not react...</span>")
 			return
-		M.visible_message("<span class='warning'>[M]'s body starts convulsing!</span>")
-		if(!M)
+		if(M.getBruteLoss() >= 100 || M.getFireLoss() >= 100 || M.has_trait(TRAIT_HUSK)) //body is too damaged to be revived
+			M.visible_message("<span class='warning'>[M]'s body convulses a bit, and then falls still once more.</span>")
 			return
-		if(M.notify_ghost_cloning(source = M))
-			spawn (100) //so the ghost has time to re-enter
-				return
 		else
+			M.visible_message("<span class='warning'>[M]'s body starts convulsing!</span>")
+			M.notify_ghost_cloning(source = M)
+			sleep(100) //so the ghost has time to re-enter
 			M.adjustOxyLoss(-20, 0)
 			M.adjustToxLoss(-20, 0)
 			M.updatehealth()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -782,7 +782,7 @@
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
 	id = "strange_reagent"
-	description = "A miracle drug capable of bringing the dead back to life. Only functions if the target has less than 100 brute and burn damage (independent of one another), and causes slight damage to the living."
+	description = "A miracle drug capable of bringing the dead back to life. Only functions if the target has less than 100 brute and burn damage (independent of one another) and hasn't been husked. Causes slight damage to the living."
 	reagent_state = LIQUID
 	color = "#A0E85E"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -793,20 +793,22 @@
 		if(M.getBruteLoss() >= 100 || M.getFireLoss() >= 100 || M.has_trait(TRAIT_HUSK))
 			M.visible_message("<span class='warning'>[M]'s body convulses a bit, and then falls still once more.</span>")
 			return
-		M.visible_message("<span class='warning'>[M]'s body convulses a bit.</span>")
-		if(!M.suiciding && !M.hellbound)
-			if(!M)
+		if(M.suiciding || M.hellbound)
+			M.visible_message("<span class='warning'>[M]'s body does not react...</span>")
+			return
+		M.visible_message("<span class='warning'>[M]'s body starts convulsing!</span>")
+		if(!M)
+			return
+		if(M.notify_ghost_cloning(source = M))
+			spawn (100) //so the ghost has time to re-enter
 				return
-			if(M.notify_ghost_cloning(source = M))
-				spawn (100) //so the ghost has time to re-enter
-					return
-			else
-				M.adjustOxyLoss(-20, 0)
-				M.adjustToxLoss(-20, 0)
-				M.updatehealth()
-				if(M.revive())
-					M.emote("gasp")
-					log_combat(M, M, "revived", src)
+		else
+			M.adjustOxyLoss(-20, 0)
+			M.adjustToxLoss(-20, 0)
+			M.updatehealth()
+			if(M.revive())
+				M.emote("gasp")
+				log_combat(M, M, "revived", src)
 	..()
 
 /datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -790,7 +790,7 @@
 
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/carbon/human/M, method=TOUCH, reac_volume)
 	if(M.stat == DEAD)
-		if(M.suiciding || M.hellbound || !M) //it's dead, Jim
+		if(M.suiciding || M.hellbound) //they are never coming back
 			M.visible_message("<span class='warning'>[M]'s body does not react...</span>")
 			return
 		if(M.getBruteLoss() >= 100 || M.getFireLoss() >= 100 || M.has_trait(TRAIT_HUSK)) //body is too damaged to be revived


### PR DESCRIPTION
:cl: Denton
fix: Strange Reagent now takes ten seconds to revive people and also notifies ghosts that their body is being revived.
spellcheck: Improved Strange Reagent's description and added a separate "does not react" message for when players try to revive hellbound or suicided corpses.
/:cl:

Looks like Strange Reagent was always supposed to take ~10 seconds to revive players and notify their ghost about it. I readded this, since it seems like a better way to handle revival.

The PR also adds a seperate "does not react" message for when you try to apply strange reagent to hellbound/suicided players. It also updates the desc to mention that it won't work for reviving husked players.