### PR TITLE
Fixes Spontaneous Brain Trauma runtimes

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -297,9 +297,17 @@
 		new /obj/item/reagent_containers/pill/happiness(src)
 
 /obj/item/storage/pill_bottle/penacid
-	name = "bottle of pentetic acid"
+	name = "bottle of pentetic acid pills"
 	desc = "Contains pills to expunge radioation and toxins"
 
 /obj/item/storage/pill_bottle/penacid/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/pill/penacid(src)
+
+/obj/item/storage/pill_bottle/neurine
+	name = "bottle of neurine pills"
+	desc = "Contains pills to treat non-severe mental traumas."
+
+/obj/item/storage/pill_bottle/neurine/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/neurine(src)

--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -20,11 +20,12 @@
 		break
 
 /datum/round_event/brain_trauma/proc/traumatize(mob/living/carbon/human/H)
-	var/resistance = pickweight(list(
-		TRAUMA_RESILIENCE_BASIC = 50,
-		TRAUMA_RESILIENCE_SURGERY = 30,
-		TRAUMA_RESILIENCE_LOBOTOMY = 15,
-		TRAUMA_RESILIENCE_MAGIC = 5))
+	var/resistance = pick(
+		50;TRAUMA_RESILIENCE_BASIC,
+		30;TRAUMA_RESILIENCE_SURGERY,
+		15;TRAUMA_RESILIENCE_LOBOTOMY,
+		5;TRAUMA_RESILIENCE_MAGIC)
+
 	var/trauma_type = pickweight(list(
 		BRAIN_TRAUMA_MILD = 60,
 		BRAIN_TRAUMA_SEVERE = 30,

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -160,10 +160,11 @@
 
 /obj/item/reagent_containers/pill/psicodine
 	name = "psicodine pill"
-	desc = "Used to treat mental instability and traumas."
+	desc = "Used to treat mental instability and phobias."
 	list_reagents = list("psicodine" = 10)
 	icon_state = "pill22"
 	roundstart = TRUE
+
 /obj/item/reagent_containers/pill/penacid
 	name = "pentetic acid pill"
 	desc = "Used to expunge radioation and toxins."
@@ -202,6 +203,13 @@
 	desc = "It has a creepy smiling face on it."
 	icon_state = "pill_happy"
 	list_reagents = list("happiness" = 10)
+
+/obj/item/reagent_containers/pill/neurine
+	name = "neurine pill"
+	desc = "Used to treat non-severe mental traumas."
+	list_reagents = list("neurine" = 10)
+	icon_state = "pill22"
+	roundstart = TRUE
 
 
 /obj/item/reagent_containers/pill/floorpill


### PR DESCRIPTION
:cl: coiax
fix: The Spontaneous Brain Trauma event now has a range of possible severities,
and no longer runtimes.
/:cl:

In addition, I changed the description/names of some pills to make them more
accurate, and added some neurine pills, because I needed them for testing.

With thanks to @oranges for spotting the runtime in the first place.