### PR TITLE
Makes saline-glucose OD slightly stronger

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -334,8 +334,8 @@
 		holder.add_reagent("sugar", 1)
 		holder.remove_reagent("salglu_solution", 0.5)
 	if(prob(33))
-		M.adjustBruteLoss(0.5*REM, FALSE, FALSE, BODYPART_ORGANIC)
-		M.adjustFireLoss(0.5*REM, FALSE, FALSE, BODYPART_ORGANIC)
+		M.adjustBruteLoss(1*REM, FALSE, FALSE, BODYPART_ORGANIC)
+		M.adjustFireLoss(1*REM, FALSE, FALSE, BODYPART_ORGANIC)
 		. = TRUE
 	..()
 


### PR DESCRIPTION
:cl: Denton
balance: Overdosing on saline-glucose solution now deals a little more damage than the solution itself heals.
/:cl:

Having an OD with a 33% chance to deal 0.5 brute/fire damage is a bit silly if the reagent itself also has a 33% chance to heal 0.5 brute/fire damage.
Now the OD has a 33% chance to deal 1 brute/fire damage. It won't instantly kill people, but it will at least make overdosing harmful.