### PR TITLE
Slightly modifies the plastitanium wall description to make it less evil.

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -572,7 +572,7 @@
 
 /obj/structure/window/plastitanium
 	name = "plastitanium window"
-	desc = "An evil looking window of plasma and titanium."
+	desc = "A durable looking window made of an alloy of of plasma and titanium."
 	icon = 'icons/obj/smooth_structures/plastitanium_window.dmi'
 	icon_state = "plastitanium_window"
 	dir = FULLTILE_WINDOW_DIR

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -249,7 +249,7 @@
 
 /turf/closed/wall/mineral/plastitanium
 	name = "wall"
-	desc = "An evil wall of plasma and titanium."
+	desc = "An durable wall made of an alloy of plasma and titanium."
 	icon = 'icons/turf/walls/plastitanium_wall.dmi'
 	icon_state = "map-shuttle"
 	explosion_block = 4

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -249,7 +249,7 @@
 
 /turf/closed/wall/mineral/plastitanium
 	name = "wall"
-	desc = "An durable wall made of an alloy of plasma and titanium."
+	desc = "A durable wall made of an alloy of plasma and titanium."
 	icon = 'icons/turf/walls/plastitanium_wall.dmi'
 	icon_state = "map-shuttle"
 	explosion_block = 4


### PR DESCRIPTION

:cl:
tweak: Plastitanium walls are no longer evil.
/:cl:

This description doesn't really make much sense when people use them for flavor on stations and sometimes to make entire NT shuttles out of. So it's no longer evil.