### PR TITLE
dna console grammar

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -722,7 +722,7 @@
 						var/datum/mutation/human/HM = new A.type()
 						diskette.mutations += HM
 						HM.copy_mutation(A)
-						to_chat(usr, "<span class='notice'>Succesfully written [A.name] to [diskette.name].</span>")
+						to_chat(usr, "<span class='notice'>Successfully wrote [A.name] to [diskette.name].</span>")
 		if("deletediskmut")
 			if(diskette && !diskette.read_only)
 				if(num && (LAZYLEN(diskette.mutations) >= num))
@@ -736,7 +736,7 @@
 					var/datum/mutation/human/HM = new A.type()
 					HM.copy_mutation(A)
 					stored_mutations[HM] = get_sequence(HM.type)
-					to_chat(usr,"<span class='notice'>Succesfully written [A.name] to storage.")
+					to_chat(usr,"<span class='notice'>Successfully wrote [A.name] to storage.")
 		if("combine")
 			if(num && (LAZYLEN(stored_mutations) >= num))
 				if(LAZYLEN(stored_mutations) < max_storage)


### PR DESCRIPTION
:cl:
spellcheck: Made some grammar better with genetics consoles when they import and export disks.
/:cl:

Written -> wrote is because of past participle vs past tense
Succesfully -> Successfully because success has two Cs and two Ss (havent checked if this is an america vs elsewhere spelling thing but i dont think it is?)