### PR TITLE
Fixes extraneous naked human icon appearing below all humans

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2,13 +2,15 @@
 	name = "Unknown"
 	real_name = "Unknown"
 	icon = 'icons/mob/human.dmi'
-	icon_state = ""
+	icon_state = "human_basic"
 	appearance_flags = KEEP_TOGETHER|TILE_BOUND|PIXEL_SCALE
 
 /mob/living/carbon/human/Initialize()
 	verbs += /mob/living/proc/mob_sleep
 	verbs += /mob/living/proc/lay_down
-
+	
+	icon_state = ""		//Remove the inherent human icon that is visible on the map editor. We're rendering ourselves limb by limb, having it still be there results in a bug where the basic human icon appears below as south in all directions and generally looks nasty.
+	
 	//initialize limbs first
 	create_bodyparts()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2,7 +2,7 @@
 	name = "Unknown"
 	real_name = "Unknown"
 	icon = 'icons/mob/human.dmi'
-	icon_state = "human_basic"
+	icon_state = ""
 	appearance_flags = KEEP_TOGETHER|TILE_BOUND|PIXEL_SCALE
 
 /mob/living/carbon/human/Initialize()


### PR DESCRIPTION
Closes https://github.com/tgstation/tgstation/issues/42145

![image](https://user-images.githubusercontent.com/2003111/50561370-de099400-0cbe-11e9-830f-e5e4395f92f2.png)
How this is happening (to my knowledge) is this:
Although @81Denton was fixing a broken icon_state what he failed to realize (I'm not the only one who doesn't test okay?) is that we use overlays to render all parts of a human, rather than a single sprite.
Hell the sprite it was changed to doesn't even have directionals. 
That sprite was displayed instead of the usually "broken" non-existing icon (it didn't exist because we never used it due to the fact we render every part of a human including bodyparts with overlays instead of a base icon, after dismemberment I believe?)
Yeah. This fixes that by nulling the icon_state so it's humans are invisible by default before their overlays are applied (which is the behavior before Denton's PR).
Tell me if this isn't the correct fix?