### PR TITLE
pacifist antags retain pacifism

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -365,3 +365,114 @@
 		if(prob(1))
 			new/obj/item/reagent_containers/food/snacks/spaghetti/pastatomato(get_turf(H)) //now that's what I call spaghetti code
 
+//If you want to make some kind of junkie variant, just extend this quirk.
+/datum/quirk/junkie
+	name = "Junkie"
+	desc = "You can't get enough of hard drugs."
+	value = -2
+	gain_text = "<span class='danger'>You suddenly feel the craving for drugs.</span>"
+	lose_text = "<span class='notice'>You feel like you should kick your drug habit.</span>"
+	medical_record_text = "Patient has a history of hard drugs."
+	var/drug_list = list("crank", "krokodil", "morphine", "happiness", "methamphetamine") //List of possible IDs
+	var/reagent_id //ID picked from list
+	var/datum/reagent/reagent_type //If this is defined, reagent_id will be unused and the defined reagent type will be instead.
+	var/datum/reagent/reagent_instance
+	var/where_drug
+	var/obj/item/drug_container_type //If this is defined before pill generation, pill generation will be skipped. This is the type of the pill bottle.
+	var/obj/item/drug_instance
+	var/where_accessory
+	var/obj/item/accessory_type //If this is null, it won't be spawned.
+	var/obj/item/accessory_instance
+	var/tick_counter = 0
+
+/datum/quirk/junkie/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	reagent_id = pick(drug_list)
+	if (!reagent_type)
+		var/datum/reagent/prot_holder = GLOB.chemical_reagents_list[reagent_id]
+		reagent_type = prot_holder.type
+	reagent_instance = new reagent_type()
+	H.reagents.addiction_list.Add(reagent_instance)
+	var/current_turf = get_turf(quirk_holder)
+	if (!drug_container_type)
+		drug_container_type = /obj/item/storage/pill_bottle
+	drug_instance = new drug_container_type(current_turf)
+	if (istype(drug_instance, /obj/item/storage/pill_bottle))
+		var/pill_state = "pill[rand(1,20)]"
+		for(var/i in 1 to 7)
+			var/obj/item/reagent_containers/pill/P = new(drug_instance)
+			P.icon_state = pill_state
+			P.list_reagents = list("[reagent_id]" = 1)
+
+	if (accessory_type)
+		accessory_instance = new accessory_type(current_turf)
+	var/list/slots = list(
+		"in your left pocket" = SLOT_L_STORE,
+		"in your right pocket" = SLOT_R_STORE,
+		"in your backpack" = SLOT_IN_BACKPACK
+	)
+	where_drug = H.equip_in_one_of_slots(drug_instance, slots, FALSE) || "at your feet"
+	if (accessory_instance)
+		where_accessory = H.equip_in_one_of_slots(accessory_instance, slots, FALSE) || "at your feet"
+	announce_drugs()
+
+/datum/quirk/junkie/post_add()
+	if(where_drug == "in your backpack" || where_accessory == "in your backpack")
+		var/mob/living/carbon/human/H = quirk_holder
+		SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H)
+
+/datum/quirk/junkie/proc/announce_drugs()
+	to_chat(quirk_holder, "<span class='boldnotice'>There is a [drug_instance.name] of [reagent_instance.name] [where_drug]. Better hope you don't run out...</span>")
+
+/datum/quirk/junkie/on_process()
+	var/mob/living/carbon/human/H = quirk_holder
+	if (tick_counter == 60) //Halfassed optimization, increase this if there's slowdown due to this quirk
+		var/in_list = FALSE
+		for (var/datum/reagent/entry in H.reagents.addiction_list)
+			if(istype(entry, reagent_type))
+				in_list = TRUE
+				break
+		if(!in_list)
+			H.reagents.addiction_list += reagent_instance
+			reagent_instance.addiction_stage = 0
+			to_chat(quirk_holder, "<span class='danger'>You thought you kicked it, but you suddenly feel like you need [reagent_instance.name] again...")
+		tick_counter = 0
+	else
+		++tick_counter
+
+/datum/quirk/junkie/smoker
+	name = "Smoker"
+	desc = "Sometimes you just really want a smoke. Probably not great for your lungs."
+	value = -1
+	gain_text = "<span class='danger'>You could really go for a smoke right about now.</span>"
+	lose_text = "<span class='notice'>You feel like you should quit smoking.</span>"
+	medical_record_text = "Patient is a current smoker."
+	reagent_type = /datum/reagent/drug/nicotine
+	accessory_type = /obj/item/lighter/greyscale
+
+/datum/quirk/junkie/smoker/on_spawn()
+	drug_container_type = pick(/obj/item/storage/fancy/cigarettes,
+		/obj/item/storage/fancy/cigarettes/cigpack_midori,
+		/obj/item/storage/fancy/cigarettes/cigpack_uplift,
+		/obj/item/storage/fancy/cigarettes/cigpack_robust,
+		/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
+		/obj/item/storage/fancy/cigarettes/cigpack_carp,
+		/obj/item/storage/fancy/cigarettes/cigars,
+		/obj/item/storage/fancy/cigarettes/cigars/cohiba,
+		/obj/item/storage/fancy/cigarettes/cigars/havana)
+	. = ..()	
+
+/datum/quirk/junkie/smoker/announce_drugs()
+	to_chat(quirk_holder, "<span class='boldnotice'>There is a [drug_instance.name] [where_drug], and a lighter [where_accessory]. Make sure you get your favorite brand when you run out.</span>")
+	
+
+/datum/quirk/junkie/smoker/on_process()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/I = H.get_item_by_slot(SLOT_WEAR_MASK)
+	if (istype(I, /obj/item/clothing/mask/cigarette))
+		var/obj/item/storage/fancy/cigarettes/C = drug_instance
+		if(istype(I, C.spawn_type))	
+			SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "wrong_cigs")
+			return
+SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "wrong_cigs", /datum/mood_event/wrong_brand)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -260,11 +260,6 @@
 	lose_text = "<span class='notice'>You think you can defend yourself again.</span>"
 	medical_record_text = "Patient is unusually pacifistic and cannot bring themselves to cause physical harm."
 
-/datum/quirk/nonviolent/on_process()
-	if(quirk_holder.mind && LAZYLEN(quirk_holder.mind.antag_datums))
-		to_chat(quirk_holder, "<span class='boldannounce'>Your antagonistic nature has caused you to renounce your pacifism.</span>")
-		qdel(src)
-
 /datum/quirk/poor_aim
 	name = "Poor Aim"
 	desc = "You're terrible with guns and can't line up a straight shot to save your life. Dual-wielding is right out."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -260,6 +260,41 @@
 	lose_text = "<span class='notice'>You think you can defend yourself again.</span>"
 	medical_record_text = "Patient is unusually pacifistic and cannot bring themselves to cause physical harm."
 
+/datum/quirk/paraplegic
+	name = "Paraplegic"
+	desc = "Your legs do not function. Nothing will ever fix this. But hey, free wheelchair!"
+	value = -3
+	human_only = TRUE
+	gain_text = null // Handled by trauma.
+	lose_text = null
+	medical_record_text = "Patient has an untreatable impairment in motor function in the lower extremities."
+
+/datum/quirk/paraplegic/add()
+	var/datum/brain_trauma/severe/paralysis/paraplegic/T = new()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(T, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/paraplegic/on_spawn()
+	if(quirk_holder.buckled) // Handle late joins being buckled to arrival shuttle chairs.
+		quirk_holder.buckled.unbuckle_mob(quirk_holder)
+
+	var/turf/T = get_turf(quirk_holder)
+	var/obj/structure/chair/spawn_chair = locate() in T
+
+	var/obj/vehicle/ridden/wheelchair/wheels = new(T)
+	if(spawn_chair) // Makes spawning on the arrivals shuttle more consistent looking
+		wheels.setDir(spawn_chair.dir)
+
+	wheels.buckle_mob(quirk_holder)
+
+	// During the spawning process, they may have dropped what they were holding, due to the paralysis
+	// So put the things back in their hands.
+
+	for(var/obj/item/I in T)
+		if(I.fingerprintslast == quirk_holder.ckey)
+			quirk_holder.put_in_hands(I)
+
+
 /datum/quirk/poor_aim
 	name = "Poor Aim"
 	desc = "You're terrible with guns and can't line up a straight shot to save your life. Dual-wielding is right out."
@@ -475,4 +510,4 @@
 		if(istype(I, C.spawn_type))	
 			SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "wrong_cigs")
 			return
-SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "wrong_cigs", /datum/mood_event/wrong_brand)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "wrong_cigs", /datum/mood_event/wrong_brand)


### PR DESCRIPTION
## About The Pull Request

Just deletes a few lines of code.

## Why It's Good For The Game

Pacifism is an opt-in negative quirk. It can be worked around in many ways on the off-chance you get nukie or something as well. It's essentially free trait points when you're antag for whatever it's worth.

## Changelog
:cl: imsxz
tweak: antags with the pacifist trait no longer lose pacifism.
/:cl: