### PR TITLE
Halves strength of nitroglycerin

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -28,7 +28,7 @@
 	id = "nitroglycerin"
 	results = list("nitroglycerin" = 2)
 	required_reagents = list("glycerol" = 1, "facid" = 1, "sacid" = 1)
-	strengthdiv = 2
+	strengthdiv = 4
 
 /datum/chemical_reaction/reagent_explosion/nitroglycerin/on_reaction(datum/reagents/holder, created_volume)
 	if(holder.has_reagent("stabilizing_agent"))
@@ -41,7 +41,7 @@
 	id = "nitroglycerin_explosion"
 	required_reagents = list("nitroglycerin" = 1)
 	required_temp = 474
-	strengthdiv = 2
+	strengthdiv = 4
 
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Halves the explosion strength of nitroglycerin reactions.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Nitroglycerin is absurdly strong and relatively easy to obtain. Chemistry should not be easily able to beat toxins with pocket sized bombs. We should start stepping away from chemistry being a jack of all trades department that can do things better than others.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Halved strength of nitroglycerin explosions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
