### PR TITLE
Donutstation Tweaks

### DIFF
--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -4868,12 +4868,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"ali" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "alj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -4942,14 +4936,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"alt" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "alu" = (
@@ -5466,14 +5452,6 @@
 /obj/item/lighter,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"ams" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "amt" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -6638,12 +6616,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -7102,17 +7076,25 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "apK" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "apL" = (
 /obj/structure/cable/yellow{
@@ -7678,6 +7660,9 @@
 	c_tag = "Civilian - Dorm Main 1";
 	dir = 2;
 	network = list("ss13")
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
@@ -13494,6 +13479,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aDo" = (
@@ -15660,18 +15648,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"aHz" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "aHA" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/newscaster/security_unit{
@@ -17911,6 +17887,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "aMG" = (
@@ -18083,6 +18062,9 @@
 "aMZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "aNa" = (
@@ -29433,14 +29415,7 @@
 /area/security/brig)
 "biI" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
 	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -37960,6 +37935,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bxG" = (
@@ -38875,6 +38853,9 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -40098,6 +40079,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
@@ -40685,17 +40669,23 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bCH" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/turf/open/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bCI" = (
 /obj/machinery/firealarm{
@@ -40872,17 +40862,11 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -41871,18 +41855,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"bEK" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "bEL" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -43312,23 +43284,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -43766,6 +43729,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bHS" = (
@@ -46705,6 +46671,9 @@
 	c_tag = "Medical - Virology Main";
 	dir = 1;
 	network = list("ss13","Medical")
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -55083,6 +55052,16 @@
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
+"fZj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gst" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55120,6 +55099,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
+"htu" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "hGn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -55140,6 +55130,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"isn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"iZF" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "jro" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light/small{
@@ -55169,6 +55177,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jJq" = (
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Secure - Captain's Private Quarters External";
+	dir = 4;
+	network = list("AISat")
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"kte" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "kLE" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/fitness/locker_room";
@@ -55221,6 +55247,14 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
+"mKl" = (
+/obj/machinery/camera/motion{
+	c_tag = "Secure - Captain's Office External";
+	dir = 4;
+	network = list("AISat")
+	},
+/turf/open/space/basic,
+/area/space)
 "nuq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
@@ -55231,9 +55265,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"oRW" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "pBI" = (
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"qtb" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/lab)
 "qxZ" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = 32
@@ -55259,6 +55310,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
+"rcr" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
+"rXc" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "tQN" = (
 /obj/machinery/shower{
 	dir = 1
@@ -76798,7 +76864,7 @@ aco
 aev
 aiZ
 bUj
-adN
+iZF
 bUr
 aew
 aew
@@ -81898,7 +81964,7 @@ bfz
 awe
 aks
 awe
-awe
+rXc
 awe
 asn
 awe
@@ -82190,7 +82256,7 @@ bmY
 bsh
 brb
 bgh
-aih
+kte
 aih
 aLe
 acy
@@ -82708,7 +82774,7 @@ aKT
 bro
 bkY
 acy
-bVO
+qtb
 bVO
 acW
 adc
@@ -90436,9 +90502,9 @@ aat
 amy
 aav
 bPT
-alt
-alt
-alt
+apg
+apg
+apg
 bPT
 aav
 amy
@@ -90693,9 +90759,9 @@ aay
 alf
 amN
 aHD
-amN
-amN
-amN
+oRW
+oRW
+oRW
 bPV
 amR
 amJ
@@ -90710,7 +90776,7 @@ ahP
 aau
 aad
 bCF
-bEK
+bFB
 azW
 aor
 apA
@@ -90967,8 +91033,8 @@ anz
 aau
 aad
 apK
-bFB
-azW
+isn
+aUT
 aor
 apB
 aTL
@@ -91225,7 +91291,7 @@ alQ
 aHR
 bCX
 bHc
-aUT
+aor
 aor
 aTU
 apq
@@ -91716,8 +91782,8 @@ aRx
 aad
 aah
 alM
-ali
-aaz
+alM
+rcr
 aaH
 aaH
 aaH
@@ -91973,8 +92039,8 @@ bfU
 aad
 aaw
 alM
-ali
-aaz
+alM
+rcr
 aaG
 alc
 alc
@@ -92230,8 +92296,8 @@ aRB
 aad
 aaj
 alM
-ali
-aaz
+alM
+rcr
 aaH
 aaH
 aaH
@@ -92767,7 +92833,7 @@ alQ
 aIm
 aoQ
 biI
-aHr
+aor
 aor
 bzT
 apq
@@ -93023,8 +93089,8 @@ anB
 aau
 aad
 bCH
-blb
-azW
+fZj
+aHr
 aor
 aVq
 boH
@@ -93263,9 +93329,9 @@ abY
 amB
 amN
 bPU
-amN
-amN
-amN
+htu
+htu
+htu
 bPZ
 amN
 amS
@@ -93280,7 +93346,7 @@ ahP
 aau
 aad
 azX
-aHz
+blb
 anN
 aNK
 aUU
@@ -93520,9 +93586,9 @@ aax
 amL
 aav
 bPW
-ams
-ams
-ams
+apg
+apg
+apg
 bPT
 aav
 bPK
@@ -103274,7 +103340,7 @@ aiV
 aiV
 aiV
 aaa
-aau
+jJq
 aaa
 aED
 ahC
@@ -103803,7 +103869,7 @@ bCt
 bCt
 bKB
 aaa
-aaa
+mKl
 aij
 adI
 aiz

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -8186,7 +8186,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "arW" = (
-/obj/structure/table/glass,
+/obj/machinery/computer/rdconsole/production{
+	icon_state = "computer";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "arX" = (
@@ -8417,9 +8424,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ass" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ast" = (
@@ -11153,9 +11158,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ayq" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -11184,8 +11186,9 @@
 /area/engine/atmos)
 "ayt" = (
 /obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
+	name = "Atmospherics Foyer";
+	req_access_txt = "0";
+	req_one_access_txt = "24;10"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -38641,15 +38644,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"byY" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/rnd/production/techfab/department/engineering,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "byZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -43537,10 +43531,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bHx" = (
-/obj/structure/table/glass,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bHy" = (
@@ -44625,15 +44626,13 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "bJM" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
 /obj/machinery/light/small,
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Breakroom";
 	dir = 1;
 	network = list("ss13","Atmospherics")
 	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bJN" = (
@@ -48729,11 +48728,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bRw" = (
-/obj/structure/table/glass,
-/obj/item/toy/figure/atmos,
-/obj/item/toy/figure/atmos{
-	pixel_x = 6;
-	pixel_y = 4
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -54461,7 +54462,8 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/southleft{
 	name = "Atmospherics Delivery Access";
-	req_access_txt = "24"
+	req_access_txt = "0";
+	req_one_access_txt = "24;10"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -55008,6 +55010,17 @@
 "cIZ" = (
 /turf/closed/wall,
 /area/crew_quarters/fitness/locker_room)
+"cOZ" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "dns" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -55026,6 +55039,20 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"dQM" = (
+/obj/machinery/computer/rdconsole/production{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/space)
 "esU" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -55052,14 +55079,16 @@
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"fZj" = (
+"eRe" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "gst" = (
@@ -55084,6 +55113,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
+"hac" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/checker,
+/area/space)
 "hnd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55099,17 +55139,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"htu" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable{
-	icon_state = "0-4"
+"htS" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
 	},
-/obj/effect/turf_decal/bot,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/circuit/airless,
-/area/engine/engineering)
+/turf/open/floor/plasteel/dark,
+/area/science/lab)
 "hGn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -55130,24 +55165,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"isn" = (
-/obj/effect/turf_decal/stripes/line{
+"iJC" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
+"jjJ" = (
+/obj/machinery/light_switch{
+	pixel_x = -23
+	},
+/obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"iZF" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
+/area/space)
 "jro" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light/small{
@@ -55177,24 +55220,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jJq" = (
-/obj/structure/lattice,
-/obj/machinery/camera/motion{
-	c_tag = "Secure - Captain's Private Quarters External";
-	dir = 4;
-	network = list("AISat")
+"jZv" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"kte" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
+/area/engine/engineering)
+"kow" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "kLE" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/fitness/locker_room";
@@ -55247,14 +55289,12 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"mKl" = (
-/obj/machinery/camera/motion{
-	c_tag = "Secure - Captain's Office External";
-	dir = 4;
-	network = list("AISat")
+"njx" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "nuq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
@@ -55265,26 +55305,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"oRW" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable{
-	icon_state = "0-8"
+"plI" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/obj/effect/turf_decal/bot,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/circuit/airless,
-/area/engine/engineering)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "pBI" = (
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"qtb" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
+"pWc" = (
+/obj/machinery/camera/motion{
+	c_tag = "Secure - Captain's Office External";
+	dir = 4;
+	network = list("AISat")
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/lab)
+/turf/open/space/basic,
+/area/space)
 "qxZ" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = 32
@@ -55301,6 +55338,15 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"qBt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "qIb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -55310,21 +55356,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"rcr" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+"rfC" = (
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Secure - Captain's Private Quarters External";
+	dir = 4;
+	network = list("AISat")
 	},
-/turf/open/floor/circuit/airless,
-/area/engine/engineering)
-"rXc" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/turf/open/space/basic,
+/area/space/nearstation)
 "tQN" = (
 /obj/machinery/shower{
 	dir = 1
@@ -55360,6 +55400,16 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
+"vws" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vxP" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -76864,7 +76914,7 @@ aco
 aev
 aiZ
 bUj
-iZF
+njx
 bUr
 aew
 aew
@@ -81964,7 +82014,7 @@ bfz
 awe
 aks
 awe
-rXc
+plI
 awe
 asn
 awe
@@ -82256,7 +82306,7 @@ bmY
 bsh
 brb
 bgh
-kte
+qBt
 aih
 aLe
 acy
@@ -82774,7 +82824,7 @@ aKT
 bro
 bkY
 acy
-qtb
+htS
 bVO
 acW
 adc
@@ -89484,9 +89534,9 @@ anB
 aau
 aaa
 aaa
-aaa
-aaa
-aaa
+dQM
+jjJ
+hac
 aaa
 aaa
 aaa
@@ -90759,9 +90809,9 @@ aay
 alf
 amN
 aHD
-oRW
-oRW
-oRW
+iJC
+iJC
+iJC
 bPV
 amR
 amJ
@@ -91033,7 +91083,7 @@ anz
 aau
 aad
 apK
-isn
+eRe
 aUT
 aor
 apB
@@ -91783,7 +91833,7 @@ aad
 aah
 alM
 alM
-rcr
+kow
 aaH
 aaH
 aaH
@@ -92040,7 +92090,7 @@ aad
 aaw
 alM
 alM
-rcr
+kow
 aaG
 alc
 alc
@@ -92065,8 +92115,8 @@ bPI
 aUX
 bRr
 caG
-byY
 bsU
+jZv
 aBK
 bpx
 bAB
@@ -92297,7 +92347,7 @@ aad
 aaj
 alM
 alM
-rcr
+kow
 aaH
 aaH
 aaH
@@ -93089,7 +93139,7 @@ anB
 aau
 aad
 bCH
-fZj
+vws
 aHr
 aor
 aVq
@@ -93329,9 +93379,9 @@ abY
 amB
 amN
 bPU
-htu
-htu
-htu
+cOZ
+cOZ
+cOZ
 bPZ
 amN
 amS
@@ -103340,7 +103390,7 @@ aiV
 aiV
 aiV
 aaa
-jJq
+rfC
 aaa
 aED
 ahC
@@ -103869,7 +103919,7 @@ bCt
 bCt
 bKB
 aaa
-mKl
+pWc
 aij
 adI
 aiz


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Added several extinguisher cabinets in public areas that were lacking
- Rad collectors have been moved one tile closer to containment.
- Two external cameras added near the hull of the captain's rooms.
- Two SMES were removed from Engineering to cut down on round-start prep.
- A departmental protolathe/circuit printer were added to the atmospherics foyer. The tech fab was removed and Engineers can now access the atmospherics foyer.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because maintaining maps and tweaking them to better fit is good for the game okay thank you.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: MMMiracles
tweak: Several small tweaks have been done on Donutstation based on feedback.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
