### PR TITLE
MakeDirty() is only called 33% of the time

### DIFF
--- a/code/game/turfs/simulated/dirtystation.dm
+++ b/code/game/turfs/simulated/dirtystation.dm
@@ -8,8 +8,7 @@
 //Making the station dirty, one tile at a time. Called by master controller's setup_objects
 
 /turf/open/floor/proc/MakeDirty()
-	if(prob(66))	//fastest possible exit 2/3 of the time
-		return
+	// We start with a 1/3 chance of having this proc called by Initialize()
 
 	if(!(flags_1 & CAN_BE_DIRTY_1))
 		return

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -54,7 +54,7 @@
 		icon_regular_floor = "floor"
 	else
 		icon_regular_floor = icon_state
-	if(mapload)
+	if(mapload && prob(33))
 		MakeDirty()
 
 /turf/open/floor/ex_act(severity, target)


### PR DESCRIPTION
I randomly thought of this. On Metastation there are ~44,000 floor
turfs being initialized, and by moving the prob for dirtiness out of the
proc, we should be able to avoid about 2/3 of those (so around ~29,000).

I don't think I've ever done profiling, so I'm unclear how to test it.

But it seemed like maybe a good idea?