### PR TITLE
Moves strange seeds from contraband to regular so they no longer have to be paid for.

### DIFF
--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -38,7 +38,8 @@
 					/obj/item/seeds/tower = 3,
 					/obj/item/seeds/watermelon = 3,
 					/obj/item/seeds/wheat = 3,
-					/obj/item/seeds/whitebeet = 3)
+					/obj/item/seeds/whitebeet = 3,
+					/obj/item/seeds/random = 2)
 	contraband = list(/obj/item/seeds/amanita = 2,
 		              /obj/item/seeds/glowshroom = 2,
 		              /obj/item/seeds/liberty = 2,
@@ -46,8 +47,7 @@
 					  /obj/item/seeds/plump = 2,
 					  /obj/item/seeds/reishi = 2,
 					  /obj/item/seeds/cannabis = 3,
-					  /obj/item/seeds/starthistle = 2,
-					  /obj/item/seeds/random = 2)
+					  /obj/item/seeds/starthistle = 2)
 	premium = list(/obj/item/reagent_containers/spray/waterflower = 1)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION
:cl:
balance: Strange Seeds are now a regular item in the Megaseed vendor, moved from contraband.
/:cl:

Strange seeds are an important part of botanists' jobs. Making them pay for it just causes a bunch of trouble for botanists and prevents them from actually going out and spending their money on other stuff on the station. The last time someone PRed a similar change was https://github.com/tgstation/tgstation/pull/40848, and they were told by maintainers to simply move necessary items out of contraband rather than making them free, so here it is.