### PR TITLE
Perfluorodecalin is now a toxin, and is metabolised faster

### DIFF
--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -131,7 +131,7 @@
 		/datum/reagent/medicine/leporazine,\
 		/datum/reagent/medicine/clonexadone,\
 		/datum/reagent/medicine/mine_salve,\
-		/datum/reagent/medicine/perfluorodecalin,\
+		/datum/reagent/toxin/perfluorodecalin,\
 		/datum/reagent/medicine/ephedrine,\
 		/datum/reagent/medicine/diphenhydramine,\
 		/datum/reagent/drug/space_drugs,\

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -525,21 +525,6 @@
 	..()
 	. = 1
 
-/datum/reagent/medicine/perfluorodecalin
-	name = "Perfluorodecalin"
-	id = "perfluorodecalin"
-	description = "Extremely rapidly restores oxygen deprivation, but inhibits speech. May also heal small amounts of bruising and burns."
-	reagent_state = LIQUID
-	color = "#FF6464"
-	metabolization_rate = 0.25 * REAGENTS_METABOLISM
-
-/datum/reagent/medicine/perfluorodecalin/on_mob_life(mob/living/carbon/human/M)
-	M.adjustOxyLoss(-12*REM, 0)
-	M.adjustToxLoss(2.5*REM, 0)
-	M.adjustBruteLoss(-0.5*REM, 0)
-	M.adjustFireLoss(-0.5*REM, 0)
-	..()
-	return TRUE
 
 /datum/reagent/medicine/ephedrine
 	name = "Ephedrine"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -967,3 +967,18 @@
 				to_chat(M, "<span class='warning'>Your missing arm aches from wherever you left it.</span>")
 				M.emote("sigh")
 	return ..()
+
+/datum/reagent/toxin/perfluorodecalin
+	name = "Perfluorodecalin"
+	id = "perfluorodecalin"
+	description = "Extremely rapidly restores oxygen deprivation, but deals toxin damage over time. Also heals small amounts of bruising and burns."
+	reagent_state = LIQUID
+	color = "#FF6464"
+	silent_toxin = TRUE
+
+/datum/reagent/toxin/perfluorodecalin/on_mob_life(mob/living/carbon/human/M)
+	M.adjustOxyLoss(-12*REM, 0)
+	M.adjustBruteLoss(-0.5*REM, 0)
+	M.adjustFireLoss(-0.5*REM, 0)
+	..()
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
balance: increased the metabolisation rate and reduced the toxic power of perfluorodecalin and allowed it to be filtered by the liver
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Perfluoro is now a toxin, meaning it is affected by the liver, and has had its metabolisation rate increased and toxic power decreased to the default of 1.5. Also fixed the description.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
The liver change in specific will make it less effective as part of fast-killing toxin mixes, while  the toxic damage nerf will make it more useful for its intended purpose. I still don't think it's MUCH of a problem as it is now - it's worse than amatoxin for offensive purposes because it heals too. Compared to top tier poisons like coniine (4.75 damage per tick toxin and oxy combined) it's well down the list. However, it's still pretty good when mixed because of its rock bottom metabolisation rate and ability to be added as a 1u bonus, and so a fix is necessary.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
