### PR TITLE
Replace the objectively inferior straight quotes with objectively superior curly quotes

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -95,7 +95,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		spans |= SPAN_YELL
 
 	var/spanned = attach_spans(input, spans)
-	return "[say_mod(input, message_mode)], \"[spanned]\""
+	return "[say_mod(input, message_mode)], &ldquo;[spanned]&rdquo;"
 
 /atom/movable/proc/lang_treat(atom/movable/speaker, datum/language/language, raw_message, list/spans, message_mode)
 	if(has_language(language))


### PR DESCRIPTION
:cl: monster860
tweak: The disgusting VIRGIN inferior straight quotes in your speech have been replaced with objectively superior beautifly CHAD curly quotes. Now, instead of being disgusted by your poor taste in quotation marks, people will fawn over you and your exceptionally good taste in quotation mark choices. Instead of having your maint screams for help ignored due to your inferior VIRGIN straight quotes, security will be instantly teleported to you because you made the correct choice of having objectively superior CHAD curly quotes.
/:cl:

![image](https://user-images.githubusercontent.com/3681297/51291335-b875cd80-19d4-11e9-812a-9ad9cae845db.png)
