### PR TITLE
Code no longer runtimes on species change for mobs

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -301,10 +301,12 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		C.Digitigrade_Leg_Swap(TRUE)
 	for(var/X in inherent_traits)
 		C.remove_trait(X, SPECIES_TRAIT)
+
+	//If their inert mutation is not the same, swap it out
 	if((inert_mutation != new_species.inert_mutation) && LAZYLEN(C.dna.mutation_index))
 		C.dna.remove_mutation(inert_mutation)
-		C.dna.mutation_index[C.dna.mutation_index.Find(inert_mutation)] = new_species.inert_mutation
-		C.dna.mutation_index[new_species.inert_mutation] = create_sequence(new_species.inert_mutation)
+		C.dna.add_mutation(new_species.inert_mutation)
+
 	C.remove_movespeed_modifier(MOVESPEED_ID_SPECIES)
 
 	SEND_SIGNAL(C, COMSIG_SPECIES_LOSS, src)


### PR DESCRIPTION
on species change was removing the inert mutation (from the mutation
index and mutation list) before trying to find it in that same list and
checking the index.

Instead we get the index first and then remove it.

possible @Time-Green added in  #41258, could you explain the logic in this code? it doesn't make much sense.

First it tries to get an index of an item it removed, then it tries to add to the mutation index in the same place but then looks up the index by the inert_mutation setting in the index? not sure how any of that is supposed to work, considering inert_mutation should be the value, not the key