### PR TITLE
[READY]Atmos: Things Other Than Bombs Edition

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -15,7 +15,7 @@
 #define TRITIUM_BURN_TRIT_FACTOR			10
 #define TRITIUM_BURN_RADIOACTIVITY_FACTOR	50000 	//The neutrons gotta go somewhere. Completely arbitrary number.
 #define TRITIUM_MINIMUM_RADIATION_ENERGY	0.1  	//minimum 0.01 moles trit or 10 moles oxygen to start producing rads
-#define MINIMUM_TRIT_OXYBURN_ENERGY 		100000	//This is calculated to help prevent singlecap bombs(Overpowered tritium/oxygen single tank bombs)
+#define MINIMUM_TRIT_OXYBURN_ENERGY 		2000000	//This is calculated to help prevent singlecap bombs(Overpowered tritium/oxygen single tank bombs)
 #define SUPER_SATURATION_THRESHOLD			96
 #define STIMULUM_HEAT_SCALE					100000
 #define STIMULUM_FIRST_RISE					0.65

--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -15,6 +15,7 @@
 #define TRITIUM_BURN_TRIT_FACTOR			10
 #define TRITIUM_BURN_RADIOACTIVITY_FACTOR	50000 	//The neutrons gotta go somewhere. Completely arbitrary number.
 #define TRITIUM_MINIMUM_RADIATION_ENERGY	0.1  	//minimum 0.01 moles trit or 10 moles oxygen to start producing rads
+#define MINIMUM_TRIT_OXYBURN_ENERGY 		100000	//This is calculated to help prevent singlecap bombs(Overpowered tritium/oxygen single tank bombs)
 #define SUPER_SATURATION_THRESHOLD			96
 #define STIMULUM_HEAT_SCALE					100000
 #define STIMULUM_FIRST_RISE					0.65
@@ -23,6 +24,11 @@
 #define STIMULUM_ABSOLUTE_DROP				0.00000335
 #define REACTION_OPPRESSION_THRESHOLD		5
 #define NOBLIUM_FORMATION_ENERGY			2e9 	//1 Mole of Noblium takes the planck energy to condense.
+//Research point amounts
+#define NOBLIUM_RESEARCH_AMOUNT				1000
+#define BZ_RESEARCH_AMOUNT					150
+#define MIASMA_RESEARCH_AMOUNT				160
+#define STIMULUM_RESEARCH_AMOUNT			50
 //Plasma fusion properties
 #define FUSION_ENERGY_THRESHOLD				3e9 	//Amount of energy it takes to start a fusion reaction
 #define FUSION_TEMPERATURE_THRESHOLD		1000 	//Temperature required to start a fusion reaction

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -393,7 +393,7 @@
 	cached_gases[/datum/gas/nitrous_oxide][MOLES] -= reaction_efficency
 	cached_gases[/datum/gas/plasma][MOLES]  -= 2*reaction_efficency
 
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, reaction_efficency*100)
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, (reaction_efficency**0.5)*200)
 
 	if(energy_released > 0)
 		var/new_heat_capacity = air.heat_capacity()
@@ -428,7 +428,7 @@
 	cached_gases[/datum/gas/tritium][MOLES] -= heat_scale
 	cached_gases[/datum/gas/plasma][MOLES] -= heat_scale
 	cached_gases[/datum/gas/nitryl][MOLES] -= heat_scale
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, stim_energy_change/100)
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, 50*max(stim_energy_change,0))
 	if(stim_energy_change)
 		var/new_heat_capacity = air.heat_capacity()
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
@@ -490,4 +490,4 @@
 
 	//Possibly burning a bit of organic matter through maillard reaction, so a *tiny* bit more heat would be understandable
 	air.temperature += cleaned_air * 0.002
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, cleaned_air*1000)//Turns out the burning of miasma is kinda interesting.
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, cleaned_air*160)//Turns out the burning of miasma is kinda interesting to scientists

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -101,9 +101,12 @@
 	var/list/cached_results = air.reaction_results
 	cached_results["fire"] = 0
 	var/turf/open/location = isturf(holder) ? holder : null
-
+	var/rare_oxidizers = 0
+	air.assert_gases(/datum/gas/nitryl,/datum/gas/nitrous_oxide)
+	if ((cached_gases[/datum/gas/nitryl][MOLES] + cached_gases[/datum/gas/nitrous_oxide][MOLES]) > 10)
+		rare_oxidizers = (cached_gases[/datum/gas/nitryl][MOLES]*cached_gases[/datum/gas/nitryl][GAS_META][META_GAS_FUSION_POWER]) + cached_gases[/datum/gas/nitrous_oxide][MOLES]
 	var/burned_fuel = 0
-	if(cached_gases[/datum/gas/oxygen][MOLES] < cached_gases[/datum/gas/tritium][MOLES])
+	if(cached_gases[/datum/gas/oxygen][MOLES] < cached_gases[/datum/gas/tritium][MOLES] + rare_oxidizers)
 		burned_fuel = cached_gases[/datum/gas/oxygen][MOLES]/TRITIUM_BURN_OXY_FACTOR
 		cached_gases[/datum/gas/tritium][MOLES] -= burned_fuel
 	else
@@ -112,7 +115,7 @@
 		cached_gases[/datum/gas/oxygen][MOLES] -= cached_gases[/datum/gas/tritium][MOLES]
 
 	if(burned_fuel)
-		energy_released += FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel
+		energy_released += (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel) + (rare_oxidizers*450) - rare_oxidizers**2
 		if(location && prob(10) && burned_fuel > TRITIUM_MINIMUM_RADIATION_ENERGY) //woah there let's not crash the server
 			radiation_pulse(location, energy_released/TRITIUM_BURN_RADIOACTIVITY_FACTOR)
 
@@ -308,6 +311,7 @@
 			if(do_explosion)
 				explosion(location, 0, 0, 5, power_ratio, TRUE, TRUE) //large shockwave, the actual radius is quite small - people will recognize that you're doing fusion
 			radiation_pulse(location, radiation_power) //You mean causing a super-tier fusion reaction in the halls is a bad idea?
+			SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, 30000)//The science is cool though.
 			playsound(location, 'sound/effects/supermatter.ogg', 100, 0)
 		else
 			playsound(location, 'sound/effects/phasein.ogg', 75, 0)
@@ -374,13 +378,22 @@
 	var/old_heat_capacity = air.heat_capacity()
 	var/reaction_efficency = min(1/((pressure/(0.1*ONE_ATMOSPHERE))*(max(cached_gases[/datum/gas/plasma][MOLES]/cached_gases[/datum/gas/nitrous_oxide][MOLES],1))),cached_gases[/datum/gas/nitrous_oxide][MOLES],cached_gases[/datum/gas/plasma][MOLES]/2)
 	var/energy_released = 2*reaction_efficency*FIRE_CARBON_ENERGY_RELEASED
+	if(cached_gases[/datum/gas/miasma] && cached_gases[/datum/gas/miasma][MOLES] > 0)
+		energy_released /= cached_gases[/datum/gas/miasma][MOLES]*0.1
+	if(cached_gases[/datum/gas/bz] && cached_gases[/datum/gas/bz][MOLES] > 0)
+		energy_released *= cached_gases[/datum/gas/bz][MOLES]*0.1
 	if ((cached_gases[/datum/gas/nitrous_oxide][MOLES] - reaction_efficency < 0 )|| (cached_gases[/datum/gas/plasma][MOLES] - (2*reaction_efficency) < 0)) //Shouldn't produce gas from nothing.
 		return NO_REACTION
 	ASSERT_GAS(/datum/gas/bz,air)
 	cached_gases[/datum/gas/bz][MOLES] += reaction_efficency
+	if(reaction_efficency == cached_gases[/datum/gas/nitrous_oxide][MOLES])
+		ASSERT_GAS(/datum/gas/oxygen,air)
+		cached_gases[/datum/gas/bz][MOLES] -= min(pressure,1)
+		cached_gases[/datum/gas/oxygen][MOLES] += min(pressure,1)
 	cached_gases[/datum/gas/nitrous_oxide][MOLES] -= reaction_efficency
 	cached_gases[/datum/gas/plasma][MOLES]  -= 2*reaction_efficency
 
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, reaction_efficency*100)
 
 	if(energy_released > 0)
 		var/new_heat_capacity = air.heat_capacity()
@@ -415,7 +428,7 @@
 	cached_gases[/datum/gas/tritium][MOLES] -= heat_scale
 	cached_gases[/datum/gas/plasma][MOLES] -= heat_scale
 	cached_gases[/datum/gas/nitryl][MOLES] -= heat_scale
-
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, stim_energy_change/100)
 	if(stim_energy_change)
 		var/new_heat_capacity = air.heat_capacity()
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
@@ -444,7 +457,7 @@
 	cached_gases[/datum/gas/tritium][MOLES] -= 10*nob_formed
 	cached_gases[/datum/gas/nitrogen][MOLES] -= 20*nob_formed
 	cached_gases[/datum/gas/hypernoblium][MOLES]+= nob_formed
-
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, nob_formed*1000)
 
 	if (nob_formed)
 		var/new_heat_capacity = air.heat_capacity()
@@ -477,3 +490,4 @@
 
 	//Possibly burning a bit of organic matter through maillard reaction, so a *tiny* bit more heat would be understandable
 	air.temperature += cleaned_air * 0.002
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, cleaned_air*1000)//Turns out the burning of miasma is kinda interesting.

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -101,12 +101,8 @@
 	var/list/cached_results = air.reaction_results
 	cached_results["fire"] = 0
 	var/turf/open/location = isturf(holder) ? holder : null
-	var/rare_oxidizers = 0
-	air.assert_gases(/datum/gas/nitryl,/datum/gas/nitrous_oxide)
-	if ((cached_gases[/datum/gas/nitryl][MOLES] + cached_gases[/datum/gas/nitrous_oxide][MOLES]) > 10)
-		rare_oxidizers = (cached_gases[/datum/gas/nitryl][MOLES]*cached_gases[/datum/gas/nitryl][GAS_META][META_GAS_FUSION_POWER]) + cached_gases[/datum/gas/nitrous_oxide][MOLES]
 	var/burned_fuel = 0
-	if(cached_gases[/datum/gas/oxygen][MOLES] < cached_gases[/datum/gas/tritium][MOLES] + rare_oxidizers)
+	if(cached_gases[/datum/gas/oxygen][MOLES] < cached_gases[/datum/gas/tritium][MOLES] || MINIMUM_TRIT_OXYBURN_ENERGY > air.thermal_energy())
 		burned_fuel = cached_gases[/datum/gas/oxygen][MOLES]/TRITIUM_BURN_OXY_FACTOR
 		cached_gases[/datum/gas/tritium][MOLES] -= burned_fuel
 	else
@@ -115,7 +111,7 @@
 		cached_gases[/datum/gas/oxygen][MOLES] -= cached_gases[/datum/gas/tritium][MOLES]
 
 	if(burned_fuel)
-		energy_released += (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel) + (rare_oxidizers*450) - rare_oxidizers**2
+		energy_released += (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel)
 		if(location && prob(10) && burned_fuel > TRITIUM_MINIMUM_RADIATION_ENERGY) //woah there let's not crash the server
 			radiation_pulse(location, energy_released/TRITIUM_BURN_RADIOACTIVITY_FACTOR)
 
@@ -393,7 +389,7 @@
 	cached_gases[/datum/gas/nitrous_oxide][MOLES] -= reaction_efficency
 	cached_gases[/datum/gas/plasma][MOLES]  -= 2*reaction_efficency
 
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, (reaction_efficency**0.5)*200)
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, (reaction_efficency**0.5)*BZ_RESEARCH_AMOUNT)
 
 	if(energy_released > 0)
 		var/new_heat_capacity = air.heat_capacity()
@@ -428,7 +424,7 @@
 	cached_gases[/datum/gas/tritium][MOLES] -= heat_scale
 	cached_gases[/datum/gas/plasma][MOLES] -= heat_scale
 	cached_gases[/datum/gas/nitryl][MOLES] -= heat_scale
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, 50*max(stim_energy_change,0))
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, STIMULUM_RESEARCH_AMOUNT*max(stim_energy_change,0))
 	if(stim_energy_change)
 		var/new_heat_capacity = air.heat_capacity()
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
@@ -457,7 +453,7 @@
 	cached_gases[/datum/gas/tritium][MOLES] -= 10*nob_formed
 	cached_gases[/datum/gas/nitrogen][MOLES] -= 20*nob_formed
 	cached_gases[/datum/gas/hypernoblium][MOLES]+= nob_formed
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, nob_formed*1000)
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, nob_formed*NOBLIUM_RESEARCH_AMOUNT)
 
 	if (nob_formed)
 		var/new_heat_capacity = air.heat_capacity()
@@ -490,4 +486,4 @@
 
 	//Possibly burning a bit of organic matter through maillard reaction, so a *tiny* bit more heat would be understandable
 	air.temperature += cleaned_air * 0.002
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, cleaned_air*160)//Turns out the burning of miasma is kinda interesting to scientists
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, cleaned_air*MIASMA_RESEARCH_AMOUNT)//Turns out the burning of miasma is kinda interesting to scientists

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -137,7 +137,7 @@
 	cost = 10 //Base cost of canister. You get more for nice gases inside.
 	unit_name = "Gas Canister"
 	export_types = list(/obj/machinery/portable_atmospherics/canister)
-/datum/export/large/gas_canister/get_cost(obj/o)
+/datum/export/large/gas_canister/get_cost(obj/O)
 	var/obj/machinery/portable_atmospherics/canister/C = O
 	var/worth = 10
 	var/gases = C.air_contents.gases

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -142,10 +142,10 @@
 	var/gas_worth = 0
 	var/gases = C.air_contents.gases
 	C.air_contents.assert_gases(/datum/gas/bz,/datum/gas/stimulum,/datum/gas/hypernoblium,/datum/gas/miasma,/datum/gas/tritium,/datum/gas/pluox)
-	gas_worth += gases[/datum/gas/bz][MOLES]*50
+	gas_worth += gases[/datum/gas/bz][MOLES]*4
 	gas_worth += gases[/datum/gas/stimulum][MOLES]*100
 	gas_worth += gases[/datum/gas/hypernoblium][MOLES]*1000
 	gas_worth += gases[/datum/gas/miasma][MOLES]*40
 	gas_worth += gases[/datum/gas/tritium]*10
-	gas_worth += gases[/datum/gas/pluox]*100
+	gas_worth += gases[/datum/gas/pluoxium]*100
 	return ..() + gas_worth

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -137,6 +137,7 @@
 	cost = 10 //Base cost of canister. You get more for nice gases inside.
 	unit_name = "Gas Canister"
 	export_types = list(/obj/machinery/portable_atmospherics/canister)
+/datum/export/large/gas_canister/get_cost(obj/o)
 	var/obj/machinery/portable_atmospherics/canister/C = O
 	var/worth = 10
 	var/gases = C.air_contents.gases

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -133,3 +133,19 @@
 	unit_name = "security barrier"
 	export_types = list(/obj/item/grenade/barrier, /obj/structure/barricade/security)
 
+/datum/export/large/gas_canister
+	cost = 10 //Base cost of canister. You get more for nice gases inside.
+	unit_name = "Canister of gas"
+	export_types = list(/obj/machinery/portable_atmospherics/canister)
+/datum/export/large/canister/get_cost(obj/O)
+	var/obj/machinery/portable_atmospherics/canister/C = O
+	var/gas_worth = 0
+	var/gases = C.air_contents.gases
+	C.air_contents.assert_gases(/datum/gas/bz,/datum/gas/stimulum,/datum/gas/hypernoblium,/datum/gas/miasma,/datum/gas/tritium,/datum/gas/pluox)
+	gas_worth += gases[/datum/gas/bz][MOLES]*50
+	gas_worth += gases[/datum/gas/stimulum][MOLES]*100
+	gas_worth += gases[/datum/gas/hypernoblium][MOLES]*1000
+	gas_worth += gases[/datum/gas/miasma][MOLES]*40
+	gas_worth += gases[/datum/gas/tritium]*10
+	gas_worth += gases[/datum/gas/pluox]*100
+	return ..() + gas_worth

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -135,17 +135,19 @@
 
 /datum/export/large/gas_canister
 	cost = 10 //Base cost of canister. You get more for nice gases inside.
-	unit_name = "Canister of gas"
+	unit_name = "Gas Canister"
 	export_types = list(/obj/machinery/portable_atmospherics/canister)
-/datum/export/large/canister/get_cost(obj/O)
+
+/datum/export/large/gas_canister/get_cost(obj/O, allowed_catergories = NONE, apply_elastic = FALSE)
 	var/obj/machinery/portable_atmospherics/canister/C = O
-	var/gas_worth = 0
+	var/worth = 10
 	var/gases = C.air_contents.gases
-	C.air_contents.assert_gases(/datum/gas/bz,/datum/gas/stimulum,/datum/gas/hypernoblium,/datum/gas/miasma,/datum/gas/tritium,/datum/gas/pluox)
-	gas_worth += gases[/datum/gas/bz][MOLES]*50
-	gas_worth += gases[/datum/gas/stimulum][MOLES]*100
-	gas_worth += gases[/datum/gas/hypernoblium][MOLES]*1000
-	gas_worth += gases[/datum/gas/miasma][MOLES]*40
-	gas_worth += gases[/datum/gas/tritium]*10
-	gas_worth += gases[/datum/gas/pluox]*100
-	return ..() + gas_worth
+	C.air_contents.assert_gases(/datum/gas/bz,/datum/gas/stimulum,/datum/gas/hypernoblium,/datum/gas/miasma,/datum/gas/tritium,/datum/gas/pluoxium)
+
+	worth += gases[/datum/gas/bz][MOLES]*50
+	worth += gases[/datum/gas/stimulum][MOLES]*100
+	worth += gases[/datum/gas/hypernoblium][MOLES]*1000
+	worth += gases[/datum/gas/miasma][MOLES]*40
+	worth += gases[/datum/gas/tritium][MOLES]*10
+	worth += gases[/datum/gas/pluoxium][MOLES]*100
+	return worth

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -141,7 +141,7 @@
 	var/obj/machinery/portable_atmospherics/canister/C = O
 	var/gas_worth = 0
 	var/gases = C.air_contents.gases
-	C.air_contents.assert_gases(/datum/gas/bz,/datum/gas/stimulum,/datum/gas/hypernoblium,/datum/gas/miasma,/datum/gas/tritium,/datum/gas/pluox)
+	C.air_contents.assert_gases(/datum/gas/bz,/datum/gas/stimulum,/datum/gas/hypernoblium,/datum/gas/miasma,/datum/gas/tritium,/datum/gas/pluoxium)
 	gas_worth += gases[/datum/gas/bz][MOLES]*4
 	gas_worth += gases[/datum/gas/stimulum][MOLES]*100
 	gas_worth += gases[/datum/gas/hypernoblium][MOLES]*1000


### PR DESCRIPTION
Due to the difficulty of interacting with the more complicated atmos content, the only things that toxin scientists and atmospheric technicians tend to focus on is bombs. The goal here is to give them some more productive things to do that encourage them to branch out beyond Tritium production and bomb rushing.  Singlecaps, single tank bombs made with oxygen and tritium are also a recent balance concern that this hopefully addresses by adding a thermal energy requirement, which hopefully should make singlecaps either impossible or at least more difficult to construct, but leave normal bombs more or less intact. Also adds some ways for other gases in the mix to influence the BZ production reaction.

I'm looking for feedback on the specific number for values for how many points reactions give. I did my best to figure out some reasonable amounts via math, but I don't know that much about how techwebs are balanced.

:cl: as334
add: Tritium now needs to be an environment with a sizable thermal mass for full efficiency combustion.
add: Advanced Gas reactions now produce research points. 
add: A gas canister with Pluoxium, Noblium, Stimulum, Miasma or BZ inside now produces points when sold via cargo.
/:cl:



