### PR TITLE
[Ready] Adds a Scatter Shot bulldog drum for 4Tc

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/external/shotgun.dm
@@ -34,3 +34,8 @@
 	name = "shotgun magazine (12g meteor slugs)"
 	icon_state = "m12gbc"
 	ammo_type = /obj/item/ammo_casing/shotgun/meteorslug
+
+/obj/item/ammo_box/magazine/m12g/scatter
+	name = "shotgun magazine (12g Scatter-laser shot slugs)"
+	icon_state = "m12gb"
+	ammo_type = /obj/item/ammo_casing/shotgun/laserslug

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -668,6 +668,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/ammo_box/magazine/m12g/stun
 	include_modes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/ammo/shotgun/scatter
+	name = "12g Scatter Laser shot Slugs"
+	desc = "An alternative 8-round Scatter Laser Shot magazine for use in the Bulldog shotgun."
+	item = /obj/item/ammo_box/magazine/m12g/scatter
+	cost = 4
+	include_modes = list(/datum/game_mode/nuclear)
+
 /datum/uplink_item/ammo/revolver
 	name = ".357 Speed Loader"
 	desc = "A speed loader that contains seven additional .357 Magnum rounds; usable with the Syndicate revolver. \


### PR DESCRIPTION
[Changelogs
Nukies have gotten the power of ScatterShot slugs, and have placed them in a drum for rapid use!
Do to most armor If I Recall Correctly having less armor for laser shot compared to bullet it cost 4Tc for balance!
[why]
They have, Meteor/Stun/12g/Dragon and other types! Why not laser scatter shot for a single more Tc