### PR TITLE
made cult mirror shields not shatter from stamina damage

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -928,7 +928,7 @@
 	if(iscultist(owner))
 		if(istype(hitby, /obj/item/projectile))
 			var/obj/item/projectile/P = hitby
-			if(P.damage >= 30)
+			if(P.damage >= 30 && P.damage_type != STAMINA)
 				var/turf/T = get_turf(owner)
 				T.visible_message("<span class='warning'>The sheer force from [P] shatters the mirror shield!</span>")
 				new /obj/effect/temp_visual/cult/sparks(T)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Referencing issue #42421, this pr makes mirror shields not shatter from disabler beams. 

## Why It's Good For The Game

Disabler beams lack the force necessary to shatter objects, why would they shatter the mirror shield? This change just makes it so that you need something that doesn't deal STAMINA damage.

## Changelog
:cl:
fix: cult mirror shield now doesn't shatter when hit by disabler beams
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
