### PR TITLE
Adds a cautery to Robotics on Metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -72426,6 +72426,7 @@
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
+/obj/item/cautery,
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},


### PR DESCRIPTION
:cl: coiax
tweak: Metastation Robotics now has a cautery.
/:cl:

RIP the end of the welding-tool-era.

Why? Because Robotics does more surgery than just removing peoples brains.