### PR TITLE
[READY] petting all dogs makes you happy, petting cats now makes you happy #freepugs

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -23,13 +23,14 @@
 	mood_change = 3
 	timeout = 3000
 
-/datum/mood_event/pet_doggie
-	description = "<span class='nicegreen'>Dogs are adorable! I can't stop petting them!</span>\n"
+/datum/mood_event/pet_animal
+	description = "<span class='nicegreen'>Animals are adorable! I can't stop petting them!</span>\n"
 	mood_change = 3
 	timeout = 3000
 
-/datum/mood_event/pet_doggie/add_effects(name)//initial name of the animal, not a pet name
-	description = "<span class='nicegreen'>[name]s are adorable! I can't stop petting them!</span>\n"
+/datum/mood_event/pet_animal/add_effects(name)
+	var/propername = capitalize(name)//if capitalize did nothing, then it already was capitalized and thus proper
+	description = "<span class='nicegreen'>[name][findtextEx(propername, name) ? " is" : "s are"] adorable! I can't stop petting them!</span>\n"
 
 /datum/mood_event/honk
 	description = "<span class='nicegreen'>Maybe clowns aren't so bad after all. Honk!</span>\n"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -29,8 +29,7 @@
 	timeout = 3000
 
 /datum/mood_event/pet_animal/add_effects(name)
-	var/propername = capitalize(name)//if capitalize did nothing, then it already was capitalized and thus proper
-	description = "<span class='nicegreen'>[name][findtextEx(propername, name) ? " is" : "s are"] adorable! I can't stop petting them!</span>\n"
+	description = "<span class='nicegreen'>\The [name] is adorable! I can't stop petting \him!</span>\n"
 
 /datum/mood_event/honk
 	description = "<span class='nicegreen'>Maybe clowns aren't so bad after all. Honk!</span>\n"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -23,10 +23,13 @@
 	mood_change = 3
 	timeout = 3000
 
-/datum/mood_event/pet_corgi
-	description = "<span class='nicegreen'>Corgis are adorable! I can't stop petting them!</span>\n"
+/datum/mood_event/pet_doggie
+	description = "<span class='nicegreen'>Dogs are adorable! I can't stop petting them!</span>\n"
 	mood_change = 3
 	timeout = 3000
+
+/datum/mood_event/pet_doggie/add_effects(name)//initial name of the animal, not a pet name
+	description = "<span class='nicegreen'>[name]s are adorable! I can't stop petting them!</span>\n"
 
 /datum/mood_event/honk
 	description = "<span class='nicegreen'>Maybe clowns aren't so bad after all. Honk!</span>\n"

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -238,6 +238,7 @@
 			if(M && stat != DEAD)
 				new /obj/effect/temp_visual/heart(loc)
 				emote("me", 1, "purrs!")
+				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, name, /datum/mood_event/pet_animal, name)
 		else
 			if(M && stat != DEAD)
 				emote("me", 1, "hisses!")

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -267,7 +267,7 @@
 		return
 	if(!item_to_add)
 		user.visible_message("[user] pets [src].","<span class='notice'>You rest your hand on [src]'s head for a moment.</span>")
-		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "pet_doggie", /datum/mood_event/pet_doggie, initial(src.name))
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, name, /datum/mood_event/pet_animal, name)
 		return
 
 	if(user && !user.temporarilyRemoveItemFromInventory(item_to_add))
@@ -650,7 +650,7 @@
 			if(M && stat != DEAD) // Added check to see if this mob (the dog) is dead to fix issue 2454
 				new /obj/effect/temp_visual/heart(loc)
 				emote("me", 1, "yaps happily!")
-				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "pet_doggie", /datum/mood_event/pet_doggie, initial(src.name))
+				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, name, /datum/mood_event/pet_animal, name)
 		else
 			if(M && stat != DEAD) // Same check here, even though emote checks it as well (poor form to check it only in the help case)
 				emote("me", 1, "growls!")

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -650,7 +650,7 @@
 			if(M && stat != DEAD) // Added check to see if this mob (the dog) is dead to fix issue 2454
 				new /obj/effect/temp_visual/heart(loc)
 				emote("me", 1, "yaps happily!")
-				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "pet_corgi", /datum/mood_event/pet_corgi)
+				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "pet_doggie", /datum/mood_event/pet_doggie, initial(src.name))
 		else
 			if(M && stat != DEAD) // Same check here, even though emote checks it as well (poor form to check it only in the help case)
 				emote("me", 1, "growls!")

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -267,7 +267,7 @@
 		return
 	if(!item_to_add)
 		user.visible_message("[user] pets [src].","<span class='notice'>You rest your hand on [src]'s head for a moment.</span>")
-		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "pet_corgi", /datum/mood_event/pet_corgi)
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "pet_doggie", /datum/mood_event/pet_doggie, initial(src.name))
 		return
 
 	if(user && !user.temporarilyRemoveItemFromInventory(item_to_add))


### PR DESCRIPTION
fixes #42361 
closes #42363 

i changed the moodlet instead of where the wuv proc is, so it should pick the initial name of the dog and say something like "pugs are so adorable! i can't stop petting them!" but for all kinds of dogs

the only thing is that this name doesn't change if you pet a pug and then a corgi because they are classified as the same buff, i could make the name of the buff the same as the mob you are petting so you could stack happiness but that would be a balance change, imagine how happy you could get locked in a room with every kind of dog in the game