### PR TITLE
Holograms will no longer become sentient animals via the Random Human-level Intelligence event

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -43,7 +43,7 @@ GLOBAL_LIST_INIT(high_priority_sentience, typecacheof(list(
 	candidates = get_candidates(ROLE_ALIEN, null, ROLE_ALIEN)
 
 	// find our chosen mob to breathe life into
-	// Mobs have to be simple animals, mindless and on station
+	// Mobs have to be simple animals, mindless, on station, and NOT holograms.
 	// prioritize starter animals that people will recognise
 
 
@@ -56,7 +56,7 @@ GLOBAL_LIST_INIT(high_priority_sentience, typecacheof(list(
 		var/turf/T = get_turf(L)
 		if(!T || !is_station_level(T.z))
 			continue
-		if((L in GLOB.player_list) || L.mind)
+		if((L in GLOB.player_list) || L.mind || (L.flags_1 & HOLOGRAM_1))
 			continue
 		if(is_type_in_typecache(L, GLOB.high_priority_sentience))
 			hi_pri += L


### PR DESCRIPTION
Fixes #42300

Xenobio sentience is still a thing, which is intentional.
https://github.com/tgstation/tgstation/blob/2abce8170760399365a30cb74ac60b6fc3d1f7f6/code/modules/research/xenobiology/xenobiology.dm#L682-L683

:cl: ShizCalev
fix: The Random Human-level Intelligence event will no longer create sentient animal holograms that disappear when they leave the holodeck.
/:cl:
