### PR TITLE
fixes inconsistency in syndicate simple mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -75,7 +75,7 @@
 	maxHealth = 250
 	health = 250
 
-/mob/living/simple_animal/hostile/syndicate/melee
+/mob/living/simple_animal/hostile/syndicate/melee //dude with a knife and no shields
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	icon_state = "syndicate_knife"
@@ -84,7 +84,7 @@
 	attacktext = "slashes"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	status_flags = 0
-	var/projectile_deflect_chance = 50
+	var/projectile_deflect_chance = 0
 
 /mob/living/simple_animal/hostile/syndicate/melee/space
 	icon_state = "syndicate_space_knife"
@@ -96,6 +96,7 @@
 	minbodytemp = 0
 	speed = 1
 	spacewalk = TRUE
+	projectile_deflect_chance = 50
 
 /mob/living/simple_animal/hostile/syndicate/melee/space/Initialize()
 	. = ..()
@@ -107,6 +108,7 @@
 	name = "Syndicate Stormtrooper"
 	maxHealth = 250
 	health = 250
+	projectile_deflect_chance = 50
 
 /mob/living/simple_animal/hostile/syndicate/melee/sword
 	melee_damage_lower = 30
@@ -119,6 +121,7 @@
 	light_color = LIGHT_COLOR_RED
 	status_flags = 0
 	var/obj/effect/light_emitter/red_energy_sword/sord
+	projectile_deflect_chance = 50
 
 /mob/living/simple_animal/hostile/syndicate/melee/sword/Initialize()
 	. = ..()
@@ -145,6 +148,7 @@
 	minbodytemp = 0
 	speed = 1
 	spacewalk = TRUE
+	projectile_deflect_chance = 50
 
 /mob/living/simple_animal/hostile/syndicate/melee/sword/space/Initialize()
 	. = ..()
@@ -161,6 +165,7 @@
 	name = "Syndicate Stormtrooper"
 	maxHealth = 250
 	health = 250
+	projectile_deflect_chance = 50
 
 ///////////////Guns////////////
 


### PR DESCRIPTION
:cl:
fix: some syndicate operatives simple mobs no longer have an invisible shield
/:cl:

they visually only have 1 knife, while their subtypes have a shield  kevin put the var in the wrong place
