### PR TITLE
BZ Tweaks

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -26,7 +26,8 @@
 #define NOBLIUM_FORMATION_ENERGY			2e9 	//1 Mole of Noblium takes the planck energy to condense.
 //Research point amounts
 #define NOBLIUM_RESEARCH_AMOUNT				1000
-#define BZ_RESEARCH_AMOUNT					150
+#define BZ_RESEARCH_SCALE					4
+#define BZ_RESEARCH_MAX_AMOUNT				400
 #define MIASMA_RESEARCH_AMOUNT				160
 #define STIMULUM_RESEARCH_AMOUNT			50
 //Plasma fusion properties

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -370,15 +370,10 @@
 	var/list/cached_gases = air.gases
 	var/temperature = air.temperature
 	var/pressure = air.return_pressure()
-
 	var/old_heat_capacity = air.heat_capacity()
 	var/reaction_efficency = min(1/((pressure/(0.1*ONE_ATMOSPHERE))*(max(cached_gases[/datum/gas/plasma][MOLES]/cached_gases[/datum/gas/nitrous_oxide][MOLES],1))),cached_gases[/datum/gas/nitrous_oxide][MOLES],cached_gases[/datum/gas/plasma][MOLES]/2)
 	var/energy_released = 2*reaction_efficency*FIRE_CARBON_ENERGY_RELEASED
-	if(cached_gases[/datum/gas/miasma] && cached_gases[/datum/gas/miasma][MOLES] > 0)
-		energy_released /= cached_gases[/datum/gas/miasma][MOLES]*0.1
-	if(cached_gases[/datum/gas/bz] && cached_gases[/datum/gas/bz][MOLES] > 0)
-		energy_released *= cached_gases[/datum/gas/bz][MOLES]*0.1
-	if ((cached_gases[/datum/gas/nitrous_oxide][MOLES] - reaction_efficency < 0 )|| (cached_gases[/datum/gas/plasma][MOLES] - (2*reaction_efficency) < 0)) //Shouldn't produce gas from nothing.
+	if ((cached_gases[/datum/gas/nitrous_oxide][MOLES] - reaction_efficency < 0 )|| (cached_gases[/datum/gas/plasma][MOLES] - (2*reaction_efficency) < 0) || energy_released <= 0) //Shouldn't produce gas from nothing.
 		return NO_REACTION
 	ASSERT_GAS(/datum/gas/bz,air)
 	cached_gases[/datum/gas/bz][MOLES] += reaction_efficency
@@ -389,7 +384,7 @@
 	cached_gases[/datum/gas/nitrous_oxide][MOLES] -= reaction_efficency
 	cached_gases[/datum/gas/plasma][MOLES]  -= 2*reaction_efficency
 
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, (reaction_efficency**0.5)*BZ_RESEARCH_AMOUNT)
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min((reaction_efficency**2)*BZ_RESEARCH_SCALE),BZ_RESEARCH_MAX_AMOUNT)
 
 	if(energy_released > 0)
 		var/new_heat_capacity = air.heat_capacity()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After some very vigorous testing by Unit2E, it was discovered that there was a large potential for abuse of the BZ generation process for research points through massive amounts of inefficient reactions. This changes it to reward fewer, but more efficient reactions more. It also generally cuts down how many points are produced. 
He also discovered that there were a lot of potential Thermal Energy and temperature related bugs and balance issues caused by the way BZ and Miasma interacted with the energy level of the reaction. I wasn't happy with how they turned out in gameplay either, so those checks were just removed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Getting 1000 research points per second is bad, and so are undefined temperatures.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: As334 and Unit2E
tweak: Miasma and BZ no longer affect the energy level of the BZ generation reaction.
balance: Tweaked how BZ generation's research points work to reward higher efficiency setups.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
