### PR TITLE
Valentines antagonists will now only show on the roundend if they failed their date

### DIFF
--- a/code/modules/antagonists/valentines/valentine.dm
+++ b/code/modules/antagonists/valentines/valentine.dm
@@ -38,7 +38,5 @@
 				objectives_complete = FALSE
 				break
 
-	if(objectives_complete)
-		return "<span class='greentext big'>[owner.name] protected [owner.p_their()] date</span>"
-	else
+	if(!objectives_complete)
 		return "<span class='redtext big'>[owner.name] date failed!</span>"


### PR DESCRIPTION
Roundend on valentines gets cluttered, this should make it a little bit shorter
kinda fixes #42762 but perhaps 

>That said, the mulligan system should check for a variable on the antag to signal that it can not count those as delaying round end tbh.

should be done as well.

:cl:
tweak: the game will now specifically call you out if you fail the date on valentines!
/:cl:

My other idea is checking if more than half the station completed their date, and changing if it shows who completed/failed based on the smaller group. In the face of complete chaos only these completed their dates/most managed to keep their dates except for these losers!
