### PR TITLE
Fixes some glitches with auto-rotation of vis_overlays

### DIFF
--- a/code/controllers/subsystem/vis_overlays.dm
+++ b/code/controllers/subsystem/vis_overlays.dm
@@ -67,10 +67,14 @@ SUBSYSTEM_DEF(vis_overlays)
 		UnregisterSignal(thing, COMSIG_ATOM_DIR_CHANGE)
 
 /datum/controller/subsystem/vis_overlays/proc/rotate_vis_overlay(atom/thing, old_dir, new_dir)
+	if(old_dir == new_dir)
+		return
 	var/rotation = dir2angle(old_dir) - dir2angle(new_dir)
 	var/list/overlays_to_remove = list()
-	for(var/i in thing.managed_vis_overlays)
+	//the next loop is going to mess with thing.managed_vis_overlays, so iterate on a copy of it
+	var/list/managed_vis_overlays = thing.managed_vis_overlays
+	for(var/i in managed_vis_overlays)
 		var/obj/effect/overlay/vis/overlay = i
-		add_vis_overlay(thing, overlay.icon, overlay.icon_state, overlay.layer, overlay.plane, turn(overlay.dir, rotation))
+		add_vis_overlay(thing, overlay.icon, overlay.icon_state, overlay.layer, overlay.plane, turn(overlay.dir, rotation), overlay.alpha, overlay.appearance_flags)
 		overlays_to_remove += overlay
 	remove_vis_overlay(thing, overlays_to_remove)

--- a/code/controllers/subsystem/vis_overlays.dm
+++ b/code/controllers/subsystem/vis_overlays.dm
@@ -71,9 +71,7 @@ SUBSYSTEM_DEF(vis_overlays)
 		return
 	var/rotation = dir2angle(old_dir) - dir2angle(new_dir)
 	var/list/overlays_to_remove = list()
-	//the next loop is going to mess with thing.managed_vis_overlays, so iterate on a copy of it
-	var/list/managed_vis_overlays = thing.managed_vis_overlays
-	for(var/i in managed_vis_overlays)
+	for(var/i in thing.managed_vis_overlays)
 		var/obj/effect/overlay/vis/overlay = i
 		add_vis_overlay(thing, overlay.icon, overlay.icon_state, overlay.layer, overlay.plane, turn(overlay.dir, rotation), overlay.alpha, overlay.appearance_flags)
 		overlays_to_remove += overlay


### PR DESCRIPTION
## About The Pull Request

Fixes some glitches and oversights with `vis_overlays` that prevented proper overlays auto-rotation.
Fixes #42138.

## Changelog
:cl: Menshin
fix: Plastic flaps won't become invisible on unscrew anymore
/:cl: