### PR TITLE
Fix modular processor runtime

### DIFF
--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -1,4 +1,5 @@
 // Held by /obj/machinery/modular_computer to reduce amount of copy-pasted code.
+//TODO: REFACTOR THIS SPAGHETTI CODE, MAKE IT A COMPUTER_HARDWARE COMPONENT OR REMOVE IT
 /obj/item/modular_computer/processor
 	name = "processing unit"
 	desc = "You shouldn't see this. If you do, report it."
@@ -17,6 +18,7 @@
 	machinery_computer = null
 
 /obj/item/modular_computer/processor/New(comp)
+	..()
 	STOP_PROCESSING(SSobj, src) // Processed by its machine
 
 	if(!comp || !istype(comp, /obj/machinery/modular_computer))


### PR DESCRIPTION
🆑 Nirnael
fix: Fix modular computer processor runtime
🆑 
Tested and working.
Thanks to SpaceManiac for guiding me through spaghetti.
Processor didn't call parent New() (why is this code even in New and not Initialize????) and therefore through tgcoder abuse of the loose type fuckfest that is byond, a datum became a list and was never turned back into a datum in the atoms/Initialize proc for armor.
> Runtime in obj_defense.dm,33: undefined proc or verb /list/getRating().
> 
>   proc name: run obj armor (/obj/proc/run_obj_armor)
>   usr: Nirnael/(Mariana Philips)
>   usr.loc: (Central Primary Hallway (122, 140, 2))
>   src: the command console (/obj/item/modular_computer/processor)
>   src.loc: the command console (/obj/machinery/modular_computer/console/preset/command)
>   call stack:
>   the command console (/obj/item/modular_computer/processor): run obj armor(67, "brute", "bomb", null, 0)
>   the command console (/obj/item/modular_computer/processor): take damage(67, "brute", "bomb", 0, null, 0)
>   the command console (/obj/item/modular_computer/processor): take damage(67, "brute", "bomb", 0)
>   the command console (/obj/item/modular_computer/processor): ex act(3, null)
>   the command console (/obj/machinery/modular_computer/console/preset/command): ex act(3, null)
>   the floor (115,138,2) (/turf/open/floor/plasteel): contents explosion(3, null)
>   the floor (115,138,2) (/turf/open/floor/plasteel): ex act(3, null)
>   the floor (115,138,2) (/turf/open/floor/plasteel): ex act(3, null)
>   /datum/explosion (/datum/explosion): New(space (128,140,2) (/turf/open/space), 5, 10, 20, 20, 1, 0, 0, 0, 0)