### PR TITLE
Adds a "transfer overlays" option to alternate appearances

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -156,3 +156,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 // radiation
 #define RAD_PROTECT_CONTENTS (1<<0)
 #define RAD_NO_CONTAMINATE (1<<1)
+
+//alternate appearance flags
+#define AA_TARGET_SEE_APPEARANCE (1<<0)
+#define AA_MATCH_TARGET_OVERLAYS (1<<1)

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -141,5 +141,13 @@
 		if(LAZYLEN(po)){\
 			A.overlays |= po;\
 		}\
+		if(A.alternate_appearances){\
+			for(var/I in A.alternate_appearances){\
+				var/datum/atom_hud/alternate_appearance/AA = A.alternate_appearances[I];\
+				if(AA.transfer_overlays){\
+					AA.copy_overlays(A, TRUE);\
+				}\
+			}\
+		}\
 		A.flags_1 &= ~OVERLAY_QUEUED_1;\
 	}

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -141,12 +141,10 @@
 		if(LAZYLEN(po)){\
 			A.overlays |= po;\
 		}\
-		if(A.alternate_appearances){\
-			for(var/I in A.alternate_appearances){\
-				var/datum/atom_hud/alternate_appearance/AA = A.alternate_appearances[I];\
-				if(AA.transfer_overlays){\
-					AA.copy_overlays(A, TRUE);\
-				}\
+		for(var/I in A.alternate_appearances){\
+			var/datum/atom_hud/alternate_appearance/AA = A.alternate_appearances[I];\
+			if(AA.transfer_overlays){\
+				AA.copy_overlays(A, TRUE);\
 			}\
 		}\
 		A.flags_1 &= ~OVERLAY_QUEUED_1;\

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -685,6 +685,7 @@
 /datum/action/small_sprite
 	name = "Toggle Giant Sprite"
 	desc = "Others will always see you as giant"
+	icon_icon = 'icons/mob/actions/actions_xeno.dmi'
 	button_icon_state = "smallqueen"
 	background_icon_state = "bg_alien"
 	var/small = FALSE
@@ -706,7 +707,7 @@
 		I.override = TRUE
 		I.pixel_x -= owner.pixel_x
 		I.pixel_y -= owner.pixel_y
-		owner.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic, "smallsprite", I)
+		owner.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic, "smallsprite", I, AA_TARGET_SEE_APPEARANCE | AA_MATCH_TARGET_OVERLAYS)
 		small = TRUE
 	else
 		owner.remove_alt_appearance("smallsprite")

--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 
 /datum/atom_hud/alternate_appearance
 	var/appearance_key
+	var/transfer_overlays = FALSE
 
 /datum/atom_hud/alternate_appearance/New(key)
 	..()
@@ -50,6 +51,8 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 	if(.)
 		LAZYREMOVE(A.alternate_appearances, appearance_key)
 
+/datum/atom_hud/alternate_appearance/proc/copy_overlays()
+	return
 
 //an alternate appearance that attaches a single image to a single atom
 /datum/atom_hud/alternate_appearance/basic
@@ -58,19 +61,23 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 	var/add_ghost_version = FALSE
 	var/ghost_appearance
 
-/datum/atom_hud/alternate_appearance/basic/New(key, image/I, target_sees_appearance = TRUE)
+/datum/atom_hud/alternate_appearance/basic/New(key, image/I, options = AA_TARGET_SEE_APPEARANCE)
 	..()
+	transfer_overlays = options & AA_MATCH_TARGET_OVERLAYS
 	theImage = I
 	target = I.loc
+	if(transfer_overlays)
+		I.copy_overlays(target)
+
 	hud_icons = list(appearance_key)
 	add_to_hud(target, I)
-	if(target_sees_appearance && ismob(target))
+	if((options & AA_TARGET_SEE_APPEARANCE) && ismob(target))
 		add_hud_to(target)
 	if(add_ghost_version)
 		var/image/ghost_image = image(icon = I.icon , icon_state = I.icon_state, loc = I.loc)
 		ghost_image.override = FALSE
 		ghost_image.alpha = 128
-		ghost_appearance = new /datum/atom_hud/alternate_appearance/basic/observers(key + "_observer", ghost_image, FALSE)
+		ghost_appearance = new /datum/atom_hud/alternate_appearance/basic/observers(key + "_observer", ghost_image, NONE)
 
 /datum/atom_hud/alternate_appearance/basic/Destroy()
 	. = ..()
@@ -87,6 +94,9 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 	A.hud_list -= appearance_key
 	if(. && !QDELETED(src))
 		qdel(src)
+
+/datum/atom_hud/alternate_appearance/basic/copy_overlays(atom/other, cut_old)
+		theImage.copy_overlays(other, cut_old)
 
 /datum/atom_hud/alternate_appearance/basic/everyone
 	add_ghost_version = TRUE

--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -51,7 +51,7 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 	if(.)
 		LAZYREMOVE(A.alternate_appearances, appearance_key)
 
-/datum/atom_hud/alternate_appearance/proc/copy_overlays()
+/datum/atom_hud/alternate_appearance/proc/copy_overlays(atom/other, cut_old)
 	return
 
 //an alternate appearance that attaches a single image to a single atom

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -263,7 +263,7 @@
 		H.hallucination = max(H.hallucination, 120)
 		SEND_SOUND(ranged_ability_user, sound('sound/effects/ghost.ogg',0,1,50))
 		var/image/C = image('icons/effects/cult_effects.dmi',H,"bloodsparkles", ABOVE_MOB_LAYER)
-		add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/cult, "cult_apoc", C, FALSE)
+		add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/cult, "cult_apoc", C, NONE)
 		addtimer(CALLBACK(H,/atom/.proc/remove_alt_appearance,"cult_apoc",TRUE), 2400, TIMER_OVERRIDE|TIMER_UNIQUE)
 		to_chat(ranged_ability_user,"<span class='cult'><b>[H] has been cursed with living nightmares!</b></span>")
 		attached_action.charges--

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -982,7 +982,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 				addtimer(CALLBACK(GLOBAL_PROC, .proc/hudFix, M), duration)
 			var/image/A = image('icons/mob/mob.dmi',M,"cultist", ABOVE_MOB_LAYER)
 			A.override = 1
-			add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/noncult, "human_apoc", A, FALSE)
+			add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/noncult, "human_apoc", A, NONE)
 			addtimer(CALLBACK(M,/atom/.proc/remove_alt_appearance,"human_apoc",TRUE), duration)
 			images += A
 			SEND_SOUND(M, pick(sound('sound/ambience/antag/bloodcult.ogg'),sound('sound/spookoween/ghost_whisper.ogg'),sound('sound/spookoween/ghosty_wind.ogg')))
@@ -990,13 +990,13 @@ structure_check() searches for nearby cultist structures required for the invoca
 			var/construct = pick("floater","artificer","behemoth")
 			var/image/B = image('icons/mob/mob.dmi',M,construct, ABOVE_MOB_LAYER)
 			B.override = 1
-			add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/noncult, "mob_apoc", B, FALSE)
+			add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/noncult, "mob_apoc", B, NONE)
 			addtimer(CALLBACK(M,/atom/.proc/remove_alt_appearance,"mob_apoc",TRUE), duration)
 			images += B
 		if(!iscultist(M))
 			if(M.client)
 				var/image/C = image('icons/effects/cult_effects.dmi',M,"bloodsparkles", ABOVE_MOB_LAYER)
-				add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/cult, "cult_apoc", C, FALSE)
+				add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/cult, "cult_apoc", C, NONE)
 				addtimer(CALLBACK(M,/atom/.proc/remove_alt_appearance,"cult_apoc",TRUE), duration)
 				images += C
 		else


### PR DESCRIPTION
* Added an option to transfer (and update) source overlays on an alternate appearance image
* Fixed a missing Xeno Queen action icon (switch size)

It's now limited to the Xeno queen (and the ashdrake), since i don't know of other mobs/atoms that would requires it. Easily extensible by changing flags.

Fixes #42303.

Also, should we rather define `/atom var/alternate_appearance`  in the `atoms.dm` file instead of `alternate_appearance.dm` ? 

:cl: Menshin
add: Xeno queens now transfer overlays on size change (meaning it will now display on fire, etc)
fix: restored a missing Xeno queen icon
/:cl:
