### PR TITLE
Makes Asteroid Shuttle Free (Alt to #42730)

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -211,7 +211,7 @@
 	name = "Asteroid With Engines Strapped To It"
 	description = "A hollowed out asteroid with engines strapped to it. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
-	credit_cost = -5000
+	credit_cost = 0
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/luxury


### PR DESCRIPTION
## About The Pull Request

Lately I've seen nerfs go through even when they aren't the ideal one. I feel maintainers will just merge that one, and since the creator doesn't seem willing to budge, I figured I'd make this to give them a sense of variety. Makes the asteroid shuttle free as opposed to awarding the station with 5000 credits. 

## Why It's Good For The Game

Making it cost any amount of credits is pretty dumb, because no one will order it anymore since stuff like battle raven would just be several racks more. Yeah, its hijack/bomb proof, but its ugly as shit, destroys departures and anyone in it, usually has messed up atmos, and has no departments. 

## Changelog
:cl: wesoda
balance: asteroid shuttle is now free
/:cl:
