### PR TITLE
Removes the stamina version of .45 ammo

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/stickman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/stickman.dm
@@ -39,7 +39,7 @@
 	minimum_distance = 5
 	icon_state = "stickmanranged"
 	icon_living = "stickmanranged"
-	casingtype = /obj/item/ammo_casing/c45/nostamina
+	casingtype = /obj/item/ammo_casing/c45
 	projectilesound = 'sound/misc/bang.ogg'
 	loot = list(/obj/item/gun/ballistic/automatic/pistol/stickman)
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -206,7 +206,7 @@
 	rapid = 2
 	icon_state = "syndicate_smg"
 	icon_living = "syndicate_smg"
-	casingtype = /obj/item/ammo_casing/c45/nostamina
+	casingtype = /obj/item/ammo_casing/c45
 	projectilesound = 'sound/weapons/gunshot_smg.ogg'
 
 /mob/living/simple_animal/hostile/syndicate/ranged/smg/pilot //caravan ambush ruin

--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -23,6 +23,3 @@
 	desc = "A .45 bullet casing."
 	caliber = ".45"
 	projectile_type = /obj/item/projectile/bullet/c45
-
-/obj/item/ammo_casing/c45/nostamina
-	projectile_type = /obj/item/projectile/bullet/c45_nostamina

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -60,7 +60,7 @@
 /obj/item/ammo_box/magazine/smgm45
 	name = "SMG magazine (.45)"
 	icon_state = "c20r45-24"
-	ammo_type = /obj/item/ammo_casing/c45/nostamina
+	ammo_type = /obj/item/ammo_casing/c45
 	caliber = ".45"
 	max_ammo = 24
 

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -2,11 +2,6 @@
 
 /obj/item/projectile/bullet/c45
 	name = ".45 bullet"
-	damage = 20
-	stamina = 65
-
-/obj/item/projectile/bullet/c45_nostamina
-	name = ".45 bullet"
 	damage = 30
 
 // 4.6x30mm (Autorifles)


### PR DESCRIPTION
:cl: the big gay
del: The old stamina damage dealing .45 ammo has been removed. This only affects the 1911 handgun.
/:cl:

Why:
With other epic gamer loot getting nerfed, the latest bit of gamer gear was the 1911 handgun, of which a few are available with magazines pretty safely in a space ruin with a GPS signal. It's particularly powerful because of its' stamina damage. Functionally, all this change means is that the 1911 won't knock people into stamcrit in 2 shots anymore, on a regular human being it'll take 4 shots to crit someone with brute damage. I don't actually know if this will compile but if it doesn't I'll fix it up when it isn't 2 AM. 

In before someone still thinks the C-20r still did stamina damage.