### PR TITLE
Removes death

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,24 +1,11 @@
-/mob/living/gib(no_brain, no_organs, no_bodyparts)
-	var/prev_lying = lying
-	if(stat != DEAD)
-		death(TRUE)
-
-	if(!prev_lying)
-		gib_animation()
-
-	spill_organs(no_brain, no_organs, no_bodyparts)
-
-	if(!no_bodyparts)
-		spread_bodyparts(no_brain, no_organs)
-
-	spawn_gibs(no_bodyparts)
-	qdel(src)
+/mob/living/gib
+	return
 
 /mob/living/proc/gib_animation()
 	return
 
 /mob/living/proc/spawn_gibs()
-	new /obj/effect/gibspawner/generic(drop_location(), src, get_static_viruses())
+	return
 
 /mob/living/proc/spill_organs()
 	return
@@ -26,68 +13,14 @@
 /mob/living/proc/spread_bodyparts()
 	return
 
-/mob/living/dust(just_ash, drop_items, force)
-	death(TRUE)
-
-	if(drop_items)
-		unequip_everything()
-
-	if(buckled)
-		buckled.unbuckle_mob(src, force = TRUE)
-
-	dust_animation()
-	spawn_dust(just_ash)
-	QDEL_IN(src,5) // since this is sometimes called in the middle of movement, allow half a second for movement to finish, ghosting to happen and animation to play. Looks much nicer and doesn't cause multiple runtimes.
+/mob/living/dust()
+	return
 
 /mob/living/proc/dust_animation()
 	return
 
 /mob/living/proc/spawn_dust(just_ash = FALSE)
-	new /obj/effect/decal/cleanable/ash(loc)
+	return
 
-
-/mob/living/death(gibbed)
-	stat = DEAD
-	unset_machine()
-	timeofdeath = world.time
-	tod = station_time_timestamp()
-	var/turf/T = get_turf(src)
-	for(var/obj/item/I in contents)
-		I.on_mob_death(src, gibbed)
-	if(mind && mind.name && mind.active && !istype(T.loc, /area/ctf))
-		var/rendered = "<span class='deadsay'><b>[mind.name]</b> has died at <b>[get_area_name(T)]</b>.</span>"
-		deadchat_broadcast(rendered, follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)
-	if(mind)
-		mind.store_memory("Time of death: [tod]", 0)
-	GLOB.alive_mob_list -= src
-	if(!gibbed)
-		GLOB.dead_mob_list += src
-	set_drugginess(0)
-	set_disgust(0)
-	SetSleeping(0, 0)
-	blind_eyes(1)
-	reset_perspective(null)
-	reload_fullscreen()
-	update_action_buttons_icon()
-	update_damage_hud()
-	update_health_hud()
-	update_mobility()
-	med_hud_set_health()
-	med_hud_set_status()
-	if(!gibbed && !QDELETED(src))
-		addtimer(CALLBACK(src, .proc/med_hud_set_status), (DEFIB_TIME_LIMIT * 10) + 1)
-	stop_pulling()
-
-	. = ..()
-
-	if (client)
-		client.move_delay = initial(client.move_delay)
-
-	for(var/s in ownedSoullinks)
-		var/datum/soullink/S = s
-		S.ownerDies(gibbed)
-	for(var/s in sharedSoullinks)
-		var/datum/soullink/S = s
-		S.sharerDies(gibbed)
-
-	return TRUE
+/mob/living/death()
+	return FALSE


### PR DESCRIPTION
:cl: 
del: Death has been removed, it is no longer possible to die.
/:cl:

Why: Death is extremely overpowered. By just hitting someone repeatedly, putting some chems in them, or just throwing them into space, you can permanently remove someone from the round. This should nerf it, while also making the game more fun to play and opening up new opportunities for interesting gameplay.