### PR TITLE
Capacitor stock part now only does half as much damage resist

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -215,7 +215,7 @@
 		step_energy_drain = normal_step_energy_drain
 		qdel(SM)
 	if(CP)
-		armor = armor.modifyRating(energy = (CP.rating * 10)) //Each level of capacitor protects the mech against emp by 10%
+		armor = armor.modifyRating(energy = (CP.rating * 5)) //Each level of capacitor protects the mech against emp by 5%
 		qdel(CP)
 
 ////////////////////////


### PR DESCRIPTION
Given mechs are more agile with the new hotkeys, this buffs their
hardcounter EMP's to be more effective

:cl: oranges
balance: Mecha capacitor stock part now only does half as much damage resist for emps
/:cl:
