### PR TITLE
Prevents bluespace beakers from being added to chem grenades

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -67,7 +67,7 @@
 		else if(stage == EMPTY)
 			to_chat(user, "<span class='warning'>You need to add an activation mechanism!</span>")
 
-	else if(stage == WIRED && is_type_in_list(I, allowed_containers))
+	else if(stage == WIRED && is_type_in_list(I, allowed_containers) && !istype(I, /obj/item/reagent_containers/glass/beaker/bluespace))
 		. = 1 //no afterattack
 		if(beakers.len == 2)
 			to_chat(user, "<span class='warning'>[src] can not hold more containers!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a condition to stop bluespace beakers from being added to chem grenades.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Chem grenades can be devastating even with large beakers, so going above that is a bit excessive. I doubt the effects of this limitation will be felt by most antagonists other than a slightly smaller hole in the ship.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Chem grenades no longer accept bluespace beakers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
