### PR TITLE
Fix tourettes processing bug

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -110,7 +110,7 @@
 	quality = NEGATIVE
 	text_gain_indication = "<span class='danger'>You twitch.</span>"
 
-/datum/mutation/human/tourettes/on_life(mob/living/carbon/human/owner)
+/datum/mutation/human/tourettes/on_life()
 	if(prob(10) && owner.stat == CONSCIOUS && !owner.IsStun())
 		owner.Stun(200)
 		switch(rand(1, 3))


### PR DESCRIPTION
:cl:Nirnael
fix: Tourettes bug fix. You can now swear and get stunned yet again.
/:cl:

Just today:

> The following runtime has occurred 172 time(s).
runtime error: Cannot read null.stat
 proc name: on life (/datum/mutation/human/tourettes/on_life)
 source file: body.dm,114

@Time-Green forgot to remove the overloaded on_life parameter. Byond is fucking retarded so it silently lets you do that.