### PR TITLE
Addressing the Creep murderbone problem

### DIFF
--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -52,3 +52,6 @@
 //Called when hugging. expand into generally interacting, where future coders could switch the intent?
 /datum/brain_trauma/proc/on_hug(mob/living/hugger, mob/living/hugged)
 	return
+
+/datum/brain_trauma/proc/on_weapon_hit(mob/living/attacker, mob/living/attacked)
+	return


### PR DESCRIPTION
Very much not done but assumingly very easy to finish so yeah
:cl:
balance: Creeps now get a permanent stacking mood loss when they attack a non-target
/:cl:

At first I thought the increasing depression from having an obsession would stop murderbone but I forgot the fact it disables after the obsession is dead. Very stupid oversight on my part, I just need some kind of way to dissuade but still allow for murder