### PR TITLE
Observers can tell if an object is a family heirloom on examine()

### DIFF
--- a/code/datums/components/heirloom.dm
+++ b/code/datums/components/heirloom.dm
@@ -14,6 +14,10 @@
 /datum/component/heirloom/proc/examine(datum/source, mob/user)
 	if(user.mind == owner)
 		to_chat(user, "<span class='notice'>It is your precious [family_name] family heirloom. Keep it safe!</span>")
-	var/datum/antagonist/creep/creeper = user.mind.has_antag_datum(/datum/antagonist/creep)
-	if(creeper && creeper.trauma.obsession == owner)
-		to_chat(user, "<span class='nicegreen'>This must be [owner]'s family heirloom! It smells just like them...</span>")
+	else if(isobserver(user))
+		to_chat(user, "<span class='notice'>It is the [family_name] family heirloom, belonging to [owner].</span>")
+	else
+		var/datum/antagonist/creep/creeper = user.mind.has_antag_datum(/datum/antagonist/creep)
+		if(creeper && creeper.trauma.obsession == owner)
+			to_chat(user, "<span class='nicegreen'>This must be [owner]'s family heirloom! It smells just like them...</span>")
+


### PR DESCRIPTION
:cl: coiax
tweak: Observers are able to see family heirloom messages when examining
objects.
/:cl:

I mean, it bugged me the once time that I suspected a random object was
an heirloom, but had to use VV to check.