### PR TITLE
Adds flyswatter to beekeeper suit storage

### DIFF
--- a/code/modules/hydroponics/beekeeping/beekeeper_suit.dm
+++ b/code/modules/hydroponics/beekeeping/beekeeper_suit.dm
@@ -13,3 +13,4 @@
 	icon_state = "beekeeper"
 	item_state = "beekeeper"
 	clothing_flags = THICKMATERIAL
+	allowed = list(/obj/item/melee/flyswatter)

--- a/code/modules/hydroponics/beekeeping/beekeeper_suit.dm
+++ b/code/modules/hydroponics/beekeeping/beekeeper_suit.dm
@@ -13,4 +13,4 @@
 	icon_state = "beekeeper"
 	item_state = "beekeeper"
 	clothing_flags = THICKMATERIAL
-	allowed = list(/obj/item/melee/flyswatter)
+	allowed = list(/obj/item/melee/flyswatter, /obj/item/reagent_containers/spray/plantbgone, /obj/item/plant_analyzer, /obj/item/seeds, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/glass/beaker, /obj/item/cultivator, /obj/item/reagent_containers/spray/pestspray, /obj/item/hatchet, /obj/item/storage/bag/plants)


### PR DESCRIPTION
## About The Pull Request

Lets beekeepers store their flyswatter in their beekeeper suit


## Why It's Good For The Game

It makes sense that the only beekeeping tool can be stored in their suit

## Changelog
:cl:Mickyy5
tweak: Beekeepers can finally store their flyswatters in their suit storage
/:cl:
