### PR TITLE
Adds Combat Gloves Plus for operatives at 5tc

### DIFF
--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -192,3 +192,22 @@
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	resistance_flags = NONE
+
+/obj/item/clothing/gloves/combat/plus
+	name = "combat gloves plus"
+	desc = "These tactical gloves are fireproof and shock resistant, and using nanochip technology it teaches you the powers of krav maga."
+	var/datum/martial_art/krav_maga/style = new
+
+/obj/item/clothing/gloves/combat/plus/equipped(mob/user, slot)
+	if(!ishuman(user))
+		return
+	if(slot == SLOT_GLOVES)
+		var/mob/living/carbon/human/H = user
+		style.teach(H,1)
+
+/obj/item/clothing/gloves/combat/plus/dropped(mob/user)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(H.get_item_by_slot(SLOT_GLOVES) == src)
+		style.remove(H)

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -193,21 +193,17 @@
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	resistance_flags = NONE
 
-/obj/item/clothing/gloves/combat/plus
+/obj/item/clothing/gloves/krav_maga/combatglovesplus
 	name = "combat gloves plus"
 	desc = "These tactical gloves are fireproof and shock resistant, and using nanochip technology it teaches you the powers of krav maga."
-	var/datum/martial_art/krav_maga/style = new
-
-/obj/item/clothing/gloves/combat/plus/equipped(mob/user, slot)
-	if(!ishuman(user))
-		return
-	if(slot == SLOT_GLOVES)
-		var/mob/living/carbon/human/H = user
-		style.teach(H,1)
-
-/obj/item/clothing/gloves/combat/plus/dropped(mob/user)
-	if(!ishuman(user))
-		return
-	var/mob/living/carbon/human/H = user
-	if(H.get_item_by_slot(SLOT_GLOVES) == src)
-		style.remove(H)
+	icon_state = "black"
+	item_state = "blackglovesplus"
+	siemens_coefficient = 0
+	permeability_coefficient = 0.05
+	strip_delay = 80
+	cold_protection = HANDS
+	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
+	heat_protection = HANDS
+	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+	resistance_flags = NONE
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 50)

--- a/code/game/gamemodes/clown_ops/clown_ops.dm
+++ b/code/game/gamemodes/clown_ops/clown_ops.dm
@@ -56,6 +56,6 @@
 /datum/outfit/syndicate/clownop/leader
 	name = "Clown Operative Leader - Basic"
 	id = /obj/item/card/id/syndicate/nuke_leader
+	gloves = /obj/item/clothing/gloves/combat/plus
 	r_hand = /obj/item/nuclear_challenge/clownops
 	command_radio = TRUE
-	gloves = /obj/item/clothing/gloves/combat/plus

--- a/code/game/gamemodes/clown_ops/clown_ops.dm
+++ b/code/game/gamemodes/clown_ops/clown_ops.dm
@@ -56,6 +56,6 @@
 /datum/outfit/syndicate/clownop/leader
 	name = "Clown Operative Leader - Basic"
 	id = /obj/item/card/id/syndicate/nuke_leader
-	gloves = /obj/item/clothing/gloves/combat/plus
+	gloves = /obj/item/clothing/gloves/krav_maga/combatglovesplus
 	r_hand = /obj/item/nuclear_challenge/clownops
 	command_radio = TRUE

--- a/code/game/gamemodes/clown_ops/clown_ops.dm
+++ b/code/game/gamemodes/clown_ops/clown_ops.dm
@@ -58,3 +58,4 @@
 	id = /obj/item/card/id/syndicate/nuke_leader
 	r_hand = /obj/item/nuclear_challenge/clownops
 	command_radio = TRUE
+	gloves = /obj/item/clothing/gloves/combat/plus

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -132,7 +132,7 @@
 /datum/outfit/syndicate/leader
 	name = "Syndicate Leader - Basic"
 	id = /obj/item/card/id/syndicate/nuke_leader
-	gloves = /obj/item/clothing/gloves/combat/plus
+	gloves = /obj/item/clothing/gloves/krav_maga/combatglovesplus
 	r_hand = /obj/item/nuclear_challenge
 	command_radio = TRUE
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -132,9 +132,9 @@
 /datum/outfit/syndicate/leader
 	name = "Syndicate Leader - Basic"
 	id = /obj/item/card/id/syndicate/nuke_leader
+	gloves = /obj/item/clothing/gloves/combat/plus
 	r_hand = /obj/item/nuclear_challenge
 	command_radio = TRUE
-	gloves = /obj/item/clothing/gloves/combat/plus
 
 /datum/outfit/syndicate/no_crystals
 	tc = 0

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -134,6 +134,7 @@
 	id = /obj/item/card/id/syndicate/nuke_leader
 	r_hand = /obj/item/nuclear_challenge
 	command_radio = TRUE
+	gloves = /obj/item/clothing/gloves/combat/plus
 
 /datum/outfit/syndicate/no_crystals
 	tc = 0

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -42,7 +42,7 @@
 
 /obj/item/clothing/gloves/combat/plus
 	name = "combat gloves plus"
-	desc = "These tactical gloves are fireproof and shock resistant,and using a nanochip technology it teaches you the powers of krav maga."
+	desc = "These tactical gloves are fireproof and shock resistant, and using a nanochip technology it teaches you the powers of krav maga."
 	var/datum/martial_art/krav_maga/style = new
 
 /obj/item/clothing/gloves/combat/plus/equipped(mob/user, slot)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -40,6 +40,23 @@
 	resistance_flags = NONE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 50)
 
+/obj/item/clothing/gloves/combat/plus
+	name = "combat gloves plus"
+	desc = "These tactical gloves are fireproof and shock resistant,and using a nanochip it teaches you to perform krav maga."
+
+/obj/item/clothing/gloves/combat/plus/equipped(mob/user, slot)
+	if(!ishuman(user))
+		return
+	if(slot == SLOT_GLOVES)
+		var/mob/living/carbon/human/H = user
+		style.teach(H,1)
+
+/obj/item/clothing/gloves/combat/plus/dropped(mob/user)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(H.get_item_by_slot(SLOT_GLOVES) == src)
+		style.remove(H)
 
 /obj/item/clothing/gloves/bracer
 	name = "bone bracers"

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -42,7 +42,7 @@
 
 /obj/item/clothing/gloves/combat/plus
 	name = "combat gloves plus"
-	desc = "These tactical gloves are fireproof and shock resistant, and using a nanochip technology it teaches you the powers of krav maga."
+	desc = "These tactical gloves are fireproof and shock resistant, and using nanochip technology it teaches you the powers of krav maga."
 	var/datum/martial_art/krav_maga/style = new
 
 /obj/item/clothing/gloves/combat/plus/equipped(mob/user, slot)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -40,25 +40,6 @@
 	resistance_flags = NONE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 50)
 
-/obj/item/clothing/gloves/combat/plus
-	name = "combat gloves plus"
-	desc = "These tactical gloves are fireproof and shock resistant, and using nanochip technology it teaches you the powers of krav maga."
-	var/datum/martial_art/krav_maga/style = new
-
-/obj/item/clothing/gloves/combat/plus/equipped(mob/user, slot)
-	if(!ishuman(user))
-		return
-	if(slot == SLOT_GLOVES)
-		var/mob/living/carbon/human/H = user
-		style.teach(H,1)
-
-/obj/item/clothing/gloves/combat/plus/dropped(mob/user)
-	if(!ishuman(user))
-		return
-	var/mob/living/carbon/human/H = user
-	if(H.get_item_by_slot(SLOT_GLOVES) == src)
-		style.remove(H)
-
 /obj/item/clothing/gloves/bracer
 	name = "bone bracers"
 	desc = "For when you're expecting to get slapped on the wrist. Offers modest protection to your arms."

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -42,7 +42,7 @@
 
 /obj/item/clothing/gloves/combat/plus
 	name = "combat gloves plus"
-	desc = "These tactical gloves are fireproof and shock resistant,and using a nanochip it teaches you to perform krav maga."
+	desc = "These tactical gloves are fireproof and shock resistant,and using a nanochip technology it teaches you the powers of krav maga."
 	var/datum/martial_art/krav_maga/style = new
 
 /obj/item/clothing/gloves/combat/plus/equipped(mob/user, slot)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -43,6 +43,7 @@
 /obj/item/clothing/gloves/combat/plus
 	name = "combat gloves plus"
 	desc = "These tactical gloves are fireproof and shock resistant,and using a nanochip it teaches you to perform krav maga."
+	var/datum/martial_art/krav_maga/style = new
 
 /obj/item/clothing/gloves/combat/plus/equipped(mob/user, slot)
 	if(!ishuman(user))

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1611,6 +1611,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	category = "(Pointless) Badassery"
 	surplus = 0
 
+/datum/uplink_item/badass/combatglovesplus
+	name = "Combat Gloves Plus"
+	desc = "A pair of gloves that are fireproof and shock resistant, however unlike the regular Combat Gloves this one uses nanotechnology \
+			to learn the abilities of krav maga to the wearer."
+	item = /obj/item/clothing/gloves/krav_maga/combatglovesplus
+	cost = 5
+	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+
 /datum/uplink_item/badass/costumes/obvious_chameleon
 	name = "Broken Chameleon Kit"
 	desc = "A set of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more! \


### PR DESCRIPTION
Changelogs: Adds Combat Gloves Plus,the Combat Gloves Plus will be given to Syndicate nuclear operative leader(s) it does everything that the normal Combat Gloves does but has an added extra of teaching people krav maga for as long as they wear it. And you can buy it for 5tc for any other nuclear operative who wants to get in on the deal.

:cl: mrhugo13
add: The Syndicate has decided to equip their Syndicate leaders operative (Aswell as their clown counterparts) with the new Combat Glove Plus! The new Combat Glove Plus does everything the old boring Combat Gloves does but with the added extra of learning Krav Maga upon wearing them, any other Syndicate operative who wants to get in on the action will have to pay 5tc.
/:cl:

Why: It'd be a minor buff to Syndies/Clowns but it'd also promote the idea of fighting in CQC more for Syndicate Operatives (Making them a easier target for the crew aswell as giving them a minor buff)