### PR TITLE
Glowing goo glows more; roundstart goo contains radium or uranium

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -79,12 +79,12 @@
 	light_range = 2
 	light_color = LIGHT_COLOR_GREEN
 
-/obj/effect/decal/cleanable/greenglow/Initialize(mapload, radium_volume=5)
-	. = ..()
-	reagents.add_reagent("radium", radium_volume)
-
 /obj/effect/decal/cleanable/greenglow/ex_act()
 	return
+
+/obj/effect/decal/cleanable/greenglow/filled/Initialize()
+	. = ..()
+	reagents.add_reagent(pick("uranium", "radium"), 5)
 
 /obj/effect/decal/cleanable/cobweb
 	name = "cobweb"

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -74,12 +74,14 @@
 /obj/effect/decal/cleanable/greenglow
 	name = "glowing goo"
 	desc = "Jeez. I hope that's not for lunch."
-	light_color = LIGHT_COLOR_GREEN
 	icon_state = "greenglow"
+	light_power = 3
+	light_range = 2
+	light_color = LIGHT_COLOR_GREEN
 
-/obj/effect/decal/cleanable/greenglow/Initialize(mapload)
+/obj/effect/decal/cleanable/greenglow/Initialize(mapload, radium_volume=5)
 	. = ..()
-	set_light(1)
+	reagents.add_reagent("radium", radium_volume)
 
 /obj/effect/decal/cleanable/greenglow/ex_act()
 	return

--- a/code/game/turfs/simulated/dirtystation.dm
+++ b/code/game/turfs/simulated/dirtystation.dm
@@ -125,7 +125,7 @@
 														/area/crew_quarters/heads/hor))
 	if(is_type_in_typecache(A, medical_dirt_areas))
 		if(prob(20))
-			new /obj/effect/decal/cleanable/greenglow(src)	//this cleans itself up but it might startle you when you see it.
+			new /obj/effect/decal/cleanable/greenglow/filled(src)	//this cleans itself up but it might startle you when you see it.
 		return
 
 	return TRUE

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -846,8 +846,10 @@
 /datum/reagent/radium/reaction_turf(turf/T, reac_volume)
 	if(reac_volume >= 3)
 		if(!isspaceturf(T))
-			if(!locate(/obj/effect/decal/cleanable/greenglow in T.contents))
-				new /obj/effect/decal/cleanable/greenglow(T, reac_volume)
+		var/obj/effect/decal/cleanable/greenglow/GG = locate() in T.contents
+		if(!GG)
+			new /obj/effect/decal/cleanable/greenglow(T)
+		GG.reagents.add_reagent(id, reac_volume)
 
 /datum/reagent/space_cleaner/sterilizine
 	name = "Sterilizine"
@@ -923,7 +925,7 @@
 			var/obj/effect/decal/cleanable/greenglow/GG = locate() in T.contents
 			if(!GG)
 				GG = new/obj/effect/decal/cleanable/greenglow(T)
-			GG.reagents.add_reagent("uranium", reac_volume)
+			GG.reagents.add_reagent(id, reac_volume)
 
 /datum/reagent/bluespace
 	name = "Bluespace Dust"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -831,26 +831,6 @@
 	color = "#808080" // rgb: 128, 128, 128
 	taste_description = "sweetness"
 
-/datum/reagent/radium
-	name = "Radium"
-	id = "radium"
-	description = "Radium is an alkaline earth metal. It is extremely radioactive."
-	reagent_state = SOLID
-	color = "#C7C7C7" // rgb: 199,199,199
-	taste_description = "the colour blue and regret"
-
-/datum/reagent/radium/on_mob_life(mob/living/carbon/M)
-	M.apply_effect(2*REM/M.metabolism_efficiency,EFFECT_IRRADIATE,0)
-	..()
-
-/datum/reagent/radium/reaction_turf(turf/T, reac_volume)
-	if(reac_volume >= 3)
-		if(!isspaceturf(T))
-		var/obj/effect/decal/cleanable/greenglow/GG = locate() in T.contents
-		if(!GG)
-			new /obj/effect/decal/cleanable/greenglow(T)
-		GG.reagents.add_reagent(id, reac_volume)
-
 /datum/reagent/space_cleaner/sterilizine
 	name = "Sterilizine"
 	id = "sterilizine"
@@ -914,9 +894,10 @@
 	reagent_state = SOLID
 	color = "#B8B8C0" // rgb: 184, 184, 192
 	taste_description = "the inside of a reactor"
+	var/irradiation_level = 1
 
 /datum/reagent/uranium/on_mob_life(mob/living/carbon/M)
-	M.apply_effect(1/M.metabolism_efficiency,EFFECT_IRRADIATE,0)
+	M.apply_effect(irradiation_level/M.metabolism_efficiency,EFFECT_IRRADIATE,0)
 	..()
 
 /datum/reagent/uranium/reaction_turf(turf/T, reac_volume)
@@ -926,6 +907,15 @@
 			if(!GG)
 				GG = new/obj/effect/decal/cleanable/greenglow(T)
 			GG.reagents.add_reagent(id, reac_volume)
+
+/datum/reagent/uranium/radium
+	name = "Radium"
+	id = "radium"
+	description = "Radium is an alkaline earth metal. It is extremely radioactive."
+	reagent_state = SOLID
+	color = "#C7C7C7" // rgb: 199,199,199
+	taste_description = "the colour blue and regret"
+	irradiation_level = 2*REM
 
 /datum/reagent/bluespace
 	name = "Bluespace Dust"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -846,10 +846,8 @@
 /datum/reagent/radium/reaction_turf(turf/T, reac_volume)
 	if(reac_volume >= 3)
 		if(!isspaceturf(T))
-			var/obj/effect/decal/cleanable/greenglow/GG = locate() in T.contents
-			if(!GG)
-				GG = new/obj/effect/decal/cleanable/greenglow(T)
-			GG.reagents.add_reagent("radium", reac_volume)
+			if(!locate(/obj/effect/decal/cleanable/greenglow in T.contents))
+				new /obj/effect/decal/cleanable/greenglow(T, reac_volume)
 
 /datum/reagent/space_cleaner/sterilizine
 	name = "Sterilizine"


### PR DESCRIPTION
:cl: coiax
tweak: Glowing goo now glows a lot more noticeably in the dark, will always
contain either radium or uranium.
/:cl:

You can barely see it in the dark, should glow more. Also, the normal
in-game method of creating it is spilling radium/uranium on the floor, so all
glowing goo should have radium/uranium in it, even the roundstart stuff.

- Radium is now a subtype of uranium, because of their literally identical behaviour and effects (apart from radiation severity)