### PR TITLE
The wizard Shuffle Race event now no longer changes people's names

### DIFF
--- a/code/modules/events/wizard/race.dm
+++ b/code/modules/events/wizard/race.dm
@@ -22,7 +22,6 @@
 
 	for(var/mob/living/carbon/human/H in GLOB.carbon_list) //yes, even the dead
 		H.set_species(new_species)
-		H.real_name = H.dna.species.random_name(H.gender,1)
 		H.dna.unique_enzymes = H.dna.generate_unique_enzymes()
 		to_chat(H, "<span class='notice'>You feel somehow... different?</span>")
 		if(!all_the_same)


### PR DESCRIPTION
:cl: coiax
tweak: The Shuffle Race wizard event no longer changes people's names.
/:cl:

We've got Change Names and Change Faces for this, sometimes you just wanna stab
a button and make everyone DIFFERENT, but not DIFFERENT PEOPLE.

Fixes #39474