### PR TITLE
Fixes defib mount and portable turret runtimes

### DIFF
--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -78,7 +78,7 @@
 		defib = I
 		update_icon()
 		return
-	else if(I == defib.paddles)
+	else if(defib && I == defib.paddles)
 		defib.paddles.snap_back()
 		return
 	var/obj/item/card/id = I.GetID()

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -325,7 +325,7 @@
 
 /obj/machinery/porta_turret/take_damage(damage, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)
 	. = ..()
-	if(.) //damage received
+	if(. && obj_integrity > 0) //damage received
 		if(prob(30))
 			spark_system.start()
 		if(on && !attacked && !(obj_flags & EMAGGED))


### PR DESCRIPTION
🆑 Nirnael
fix: Fix defib mount runtime
fix: Fix portable turret runtime
🆑 

- Defib runtime had no check for defib attached.
> [2019-02-10 02:30:47.843] runtime error: Cannot read null.paddles
>  - proc name: attackby (/obj/machinery/defibrillator_mount/attackby)
>  -   source file: defibrillator_mount.dm,81
>  -   usr: Pepper Oni (/mob/living/carbon/human)
>  -   src: the defibrillator mount (/obj/machinery/defibrillator_mount)
>  -   usr.loc: the floor (87,105,2) (/turf/open/floor/plasteel/white)
>  -   src.loc: the floor (88,105,2) (/turf/open/floor/plasteel/white)
>  -   call stack:
>  - the defibrillator mount (/obj/machinery/defibrillator_mount): attackby(the medical wrench (/obj/item/wrench/medical), Pepper Oni (/mob/living/carbon/human), "icon-x=18;icon-y=16;left=1;scr...")

- Runtime comes from spark_system being null. Related runtimes around this one about addtimer on a qdeleted spark_spread object leads me to believe it was qdeleted and not magically null since it is initialized properly.
The only thing I can trace it down to without testing is the turret being qdeleted in the parent take_damage proc through obj_destruction, that is called right before the spark_system, due to integrity falling below 0. Furthermore, even if this is not the actual cause, I believe this code should not run when the turret has integrity below 0, i.e. destroyed. Correct me if I'm wrong.
**It is now tested and no longer runtimes with this fix, though the addtimer for spark_spread is still runtiming**
Partially solves #34930. However, timers will still call the qdeleted object. Not sure if there is a way to signal them to stop.
> [2019-02-10 04:15:06.856] runtime error: Cannot execute null.start().
>  - proc name: take damage (/obj/machinery/porta_turret/take_damage)
>  -   source file: portable_turret.dm,330
>  -   usr: null
>  -   src: the turret (/obj/machinery/porta_turret/syndicate)
>  -   src.loc: null
>  -   call stack:
>  - the turret (/obj/machinery/porta_turret/syndicate): take damage(205, "brute", "bomb", 0)
>  - the turret (/obj/machinery/porta_turret/syndicate): ex act(2, null)
>  - the plating (87,146,5) (/turf/open/floor/plating): contents explosion(2, null)