### PR TITLE
The actually good Perfluorodecalin change

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -534,8 +534,9 @@
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/perfluorodecalin/on_mob_life(mob/living/carbon/human/M)
-	M.adjustOxyLoss(-12*REM, 0)
-	M.silent = max(M.silent, 5)
+	if(current_cycle > 5)
+		M.adjustOxyLoss(-12*REM, 0)
+		M.silent = max(M.silent, 5)
 	if(prob(33))
 		M.adjustBruteLoss(-0.5*REM, 0)
 		M.adjustFireLoss(-0.5*REM, 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
balance: Perfluorodecalin takes a few seconds to mute
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Closes #42501 
because this is actually bad

Closes #42506 
Closes #42507 
because apparently the problem is perf+neuro and i don't want any of you quick reactionary mofos causing more problems

Y'all bad at nerfing shit.

Perfluorodecalin now takes five cycles for the mute and oxy healing to kick in. Enough for "HELP MAINT" but not enough for "Help, the chemist has injected me with some bad shit in aft solar maintinence please assist me fellow secfrieinds". If the former's going to annoy you as chemist, well that's what mute toxin is for.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game

prevents bad nerfs

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
