### PR TITLE
Fix mousetrap boxes having no illustration

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -567,7 +567,7 @@
 /obj/item/storage/box/mousetraps
 	name = "box of Pest-B-Gon mousetraps"
 	desc = "<span class='alert'>Keep out of reach of children.</span>"
-	illustration = "mousetraps"
+	illustration = "mousetrap"
 
 /obj/item/storage/box/mousetraps/PopulateContents()
 	for(var/i in 1 to 6)


### PR DESCRIPTION
`mousetrap` in the dmi, `mousetraps` in the code

![image](https://user-images.githubusercontent.com/222630/51436239-823b8680-1c3e-11e9-9d7c-9a2d56009a1a.png)

:cl:
fix: Mousetrap boxes now have their illustration again.
/:cl: