### PR TITLE
Fixes petting moodlets not showing the correct gender of the animal.

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -28,8 +28,8 @@
 	mood_change = 3
 	timeout = 3000
 
-/datum/mood_event/pet_animal/add_effects(name)
-	description = "<span class='nicegreen'>\The [name] is adorable! I can't stop petting \him!</span>\n"
+/datum/mood_event/pet_animal/add_effects(name, gender)
+	description = "<span class='nicegreen'>\The [name] is adorable! I can't stop petting [gender]!</span>\n"
 
 /datum/mood_event/honk
 	description = "<span class='nicegreen'>Maybe clowns aren't so bad after all. Honk!</span>\n"

--- a/code/datums/mood_events/mood_event.dm
+++ b/code/datums/mood_events/mood_event.dm
@@ -16,7 +16,7 @@
 	remove_effects()
 	return ..()
 
-/datum/mood_event/proc/add_effects(param)
+/datum/mood_event/proc/add_effects(param, param)
 	return
 
 /datum/mood_event/proc/remove_effects()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -238,7 +238,7 @@
 			if(M && stat != DEAD)
 				new /obj/effect/temp_visual/heart(loc)
 				emote("me", 1, "purrs!")
-				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, name, /datum/mood_event/pet_animal, name)
+				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, src, /datum/mood_event/pet_animal, name, p_them())
 		else
 			if(M && stat != DEAD)
 				emote("me", 1, "hisses!")

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -267,7 +267,7 @@
 		return
 	if(!item_to_add)
 		user.visible_message("[user] pets [src].","<span class='notice'>You rest your hand on [src]'s head for a moment.</span>")
-		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, name, /datum/mood_event/pet_animal, name)
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, src, /datum/mood_event/pet_animal, name, p_them())
 		return
 
 	if(user && !user.temporarilyRemoveItemFromInventory(item_to_add))
@@ -650,7 +650,7 @@
 			if(M && stat != DEAD) // Added check to see if this mob (the dog) is dead to fix issue 2454
 				new /obj/effect/temp_visual/heart(loc)
 				emote("me", 1, "yaps happily!")
-				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, name, /datum/mood_event/pet_animal, name)
+				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, src, /datum/mood_event/pet_animal, name, p_them())
 		else
 			if(M && stat != DEAD) // Same check here, even though emote checks it as well (poor form to check it only in the help case)
 				emote("me", 1, "growls!")


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed petting moodlets showing an animal's pronouns as simply "it", instead of their actual pronoun.
/:cl:

Merge after #42650 plz