### PR TITLE
turns the 2 hygiene quirks into mood quirks

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -153,6 +153,7 @@
 	mob_trait = TRAIT_NEET
 	gain_text = "<span class='notice'>You feel useless to society.</span>"
 	lose_text = "<span class='danger'>You no longer feel useless to society.</span>"
+	mood_quirk = TRUE
 
 /datum/quirk/neet/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -95,6 +95,7 @@
 	mob_trait = TRAIT_NEAT
 	gain_text = "<span class='notice'>You feel like you have to stay clean.</span>"
 	lose_text = "<span class='danger'>You no longer feel the need to always be clean.</span>"
+	mood_quirk = TRUE
 
 /datum/quirk/monochromatic
 	name = "Monochromacy"


### PR DESCRIPTION
:cl: Noch
fix: the 2 hygiene quirks are now designated as mood_quirks, since they center around mood
/:cl:

The 2 quirks center around liking/dislinking being dirty, so they should be designated as mood_quirks
