### PR TITLE
Replaces the insulated gloves in the CE's locker with red insulateds

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -9,7 +9,7 @@
 	new /obj/item/clothing/under/rank/chief_engineer(src)
 	new /obj/item/clothing/head/hardhat/white(src)
 	new /obj/item/clothing/head/welding(src)
-	new /obj/item/clothing/gloves/color/yellow(src)
+	new /obj/item/clothing/gloves/color/red/insulated(src)
 	new /obj/item/clothing/shoes/sneakers/brown(src)
 	new /obj/item/tank/jetpack/suit(src)
 	new /obj/item/cartridge/ce(src)


### PR DESCRIPTION
:cl: 
tweak: The gloves in the CE's locker are red now. Still insulated.
/:cl:

These exist in the code but they're not used anywhere. I thought it would make for an interesting bit of flavor - they're unique to the CE. It looks nice IMO.