### PR TITLE
Stop alien infestation failing

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -47,6 +47,8 @@
 			continue
 		if(is_station_level(temp_vent.loc.z) && !temp_vent.welded)
 			var/datum/pipeline/temp_vent_parent = temp_vent.parents[1]
+			if(!temp_vent_parent)
+				continue//no parent vent
 			//Stops Aliens getting stuck in small networks.
 			//See: Security, Virology
 			if(temp_vent_parent.other_atmosmch.len > 20)


### PR DESCRIPTION
It appears that some vents do not have any parents, so there is a null runtime when trying to check other_atmosmch 

The event then fails
