### PR TITLE
Fixes bad default ethereal preference color

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -49,8 +49,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		pda_style = "mono"
 	if(current_version < 20)
 		pda_color = "#808000"
-	if((current_version < 21) && S["feature_ethcolor"] && (S["feature_ethcolor"] == "#9c3030"))
-		WRITE_FILE(S["feature_ethcolor"]	, "9c3030")
+	if((current_version < 21) && features["ethcolor"] && (features["ethcolor"] == "#9c3030"))
+		features["ethcolor"] = "9c3030"
 
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	20
+#define SAVEFILE_VERSION_MAX	21
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -49,6 +49,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		pda_style = "mono"
 	if(current_version < 20)
 		pda_color = "#808000"
+	if((current_version < 21) && S["feature_ethcolor"] && (S["feature_ethcolor"] == "#9c3030"))
+		WRITE_FILE(S["feature_ethcolor"]	, "9c3030")
+
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)
@@ -212,9 +215,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	if(!S["features["mcolor"]"] || S["features["mcolor"]"] == "#000")
 		WRITE_FILE(S["features["mcolor"]"]	, "#FFF")
-	
+
 	if(!S["feature_ethcolor"] || S["feature_ethcolor"] == "#000")
-		WRITE_FILE(S["feature_ethcolor"]	, "#9c3030")
+		WRITE_FILE(S["feature_ethcolor"]	, "9c3030")
 
 	//Character
 	S["real_name"]			>> real_name
@@ -295,7 +298,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	if(!features["mcolor"] || features["mcolor"] == "#000")
 		features["mcolor"] = pick("FFFFFF","7F7F7F", "7FFF7F", "7F7FFF", "FF7F7F", "7FFFFF", "FF7FFF", "FFFF7F")
-	
+
 	if(!features["ethcolor"] || features["ethcolor"] == "#000")
 		features["ethcolor"] = GLOB.color_list_ethereal[pick(GLOB.color_list_ethereal)]
 


### PR DESCRIPTION
Fixed malformed hex runtime since the `#` is automatically prefixed to this value when it's present.

Think this is the right way, but I hate touching savefile crap. @Cyberboss @MrStonedOne look good to you guys?

```
[18:31:07] Runtime in type2type.dm, line 34: Malformed hex number
proc name: hex2num (/proc/hex2num)
usr: BudyMan1/(BudyMan1)
usr.loc: (start area (8, 174, 1))
src: null
call stack:
hex2num("#9", 0)
GetRedPart("##9c303")
Ethereal (/datum/species/ethereal): on species gain(Ivan Andropow (/mob/living/carbon/human/dummy), Flyperson (/datum/species/fly), 1)
Ivan Andropow (/mob/living/carbon/human/dummy): set species(/datum/species/ethereal (/datum/species/ethereal), 0, 1)
Ivan Andropow (/mob/living/carbon/human/dummy): set species(/datum/species/ethereal (/datum/species/ethereal), 0, 1)
/datum/preferences (/datum/preferences): copy to(Ivan Andropow (/mob/living/carbon/human/dummy), 1, 1)
/datum/preferences (/datum/preferences): update preview icon()
/datum/preferences (/datum/preferences): ShowChoices(BudyMan1 (/mob/dead/new_player))
/datum/preferences (/datum/preferences): process link(BudyMan1 (/mob/dead/new_player), /list (/list))
BudyMan1 (/client): Topic("_src_=prefs;preference=species...", /list (/list), null)
BudyMan1 (/client): Topic("_src_=prefs;preference=species...", /list (/list))
```


:cl: ShizCalev
fix: Fixed incorrect default ethereal color causing a runtime when opening player preferences.
/:cl:
