### PR TITLE
Hypnosis event

### DIFF
--- a/code/modules/events/hypnosis.dm
+++ b/code/modules/events/hypnosis.dm
@@ -1,0 +1,29 @@
+/datum/round_event_control/hypnosis
+	name = "Hypnosis"
+	typepath = /datum/round_event/hypnosis
+	weight = 15
+	min_players = 10
+
+/datum/round_event/hypnosis
+	announceWhen = 120
+	var/count = 4
+
+/datum/round_event/hypnosis/announce(fake)
+	priority_announce("Auditing has discovered some psychotropic agents were added to the supply chain of [station_name()]'s food by corporate saboteurs, which have been found to increase suggestability in mice and clowns. Please be on the lookout for any odd behaviour.")
+
+/datum/round_event/hypnosis/start()
+	for(var/mob/living/carbon/human/H in shuffle(GLOB.alive_mob_list))
+		if(count <= 0)
+			break
+
+		if(!H.client)
+			continue
+		if(H.stat == DEAD)
+			continue
+		if(!H.getorgan(/obj/item/organ/brain))
+			continue
+		if(H.has_trait(TRAIT_NOHUNGER)) // Never ate the food.
+			continue
+		H.apply_status_effect(/datum/status_effect/trance, rand(10 SECONDS, 30 SECONDS), TRUE)
+		announce_to_ghosts(H)
+		count--

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1579,6 +1579,7 @@
 #include "code\modules\events\grid_check.dm"
 #include "code\modules\events\heart_attack.dm"
 #include "code\modules\events\high_priority_bounty.dm"
+#include "code\modules\events\hypnosis.dm"
 #include "code\modules\events\immovable_rod.dm"
 #include "code\modules\events\ion_storm.dm"
 #include "code\modules\events\major_dust.dm"


### PR DESCRIPTION
:cl: coiax
add: Added the new Hypnosis event, which causes four random alive human
player controlled mobs to enter a trance for the next 10 to 30 seconds.
If they hear any speech in that time, they will get hypnotised on that
phrase.
/:cl:

For LORE reasons, anyone who doesn't eat (abductors, ethereals,
shadowpeople, skeletons, plasmamen) is immune to this event, because
they couldn't have eaten those donkpockets with the paint chips.