### PR TITLE
Fixes lizards instantly getting firebreath

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -303,9 +303,12 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		C.remove_trait(X, SPECIES_TRAIT)
 
 	//If their inert mutation is not the same, swap it out
-	if((inert_mutation != new_species.inert_mutation) && LAZYLEN(C.dna.mutation_index))
+	if((inert_mutation != new_species.inert_mutation) && LAZYLEN(C.dna.mutation_index) && (inert_mutation in C.dna.mutation_index))
 		C.dna.remove_mutation(inert_mutation)
-		C.dna.add_mutation(new_species.inert_mutation)
+		//keep it at the right spot, so we can't have people taking shortcuts
+		var/location = C.dna.mutation_index.Find(inert_mutation)
+		C.dna.mutation_index[location] = new_species.inert_mutation
+		C.dna.mutation_index[new_species.inert_mutation] = create_sequence(new_species.inert_mutation)
 
 	C.remove_movespeed_modifier(MOVESPEED_ID_SPECIES)
 


### PR DESCRIPTION
fixes #42333 
I see why it happened. I called remove_mutation to remove the active mutation in-case its there and @optimumtact assumed it was the thing that removed it from the index. Thus thinking that he probably added add_mutation to add it to the index, while it really just gave every lizard superpowers.

:cl:
fix: lizards will no longer always have firebreath
/:cl: