### PR TITLE
Allows coloring objects with spray cans

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -651,10 +651,10 @@
 
 		return
 
-	if(istype(target, /obj/structure/window))
+	if(isobj(target))
 		if(actually_paints)
 			target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
-			if(color_hex2num(paint_color) < 255)
+			if(color_hex2num(paint_color) < 255 && istype(target, /obj/structure/window))
 				target.set_opacity(255)
 			else
 				target.set_opacity(initial(target.opacity))
@@ -665,6 +665,7 @@
 
 		if(pre_noise || post_noise)
 			playsound(user.loc, 'sound/effects/spray.ogg', 5, 1, 5)
+		user.visible_message("[user] coats [target] with spray paint!", "<span class='notice'>You coat [target] with spray paint.</span>")
 		return
 
 	. = ..()


### PR DESCRIPTION
:cl: Mickyan
add: Most objects can now be colored using a spray can
spellcheck: Added visible message to spraying objects and windows
/:cl:

I noticed using crayon powder you can paint literally anything and even clothes show up as you'd expect when you wear them, but since you get a very limited range of colors this seemed like a wasted opportunity

![paint](https://user-images.githubusercontent.com/38563876/51063438-4a5b9000-15fb-11e9-974c-809cb5a9d0af.png)
