### PR TITLE
Makes BoxStation vacant comissary disposal unit linked to cargo outlet

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -7568,13 +7568,16 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aqW" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light_switch{
+	pixel_x = -27
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "aqY" = (
@@ -22253,6 +22256,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "baY" = (
@@ -22588,8 +22594,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
@@ -22619,7 +22625,7 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -22885,9 +22891,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "bcH" = (
@@ -22898,9 +22901,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "bcI" = (
@@ -23935,9 +23935,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "bfj" = (
-/obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
 	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
@@ -24410,15 +24412,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "bgB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/closed/wall,
-/area/quartermaster/sorting)
-"bgC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+/obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/quartermaster/sorting)
 "bgD" = (
@@ -37680,7 +37674,7 @@
 	name = "Commissary Door Lock";
 	normaldoorcontrol = 1;
 	pixel_x = -26;
-	pixel_y = 6;
+	pixel_y = -8;
 	specialfunctions = 4
 	},
 /obj/machinery/disposal/bin,
@@ -56073,22 +56067,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"jxK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	id = "commissaryshutter";
-	name = "Vacant Commissary Shutter"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/vacant_room/commissary)
 "jyF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -56735,6 +56713,23 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"nXi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutter";
+	name = "Vacant Commissary Shutter"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "nXP" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -56798,6 +56793,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"oPj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/vacant_room/commissary)
 "oUq" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8
@@ -56954,6 +56955,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/wood,
 /area/lawoffice)
+"pVb" = (
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/quartermaster/sorting)
 "pWN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57145,6 +57152,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"rPX" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/maintenance/port)
 "rYJ" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot{
@@ -57261,6 +57272,9 @@
 /area/maintenance/starboard/aft)
 "sST" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "sSW" = (
@@ -79975,8 +79989,8 @@ aPK
 cCl
 aYh
 elq
-dfx
 cCm
+aSg
 aSg
 aPz
 bdW
@@ -80234,9 +80248,9 @@ cCj
 soQ
 sST
 bbU
-aSg
-aPz
-aZK
+dfx
+rPX
+pVb
 bgB
 bhX
 bgv
@@ -80489,12 +80503,12 @@ aPK
 tav
 yeu
 tav
-tav
+oPj
 oXE
 tav
 tav
 bfj
-bgC
+aZK
 bia
 aZK
 bjs
@@ -81003,7 +81017,7 @@ aVa
 tav
 aWE
 aYZ
-aYZ
+bbT
 bcG
 kRN
 tav
@@ -81517,8 +81531,8 @@ aUw
 tav
 hqp
 avr
-aYZ
 bbT
+aYZ
 kRN
 tav
 aZH
@@ -81774,8 +81788,8 @@ aSr
 tav
 aYZ
 gES
-aYZ
 bbT
+aYZ
 eAi
 tav
 beA
@@ -82031,8 +82045,8 @@ aWD
 tav
 aYj
 tav
-jxK
 baU
+nXi
 bcV
 bcV
 bfn


### PR DESCRIPTION
[Changelogs]: # 
:cl:
fix: Vacant comissary disposals in BoxStation are no longer directly linked to the recycler room outlet.
/:cl: