### PR TITLE
Banning panel change and two fixes

### DIFF
--- a/html/admin/banpanel.css
+++ b/html/admin/banpanel.css
@@ -72,6 +72,10 @@
     background-color: #ff00ff;
 }
 
+.abstract {
+    background-color: #708090;
+}
+
 .civilian {
     background-color: #6eaa2c;
 }


### PR DESCRIPTION
Moves the role bans for `Appearance`, `Emote` and `OOC` out of the `Ghost and Other Roles` category as requested by @Arianya. The new category is called `Abstract` and colored slate gray #708090.
Fixes a javascript error caused by `AI` having no corresponding command role to find a `toggle_head()` reference for.
Fixes role bans disconnecting a client.