### PR TITLE
Yet more gun fixes

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -176,7 +176,7 @@
 		insert_magazine(user, tac_load, FALSE)
 		to_chat(user, "<span class='notice'>You perform a tactical reload on \the [src].")
 	user.put_in_hands(old_mag)
-	magazine.update_icon()
+	old_mag.update_icon()
 	if (!tac_load)
 		magazine = null
 	if (display_message)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -36,14 +36,14 @@
 	//Four bolt types:
 	//BOLT_TYPE_STANDARD: Gun has a bolt, it stays closed while not cycling. The gun must be racked to have a bullet chambered when a mag is inserted.
 	//Example: c20, shotguns, m90
-	//BOLT_TYPE_OPEN: Gun has a bolt, it is open when ready to fire. Largely the same as standard, except the gun can never have a chambered bullet with no magazine.
+	//BOLT_TYPE_OPEN: Gun has a bolt, it is open when ready to fire. The gun can never have a chambered bullet with no magazine, but the bolt stays ready when a mag is removed.
 	//Example: Some SMGs, the L6
 	//BOLT_TYPE_NO_BOLT: Gun has no moving bolt mechanism, it cannot be racked. Also dumps the entire contents when emptied instead of a magazine.
 	//Example: Break action shotguns, revolvers
 	//BOLT_TYPE_LOCKING: Gun has a bolt, it locks back when empty. It can be released to chamber a round if a magazine is in.
 	//Example: Pistols with a slide lock, some SMGs
 	var/bolt_type = BOLT_TYPE_STANDARD
-	var/bolt_locked = FALSE
+	var/bolt_locked = FALSE //Used for locking bolt and open bolt guns. Set a bit differently for the two but prevents firing when true for both.
 	var/bolt_wording = "bolt" //bolt, slide, etc.
 	var/semi_auto = TRUE //Whether the gun has to be racked each shot or not.
 	var/obj/item/ammo_box/magazine/magazine
@@ -77,6 +77,8 @@
 	cut_overlays()
 	if (bolt_type == BOLT_TYPE_LOCKING)
 		add_overlay("[icon_state]_bolt[bolt_locked ? "_locked" : ""]")
+	if (bolt_type == BOLT_TYPE_OPEN && bolt_locked)
+		add_overlay("[icon_state]_bolt")
 	if (suppressed)
 		add_overlay("[icon_state]_suppressor")
 	if(!chambered && empty_indicator)
@@ -129,10 +131,12 @@
 /obj/item/gun/ballistic/proc/rack(mob/user = null)
 	if (bolt_type == BOLT_TYPE_NO_BOLT) //If there's no bolt, nothing to rack
 		return
-	if (bolt_type == BOLT_TYPE_OPEN && chambered != null) //If it's an open bolt, there's no way to rack it once it's open
-		if (user)
-			to_chat("<span class='notice'>It's already chambered!</span>")
-		return
+	if (bolt_type == BOLT_TYPE_OPEN)
+		if(!bolt_locked)	//If it's an open bolt, racking again would do nothing
+			if (user)
+				to_chat(user, "<span class='notice'>\The [src] is already ready to fire!</span>")
+			return
+		bolt_locked = FALSE
 	if (user)
 		to_chat(user, "<span class='notice'>You rack the [bolt_wording] of \the [src].</span>")
 	process_chamber(!chambered, FALSE)
@@ -157,6 +161,8 @@
 		if (display_message)
 			to_chat(user, "<span class='notice'>You load a new [magazine_wording] into \the [src].</span>")
 		playsound(src, load_empty_sound, load_sound_volume, load_sound_vary)
+		if (bolt_type == BOLT_TYPE_OPEN && !bolt_locked)
+			chamber_round()
 		update_icon()
 		return TRUE
 	else
@@ -258,10 +264,18 @@
 			update_icon()
 			return
 
-/obj/item/gun/ballistic/proc/empty_checks()
+/obj/item/gun/ballistic/proc/prefire_empty_checks()
+	if (!chambered && !get_ammo())
+		if (bolt_type == BOLT_TYPE_OPEN && !bolt_locked)
+			bolt_locked = TRUE
+			playsound(src, bolt_drop_sound, bolt_drop_sound_volume)
+			update_icon()
+
+
+/obj/item/gun/ballistic/proc/postfire_empty_checks()
 	if (!chambered && !get_ammo())
 		if (!alarmed && empty_alarm)
-			playsound(src.loc, empty_alarm_sound, empty_alarm_volume, empty_alarm_vary)
+			playsound(src, empty_alarm_sound, empty_alarm_volume, empty_alarm_vary)
 			alarmed = TRUE
 			update_icon()
 		if (bolt_type == BOLT_TYPE_LOCKING)
@@ -269,8 +283,9 @@
 			update_icon()
 
 /obj/item/gun/ballistic/afterattack()
-	. = ..()
-	empty_checks()
+	prefire_empty_checks()
+	. = ..() //The gun actually firing
+	postfire_empty_checks()
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/gun/ballistic/attack_hand(mob/user)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -269,8 +269,8 @@
 			update_icon()
 
 /obj/item/gun/ballistic/afterattack()
-	empty_checks()
 	. = ..()
+	empty_checks()
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/gun/ballistic/attack_hand(mob/user)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -83,7 +83,7 @@
 		add_overlay("[icon_state]_empty")
 	if (magazine)
 		if (special_mags)
-			add_overlay("[icon_state]_mag_[magazine.icon_state]")
+			add_overlay("[icon_state]_mag_[initial(magazine.icon_state)]")
 			if (!magazine.ammo_count())
 				add_overlay("[icon_state]_mag_empty")
 		else

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -104,7 +104,6 @@
 	burst_size = 2
 	bolt_type = BOLT_TYPE_OPEN
 	mag_display = TRUE
-	empty_indicator = TRUE
 
 /obj/item/gun/ballistic/automatic/m90
 	name = "\improper M-90gl Carbine"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -234,7 +234,7 @@
 
 /obj/item/gun/ballistic/automatic/l6_saw/examine(mob/user)
 	..()
-	to_chat(user, "<b>ctrl + click</b> to [cover_open ? "close" : "open"] the dust cover.")
+	to_chat(user, "<b>alt + click</b> to [cover_open ? "close" : "open"] the dust cover.")
 	if(cover_open && magazine)
 		to_chat(user, "<span class='notice'>It seems like you could use an <b>empty hand</b> to remove the magazine.</span>")
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -104,6 +104,7 @@
 	burst_size = 2
 	bolt_type = BOLT_TYPE_OPEN
 	mag_display = TRUE
+	rack_sound = "sound/weapons/pistollock.ogg"
 
 /obj/item/gun/ballistic/automatic/m90
 	name = "\improper M-90gl Carbine"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -104,6 +104,7 @@
 	burst_size = 2
 	bolt_type = BOLT_TYPE_OPEN
 	mag_display = TRUE
+	empty_indicator = TRUE
 
 /obj/item/gun/ballistic/automatic/m90
 	name = "\improper M-90gl Carbine"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Continues fixing the tide of broken shit with my awful PR.

This time around:
Corrects a control message for the l6 saw on examine
Reworks the way that open bolt guns work so that they actually work the way open bolt guns are supposed to. Loud bolt drop when you try to fire an empty magazine included.
Fixes bulldog magazine overlays.
Fixes an issue with tacloads not updating the removed magazine's icon state correctly.
Fixes locking bolt not locking back on the last bullet fired but instead on the

## Why It's Good For The Game

Fixes broken shit.

## Changelog
:cl:
fix: more gun fixes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
