### PR TITLE
[s] disables the Middle Mouse Button exploit

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -354,6 +354,10 @@
 /datum/config_entry/string/client_error_message
 	config_entry_value = "Your version of byond is too old, may have issues, and is blocked from accessing this server."
 
+/datum/config_entry/number/client_error_build
+	config_entry_value = null
+	min_val = 0
+
 /datum/config_entry/number/minute_topic_limit
 	config_entry_value = null
 	min_val = 0

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -699,10 +699,9 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	var/ab = FALSE
 	var/list/L = params2list(params)
 
-	if(L["drag"]) //This should disable the Middle Mouse Button exploit.
-		var/dragged = L["drag"]
-		if(!L[dragged])
-			return
+	var/dragged = L["drag"]
+	if(dragged && !L[dragged])
+		return
 
 	if (object && object == middragatom && L["left"])
 		ab = max(0, 5 SECONDS-(world.time-middragtime)*0.1)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -273,6 +273,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	connection_timeofday = world.timeofday
 	winset(src, null, "command=\".configure graphics-hwmode on\"")
 	var/cev = CONFIG_GET(number/client_error_version)
+	var/ceb = CONFIG_GET(number/client_error_build)
 	var/cwv = CONFIG_GET(number/client_warn_version)
 	if (byond_version < cev)		//Out of date client.
 		to_chat(src, "<span class='danger'><b>Your version of BYOND is too old:</b></span>")
@@ -280,6 +281,17 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		to_chat(src, "Your version: [byond_version]")
 		to_chat(src, "Required version: [cev] or later")
 		to_chat(src, "Visit <a href=\"https://secure.byond.com/download\">BYOND's website</a> to get the latest version of BYOND.")
+		if (connecting_admin)
+			to_chat(src, "Because you are an admin, you are being allowed to walk past this limitation, But it is still STRONGLY suggested you upgrade")
+		else
+			qdel(src)
+			return 0
+	else if (byond_build < ceb) //Out of date client.
+		to_chat(src, "<span class='danger'><b>Your build of BYOND is too old:</b></span>")
+		to_chat(src, CONFIG_GET(string/client_error_message))
+		to_chat(src, "Your build: [byond_build]")
+		to_chat(src, "Required build: [ceb] or later")
+		to_chat(src, "Visit <a href=\"https://secure.byond.com/download\">BYOND's website</a> to get the latest build of BYOND.")
 		if (connecting_admin)
 			to_chat(src, "Because you are an admin, you are being allowed to walk past this limitation, But it is still STRONGLY suggested you upgrade")
 		else

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -695,10 +695,10 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		ip_intel = res.intel
 
 /client/Click(atom/object, atom/location, control, params)
-	var/ab = FALSE
 	var/list/L = params2list(params)
-	if (object && object == middragatom && L["left"])
-		ab = max(0, 5 SECONDS-(world.time-middragtime)*0.1)
+	if(L["drag"] == "middle") //This should disable the MMB exploit.
+		return
+
 	var/mcl = CONFIG_GET(number/minute_click_limit)
 	if (!holder && mcl)
 		var/minute = round(world.time, 600)
@@ -707,18 +707,12 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		if (minute != clicklimiter[CURRENT_MINUTE])
 			clicklimiter[CURRENT_MINUTE] = minute
 			clicklimiter[MINUTE_COUNT] = 0
-		clicklimiter[MINUTE_COUNT] += 1+(ab)
 		if (clicklimiter[MINUTE_COUNT] > mcl)
 			var/msg = "Your previous click was ignored because you've done too many in a minute."
 			if (minute != clicklimiter[ADMINSWARNED_AT]) //only one admin message per-minute. (if they spam the admins can just boot/ban them)
 				clicklimiter[ADMINSWARNED_AT] = minute
 
 				msg += " Administrators have been informed."
-				if (ab)
-					log_game("[key_name(src)] is using the middle click aimbot exploit")
-					message_admins("[ADMIN_LOOKUPFLW(src)] [ADMIN_KICK(usr)] is using the middle click aimbot exploit</span>")
-					add_system_note("aimbot", "Is using the middle click aimbot exploit")
-
 				log_game("[key_name(src)] Has hit the per-minute click limit of [mcl] clicks in a given game minute")
 				message_admins("[ADMIN_LOOKUPFLW(src)] [ADMIN_KICK(usr)] Has hit the per-minute click limit of [mcl] clicks in a given game minute")
 			to_chat(src, "<span class='danger'>[msg]</span>")
@@ -732,7 +726,6 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		if (second != clicklimiter[CURRENT_SECOND])
 			clicklimiter[CURRENT_SECOND] = second
 			clicklimiter[SECOND_COUNT] = 0
-		clicklimiter[SECOND_COUNT] += 1+(!!ab)
 		if (clicklimiter[SECOND_COUNT] > scl)
 			to_chat(src, "<span class='danger'>Your previous click was ignored because you've done too many in a second</span>")
 			return

--- a/config/config.txt
+++ b/config/config.txt
@@ -386,6 +386,8 @@ AUTOADMIN_RANK Game Master
 #CLIENT_WARN_MESSAGE Byond released 511 as the stable release. You can set the framerate your client runs at, which makes the game feel very different and cool. Shortly after its release we will end up using 511 client features and you will be forced to update.
 CLIENT_ERROR_VERSION 511
 CLIENT_ERROR_MESSAGE Your version of byond is not supported. Please upgrade.
+## The minimum build needed for joining the server, if using 512, a good minimum build would be 1421 as that disables the MMB exploit.
+CLIENT_ERROR_BUILD 0
 
 ## TOPIC RATE LIMITING
 ## This allows you to limit how many topic calls (clicking on an interface window) the client can do in any given game second and/or game minute.

--- a/config/config.txt
+++ b/config/config.txt
@@ -387,7 +387,7 @@ AUTOADMIN_RANK Game Master
 CLIENT_ERROR_VERSION 511
 CLIENT_ERROR_MESSAGE Your version of byond is not supported. Please upgrade.
 ## The minimum build needed for joining the server, if using 512, a good minimum build would be 1421 as that disables the Middle Mouse Button exploit.
-CLIENT_ERROR_BUILD 0
+CLIENT_ERROR_BUILD 1421
 
 ## TOPIC RATE LIMITING
 ## This allows you to limit how many topic calls (clicking on an interface window) the client can do in any given game second and/or game minute.

--- a/config/config.txt
+++ b/config/config.txt
@@ -386,7 +386,7 @@ AUTOADMIN_RANK Game Master
 #CLIENT_WARN_MESSAGE Byond released 511 as the stable release. You can set the framerate your client runs at, which makes the game feel very different and cool. Shortly after its release we will end up using 511 client features and you will be forced to update.
 CLIENT_ERROR_VERSION 511
 CLIENT_ERROR_MESSAGE Your version of byond is not supported. Please upgrade.
-## The minimum build needed for joining the server, if using 512, a good minimum build would be 1421 as that disables the MMB exploit.
+## The minimum build needed for joining the server, if using 512, a good minimum build would be 1421 as that disables the Middle Mouse Button exploit.
 CLIENT_ERROR_BUILD 0
 
 ## TOPIC RATE LIMITING


### PR DESCRIPTION
## About The Pull Request

Disables the Middle Mouse Button exploit, which allowed users to lock on to other players by clicking and holding the Middle Mouse Button while mousing over the other player, meaning they would be able to hit the person 100% of the time in meelee regardless of whether or not they were actually clicking on the other person.

## Why It's Good For The Game

Because it disables the above Middle Mouse button exploit

## Changelog
:cl: Amelia0010
fix: the Middle Mouse Button aimbot exploit should no longer be usable
/:cl:
