### PR TITLE
Reworks spearguns, adds Syndicate bundle, carp clothing adds carp faction

### DIFF
--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -315,3 +315,23 @@
 /obj/item/pneumatic_cannon/speargun/Initialize()
 	. = ..()
 	allowed_typecache = magspear_typecache
+
+/obj/item/storage/backpack/magspear_quiver
+	name = "quiver"
+	desc = "A quiver for holding magspears."
+	icon_state = "quiver"
+	item_state = "quiver"
+
+/obj/item/storage/backpack/magspear_quiver/ComponentInitialize()
+	. = ..()
+	GET_COMPONENT(STR, /datum/component/storage)
+	STR.max_items = 20
+	STR.max_combined_w_class = 40
+	STR.display_numerical_stacking = TRUE
+	STR.can_hold = typecacheof(list(
+		/obj/item/throwing_star/magspear
+		))
+
+/obj/item/storage/backpack/magspear_quiver/PopulateContents()
+	for(var/i in 1 to 20)
+		new /obj/item/throwing_star/magspear(src)

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -32,6 +32,8 @@
 	var/charge_tick = 0
 	var/charge_type
 	var/selfcharge = FALSE
+	var/fire_sound = 'sound/weapons/sonic_jackhammer.ogg'
+	var/spin_item = TRUE //Do the projectiles spin when launched?
 	trigger_guard = TRIGGER_GUARD_NORMAL
 
 
@@ -165,7 +167,7 @@
 				    		 "<span class='danger'>You fire \the [src]!</span>")
 	log_combat(user, target, "fired at", src)
 	var/turf/T = get_target(target, get_turf(src))
-	playsound(src, 'sound/weapons/sonic_jackhammer.ogg', 50, 1)
+	playsound(src, fire_sound, 50, 1)
 	fire_items(T, user)
 	if(pressureSetting >= 3 && iscarbon(user))
 		var/mob/living/carbon/C = user
@@ -195,7 +197,7 @@
 	loadedItems -= I
 	loadedWeightClass -= I.w_class
 	I.forceMove(get_turf(src))
-	I.throw_at(target, pressureSetting * 10 * range_multiplier, pressureSetting * 2, user)
+	I.throw_at(target, pressureSetting * 10 * range_multiplier, pressureSetting * 2, user, spin_item)
 	return TRUE
 
 /obj/item/pneumatic_cannon/proc/get_target(turf/target, turf/starting)
@@ -292,3 +294,24 @@
 	charge_type = /obj/item/reagent_containers/food/snacks/pie/cream/nostun
 	maxWeightClass = 6		//2 pies
 	charge_ticks = 2		//4 second/pie
+
+/obj/item/pneumatic_cannon/speargun
+	name = "kinetic speargun"
+	desc = "A weapon favored by carp hunters. Fires specialized spears using kinetic energy."
+	icon = 'icons/obj/guns/projectile.dmi'
+	icon_state = "speargun"
+	item_state = "speargun"
+	w_class = WEIGHT_CLASS_BULKY
+	force = 10
+	fire_sound = 'sound/weapons/grenadelaunch.ogg'
+	gasPerThrow = 0
+	checktank = FALSE
+	range_multiplier = 3
+	throw_amount = 1
+	maxWeightClass = 2 //a single magspear
+	spin_item = FALSE
+	var/static/list/magspear_typecache = typecacheof(/obj/item/throwing_star/magspear)
+
+/obj/item/pneumatic_cannon/speargun/Initialize()
+	. = ..()
+	allowed_typecache = magspear_typecache

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -531,24 +531,6 @@
 		/obj/item/ammo_casing/shotgun
 		))
 
-/obj/item/storage/belt/bandolier/magspear
-	name = "magspear bandolier"
-	desc = "A bandolier for holding magnetic spears."
-
-/obj/item/storage/belt/bandolier/magspear/ComponentInitialize()
-	. = ..()
-	GET_COMPONENT(STR, /datum/component/storage)
-	STR.max_items = 20
-	STR.display_numerical_stacking = TRUE
-	STR.can_hold = typecacheof(list(
-		/obj/item/throwing_star/magspear
-		))
-
-/obj/item/storage/belt/bandolier/magspear/PopulateContents()
-	var/static/items_inside = list(
-		/obj/item/throwing_star/magspear = 15)
-	generate_items_inside(items_inside,src)
-
 /obj/item/storage/belt/holster
 	name = "shoulder holster"
 	desc = "A holster to carry a handgun and ammo. WARNING: Badasses only."

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -538,7 +538,7 @@
 /obj/item/storage/belt/bandolier/magspear/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.max_items = 15
+	STR.max_items = 20
 	STR.display_numerical_stacking = TRUE
 	STR.can_hold = typecacheof(list(
 		/obj/item/throwing_star/magspear

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -531,6 +531,24 @@
 		/obj/item/ammo_casing/shotgun
 		))
 
+/obj/item/storage/belt/bandolier/magspear
+	name = "magspear bandolier"
+	desc = "A bandolier for holding magnetic spears."
+
+/obj/item/storage/belt/bandolier/magspear/ComponentInitialize()
+	. = ..()
+	GET_COMPONENT(STR, /datum/component/storage)
+	STR.max_items = 15
+	STR.display_numerical_stacking = TRUE
+	STR.can_hold = typecacheof(list(
+		/obj/item/throwing_star/magspear
+		))
+
+/obj/item/storage/belt/bandolier/magspear/PopulateContents()
+	var/static/items_inside = list(
+		/obj/item/throwing_star/magspear = 15)
+	generate_items_inside(items_inside,src)
+
 /obj/item/storage/belt/holster
 	name = "shoulder holster"
 	desc = "A holster to carry a handgun and ammo. WARNING: Badasses only."

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -128,7 +128,7 @@
 
 		if("white_whale_holy_grail") //Unique items that don't appear anywhere else
 			new /obj/item/pneumatic_cannon/speargun(src)
-			new /obj/item/storage/belt/bandolier/magspear(src)
+			new /obj/item/storage/backpack/magspear_quiver(src)
 			new /obj/item/clothing/suit/space/hardsuit/carp(src)
 			new /obj/item/clothing/mask/gas/carp(src)
 			new /obj/item/grenade/spawnergrenade/spesscarp(src)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -1,7 +1,7 @@
 /obj/item/storage/box/syndicate
 
 /obj/item/storage/box/syndicate/PopulateContents()
-	switch (pickweight(list("bloodyspai" = 3, "stealth" = 2, "bond" = 2, "screwed" = 2, "sabotage" = 3, "guns" = 2, "murder" = 2, "implant" = 1, "hacker" = 3, "darklord" = 1, "sniper" = 1, "metaops" = 1, "ninja" = 1)))
+	switch (pickweight(list("bloodyspai" = 3, "stealth" = 2, "bond" = 2, "screwed" = 2, "sabotage" = 3, "guns" = 2, "murder" = 2, "implant" = 1, "hacker" = 3, "darklord" = 1, "sniper" = 1, "metaops" = 1, "ninja" = 1, "white_whale_holy_grail" = 2)))
 		if("bloodyspai") // 27 tc now this is more right
 			new /obj/item/clothing/under/chameleon(src) // 2 tc since it's not the full set
 			new /obj/item/clothing/mask/chameleon(src) // Goes with above
@@ -125,6 +125,13 @@
 			new /obj/item/storage/belt/chameleon(src) // Unique but worth at least 2 tc
 			new /obj/item/card/id/syndicate(src) // 2 tc
 			new /obj/item/chameleon(src) // 7 tc
+
+		if("white_whale_holy_grail") //Unique items that don't appear anywhere else
+			new /obj/item/pneumatic_cannon/speargun(src)
+			new /obj/item/storage/belt/bandolier/magspear(src)
+			new /obj/item/clothing/suit/space/hardsuit/carp(src)
+			new /obj/item/clothing/mask/gas/carp(src)
+			new /obj/item/grenade/spawnergrenade/spesscarp(src)
 
 /obj/item/storage/box/syndie_kit
 	name = "box"

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -277,7 +277,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	force = 2
-	throwforce = 20 //This is never used on mobs since this has a 100% embed chance.
+	throwforce = 20 //20 + 2 (WEIGHT_CLASS_SMALL) * 4 (EMBEDDED_IMPACT_PAIN_MULTIPLIER) = 28 damage on hit due to guaranteed embedding
 	throw_speed = 4
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 100, "embedded_fall_chance" = 0)
 	w_class = WEIGHT_CLASS_SMALL
@@ -285,6 +285,14 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	materials = list(MAT_METAL=500, MAT_GLASS=500)
 	resistance_flags = FIRE_PROOF
 
+/obj/item/throwing_star/magspear
+	name = "magnetic spear"
+	desc = "A reusable spear that is typically loaded into kinetic spearguns."
+	icon = 'icons/obj/ammo.dmi'
+	icon_state = "magspear"
+	force = 10
+	attack_verb = list("stabbed", "ripped", "gored", "impaled")
+	embedding = list("embedded_pain_multiplier" = 8, "embed_chance" = 100, "embedded_fall_chance" = 0, "embedded_impact_pain_multiplier" = 15) //50 damage+embed on hit
 
 /obj/item/switchblade
 	name = "switchblade"

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -290,9 +290,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "A reusable spear that is typically loaded into kinetic spearguns."
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "magspear"
+	throwforce = 25 //kills regular carps in one hit
 	force = 10
 	attack_verb = list("stabbed", "ripped", "gored", "impaled")
-	embedding = list("embedded_pain_multiplier" = 8, "embed_chance" = 100, "embedded_fall_chance" = 0, "embedded_impact_pain_multiplier" = 15) //50 damage+embed on hit
+	embedding = list("embedded_pain_multiplier" = 8, "embed_chance" = 100, "embedded_fall_chance" = 0, "embedded_impact_pain_multiplier" = 15) //55 damage+embed on hit
 
 /obj/item/switchblade
 	name = "switchblade"

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -277,7 +277,6 @@ Contains:
 	actions_types = list()
 	item_flags = NODROP
 
-
 /obj/item/clothing/suit/space/hardsuit/carp
 	name = "carp space suit"
 	desc = "A slimming piece of dubious space carp technology, you suspect it won't stand up to hand-to-hand blows."
@@ -285,9 +284,18 @@ Contains:
 	item_state = "space_suit_syndicate"
 	slowdown = 0	//Space carp magic, never stop believing
 	armor = list("melee" = -20, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 75, "fire" = 60, "acid" = 75) //As whimpy whimpy whoo
-	allowed = list(/obj/item/tank/internals, /obj/item/gun/ballistic/automatic/speargun)	//I'm giving you a hint here
+	allowed = list(/obj/item/tank/internals, /obj/item/pneumatic_cannon/speargun)	//I'm giving you a hint here
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/carp
 
+/obj/item/clothing/head/helmet/space/hardsuit/carp/equipped(mob/living/carbon/human/user, slot)
+	..()
+	if (slot == SLOT_HEAD)
+		user.faction |= "carp"
+
+/obj/item/clothing/head/helmet/space/hardsuit/carp/dropped(mob/living/carbon/human/user)
+	..()
+	if (user.head == src)
+		user.faction -= "carp"
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal
 	name = "paranormal response team helmet"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -255,7 +255,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT	//Space carp like space, so you should too
-	allowed = list(/obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/gun/ballistic/automatic/speargun)
+	allowed = list(/obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/pneumatic_cannon/speargun)
 	hoodtype = /obj/item/clothing/head/hooded/carp_hood
 
 /obj/item/clothing/head/hooded/carp_hood
@@ -266,6 +266,16 @@
 	cold_protection = HEAD
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	flags_inv = HIDEHAIR|HIDEEARS
+
+/obj/item/clothing/head/hooded/carp_hood/equipped(mob/living/carbon/human/user, slot)
+	..()
+	if (slot == SLOT_HEAD)
+		user.faction |= "carp"
+
+/obj/item/clothing/head/hooded/carp_hood/dropped(mob/living/carbon/human/user)
+	..()
+	if (user.head == src)
+		user.faction -= "carp"
 
 /obj/item/clothing/suit/hooded/ian_costume	//It's Ian, rub his bell- oh god what happened to his inside parts?
 	name = "corgi costume"

--- a/code/modules/projectiles/ammunition/caseless/misc.dm
+++ b/code/modules/projectiles/ammunition/caseless/misc.dm
@@ -1,12 +1,3 @@
-/obj/item/ammo_casing/caseless/magspear
-	name = "magnetic spear"
-	desc = "A reusable spear that is typically loaded into kinetic spearguns."
-	projectile_type = /obj/item/projectile/bullet/reusable/magspear
-	caliber = "speargun"
-	icon_state = "magspear"
-	throwforce = 15 //still deadly when thrown
-	throw_speed = 3
-
 /obj/item/ammo_casing/caseless/laser
 	name = "laser casing"
 	desc = "You shouldn't be seeing this."

--- a/code/modules/projectiles/boxes_magazines/internal/misc.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/misc.dm
@@ -1,9 +1,3 @@
-/obj/item/ammo_box/magazine/internal/speargun
-	name = "speargun internal magazine"
-	ammo_type = /obj/item/ammo_casing/caseless/magspear
-	caliber = "speargun"
-	max_ammo = 1
-
 /obj/item/ammo_box/magazine/internal/minigun
 	name = "gatling gun fusion core"
 	ammo_type = /obj/item/ammo_casing/caseless/laser/gatling

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -45,35 +45,6 @@
 	..()
 	icon_state = "[initial(icon_state)][magazine ? "loaded" : ""]"
 
-/obj/item/gun/ballistic/automatic/speargun
-	name = "kinetic speargun"
-	desc = "A weapon favored by carp hunters. Fires specialized spears using kinetic energy."
-	icon_state = "speargun"
-	item_state = "speargun"
-	w_class = WEIGHT_CLASS_BULKY
-	force = 10
-	can_suppress = FALSE
-	mag_type = /obj/item/ammo_box/magazine/internal/speargun
-	fire_sound = 'sound/weapons/grenadelaunch.ogg'
-	burst_size = 1
-	fire_delay = 0
-	select = 0
-	actions_types = list()
-	casing_ejector = FALSE
-
-/obj/item/gun/ballistic/automatic/speargun/update_icon()
-	return
-
-/obj/item/gun/ballistic/automatic/speargun/attack_self()
-	return
-
-/obj/item/gun/ballistic/automatic/speargun/attackby(obj/item/A, mob/user, params)
-	var/num_loaded = magazine.attackby(A, user, params, 1)
-	if(num_loaded)
-		to_chat(user, "<span class='notice'>You load [num_loaded] spear\s into \the [src].</span>")
-		update_icon()
-		chamber_round()
-
 /obj/item/gun/ballistic/rocketlauncher
 	name = "rocket propelled grenade launcher"
 	desc = "A reusable rocket propelled grenade launcher."

--- a/code/modules/projectiles/projectile/reusable/magspear.dm
+++ b/code/modules/projectiles/projectile/reusable/magspear.dm
@@ -1,6 +1,0 @@
-/obj/item/projectile/bullet/reusable/magspear
-	name = "magnetic spear"
-	desc = "WHITE WHALE, HOLY GRAIL"
-	damage = 30 //takes 3 spears to kill a mega carp, one to kill a normal carp
-	icon_state = "magspear"
-	ammo_type = /obj/item/ammo_casing/caseless/magspear

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -19,7 +19,7 @@ GLOBAL_LIST_INIT(summoned_guns, list(
 	/obj/item/gun/ballistic/automatic/ar,
 	/obj/item/gun/ballistic/revolver/mateba,
 	/obj/item/gun/ballistic/shotgun/boltaction,
-	/obj/item/gun/ballistic/automatic/speargun,
+	/obj/item/pneumatic_cannon/speargun,
 	/obj/item/gun/ballistic/automatic/mini_uzi,
 	/obj/item/gun/energy/lasercannon,
 	/obj/item/gun/energy/kinetic_accelerator/crossbow/large,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2378,7 +2378,6 @@
 #include "code\modules\projectiles\projectile\magic\spellcard.dm"
 #include "code\modules\projectiles\projectile\reusable\_reusable.dm"
 #include "code\modules\projectiles\projectile\reusable\foam_dart.dm"
-#include "code\modules\projectiles\projectile\reusable\magspear.dm"
 #include "code\modules\projectiles\projectile\special\curse.dm"
 #include "code\modules\projectiles\projectile\special\floral.dm"
 #include "code\modules\projectiles\projectile\special\gravity.dm"


### PR DESCRIPTION
:cl: Denton
tweak: Wearing a carp costume or hardsuit with its hood equipped now prevents users from being attacked by wild space carp.
tweak: Reworked the kinetic speargun: Its projectiles now embed and cause more damage.
add: Added a Syndicate bundle that contains a speargun, a quiver with magspears, a carp hardsuit as well as other carp accessories.
/:cl:

I reworked the speargun as a pneumatic cannon subtype - this allows spears to embed and let me control the embedding behavior. Thanks to @Tlaltecuhtli for the idea!
Magspears are now a throwing star subtype that deals increased damage.

Second change: A syndicate bundle that contains a speargun, a bandolier with 20 magspears, carp hardsuit+mask and a carp spawner grenade.

Lastly, wearing a carp costume/hardsuit with its hood adds the carp faction to players.