### PR TITLE
After a curse of madness has been triggered, even latejoiners are affected

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -384,6 +384,8 @@
 			give_guns(humanc)
 		if(GLOB.summon_magic_triggered)
 			give_magic(humanc)
+		if(GLOB.curse_of_madness_triggered)
+			give_madness(humanc, GLOB.curse_of_madness_triggered)
 
 	GLOB.joined_player_list += character.ckey
 

--- a/code/modules/spells/spell_types/curse.dm
+++ b/code/modules/spells/spell_types/curse.dm
@@ -1,8 +1,12 @@
+GLOBAL_VAR_INIT(curse_of_madness_triggered, FALSE)
+
 /proc/curse_of_madness(mob/user, message)
 	if(user) //in this case either someone holding a spellbook or a badmin
 		to_chat(user, "<span class='warning'>You sent a curse of madness with the message \"[message]\"!</span>")
 		message_admins("[ADMIN_LOOKUPFLW(user)] sent a curse of madness with the message \"[message]\"!")
 		log_game("[key_name(user)] sent a curse of madness with the message \"[message]\"!")
+
+	GLOB.curse_of_madness_triggered = message // So latejoiners are also afflicted.
 
 	deadchat_broadcast("<span class='deadsay'>A <span class='name'>Curse of Madness</span> has stricken the station, shattering their minds with the awful secret: \"<span class='big hypnophrase'>[message]</span>\"</span>")
 
@@ -18,16 +22,19 @@
 		if(istype(H.get_item_by_slot(SLOT_HEAD), /obj/item/clothing/head/foilhat))
 			to_chat(H, "<span class='warning'>Your protective headgear successfully deflects mind controlling brainwaves!</span>")
 			continue
-		H.playsound_local(H,'sound/hallucinations/veryfar_noise.ogg',40,1)
-		to_chat(H, "<span class='reallybig hypnophrase'>[message]</span>")
-		to_chat(H, "<span class='warning'>Your mind shatters!</span>")
-		switch(rand(1,10))
-			if(1 to 3)
-				H.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_LOBOTOMY)
-				H.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_LOBOTOMY)
-			if(4 to 6)
-				H.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_LOBOTOMY)
-			if(7 to 8)
-				H.gain_trauma_type(BRAIN_TRAUMA_MAGIC, TRAUMA_RESILIENCE_LOBOTOMY)
-			if(9 to 10)
-				H.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_LOBOTOMY)
+		give_madness(H, message)
+
+/proc/give_madness(mob/living/carbon/human/H, message)
+	H.playsound_local(H,'sound/hallucinations/veryfar_noise.ogg',40,1)
+	to_chat(H, "<span class='reallybig hypnophrase'>[message]</span>")
+	to_chat(H, "<span class='warning'>Your mind shatters!</span>")
+	switch(rand(1,10))
+		if(1 to 3)
+			H.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_LOBOTOMY)
+			H.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_LOBOTOMY)
+		if(4 to 6)
+			H.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_LOBOTOMY)
+		if(7 to 8)
+			H.gain_trauma_type(BRAIN_TRAUMA_MAGIC, TRAUMA_RESILIENCE_LOBOTOMY)
+		if(9 to 10)
+			H.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_LOBOTOMY)


### PR DESCRIPTION
:cl: coiax
tweak: After a Curse of Madness has ravaged the mind of the station,
the lingering magics also affect anyone arriving to the station late.
/:cl:

Why? People joining late get summoned guns, and summoned magic, they should
get summoned madness as well. Why should they miss out on the "fun"?
