### PR TITLE
Fixes smuggler's satchels not being visible with t-ray

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -70,7 +70,7 @@
 
 //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it
-
+#define TRAIT_T_RAY_VISIBLE     "t-ray-visible" // Visible on t-ray scanners if the atom/var/level == 1
 
 #define TRAIT_ALCOHOL_TOLERANCE	"alcohol_tolerance"
 #define TRAIT_AGEUSIA			"ageusia"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -60,7 +60,7 @@ NANITE SCANNER
 		if(O.level != 1)
 			continue
 
-		if(O.invisibility == INVISIBILITY_MAXIMUM)
+		if(O.invisibility == INVISIBILITY_MAXIMUM || O.has_trait(TRAIT_T_RAY_VISIBLE))
 			var/image/I = new(loc = get_turf(O))
 			var/mutable_appearance/MA = new(O)
 			MA.alpha = 128

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -297,6 +297,10 @@
 	w_class = WEIGHT_CLASS_NORMAL //Can fit in backpacks itself.
 	level = 1
 
+/obj/item/storage/backpack/satchel/flat/Initialize()
+	. = ..()
+	add_trait(TRAIT_T_RAY_VISIBLE, TRAIT_GENERIC)
+
 /obj/item/storage/backpack/satchel/flat/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1020,7 +1020,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "This satchel is thin enough to be hidden in the gap between plating and tiling; great for stashing \
 			your stolen goods. Comes with a crowbar, a floor tile and some contraband inside."
 	item = /obj/item/storage/backpack/satchel/flat/with_tools
-	cost = 2
+	cost = 1
 	surplus = 30
 
 //Space Suits and Hardsuits


### PR DESCRIPTION
:cl: coiax
fix: Smuggler's satchels can now be found with t-ray scanners, as
intended.
balance: Smuggler's satchels now cost 1 TC, down from 2 TC.
/:cl:

Fixes #42296.

I used a trait because currently this is the only object that I'm aware
of that uses partial invisibility (because it wants to be visible to
ghosts), and it seems a waste to dedicate an entire obj_flag to one
item, or put a hardcoded typepath.