### PR TITLE
Family heirloom no longer provides a positive moodlet

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -78,7 +78,7 @@
 
 /datum/mood_event/family_heirloom
 	description = "<span class='nicegreen'>My family heirloom is safe with me.</span>\n"
-	mood_change = 1
+	mood_change = 0
 
 /datum/mood_event/goodmusic
 	description = "<span class='nicegreen'>There is something soothing about this music.</span>\n"


### PR DESCRIPTION
:cl: coiax
balance: The Family Heirloom quirk no longer provides a positive mood
boost when you are holding your heirloom. You still have the moodlet on
examining your mood, but it provides no mood bonus.
/:cl:

It's a negative quirk, and an often picked one, and the fact that it
provided a constant mild mood boost never sat right with me. If you're
never killed and cloned, it's essentially a positive.