### PR TITLE
Fix compile error in ethereal light handling

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -626,11 +626,12 @@
 		var/mob/living/carbon/human/H = user
 
 		if(istype(H))
-			if(isethereal(H))
+			var/datum/species/ethereal/eth_species = H.dna?.species
+			if(istype(eth_species))
 				to_chat(H, "<span class='notice'>You start channeling some power through the [fitting] into your body.</span>")
 				if(do_after(user, 50, target = src))
 					to_chat(H, "<span class='notice'>You receive some charge from the [fitting].</span>")
-					H.dna?.species.adjust_charge(5)
+					eth_species.adjust_charge(5)
 					return
 				return
 


### PR DESCRIPTION
The [512.1463 release notes](http://www.byond.com/docs/notes/512.html) state:

> The ?. operator did not do proper type checking for procs when it was able to. (Memeopolis)

Now this line errors:

```
code\modules\power\lighting.dm:633:error: H.dna.species.adjust_charge: undefined proc
```

Let's fix that.