### PR TITLE
[WIP] Adds a PDA door requests system

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -2,6 +2,8 @@
 	Station Airlocks Regular
 */
 
+//TODO: set a department_owner job for each type (IE "Captain", "Chief Medical Officer")
+
 /obj/machinery/door/airlock/command
 	icon = 'icons/obj/doors/airlocks/station/command.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_com

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -79,6 +79,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	var/underline_flag = TRUE //flag for underline
 
+	var/door_request_cd = 0//cooldown on sending door open requests
+
 /obj/item/pda/suicide_act(mob/living/carbon/user)
 	var/deathMessage = msg_input(user)
 	if (!deathMessage)
@@ -600,8 +602,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if(H.wear_id == src)
 				H.sec_hud_set_ID()
 
-/obj/item/pda/proc/msg_input(mob/living/U = usr)
-	var/t = stripped_input(U, "Please enter message", name)
+/obj/item/pda/proc/msg_input(mob/living/U = usr, prompt = "Please enter message:")
+	var/t = stripped_input(U, prompt, name)
 	if (!t || toff)
 		return
 	if(!U.canUseTopic(src, BE_CLOSE))
@@ -610,8 +612,10 @@ GLOBAL_LIST_EMPTY(PDAs)
 		t = Gibberish(t, 100)
 	return t
 
-/obj/item/pda/proc/send_message(mob/living/user, list/obj/item/pda/targets, everyone)
-	var/message = msg_input(user)
+/obj/item/pda/proc/send_message(mob/living/user, list/obj/item/pda/targets, everyone, prewritten)
+	var/message = prewritten
+	if(!message)
+		message = msg_input(user)
 	if(!message || !targets.len)
 		return
 	if((last_text && world.time < last_text + 10) || (everyone && last_everyone && world.time < last_everyone + PDA_SPAM_DELAY))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -612,7 +612,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		t = Gibberish(t, 100)
 	return t
 
-/obj/item/pda/proc/send_message(mob/living/user, list/obj/item/pda/targets, everyone, prewritten)
+/obj/item/pda/proc/send_message(mob/living/user, list/obj/item/pda/targets, everyone, var/prewritten = null)
 	var/message = prewritten
 	if(!message)
 		message = msg_input(user)


### PR DESCRIPTION
:cl: PKPenguin321
add: You can now use your PDA on an airlock that you lack access for to send a message to the department owner (HoP, CE, CMO, etc) of that airlock requesting that they open it. The department owner will receive the message, along with a button in chat that they can press to remotely open the door.
fix: PDAs can now be used on airlocks to open them (assuming the PDA is holding an ID with access), where before they would simply do nothing.
/:cl:

Idea lifted from https://tgstation13.org/phpBB/viewtopic.php?f=9&t=21529

WIP because I'm not sure how to proceed (see the TODO comments in the lines added). The "button in chat" part seems to require hrefs, and I'm really not sure what I'm doing with them. Help would be appreciated.