### PR TITLE
Add vscode extension to use the .editorconfig

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "gbasood.byond-dm-language-support",
-        "platymuus.dm-langclient"
+        "platymuus.dm-langclient",
+        "EditorConfig.EditorConfig"
     ]
 }


### PR DESCRIPTION
Vscode doesn't use it by default and considering it's our recommended editor that seems like an oversight.