### PR TITLE
Adds more sounds to the H.O.N.K. sound panel

### DIFF
--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -104,6 +104,14 @@
 						<a href='?src=[REF(src)];play_sound=airhorn2'>Air Horn</a>
 						<a href='?src=[REF(src)];play_sound=carhorn'>Car Horn</a>
 						<a href='?src=[REF(src)];play_sound=party_horn'>Party Horn</a>
+						<a href='?src=[REF(src)];play_sound=reee'>Reee</a>
+						<a href='?src=[REF(src)];play_sound=weeoo1'>Siren</a>
+						<a href='?src=[REF(src)];play_sound=hiss1'>Hissing Creature</a>
+						<a href='?src=[REF(src)];play_sound=armbomb'>Armed Grenade</a>
+						<a href='?src=[REF(src)];play_sound=saberon'>Energy Sword</a>
+						<a href='?src=[REF(src)];play_sound=airlock_alien_prying'>Airlock Prying</a>
+						<a href='?src=[REF(src)];play_sound=lightningbolt'>Lightning Bolt</a>
+						<a href='?src=[REF(src)];play_sound=explosionfar'>Distant Explosion</a>
 						</div>
 						</div>
 						"}
@@ -146,6 +154,22 @@
 				playsound(src, 'sound/items/carhorn.ogg', 80) //soundfile has lower than average volume
 			if("party_horn")
 				playsound(src, 'sound/items/party_horn.ogg', 50)
+			if("reee")
+				playsound(src, 'sound/effects/reee.ogg', 50)
+			if("weeoo1")
+				playsound(src, 'sound/items/weeoo1.ogg', 50)
+			if("hiss1")
+				playsound(src, 'sound/voice/hiss1.ogg', 50)
+			if("armbomb")
+				playsound(src, 'sound/weapons/armbomb.ogg', 50)
+			if("saberon")
+				playsound(src, 'sound/weapons/saberon.ogg', 50)
+			if("airlock_alien_prying")
+				playsound(src, 'sound/machines/airlock_alien_prying.ogg', 50)
+			if("lightningbolt")
+				playsound(src, 'sound/magic/lightningbolt.ogg', 50)
+			if("explosionfar")
+				playsound(src, 'sound/effects/explosionfar.ogg', 50)
 	return
 
 /proc/rand_hex_color()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds more sounds to the "sounds of HONK" panel.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's a clown's mech, noises like a drawn esword or primed grenade would be perfect for pranking the crew with.
These mechs also rarely ever get built which keeps the sound panel pranking from getting too annoying.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Added a bigger selection of sounds to the H.O.N.K. mech's "Sounds of HONK" panel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->