### PR TITLE
Properly adds a drill sergeant hat to the warden's locker

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -38,6 +38,7 @@
 #define INSULATED	/datum/mutation/human/insulated
 #define SHOCKTOUCH	/datum/mutation/human/shock
 #define OLFACTION	/datum/mutation/human/olfaction
+#define YELLING		/datum/mutation/human/yelling
 
 #define UI_CHANGED "ui changed"
 #define UE_CHANGED "ue changed"

--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -219,3 +219,16 @@
 	..()
 	owner.grant_language(/datum/language/common)
 	owner.remove_language(/datum/language/beachbum)
+
+/datum/mutation/human/yelling
+	name = "Yelling"
+	desc = "A mutation that forces the host to constantly yell their sentences out."
+	quality = MINOR_NEGATIVE
+	locked = TRUE
+	text_gain_indication = "<span class='danger'>You feel really angry.</span>"
+	text_lose_indication = "<span class='notice'>You feel calmer.</span>"
+
+/datum/mutation/human/yelling/say_mod(message)
+	if(message)
+		message = "[uppertext(replacetext(message, ".", "!"))]!!"
+	return (message)

--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -230,5 +230,5 @@
 
 /datum/mutation/human/yelling/say_mod(message)
 	if(message)
-		message = "[uppertext(replacetext(message, ".", "!"))]!!"
+		message = "[uppertext(replacetext(message, ".", "!"))]!"
 	return (message)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -104,6 +104,7 @@
 	new /obj/item/radio/headset/headset_sec(src)
 	new /obj/item/clothing/suit/armor/vest/warden(src)
 	new /obj/item/clothing/head/warden(src)
+	new /obj/item/clothing/head/warden/drill(src)
 	new /obj/item/clothing/head/beret/sec/navywarden(src)
 	new /obj/item/clothing/suit/armor/vest/warden/alt(src)
 	new /obj/item/clothing/under/rank/warden/navyblue(src)

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -145,6 +145,21 @@
 	strip_delay = 60
 	dog_fashion = /datum/dog_fashion/head/warden
 
+/obj/item/clothing/head/warden/drill
+	name = "warden's drill hat"
+	desc = "A special armored campaign hat with the security insignia emblazoned on it. Uses reinforced fabric to offer sufficient protection. Has the letters 'FMJ' enscribed on it's side."
+	icon_state = "wardendrill"
+	item_state= "wardendrill"
+	dog_fashion = null
+	var/datum/mutation/human/yelling
+
+/obj/item/clothing/head/warden/drill/equipped(mob/living/carbon/human/user, slot)
+	..()
+	if(slot == SLOT_HEAD)
+		user.dna.add_mutation(YELLING)
+	else
+		user.dna.remove_mutation(YELLING)
+
 /obj/item/clothing/head/beret/sec
 	name = "security beret"
 	desc = "A robust beret with the security insignia emblazoned on it. Uses reinforced fabric to offer sufficient protection."

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -151,7 +151,6 @@
 	icon_state = "wardendrill"
 	item_state= "wardendrill"
 	dog_fashion = null
-	var/datum/mutation/human/yelling
 
 /obj/item/clothing/head/warden/drill/equipped(mob/living/carbon/human/user, slot)
 	..()

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -149,7 +149,7 @@
 	name = "warden's drill hat"
 	desc = "A special armored campaign hat with the security insignia emblazoned on it. Uses reinforced fabric to offer sufficient protection. Has the letters 'FMJ' enscribed on it's side."
 	icon_state = "wardendrill"
-	item_state= "wardendrill"
+	item_state = "wardendrill"
 	dog_fashion = null
 
 /obj/item/clothing/head/warden/drill/equipped(mob/living/carbon/human/user, slot)

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -147,7 +147,7 @@
 
 /obj/item/clothing/head/warden/drill
 	name = "warden's drill hat"
-	desc = "A special armored campaign hat with the security insignia emblazoned on it. Uses reinforced fabric to offer sufficient protection. Has the letters 'FMJ' enscribed on it's side."
+	desc = "A special armored campaign hat with the security insignia emblazoned on it. Uses reinforced fabric to offer sufficient protection. Has the letters 'FMJ' enscribed on its side."
 	icon_state = "wardendrill"
 	item_state = "wardendrill"
 	dog_fashion = null

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -156,7 +156,8 @@
 	..()
 	if(slot == SLOT_HEAD)
 		user.dna.add_mutation(YELLING)
-	else
+
+/obj/item/clothing/head/warden/drill/dropped(mob/living/carbon/human/user)
 		user.dna.remove_mutation(YELLING)
 
 /obj/item/clothing/head/beret/sec


### PR DESCRIPTION
## Changelog
:cl: Vile Beggar
add: Warden now has an added drill hat in his locker.
/:cl:

## About The Pull Request
Adds a drill sergeant's hat into the warden's locker, wearing it forces you to shout.
Sprites aren't made by me but I saw them gathering dust in the code though.

![image](https://user-images.githubusercontent.com/17518895/51788840-e43a4580-2182-11e9-94e9-bd7c085352f6.png)

## Why It's Good For The Game
More choice in fashion is good. The warden doesn't have much of a job to do besides looking pretty at the desk and this hat helps him do that better.
Besides, I know we all wanna do some epic roleplay as our favorite drill sergeant: http://i.imgur.com/fU0sbp5.jpg and of course https://i.imgur.com/EyvX0VB.png