### PR TITLE
Fixes lings not getting some last words on absorb

### DIFF
--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -67,9 +67,16 @@
 
 		//Some of target's recent speech, so the changeling can attempt to imitate them better.
 		//Recent as opposed to all because rounds tend to have a LOT of text.
-		var/list/recent_speech = list()
 
-		var/list/say_log = target.logging[LOG_SAY]
+		var/list/recent_speech = list()
+		var/list/say_log = list()
+		var/log_source = target.logging
+		for(var/log_type in log_source)
+			var/nlog_type = text2num(log_type)
+			if(nlog_type & LOG_SAY)
+				var/list/reversed = log_source[log_type]
+				if(islist(reversed))
+					say_log = reverseRange(reversed.Copy())
 
 		if(LAZYLEN(say_log) > LING_ABSORB_RECENT_SPEECH)
 			recent_speech = say_log.Copy(say_log.len-LING_ABSORB_RECENT_SPEECH+1,0) //0 so len-LING_ARS+1 to end of list

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -77,6 +77,7 @@
 				var/list/reversed = log_source[log_type]
 				if(islist(reversed))
 					say_log = reverseRange(reversed.Copy())
+					break
 
 		if(LAZYLEN(say_log) > LING_ABSORB_RECENT_SPEECH)
 			recent_speech = say_log.Copy(say_log.len-LING_ABSORB_RECENT_SPEECH+1,0) //0 so len-LING_ARS+1 to end of list


### PR DESCRIPTION
:cl: PKPenguin321
fix: Lings should be able to see some of their victim's last words when they absorb them.
/:cl:

Tested this while trying to replicate it for https://github.com/tgstation/tgstation/pull/42443 and it didn't work at all, so I found a new way to do it. I'd bet that changes to how logs are stored on the mob broke it.