### PR TITLE
Fixes Syndicate access from Grant Full Access verb

### DIFF
--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -149,7 +149,7 @@
 			return list(ACCESS_CENT_GENERAL, ACCESS_CENT_SPECOPS, ACCESS_CENT_MEDICAL, ACCESS_CENT_LIVING)
 
 /proc/get_all_syndicate_access()
-	return list(ACCESS_SYNDICATE, ACCESS_SYNDICATE)
+	return list(ACCESS_SYNDICATE, ACCESS_SYNDICATE_LEADER)
 
 /proc/get_region_accesses(code)
 	switch(code)


### PR DESCRIPTION
Grant Full Access was giving two copies of the basic Syndicate access instead of one Syndicate and one Syndicate Leader.