### PR TITLE
Meth no longer explodes

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -160,27 +160,6 @@
 		new /obj/effect/hotspot(turf)
 	holder.chem_temp = 1000 // hot as shit
 
-/datum/chemical_reaction/reagent_explosion/methsplosion
-	name = "Meth explosion"
-	id = "methboom1"
-	required_temp = 380 //slightly above the meth mix time.
-	required_reagents = list("methamphetamine" = 1)
-	strengthdiv = 6
-	modifier = 1
-	mob_react = FALSE
-
-/datum/chemical_reaction/reagent_explosion/methsplosion/on_reaction(datum/reagents/holder, created_volume)
-	var/turf/T = get_turf(holder.my_atom)
-	for(var/turf/turf in range(1,T))
-		new /obj/effect/hotspot(turf)
-	holder.chem_temp = 1000 // hot as shit
-	..()
-
-/datum/chemical_reaction/reagent_explosion/methsplosion/methboom2
-	id = "methboom2"
-	required_reagents = list("diethylamine" = 1, "iodine" = 1, "phosphorus" = 1, "hydrogen" = 1) //diethylamine is often left over from mixing the ephedrine.
-	required_temp = 300 //room temperature, chilling it even a little will prevent the explosion
-
 /datum/chemical_reaction/sorium
 	name = "Sorium"
 	id = "sorium"


### PR DESCRIPTION
:cl: Kierany9
del: Meth no longer explodes
/:cl:

Meth explosions were nothing but a bandaid fix and noob trap that did nothing to fix any underlying issues there may have been, and with the blast being as strong as blackpowder and without the massive downside that is the 5-10 second fuse, it's far easier to weaponize than it has any right to be.