### PR TITLE
Prevents admins from doing stupid things

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -83,7 +83,7 @@
 	return T.zPassOut(src, direction, destination) && destination.zPassIn(src, direction, T)
 
 /atom/movable/vv_edit_var(var_name, var_value)
-	var/static/list/banned_edits = list("step_x", "step_y", "step_size")
+	var/static/list/banned_edits = list("step_x", "step_y", "step_size", "bounds")
 	var/static/list/careful_edits = list("bound_x", "bound_y", "bound_width", "bound_height")
 	if(var_name in banned_edits)
 		return FALSE	//PLEASE no.


### PR DESCRIPTION
So we had a round on yogs today where one of the admins made the unfortunate decision of changing the `bounds` var on a briefcase, which has no protections at all, to `2, 2`resulting in jerky movement.

If you make something idiot-proof, the world will just invent a better idiot.