### PR TITLE
Removes miasma from default filtered gases

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -514,7 +514,7 @@
 			for(var/device_id in A.air_scrub_names)
 				send_signal(device_id, list(
 					"power" = 1,
-					"set_filters" = list(/datum/gas/carbon_dioxide, /datum/gas/miasma),
+					"set_filters" = list(/datum/gas/carbon_dioxide),
 					"scrubbing" = 1,
 					"widenet" = 0,
 				))

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -567,7 +567,7 @@
 			for(var/device_id in A.air_scrub_names)
 				send_signal(device_id, list(
 					"power" = 1,
-					"set_filters" = list(/datum/gas/carbon_dioxide, /datum/gas/miasma),
+					"set_filters" = list(/datum/gas/carbon_dioxide),
 					"scrubbing" = 1,
 					"widenet" = 0,
 				))


### PR DESCRIPTION
:cl: Denton
tweak: Air scrubbers do not filter miasma by default anymore ("Filtering" and "Refill" modes).
/:cl:

Miasma buildup is never a serious issue since scrubbers remove most of it by default. I removed it from default filtering so that either A) people have to take care of corpses or B) air alarms have to be adjusted to deal with it.