### PR TITLE
Nerfs legion core healing

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -114,7 +114,7 @@
 	mood_change = -4
 
 /datum/mood_event/healsbadman
-	description = "<span class='warning'>I feel a lot better, but wow that was disgusting.</span>\n" //when you read the latest felinid removal PR and realize you're really not that much of a degenerate
+	description = "<span class='warning'>I look much better, but my head still hurts.</span>\n" //when you read the latest felinid removal PR and realize you're really not that much of a degenerate
 	mood_change = -4
 	timeout = 1200
 

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -83,7 +83,9 @@
 			else
 				to_chat(user, "<span class='notice'>You start to smear [src] on yourself. It feels and smells disgusting, but you feel amazingly refreshed in mere moments.</span>")
 				SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "self"))
-			H.revive(full_heal = 1)
+			H.adjustBruteLoss(-75)
+			H.adjustFireLoss(-25)
+			H.adjustBrainLoss(5)
 			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "core", /datum/mood_event/healsbadman) //Now THIS is a miner buff (fixed - nerf)
 			qdel(src)
 

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -20,7 +20,7 @@
 /************************Hivelord core*******************/
 /obj/item/organ/regenerative_core
 	name = "regenerative core"
-	desc = "All that remains of a hivelord. It can be used to heal completely, but it will rapidly decay into uselessness."
+	desc = "All that remains of a hivelord. It can be used to heal physical injuries, but it will rapidly decay into uselessness."
 	icon_state = "roro core 2"
 	item_flags = NOBLUDGEON
 	slot = "hivecore"
@@ -41,7 +41,7 @@
 	inert = FALSE
 	preserved = TRUE
 	update_icon()
-	desc = "All that remains of a hivelord. It is preserved, allowing you to use it to heal completely without danger of decay."
+	desc = "All that remains of a hivelord. It is preserved, allowing you to use it to heal physical injuries without danger of decay."
 	if(implanted)
 		SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "implanted"))
 	else
@@ -81,10 +81,10 @@
 				H.visible_message("[user] forces [H] to apply [src]... [H.p_they()] quickly regenerate all injuries!")
 				SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "other"))
 			else
-				to_chat(user, "<span class='notice'>You start to smear [src] on yourself. It feels and smells disgusting, but you feel amazingly refreshed in mere moments.</span>")
+				to_chat(user, "<span class='notice'>You smear [src] on yourself. You still feel disgusting, but your wounds appear to be healed.</span>")
 				SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "self"))
 			H.adjustBruteLoss(-75)
-			H.adjustFireLoss(-25)
+			H.adjustFireLoss(-75)
 			H.adjustBrainLoss(5)
 			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "core", /datum/mood_event/healsbadman) //Now THIS is a miner buff (fixed - nerf)
 			qdel(src)
@@ -106,7 +106,7 @@
 
 /*************************Legion core********************/
 /obj/item/organ/regenerative_core/legion
-	desc = "A strange rock that crackles with power. It can be used to heal completely, but it will rapidly decay into uselessness."
+	desc = "A strange rock that crackles with power. It can be used to heal physical injuries, but it will rapidly decay into uselessness."
 	icon_state = "legion_soul"
 
 /obj/item/organ/regenerative_core/legion/Initialize()
@@ -128,4 +128,4 @@
 
 /obj/item/organ/regenerative_core/legion/preserved(implanted = 0)
 	..()
-	desc = "[src] has been stabilized. It is preserved, allowing you to use it to heal completely without danger of decay."
+	desc = "[src] has been stabilized. It is preserved, allowing you to use it to heal physical injuries without danger of decay."

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -680,6 +680,7 @@
 	if(prob(80))
 		M.adjustBruteLoss(-1*REM, 0)
 		M.adjustFireLoss(-1*REM, 0)
+		M.adjustBrainLoss(-1*REM, 0)
 		. = TRUE
 	..()
 


### PR DESCRIPTION
:cl: 
tweak: Legion cores now can only heal 75 brute and 75 burn damage when applied directly to the forehead, which will cause slight brain damage when done repeatedly. implanted cores are as strong as ever.
tweak: lavaland cacti can heal minor brain damage.
/:cl:

[why]: I strongly dislike the idea of mining infinitely better than anything medbay has on offer. Their survival medipens are already better than any pen medbay can get, but cores are absurdly overpowered. This change still allows them extreme healing power inside and outside mining, but they won't fix everything, and spamming them to hell and back would be punished just enough that you can't take down a legion tendril using a toolbox. Using cores sparsely and eating cacti or getting like two mannitol pills from medbay will completely fix this issue. Miners have plenty of heals in their medipens, cacti, and donk pockets. If a miner is concerned because they rely on them to defeat bosses that give them wizard items, they still have a few options:
-carry extra cores if the boss deals massive amounts of burn damage
-get a core surgically implanted, which will still instantly fully heal.
-use the survival medipens that they also have access to
-get chemicals from medbay, either to heal or to increase movement speed to avoid damage slowdown
-bringing help to distract the boss while they heal in a game designed for 50+ players on one server
among others. I think this is for the best.