### PR TITLE
Adds Gondola and Tarzan Grenades

### DIFF
--- a/code/game/objects/items/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/grenades/spawnergrenade.dm
@@ -51,4 +51,4 @@
 /obj/item/grenade/spawnergrenade/gondola
 	name = "gondola delivery grenade"
 	spawner_type = /mob/living/simple_animal/pet/gondola
-	deliveryamt = 7
+	deliveryamt = 3

--- a/code/game/objects/items/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/grenades/spawnergrenade.dm
@@ -41,3 +41,14 @@
 	icon_state = "holy_grenade"
 	spawner_type = /mob/living/simple_animal/hostile/poison/bees/toxin
 	deliveryamt = 10
+
+/obj/item/grenade/spawnergrenade/tarzan
+	name = "Into the Jungle"
+	desc = "For getting in touch with your wild side"
+	spawner_type = /mob/living/simple_animal/hostile/gorilla
+	deliveryamt = 3
+	
+/obj/item/grenade/spawnergrenade/gondola
+	name = "gondola delivery grenade"
+	spawner_type = /mob/living/simple_animal/pet/gondola
+	deliveryamt = 7

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -105,6 +105,14 @@
 	category= CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
+/datum/crafting_recipe/gondolagrenade
+	name = "Gondola Delivery Grenade"
+	result = /obj/item/grenade/spawnergrenade/gondola
+	reqs = list(/obj/item/stack/sheet/animalhide/gondola = 3,
+				/obj/item/grenade/chem_grenade)
+	time = 60
+	category = CAT_MISC
+
 /datum/crafting_recipe/tailclub
 	name = "Tail Club"
 	result = /obj/item/tailclub


### PR DESCRIPTION
## About The Pull Request

Adds Tarzan (which spawns 3 gorillas) and Gondola Delivery Grenades (which spawns 3 gondolas). Gondola is craft-able via 3 gondola hides and one empty grenade casing. 

## Why It's Good For The Game

Just some cool stuff. I'm gonna use tarzan for a later PR, got the idea for Gondola, and decided to make them into one together. 

## Changelog
:cl:
add: Gondola delivery grenade
add: Tarzan Grenade
:cl:

