### PR TITLE
Allows mechas to turn in strafe mode if the user holds Alt

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -541,7 +541,7 @@
 	var/oldloc = loc
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		move_result = mechsteprand()
-	else if(dir != direction && (!strafe || occupant.m_intent == MOVE_INTENT_WALK))
+	else if(dir != direction && (!strafe || ("Alt" in occupant.client.keys_held)))
 		move_result = mechturn(direction)
 	else
 		move_result = mechstep(direction)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -541,7 +541,7 @@
 	var/oldloc = loc
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		move_result = mechsteprand()
-	else if(dir != direction && (!strafe || ("Alt" in occupant.client.keys_held)))
+	else if(dir != direction && (!strafe || occupant.client.keys_held["Alt"]))
 		move_result = mechturn(direction)
 	else
 		move_result = mechstep(direction)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -541,7 +541,7 @@
 	var/oldloc = loc
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		move_result = mechsteprand()
-	else if(dir != direction && !strafe)
+	else if(dir != direction && (!strafe || occupant.m_intent == "walk"))
 		move_result = mechturn(direction)
 	else
 		move_result = mechstep(direction)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -541,7 +541,7 @@
 	var/oldloc = loc
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		move_result = mechsteprand()
-	else if(dir != direction && (!strafe || occupant.m_intent == "walk"))
+	else if(dir != direction && (!strafe || occupant.m_intent == MOVE_INTENT_WALK))
 		move_result = mechturn(direction)
 	else
 		move_result = mechstep(direction)

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -128,7 +128,7 @@
 
 
 /datum/action/innate/mecha/strafe
-	name = "Toggle Strafing"
+	name = "Toggle Strafing. Disabled when walk intent is set (or Alt is held)."
 	button_icon_state = "strafe"
 
 /datum/action/innate/mecha/strafe/Activate()

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -128,7 +128,7 @@
 
 
 /datum/action/innate/mecha/strafe
-	name = "Toggle Strafing. Disabled when walk intent is set (or Alt is held)."
+	name = "Toggle Strafing. Disabled when Alt is held."
 	button_icon_state = "strafe"
 
 /datum/action/innate/mecha/strafe/Activate()


### PR DESCRIPTION
:cl: Zxaber
add: Mechas now ignore strafe mode and turn if the user is holding Alt.
/:cl:

QoL change, clicking the strafe button gets tedious. Actually, I just found out you can Alt-click the mech itself to toggle, but this seems like it would be nicer.