### PR TITLE
Chaplain rod no longer blocks spells from its user

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -181,7 +181,7 @@
 
 /obj/item/nullrod/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+	AddComponent(/datum/component/anti_magic, TRUE, TRUE, null, FALSE)
 
 /obj/item/nullrod/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is killing [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to get closer to god!</span>")


### PR DESCRIPTION
closes #42633 

I made a really snarky remark in the thread but the explanation actually does make a lot of sense so i thought i'd just really quickly crunch out a fix

For people who didn't see the issue, the problem is not that anti-magic blocks the user but that the anti-magic on the rod blocks the user when it really shouldn't, the chaplain starts with a smoke book yet can't use it.