### PR TITLE
Removes revolutions

### DIFF
--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -180,7 +180,7 @@ As a Blobbernaut, you can communicate with overminds and other Blobbernauts via 
 As a Blobbernaut, your HUD shows your health and the core health of the overmind that created you.
 As a Revolutionary, you cannot convert a head of staff or someone who has a mindshield implant, such as a security officer or those they implant. Implants can however be surgically removed, and do not carry over with cloning. Take control of medbay to keep control of conversions!
 As a Revolutionary, cargo can be your best friend or your worst nightmare. In the best case scenario you will be able to order a limitless amount of guns and armor, in the worst case scenario security will take control and order a limitless number of mindshield implants to turn your fellow revolutionaries against you.
-As a Revolutionary, your main power comes from how quickly you spread. Convert people as fast as you can and overwhelm the heads of staff before security can arm up.
+As a Revolutionary, your main power comes from who you convert, choose your converts wisely to ensure you win the round.
 As a Changeling, the Extract DNA sting counts for your genome absorb objective, but does not let you respec your powers.
 As a Changeling, you can absorb someone by strangling them and using the Absorb verb; this gives you the ability to rechoose your powers, the DNA of whoever you absorbed, the memory of the absorbed, and some samples of things the absorbed said.
 As a Cultist, do not cause too much chaos before your objective is completed. If the shuttle gets called too soon, you may not have enough time to win.


### PR DESCRIPTION
tip that wasn't accurate.

Revolutionary is more about who you convert (both in a meta sense of robust people) and their job accesses.
