### PR TITLE
fixes borg wheelchair sanic speed (plus the whip)

### DIFF
--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -107,5 +107,5 @@
 	var/mob/living/carbon/human/H = user
 	if(istype(H))
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
-		D.vehicle_move_delay = 10 / H.get_num_arms()
+		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 6.7) / H.get_num_arms()
 	..()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -43,7 +43,7 @@
 			addtimer(VARSET_CALLBACK(src, canmove , TRUE), 20)
 			return FALSE
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
-		D.vehicle_move_delay = min(10/H.get_num_arms(), 2)
+		D.vehicle_move_delay = min(10/H.get_num_arms(), 10/2)
 	..()
 
 /obj/vehicle/ridden/wheelchair/Moved()
@@ -110,5 +110,5 @@
 			addtimer(VARSET_CALLBACK(src, canmove , TRUE), 20)
 			return FALSE
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
-		D.vehicle_move_delay = max(10/H.get_num_arms(), 2)
+		D.vehicle_move_delay = max(10/H.get_num_arms(), 10/2)
 	..()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -104,11 +104,6 @@
 /obj/vehicle/ridden/wheelchair/the_whip/driver_move(mob/living/user, direction)
 	var/mob/living/carbon/human/H = user
 	if(istype(H))
-		if(!H.get_num_arms() && canmove)
-			to_chat(H, "<span class='warning'>You can't move the wheels without arms!</span>")
-			canmove = FALSE
-			addtimer(VARSET_CALLBACK(src, canmove , TRUE), 20)
-			return FALSE
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
 		D.vehicle_move_delay = max(10/H.get_num_arms(), 10/2)
 	..()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -43,8 +43,20 @@
 			addtimer(VARSET_CALLBACK(src, canmove , TRUE), 20)
 			return FALSE
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
-		D.vehicle_move_delay = 10 / min(H.get_num_arms(), 2)
+		//1.5 (movespeed as of this change) multiplied by 6.7 gets ABOUT 10 (rounded), the old constant for the wheelchair that gets divided by how many arms they have
+		//if that made no sense this simply makes the wheelchair speed change along with movement speed delay
+		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 6.7) / min(H.get_num_arms(), 2)
 	..()
+
+10 / 2 = 5
+
+10 / 1 = 10
+
+1.5 / 2 = 0.75
+
+1.5 / 1 = 1.5
+
+(<some constant> * CONFIG_GET(number/<whatever>))
 
 /obj/vehicle/ridden/wheelchair/Moved()
 	. = ..()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -43,7 +43,7 @@
 			addtimer(VARSET_CALLBACK(src, canmove , TRUE), 20)
 			return FALSE
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
-		D.vehicle_move_delay = min(10/H.get_num_arms(), 10/2)
+		D.vehicle_move_delay = 10 / min(H.get_num_arms(), 2)
 	..()
 
 /obj/vehicle/ridden/wheelchair/Moved()
@@ -105,5 +105,5 @@
 	var/mob/living/carbon/human/H = user
 	if(istype(H))
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
-		D.vehicle_move_delay = max(10/H.get_num_arms(), 10/2)
+		D.vehicle_move_delay = 10 / H.get_num_arms()
 	..()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -48,16 +48,6 @@
 		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 6.7) / min(H.get_num_arms(), 2)
 	..()
 
-10 / 2 = 5
-
-10 / 1 = 10
-
-1.5 / 2 = 0.75
-
-1.5 / 1 = 1.5
-
-(<some constant> * CONFIG_GET(number/<whatever>))
-
 /obj/vehicle/ridden/wheelchair/Moved()
 	. = ..()
 	cut_overlays()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -43,7 +43,7 @@
 			addtimer(VARSET_CALLBACK(src, canmove , TRUE), 20)
 			return FALSE
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
-		D.vehicle_move_delay = 10/H.get_num_arms()
+		D.vehicle_move_delay = min(10/H.get_num_arms(), 2)
 	..()
 
 /obj/vehicle/ridden/wheelchair/Moved()
@@ -100,3 +100,15 @@
 	if(isobserver(user) && CONFIG_GET(flag/ghost_interaction))
 		return TRUE
 	return FALSE
+
+/obj/vehicle/ridden/wheelchair/the_whip/driver_move(mob/living/user, direction)
+	var/mob/living/carbon/human/H = user
+	if(istype(H))
+		if(!H.get_num_arms() && canmove)
+			to_chat(H, "<span class='warning'>You can't move the wheels without arms!</span>")
+			canmove = FALSE
+			addtimer(VARSET_CALLBACK(src, canmove , TRUE), 20)
+			return FALSE
+		var/datum/component/riding/D = GetComponent(/datum/component/riding)
+		D.vehicle_move_delay = max(10/H.get_num_arms(), 2)
+	..()


### PR DESCRIPTION
fixes #42593 
uses min() to cap the number of arms it can use to 2

i like this fix because it not only stops silicons from going out of control, but also all the problems with changing the number of arms for future stuff

alternatively, this looked like lots of fun for admins to mess with so I made the_whip version of the wheelchair that has no limits, increasing it's speed infinitely with more arms. give me a day and i'll pimp that sickly looking thing with fire and big ass wheels