### PR TITLE
Fix adjacent turf calculations for open turfs that block atmos.

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -24,7 +24,8 @@
 		R = TRUE
 	if(blocks_air || T.blocks_air)
 		R = TRUE
-
+	if (T == src)
+		return !R
 	for(var/obj/O in contents+T.contents)
 		var/turf/other = (O.loc == src ? T : src)
 		if(!(vertical? (CANVERTICALATMOSPASS(O, other)) : (CANATMOSPASS(O, other))))
@@ -43,12 +44,13 @@
 	return FALSE
 
 /turf/proc/CalculateAdjacentTurfs()
-	var/list/atmos_adjacent_turfs = src.atmos_adjacent_turfs
+	var/canpass = CANATMOSPASS(src, src) 
+	var/canvpass = CANVERTICALATMOSPASS(src, src))
 	for(var/direction in GLOB.cardinals_multiz)
 		var/turf/T = get_step_multiz(src, direction)
 		if(!isopenturf(T))
 			continue
-		if(!(blocks_air || T.blocks_air) && ((direction & (UP|DOWN))? (CANVERTICALATMOSPASS(T, src)) : (CANATMOSPASS(T, src))) )
+		if(!(blocks_air || T.blocks_air) && ((direction & (UP|DOWN))? (canvpass && CANVERTICALATMOSPASS(T, src)) : (canpass && CANATMOSPASS(T, src))) )
 			LAZYINITLIST(atmos_adjacent_turfs)
 			LAZYINITLIST(T.atmos_adjacent_turfs)
 			atmos_adjacent_turfs[T] = TRUE

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -45,7 +45,7 @@
 
 /turf/proc/CalculateAdjacentTurfs()
 	var/canpass = CANATMOSPASS(src, src) 
-	var/canvpass = CANVERTICALATMOSPASS(src, src))
+	var/canvpass = CANVERTICALATMOSPASS(src, src)
 	for(var/direction in GLOB.cardinals_multiz)
 		var/turf/T = get_step_multiz(src, direction)
 		if(!isopenturf(T))


### PR DESCRIPTION
Turfs weren't checking rather or not they themselves blocked atmos before looking for open turfs near them.
fixes #42085
