### PR TITLE
Donutstation fixes and tweaks

### DIFF
--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -4845,7 +4845,7 @@
 	icon_state = "intact"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/bar)
+/area/maintenance/port/aft)
 "alb" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -16033,12 +16033,6 @@
 "aHW" = (
 /turf/closed/wall,
 /area/medical/chemistry)
-"aHX" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/dorms)
 "aHY" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall,
@@ -16486,7 +16480,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/area/maintenance/fore)
 "aIX" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -24472,6 +24466,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
+/obj/structure/sign/warning/pods{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aYz" = (
@@ -25763,7 +25760,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/main)
+/area/maintenance/department/security)
 "baN" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -26230,7 +26227,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/maintenance/port/aft)
 "bbO" = (
 /obj/effect/landmark/start/cook,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -26817,7 +26814,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/maintenance/port)
 "bcR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -26837,7 +26834,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/aft)
 "bcT" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -28503,7 +28500,7 @@
 	req_one_access_txt = "12;26"
 	},
 /turf/open/floor/plating,
-/area/janitor)
+/area/maintenance/aft)
 "bgb" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -28644,8 +28641,8 @@
 /area/maintenance/port/aft)
 "bgp" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bgq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -28679,11 +28676,13 @@
 	req_access_txt = "28"
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/kitchen/coldroom)
 "bgu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bgv" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -28705,8 +28704,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bgx" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bgy" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -28824,17 +28826,14 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bgJ" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo";
-	pixel_x = -4
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Service - Kitchen Freezer";
-	dir = 2;
-	network = list("ss13","Bar Area")
+/obj/machinery/airalarm/kitchen_cold_room{
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bgK" = (
 /obj/structure/table/wood,
 /obj/item/candle,
@@ -29037,12 +29036,18 @@
 	name = "old sink";
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bhf" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/machinery/icecream_vat,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bhg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -29052,13 +29057,15 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bhh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bhi" = (
-/obj/machinery/icecream_vat,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/obj/machinery/gibber,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bhj" = (
 /obj/machinery/power/apc{
 	areastring = "/area/quartermaster/storage";
@@ -29201,15 +29208,12 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bhw" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
-"bhx" = (
-/mob/living/simple_animal/hostile/retaliate/goat{
-	name = "Pete"
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom{
+	icon_state = "freezer_1";
+	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bhy" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
@@ -29575,9 +29579,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bid" = (
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bie" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -29610,17 +29617,20 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/solar/aft)
+/area/maintenance/aft)
 "bii" = (
 /turf/closed/wall,
 /area/solar/aft)
 "bij" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 1
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bik" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -29644,18 +29654,15 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bim" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bin" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bio" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -29684,24 +29691,18 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/aft)
 "bir" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/sign/poster/contraband/eat{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "bis" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"bit" = (
-/obj/machinery/gibber,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "biu" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -29923,7 +29924,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/security/courtroom)
+/area/maintenance/aft)
 "biP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -35040,14 +35041,14 @@
 	name = "Kitchen Maintenance";
 	req_access_txt = "28"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/area/maintenance/port/aft)
 "brz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	icon_state = "scrub_map_on";
@@ -35067,7 +35068,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/disposal/incinerator)
+/area/maintenance/port/aft)
 "brB" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
@@ -35087,7 +35088,7 @@
 /turf/open/floor/plasteel{
 	dir = 2
 	},
-/area/crew_quarters/kitchen)
+/area/crew_quarters/kitchen/coldroom)
 "brC" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -40099,6 +40100,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bAD" = (
@@ -40197,7 +40201,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar)
+/area/maintenance/port/aft)
 "bAN" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -40825,7 +40829,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "5, 12, 47"
+	req_one_access_txt = "5;12;47"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41019,7 +41023,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/maintenance/aft)
 "bCf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -47955,6 +47959,9 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/soysauce,
 /obj/item/reagent_containers/food/condiment/sugar,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -48617,6 +48624,19 @@
 	c_tag = "Hallway - Central West 1";
 	dir = 2
 	},
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = 26
+	},
+/obj/structure/sign/directions/science{
+	dir = 8;
+	pixel_y = 34
+	},
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	icon_state = "direction_evac";
+	pixel_y = 42
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bPC" = (
@@ -49211,7 +49231,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/area/maintenance/port/aft)
 "bQN" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -50650,7 +50670,7 @@
 	req_access_txt = "5; 9; 68"
 	},
 /turf/open/floor/plating,
-/area/medical/genetics)
+/area/maintenance/port)
 "bTE" = (
 /obj/structure/closet/crate{
 	name = "Surplus Genetics Supplies"
@@ -55604,7 +55624,7 @@
 	req_one_access_txt = "5;12"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
+/area/maintenance/port)
 "ceq" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12"
@@ -55940,6 +55960,133 @@
 	dir = 1
 	},
 /area/science/xenobiology)
+"dtX" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	icon_state = "pipe11-2";
+	dir = 4
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
+"dwg" = (
+/obj/structure/reagent_dispensers/cooking_oil,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
+"esU" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
+"hGn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/firedoor,
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_x = 32
+	},
+/obj/structure/sign/directions/medical{
+	pixel_x = 32;
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"jzE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/sign/directions/command{
+	dir = 4;
+	pixel_y = 34
+	},
+/obj/structure/sign/directions/security{
+	dir = 4;
+	pixel_y = 26
+	},
+/obj/structure/sign/directions/supply{
+	dir = 1;
+	icon_state = "direction_supply";
+	pixel_y = 42
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"lDQ" = (
+/obj/machinery/rnd/production/techfab/department/engineering,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"lEx" = (
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
+"nuq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
+"pBI" = (
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
+"qxZ" = (
+/obj/structure/sign/warning/pods{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
+/area/science/research)
+"qyl" = (
+/obj/machinery/atmospherics/pipe/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 6
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
+"vMB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_x = -32;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/supply{
+	dir = 1;
+	pixel_x = -32
+	},
+/obj/structure/sign/directions/security{
+	pixel_x = -32;
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xhI" = (
+/turf/closed/wall,
+/area/crew_quarters/kitchen/coldroom)
+"xyz" = (
+/obj/machinery/atmospherics/pipe/manifold/dark/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 9
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 
 (1,1,1) = {"
 aaa
@@ -77640,7 +77787,7 @@ bTF
 bbS
 akB
 aeA
-aeB
+qxZ
 blD
 afO
 afO
@@ -84299,7 +84446,7 @@ bQj
 aaT
 bQr
 bfS
-aHX
+asF
 auK
 auZ
 auZ
@@ -85864,7 +86011,7 @@ btc
 aRp
 bgS
 axm
-bHb
+hGn
 bft
 axm
 bDS
@@ -87711,10 +87858,10 @@ bGU
 bfe
 bfe
 bHf
-alF
-alF
-alF
-alF
+xhI
+xhI
+xhI
+xhI
 bba
 bCg
 cer
@@ -87965,13 +88112,13 @@ bRM
 akl
 bcb
 bWp
-alF
-alF
-alF
-alF
+xhI
+xhI
+xhI
+xhI
 bhw
-bhw
-alF
+dwg
+xhI
 bba
 bQR
 azH
@@ -88222,11 +88369,11 @@ aoj
 anJ
 aqf
 alF
-alF
+xhI
 bgp
 bgu
 bhh
-bhh
+qyl
 bij
 bry
 bwy
@@ -88479,13 +88626,13 @@ amU
 amU
 bcz
 bce
-alF
-alF
+xhI
+xhI
 bgx
-bgx
-bgx
+nuq
+xyz
 bim
-alF
+xhI
 brS
 bYW
 aSh
@@ -88737,12 +88884,12 @@ bbM
 bcD
 bcI
 amU
-alF
+xhI
 bgJ
 bhi
-bgx
+dtX
 bin
-alF
+xhI
 bYV
 bCg
 aSh
@@ -88996,10 +89143,10 @@ bcL
 amU
 bgt
 bgx
+lEx
 bgx
-bhx
 bir
-alF
+xhI
 bba
 bQT
 aSh
@@ -89251,11 +89398,11 @@ amU
 amU
 amU
 bOA
-alF
+xhI
 bhe
+pBI
 bgx
-bgx
-bgx
+pBI
 brB
 bbe
 bQU
@@ -89508,12 +89655,12 @@ apw
 aqc
 bRy
 alF
-alF
+xhI
 bhf
-bhf
+esU
 bid
-bit
-alF
+bhi
+xhI
 bYV
 bQV
 aTn
@@ -89766,11 +89913,11 @@ acj
 acj
 acj
 acj
-alF
-alF
-alF
-alF
-alF
+xhI
+xhI
+xhI
+xhI
+xhI
 bba
 bQX
 aSh
@@ -91819,7 +91966,7 @@ bps
 aYB
 brG
 acj
-asr
+lDQ
 axP
 bnB
 bpq
@@ -94636,7 +94783,7 @@ apF
 apT
 apT
 aad
-awI
+jzE
 bDO
 bpd
 bpf
@@ -99229,7 +99376,7 @@ btm
 bte
 arA
 bHg
-bfu
+vMB
 bHj
 arA
 bHq


### PR DESCRIPTION
:cl: Denton
fix: Donutstation: Fixed emergency maintenance access not applying to some airlocks. Fixed broken access requirements in the outer medical/science maintenance airlock.
tweak: Donutstation: The kitchen coldroom is now actually cold. Or a big walk-in oven, if you mess with the freezer settings.
tweak: Donutstation: Added more department and escape pod signs.
tweak: Donutstation: Added a departmental exofab to Atmospherics.
/:cl:

Donut had some wrong areas that prevented airlocks from unlocking once emergency maint access is enabled at a comms console. Also, med/sci maint airlock had busted access requirements.

For tweaks: The kitchen coldroom is now actually cold and contains a freezer+H/E piping, similar to Metastation. I added more signs so that new players get lost less. Lastly, I added a departmental exofab to Atmospherics since the map layout is completely incompatible with a shared equipment room like on Meta or Deltastation.
