### PR TITLE
Makes compressed matter cartridges tiny

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -558,6 +558,7 @@ RLD
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "rcd"
 	item_state = "rcdammo"
+	w_class = WEIGHT_CLASS_TINY
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	materials = list(MAT_METAL=12000, MAT_GLASS=8000)


### PR DESCRIPTION
:cl: 
tweak: compressed matter cartridges are now tiny.
/:cl:

[why]: a stack of 33 glass fills an rcd near full and fits in a box. a COMPRESSED matter cartridge fills 40 nuggies and needs to be stuffed a backpack, as well as being way too hard to make. I can understand why the rcd was subject to so much quality of life aka powercreep but I think that compressed matter cartridges should at least be a moderately reasonable way to fill an rcd.