### PR TITLE
Adds improvised bruise packs and ointments

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -113,6 +113,13 @@
 	self_delay = 20
 	grind_results = list("styptic_powder" = 10)
 
+/obj/item/stack/medical/bruise_pack/improvised
+	name = "improvised bruise pack"
+	singular_name = "improvised bruise pack"
+	desc = "A pack used for treating tissue damage. This one is made from junk from all around the station."
+	heal_brute = 20
+	grind_results = list("styptic_powder" = 5, "omnizine" = 5)
+
 /obj/item/stack/medical/bruise_pack/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is bludgeoning [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return (BRUTELOSS)
@@ -167,6 +174,13 @@
 	heal_burn = 40
 	self_delay = 20
 	grind_results = list("silver_sulfadiazine" = 10)
+
+/obj/item/stack/medical/ointment/improvised
+	name = "improvised ointment"
+	desc = "Used to treat burns. Made from junk from the station"
+	singular_name = "improvised ointment"
+	heal_burn = 20
+	grind_results = list("silver_sulfadiazine" = 5, "omnizine" = 5)
 
 /obj/item/stack/medical/ointment/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is squeezing \the [src] into [user.p_their()] mouth! [user.p_do(TRUE)]n't [user.p_they()] know that stuff is toxic?</span>")

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -118,7 +118,7 @@
 	singular_name = "improvised bruise pack"
 	desc = "A pack used for treating tissue damage. This one is made from junk from all around the station."
 	heal_brute = 20
-	grind_results = list("styptic_powder" = 5, "omnizine" = 5)
+	grind_results = list("styptic_powder" = 5)
 
 /obj/item/stack/medical/bruise_pack/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is bludgeoning [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -180,7 +180,7 @@
 	desc = "Used to treat burns. Made from junk from the station"
 	singular_name = "improvised ointment"
 	heal_burn = 20
-	grind_results = list("silver_sulfadiazine" = 5, "omnizine" = 5)
+	grind_results = list("silver_sulfadiazine" = 5)
 
 /obj/item/stack/medical/ointment/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is squeezing \the [src] into [user.p_their()] mouth! [user.p_do(TRUE)]n't [user.p_they()] know that stuff is toxic?</span>")

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -663,3 +663,15 @@
 	reqs = list(/obj/item/tank/internals/oxygen/red = 2, /obj/item/extinguisher = 1, /obj/item/pipe = 3, /obj/item/stack/cable_coil = 30)//red oxygen tank so it looks right
 	category = CAT_MISC
 	tools = list(TOOL_WRENCH, TOOL_WELDER, TOOL_WIRECUTTER)
+
+/datum/crafting_recipe/improvisedbruisepack/
+	name = "Improvised Bruise Pack"
+	result = /obj/item/stack/medical/bruise_pack/improvised
+	time = 30
+	reqs = list(/obj/item/stack/sheet/cloth = 1, /obj/item/reagent_containers/food/snacks/donkpocket = 1)
+	category = CAT_MISC
+	tools = list(TOOL_WELDER)
+
+/datum/crafting_recipe/improvisedbruisepack/ointment
+	name = "Improvised Ointment"
+	result =  /obj/item/stack/medical/ointment/improvised


### PR DESCRIPTION
[Changelogs]: Adds improvised bruise packs and ointments tomedical.dm which are as half as good as the normal ones. Also adds a datum to recipes.dm to craft said items. 

The recipe for the bruise pack and the ointment is the same. Cloth + Donkpocket Tools: Welder
It can be found under the misc category.


:cl: Yokool
add: Added Improvised Bruise Packs
add: Added Improvised Ointments
add: Added a way to craft Improvised Bruise Packs and Improvised Ointments.
/:cl:



[why]: I feel like there should be a way to make makeshift bruisepacks and ointments from donkpockets that can be found in maint crates, without having the access to medical when those special plasma flood rounds happen.
