### PR TITLE
makes binoculars and beam rifles impossible to zoom with with the x-ray mutation.

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -509,7 +509,7 @@
 		parts_list -= G
 		qdel(src)
 	..()
-	
+
 
 /obj/item/twohanded/spear/explosive
 	name = "explosive lance"
@@ -538,7 +538,7 @@
 	..()
 	to_chat(user, "<span class='notice'>Alt-click to set your war cry.</span>")
 
-/obj/item/twohanded/spear/explosive/update_icon()	
+/obj/item/twohanded/spear/explosive/update_icon()
 	icon_state = "spearbomb[wielded]"
 
  //THIS MIGHT BE UNBALANCED SO I DUNNO // it totally is.
@@ -842,6 +842,10 @@
 		mobhook = user.AddComponent(/datum/component/redirect, list(COMSIG_MOVABLE_MOVED = CALLBACK(src, .proc/unwield)))
 	else
 		user.TakeComponent(mobhook)
+	var/mob/living/carbon/human/H = user
+	if(H.dna.check_mutation(XRAY))
+		to_chat(user, "<span class='warning'>Your eyes see right through the lenses!</span>")
+		return
 	user.visible_message("[user] holds [src] up to [user.p_their()] eyes.","You hold [src] up to your eyes.")
 	item_state = "binoculars_wielded"
 	user.regenerate_icons()
@@ -869,7 +873,8 @@
 	user.visible_message("[user] lowers [src].","You lower [src].")
 	item_state = "binoculars"
 	user.regenerate_icons()
-	if(user && user.client)
+	var/mob/living/carbon/human/H = user
+	if((user && user.client) && !(H.dna.check_mutation(XRAY)))
 		user.regenerate_icons()
 		var/client/C = user.client
 		C.change_view(CONFIG_GET(string/default_view))

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -843,7 +843,7 @@
 	else
 		user.TakeComponent(mobhook)
 	if iscarbon(user)
-		var/mob/living/carbon/human/H = user
+		var/mob/living/carbon/H = user
 		if (H.dna.check_mutation(XRAY))
 			to_chat(user, "<span class='warning'>Your eyes see right through the lenses!</span>")
 			return
@@ -875,7 +875,7 @@
 	item_state = "binoculars"
 	if(user && user.client)
 		if iscarbon(user)
-			var/mob/living/carbon/human/H = user
+			var/mob/living/carbon/H = user
 			if (H.dna.check_mutation(XRAY))
 				return
 		user.regenerate_icons()

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -842,10 +842,11 @@
 		mobhook = user.AddComponent(/datum/component/redirect, list(COMSIG_MOVABLE_MOVED = CALLBACK(src, .proc/unwield)))
 	else
 		user.TakeComponent(mobhook)
-	var/mob/living/carbon/human/H = user
-	if(H.dna.check_mutation(XRAY))
-		to_chat(user, "<span class='warning'>Your eyes see right through the lenses!</span>")
-		return
+	if iscarbon(user)
+		var/mob/living/carbon/human/H = user
+		if (H.dna.check_mutation(XRAY))
+			to_chat(user, "<span class='warning'>Your eyes see right through the lenses!</span>")
+			return
 	user.visible_message("[user] holds [src] up to [user.p_their()] eyes.","You hold [src] up to your eyes.")
 	item_state = "binoculars_wielded"
 	user.regenerate_icons()
@@ -872,9 +873,11 @@
 	mobhook.RemoveComponent()
 	user.visible_message("[user] lowers [src].","You lower [src].")
 	item_state = "binoculars"
-	user.regenerate_icons()
-	var/mob/living/carbon/human/H = user
-	if((user && user.client) && !(H.dna.check_mutation(XRAY)))
+	if(user && user.client)
+		if iscarbon(user)
+			var/mob/living/carbon/human/H = user
+			if (H.dna.check_mutation(XRAY))
+				return
 		user.regenerate_icons()
 		var/client/C = user.client
 		C.change_view(CONFIG_GET(string/default_view))

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -122,10 +122,11 @@
 /obj/item/gun/energy/beam_rifle/proc/handle_zooming()
 	if(!zooming || !check_user())
 		return
-	var/mob/living/carbon/human/H = current_user
-	if(H.dna.check_mutation(XRAY))
-		to_chat(current_user, "<span class='warning'>Your eyes see right through the scope!</span>")
-		return
+	if iscarbon(current_user)
+		var/mob/living/carbon/human/H = current_user
+		if (H.dna.check_mutation(XRAY))
+			to_chat(current_user, "<span class='warning'>Your eyes see right through the scope!</span>")
+			return
 	current_user.client.change_view(world.view + zoom_target_view_increase)
 	zoom_current_view_increase = zoom_target_view_increase
 	set_autozoom_pixel_offsets_immediate(zooming_angle)
@@ -147,9 +148,10 @@
 		return FALSE
 	animate(user.client, pixel_x = 0, pixel_y = 0, 0, FALSE, LINEAR_EASING, ANIMATION_END_NOW)
 	zoom_current_view_increase = 0
-	var/mob/living/carbon/human/H = user
-	if(H.dna.check_mutation(XRAY))
-		return
+	if iscarbon(user)
+		var/mob/living/carbon/human/H = user
+		if (H.dna.check_mutation(XRAY))
+			return
 	user.client.change_view(CONFIG_GET(string/default_view))
 	zooming_angle = 0
 	current_zoom_x = 0

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -123,7 +123,7 @@
 	if(!zooming || !check_user())
 		return
 	if iscarbon(current_user)
-		var/mob/living/carbon/human/H = current_user
+		var/mob/living/carbon/H = current_user
 		if (H.dna.check_mutation(XRAY))
 			to_chat(current_user, "<span class='warning'>Your eyes see right through the scope!</span>")
 			return
@@ -149,7 +149,7 @@
 	animate(user.client, pixel_x = 0, pixel_y = 0, 0, FALSE, LINEAR_EASING, ANIMATION_END_NOW)
 	zoom_current_view_increase = 0
 	if iscarbon(user)
-		var/mob/living/carbon/human/H = user
+		var/mob/living/carbon/H = user
 		if (H.dna.check_mutation(XRAY))
 			return
 	user.client.change_view(CONFIG_GET(string/default_view))

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -122,6 +122,10 @@
 /obj/item/gun/energy/beam_rifle/proc/handle_zooming()
 	if(!zooming || !check_user())
 		return
+	var/mob/living/carbon/human/H = current_user
+	if(H.dna.check_mutation(XRAY))
+		to_chat(current_user, "<span class='warning'>Your eyes see right through the scope!</span>")
+		return
 	current_user.client.change_view(world.view + zoom_target_view_increase)
 	zoom_current_view_increase = zoom_target_view_increase
 	set_autozoom_pixel_offsets_immediate(zooming_angle)
@@ -143,6 +147,9 @@
 		return FALSE
 	animate(user.client, pixel_x = 0, pixel_y = 0, 0, FALSE, LINEAR_EASING, ANIMATION_END_NOW)
 	zoom_current_view_increase = 0
+	var/mob/living/carbon/human/H = user
+	if(H.dna.check_mutation(XRAY))
+		return
 	user.client.change_view(CONFIG_GET(string/default_view))
 	zooming_angle = 0
 	current_zoom_x = 0


### PR DESCRIPTION
:cl: 
tweak: the x-ray mutation makes binoculars and beam rifle scopes impossible to use.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
Fluffy in the same way that making shield gens instagib was fluffy, makes giving xray to the detective slightly less extremely unfair to any antag ever.
