### PR TITLE
Adds jitter animation to strange reagent

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -795,10 +795,14 @@
 			return
 		if(M.getBruteLoss() >= 100 || M.getFireLoss() >= 100 || M.has_trait(TRAIT_HUSK)) //body is too damaged to be revived
 			M.visible_message("<span class='warning'>[M]'s body convulses a bit, and then falls still once more.</span>")
+			M.do_jitter_animation(10)
 			return
 		else
 			M.visible_message("<span class='warning'>[M]'s body starts convulsing!</span>")
 			M.notify_ghost_cloning(source = M)
+			M.do_jitter_animation(10)
+			addtimer(CALLBACK(M, /mob/living/carbon.proc/do_jitter_animation, 10), 40) //jitter immediately, then again after 4 and 8 seconds
+			addtimer(CALLBACK(M, /mob/living/carbon.proc/do_jitter_animation, 10), 80)
 			sleep(100) //so the ghost has time to re-enter
 			M.adjustOxyLoss(-20, 0)
 			M.adjustToxLoss(-20, 0)


### PR DESCRIPTION
This PR adds jitter animations for when strange reagent is used on corpses. One animation for failed revival ("[M]'s body convulses a bit, and then falls still once more") and three animations for successful revival ("[M]'s body starts convulsing!").