### PR TITLE
[s]Advance proc call no longer allows you to call world/datum procs as global procs

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -54,7 +54,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		return
 	
 	//strip away everything but the proc name
-	var/list/proclist = splittext(proctype, "/")
+	var/list/proclist = splittext(procname, "/")
 	if (!length(proclist))
 		return
 	procname = proclist[proclist.len]
@@ -63,7 +63,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	if ("verb" in proclist)
 		proctype = "verb"
 	
-	if(targetselected && !hascall(target,testname))
+	if(targetselected && !hascall(target, procname))
 		to_chat(usr, "<font color='red'>Error: callproc(): type [target.type] has no [proctype] named [procname].</font>")
 		return
 	else

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -52,25 +52,22 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	var/procname = input("Proc path, eg: /proc/fake_blood","Path:", null) as text|null
 	if(!procname)
 		return
-
-	//hascall() doesn't support proc paths (eg: /proc/gib(), it only supports "gib")
-	var/testname = procname
-	if(targetselected)
-		//Find one of the 3 possible ways they could have written /proc/PROCNAME
-		if(findtext(procname, "/proc/"))
-			testname = replacetext(procname, "/proc/", "")
-		else if(findtext(procname, "/proc"))
-			testname = replacetext(procname, "/proc", "")
-		else if(findtext(procname, "proc/"))
-			testname = replacetext(procname, "proc/", "")
-		//Clear out any parenthesis if they're a dummy
-		testname = replacetext(testname, "()", "")
-
+	
+	//strip away everything but the proc name
+	var/list/proclist = splittext(proctype, "/")
+	if (!length(proclist))
+		return
+	procname = proclist[proclist.len]
+	
+	var/proctype = "proc"
+	if ("verb" in proclist)
+		proctype = "verb"
+	
 	if(targetselected && !hascall(target,testname))
-		to_chat(usr, "<font color='red'>Error: callproc(): type [target.type] has no proc named [procname].</font>")
+		to_chat(usr, "<font color='red'>Error: callproc(): type [target.type] has no [proctype] named [procname].</font>")
 		return
 	else
-		var/procpath = text2path(procname)
+		var/procpath = text2path("[proctype]/[procname]")
 		if (!procpath)
 			to_chat(usr, "<font color='red'>Error: callproc(): proc [procname] does not exist. (Did you forget the /proc/ part?)</font>")
 			return


### PR DESCRIPTION
It turns out, `call()()` will let you call `world` procs as global procs, bypassing security admin proc calls have against calling world procs.

What this does is it strips everything from the proc path except the part following the last `/` character, (effectively the procname) then re-constructs a path later by appending the proc name to `/proc/`.

This pr patches an admin accessible RCE exploit.

Post merge edit: credit to volas for reporting this to me.