### PR TITLE
Lowers CO2 fusion power and slightly bumps up nitryl

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -111,7 +111,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	gas_overlay = "nitryl"
 	moles_visible = MOLES_GAS_VISIBLE
 	dangerous = TRUE
-	fusion_power = 15
+	fusion_power = 16
 	rarity = 100
 
 /datum/gas/tritium

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	id = "co2"
 	specific_heat = 30
 	name = "Carbon Dioxide"
-	fusion_power = 1.2
+	fusion_power = 1.25
 	rarity = 700
 
 /datum/gas/plasma

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	id = "co2"
 	specific_heat = 30
 	name = "Carbon Dioxide"
-	fusion_power = 3
+	fusion_power = 1.2
 	rarity = 700
 
 /datum/gas/plasma


### PR DESCRIPTION
:cl: GranpaWalton
balance: CO2 fusion power has been lowered from 3 to 1.25
balance: nitryl fusion power has been raised from 15 to 16
/:cl:

CO2 fusion has been the most popular and simplest method available due to it being just as/more effective as using the exotic gasses when it comes to resources and time used. This should encourage other methods to be used but will allow this one to still be doable as an entry point for doing fusion similar to how toxins has plasma bombs for people to learn before they move up to tritium bombs. 

Nitryl has been bumped up a little due to it needing more attention to obtain than BZ the other comparable option.

Effectively the amounts of moles and temp to cold pack needed for CO2 focused fusion will be changed as so assuming the tritium is 250 moles and the plasma is CO2 moles + tritium moles.

**Medium tier**
3,800 moles -> 9250  moles 
71.21 kelvin -> 29.25 kelvin

**High tier**
16,000 moles -> 38,250  moles 
16.65 kelvin -> 7.07 kelvin

**Super tier**
40,000 moles -> 96,000  moles 
6.72 kelvin -> 2.81 kelvin

This may still be too strong afterwards and if this is true more than just the powers should be changed as the amount of potential methods one could take to do fusion would be pretty small.