### PR TITLE
Removes Nuka Cola from Vending Machines

### DIFF
--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -15,8 +15,7 @@
 					/obj/item/reagent_containers/glass/beaker/waterbottle = 10)
 	contraband = list(/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko = 6,
 		              /obj/item/reagent_containers/food/drinks/soda_cans/shamblers = 6)
-	premium = list(/obj/item/reagent_containers/food/drinks/drinkingglass/filled/nuka_cola = 1,
-		           /obj/item/reagent_containers/food/drinks/soda_cans/air = 1,
+	premium = list( /obj/item/reagent_containers/food/drinks/soda_cans/air = 1,
 		           /obj/item/reagent_containers/food/drinks/soda_cans/grey_bull = 1)
 	refill_canister = /obj/item/vending_refill/cola
 	default_price = 10


### PR DESCRIPTION
:cl: Wesoda25
Balance: Removes Nuka Cola from vending machines, making it require actual effort to acquire
/:cl:

Note: Nothing actually being added, github seems to think I deleted Canned Air when I didn't, just moved it up a line. Only change is nuka cola being removed. 

[why]: Nuka Cola is unbalanced in the sense that it rivals some of the best antagonist gear/abilities from different gamemodes, cult (Flag robes) and changelings (strained muscles). All for the cheap price of $25 and a slight shake/color effect. I'm seeing it be used by assistants, antags, and security alike, and its incredibly difficult to keep up with. 

I considered spiking the price, but money is easy to get for any job other than assistant. Nuka Cola will still be obtainable via bar-tending, 1 part uranium and 6 parts cola. A pretty easy recipe, but I feel it balances it appropriately, and if not that more so than it once was. 
