### PR TITLE
Assimilation runtime & bug fixes

### DIFF
--- a/code/game/gamemodes/hivemind/hivemind.dm
+++ b/code/game/gamemodes/hivemind/hivemind.dm
@@ -57,16 +57,17 @@
 			return TRUE
 	return FALSE
 
-/proc/remove_hivemember(mob/living/M) //Removes somebody from all hives as opposed to the antag proc remove_from_hive()
-	if(!M)
+/proc/remove_hivemember(mob/living/L) //Removes somebody from all hives as opposed to the antag proc remove_from_hive()
+	if(!L && !L.mind)
 		return
+	var/datum/mind/M = L.mind
 	for(var/datum/antagonist/hivemind/H in GLOB.antagonists)
 		if(H.hivemembers.Find(M))
 			H.hivemembers -= M
 			H.calc_size()
-	var/datum/antagonist/hivevessel/V = M.is_wokevessel()
-	if(V && M.mind)
-		M.mind.remove_antag_datum(/datum/antagonist/hivevessel)
+	var/datum/antagonist/hivevessel/V = L.is_wokevessel()
+	if(V && M)
+		M.remove_antag_datum(/datum/antagonist/hivevessel)
 
 /datum/game_mode/hivemind/pre_setup()
 

--- a/code/game/gamemodes/hivemind/hivemind.dm
+++ b/code/game/gamemodes/hivemind/hivemind.dm
@@ -64,6 +64,9 @@
 		if(H.hivemembers.Find(M))
 			H.hivemembers -= M
 			H.calc_size()
+	var/datum/antagonist/hivevessel/V = M.is_wokevessel()
+	if(V && M.mind)
+		M.mind.remove_antag_datum(/datum/antagonist/hivevessel)
 
 /datum/game_mode/hivemind/pre_setup()
 

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -213,6 +213,7 @@
 
 	if(H)
 		H.faction |= factions
+		remove_hivemember(H)
 
 		for(var/V in quirks)
 			var/datum/quirk/Q = new V(H)

--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -86,13 +86,13 @@
 			to_chat(owner, "<big><span class='assimilator'>Our true power, the One Mind, is finally within reach.</span></big>")
 
 /datum/antagonist/hivemind/proc/add_track_bonus(datum/antagonist/hivemind/enemy, bonus)
-	if(individual_track_bonus[enenmy])
+	if(individual_track_bonus[enemy])
 		individual_track_bonus[enemy] = bonus
 	else
 		individual_track_bonus[enemy] += bonus
 
 /datum/antagonist/hivemind/proc/get_track_bonus(datum/antagonist/hivemind/enemy)
-	if(individual_track_bonus[enenmy])
+	if(individual_track_bonus[enemy])
 		. = 0
 	else
 		. = individual_track_bonus[enemy]

--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -127,6 +127,10 @@
 	if(M)
 		hivemembers -= M
 		calc_size()
+		if(active_one_mind)
+			var/datum/antagonist/hivevessel/V = C.is_wokevessel()
+			if(V)
+				M.remove_antag_datum(/datum/antagonist/hivevessel)
 
 /datum/antagonist/hivemind/proc/handle_ejection(mob/living/carbon/C)
 	var/user_warning = "The enemy host has been ejected from our mind"

--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -165,7 +165,7 @@
 	calc_size()
 
 /datum/antagonist/hivemind/antag_panel_data()
-	return "Vessels Assimilated: [hive_size]"
+	return "Vessels Assimilated: [hive_size] (+[size_mod])"
 
 /datum/antagonist/hivemind/proc/awaken()
 	if(!owner?.current)

--- a/code/modules/antagonists/hivemind/vessel.dm
+++ b/code/modules/antagonists/hivemind/vessel.dm
@@ -14,7 +14,7 @@
 /mob/living/proc/is_wokevessel()
 	return mind?.has_antag_datum(/datum/antagonist/hivevessel)
 
-/mob/living/proc/hive_awaken(objective, datum/team/final_form)
+/mob/living/proc/hive_awaken(objective, datum/team/hivemind/final_form)
 	if(!mind)
 		return
 	var/datum/mind/M = mind

--- a/code/modules/antagonists/hivemind/vessel.dm
+++ b/code/modules/antagonists/hivemind/vessel.dm
@@ -33,9 +33,10 @@
 	else
 		var/datum/objective/brainwashing/obj = new(objective)
 		vessel.objectives += obj
-		M.add_antag_datum(vessel)
 		var/message = "<span class='deadsay'><b>[M]</b> has been brainwashed with the following objectives: [objective]."
 		deadchat_broadcast(message, follow_target = M, turf_target = get_turf(M), message_type=DEADCHAT_REGULAR)
+	if(!M.has_antag_datum(/datum/antagonist/hivevessel))
+		M.add_antag_datum(vessel)
 
 /datum/antagonist/hivevessel/apply_innate_effects()
 	if(owner.assigned_role == "Clown")

--- a/code/modules/spells/spell_types/hivemind.dm
+++ b/code/modules/spells/spell_types/hivemind.dm
@@ -875,7 +875,7 @@
 	one_mind_team.objectives += objective
 	for(var/datum/antagonist/hivevessel/vessel in GLOB.antagonists)
 		var/mob/living/carbon/C = vessel.owner?.current
-		if(hive.is_carbon_member(C))
+		if(C && hive.is_carbon_member(C))
 			vessel.one_mind = one_mind_team
 	for(var/datum/antagonist/hivemind/enemy in GLOB.antagonists)
 		if(enemy.owner)
@@ -902,7 +902,6 @@
 		addtimer(CALLBACK(GLOBAL_PROC, /proc/to_chat, C, "<span class='assimilator'>There is no you...</span>"), 110)
 		addtimer(CALLBACK(GLOBAL_PROC, /proc/to_chat, C, "<span class='bigassimilator'>...there is only us.</span>"), 130)
 		addtimer(CALLBACK(C, /mob/living/proc/hive_awaken, objective, one_mind_team), 150)
-		addtimer(CALLBACK(one_mind_team, /datum/team/proc/add_member, C.mind), 150)
 
 /obj/effect/proc_holder/spell/self/hive_comms
 	name = "Hive Communication"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Partially fixes #42767

- Fixed a null list runtime causing the track bonus not to work.
- Fixed an erroneous use of locate in the track bonus procs.
- Fixed a runtime that occurred due to a lack of mind checks.
- Fixed a runtime with the One Mind's objective being a string and not an objective datum.
- Added a couple of sanity checks.
- Removed a redundant callback.
- Fixed several runtimes due to a proc setting the One Mind team to `true` when an actual team had already been assigned to it.
- Fixed the remove_hivemember proc to work with minds instead of mobs.
- Vessels lose their vessel status upon being cloned (As was originally intended with assimilation being tied to the body).
- Vessels stop being woke when de-assimilated.
- Fixed vessels that aren't already woke not becoming antags when the One Mind activates.
- Added Reclaim's bonus vessels to the antag panel.
- Made Mind Control's ejection less janky, there is now a warning and 3 seconds to turn back.
- Assimilate Vessel now alerts the user if they've been stunned by bruteforce.
- Removed Bruteforce's cooldown when activating. It still has a cooldown after being deactivated.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
it makes the gamemode work better
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Kierany9
fix: Fixed several bugs involving hivemind tracking, team assignation and de-assimilation not working.
tweak: Assimilated vessels lose their vessel status when cloned once again.
tweak: Made several hivemind abilities less janky.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
