### PR TITLE
Ports Vendor Icon Display instead of Color from Yogs, with some fixes.

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_EMPTY(deliverybeacontags)			    //list of all tags associated with d
 GLOBAL_LIST_EMPTY(nuke_list)
 GLOBAL_LIST_EMPTY(alarmdisplay)				        //list of all machines or programs that can display station alerts
 GLOBAL_LIST_EMPTY(singularities)				    //list of all singularities on the station (actually technically all engines)
+GLOBAL_LIST_EMPTY(vending_cache)
 
 GLOBAL_LIST(chemical_reactions_list)				//list of all /datum/chemical_reaction datums. Used during chemical reactions
 GLOBAL_LIST(chemical_reagents_list)				//list of all /datum/reagent datums indexed by reagent id. Used by chemistry stuff

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -21,7 +21,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/product_path = null
 	var/amount = 0
 	var/max_amount = 0
-	//var/display_color = "blue" //Icon instead of color change. Left this in for easy revert.
 	var/custom_price
 	var/custom_premium_price
 
@@ -343,7 +342,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 		var/list/display_records = product_records + coin_records
 		if(extended_inventory)
 			display_records = product_records + coin_records + hidden_records
-		dat += "<table>" //icon instead of color change starting point.
+		dat += "<table>"
 		for (var/datum/data/vending_product/R in display_records)
 			var/price_listed = "$[default_price]"
 			var/is_hidden = hidden_records.Find(R)
@@ -362,7 +361,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			else
 				dat += "<td align='right'><span class='linkOff'>Not&nbsp;Available</span></td>"
 			dat += "</tr>"
-		dat += "</table>" //icon instead of color change ending point.
+		dat += "</table>"
 	dat += "</div>"
 	if(onstation && C && C.registered_account)
 		dat += "<b>Balance: $[account.account_balance]</b>"

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -188,7 +188,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 		if(!start_empty)
 			R.amount = amount
 		R.max_amount = amount
-		//R.display_color = pick("#ff8080","#80ff80","#8080ff") - We're using icon instead of color, but this is here incase someone wants to easily revert the change.
 		R.custom_price = initial(temp.custom_price)
 		R.custom_premium_price = initial(temp.custom_premium_price)
 		recordlist += R

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -358,9 +358,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			dat += "<tr><td><img src='data:image/jpeg;base64,[GetIconForProduct(R)]'/></td>"
 			dat += "<td style=\"width: 100%\"><b>[sanitize(R.name)]  ([price_listed])</b></td>"
 			if(R.amount > 0 && ((C && C.registered_account && onstation) || (!onstation && isliving(user))))
-				dat += "<td align='right'><b>[R.amount]&nbsp;</b></td><td><a href='byond://?src=[REF(src)];vend=[REF(R)]'>Vend</a></td>"
+				dat += "<td align='right'><b>[R.amount]&nbsp;</b><a href='byond://?src=[REF(src)];vend=[REF(R)]'>Vend</a></td>"
 			else
-				dat += "<td><span class='linkOff'>Not&nbsp;Available</span></td>"
+				dat += "<td align='right'><span class='linkOff'>Not&nbsp;Available</span></td>"
 			dat += "</tr>"
 		dat += "</table>" //icon instead of color change ending point.
 	dat += "</div>"

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -359,7 +359,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			dat += "<tr><td><img src='data:image/jpeg;base64,[GetIconForProduct(R)]'/></td>"
 			dat += "<td style=\"width: 100%\"><b>[sanitize(R.name)]  ([price_listed])</b></td>"
 			if(R.amount > 0 && ((C && C.registered_account && onstation) || (!onstation && isliving(user))))
-				dat += "<td><b>[R.amount]&nbsp;</b></td><td><a href='byond://?src=[REF(src)];vend=[REF(R)]'>Vend</a></td>"
+				dat += "<td align='right'><b>[R.amount]&nbsp;</b></td><td><a href='byond://?src=[REF(src)];vend=[REF(R)]'>Vend</a></td>"
 			else
 				dat += "<td><span class='linkOff'>Not&nbsp;Available</span></td>"
 			dat += "</tr>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Port of https://github.com/yogstation13/Yogstation-TG/pull/2549
which is a port of https://github.com/Citadel-Station-13/Citadel-Station-13/pull/7442
which is a port of https://github.com/OracleStation/OracleStation/pull/50 (jesus)
All of which contain improvements on the previous tier of the port, including mine as well.

This port visualizes items in all machines handled by _vending.dm, allowing a person to see what they're buying before buying it. This is very useful for clothing vendors for example, and much better than the previous system that had vending machines choose from three colors randomly.

Here's a preview of it in action. (Edit: New Picture with all the fixes)
![image](https://user-images.githubusercontent.com/12734451/52302622-c7102e80-295b-11e9-844f-e534e78c9651.png)


Credits to:

- AndrewMontagne (Oracle, original implementation)
- FlattestGuitar (Citadel)
- nichlas0010 (Yogstation)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Adds the ability to preview what the item you're buying looks like before purchasing it. This allows for a more informed decision when purchasing clothes and other items, instead of wasting stock and throwing it away somewhere where other crew members wouldn't be able to use it unless they go find it (though you can still do this if you want to be a dick, I guess.)

Besides, it looks nice.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: AndrewMontague, FlattestGuitar, nichlas0010, TheMythicGhost
tweak: Changes vending machine selections to now display their contents icon instead of just their name and a random color.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
