### PR TITLE
removes flashes from most cyborg modules

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -235,7 +235,6 @@
 /obj/item/robot_module/standard
 	name = "Standard"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/reagent_containers/borghypo/epi,
 		/obj/item/healthanalyzer,
 		/obj/item/weldingtool/largetank/cyborg,
@@ -261,7 +260,6 @@
 /obj/item/robot_module/medical
 	name = "Medical"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/healthanalyzer,
 		/obj/item/reagent_containers/borghypo,
 		/obj/item/reagent_containers/glass/beaker/large,
@@ -292,7 +290,6 @@
 /obj/item/robot_module/engineering
 	name = "Engineering"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/borg/sight/meson,
 		/obj/item/construction/rcd/borg,
 		/obj/item/pipe_dispenser,
@@ -384,7 +381,6 @@
 /obj/item/robot_module/janitor
 	name = "Janitor"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/screwdriver/cyborg,
 		/obj/item/crowbar/cyborg,
 		/obj/item/stack/tile/plasteel/cyborg,
@@ -431,7 +427,6 @@
 /obj/item/robot_module/clown
 	name = "Clown"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/toy/crayon/rainbow,
 		/obj/item/instrument/bikehorn,
 		/obj/item/stamp/clown,
@@ -462,7 +457,6 @@
 /obj/item/robot_module/butler
 	name = "Service"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/reagent_containers/food/drinks/drinkingglass,
 		/obj/item/reagent_containers/food/condiment/enzyme,
 		/obj/item/pen,
@@ -516,7 +510,6 @@
 /obj/item/robot_module/miner
 	name = "Miner"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/borg/sight/meson,
 		/obj/item/storage/bag/ore/cyborg,
 		/obj/item/pickaxe/drill/cyborg,

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -12,6 +12,7 @@
 Optimumtact = Host
 CitrusGender = Game Master
 NewSta = Game Master
+Imsxz = Game Master
 Expletives = Game Master
 kingofkosmos = Game Master
 MrStonedOne = Lazy Master


### PR DESCRIPTION
:cl: the hero cyborgs DESERVE
del: most cyborg modules no longer have a flash
/:cl:
cyborgs ability to "prevent harm" is simply strong enough with constant full movespeed, ability to remotely bolt doors behind and around them, and drag people away while being impervious to most stuns. giving them access to a reliable chain stunning tool encourages validhunting behavior which is quite undesirable to see in cyborgs as that mindset generally causes players to ignore their laws in favor of getting the antag lynched.

likewise, rogue silicons are beyond powerful enough without any modules, let alone their already overloaded respective kits, let alone a powerful tool for chainstunning. giving them the power to chainstun most of the crew (while powergamers argue that its simple to just grab sunglasses, they're limited and not everyone makes a mad dash to secure a pair roundstart, leaving most of the crew exposed) isn't necessary in the slightest, it's more fuel to the raging fire that coincidentally also doesn't hurt the rogue silicon. i play rogue silicon often enough to say that they won't feel much loss from flash removal.

 say ided if you want, but i rush sunglasses like the dirty powergamer i am anyways, i make this PR on behalf of the 90% who dont.

peacekeeper, security, and syndicate modules are unchanged