### PR TITLE
Science areas can now be dirty

### DIFF
--- a/code/game/turfs/simulated/dirtystation.dm
+++ b/code/game/turfs/simulated/dirtystation.dm
@@ -123,7 +123,7 @@
 		//Science messes. Mostly green glowy stuff -WHICH YOU SHOULD NOT INJEST-.
 	var/static/list/science_dirt_areas = typecacheof(list(/area/science,
 														/area/crew_quarters/heads/hor))
-	if(is_type_in_typecache(A, medical_dirt_areas))
+	if(is_type_in_typecache(A, science_dirt_areas))
 		if(prob(20))
 			new /obj/effect/decal/cleanable/greenglow(src)	//this cleans itself up but it might startle you when you see it.
 		return


### PR DESCRIPTION
:cl: coiax
fix: Science areas now have small patches of glowing green goo
occasionally, as intended.
/:cl:

Someone used the wrong area var to check, so science was never getting
random green goo.