### PR TITLE
[ready] Adds discord webhook support to the github webhook processor.

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -605,7 +605,7 @@ $github_diff = null;
 
 function get_diff($payload) {
 	global $github_diff;
-	if ($github_diff === null) {
+	if ($github_diff === null && $payload['pull_request']['diff_url']) {
 		//go to the diff url
 		$url = $payload['pull_request']['diff_url'];
 		$github_diff = file_get_contents($url);

--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -577,6 +577,8 @@ function discord_announce($action, $payload, $pr_flags) {
 			$sending_data['embeds'] = $embeds;
 			if (!isset($discordWebHook['no_text']) || !$discordWebHook['no_text'])
 				$sending_data['content'] = $content;
+		} else {
+			$sending_data['content'] = $content;
 		}
 		discord_webhook_send($discordWebHook['url'], $sending_data);
 	}

--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -587,7 +587,7 @@ function discord_announce($action, $payload, $pr_flags) {
 
 function discord_sanitize($text, $flags = S_MENTIONS|S_LINK_EMBED|S_MARKDOWN) { 
 	if ($flags & S_MARKDOWN)
-		$text = str_ireplace(array('\\', '*', '_', '~', '`'), (array('\\\\', '\\*', '\\_', '\\~', '\\`')), $text);
+		$text = str_ireplace(array('\\', '*', '_', '~', '`', '|'), (array('\\\\', '\\*', '\\_', '\\~', '\\`', '\\|')), $text);
 	
 	if ($flags & S_HTML_COMMENTS)
 		$text = preg_replace('/<!--(.*)-->/Uis', '', $text);

--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -470,7 +470,7 @@ function filter_announce_targets($targets, $owner, $repo, $action, $pr_flags) {
 		if (isset($target['include_repos'])) {
 			foreach ($target['include_repos'] as $match_string) {
 				$owner_repo_pair = explode('/', strtolower($match_string));
-				if (count($org_repo_pair) != 2) {
+				if (count($owner_repo_pair) != 2) {
 					log_error('Bad include repo: `'. $match_string.'`');
 					continue;
 				}
@@ -492,7 +492,7 @@ function filter_announce_targets($targets, $owner, $repo, $action, $pr_flags) {
 		if (isset($target['exclude_repos']))
 			foreach ($target['exclude_repos'] as $match_string) {
 				$owner_repo_pair = explode('/', strtolower($match_string));
-				if (count($org_repo_pair) != 2) {
+				if (count($owner_repo_pair) != 2) {
 					log_error('Bad exclude repo: `'. $match_string.'`');
 					continue;
 				}

--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -140,8 +140,6 @@ function github_apisend($url, $method = 'GET', $content = NULL) {
 	apisend($url, $method, $content, 'token ' . $apiKey);
 }
 function discord_webhook_send($webhook, $content) {
-	echo "$webhook\r\n";
-	echo json_encode($content);
 	apisend($webhook, 'POST', $content);
 }
 function validate_user($payload) {

--- a/tools/WebhookProcessor/secret.php
+++ b/tools/WebhookProcessor/secret.php
@@ -4,7 +4,6 @@
 //Github lets you have it sign the message with a secret that you can validate. This prevents people from faking events.
 //This var should match the secret you configured for this webhook on github.
 //This is required as otherwise somebody could trick the script into leaking the api key.
-
 $hookSecret = '08ajh0qj93209qj90jfq932j32r';
 
 //Api key for pushing changelogs.
@@ -14,23 +13,12 @@ $apiKey = '209ab8d879c0f987d06a09b9d879c0f987d06a09b9d8787d0a089c';
 //Used to prevent potential RCEs
 $repoOwnerAndName = "tgstation/tgstation";
 
-//servers to announce PRs to
-$servers = array();
-/*
-$servers[0] = array();
-$servers[0]['address'] = 'game.tgstation13.org';
-$servers[0]['port'] = '1337';
-$servers[0]['comskey'] = '89aj90cq2fm0amc90832mn9rm90';
-$servers[1] = array();
-$servers[1]['address'] = 'game.tgstation13.org';
-$servers[1]['port'] = '2337';
-$servers[1]['comskey'] = '89aj90cq2fm0amc90832mn9rm90';
-*/
-
+//Auto update settings
 $enable_live_tracking = true;	//auto update this file from the repository
 $path_to_script = 'tools/WebhookProcessor/github_webhook_processor.php';
 $tracked_branch = "master";
 
+//PR balance settings.
 $trackPRBalance = true;	//set this to false to disable PR balance tracking
 $prBalanceJson = '';	//Set this to the path you'd like the writable pr balance file to be stored, not setting it writes it to the working directory
 $startingPRBalance = 5;	//Starting balance for never before seen users
@@ -44,6 +32,7 @@ $maintainer_team_id = 133041;	//org team id that is exempt from PR balance syste
 //	"org" - user has to have a pr merged in any repo in the organization (for repos owned directly by users, this applies to any repo directly owned by the same user.)
 //	"disable" - disables.
 //defaults to org if left blank or given invalid values.
+//This can also be ignored on a per webhook or per game server bases.
 $validation = "org";
 
 //how many merged prs must they have under the rules above to have their pr announced to the game servers.
@@ -52,8 +41,93 @@ $validation_count = 1;
 //enforce changelogs on PRs
 $require_changelogs = false;
 
-//Discord webhooks to announce PRs to. (Given as full urls)
 /*
-$discordWebHooks[] = "https://discordapp.com/api/webhooks/538933489920245771/xaoYtVuype-P1rb_uthQLkh_C4iVL3sjtIvFEp7rsfhbBs8tDsSJgE0a9MNWJaoSPBPK";
-$discordWebHooks[] = "https://discordapp.com/api/webhooks/538933686956064769/q0uDel7S6eutvRIyEwsuZo_ppzAoxqUNeU2PRChYVsYoJmmn2f2YYSDoMjy9FhhXKqpI";
+ * Announcement Settings.
+ * 	Allows you to announce prs to discord webhooks or the game servers
+ */
+
+/* Common configs:
+The following config items can be added to both game server and discord announcement endpoints. Simply replace the $servers part with $discordWebHooks:
+
+include_repos - List of repos in owner/repo format to send to this endpoint. (defaults to all repos if not defined)
+	* can be given in place of repo to match all repos under an organization
+$servers[$configitem]['include_repos'][] = "tgstation/*";
+
+exclude_repos - List of repos in owner/repo format to not send to this endpoint.
+	* can be given in place of repo to match all repos under an organization
+$servers[$configitem]['exclude_repos'][] = 'tgstation/TerraGov-Marine-Corps';
+$servers[$configitem]['exclude_repos'][] = 'tgstation/tgstation13.org';
+
+exclude_events - List of events to not announce, values: opened, closed, reopened, or merged
+$servers[$configitem]['exclude_events'][] = 'closed';
+$servers[$configitem]['exclude_events'][] = 'reopened';
+
+announce_secret - Announce secret/security prs that have a [s] in front of the title? Defaults to no.
+	Can also be set to 'only' to only announce secret prs.
+$servers[$configitem]['announce_secret'] = false;
+$servers[$configitem]['announce_secret'] = 'only';
+
+announce_unvalidated - Announce prs by unvalidated users (see the validation setting above)? Defaults to no. 
+	Can also be set to 'only' to only announce prs by unvalidated users.
+$servers[$configitem]['announce_unvalidated'] = false;
+
+//Note: the same webhook or game server can be given in mutiple announce endpoints with different settings, allowing you to say, have embeds only show on prs to certain repos by excluding the repo in a endpoint with embed = false, and including the repo in a endpoint with embed = true true. This could also be used to only block closed and reopened events on prs by unvalidated users.
+
+
+
+//Game servers to announce PRs to.
+/*
+$configitem = -1;//ignore me
+
+//Game Server Start
+$servers[++$configitem] = array();
+$servers[$configitem]['address'] = 'game.tgstation13.org';
+$servers[$configitem]['port'] = '1337';
+$servers[$configitem]['comskey'] = '89aj90cq2fm0amc90832mn9rm90';
+//Game Server End
+
+//Game Server Start
+$servers[++$configitem] = array();
+$servers[$configitem]['address'] = 'game.tgstation13.org';
+$servers[$configitem]['port'] = '2337';
+$servers[$configitem]['comskey'] = '89aj90cq2fm0amc90832mn9rm90';
+//Game Server End
+
+unset($configitem);//ignore
 */
+
+//discord webhooks to announce PRs to.
+/*
+$configitem = -1;//ignore me
+
+//Discord Webhook Start
+$discordWebHooks[++$configitem] = array();
+
+// Webhook Url (you can get this from discord via the webhook setting menu of the server or a channel.)
+$discordWebHooks[$configitem]['url'] = 'https://discordapp.com/api/webhooks/538933489920245771/xaoYtVuype-P1rb_uthQLkh_C4iVL3sjtIvFEp7rsfhbBs8tDsSJgE0a9MNWJaoSPBPK';
+
+// show an embed with more info?
+$discordWebHooks[$configitem]['embed'] = true;
+
+// if the above is true, don't include the text portion before the embed.
+//	 (This option is not advised as it's not compatible with users who disable embeds).
+$discordWebHooks[$configitem]['no_text'] = false;
+//Discord Webhook End
+
+//Discord Webhook Start
+$discordWebHooks[++$configitem] = array();
+
+// Webhook Url (you can get this from discord via the webhook setting menu of the server or a channel.)
+$discordWebHooks[$configitem]['url'] = 'https://discordapp.com/api/webhooks/538933686956064769/q0uDel7S6eutvRIyEwsuZo_ppzAoxqUNeU2PRChYVsYoJmmn2f2YYSDoMjy9FhhXKqpI';
+
+// show an embed with more info?
+$discordWebHooks[$configitem]['embed'] = true;
+
+// if the above is true, don't include the text portion before the embed.
+//	 (This option is not advised as it's not compatible with users who disable embeds).
+$discordWebHooks[$configitem]['no_text'] = false;
+//Discord Webhook End
+*/
+
+unset($configitem); //ignore
+

--- a/tools/WebhookProcessor/secret.php
+++ b/tools/WebhookProcessor/secret.php
@@ -54,6 +54,6 @@ $require_changelogs = false;
 
 //Discord webhooks to announce PRs to. (Given as full urls)
 /*
-$discordWebHooks[] = "https://discordapp.com/api/webhooks/538933489920245771/xaoYtVuype-P1rb_uthQLkh_C4iVL3sjtIvFEp7rsfhbBs8tDsSJgE0a9MNWJaoSPBPK"
-$discordWebHooks[] = "https://discordapp.com/api/webhooks/538933686956064769/q0uDel7S6eutvRIyEwsuZo_ppzAoxqUNeU2PRChYVsYoJmmn2f2YYSDoMjy9FhhXKqpI"
+$discordWebHooks[] = "https://discordapp.com/api/webhooks/538933489920245771/xaoYtVuype-P1rb_uthQLkh_C4iVL3sjtIvFEp7rsfhbBs8tDsSJgE0a9MNWJaoSPBPK";
+$discordWebHooks[] = "https://discordapp.com/api/webhooks/538933686956064769/q0uDel7S6eutvRIyEwsuZo_ppzAoxqUNeU2PRChYVsYoJmmn2f2YYSDoMjy9FhhXKqpI";
 */

--- a/tools/WebhookProcessor/secret.php
+++ b/tools/WebhookProcessor/secret.php
@@ -51,3 +51,9 @@ $validation_count = 1;
 
 //enforce changelogs on PRs
 $require_changelogs = false;
+
+//Discord webhooks to announce PRs to. (Given as full urls)
+/*
+$discordWebHooks[] = "https://discordapp.com/api/webhooks/538933489920245771/xaoYtVuype-P1rb_uthQLkh_C4iVL3sjtIvFEp7rsfhbBs8tDsSJgE0a9MNWJaoSPBPK"
+$discordWebHooks[] = "https://discordapp.com/api/webhooks/538933686956064769/q0uDel7S6eutvRIyEwsuZo_ppzAoxqUNeU2PRChYVsYoJmmn2f2YYSDoMjy9FhhXKqpI"
+*/


### PR DESCRIPTION
This allows you to give an array of discord webhook endpoints to announce pr open/close/merge events to.
Github's built in virgin embed:
![image](https://user-images.githubusercontent.com/7069733/51796515-abfa2d80-21a9-11e9-9b7f-36d8d78252e5.png)


/tg/'s chad embed:
![image](https://user-images.githubusercontent.com/7069733/51796441-85d38e00-21a7-11e9-9c34-5d005211020b.png)