### PR TITLE
Fixes mobs being left in inconsistent state with the Void mutation

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -8,12 +8,6 @@
 	power = /obj/effect/proc_holder/spell/targeted/telepathy
 	instability = 10
 
-/datum/mutation/human/telepathy/on_acquiring(mob/living/carbon/human/owner)
-	. = ..()
-
-/datum/mutation/human/telepathy/on_losing(mob/living/carbon/human/owner)
-	. = ..()
-
 /datum/mutation/human/firebreath
 	name = "Fire Breath"
 	desc = "An ancient mutation that gives lizards breath of fire."
@@ -65,14 +59,10 @@
 	power = /obj/effect/proc_holder/spell/self/void
 
 /datum/mutation/human/void/on_life()
-	var/obj/effect/proc_holder/spell/self/void/voidpower = power
-	if(voidpower.in_use) //i don't know how rare this is but coughs are 10% on life so in theory this should be okay
+	if(!isturf(owner.loc))
 		return
 	if(prob(0.5+((100-dna.stability)/20))) //very rare, but enough to annoy you hopefully. +0.5 probability for every 10 points lost in stability
-		if(voidpower.action)
-			voidpower.action.UpdateButtonIcon()
-		voidpower.invocation_type = "none"
-		voidpower.cast(user=owner)
+		new /obj/effect/immortality_talisman/void(get_turf(owner), owner)
 
 /obj/effect/proc_holder/spell/self/void
 	name = "Convoke Void" //magic the gathering joke here
@@ -83,31 +73,12 @@
 	invocation = "DOOOOOOOOOOOOOOOOOOOOM!!!"
 	invocation_type = "shout"
 	action_icon_state = "void_magnet"
-	var/in_use = FALSE //so it doesnt cast while you are already deep innit
 
 /obj/effect/proc_holder/spell/self/void/can_cast(mob/user = usr)
 	. = ..()
-	if(in_use)
+	if(!isturf(user.loc))
 		return FALSE
 
 /obj/effect/proc_holder/spell/self/void/cast(mob/user = usr)
-	in_use = TRUE
-	user.visible_message("<span class='danger'>[user] is dragged into the void, leaving a hole in [user.p_their()] place!</span>")
-	var/obj/effect/immortality_talisman/Z = new(get_turf(user))
-	Z.name = "hole in reality"
-	Z.desc = "It's shaped an awful lot like [user.name]."
-	Z.setDir(user.dir)
-	user.forceMove(Z)
-	user.notransform = 1
-	user.status_flags |= GODMODE
-	addtimer(CALLBACK(src, .proc/return_to_reality, user, Z), 100)
-
-/obj/effect/proc_holder/spell/self/void/proc/return_to_reality(mob/user, obj/effect/immortality_talisman/Z)
-	in_use = FALSE
-	invocation_type = initial(invocation_type)
-	user.status_flags &= ~GODMODE
-	user.notransform = 0
-	user.forceMove(get_turf(Z))
-	user.visible_message("<span class='danger'>[user] pops back into reality!</span>")
-	Z.can_destroy = TRUE
-	qdel(Z)
+	. = ..()
+	new /obj/effect/immortality_talisman/void(get_turf(user), user)

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -296,6 +296,14 @@
 	name = "\improper DNA injector (Anti-Laser Eyes)"
 	remove_mutations = list(LASEREYES)
 
+/obj/item/dnainjector/void
+	name = "\improper DNA injector (Void)"
+	add_mutations = list(VOID)
+
+/obj/item/dnainjector/antivoid
+	name = "\improper DNA injector (Anti-Void)"
+	remove_mutations = list(VOID)
+
 /obj/item/dnainjector/timed
 	var/duration = 600
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -461,30 +461,45 @@
 	if(cooldown < world.time)
 		SSblackbox.record_feedback("amount", "immortality_talisman_uses", 1)
 		cooldown = world.time + 600
-		user.visible_message("<span class='danger'>[user] vanishes from reality, leaving a hole in [user.p_their()] place!</span>")
-		var/obj/effect/immortality_talisman/Z = new(get_turf(src.loc))
-		Z.name = "hole in reality"
-		Z.desc = "It's shaped an awful lot like [user.name]."
-		Z.setDir(user.dir)
-		user.forceMove(Z)
-		user.notransform = 1
-		user.status_flags |= GODMODE
-		addtimer(CALLBACK(src, .proc/return_to_reality, user, Z), 100)
+		new /obj/effect/immortality_talisman(get_turf(user), user)
 	else
 		to_chat(user, "<span class='warning'>[src] is not ready yet!</span>")
 
-/obj/item/immortality_talisman/proc/return_to_reality(mob/user, obj/effect/immortality_talisman/Z)
-	user.status_flags &= ~GODMODE
-	user.notransform = 0
-	user.forceMove(get_turf(Z))
-	user.visible_message("<span class='danger'>[user] pops back into reality!</span>")
-	Z.can_destroy = TRUE
-	qdel(Z)
-
 /obj/effect/immortality_talisman
+	name = "hole in reality"
+	desc = "It's shaped an awful lot like a person."
 	icon_state = "blank"
 	icon = 'icons/effects/effects.dmi'
-	var/can_destroy = FALSE
+	var/vanish_description = "vanishes from reality"
+	var/can_destroy = TRUE
+
+/obj/effect/immortality_talisman/Initialize(mapload, mob/new_user)
+	. = ..()
+	if(new_user)
+		vanish(new_user)
+
+/obj/effect/immortality_talisman/proc/vanish(mob/user)
+	user.visible_message("<span class='danger'>[user] [vanish_description], leaving a hole in [user.p_their()] place!</span>")
+
+	desc = "It's shaped an awful lot like [user.name]."
+	setDir(user.dir)
+
+	user.forceMove(src)
+	user.notransform = TRUE
+	user.status_flags |= GODMODE
+
+	can_destroy = FALSE
+
+	addtimer(CALLBACK(src, .proc/unvanish, user), 10 SECONDS)
+
+/obj/effect/immortality_talisman/proc/unvanish(mob/user)
+	user.status_flags &= ~GODMODE
+	user.notransform = FALSE
+	user.forceMove(get_turf(src))
+
+	user.visible_message("<span class='danger'>[user] pops back into reality!</span>")
+	can_destroy = TRUE
+	qdel(src)
 
 /obj/effect/immortality_talisman/attackby()
 	return
@@ -501,6 +516,8 @@
 	else
 		. = ..()
 
+/obj/effect/immortality_talisman/void
+	vanish_description = "dragged into the void"
 
 //Shared Bag
 


### PR DESCRIPTION
:cl: coiax
fix: Humans with the Void mutation will no longer be able to enter the void
while inside something else (eg. cloning pod, cryotube) willingly or unwillingly.
/:cl:

- I refactored immortality talisman effects to stop all this ugly ass code
reusing, and stop the weird modification of the speech invocation.
- I added DNA injectors for the Void mutation for testing.