### PR TITLE
Removes the plasmaman species slowdown.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -16,7 +16,6 @@
 	burnmod = 1.5
 	heatmod = 1.5
 	breathid = "tox"
-	speedmod = 1
 	damage_overlay_type = ""//let's not show bloody wounds or burns over bones.
 	var/internal_fire = FALSE //If the bones themselves are burning clothes won't help you much
 	disliked_food = FRUIT


### PR DESCRIPTION

:cl: 
balance: Plasmamen now run at the same speed as normal humans.
/:cl:

Not really balance but whatever, I'll take the GBP loss to avoid arguing about it. Plasmamen become disproportionately less fun to play on slower speeds. Rather than having to worry about this forever or making the most unique race on /tg/ station less fun we can just remove it and come up with other ways to nerf plasmamen if necessary. Oranges Approved™

![discord_2019-01-05_18-53-32](https://user-images.githubusercontent.com/38303698/50731548-8767e400-111c-11e9-9316-af1c0be7e0f4.png)
