### PR TITLE
Mime Foods/Drinks Now Silence the Mime

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -27,3 +27,5 @@
 #define DEL_REAGENT		1	// reagent deleted (fully cleared)
 #define ADD_REAGENT		2	// reagent added
 #define REM_REAGENT		3	// reagent removed (may still exist)
+
+#define MIMEDRINK_SILENCE_DURATION 30  //ends up being 60 seconds given 1 tick every 2 seconds

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -27,3 +27,5 @@
 #define DEL_REAGENT		1	// reagent deleted (fully cleared)
 #define ADD_REAGENT		2	// reagent added
 #define REM_REAGENT		3	// reagent removed (may still exist)
+
+#define MIMEDRINK_SILENCE_DURATION (30 SECONDS)

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -28,4 +28,4 @@
 #define ADD_REAGENT		2	// reagent added
 #define REM_REAGENT		3	// reagent removed (may still exist)
 
-#define MIMEDRINK_SILENCE_DURATION (3 SECONDS) //equal to about 50 seconds
+#define MIMEDRINK_SILENCE_DURATION (3 SECONDS) //ends up being ~60 seconds

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -27,5 +27,3 @@
 #define DEL_REAGENT		1	// reagent deleted (fully cleared)
 #define ADD_REAGENT		2	// reagent added
 #define REM_REAGENT		3	// reagent removed (may still exist)
-
-#define MIMEDRINK_SILENCE_DURATION (3 SECONDS) //ends up being ~60 seconds

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -28,4 +28,4 @@
 #define ADD_REAGENT		2	// reagent added
 #define REM_REAGENT		3	// reagent removed (may still exist)
 
-#define MIMEDRINK_SILENCE_DURATION (30 SECONDS)
+#define MIMEDRINK_SILENCE_DURATION (3 SECONDS) //equal to about 30 seconds

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -28,4 +28,4 @@
 #define ADD_REAGENT		2	// reagent added
 #define REM_REAGENT		3	// reagent removed (may still exist)
 
-#define MIMEDRINK_SILENCE_DURATION (3 SECONDS) //equal to about 30 seconds
+#define MIMEDRINK_SILENCE_DURATION (3 SECONDS) //equal to about 50 seconds

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -28,4 +28,4 @@
 #define ADD_REAGENT		2	// reagent added
 #define REM_REAGENT		3	// reagent removed (may still exist)
 
-#define MIMEDRINK_SILENCE_DURATION (300 SECONDS)
+#define MIMEDRINK_SILENCE_DURATION (30 SECONDS)

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -28,4 +28,4 @@
 #define ADD_REAGENT		2	// reagent added
 #define REM_REAGENT		3	// reagent removed (may still exist)
 
-#define MIMEDRINK_SILENCE_DURATION (30 SECONDS)
+#define MIMEDRINK_SILENCE_DURATION (300 SECONDS)

--- a/code/modules/food_and_drinks/food/snacks_burgers.dm
+++ b/code/modules/food_and_drinks/food/snacks_burgers.dm
@@ -122,7 +122,7 @@
 	name = "mime burger"
 	desc = "Its taste defies language."
 	icon_state = "mimeburger"
-	bonus_reagents = list("nutriment" = 4, "vitamin" = 6, "nothing" = 6, "mutetoxin" = 5)
+	bonus_reagents = list("nutriment" = 4, "vitamin" = 6, "nothing" = 6)
 	foodtype = GRAIN
 
 /obj/item/reagent_containers/food/snacks/burger/brain

--- a/code/modules/food_and_drinks/food/snacks_burgers.dm
+++ b/code/modules/food_and_drinks/food/snacks_burgers.dm
@@ -122,7 +122,7 @@
 	name = "mime burger"
 	desc = "Its taste defies language."
 	icon_state = "mimeburger"
-	bonus_reagents = list("nutriment" = 4, "vitamin" = 6, "nothing" = 6)
+	bonus_reagents = list("nutriment" = 4, "vitamin" = 6, "nothing" = 6, "mutetoxin" = 5)
 	foodtype = GRAIN
 
 /obj/item/reagent_containers/food/snacks/burger/brain

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1169,7 +1169,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
+		M.silent = max(M.silent, 30)
 		M.heal_bodypart_damage(1,1)
 		. = 1
 	return ..() || .

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1856,7 +1856,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
+		M.silent = max(M.silent, 30)
 		M.heal_bodypart_damage(1,1)
 		. = 1
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1169,7 +1169,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		M.silent = max(M.silent, 3)
+		M.silent = max(M.silent, 30)
 		M.heal_bodypart_damage(1,1)
 		. = 1
 	return ..() || .

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1168,7 +1168,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink from Mime Heaven."
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/M)
-		M.silent = max(M.silent, 3)
+	M.silent = max(M.silent, 3)
 	if(ishuman(M) && M.job == "Mime")
 		M.heal_bodypart_damage(1,1)
 		. = 1

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1856,6 +1856,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
+		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1,1)
 		. = 1
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1169,7 +1169,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		M.silent = max(M.silent, 30)
+		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1,1)
 		. = 1
 	return ..() || .
@@ -1856,7 +1856,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		M.silent = max(M.silent, 30)
+		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1,1)
 		. = 1
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1169,7 +1169,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		M.silent = max(M.silent, 30)
+		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1,1)
 		. = 1
 	return ..() || .

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1168,8 +1168,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink from Mime Heaven."
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/M)
-	M.silent = max(M.silent, 3)
 	if(ishuman(M) && M.job == "Mime")
+		M.silent = max(M.silent, 3)
 		M.heal_bodypart_damage(1,1)
 		. = 1
 	return ..() || .

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1168,6 +1168,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink from Mime Heaven."
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/M)
+		M.silent = max(M.silent, 3)
 	if(ishuman(M) && M.job == "Mime")
 		M.heal_bodypart_damage(1,1)
 		. = 1

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -153,6 +153,7 @@
 	shot_glass_icon_state = "shotglass"
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
+		M.silent = max(M.silent, 3)
 	if(ishuman(M) && M.job == "Mime")
 		M.heal_bodypart_damage(1,1, 0)
 		. = 1

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -154,7 +154,7 @@
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		M.silent = max(M.silent, 3)
+		M.silent = max(M.silent, 30)
 		M.heal_bodypart_damage(1,1, 0)
 		. = 1
 	..()

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -153,7 +153,7 @@
 	shot_glass_icon_state = "shotglass"
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
-		M.silent = max(M.silent, 3)
+	M.silent = max(M.silent, 3)
 	if(ishuman(M) && M.job == "Mime")
 		M.heal_bodypart_damage(1,1, 0)
 		. = 1

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -153,8 +153,8 @@
 	shot_glass_icon_state = "shotglass"
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
-	M.silent = max(M.silent, 3)
 	if(ishuman(M) && M.job == "Mime")
+		M.silent = max(M.silent, 3)
 		M.heal_bodypart_damage(1,1, 0)
 		. = 1
 	..()

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -154,7 +154,7 @@
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
+		M.silent = max(M.silent, 30)
 		M.heal_bodypart_damage(1,1, 0)
 		. = 1
 	..()

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -154,7 +154,7 @@
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		M.silent = max(M.silent, 30)
+		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1,1, 0)
 		. = 1
 	..()


### PR DESCRIPTION
Mime stuff silences  the mime now
:cl:
tweak: The nothing, silencer, and blank paper beverages now apply a mute on the mime for their duration (and a bit after). 
:cl:

If you want to heal as a mime, you should not be allowed to speak. By extension things such as mime burgers will have this effect given the fact that they have nothing inside them (the reagent). 