### PR TITLE
Nitrous Oxide (Reagent) Anemiates (anemiates??) Blood faster

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1209,7 +1209,7 @@
 	M.drowsyness += 2
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.blood_volume = max(H.blood_volume - 2.5, 0)
+		H.bleed_rate = min(H.bleed_rate + 1, 6)
 	if(prob(20))
 		M.losebreath += 2
 		M.confused = min(M.confused + 2, 5)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1209,7 +1209,7 @@
 	M.drowsyness += 2
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.bleed_rate = min(H.bleed_rate + 1, 6)
+		H.blood_volume = max(H.blood_volume - 10, 0)
 	if(prob(20))
 		M.losebreath += 2
 		M.confused = min(M.confused + 2, 5)


### PR DESCRIPTION
Simply put, Nitrous Oxide is a joke in its current state. 5 units result in less than 7% blood level lost. For reference, 5 units of heparin result in a blood level of 62% (enough to suffocate on). Its former rate of blood volume loss (2.5), is so miserably weak it doesn't actually do anything. So I made it anemiate blood 4x faster.  5 units now result in 18% blood level lost, which will hopefully make this neat chem a bit more popular. 

🆑 
balance: Nitrous Oxide subtracts from blood volume faster. 
🆑 