### PR TITLE
Fixes incorrect datum/outputs type check in playsounds

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -27,7 +27,7 @@
 			sound_or_datum(M, turf_source, input, vol, vary, frequency, falloff, channel, pressure_affected)
 
 /proc/sound_or_datum(mob/receiver, turf/turf_source, input, vol as num, vary, frequency, falloff, channel = 0, pressure_affected = TRUE)
-	if(istype(input,/datum))
+	if(istype(input, /datum/outputs))
 		var/datum/outputs/O = input
 		O.send_info(receiver, turf_source, vol, vary, frequency, falloff, channel, pressure_affected)
 	else


### PR DESCRIPTION
:cl:
fix: Fixed a runtime which caused microwaves/showers/ect to not play sounds.
/:cl:

literally 17k runtimes a round due to this.

```
[09:09:38] Runtime in sound.dm, line 32: undefined proc or verb /sound/send info(). 
proc name: sound or datum (/proc/sound_or_datum)
usr: Jimdunlop0812/(Alfredo Hook)
usr.loc: (Medbay Central (90, 102, 2))
src: null
call stack:
sound or datum(Fails-the-Surgery (/mob/living/carbon/human), the floor (92,94,2) (/turf/open/floor/plasteel/dark), /sound (/sound), 20, null, null, null, 807, 1)
playsound(the shower (/obj/machinery/shower), /sound (/sound), 20, null, null, null, null, 807, 1, 1)
/datum/looping_sound/showering (/datum/looping_sound/showering): play('sound/machines/shower/shower_m...')
/datum/looping_sound/showering (/datum/looping_sound/showering): sound loop(10449)
/datum/callback (/datum/callback): Invoke()
world: PushUsr(Alfredo Hook (/mob/living/carbon/human), /datum/callback (/datum/callback))
/datum/callback (/datum/callback): InvokeAsync()
Timer (/datum/controller/subsystem/timer): fire(0)
Timer (/datum/controller/subsystem/timer): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```