### PR TITLE
Fix a dirtboy coder null pointer

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -94,7 +94,7 @@
 				if(get_dist(user, src) <= 1)	//people with TK won't get smeared with blood
 					user.add_mob_blood(src)
 					if(ishuman(user))
-						var/mob/living/carbon/human/dirtyboy
+						var/mob/living/carbon/human/dirtyboy = user
 						dirtyboy.adjust_hygiene(-10)
 				if(affecting.body_zone == BODY_ZONE_HEAD)
 					if(wear_mask)


### PR DESCRIPTION
🆑 Nirnael
fix: Fixed a runtime relating to hygiene processing
/:cl:

This month:
> The following runtime has occurred 27201 time(s).
runtime error: Cannot execute null.adjust hygiene().
 proc name: attacked by (/mob/living/carbon/attacked_by)
 source file: carbon_defense.dm,98


Dirtyboy-meme coder forgot to assign a pointer.