### PR TITLE
Improves Spiritual quirk

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -98,3 +98,7 @@
 	description = "<span class='nicegreen'>*WHEEZE*</span>\n"
 	mood_change = 12
 	timeout = 1800
+
+/datum/mood_event/religiously_comforted
+	description = "<span class='nicegreen'>You are comforted by the presence of a holy person.</span>"
+	mood_change = 3

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -117,11 +117,27 @@
 
 /datum/quirk/spiritual
 	name = "Spiritual"
-	desc = "You're in tune with the gods, and your prayers may be more likely to be heard. Or not."
+	desc = "You hold a spiritual belief, whether in God, nature or the arcane rules of the universe. You gain comfort from the presence of holy people, and believe that your prayers are more special than others."
 	value = 1
 	mob_trait = TRAIT_SPIRITUAL
-	gain_text = "<span class='notice'>You feel a little more faithful to the gods today.</span>"
-	lose_text = "<span class='danger'>You feel less faithful in the gods.</span>"
+	gain_text = "<span class='notice'>You have faith in a higher power.</span>"
+	lose_text = "<span class='danger'>You lose faith!</span>"
+
+/datum/quirk/spiritual/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.equip_to_slot_or_del(new /obj/item/storage/fancy/candle_box(H), SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/storage/box/matches(H), SLOT_IN_BACKPACK)
+
+/datum/quirk/spiritual/on_process()
+	var/comforted = FALSE
+	for(var/mob/living/L in oview(5, quirk_holder))
+		if(L.mind && L.mind.isholy && L.stat == CONSCIOUS)
+			comforted = TRUE
+			break
+	if(comforted)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "religious_comfort", /datum/mood_event/religiously_comforted)
+	else
+		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "religious_comfort")
 
 /datum/quirk/tagger
 	name = "Tagger"


### PR DESCRIPTION
:cl: coiax
add: Players with the Spiritual quirk now spawn with a pack of candles
and a box of matches, for better communion with their chosen power, and
get a mood boost while near a holy person (generally the chaplain).
/:cl:

Makes Spiritual not just a quirk that literally requires admin
approval to pay off. Have some free candles, talk to the chaplain to
cheer up, and maybe you'll be able to gang together to convince the gods
to give you an angry bloodcrawling duck.
