### PR TITLE
Adds messages for survival medipens, renames lavaland extract

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1117,25 +1117,33 @@
 	..()
 	return TRUE
 
-/datum/reagent/medicine/lavaland_extract
-	name = "Lavaland Extract"
-	id = "lavaland_extract"
-	description = "An extract of lavaland atmospheric and mineral elements. Heals the user in small doses, but is extremely toxic otherwise."
+/datum/reagent/medicine/borathium //aka lavaland extract, survival medipen juice, star trek reference no.6546515619
+	name = "Borathium"
+	id = "borathium"
+	description = "A cutting-edge drug that greatly accelerates wound healing, but easily causes overdoses."
 	color = "#C8A5DC" // rgb: 200, 165, 220
 	overdose_threshold = 3 //To prevent people stacking massive amounts of a very strong healing reagent
 	can_synth = FALSE
 
-/datum/reagent/medicine/lavaland_extract/on_mob_life(mob/living/carbon/M)
+/datum/reagent/medicine/borathium/on_mob_life(mob/living/carbon/M)
 	M.heal_bodypart_damage(5,5)
 	..()
 	return TRUE
 
-/datum/reagent/medicine/lavaland_extract/overdose_process(mob/living/M)
+/datum/reagent/medicine/borathium/overdose_process(mob/living/M)
 	M.adjustBruteLoss(3*REM, 0, FALSE, BODYPART_ORGANIC)
 	M.adjustFireLoss(3*REM, 0, FALSE, BODYPART_ORGANIC)
 	M.adjustToxLoss(3*REM, 0)
 	..()
 	return TRUE
+
+/datum/reagent/medicine/borathium/on_mob_add(mob/living/M)
+	..()
+	to_chat(M, "<span class='notice'>You feel your body glowing hot as Boratium courses through your bloodstream.</span>")
+
+/datum/reagent/medicine/borathium/on_mob_delete(mob/living/M)
+	to_chat(M, "<span class='notice'>You feel the warmth of the Borathium fade away.</span>")
+	..()
 
 //used for changeling's adrenaline power
 /datum/reagent/medicine/changelingadrenaline

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -159,7 +159,7 @@
 	icon_state = "stimpen"
 	volume = 57
 	amount_per_transfer_from_this = 57
-	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "tricordrazine" = 15, "epinephrine" = 10, "lavaland_extract" = 2, "omnizine" = 5)
+	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "tricordrazine" = 15, "epinephrine" = 10, "borathium" = 2, "omnizine" = 5)
 
 /obj/item/reagent_containers/hypospray/medipen/species_mutator
 	name = "species mutator medipen"


### PR DESCRIPTION
:cl: Denton
tweak: Added messages that show when survival medipen reagents first enter and exit the user's body.
/:cl:

I had two gripes with survival medipens:
1) There is no real way to tell when lavaland extract has finished metabolizing, and when you can inject the next pen without risking death by overdose. 
2) "Lavaland extract" is a dumb name

I added messages that show when the reagent enters the system and when it finishes metabolizing. I also renamed the reagent to "Borathium":

![weed](https://user-images.githubusercontent.com/32391752/50793569-eec29700-12c8-11e9-84c7-cc95b1b5e283.PNG)