### PR TITLE
Adds Paraplegic quirk (FREE ROUNDSTART WHEELCHAIR*)

### DIFF
--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -69,7 +69,8 @@
 	 //for descriptions
 
 /datum/brain_trauma/severe/paralysis/New(specific_type)
-	paralysis_type = specific_type
+	if(specific_type)
+		paralysis_type = specific_type
 	if(!paralysis_type)
 		paralysis_type = pick("full","left","right","arms","legs","r_arm","l_arm","r_leg","l_leg")
 	var/subject
@@ -116,6 +117,11 @@
 	for(var/X in paralysis_traits)
 		owner.remove_trait(X, "trauma_paralysis")
 	owner.update_disabled_bodyparts()
+
+/datum/brain_trauma/severe/paralysis/paraplegic
+	random_gain = FALSE
+	paralysis_type = "legs"
+	resilience = TRAUMA_RESILIENCE_ABSOLUTE
 
 /datum/brain_trauma/severe/narcolepsy
 	name = "Narcolepsy"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -265,6 +265,41 @@
 		to_chat(quirk_holder, "<span class='boldannounce'>Your antagonistic nature has caused you to renounce your pacifism.</span>")
 		qdel(src)
 
+/datum/quirk/paraplegic
+	name = "Paraplegic"
+	desc = "Your legs do not function. Nothing will ever fix this. But hey, free wheelchair!"
+	value = -3
+	human_only = TRUE
+	gain_text = null // Handled by trauma.
+	lose_text = null
+	medical_record_text = "Patient has an untreatable impairment in motor function in the lower extremities."
+
+/datum/quirk/paraplegic/add()
+	var/datum/brain_trauma/severe/paralysis/paraplegic/T = new()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(T, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/paraplegic/on_spawn()
+	if(quirk_holder.buckled) // Handle late joins being buckled to arrival shuttle chairs.
+		quirk_holder.buckled.unbuckle_mob(quirk_holder)
+
+	var/turf/T = get_turf(quirk_holder)
+	var/obj/structure/chair/spawn_chair = locate() in T
+
+	var/obj/vehicle/ridden/wheelchair/wheels = new(T)
+	if(spawn_chair) // Makes spawning on the arrivals shuttle more consistent looking
+		wheels.setDir(spawn_chair.dir)
+
+	wheels.buckle_mob(quirk_holder)
+
+	// During the spawning process, they may have dropped what they were holding, due to the paralysis
+	// So put the things back in their hands.
+
+	for(var/obj/item/I in T)
+		if(I.fingerprintslast == quirk_holder.ckey)
+			quirk_holder.put_in_hands(I)
+
+
 /datum/quirk/poor_aim
 	name = "Poor Aim"
 	desc = "You're terrible with guns and can't line up a straight shot to save your life. Dual-wielding is right out."


### PR DESCRIPTION
* Terms and conditions apply.

:cl: coiax
add: Adds the Paraplegic quirk for -3 points. You start with unhealable leg paralysis
(persists through cloning), and have a wheelchair to move around the station.
/:cl:

This is really popular for some reason.

This required a surprising amount of small code tweaks for it to "feel"
right in edge cases like being a job that had items in their hands or
joining on the arrivals shuttle.

Justification for -3 points: You move REALLY slowly, in a game that's
about generally running from security/the guy with the esword. And if
you die and get cloned and don't have your chair, you move even slower.