### PR TITLE
Fix miasma infecting space

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -329,6 +329,8 @@
 
 	var/turf/T = get_turf(H)
 	var/datum/gas_mixture/air = T.return_air()
+	if(istype(air, /datum/gas_mixture/immutable))
+		return
 	var/list/cached_gases = air.gases
 
 	ASSERT_GAS(/datum/gas/miasma, air)

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -328,13 +328,10 @@
 		return
 
 	var/turf/T = get_turf(H)
-	var/datum/gas_mixture/air = T.return_air()
-	if(istype(air, /datum/gas_mixture/immutable))
-		return
-	var/list/cached_gases = air.gases
-
-	ASSERT_GAS(/datum/gas/miasma, air)
-	cached_gases[/datum/gas/miasma][MOLES] += MIASMA_HYGIENE_MOLES
+	var/datum/gas_mixture/stank = new
+	ADD_GAS(/datum/gas/miasma, stank.gases)
+	stank.gases[/datum/gas/miasma][MOLES] = MIASMA_HYGIENE_MOLES
+	T.assume_air(stank)
 	T.air_update_turf()
 
 #undef MINOR_INSANITY_PEN

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -17,13 +17,10 @@
 	if(!istype(T))
 		return
 
-	var/datum/gas_mixture/air = T.return_air()
-	if(istype(air, /datum/gas_mixture/immutable))
-		return
-	var/list/cached_gases = air.gases
-
-	ASSERT_GAS(/datum/gas/miasma, air)
-	cached_gases[/datum/gas/miasma][MOLES] += amount
+	var/datum/gas_mixture/stank = new
+	ADD_GAS(/datum/gas/miasma, stank.gases)
+	stank.gases[/datum/gas/miasma][MOLES] = amount
+	T.assume_air(stank)
 	T.air_update_turf()
 
 /datum/component/rot/corpse

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -18,6 +18,8 @@
 		return
 
 	var/datum/gas_mixture/air = T.return_air()
+	if(istype(air, /datum/gas_mixture/immutable))
+		return
 	var/list/cached_gases = air.gases
 
 	ASSERT_GAS(/datum/gas/miasma, air)


### PR DESCRIPTION
:cl:
fix: Corpses in space no longer add miasma to the gas readout of space.
/:cl:

Fixes #42177. As mentioned in that ticket, the way space is implemented this doesn't cause real problems, but it'd be nice to not have weird inconsistencies.