### PR TITLE
Makes the steamed hams meme event rarer

### DIFF
--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -2,7 +2,7 @@
 	name = "Aurora Caelus"
 	typepath = /datum/round_event/aurora_caelus
 	max_occurrences = 1
-	weight = 4
+	weight = 1
 	earliest_start = 5 MINUTES
 
 /datum/round_event_control/aurora_caelus/canSpawnEvent(players, gamemode)


### PR DESCRIPTION
:cl:
tweak: Aurora Caelus is 4x rarer
/:cl:

[why]: 

The event calls itself very rare and not only was added as a dead meme, but makes nanotrasen seem unenecessarily friendly. Now it will actually be rare-ish. The  effect of the event itself is ugly anyways, this event is basically a "nothing happens" event.