### PR TITLE
Increase drop chance for Crusher trophies

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -20,7 +20,7 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	mob_size = MOB_SIZE_LARGE
 	var/icon_aggro = null
-	var/crusher_drop_mod = 5
+	var/crusher_drop_mod = 25
 
 /mob/living/simple_animal/hostile/asteroid/Initialize(mapload)
 	. = ..()
@@ -58,7 +58,7 @@
 /mob/living/simple_animal/hostile/asteroid/death(gibbed)
 	SSblackbox.record_feedback("tally", "mobs_killed_mining", 1, type)
 	var/datum/status_effect/crusher_damage/C = has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
-	if(C && crusher_loot && prob((C.total_damage/maxHealth) * crusher_drop_mod)) //on average, you'll need to kill 20 creatures before getting the item
+	if(C && crusher_loot && prob((C.total_damage/maxHealth) * crusher_drop_mod)) //on average, you'll need to kill 4 creatures before getting the item
 		spawn_crusher_loot()
 	..(gibbed)
 


### PR DESCRIPTION
:cl:
tweak: increased drop chance of crusher trophies on mining mobs from 1 in 20 to 1 in 4
/:cl:

Crusher trophies take way too long to get, which kind of makes the crusher useless. this won't make it as good as a PKA, but at least it makes it more worth using.
also first PR. yay.