### PR TITLE
Fixes odysseus syringes not transfering reagants on hit + minor prehit() reverts

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -337,7 +337,7 @@
 						mechsyringe.icon_state = initial(mechsyringe.icon_state)
 						mechsyringe.icon = initial(mechsyringe.icon)
 						mechsyringe.reagents.reaction(M, INJECT)
-						mechsyringe.reagents.trans_to(M, mechsyringe.reagents.total_volume, transfered_by = chassis.occupant)
+						mechsyringe.reagents.trans_to(M, mechsyringe.reagents.total_volume, transfered_by = originaloccupant)
 						M.take_bodypart_damage(2)
 						log_combat(originaloccupant, M, "shot", "syringegun")
 					break

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -130,7 +130,7 @@
 		return BODY_ZONE_CHEST
 
 /obj/item/projectile/proc/prehit(atom/target)
-	return BULLET_ACT_HIT
+	return TRUE
 
 /obj/item/projectile/proc/on_hit(atom/target, blocked = FALSE)
 	var/turf/target_loca = get_turf(target)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -379,11 +379,11 @@
 		if(M.anti_magic_check())
 			M.visible_message("<span class='warning'>[src] vanishes on contact with [A]!</span>")
 			qdel(src)
-			return BULLET_ACT_BLOCK
+			return
 		if(M.anchored)
 			return ..()
 		M.forceMove(src)
-		return BULLET_ACT_HIT
+		return FALSE
 	return ..()
 
 /obj/item/projectile/magic/locker/on_hit(target)

--- a/code/modules/projectiles/projectile/special/curse.dm
+++ b/code/modules/projectiles/projectile/special/curse.dm
@@ -30,7 +30,7 @@
 	if(target == original)
 		DISABLE_BITFIELD(movement_type, UNSTOPPABLE)
 	else if(!isturf(target))
-		return BULLET_ACT_HIT
+		return FALSE
 	return ..()
 
 /obj/item/projectile/curse_hand/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The mecha syringe gun code is really awful and has its own code to (badly) process fired syringes, including `spawning(0)` some code which would set `src` to `null` to insure it processes even if the gun is deleted.
Of course it runtimed three code lines later because `src.chassis` didn't exist anymore...

The code should probably be aligned to use projectiles like all other guns, but this is rather a bandaid PR than a refactor one.

* Fix a runtime on mecha syringe gun hitting that prevented reagent transfer
* Reverted some hastily (and wrongly) made changes to prehit() procs (while i was at it).

Fixes #42634.

## Changelog
:cl: Menshin
fix: syringes launched from the mecha syringe gun will now properly transfer reagents
/:cl:
