### PR TITLE
Kaledioscope component, for colour-changing pattern

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -286,3 +286,7 @@
 #define COMSIG_XENO_TURF_CLICK_SHIFT "xeno_turf_click_shift"				//from turf ShiftClickOn(): (/mob)
 #define COMSIG_XENO_TURF_CLICK_CTRL "xeno_turf_click_alt"					//from turf AltClickOn(): (/mob)
 #define COMSIG_XENO_MONKEY_CLICK_CTRL "xeno_monkey_click_ctrl"				//from monkey CtrlClickOn(): (/mob)
+
+#define KALEDIOSCOPE_ORDERED_LIST 1
+#define KALEDIOSCOPE_PICK_FROM_LIST 2
+#define KALEDIOSCOPE_RANDOM_COLOUR 3

--- a/code/datums/components/kaleidoscope.dm
+++ b/code/datums/components/kaleidoscope.dm
@@ -1,0 +1,52 @@
+/datum/component/kaleidoscope
+	var/list/colours
+	var/mode = KALEDIOSCOPE_RANDOM_COLOUR
+	var/colour_priority = ADMIN_COLOUR_PRIORITY
+	var/delay = 1
+	var/cleanup = TRUE
+	var/_index = 1 // Curse you DM, and your 1-indexed lists
+
+/datum/component/kaleidoscope/Initialize()
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+	paint()
+
+/datum/component/kaleidoscope/proc/paint()
+	if(QDELETED(src))
+		return
+	var/chosen
+	switch(mode)
+		if(KALEDIOSCOPE_ORDERED_LIST)
+			chosen = colours[_index]
+			if(_index >= length(colours))
+				_index = 1
+			else
+				_index = _index + 1
+		if(KALEDIOSCOPE_PICK_FROM_LIST)
+			chosen = pick(colours)
+		if(KALEDIOSCOPE_RANDOM_COLOUR)
+			chosen = "#[random_color()]"
+
+	var/atom/A = parent
+	A.add_atom_colour(chosen, colour_priority)
+	addtimer(CALLBACK(src, .proc/paint), delay, TIMER_UNIQUE | TIMER_OVERRIDE)
+
+/datum/component/kaleidoscope/UnregisterFromParent()
+	if(cleanup)
+		var/atom/A = parent
+		A.remove_atom_colour(colour_priority)
+
+/datum/component/kaleidoscope/suicide_by_disk
+	colours = list("#00FF00", "#FF0000")
+	mode = KALEDIOSCOPE_ORDERED_LIST
+
+/datum/component/kaleidoscope/colorful_reagent
+	colours = list("#00aedb","#a200ff","#f47835","#d41243","#d11141","#00b159","#00aedb","#f37735","#ffc425","#008744","#0057e7","#d62d20","#ffa700")
+	mode = KALEDIOSCOPE_PICK_FROM_LIST
+	colour_priority = WASHABLE_COLOUR_PRIORITY
+	delay = 10
+	cleanup = FALSE
+
+/datum/component/kaleidoscope/colorful_reagent/once/paint()
+	..()
+	qdel(src)

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -642,13 +642,12 @@ This is here to make the tiles around the station mininuke change when it's arme
 /obj/item/disk/nuclear/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is going delta! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(src, 'sound/machines/alarm.ogg', 50, -1, 1)
-	for(var/i in 1 to 100)
-		addtimer(CALLBACK(user, /atom/proc/add_atom_colour, (i % 2)? "#00FF00" : "#FF0000", ADMIN_COLOUR_PRIORITY), i)
+	user.AddComponent(/datum/component/kaleidoscope/suicide_by_disk)
 	addtimer(CALLBACK(src, .proc/manual_suicide, user), 101)
 	return MANUAL_SUICIDE
 
 /obj/item/disk/nuclear/proc/manual_suicide(mob/living/user)
-	user.remove_atom_colour(ADMIN_COLOUR_PRIORITY)
+	qdel(user.GetComponent(/datum/component/kaleidoscope/suicide_by_disk))
 	user.visible_message("<span class='suicide'>[user] was destroyed by the nuclear blast!</span>")
 	user.adjustOxyLoss(200)
 	user.death(0)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1259,84 +1259,100 @@
 //For colouring in /proc/mix_color_from_reagents
 
 
-/datum/reagent/colorful_reagent/crayonpowder
+/datum/reagent/crayonpowder
 	name = "Crayon Powder"
 	id = "crayon powder"
 	var/colorname = "none"
 	description = "A powder made by grinding down crayons, good for colouring chemical reagents."
 	reagent_state = SOLID
 	color = "#FFFFFF" // rgb: 207, 54, 0
+	var/true_colour // if non-null, used instead of var/color for colouring things
 	taste_description = "the back of class"
 
-/datum/reagent/colorful_reagent/crayonpowder/New()
+/datum/reagent/crayonpowder/New()
 	description = "\an [colorname] powder made by grinding down crayons, good for colouring chemical reagents."
 
+/datum/reagent/crayonpowder/proc/paint(atom/A)
+	if(A)
+		var/chosen = color
+		if(true_colour)
+			chosen = true_colour
+		A.add_atom_colour(chosen, WASHABLE_COLOUR_PRIORITY)
 
-/datum/reagent/colorful_reagent/crayonpowder/red
+/datum/reagent/crayonpowder/on_mob_life(mob/living/carbon/M)
+	paint(M)
+	..()
+
+/datum/reagent/crayonpowder/reaction_mob(mob/living/M, reac_volume)
+	paint(M)
+	..()
+
+/datum/reagent/crayonpowder/reaction_obj(obj/O, reac_volume)
+	paint(O)
+	..()
+
+/datum/reagent/crayonpowder/reaction_turf(turf/T, reac_volume)
+	paint(T)
+	..()
+
+
+/datum/reagent/crayonpowder/red
 	name = "Red Crayon Powder"
 	id = "redcrayonpowder"
 	colorname = "red"
 	color = "#DA0000" // red
-	random_color_list = list("#DA0000")
 
-/datum/reagent/colorful_reagent/crayonpowder/orange
+/datum/reagent/crayonpowder/orange
 	name = "Orange Crayon Powder"
 	id = "orangecrayonpowder"
 	colorname = "orange"
 	color = "#FF9300" // orange
-	random_color_list = list("#FF9300")
 
-/datum/reagent/colorful_reagent/crayonpowder/yellow
+/datum/reagent/crayonpowder/yellow
 	name = "Yellow Crayon Powder"
 	id = "yellowcrayonpowder"
 	colorname = "yellow"
 	color = "#FFF200" // yellow
-	random_color_list = list("#FFF200")
 
-/datum/reagent/colorful_reagent/crayonpowder/green
+/datum/reagent/crayonpowder/green
 	name = "Green Crayon Powder"
 	id = "greencrayonpowder"
 	colorname = "green"
 	color = "#A8E61D" // green
-	random_color_list = list("#A8E61D")
 
-/datum/reagent/colorful_reagent/crayonpowder/blue
+/datum/reagent/crayonpowder/blue
 	name = "Blue Crayon Powder"
 	id = "bluecrayonpowder"
 	colorname = "blue"
 	color = "#00B7EF" // blue
-	random_color_list = list("#00B7EF")
 
-/datum/reagent/colorful_reagent/crayonpowder/purple
+/datum/reagent/crayonpowder/purple
 	name = "Purple Crayon Powder"
 	id = "purplecrayonpowder"
 	colorname = "purple"
 	color = "#DA00FF" // purple
-	random_color_list = list("#DA00FF")
 
-/datum/reagent/colorful_reagent/crayonpowder/invisible
+/datum/reagent/crayonpowder/invisible
 	name = "Invisible Crayon Powder"
 	id = "invisiblecrayonpowder"
 	colorname = "invisible"
 	color = "#FFFFFF00" // white + no alpha
-	random_color_list = list(null)	//because using the powder color turns things invisible
 
-/datum/reagent/colorful_reagent/crayonpowder/black
+/datum/reagent/crayonpowder/invisible/paint()
+	return // Otherwise, it turns atoms invisible.
+
+/datum/reagent/crayonpowder/black
 	name = "Black Crayon Powder"
 	id = "blackcrayonpowder"
 	colorname = "black"
 	color = "#1C1C1C" // not quite black
-	random_color_list = list("#404040")
+	true_colour = "#404040"
 
-/datum/reagent/colorful_reagent/crayonpowder/white
+/datum/reagent/crayonpowder/white
 	name = "White Crayon Powder"
 	id = "whitecrayonpowder"
 	colorname = "white"
 	color = "#FFFFFF" // white
-	random_color_list = list("#FFFFFF") //doesn't actually change appearance at all
-
-
-
 
 //////////////////////////////////Hydroponics stuff///////////////////////////////
 
@@ -1466,26 +1482,27 @@
 	description = "Thoroughly sample the rainbow."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
-	var/list/random_color_list = list("#00aedb","#a200ff","#f47835","#d41243","#d11141","#00b159","#00aedb","#f37735","#ffc425","#008744","#0057e7","#d62d20","#ffa700")
 	taste_description = "rainbows"
+	// See code/datums/components/kaleidoscope.dm for the list of colours this applies.
 
 
 /datum/reagent/colorful_reagent/on_mob_life(mob/living/carbon/M)
-	M.add_atom_colour(pick(random_color_list), WASHABLE_COLOUR_PRIORITY)
+	M.AddComponent(/datum/component/kaleidoscope/colorful_reagent)
 	..()
 
+/datum/reagent/colorful_reagent/on_mob_delete(mob/living/carbon/M)
+	qdel(M.GetComponent(/datum/component/kaleidoscope/colorful_reagent))
+
 /datum/reagent/colorful_reagent/reaction_mob(mob/living/M, reac_volume)
-	M.add_atom_colour(pick(random_color_list), WASHABLE_COLOUR_PRIORITY)
+	M.AddComponent(/datum/component/kaleidoscope/colorful_reagent/once)
 	..()
 
 /datum/reagent/colorful_reagent/reaction_obj(obj/O, reac_volume)
-	if(O)
-		O.add_atom_colour(pick(random_color_list), WASHABLE_COLOUR_PRIORITY)
+	O.AddComponent(/datum/component/kaleidoscope/colorful_reagent/once)
 	..()
 
 /datum/reagent/colorful_reagent/reaction_turf(turf/T, reac_volume)
-	if(T)
-		T.add_atom_colour(pick(random_color_list), WASHABLE_COLOUR_PRIORITY)
+	T.AddComponent(/datum/component/kaleidoscope/colorful_reagent/once)
 	..()
 
 /datum/reagent/hair_dye

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -320,3 +320,12 @@
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	volume = 100
 	list_reagents = list("plantbgone" = 100)
+
+/obj/item/reagent_containers/spray/colorful
+	name = "colorful bottle"
+	desc = "Can you paint with all the colours of the wind?"
+	list_reagents = list("colorful_reagent" = 250)
+
+/obj/item/reagent_containers/spray/colorful/Initialize()
+	. = ..()
+	AddComponent(/datum/component/kaleidoscope/colorful_reagent)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -347,6 +347,7 @@
 #include "code\datums\components\heirloom.dm"
 #include "code\datums\components\infective.dm"
 #include "code\datums\components\jousting.dm"
+#include "code\datums\components\kaleidoscope.dm"
 #include "code\datums\components\knockoff.dm"
 #include "code\datums\components\lockon_aiming.dm"
 #include "code\datums\components\magnetic_catch.dm"


### PR DESCRIPTION
:cl: coiax
refactor: The way that colorful reagent, crayon powder,
and the nuke disk suicide function at a code level has been changed.
/:cl:

The kaleidoscope component standardises the "changes colour every X
tickets" component that the nuke disk and (sort of) colorful reagent
exhibit.

I have something in mind for this sort of pattern, where you
can just put the component on something, then remove it later when
you're done with the color changing, but this is a complex enough change
that I wanted to make it seperate.

- Crayonpowder is no longer a subtype of colorful reagent, given it
has only a single colour to apply (but I'm not wedded to the idea, it
just seemed simpler).

- Coding/admin item, the "colorful spray bottle", which has colorful
reagent, and also has the kaleidoscope component which means it changes
colour constantly on its own anyway.

- For badminry, adding the kaledioscope component (or one of its
subtypes) to an atom will have it strobe through colours. No clue what
you'd use it for.