### PR TITLE
Fixes grinder interaction with empty beaker

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -128,7 +128,6 @@
 			return
 		replace_beaker(user, B)
 		to_chat(user, "<span class='notice'>You add [B] to [src].</span>")
-		updateUsrDialog()
 		update_icon()
 		return TRUE //no afterattack
 


### PR DESCRIPTION
:cl: Yenwodyah
fix: Empty beakers can be added to grinders again
/:cl:
The problem (I think) is that this would open the grinder's radial menu and automatically eject the beaker, since 'eject' was the only possible radial action.