### PR TITLE
Fentanyl Nerf

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -474,7 +474,7 @@
 	description = "Fentanyl will inhibit brain function and cause toxin damage before eventually knocking out its victim."
 	reagent_state = LIQUID
 	color = "#64916E"
-	metabolization_rate = 0.125 * REAGENTS_METABOLISM
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	toxpwr = 0
 
 /datum/reagent/toxin/fentanyl/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -474,11 +474,11 @@
 	description = "Fentanyl will inhibit brain function and cause toxin damage before eventually knocking out its victim."
 	reagent_state = LIQUID
 	color = "#64916E"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	toxpwr = 0
 
 /datum/reagent/toxin/fentanyl/on_mob_life(mob/living/carbon/M)
-	M.adjustBrainLoss(3*REM, 150)
+	M.adjustBrainLoss(2*REM, 100)
 	if(M.toxloss <= 60)
 		M.adjustToxLoss(1*REM, 0)
 	if(current_cycle >= 18)

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -9,8 +9,8 @@
 /datum/chemical_reaction/fentanyl
 	name = "fentanyl"
 	id = "fentanyl"
-	results = list("fentanyl" = 1)
-	required_reagents = list("space_drugs" = 1)
+	results = list("fentanyl" = 4)
+	required_reagents = list("space_drugs" = 1, "cyanide" = 1, "ammonia" = 1, "oxygen" = 1)
 	required_temp = 674
 
 /datum/chemical_reaction/cyanide


### PR DESCRIPTION
## About The Pull Request

Makes the recipe for Fentanyl more complex and reduces the overall brain damage.

## Why It's Good For The Game

Makes an overpowered chem less overpowered

## Changelog
:cl:
tweak: Changed recipe for Fentanyl from just heated space drugs to space drugs, cyanide, ammonia, and oxygen heated together
balance: Reduced brain damage gain speed, as well as overall brain damage inflicted
/:cl:

