### PR TITLE
[WIP] Some Modifications to the Force Field Projector

### DIFF
--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -85,7 +85,7 @@
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	resistance_flags = INDESTRUCTIBLE
 	CanAtmosPass = ATMOS_PASS_DENSITY
-	armor = list("melee" = 0, "bullet" = 25, "laser" = 50, "energy" = 50, "bomb" = 25, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
+	armor = list("melee" = -100, "bullet" = 25, "laser" = 50, "energy" = 50, "bomb" = 25, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
 	var/obj/item/forcefield_projector/generator
 
 /obj/structure/projected_forcefield/Initialize(mapload, obj/item/forcefield_projector/origin)

--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -1,6 +1,6 @@
 /obj/item/forcefield_projector
 	name = "forcefield projector"
-	desc = "An experimental device that can create several forcefields at a distance."
+	desc = "An experimental device that can create several forcefields at a limited distance."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "signmaker_forcefield"
 	slot_flags = ITEM_SLOT_BELT

--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -14,7 +14,7 @@
 	var/shield_integrity = 250
 	var/max_fields = 3
 	var/list/current_fields
-	var/field_distance_limit = 7
+	var/field_distance_limit = 2
 
 /obj/item/forcefield_projector/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Force Field Projector has had its range decreased from 7 (anywhere on screen) to 2. Also, its easier to break down.

## Why It's Good For The Game

Theres been a spike of people using these solely to valid hunt, aka if a traitor does anything they trap them with these and call security. Since the fields have a a very high amount of health, it often takes the traitor too long to escape, and ruins their game unfairly. Lowering the range should limit this behavior, and make sure it only does what is intended (engi/atmos related stuff this item is pretty stupid to begin with). 

## Changelog
:cl:
balance: Force Field Projector now has a range of 2 tiles as opposed to 7
balance: Force Field Projector is much less resistant to melee damage
:cl:
