### PR TITLE
Fixes Malf AIs spawing multiple doomsdays

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -238,6 +238,8 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		return
 	if(alert(owner, "Send arming signal? (true = arm, false = cancel)", "purge_all_life()", "confirm = TRUE;", "confirm = FALSE;") != "confirm = TRUE;")
 		return
+	if (active)
+		return //prevent the AI from activating an already active doomsday
 	active = TRUE
 	set_us_up_the_bomb(owner)
 


### PR DESCRIPTION
[Changelogs]: 
:cl: Zxaber
fix: Malfunctioning AIs can no longer abuse the confirmation popup to create extra (unstoppable) doomsdays.
/:cl:

Fixes #42323