### PR TITLE
Xenos now have a liver and process reagents

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -40,6 +40,7 @@
 	internal_organs += new /obj/item/organ/alien/hivenode
 	internal_organs += new /obj/item/organ/tongue/alien
 	internal_organs += new /obj/item/organ/eyes/night_vision/alien
+	internal_organs += new /obj/item/organ/liver/alien
 	internal_organs += new /obj/item/organ/ears
 	..()
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -585,7 +585,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 
 /mob/living/carbon/proc/handle_liver()
 	var/obj/item/organ/liver/liver = getorganslot(ORGAN_SLOT_LIVER)
-	if((!dna && !liver) || (NOLIVER in dna.species.species_traits))
+	if((!dna || !liver) || (NOLIVER in dna.species.species_traits))
 		return
 	if(liver)
 		if(liver.damage >= liver.maxHealth)

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -73,6 +73,13 @@
 	icon_state = "liver-p"
 	desc = "A large crystal that is somehow capable of metabolizing chemicals, these are found in plasmamen."
 
+/obj/item/organ/liver/alien
+	name = "alien liver" // doesnt matter for actual aliens because they dont take toxin damage
+	icon_state = "liver-x" // Same sprite as fly-person liver.
+	desc = "A liver that used to belong to a killer alien, who knows what it used to eat."
+	toxLethality = LIVER_DEFAULT_TOX_LETHALITY * 2.5 // rejects its owner early after too much punishment
+	toxTolerance = 15 // complete toxin immunity like xenos have would be too powerful
+
 /obj/item/organ/liver/cybernetic
 	name = "cybernetic liver"
 	icon_state = "liver-c"


### PR DESCRIPTION
:cl: GranpaWalton
add: Xenos now have a liver that processes toxins really well but will reject a human host when it takes too much damage
fix: Xenos will now process regents because of their new liver, they will still not take toxin damage, stamina damage, or have liver failure
/:cl:

After looking at the options it was the best way I could think of to handle #42161 , if someone can think of a better please let me know.

The new liver does not effect the xenos but will give humans a better resistance to toxin at the risk of it failing rather easily, which is currently pretty rare.

The NOLIVER flag in dna is unused so I dont know whether or not we should look at it or leave it in.

