### PR TITLE
Alt-Clicking no longer bypasses the Security Level lock on escape pods safes.

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -547,10 +547,15 @@
 	if(can_interact(usr))
 		return ..()
 
+/obj/item/storage/pod/AltClick(mob/user)
+	if(!can_interact(user))
+		return
+	..()
+
 /obj/item/storage/pod/can_interact(mob/user)
 	if(!..())
 		return FALSE
-	if(GLOB.security_level == SEC_LEVEL_RED || GLOB.security_level == SEC_LEVEL_DELTA || unlocked)
+	if(GLOB.security_level >= SEC_LEVEL_RED || unlocked)
 		return TRUE
 	to_chat(user, "The storage unit will only unlock during a Red or Delta security alert.")
 


### PR DESCRIPTION
Fixes #42558

## About The Pull Request

Alt-Clicking open an emergency suit safe will no longer ignore the alert level, and will not be able to open it if the alert level is under red. I have made the check for the security level a bit better.

## Why It's Good For The Game

This is a bug, Alt clicking shouldnt be able to bypass security levels.

## Changelog
:cl:
fix: Alt-Clicking open the Escape Pods safes will no longer ignore the alert level.
/:cl:
