### PR TITLE
Dead people do not suffer hygiene problems, as they are busy decomposing

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -39,7 +39,8 @@
 		//Stuff jammed in your limbs hurts
 		handle_embedded_objects()
 
-	handle_hygiene()
+	if(stat != DEAD)
+		handle_hygiene()
 
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()


### PR DESCRIPTION
:cl: coiax
tweak: Dead bodies do not slowly have their hygiene decrease, as dead
bodies just smell generally because of the decomposition.
/:cl:

We already have dead bodies rotting miasma, they don't need green stink
clouds as well.
