### PR TITLE
fixes layer 3 injectors and replaces a scrubber with a air pump on sy…

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -4505,9 +4505,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "lv" = (

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -3,7 +3,7 @@
 
 	name = "air injector"
 	desc = "Has a valve and pump attached to it."
-	
+
 	use_power = IDLE_POWER_USE
 	can_unwrench = TRUE
 	shift_underlay_only = FALSE
@@ -192,8 +192,8 @@
 	icon_state = "inje_map-1"
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer3
-	piping_layer = 2
-	icon_state = "inje_map-2"
+	piping_layer = 3
+	icon_state = "inje_map-3"
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/on
 	on = TRUE
@@ -203,8 +203,8 @@
 	icon_state = "inje_map-1"
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3
-	piping_layer = 2
-	icon_state = "inje_map-2"
+	piping_layer = 3
+	icon_state = "inje_map-3"
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos
 	frequency = FREQ_ATMOS_STORAGE


### PR DESCRIPTION
## About The Pull Request

Layer 3 injectors where initializing on layer 2, I also replaced a scrubber with a pump as requested

The game was screaming the following runtimes but it always does that with atmos stuff that isnt on layer 2
`Runtime in LINDA_turf_tile.dm, line 178: undefined variable /turf/closed/wall/mineral/plastitanium/nodiagonal/var/air`
`Runtime in LINDA_turf_tile.dm, line 90: Cannot execute null.archive()`
`Runtime in gas_mixture.dm, line 378: Cannot read null.gases`

## Why It's Good For The Game

Fixes #42744 

## Changelog
:cl: GranpaWalton
tweak: A lavaland syndicate base portable scrubber was replaced with a portable pump
fix: layer 3 injectors now properly initialize on layer 3 instead of 2
/:cl: