### PR TITLE
Takes headslugs out of the gold extract spawn pool

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -22,7 +22,6 @@
 	ventcrawler = VENTCRAWLER_ALWAYS
 	var/datum/mind/origin
 	var/egg_lain = 0
-	gold_core_spawnable = HOSTILE_SPAWN //are you sure about this??
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/body_egg/changeling_egg/egg = new(victim)


### PR DESCRIPTION
:cl:
del: Headslugs have been removed from the gold extract spawn pool.
/:cl:

Why?
A couple of reasons. Primarily, it's pretty obvious how overpowered xenobio is these days. Secondly, this isn't really real content, it's just a juxtaposition of content that is normally for antags (changeling). Third, this specific "content" really only benefits the person doing it (the xenobiologist) and is usually just used to validhunt or to killbait. 

Or to rephrase, xenolings are only really ever fun for the person doing it and it's either directly or indirectly less fun for everyone else involved. Since there is a real reason to nerf xenobio (it's quite overpowered) this is a pretty good target.

The way that I've gone about this in particular avoids nerfing any of the more interesting interactions in xenobio as well. Something like the mind swap potion, or just gold slime core reactions as they currently work, could have gone away entirely. But this is probably the lesser evil.