### PR TITLE
Botany can now make Unstable Mutagen in the Biogenerator for 600 Biomass!

### DIFF
--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -75,6 +75,14 @@
 	build_path = /obj/item/reagent_containers/food/snacks/monkeycube
 	category = list("initial", "Food")
 
+/datum/design/mutagen
+	name = "Unstable Mutagen"
+	id = "unstable_mutagen"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 1000)
+	build_path = /obj/item/reagent_containers/glass/bottle/mutagen
+	category = list("initial","Botany Chemicals")
+
 /datum/design/ez_nut
 	name = "E-Z Nutrient"
 	id = "ez_nut"

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -79,7 +79,7 @@
 	name = "Unstable Mutagen"
 	id = "unstable_mutagen"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 1000)
+	materials = list(MAT_BIOMASS = 600)
 	build_path = /obj/item/reagent_containers/glass/bottle/mutagen
 	category = list("initial","Botany Chemicals")
 


### PR DESCRIPTION
## About The Pull Request
Theres been some discussion recently about merging chemistry and botany together and one of the issues mentioned was botany stealing the chem dispenser just to make mutagen so decided to go ahead and make this pr (based off a feature yogs already had) to help fix that

## Why It's Good For The Game
This does not right away remove botanists dependence on chemistry 600 biomass will take some time to get so if a botanist wanted mutagen right away asking chemistry is still the best option but should still make things easier for them in the long run 

## Changelog
🆑 fluffe9911
tweak: Botany can now get mutagen from the biogenerator for 600 biomass!
/🆑