### PR TITLE
Remove power cells from light fixtures

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -84,7 +84,7 @@
 		to_chat(user, "<span class='danger'>This casing doesn't support power cells for backup power.</span>")
 		return
 
-/obj/structure/light_construct/attack_hand(mob/living/carbon/human/user)
+/obj/structure/light_construct/attack_hand(mob/user)
 	. = ..()
 	if(.)
 		return
@@ -96,6 +96,15 @@
 		src.cell = null
 		add_fingerprint(user)
 		return
+
+/obj/structure/light_construct/attack_tk(mob/user)
+	if(!cell)
+		return
+
+	to_chat(user, "<span class='notice'>You telekinetically remove \the [cell].</span>")
+	cell.forceMove(loc)
+	cell.attack_tk(user)
+	cell = null
 
 /obj/structure/light_construct/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -90,19 +90,18 @@
 		return
 
 	if(cell)
-		user.visible_message("[user] removes \the [cell] from [src]!","<span class='notice'>You remove \the [cell].</span>")
+		user.visible_message("[user] removes [cell] from [src]!","<span class='notice'>You remove [cell].</span>")
 		user.put_in_hands(cell)
 		cell.update_icon()
-		src.cell = null
+		cell = null
 		add_fingerprint(user)
-		return
 
 /obj/structure/light_construct/attack_tk(mob/user)
 	if(!cell)
 		return
 
-	to_chat(user, "<span class='notice'>You telekinetically remove \the [cell].</span>")
-	cell.forceMove(loc)
+	to_chat(user, "<span class='notice'>You telekinetically remove [cell].</span>")
+	cell.forceMove(drop_location())
 	cell.attack_tk(user)
 	cell = null
 
@@ -119,10 +118,11 @@
 			to_chat(user, "<span class='warning'>There is a power cell already installed!</span>")
 			return
 		else
+			if(!user.temporarilyRemoveItemFromInventory(W))
+				return
 			user.visible_message("<span class='notice'>[user] hooks up [W] to [src].</span>", \
 			"<span class='notice'>You add [W] to [src].</span>")
 			playsound(src, 'sound/machines/click.ogg', 50, TRUE)
-			user.dropItemToGround(W)
 			W.forceMove(src)
 			cell = W
 			add_fingerprint(user)
@@ -139,7 +139,7 @@
 						new /obj/item/stack/sheet/metal(drop_location(), sheets_refunded)
 						user.visible_message("[user.name] deconstructs [src].", \
 							"<span class='notice'>You deconstruct [src].</span>", "<span class='italics'>You hear a ratchet.</span>")
-						playsound(src.loc, 'sound/items/deconstruct.ogg', 75, 1)
+						playsound(src, 'sound/items/deconstruct.ogg', 75, 1)
 						qdel(src)
 					return
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -84,6 +84,19 @@
 		to_chat(user, "<span class='danger'>This casing doesn't support power cells for backup power.</span>")
 		return
 
+/obj/structure/light_construct/attack_hand(mob/living/carbon/human/user)
+	. = ..()
+	if(.)
+		return
+
+	if(cell)
+		user.visible_message("[user] removes \the [cell] from [src]!","<span class='notice'>You remove \the [cell].</span>")
+		user.put_in_hands(cell)
+		cell.update_icon()
+		src.cell = null
+		add_fingerprint(user)
+		return
+
 /obj/structure/light_construct/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
 	if(istype(W, /obj/item/stock_parts/cell))
@@ -93,31 +106,33 @@
 		if(W.item_flags & NODROP)
 			to_chat(user, "<span class='warning'>[W] is stuck to your hand!</span>")
 			return
-		user.dropItemToGround(W)
 		if(cell)
-			user.visible_message("<span class='notice'>[user] swaps [W] out for [src]'s cell.</span>", \
-			"<span class='notice'>You swap [src]'s power cells.</span>")
-			cell.forceMove(drop_location())
-			user.put_in_hands(cell)
+			to_chat(user, "<span class='warning'>There is a power cell already installed!</span>")
+			return
 		else
 			user.visible_message("<span class='notice'>[user] hooks up [W] to [src].</span>", \
 			"<span class='notice'>You add [W] to [src].</span>")
-		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
-		W.forceMove(src)
-		cell = W
-		add_fingerprint(user)
-		return
+			playsound(src, 'sound/machines/click.ogg', 50, TRUE)
+			user.dropItemToGround(W)
+			W.forceMove(src)
+			cell = W
+			add_fingerprint(user)
+			return
 	switch(stage)
 		if(1)
 			if(W.tool_behaviour == TOOL_WRENCH)
-				to_chat(usr, "<span class='notice'>You begin deconstructing [src]...</span>")
-				if (W.use_tool(src, user, 30, volume=50))
-					new /obj/item/stack/sheet/metal(drop_location(), sheets_refunded)
-					user.visible_message("[user.name] deconstructs [src].", \
-						"<span class='notice'>You deconstruct [src].</span>", "<span class='italics'>You hear a ratchet.</span>")
-					playsound(src.loc, 'sound/items/deconstruct.ogg', 75, 1)
-					qdel(src)
-				return
+				if(cell)
+					to_chat(user, "<span class='warning'>You have to remove the cell first!</span>")
+					return
+				else
+					to_chat(user, "<span class='notice'>You begin deconstructing [src]...</span>")
+					if (W.use_tool(src, user, 30, volume=50))
+						new /obj/item/stack/sheet/metal(drop_location(), sheets_refunded)
+						user.visible_message("[user.name] deconstructs [src].", \
+							"<span class='notice'>You deconstruct [src].</span>", "<span class='italics'>You hear a ratchet.</span>")
+						playsound(src.loc, 'sound/items/deconstruct.ogg', 75, 1)
+						qdel(src)
+					return
 
 			if(istype(W, /obj/item/stack/cable_coil))
 				var/obj/item/stack/cable_coil/coil = W
@@ -618,7 +633,7 @@
 					H.dna?.species.adjust_charge(5)
 					return
 				return
-				
+
 			if(H.gloves)
 				var/obj/item/clothing/gloves/G = H.gloves
 				if(G.max_heat_protection_temperature)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -85,10 +85,6 @@
 		return
 
 /obj/structure/light_construct/attack_hand(mob/user)
-	. = ..()
-	if(.)
-		return
-
 	if(cell)
 		user.visible_message("[user] removes [cell] from [src]!","<span class='notice'>You remove [cell].</span>")
 		user.put_in_hands(cell)
@@ -97,13 +93,11 @@
 		add_fingerprint(user)
 
 /obj/structure/light_construct/attack_tk(mob/user)
-	if(!cell)
-		return
-
-	to_chat(user, "<span class='notice'>You telekinetically remove [cell].</span>")
-	cell.forceMove(drop_location())
-	cell.attack_tk(user)
-	cell = null
+	if(cell)
+		to_chat(user, "<span class='notice'>You telekinetically remove [cell].</span>")
+		cell.forceMove(drop_location())
+		cell.attack_tk(user)
+		cell = null
 
 /obj/structure/light_construct/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
@@ -116,17 +110,14 @@
 			return
 		if(cell)
 			to_chat(user, "<span class='warning'>There is a power cell already installed!</span>")
-			return
-		else
-			if(!user.temporarilyRemoveItemFromInventory(W))
-				return
+		else if(user.temporarilyRemoveItemFromInventory(W))
 			user.visible_message("<span class='notice'>[user] hooks up [W] to [src].</span>", \
 			"<span class='notice'>You add [W] to [src].</span>")
 			playsound(src, 'sound/machines/click.ogg', 50, TRUE)
 			W.forceMove(src)
 			cell = W
 			add_fingerprint(user)
-			return
+		return
 	switch(stage)
 		if(1)
 			if(W.tool_behaviour == TOOL_WRENCH)


### PR DESCRIPTION
:cl:
tweak: Light fixture power cells can now be removed instead of swapped
/:cl:

It didn't make sense to me that you couldn't remove the cell from a light fixture once it's been inserted, costing you the cell if you ended up deconstructing the fixture. You can now remove the cell with an empty hand; swapping cells has been removed as a consequence.