### PR TITLE
Trauma gain formula fix/tweak

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -231,10 +231,10 @@
 		return
 	var/brainloss = getBrainLoss()
 	if(brainloss > BRAIN_DAMAGE_MILD)
-		if(prob(amount + amount * (max(0, brainloss - BRAIN_DAMAGE_MILD) / 100))) //Base chance is the hit damage; for every point of damage past the threshold the chance is increased by 1% //learn how to do your bloody math properly goddamnit
+		if(prob(amount * (1 + max(0, (brainloss - BRAIN_DAMAGE_MILD)/100)))) //Base chance is the hit damage; for every point of damage past the threshold the chance is increased by 1% //learn how to do your bloody math properly goddamnit
 			gain_trauma_type(BRAIN_TRAUMA_MILD)
 	if(brainloss > BRAIN_DAMAGE_SEVERE)
-		if(prob(amount + amount * (max(0, brainloss - BRAIN_DAMAGE_SEVERE) / 100))) //Base chance is the hit damage; for every point of damage past the threshold the chance is increased by 1%
+		if(prob(amount * (1 + max(0, (brainloss - BRAIN_DAMAGE_SEVERE)/100)))) //Base chance is the hit damage; for every point of damage past the threshold the chance is increased by 1%
 			if(prob(20))
 				gain_trauma_type(BRAIN_TRAUMA_SPECIAL)
 			else

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -231,10 +231,10 @@
 		return
 	var/brainloss = getBrainLoss()
 	if(brainloss > BRAIN_DAMAGE_MILD)
-		if(prob(amount * ((2 * (100 + brainloss - BRAIN_DAMAGE_MILD)) / 100))) //Base chance is the hit damage; for every point of damage past the threshold the chance is increased by 2%
+		if(prob(amount + amount * (max(0, brainloss - BRAIN_DAMAGE_MILD) / 100))) //Base chance is the hit damage; for every point of damage past the threshold the chance is increased by 1% //learn how to do your bloody math properly goddamnit
 			gain_trauma_type(BRAIN_TRAUMA_MILD)
 	if(brainloss > BRAIN_DAMAGE_SEVERE)
-		if(prob(amount * ((2 * (100 + brainloss - BRAIN_DAMAGE_SEVERE)) / 100))) //Base chance is the hit damage; for every point of damage past the threshold the chance is increased by 2%
+		if(prob(amount + amount * (max(0, brainloss - BRAIN_DAMAGE_SEVERE) / 100))) //Base chance is the hit damage; for every point of damage past the threshold the chance is increased by 1%
 			if(prob(20))
 				gain_trauma_type(BRAIN_TRAUMA_SPECIAL)
 			else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

While looking to change how gaining traumas worked to make an alternative PR to #42610 I noticed some dodgy looking math that upon closer inspection did not do what it said it did. For those unaware, the chance to get a trauma rolls whenever you take brain damage above a certain point, and the intended formula is in a comment here:

>//Base chance is the hit damage; for every point of damage past the threshold the chance is increased by 2%

What that line of code actually did was have a base chance of **double the hit damage**, and the chance is increased 1% of the base chance (or 2% of the hit damage) for every point of damage past the threshold.

This changes the code to do what the comment says, but with a 1% chance instead of a 2% chance because rolling every tick is horrible. Ideally I'd change trauma gain so that it's not rare on most brain damage sources but almost guaranteed on chemicals due to the sheer number of rolls forced, but this oversight was pretty big and i didn't want to just ignore it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

prevents bad nerfs
come at me oranges

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Kierany9
tweak: Fixed some bad math in the chance to get a brain trauma, traumas should now be a little less common.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
