### PR TITLE
Slippery skin makes Hypodermic prickles and Liquid contents trigger

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -179,6 +179,10 @@
 	// For code, see grown.dm
 	name = "Liquid Contents"
 	examine_line = "<span class='info'>It has a lot of liquid contents inside.</span>"
+	
+/datum/plant_gene/trait/squash/on_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/C)
+	// Squash the plant on slip.
+	G.squash(C)
 
 /datum/plant_gene/trait/slip
 	// Makes plant slippery, unless it has a grown-type trash. Then the trash gets slippery.
@@ -367,6 +371,9 @@
 /datum/plant_gene/trait/stinging
 	name = "Hypodermic Prickles"
 
+/datum/plant_gene/trait/stinging/on_slip(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+	on_throw_impact(G, target)
+	
 /datum/plant_gene/trait/stinging/on_throw_impact(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	if(isliving(target) && G.reagents && G.reagents.total_volume)
 		var/mob/living/L = target


### PR DESCRIPTION
:cl: Recurracy
tweak: Hypodermic prickles is triggered when someone slips over a plant with the Slippery Skin trait
tweak: Liquid contents is triggered when someone slips over a plant with the Slippery Skin trait
/:cl:

Because more variety for botanists and taternists is fun. 
Logically thinking, though, it'd make sense to me a tomato would splatter when a spessman falls on it. And if death nettle injects its garbage into you when it's thrown, it'd also make sense to me it'd do the same. Falling into a bed of nettles doesn't seem like an enjoyable experience.

tl:dr plant squash when fall, prickles prick when fall