### PR TITLE
Allows HoP to purge all IDs of their access, and implements a ID access recovery function in all PDAs

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -219,8 +219,30 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 			dat += "</td></tr>"
 		dat += "</table>"
-	else if(mode == 4) //Access Panel
-		dat = "<tt><b>Access Panel:</b><br>Please use the following options with care.<br><br><a href='?src=[REF(src)];choice=accesspurge'>Purge Access from all IDs and activate PDA recovery mode</a><br><br><a href='?src=[REF(src)];choice=mode;mode_target=0'>Access ID modification console.</a><br></tt>"
+	else if(mode == 4)
+		//Door Access Panel
+		dat = "<a href='?src=[REF(src)];choice=return'>Return</a>"
+		dat += " || Confirm Identity: "
+		var/S
+		if(scan)
+			S = html_encode(scan.name)
+		else
+			S = "--------"
+		var/ID
+		if(scan && (ACCESS_CHANGE_IDS in scan.access) && !target_dept)
+			ID = 1
+		else
+			ID = 0
+		dat += "<a href='?src=[REF(src)];choice=scan'>[S]</a></br>"
+		dat += "<tt><b>Door Access Control Panel:</b><br>Please use the following options with care.<br><br>"
+		dat += "<table><tr><td style='width:25%'></td><td style='width:25%'></td></tr>"
+		dat += "<tr><td>Purge door access from all IDs, and activate PDA recovery mode.</td>"
+		if (ID)
+			dat += "<td><a href='?src=[REF(src)];choice=accesspurge'>Purge access</a></td></tr>"
+		else
+			dat += "<td>Purge access</td></tr>"
+		dat += "</table>"
+
 	else
 		var/header = ""
 
@@ -254,8 +276,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			header += "<div align='center'><br>"
 			header += "<a href='?src=[REF(src)];choice=modify'>Remove [target_name]</a> || "
 			header += "<a href='?src=[REF(src)];choice=scan'>Remove [scan_name]</a> <br> "
-			header += "<a href='?src=[REF(src)];choice=mode;mode_target=1'>Access Crew Manifest</a> || "
-			header += "<a href='?src=[REF(src)];choice=mode;mode_target=4'>Access Access Panel</a> || "
+			header += "<a href='?src=[REF(src)];choice=mode;mode_target=1'>Access Crew Manifest</a> <br> "
 			header += "<a href='?src=[REF(src)];choice=logout'>Log Out</a></div>"
 
 		header += "<hr>"
@@ -342,6 +363,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			body += "<a href='?src=[REF(src)];choice=mode;mode_target=1'>Access Crew Manifest</a>"
 			if(!target_dept)
 				body += "<br><hr><a href = '?src=[REF(src)];choice=mode;mode_target=2'>Job Management</a>"
+				body += "<br><hr><a href = '?src=[REF(src)];choice=mode;mode_target=4'>Door Access Control Panel</a>"
 
 		dat = "<tt>[header][body]<hr><br></tt>"
 	var/datum/browser/popup = new(user, "id_com", src.name, 900, 620)
@@ -542,26 +564,21 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 				printing = null
 				playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
 		if ("accesspurge")
-			to_chat(world,"DEBUG -- access purge reached; card_id list is [GLOB.card_id.len] items long.")
 			for (var/obj/item/card/id/I in GLOB.card_id)
-				to_chat(world,"DEBUG -- ID [I.name] found.</span>")
-//				if (I.icon_state = "gold" || I.parent_type = "/obj/item/card/id/syndicate" || I.type = "/obj/item/card/id/syndicate" )
 				if ((I.type != /obj/item/card/id) && (I.type != /obj/item/card/id/silver)) //This skips any special map IDs, and also syndicate agent IDs.
-					to_chat(world,"DEBUG -- ID [I.type] was skipped======================.</span>")
-					return
-				to_chat(world,"DEBUG -- ID [I] is not a special ID and was purged.(type is [I.type])</span>")
+					continue
 				if (I.registered_name)
-					I.name = "[I.registered_name]'s ID Card (empty)"
+					I.name = "[I.registered_name]'s ID Card (blank)"
 				else if (I.type == /obj/item/card/id/silver)
 					I.name = "silver identification card"
 				else
 					I.name = "identification card"
-				I.registered_name = ""
+//				I.registered_name = ""
 				I.assignment = ""
 				I.access = ""
 			for (var/obj/item/pda/P in GLOB.PDAs)
-				//P.set_recovery()
-				P.recovery_mode = TRUE
+				P.set_recovery()
+				//P.recovery_mode = TRUE
 	if (modify)
 		modify.update_label()
 	updateUsrDialog()

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -1,5 +1,6 @@
 
 
+
 //Keeps track of the time for the ID console. Having it as a global variable prevents people from dismantling/reassembling it to
 //increase the slots of many jobs.
 GLOBAL_VAR_INIT(time_last_changed_position, 0)
@@ -218,6 +219,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 			dat += "</td></tr>"
 		dat += "</table>"
+	else if(mode == 4) //Access Panel
+		dat = "<tt><b>Access Panel:</b><br>Please use the following options with care.<br><br><a href='?src=[REF(src)];choice=accesspurge'>Purge Access from all IDs and activate PDA recovery mode</a><br><br><a href='?src=[REF(src)];choice=mode;mode_target=0'>Access ID modification console.</a><br></tt>"
 	else
 		var/header = ""
 
@@ -251,7 +254,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			header += "<div align='center'><br>"
 			header += "<a href='?src=[REF(src)];choice=modify'>Remove [target_name]</a> || "
 			header += "<a href='?src=[REF(src)];choice=scan'>Remove [scan_name]</a> <br> "
-			header += "<a href='?src=[REF(src)];choice=mode;mode_target=1'>Access Crew Manifest</a> <br> "
+			header += "<a href='?src=[REF(src)];choice=mode;mode_target=1'>Access Crew Manifest</a> || "
+			header += "<a href='?src=[REF(src)];choice=mode;mode_target=4'>Access Access Panel</a> || "
 			header += "<a href='?src=[REF(src)];choice=logout'>Log Out</a></div>"
 
 		header += "<hr>"
@@ -537,6 +541,27 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 				P.name = "paper- 'Crew Manifest'"
 				printing = null
 				playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
+		if ("accesspurge")
+			to_chat(world,"DEBUG -- access purge reached; card_id list is [GLOB.card_id.len] items long.")
+			for (var/obj/item/card/id/I in GLOB.card_id)
+				to_chat(world,"DEBUG -- ID [I.name] found.</span>")
+//				if (I.icon_state = "gold" || I.parent_type = "/obj/item/card/id/syndicate" || I.type = "/obj/item/card/id/syndicate" )
+				if ((I.type != /obj/item/card/id) && (I.type != /obj/item/card/id/silver)) //This skips any special map IDs, and also syndicate agent IDs.
+					to_chat(world,"DEBUG -- ID [I.type] was skipped======================.</span>")
+					return
+				to_chat(world,"DEBUG -- ID [I] is not a special ID and was purged.(type is [I.type])</span>")
+				if (I.registered_name)
+					I.name = "[I.registered_name]'s ID Card (empty)"
+				else if (I.type == /obj/item/card/id/silver)
+					I.name = "silver identification card"
+				else
+					I.name = "identification card"
+				I.registered_name = ""
+				I.assignment = ""
+				I.access = ""
+			for (var/obj/item/pda/P in GLOB.PDAs)
+				//P.set_recovery()
+				P.recovery_mode = TRUE
 	if (modify)
 		modify.update_label()
 	updateUsrDialog()

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -1,6 +1,3 @@
-
-
-
 //Keeps track of the time for the ID console. Having it as a global variable prevents people from dismantling/reassembling it to
 //increase the slots of many jobs.
 GLOBAL_VAR_INIT(time_last_changed_position, 0)

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -570,7 +570,6 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 					I.name = "silver identification card"
 				else
 					I.name = "identification card"
-//				I.registered_name = ""
 				I.assignment = ""
 				I.access = ""
 			for (var/obj/item/pda/P in GLOB.PDAs)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -6,6 +6,7 @@
  *		FINGERPRINT CARD
  */
 
+GLOBAL_LIST_EMPTY(card_id)
 
 
 /*
@@ -37,6 +38,7 @@
 	var/detail_color = COLOR_ASSEMBLY_ORANGE
 
 /obj/item/card/data/Initialize()
+//	GLOB.card_id += src
 	.=..()
 	update_icon()
 
@@ -122,6 +124,7 @@
 
 /obj/item/card/id/Initialize(mapload)
 	. = ..()
+	GLOB.card_id += src
 	if(mapload && access_txt)
 		access = text2access(access_txt)
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -38,7 +38,6 @@ GLOBAL_LIST_EMPTY(card_id)
 	var/detail_color = COLOR_ASSEMBLY_ORANGE
 
 /obj/item/card/data/Initialize()
-//	GLOB.card_id += src
 	.=..()
 	update_icon()
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -514,6 +514,10 @@ update_label("John Doe", "Clowny")
 	SSeconomy.dep_cards -= src
 	return ..()
 
+/obj/item/card/id/Destroy()
+	GLOB.card_id -= src
+	return
+
 /obj/item/card/id/departmental_budget/civ
 	department_ID = ACCOUNT_CIV
 	department_name = ACCOUNT_CIV_NAME

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -439,13 +439,17 @@ GLOBAL_LIST_EMPTY(PDAs)
 					return
 				id.registered_name = owner
 				id.assignment = ownjob
+				id.name = "[id.registered_name]'s ID Card ([id.assignment])"
 				var/datum/job/jobdatum
 				for(var/jobtype in typesof(/datum/job))
 					var/datum/job/J = new jobtype
 //					if(ckey(J.title) == ckey(t1))
+					to_chat(U, "<span class='notice'>DEBUG -- Does [ckey(J.title)] equal [ownjob]? FYI J equals [J].</span>")
 					if(ckey(J.title) == ownjob)
 						jobdatum = J
 						break
+						to_chat(U, "<span class='notice'>DEBUG -- Yes, breaking...</span>")
+					to_chat(U, "<span class='notice'>DEBUG -- No</span>")
 				if(!jobdatum)
 					to_chat(usr, "<span class='error'>The [src] beeps: \"Error in recovery process. Not all access has been restored. Please see your administrator.\"</span>")
 					return

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -440,6 +440,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 				if(id.assignment)
 					to_chat(U, "<span class='notice'>The [src] beeps, \"Unable to overwrite existing data.\"</span>")
 					return
+				if ((id.type != /obj/item/card/id) && (id.type != /obj/item/card/id/silver))
+					to_chat(U, "<span class='notice'>The [src] beeps, \"Unable to write to ID. Unknown error.\"</span>")
+					return
 				id.registered_name = owner
 				id.assignment = ownjob
 				id.name = "[id.registered_name]'s ID Card ([id.assignment])"

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -806,7 +806,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if(istype(C))
 				I = C
 
-//	if(I && I.registered_name)
 	if(I)
 		if(!user.transferItemToLoc(I, src))
 			return FALSE
@@ -833,9 +832,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	else if(istype(C, /obj/item/card/id))
 		var/obj/item/card/id/idcard = C
-//		if(!idcard.registered_name)
-//			to_chat(user, "<span class='warning'>\The [src] rejects the ID!</span>")
-//			return
 		if(!owner)
 			owner = idcard.registered_name
 			ownjob = idcard.assignment
@@ -926,7 +922,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 		to_chat(user, "<span class='notice'>Paper scanned. Saved to PDA's notekeeper.</span>" )
 
 /obj/item/pda/proc/set_recovery()
-//proc/set_recovery()
 	if (!ownjob || !owner) //Blank PDAs, that have not been uploaded to, need not apply.
 		return
 	if (ownjob == "Captain") //Captain IDs do not get wiped, so their PDA should not need recovery mode set.
@@ -946,11 +941,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		L = get(src, /mob/living/silicon)
 
 	if(L && L.stat != UNCONSCIOUS)
-//		var/hrefstart
-//		var/hrefend
 		if (isAI(L))
-//			hrefstart = "<a href='?src=[REF(L)];track=[html_encode(signal.data["name"])]'>"
-//			hrefend = "</a>"
 			to_chat(L, "The messaging service beeps, \"Emergency door access purge has been activated. PDA recovery mode has been unlocked where available.\"")
 		else to_chat(L, "The [src] beeps, \"Emergency door access purge has been activated. Recovery mode is available.\"")
 
@@ -1074,10 +1065,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 		if(!P.owner || P.toff || P.hidden)
 			continue
 		. += P
-
-
-
-	
 
 #undef PDA_SCANNER_NONE
 #undef PDA_SCANNER_MEDICAL

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -79,7 +79,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	var/underline_flag = TRUE //flag for underline
 	
-	var/recovery_mode = TRUE //Recovery mode allows imprinting name and job title into a blank ID card, if the data is already stored.
+	var/recovery_mode = FALSE //Recovery mode allows imprinting name and job title into a blank ID card, if the data is already stored.
 
 /obj/item/pda/suicide_act(mob/living/carbon/user)
 	var/deathMessage = msg_input(user)
@@ -432,26 +432,23 @@ GLOBAL_LIST_EMPTY(PDAs)
 				update_label()
 			if("RecoverAccess")
 				if(!id)
-					to_chat(U, "<span class='notice'>The [src] beeps: \"ID slot empty.\"</span>")
+					to_chat(U, "<span class='notice'>The [src] beeps, \"ID slot empty.\"</span>")
 					return
 				if(id.registered_name || id.assignment)
-					to_chat(U, "<span class='notice'>The [src] beeps: \"Unable to overwrite existing data.\"</span>")
+					to_chat(U, "<span class='notice'>The [src] beeps, \"Unable to overwrite existing data.\"</span>")
 					return
 				id.registered_name = owner
 				id.assignment = ownjob
 				id.name = "[id.registered_name]'s ID Card ([id.assignment])"
 				var/datum/job/jobdatum
+				var/ownjob_nospaces = replacetext("[ownjob]", " ", "")
 				for(var/jobtype in typesof(/datum/job))
 					var/datum/job/J = new jobtype
-//					if(ckey(J.title) == ckey(t1))
-					to_chat(U, "<span class='notice'>DEBUG -- Does [ckey(J.title)] equal [ownjob]? FYI J equals [J].</span>")
-					if(ckey(J.title) == ownjob)
+					if(cmptext(ckey(J.title), ownjob_nospaces)) //case-insensitive compare
 						jobdatum = J
 						break
-						to_chat(U, "<span class='notice'>DEBUG -- Yes, breaking...</span>")
-					to_chat(U, "<span class='notice'>DEBUG -- No</span>")
 				if(!jobdatum)
-					to_chat(usr, "<span class='error'>The [src] beeps: \"Error in recovery process. Not all access has been restored. Please see your administrator.\"</span>")
+					to_chat(usr, "<span class='error'>The [src] beeps, \"Error in recovery process. Access has not been restored. Please see your administrator.\"</span>")
 					return
 //				if(modify.registered_account)
 //					modify.registered_account.account_job = jobdatum // this is a terrible idea and people will grief but sure whatever
@@ -459,6 +456,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 //						modify.registered_account.add_neetbux()
 
 				id.access = jobdatum.get_access()
+				to_chat(usr, "<span class='error'>The [src] beeps, \"Recovery complete. Access has been restored from backup. Recovery mode is now disabled.\"</span>")
+				recovery_mode = FALSE
 				
 
 			if("Eject")//Ejects the cart, only done from hub.
@@ -1047,6 +1046,37 @@ GLOBAL_LIST_EMPTY(PDAs)
 		if(!P.owner || P.toff || P.hidden)
 			continue
 		. += P
+
+/*/obj/item/pda/set_recovery()
+//proc/set_recovery()
+	if (!ownjob || !owner) //Blank PDAs, that have not been uploaded to, need not apply.
+		return
+	if (ownjob == "Captain") //Captain IDs do not get wiped, so their PDA should not need recovery mode set.
+		return
+	
+	recovery_mode = TRUE
+	
+	if (!silent)
+		playsound(src, 'sound/machines/twobeep.ogg', 50, 1)
+		
+	var/mob/living/L = null
+	//Searching for owner, as stolen from above code
+	if(loc && isliving(loc))
+		L = loc
+	//Maybe they are a pAI!
+	else
+		L = get(src, /mob/living/silicon)
+
+	if(L && L.stat != UNCONSCIOUS)
+//		var/hrefstart
+//		var/hrefend
+		if (isAI(L))
+//			hrefstart = "<a href='?src=[REF(L)];track=[html_encode(signal.data["name"])]'>"
+//			hrefend = "</a>"
+			to_chat(L, "Emergency ID purge has been activated. PDA recovery mode has been unlocked where available.")
+		else to_chat(L, "Emergency ID purge has been activated. Recovery mode is available.")
+*/	
+	
 
 #undef PDA_SCANNER_NONE
 #undef PDA_SCANNER_MEDICAL


### PR DESCRIPTION
:cl: Zxaber
add: In order to cut down on costly emergency shuttles from stations overrun with All Access, the Head of Personnel can now purge access from every ID on the station.
add: PDAs now store ID access codes for backup, allowing them to restore access to blank ID cards. However, this function is only unlocked if an emergency access purge has been activated.
tweak: Due to the extra memory requirements of the backup function, PDA owner and owner job title are now stored in the PDA's ROM, and they cannot be altered once set. If you get a job change from the HoP, make sure you also ask for a replacement PDA!
/:cl:
I made a video to help demonstrate;
https://www.youtube.com/watch?v=arioXWHuHPE
Turn on CC for text.

As opposed to PKPenguin's detective HoP ideas, this is intended to be a heavy-handed method of dealing with the crew having all access once it has passed the point of "solve now or shuttle". All access tends to spread like a plague, especially due to the auxiliary ID consoles. As such, when faced with the task of keeping order against a grey tide that can go anywhere easily, Security and Command often opt for simply calling the shuttle and restarting the round. Allowing the Captain or HoP to purge access from everyone's IDs should help cut down the tide a bit.

After the purge, PDAs unlock their recovery mode (and give a helpful message), allowing them to update an ID with no job set, and giving access that the job is granted at shift start (using the same function that the ID console uses to assign default access). This means that anyone who wasn't participating in the all access shenanigans can simply recover their access quickly and are almost entirely unaffected. Anyone that did get extra access, legitimately or otherwise, will see their extra access lost. If they were granted this access by command staff, they will need to reacquire it again.

Custom (meme) job titles handed out, which are not listed in the jobs datum, will not be able to recover _any_ access, and the player will need to visit the HoP to restore their access, adding to the (potential) work load of the HoP themselves if they press the button. The PDA will give them their job title back, however.

In order to stop people from simply changing the title on their PDA, the PDA fields for owner and owner's job are now single-write. All starting PDAs already have these fields set.

In order to allow people to recover access to blank IDs, I had to remove the code where PDA's rejected IDs that didn't match their stored owner info. The end result of this is that you can someone else's ID in your PDA, and still have their access when opening doors. Since it's easy enough to just hide an ID in a pocket or somewhere else, I do not know if this is a big deal.

Golden IDs (The Cap's ID and the spare) are not affected. Whoever has one of these IDs will still have all access. That being said, because the Cap's special ID is not affected, PDAs with the job title set to Captain will also not enter recovery mode.

I would prefer this be test-merged first, since I'm dealing with some fairly critical parts of the game.