### PR TITLE
Makes the vent clog event happen more often

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -56,7 +56,7 @@
 	weight = 4
 	min_players = 25
 	max_occurrences = 1
-	earliest_start = 30 MINUTES
+	earliest_start = 35 MINUTES
 
 /datum/round_event/vent_clog/threatening
 	randomProbability = 10
@@ -68,7 +68,7 @@
 	weight = 2
 	min_players = 35
 	max_occurrences = 1
-	earliest_start = 40 MINUTES
+	earliest_start = 45 MINUTES
 
 /datum/round_event/vent_clog/catastrophic
 	randomProbability = 30

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/vent_clog
 	weight = 10
 	max_occurrences = 3
-	min_players = 25
+	min_players = 10
 
 /datum/round_event/vent_clog
 	announceWhen	= 1
@@ -54,9 +54,9 @@
 	name = "Clogged Vents: Threatening"
 	typepath = /datum/round_event/vent_clog/threatening
 	weight = 4
-	min_players = 35
+	min_players = 25
 	max_occurrences = 1
-	earliest_start = 35 MINUTES
+	earliest_start = 30 MINUTES
 
 /datum/round_event/vent_clog/threatening
 	randomProbability = 10
@@ -66,9 +66,9 @@
 	name = "Clogged Vents: Catastrophic"
 	typepath = /datum/round_event/vent_clog/catastrophic
 	weight = 2
-	min_players = 45
+	min_players = 35
 	max_occurrences = 1
-	earliest_start = 45 MINUTES
+	earliest_start = 40 MINUTES
 
 /datum/round_event/vent_clog/catastrophic
 	randomProbability = 30


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Dax Dupont
tweak: Vent clog events are more likely to happen.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I said in the original PR where I rebalanced vent clogs that I would eventually evaluate the probability of the events.

Since they don't have a too large impact, I'm rejiggling some of the requirements and time required.