### PR TITLE
Fixes Donutstation cam issue

### DIFF
--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -36984,7 +36984,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/camera/motion{
+/obj/machinery/camera/emp_proof/motion{
 	c_tag = "Engineering - External Engine Containment Northwest";
 	dir = 8;
 	network = list("Engine")
@@ -37891,7 +37891,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/camera/motion{
+/obj/machinery/camera/emp_proof/motion{
 	c_tag = "Engineering - External Engine Containment Northeast";
 	dir = 4;
 	network = list("Engine")
@@ -37903,7 +37903,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/camera/motion{
+/obj/machinery/camera/emp_proof/motion{
 	c_tag = "Engineering - External Engine Containment Southwest";
 	network = list("Engine")
 	},
@@ -37917,7 +37917,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/camera/motion{
+/obj/machinery/camera/emp_proof/motion{
 	c_tag = "Engineering - External Engine Containment Southeast";
 	network = list("Engine")
 	},

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -8,6 +8,12 @@
 	. = ..()
 	upgradeEmpProof()
 
+// EMP + Motion
+
+/obj/machinery/camera/emp_proof/motion/Initialize()
+	. = ..()
+	upgradeMotion()
+
 // X-ray
 
 /obj/machinery/camera/xray


### PR DESCRIPTION
:cl: Denton
fix: The cameras right outside of Donutstation's singularity containment have been EMP-proofed and will no longer alert silicons 24/7.
/:cl:

The cams outside Donut's singulo containment are just close enough to the singulo that they get hit by EMP all the time. This does nothing but spam silicons with unneccesary error messages; I added EMP-proofing to them.