### PR TITLE
Admins now get deadminned when roundstart antag

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -110,7 +110,7 @@
 
 	for(var/client/C in GLOB.admins)
 		var/datum/admins/D = C.holder
-		if(!D || D.deadmined || !C.mob)
+		if(D?.deadmined != FALSE || !length(C.mob?mind.?antag_datums))
 			continue
 		if(!C.mob.mind)
 			continue

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -107,9 +107,18 @@
 	if(report)
 		addtimer(CALLBACK(src, .proc/send_intercept, 0), rand(waittime_l, waittime_h))
 	generate_station_goals()
-	gamemode_ready = TRUE
-	return 1
 
+	for(var/client/C in GLOB.admins)
+		var/datum/admins/D = C.holder
+		if(!D || D.deadmined || !C.mob)
+			continue
+		if(!C.mob.mind)
+			continue
+		if(!length(C.mob.mind.antag_datums))
+			continue
+		D.deactivate()	
+	gamemode_ready = TRUE
+	return TRUE
 
 ///Handles late-join antag assignments
 /datum/game_mode/proc/make_antag_chance(mob/living/carbon/human/character)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -110,7 +110,7 @@
 
 	for(var/client/C in GLOB.admins)
 		var/datum/admins/D = C.holder
-		if(D?.deadmined != FALSE || !length(C.mob?mind.?antag_datums))
+		if(D?.deadmined != FALSE || !length(C.mob?.mind?.antag_datums))
 			continue
 		if(!C.mob.mind)
 			continue


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Dax Dupont
admin: Admins now automatically get deadminned on roundstart antag.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Sometimes you miss roundstart and you remain adminned without realizing or you can already get a lot of meta information between roundstart and hitting deadmin.

Automatically deadminning seems like a fair thing to do, you can always readmin if needed.
