### PR TITLE
Restricts magspear throw_range

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -292,6 +292,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	icon_state = "magspear"
 	throwforce = 25 //kills regular carps in one hit
 	force = 10
+	throw_range = 0 //throwing these invalidates the speargun
 	attack_verb = list("stabbed", "ripped", "gored", "impaled")
 	embedding = list("embedded_pain_multiplier" = 8, "embed_chance" = 100, "embedded_fall_chance" = 0, "embedded_impact_pain_multiplier" = 15) //55 damage+embed on hit
 


### PR DESCRIPTION
:cl: Denton
tweak: Restricted the throw range of magspears to 0 tiles.
/:cl:

This PR sets the magspear throw_range to 0 so that people have to use the speargun to launch them. Otherwise the whole speargun becomes kinda pointless.