### PR TITLE
Fixes squashing

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -101,6 +101,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/proc/squash(atom/target)
 	var/turf/T = get_turf(target)
+	forceMove(T)
 	if(ispath(splat_type, /obj/effect/decal/cleanable/food/plant_smudge))
 		if(filling_color)
 			var/obj/O = new splat_type(T)


### PR DESCRIPTION
:cl:
fix: squashed plants react on the turf they are squashed
/:cl:

Currently they react on the turf before if they hit a person because they don't move through the dense object.

fixes #33412