### PR TITLE
Rearranges uplink items

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -111,55 +111,162 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/discounts
 	category = "Discounted Gear"
 
-// Nuclear Operative (Special Offers)
-/datum/uplink_item/nukeoffer
-	category = "Special Offers"
+//All bundles and telecrystals
+/datum/uplink_item/bundles_TC
+	category = "Bundles and Telecrystals"
 	surplus = 0
-	include_modes = list(/datum/game_mode/nuclear)
 	cant_discount = TRUE
 
-/datum/uplink_item/nukeoffer/chemical
+/datum/uplink_item/bundles_TC/chemical
 	name = "Bioterror bundle"
 	desc = "For the madman: Contains a handheld Bioterror chem sprayer, a Bioterror foam grenade, a box of lethal chemicals, a dart pistol, \
 			box of syringes, Donksoft assault rifle, and some riot darts. Remember: Seal suit and equip internals before use."
 	item = /obj/item/storage/backpack/duffelbag/syndie/med/bioterrorbundle
 	cost = 30 // normally 42
+	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/nukeoffer/bulldog
+/datum/uplink_item/bundles_TC/bulldog
 	name = "Bulldog bundle"
 	desc = "Lean and mean: Optimized for people that want to get up close and personal. Contains the popular \
 			Bulldog shotgun, a 12g buckshot drum, a 12g taser slug drum and a pair of Thermal imaging goggles."
 	item = /obj/item/storage/backpack/duffelbag/syndie/bulldogbundle
 	cost = 13 // normally 16
+	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/nukeoffer/c20r
+/datum/uplink_item/bundles_TC/c20r
 	name = "C-20r bundle"
 	desc = "Old Faithful: The classic C-20r, bundled with two magazines and a (surplus) suppressor at discount price."
 	item = /obj/item/storage/backpack/duffelbag/syndie/c20rbundle
 	cost = 14 // normally 16
+	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/nukeoffer/medical
+/datum/uplink_item/bundles_TC/bundle
+	name = "Cybernetic Implants Bundle"
+	desc = "A random selection of cybernetic implants. Guaranteed 5 high quality implants. Comes with an autosurgeon."
+	item = /obj/item/storage/box/cyber_implants
+	cost = 40
+	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/bundles_TC/medical
 	name = "Medical bundle"
 	desc = "The support specialist: Aid your fellow operatives with this medical bundle. Contains a tactical medkit, \
 			a Donksoft LMG, a box of riot darts and a pair of magboots to rescue your friends in no-gravity environments."
 	item = /obj/item/storage/backpack/duffelbag/syndie/med/medicalbundle
 	cost = 15 // normally 20
+	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/nukeoffer/sniper
+/datum/uplink_item/bundles_TC/sniper
 	name = "Sniper bundle"
 	desc = "Elegant and refined: Contains a collapsed sniper rifle in an expensive carrying case, \
 			two soporific knockout magazines, a free surplus suppressor, and a sharp-looking tactical turtleneck suit. \
 			We'll throw in a free red tie if you order NOW."
 	item = /obj/item/storage/briefcase/sniperbundle
 	cost = 20 // normally 26
+	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/nukeoffer/firestarter
+/datum/uplink_item/bundles_TC/firestarter
 	name = "Spetsnaz Pyro bundle"
 	desc = "For systematic suppression of carbon lifeforms in close quarters: Contains a lethal New Russian backpack spray, Elite hardsuit, \
 			Stechkin APS pistol, two magazines, a minibomb and a stimulant syringe. \
 			Order NOW and comrade Boris will throw in an extra tracksuit."
 	item = /obj/item/storage/backpack/duffelbag/syndie/firestarter
 	cost = 30
+	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/bundles_TC/bundle
+	name = "Syndicate Bundle"
+	desc = "Syndicate Bundles are specialized groups of items that arrive in a plain box. \
+			These items are collectively worth more than 20 telecrystals, but you do not know which specialization \
+			you will receive. May contain discontinued and/or exotic items."
+	item = /obj/item/storage/box/syndicate
+	cost = 20
+	exclude_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/bundles_TC/surplus
+	name = "Syndicate Surplus Crate"
+	desc = "A dusty crate from the back of the Syndicate warehouse. Rumored to contain a valuable assortment of items, \
+			but you never know. Contents are sorted to always be worth 50 TC."
+	item = /obj/structure/closet/crate
+	cost = 20
+	player_minimum = 25
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+	var/starting_crate_value = 50
+
+/datum/uplink_item/bundles_TC/surplus/super
+	name = "Super Surplus Crate"
+	desc = "A dusty SUPER-SIZED from the back of the Syndicate warehouse. Rumored to contain a valuable assortment of items, \
+			but you never know. Contents are sorted to always be worth 125 TC."
+	cost = 40
+	player_minimum = 40
+	starting_crate_value = 125
+
+/datum/uplink_item/bundles_TC/surplus/purchase(mob/user, datum/component/uplink/U)
+	var/list/uplink_items = get_uplink_items(SSticker && SSticker.mode? SSticker.mode : null, FALSE)
+
+	var/crate_value = starting_crate_value
+	var/obj/structure/closet/crate/C = spawn_item(/obj/structure/closet/crate, user, U)
+	if(U.purchase_log)
+		U.purchase_log.LogPurchase(C, src, cost)
+	while(crate_value)
+		var/category = pick(uplink_items)
+		var/item = pick(uplink_items[category])
+		var/datum/uplink_item/I = uplink_items[category][item]
+
+		if(!I.surplus || prob(100 - I.surplus))
+			continue
+		if(crate_value < I.cost)
+			continue
+		crate_value -= I.cost
+		var/obj/goods = new I.item(C)
+		if(U.purchase_log)
+			U.purchase_log.LogPurchase(goods, I, 0)
+	return C
+
+/datum/uplink_item/bundles_TC/random
+	name = "Random Item"
+	desc = "Picking this will purchase a random item. Useful if you have some TC to spare or if you haven't decided on a strategy yet."
+	item = /obj/effect/gibspawner/generic // non-tangible item because techwebs use this path to determine illegal tech
+	cost = 0
+
+/datum/uplink_item/bundles_TC/random/purchase(mob/user, datum/component/uplink/U)
+	var/list/uplink_items = U.uplink_items
+	var/list/possible_items = list()
+	for(var/category in uplink_items)
+		for(var/item in uplink_items[category])
+			var/datum/uplink_item/I = uplink_items[category][item]
+			if(src == I || !I.item)
+				continue
+			if(U.telecrystals < I.cost)
+				continue
+			if(I.limited_stock == 0)
+				continue
+			possible_items += I
+
+	if(possible_items.len)
+		var/datum/uplink_item/I = pick(possible_items)
+		SSblackbox.record_feedback("tally", "traitor_random_uplink_items_gotten", 1, initial(I.name))
+		U.MakePurchase(user, I)
+
+/datum/uplink_item/bundles_TC/telecrystal
+	name = "Raw Telecrystal"
+	desc = "A telecrystal in its rawest and purest form; can be utilized on active uplinks to increase their telecrystal count."
+	item = /obj/item/stack/telecrystal
+	cost = 1
+	// Don't add telecrystals to the purchase_log since
+	// it's just used to buy more items (including itself!)
+	purchase_log_vis = FALSE
+
+/datum/uplink_item/bundles_TC/telecrystal/five
+	name = "5 Raw Telecrystals"
+	desc = "Five telecrystals in their rawest and purest form; can be utilized on active uplinks to increase their telecrystal count."
+	item = /obj/item/stack/telecrystal/five
+	cost = 5
+
+/datum/uplink_item/bundles_TC/telecrystal/twenty
+	name = "20 Raw Telecrystals"
+	desc = "Twenty telecrystals in their rawest and purest form; can be utilized on active uplinks to increase their telecrystal count."
+	item = /obj/item/stack/telecrystal/twenty
+	cost = 20
 
 // Dangerous Items
 /datum/uplink_item/dangerous
@@ -210,6 +317,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 20
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+
+/datum/uplink_item/dangerous/throwingweapons
+	name = "Box of Throwing Weapons"
+	desc = "A box of shurikens and reinforced bolas from ancient Earth martial arts. They are highly effective \
+			throwing weapons. The bolas can knock a target down and the shurikens will embed into limbs."
+	item = /obj/item/storage/box/syndie_kit/throwing_weapons
+	cost = 3
 
 /datum/uplink_item/dangerous/shotgun
 	name = "Bulldog Shotgun"
@@ -266,6 +380,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 4
 	surplus = 40
 	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/dangerous/rapid
+	name = "Gloves of the North Star"
+	desc = "These gloves let the user punch people very fast. Does not improve weapon attack speed or the meaty fists of a hulk."
+	item = /obj/item/clothing/gloves/rapid
+	cost = 8
 
 /datum/uplink_item/dangerous/guardian
 	name = "Holoparasites"
@@ -365,12 +485,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/stealthy_weapons
 	category = "Stealthy and Inconspicuous Weapons"
 
-/datum/uplink_item/stealthy_weapons/throwingweapons
-	name = "Box of Throwing Weapons"
-	desc = "A box of shurikens and reinforced bolas from ancient Earth martial arts. They are highly effective \
-			throwing weapons. The bolas can knock a target down and the shurikens will embed into limbs."
-	item = /obj/item/storage/box/syndie_kit/throwing_weapons
-	cost = 3
+/datum/uplink_item/stealthy_weapons/combatglovesplus
+	name = "Combat Gloves Plus"
+	desc = "A pair of gloves that are fireproof and shock resistant, however unlike the regular Combat Gloves this one uses nanotechnology \
+			to learn the abilities of krav maga to the wearer."
+	item = /obj/item/clothing/gloves/krav_maga/combatglovesplus
+	cost = 5
+	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+	surplus = 0
 
 /datum/uplink_item/stealthy_weapons/cqc
 	name = "CQC Manual"
@@ -1295,29 +1417,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	restricted = TRUE
 
-/datum/uplink_item/device_tools/telecrystal
-	name = "Raw Telecrystal"
-	desc = "A telecrystal in its rawest and purest form; can be utilized on active uplinks to increase their telecrystal count."
-	item = /obj/item/stack/telecrystal
-	cost = 1
-	surplus = 0
-	cant_discount = TRUE
-	// Don't add telecrystals to the purchase_log since
-	// it's just used to buy more items (including itself!)
-	purchase_log_vis = FALSE
-
-/datum/uplink_item/device_tools/telecrystal/five
-	name = "5 Raw Telecrystals"
-	desc = "Five telecrystals in their rawest and purest form; can be utilized on active uplinks to increase their telecrystal count."
-	item = /obj/item/stack/telecrystal/five
-	cost = 5
-
-/datum/uplink_item/device_tools/telecrystal/twenty
-	name = "20 Raw Telecrystals"
-	desc = "Twenty telecrystals in their rawest and purest form; can be utilized on active uplinks to increase their telecrystal count."
-	item = /obj/item/stack/telecrystal/twenty
-	cost = 20
-
 // Implants
 /datum/uplink_item/implants
 	category = "Implants"
@@ -1330,6 +1429,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/imp_adrenal
 	cost = 8
 	player_minimum = 25
+
+/datum/uplink_item/implants/antistun
+	name = "CNS Rebooter Implant"
+	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."
+	item = /obj/item/autosurgeon/anti_stun
+	cost = 12
+	surplus = 0
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"
@@ -1364,6 +1471,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 4
 	restricted = TRUE
 
+/datum/uplink_item/implants/reviver
+	name = "Reviver Implant"
+	desc = "This implant will attempt to revive and heal you if you lose consciousness. Comes with an autosurgeon."
+	item = /obj/item/autosurgeon/reviver
+	cost = 8
+	surplus = 0
+	include_modes = list(/datum/game_mode/nuclear)
+
 /datum/uplink_item/implants/stealthimplant
 	name = "Stealth Implant"
 	desc = "This one-of-a-kind implant will make you almost invisible if you play your cards right. \
@@ -1378,6 +1493,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/imp_storage
 	cost = 8
 
+/datum/uplink_item/implants/thermals
+	name = "Thermal Eyes"
+	desc = "These cybernetic eyes will give you thermal vision. Comes with a free autosurgeon."
+	item = /obj/item/autosurgeon/thermal_eyes
+	cost = 8
+	surplus = 0
+	include_modes = list(/datum/game_mode/nuclear)
+
 /datum/uplink_item/implants/uplink
 	name = "Uplink Implant"
 	desc = "An implant injected into the body, and later activated at the user's will. Has no telecrystals and must be charged by the use of physical telecrystals. \
@@ -1388,42 +1511,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 	restricted = TRUE
 
-// Cybernetics
-/datum/uplink_item/cyber_implants
-	category = "Cybernetic Implants"
-	surplus = 0
-	include_modes = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/cyber_implants/antistun
-	name = "CNS Rebooter Implant"
-	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."
-	item = /obj/item/autosurgeon/anti_stun
-	cost = 12
-
-/datum/uplink_item/cyber_implants/reviver
-	name = "Reviver Implant"
-	desc = "This implant will attempt to revive and heal you if you lose consciousness. Comes with an autosurgeon."
-	item = /obj/item/autosurgeon/reviver
-	cost = 8
-
-/datum/uplink_item/cyber_implants/thermals
-	name = "Thermal Eyes"
-	desc = "These cybernetic eyes will give you thermal vision. Comes with a free autosurgeon."
-	item = /obj/item/autosurgeon/thermal_eyes
-	cost = 8
-
-/datum/uplink_item/cyber_implants/xray
+/datum/uplink_item/implants/xray
 	name = "X-ray Vision Implant"
 	desc = "These cybernetic eyes will give you X-ray vision. Comes with an autosurgeon."
 	item = /obj/item/autosurgeon/xray_eyes
 	cost = 10
+	surplus = 0
+	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/cyber_implants/bundle
-	name = "Cybernetic Implants Bundle"
-	desc = "A random selection of cybernetic implants. Guaranteed 5 high quality implants. Comes with an autosurgeon."
-	item = /obj/item/storage/box/cyber_implants
-	cost = 40
-	cant_discount = TRUE
 
 //Race-specific items
 /datum/uplink_item/race_restricted
@@ -1619,14 +1714,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	category = "(Pointless) Badassery"
 	surplus = 0
 
-/datum/uplink_item/badass/combatglovesplus
-	name = "Combat Gloves Plus"
-	desc = "A pair of gloves that are fireproof and shock resistant, however unlike the regular Combat Gloves this one uses nanotechnology \
-			to learn the abilities of krav maga to the wearer."
-	item = /obj/item/clothing/gloves/krav_maga/combatglovesplus
-	cost = 5
-	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
-
 /datum/uplink_item/badass/costumes/obvious_chameleon
 	name = "Broken Chameleon Kit"
 	desc = "A set of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more! \
@@ -1649,12 +1736,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Clown Costume"
 	desc = "Nothing is more terrifying than clowns with fully automatic weaponry."
 	item = /obj/item/storage/backpack/duffelbag/clown/syndie
-
-/datum/uplink_item/badass/rapid
-	name = "Gloves of the North Star"
-	desc = "These gloves let the user punch people very fast. Does not improve weapon attack speed or the meaty fists of a hulk."
-	item = /obj/item/clothing/gloves/rapid
-	cost = 8
 
 /datum/uplink_item/badass/balloon
 	name = "Syndicate Balloon"
@@ -1688,80 +1769,3 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/fancy/cigarettes/cigpack_syndicate
 	cost = 2
 	illegal_tech = FALSE
-
-/datum/uplink_item/badass/bundle
-	name = "Syndicate Bundle"
-	desc = "Syndicate Bundles are specialized groups of items that arrive in a plain box. \
-			These items are collectively worth more than 20 telecrystals, but you do not know which specialization \
-			you will receive. May contain discontinued and/or exotic items."
-	item = /obj/item/storage/box/syndicate
-	cost = 20
-	exclude_modes = list(/datum/game_mode/nuclear)
-	cant_discount = TRUE
-
-/datum/uplink_item/badass/surplus
-	name = "Syndicate Surplus Crate"
-	desc = "A dusty crate from the back of the Syndicate warehouse. Rumored to contain a valuable assortment of items, \
-			but you never know. Contents are sorted to always be worth 50 TC."
-	item = /obj/structure/closet/crate
-	cost = 20
-	player_minimum = 25
-	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
-	cant_discount = TRUE
-	var/starting_crate_value = 50
-
-/datum/uplink_item/badass/surplus/super
-	name = "Super Surplus Crate"
-	desc = "A dusty SUPER-SIZED from the back of the Syndicate warehouse. Rumored to contain a valuable assortment of items, \
-			but you never know. Contents are sorted to always be worth 125 TC."
-	cost = 40
-	player_minimum = 40
-	starting_crate_value = 125
-
-/datum/uplink_item/badass/surplus/purchase(mob/user, datum/component/uplink/U)
-	var/list/uplink_items = get_uplink_items(SSticker && SSticker.mode? SSticker.mode : null, FALSE)
-
-	var/crate_value = starting_crate_value
-	var/obj/structure/closet/crate/C = spawn_item(/obj/structure/closet/crate, user, U)
-	if(U.purchase_log)
-		U.purchase_log.LogPurchase(C, src, cost)
-	while(crate_value)
-		var/category = pick(uplink_items)
-		var/item = pick(uplink_items[category])
-		var/datum/uplink_item/I = uplink_items[category][item]
-
-		if(!I.surplus || prob(100 - I.surplus))
-			continue
-		if(crate_value < I.cost)
-			continue
-		crate_value -= I.cost
-		var/obj/goods = new I.item(C)
-		if(U.purchase_log)
-			U.purchase_log.LogPurchase(goods, I, 0)
-	return C
-
-/datum/uplink_item/badass/random
-	name = "Random Item"
-	desc = "Picking this will purchase a random item. Useful if you have some TC to spare or if you haven't decided on a strategy yet."
-	item = /obj/effect/gibspawner/generic // non-tangible item because techwebs use this path to determine illegal tech
-	cost = 0
-	cant_discount = TRUE
-
-/datum/uplink_item/badass/random/purchase(mob/user, datum/component/uplink/U)
-	var/list/uplink_items = U.uplink_items
-	var/list/possible_items = list()
-	for(var/category in uplink_items)
-		for(var/item in uplink_items[category])
-			var/datum/uplink_item/I = uplink_items[category][item]
-			if(src == I || !I.item)
-				continue
-			if(U.telecrystals < I.cost)
-				continue
-			if(I.limited_stock == 0)
-				continue
-			possible_items += I
-
-	if(possible_items.len)
-		var/datum/uplink_item/I = pick(possible_items)
-		SSblackbox.record_feedback("tally", "traitor_random_uplink_items_gotten", 1, initial(I.name))
-		U.MakePurchase(user, I)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -248,7 +248,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 		U.MakePurchase(user, I)
 
 /datum/uplink_item/bundles_TC/telecrystal
-	name = "Raw Telecrystal"
+	name = "1 Raw Telecrystal"
 	desc = "A telecrystal in its rawest and purest form; can be utilized on active uplinks to increase their telecrystal count."
 	item = /obj/item/stack/telecrystal
 	cost = 1


### PR DESCRIPTION
:cl: Denton
tweak: Rearranged Uplink items: Bundles, random item and TC have been moved into a new category called "Bundles and Telecrystals". Gloves of the North Star and Box of Throwing Weapons have been moved to Conspicuous and Dangerous Weapons. Combat Gloves Plus have been moved to Stealthy and Inconspicuous Weapons. Moved all implants into the Implants category.
/:cl:

Some uplink items are misplaced - you have Nuke Ops bundles at the top of the uplink as "Special Offers" while regular tator bundles are near the very bottom under "(Pointless) Badassery".

I changed the following to make uplink items easier to find:
- Moved bundles, TC items and Random Item to a new category called "Bundles and Telecrystals"
- Joined "Cybernetic Implants" with "Implants"
- Moved Gloves of the North Star and Box of Throwing Weapons to Conspicuous and Dangerous Weapons
- Moved Combat Gloves Plus to Stealthy and Inconspicuous Weapons
