### PR TITLE
Adds basic chems to underused plants

### DIFF
--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -82,7 +82,8 @@
 	plantname = "Meatwheat"
 	product = /obj/item/reagent_containers/food/snacks/grown/meatwheat
 	mutatelist = list()
-
+	reagents_add = list("nutriment" = 0.04, "liquidgibs" = 0.05)
+	
 /obj/item/reagent_containers/food/snacks/grown/meatwheat
 	name = "meatwheat"
 	desc = "Some blood-drenched wheat stalks. You can crush them into what passes for meat if you squint hard enough."

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -141,7 +141,7 @@
 	icon_dead = "sunflower-dead"
 	product = /obj/item/reagent_containers/food/snacks/grown/moonflower
 	mutatelist = list()
-	reagents_add = list("salbutamol" = 0.05, "oxygen" = 0.1, "nicotine" = 0.08, "nutriment" = 0.03)
+	reagents_add = list("moonshine" = 0.2, "ethanol" = 0.1 "vitamin" = 0.02, "nutriment" = 0.02)
 	rarity = 15
 
 /obj/item/reagent_containers/food/snacks/grown/moonflower

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -141,7 +141,7 @@
 	icon_dead = "sunflower-dead"
 	product = /obj/item/reagent_containers/food/snacks/grown/moonflower
 	mutatelist = list()
-	reagents_add = list("moonshine" = 0.2, "ethanol" = 0.1 "vitamin" = 0.02, "nutriment" = 0.02)
+	reagents_add = list("moonshine" = 0.2, "ethanol" = 0.1, "vitamin" = 0.02, "nutriment" = 0.02)
 	rarity = 15
 
 /obj/item/reagent_containers/food/snacks/grown/moonflower

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -141,7 +141,7 @@
 	icon_dead = "sunflower-dead"
 	product = /obj/item/reagent_containers/food/snacks/grown/moonflower
 	mutatelist = list()
-	reagents_add = list("moonshine" = 0.2, "vitamin" = 0.02, "nutriment" = 0.02)
+	reagents_add = list("salbutamol" = 0.05, "oxygen" = 0.1, "nicotine" = 0.08, "nutriment" = 0.03)
 	rarity = 15
 
 /obj/item/reagent_containers/food/snacks/grown/moonflower

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -107,7 +107,7 @@
 	icon_grow = "sunflower-grow"
 	icon_dead = "sunflower-dead"
 	mutatelist = list(/obj/item/seeds/sunflower/moonflower, /obj/item/seeds/sunflower/novaflower)
-	reagents_add = list("cornoil" = 0.08, "nutriment" = 0.04)
+	reagents_add = list("oil" = 0.1, "nutriment" = 0.04)
 
 /obj/item/grown/sunflower // FLOWER POWER!
 	seed = /obj/item/seeds/sunflower

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -45,7 +45,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/replicapod)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("nitrogen" = 0.1, "vitamin" = 0.04, "nutriment" = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/cabbage
 	seed = /obj/item/seeds/cabbage

--- a/code/modules/hydroponics/grown/onion.dm
+++ b/code/modules/hydroponics/grown/onion.dm
@@ -13,7 +13,7 @@
 	growthstages = 3
 	weed_chance = 3
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1, "sulfur" = 0.04)
 	mutatelist = list(/obj/item/seeds/onion/red)
 
 /obj/item/reagent_containers/food/snacks/grown/onion

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -97,7 +97,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	icon_dead = "whitebeet-dead"
 	genes = list(/datum/plant_gene/trait/maxchem)
-	reagents_add = list("vitamin" = 0.05, "nutriment" = 0.05)
+	reagents_add = list("sodium" = 0.1, "vitamin" = 0.05, "nutriment" = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/redbeet
 	seed = /obj/item/seeds/redbeet

--- a/code/modules/hydroponics/grown/tobacco.dm
+++ b/code/modules/hydroponics/grown/tobacco.dm
@@ -32,7 +32,7 @@
 	plantname = "Space Tobacco Plant"
 	product = /obj/item/reagent_containers/food/snacks/grown/tobacco/space
 	mutatelist = list()
-	reagents_add = list("salbutamol" = 0.05, "nicotine" = 0.08, "nutriment" = 0.03)
+	reagents_add = list("salbutamol" = 0.05, "oxygen" = 0.1, "nicotine" = 0.08, "nutriment" = 0.03)
 	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/tobacco/space

--- a/code/modules/hydroponics/grown/tobacco.dm
+++ b/code/modules/hydroponics/grown/tobacco.dm
@@ -32,7 +32,7 @@
 	plantname = "Space Tobacco Plant"
 	product = /obj/item/reagent_containers/food/snacks/grown/tobacco/space
 	mutatelist = list()
-	reagents_add = list("salbutamol" = 0.05, "oxygen" = 0.1, "nicotine" = 0.08, "nutriment" = 0.03)
+	reagents_add = list("perfluorodecalin" = 0.1, "oxygen" = 0.1, "nicotine" = 0.08, "nutriment" = 0.03)
 	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/tobacco/space

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -16,6 +16,7 @@
 	icon_dead = "towercap-dead"
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
 	mutatelist = list(/obj/item/seeds/tower/steel)
+	reagents_add = list("carbon" = 0.1)
 
 /obj/item/seeds/tower/steel
 	name = "pack of steel-cap mycelium"
@@ -25,6 +26,7 @@
 	plantname = "Steel Caps"
 	product = /obj/item/grown/log/steel
 	mutatelist = list()
+	reagents_add = list("aluminium" = 0.1, "iron" = 0.1)
 	rarity = 20
 
 


### PR DESCRIPTION
[Changelogs]: 

Added basic chems to some underused plants in botany. Chems were mainly chosen for ones missing from some very basic recipes and medicines.
I realize there might be a backlash, but also consider that botany is just as dangerous as it is timesinking. More on this below.
_first real PR pls be gentle_

:cl: Botany Chem Tweaking
tweak: adds sulfur to onions
tweak: add liquidgibs to meatwheat
tweak: add oxygen to space tobacco
tweak: add carbon to tower caps
tweak: add iron/aluminium to steel caps
tweak: add ethanol to moonflowers
tweak: add nitrogen to cabbage
tweak: replace corn oil in sunflowers with regular oil
tweak: add sodium to red beets
/:cl:

[why]: 
Currently it takes less than 30 minutes for a skilled botanist to reliably produce near-infinite amounts of deadly weapons such as throwables containing amantin/coiine/cyanide, tesla shocks and frost oil/lube spam. You don't see this all that often due to how time and labor intensive this process is, and usually when it goes well the results are more impressive and hilarious than frustrating for the victims.

I don't think that adding basic chems and expanding the potential range of botany is something that shouldn't be tried. Don't be scared of organic autism. This PR was also geared towards medicine production. There isn't much that can be accomplished with this PR that isn't currently possible with a chem dispenser and a syringe.


--- 
Individual explanations:


- Sunflower will now produce 10% (regular) oil instead of corn oil, dunno why this wasn't the case to begin with.

- Adding nitrogen to cabbage seemed to make the most sense, alternatively coffee could be used.

- Added oxygen to space tobacco (as it's the EVA plant, just made sense)

- Added aluminum and iron to steel cap logs - I swear this used to be the case with iron; the wiki even still says so. It's nice when Botany can produce EMP 'nades to respond to an AI/mech threat. Regardless, this will still take a while as separated contents are ded. Thermite throwables will also be possible, but will require a lot of effort as the max thermite size will be 20u (as 50u and a significant amount of time are usually required for a wall.)  Aluminum is necessary for styptic powder, organic flashbangs and more. 

- Liquidgibs added to meatwheat (funny applications and could potentially lead to soapmemes) - in retrospect, could instead be added to blood matoes

- Ethanol added to moonflowers. I wanted to put this on something else, but moonflowers are the only boozy plant with a whopping 20% moonshine production. An extra 10% ethanol will make them more potent, but still in the same ballpark.
