### PR TITLE
Showers no longer runtime when you shower with an empty hand

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -131,7 +131,8 @@
 	if(iscarbon(L))
 		var/mob/living/carbon/M = L
 		. = TRUE
-		for(var/I in M.held_items)
+
+		for(var/obj/item/I in M.held_items)
 			wash_obj(I)
 
 		if(M.back && wash_obj(M.back))


### PR DESCRIPTION
held items actually contains "null" entries by default using just var/I
gets these null items and then tries to wash_obj a null causing a
runtime

Specifying /obj/item will stop the nulls being iterated
