### PR TITLE
CMO now starts with a medical belt full of T2 surgery tools, akin to the CE.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -175,6 +175,20 @@
 		/obj/item/pinpointer/crew
 		))
 
+/obj/item/storage/belt/medical/chief
+	name = "\improper Chief Medical Officer's medical belt"
+	desc = "Holds medical supplies. Looks boring."
+	icon_state = "medicalbelt"
+	item_state = "medical"
+
+/obj/item/storage/belt/medical/chief/full/PopulateContents()
+	new /obj/item/retractor/advanced(src)
+	new /obj/item/scalpel/advanced(src)
+	new /obj/item/cautery/advanced
+	new /obj/item/surgical_drapes(src)
+	new /obj/item/pinpointer/crew(src)
+	new /obj/item/healthanalyzer/advanced(src)
+
 /obj/item/storage/belt/security
 	name = "security belt"
 	desc = "Can hold security gear like handcuffs and flashes."

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -34,8 +34,8 @@ Chief Medical Officer
 	jobtype = /datum/job/cmo
 
 	id = /obj/item/card/id/silver
-	belt = /obj/item/pda/heads/cmo
-	l_pocket = /obj/item/pinpointer/crew
+	belt = /obj/item/storage/belt/medical/chief/full
+	l_pocket = /obj/item/pda/heads/cmo
 	ears = /obj/item/radio/headset/heads/cmo
 	uniform = /obj/item/clothing/under/rank/chief_medical_officer
 	shoes = /obj/item/clothing/shoes/sneakers/brown


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Frosty Fridge
add: After repeated complaints of department favoritism, Nanotrasen has begun issuing CMOs with a belt full of expensive surgical instruments.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
Now that T2 surgery tools exist, I think its reasonable to give the CMO a belt full of them at round start, like the CE's belt. The CMO's belt contains a full set of advanced surgery tools, a crew pinpointer, and an advanced health analyzer. The sprite is the same as the regular medical belt because I don't know how to sprite things. 