### PR TITLE
FREE DRONE! Allows the living to use not on station vending machines

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -348,7 +348,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			if(coin_records.Find(R) || is_hidden)
 				price_listed = "$[R.custom_premium_price ? R.custom_premium_price : extra_price]"
 			dat += "<li>"
-			if(R.amount > 0 && ((C && C.registered_account && onstation) || (!onstation && iscarbon(user))))
+			if(R.amount > 0 && ((C && C.registered_account && onstation) || (!onstation && isliving(user))))
 				dat += "<a href='byond://?src=[REF(src)];vend=[REF(R)]'>Vend</a> "
 			else
 				dat += "<span class='linkOff'>Not Available</span> "


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Dax Dupont
fix: Silicons and drones can use vending machines once again, but only if they are not on station. 
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
Fixes #42142
I labeled this as a fix because surely this must be oversight since drones/sillycones were able to use vendors before the goof disaster PR. There's no reason why they shouldn't be able to use the free vendors.