### PR TITLE
Update pygit2 version to 0.27.2

### DIFF
--- a/tools/mapmerge2/requirements.txt
+++ b/tools/mapmerge2/requirements.txt
@@ -1,3 +1,3 @@
-pygit2==0.26.0
+pygit2==0.27.2
 bidict==0.13.1
 Pillow==5.1.0


### PR DESCRIPTION
pygit2 0.26.0 does not have appropriate binaries for Python 3.7, only 3.6
pygit2 0.27.3 does not have binaries at all (https://github.com/libgit2/pygit2/issues/857)
pygit2 0.27.2 has working binaries for Python 3.6 and 3.7
(the mapmerge code requires 3.6 or newer)