### PR TITLE
Art (currently statues and framed photos) now affects mood.

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -173,6 +173,11 @@
 	mood_change = -3
 	timeout = 900
 
+/datum/mood_event/artbad
+	description = "<span class='warning'>I've produced better art than that from my ass.</span>\n"
+	mood_change = -2
+	timeout = 1200
+
 //These are unused so far but I want to remember them to use them later
 /datum/mood_event/cloned_corpse
 	description = "<span class='boldwarning'>I recently saw my own corpse...</span>\n"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -36,6 +36,21 @@
 	mood_change = 2
 	timeout = 2400
 
+/datum/mood_event/artok
+	description = "It's nice to see people are making art around here."
+	mood_change = 2
+	timeout = 2400
+
+/datum/mood_event/artgood
+	description = "What a thought-provoking piece of art. I'll remember that for a while."
+	mood_change = 3
+	timeout = 3000.
+
+/datum/mood_event/artgreat
+	description = "That work of art was so great it made me believe in the goodness of humanity. Says a lot in a place like this."
+	mood_change = 4
+	timeout = 4000
+
 /datum/mood_event/perform_cpr
 	description = "<span class='nicegreen'>It feels good to save a life.</span>\n"
 	mood_change = 6

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -478,7 +478,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	add_fingerprint(user)
 	user.visible_message("[user] rubs some dust off [src].", \
 						 "<span class='notice'>You take in [src], rubbing some dust off its surface.</span>")
-	SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artgreat", /datum/mood_event/artgreat)
+	SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artgood", /datum/mood_event/artgood)
 
 
 /obj/item/tailclub

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -470,6 +470,17 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "A bust of the famous Greek physician Hippocrates of Kos, often referred to as the father of western medicine."
 	icon_state = "hippocratic"
 
+/obj/item/statuebust/attack_self(mob/living/carbon/user)
+	. = ..()
+	if(.)
+		return
+	user.changeNext_move(CLICK_CD_MELEE)
+	add_fingerprint(user)
+	user.visible_message("[user] rubs some dust off [src].", \
+						 "<span class='notice'>You take in [src], rubbing some dust off its surface.</span>")
+	SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artgreat", /datum/mood_event/artgreat)
+
+
 /obj/item/tailclub
 	name = "tail club"
 	desc = "For the beating to death of lizards with their own tails."

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -1,3 +1,7 @@
+#define BAD_ART 12.5
+#define GOOD_ART 25
+#define GREAT_ART 50
+
 /obj/structure/statue
 	name = "statue"
 	desc = "Placeholder. Yell at Firecage if you SOMEHOW see this."
@@ -7,6 +11,7 @@
 	anchored = FALSE
 	max_integrity = 100
 	var/oreAmount = 5
+	var/impressiveness = 15
 	var/material_drop_type = /obj/item/stack/sheet/metal
 	CanAtmosPass = ATMOS_PASS_DENSITY
 
@@ -36,8 +41,20 @@
 		return
 	user.changeNext_move(CLICK_CD_MELEE)
 	add_fingerprint(user)
-	user.visible_message("[user] rubs some dust off from the [name]'s surface.", \
-						 "<span class='notice'>You rub some dust off from the [name]'s surface.</span>")
+	user.visible_message("[user] rubs some dust off [src].", \
+						 "<span class='notice'>You take in [src], rubbing some dust off its surface.</span>")
+	if(!ishuman(user)) // only humans have the capacity to appreciate art
+		return
+	var/totalimpressiveness = (impressiveness *(obj_integrity/max_integrity))
+	if(totalimpressiveness >= GREAT_ART)
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artgreat", /datum/mood_event/artgreat)
+	else if (totalimpressiveness >= GOOD_ART)
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artgood", /datum/mood_event/artgood)
+	else if (totalimpressiveness >= BAD_ART)
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artok", /datum/mood_event/artok)
+	else
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artbad", /datum/mood_event/artbad)
+
 
 /obj/structure/statue/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
@@ -56,6 +73,7 @@
 	max_integrity = 300
 	light_range = 2
 	material_drop_type = /obj/item/stack/sheet/mineral/uranium
+	impressiveness = 25 // radiation makes an impression
 	var/last_event = 0
 	var/active = null
 
@@ -99,6 +117,7 @@
 
 /obj/structure/statue/plasma
 	max_integrity = 200
+	impressiveness = 20
 	material_drop_type = /obj/item/stack/sheet/mineral/plasma
 	desc = "This statue is suitably made from plasma."
 
@@ -149,6 +168,7 @@
 
 /obj/structure/statue/gold
 	max_integrity = 300
+	impressiveness = 25
 	material_drop_type = /obj/item/stack/sheet/mineral/gold
 	desc = "This is a highly valuable statue made from gold."
 
@@ -176,6 +196,7 @@
 
 /obj/structure/statue/silver
 	max_integrity = 300
+	impressiveness = 25
 	material_drop_type = /obj/item/stack/sheet/mineral/silver
 	desc = "This is a valuable statue made from silver."
 
@@ -203,6 +224,7 @@
 
 /obj/structure/statue/diamond
 	max_integrity = 1000
+	impressiveness = 50
 	material_drop_type = /obj/item/stack/sheet/mineral/diamond
 	desc = "This is a very expensive diamond statue."
 
@@ -222,6 +244,7 @@
 
 /obj/structure/statue/bananium
 	max_integrity = 300
+	impressiveness = 50
 	material_drop_type = /obj/item/stack/sheet/mineral/bananium
 	desc = "A bananium statue with a small engraving:'HOOOOOOONK'."
 	var/spam_flag = 0
@@ -257,6 +280,7 @@
 
 /obj/structure/statue/sandstone
 	max_integrity = 50
+	impressiveness = 15
 	material_drop_type = /obj/item/stack/sheet/mineral/sandstone
 
 /obj/structure/statue/sandstone/assistant

--- a/code/modules/photography/photos/frame.dm
+++ b/code/modules/photography/photos/frame.dm
@@ -109,6 +109,7 @@
 /obj/structure/sign/picture_frame/examine(mob/user)
 	if(in_range(src, user) && framed)
 		framed.show(user)
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artok", /datum/mood_event/artok)
 	else
 		..()
 


### PR DESCRIPTION
:cl: bandit
add: Art now affects mood depending on its quality.
/:cl:

When you interact with a piece of art, you get a moodlet. The higher-quality the art, the more positive the moodlet.

There are four tiers of art quality.
- OK art. The default. Most statues and all framed photos qualify for this. Small positive moodlet.
- Good art. Gold, silver, and uranium statues qualify for this, as do statue busts (I have no idea if these are even used but they should count). Even higher moodlet. Higher moodlet.
- Great art. Diamond and bananium statues qualify for this. Highest moodlet.
- Bad art. Currently, no pieces of art start out bad. However, if statues take enough damage, they will count as bad. Higher-quality statues require more damage to be "bad" -- currently good statues need 50% damage, great statues 25%. This gives you a small negative moodlet.

Why this is added: Because we need more positive moodlets, and it also encourages people to decorate the station.

The art quality system is currently very much a rudimentary thing. Other objects things may be able to use the moodlets above in the future.