### PR TITLE
Adds two new traumas, Mind Echo and Existential Crisis

### DIFF
--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -226,3 +226,39 @@
 			addtimer(CALLBACK(owner, /mob/.proc/emote, "cough"), 12)
 		owner.emote("cough")
 	..()
+
+/datum/brain_trauma/mild/mind_echo
+	name = "Mind Echo"
+	desc = "Patient's language neurons do not terminate properly, causing previous speech patterns to occasionally resurface spontaneously."
+	scan_desc = "looping neural pattern"
+	gain_text = "<span class='warning'>You feel a faint echo of your thoughts...</span>"
+	lose_text = "<span class='notice'>The faint echo fades away.</span>"
+	var/list/hear_dejavu = list()
+	var/list/speak_dejavu = list()
+
+/datum/brain_trauma/mild/mind_echo/on_hear(message, speaker, message_language, raw_message, radio_freq)
+	if(hear_dejavu.len >= 5)
+		if(prob(15))
+			var/deja_vu = pick_n_take(hear_dejavu)
+			var/new_message = replacetext(message, regex("\".+\"", "gi"),"\"[deja_vu]\"") //Quotes included to avoid cases where someone says part of their name
+			return new_message //Message replaced with one from the past
+	if(hear_dejavu.len >= 15)
+		if(prob(50))
+			popleft(hear_dejavu) //Remove the oldest
+			hear_dejavu += raw_message
+	else
+		hear_dejavu += raw_message
+	return message
+
+/datum/brain_trauma/mild/mind_echo/on_say(message)
+	if(speak_dejavu.len >= 5)
+		if(prob(15))
+			var/deja_vu = pick_n_take(speak_dejavu)
+			return deja_vu //Message replaced with one from the past
+	if(speak_dejavu.len >= 15)
+		if(prob(50))
+			popleft(speak_dejavu) //Remove the oldest
+			speak_dejavu += message
+	else
+		speak_dejavu += message
+	return message

--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -28,8 +28,8 @@
 
 /datum/brain_trauma/special/godwoken/on_lose()
 	owner.remove_trait(TRAIT_HOLY, TRAUMA_TRAIT)
-	..()			
-			
+	..()
+
 /datum/brain_trauma/special/godwoken/proc/speak(type, include_owner = FALSE)
 	var/message
 	switch(type)
@@ -142,7 +142,7 @@
 
 /datum/brain_trauma/special/psychotic_brawling/bath_salts
 	name = "Chemical Violent Psychosis"
-	
+
 /datum/brain_trauma/special/tenacity
 	name = "Tenacity"
 	desc = "Patient is psychologically unaffected by pain and injuries, and can remain standing far longer than a normal person."
@@ -159,7 +159,7 @@
 	owner.remove_trait(TRAIT_NOSOFTCRIT, TRAUMA_TRAIT)
 	owner.remove_trait(TRAIT_NOHARDCRIT, TRAUMA_TRAIT)
 	..()
-	
+
 /datum/brain_trauma/special/death_whispers
 	name = "Functional Cerebral Necrosis"
 	desc = "Patient's brain is stuck in a functional near-death state, causing occasional moments of lucid hallucinations, which are often interpreted as the voices of the dead."
@@ -172,7 +172,7 @@
 	..()
 	if(!active && prob(2))
 		whispering()
-		
+
 /datum/brain_trauma/special/death_whispers/on_lose()
 	if(active)
 		cease_whispering()
@@ -182,8 +182,56 @@
 	owner.add_trait(TRAIT_SIXTHSENSE, TRAUMA_TRAIT)
 	active = TRUE
 	addtimer(CALLBACK(src, .proc/cease_whispering), rand(50, 300))
-	
+
 /datum/brain_trauma/special/death_whispers/proc/cease_whispering()
 	owner.remove_trait(TRAIT_SIXTHSENSE, TRAUMA_TRAIT)
 	active = FALSE
 
+/datum/brain_trauma/special/existential_crisis
+	name = "Existential Crisis"
+	desc = "Patient's hold on reality becomes faint, causing occasional bouts of non-existence."
+	scan_desc = "existential crisis"
+	gain_text = "<span class='notice'>You feel less real.</span>"
+	lose_text = "<span class='warning'>You feel more substantial again.</span>"
+	var/obj/effect/abstract/sync_holder/veil/veil
+	var/next_crisis = 0
+
+/datum/brain_trauma/special/existential_crisis/on_life()
+	..()
+	if(!veil && world.time > next_crisis && prob(3))
+		fade_out()
+
+/datum/brain_trauma/special/existential_crisis/on_lose()
+	if(veil)
+		fade_in()
+	..()
+
+/datum/brain_trauma/special/existential_crisis/proc/fade_out()
+	if(veil)
+		return
+	var/duration = pick(50, 450)
+	veil = new(owner.drop_location())
+	to_chat(owner, "<span class='warning'>[pick("You stop thinking for a moment. Therefore you are not.",\
+												"To be or not to be...",\
+												"Why exist?",\
+												"You stop keeping it real.",\
+												"Your grip on existence slips.",\
+												"Do you even exist?",\
+												"You simply fade away.")]</span>")
+	owner.forceMove(veil)
+	SEND_SIGNAL(owner, COMSIG_MOVABLE_SECLUDED_LOCATION)
+	for(var/thing in owner)
+		var/atom/movable/AM = thing
+		SEND_SIGNAL(AM, COMSIG_MOVABLE_SECLUDED_LOCATION)
+	next_crisis = world.time + 600
+	addtimer(CALLBACK(src, .proc/fade_in), duration)
+
+/datum/brain_trauma/special/existential_crisis/proc/fade_in()
+	QDEL_NULL(veil)
+	to_chat(owner, "<span class='notice'>You fade back into reality.</span>")
+	next_crisis = world.time + 600
+
+//base sync holder is in desynchronizer.dm
+/obj/effect/abstract/sync_holder/veil
+	name = "non-existence"
+	desc = "Existence is just a state of mind."

--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -199,7 +199,8 @@
 /datum/brain_trauma/special/existential_crisis/on_life()
 	..()
 	if(!veil && world.time > next_crisis && prob(3))
-		fade_out()
+		if(isturf(owner.loc))
+			fade_out()
 
 /datum/brain_trauma/special/existential_crisis/on_lose()
 	if(veil)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds two new traumas in the trauma pool.
Mind Echo: a mild trauma that records what the patient hears and says, and occasionally replaces heard or spoken messages with one of the recorded ones.
Existential Crisis: a special trauma that causes spontaneous temporary non-existence, which works like a desynchronizer does.

## Why It's Good For The Game

More variety in traumas!

## Changelog
:cl:
add: Added two new traumas in the trauma pool: Mind Echo (mild) and Existential Crisis (special).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
