### PR TITLE
Fix turning one paper into two paper airplanes

### DIFF
--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -38,6 +38,13 @@
 			qdel(src)
 	return ..()
 
+/obj/item/paperplane/Exited(atom/movable/AM, atom/newLoc)
+	. = ..()
+	if (AM == internalPaper)
+		internalPaper = null
+		if(!QDELETED(src))
+			qdel(src)
+
 /obj/item/paperplane/Destroy()
 	QDEL_NULL(internalPaper)
 	return ..()


### PR DESCRIPTION
:cl:
fix: It is no longer possible for folding paper into an airplane to appear to duplicate it.
/:cl:

Fixes #42468.