### PR TITLE
sleeping carp now deflects projectiles in random directions

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -6,6 +6,7 @@
 	var/current_target
 	var/datum/martial_art/base // The permanent style. This will be null unless the martial art is temporary
 	var/deflection_chance = 0 //Chance to deflect projectiles
+	var/reroute_deflection = FALSE //Delete the bullet, or actually deflect it in some direction?
 	var/block_chance = 0 //Chance to block melee attacks using items while on throw mode.
 	var/restraining = 0 //used in cqc's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
 	var/help_verb

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -8,6 +8,7 @@
 	name = "The Sleeping Carp"
 	id = MARTIALART_SLEEPINGCARP
 	deflection_chance = 100
+	reroute_deflection = TRUE
 	no_guns = TRUE
 	allow_temp_override = FALSE
 	help_verb = /mob/living/carbon/human/proc/sleeping_carp_help

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -56,7 +56,7 @@
 						return 0
 					else
 						P.firer = src
-						P.setAngle(rand(1, 360))//SHING
+						P.setAngle(rand(0, 360))//SHING
 						return BULLET_ACT_FORCE_PIERCE
 
 	if(!(P.original == src && P.firer == src)) //can't block or reflect when shooting yourself

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -52,7 +52,12 @@
 					else
 						visible_message("<span class='danger'>[src] deflects the projectile!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
 					playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, 1)
-					return 0
+					if(!mind.martial_art.reroute_deflection)
+						return 0
+					else
+						P.firer = src
+						P.setAngle(rand(1, 360))//SHING
+						return BULLET_ACT_FORCE_PIERCE
 
 	if(!(P.original == src && P.firer == src)) //can't block or reflect when shooting yourself
 		if(P.reflectable & REFLECT_NORMAL)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -53,7 +53,7 @@
 						visible_message("<span class='danger'>[src] deflects the projectile!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
 					playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, 1)
 					if(!mind.martial_art.reroute_deflection)
-						return 0
+						return BULLET_ACT_BLOCK
 					else
 						P.firer = src
 						P.setAngle(rand(0, 360))//SHING


### PR DESCRIPTION
:cl:
tweak: sleeping carp now deflects projectiles
/:cl:

I got the idea from the "epic idea for sleeping carp changes" thread and yeah it turned out great

upsides: slight chance the assailant hits themselves with their own projectile
downsides(?): fireballs, explosions, everything like that no longer just deletes, it'll explode near you

might need to change the deflect sound though, it sounds like they are dodging the bullet yet it changes direction and all that now