### PR TITLE
Only the surgeon of a surgery knows what method of surgery is chosen

### DIFF
--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -69,7 +69,7 @@
 
 			if(S.ignore_clothes || get_location_accessible(M, selected_zone))
 				var/datum/surgery/procedure = new S.type(M, selected_zone, affecting)
-				user.visible_message("[user] drapes [I] over [M]'s [parse_zone(selected_zone)] to prepare for \an [procedure.name].", \
+				user.visible_message("[user] drapes [I] over [M]'s [parse_zone(selected_zone)] to prepare for surgery.", \
 					"<span class='notice'>You drape [I] over [M]'s [parse_zone(selected_zone)] to prepare for \an [procedure.name].</span>")
 
 				log_combat(user, M, "operated on", null, "(OPERATION TYPE: [procedure.name]) (TARGET AREA: [selected_zone])")


### PR DESCRIPTION
:cl: coiax
tweak: When laying the drapes for surgery, only the surgeon will know
which proceedure has been initiated.
/:cl:

Why? Surgery requires trust, and additional trust will now be required, given
the "brain surgery" and "brainwashing" surgeries have very similar steps. Is
she installing a CNS rebooter, or performing a casual pacification surgery?