### PR TITLE
Valentines antagonists will no longer stop mulligan

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -235,15 +235,10 @@
 			return 0 //A resource saver: once we find someone who has to die for all antags to be dead, we can just keep checking them, cycling over everyone only when we lose our mark.
 
 		for(var/mob/Player in GLOB.alive_mob_list)
-			if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player) && Player.client)
-				if(Player.mind.special_role || LAZYLEN(Player.mind.antag_datums)) //Someone's still antaging but is their antagonist datum important enough to skip mulligan?
-					var/prevent_roundtype_conversion = FALSE
-					for(var/datum/antagonist/antag_types in Player.mind.antag_datums)
-						if(antag_types.prevent_roundtype_conversion)
-							prevent_roundtype_conversion = TRUE
-							break
-					if(prevent_roundtype_conversion)//they were an important antag, they're our new mark
-						living_antag_player = Player
+			if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player) && Player.client && Player.mind.special_role || LAZYLEN(Player.mind.antag_datums) //Someone's still antagging but is their antagonist datum important enough to skip mulligan?
+				for(var/datum/antagonist/antag_types in Player.mind.antag_datums)
+					if(antag_types.prevent_roundtype_conversion)
+						living_antag_player = Player //they were an important antag, they're our new mark
 						return 0
 
 		if(!are_special_antags_dead())

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -235,7 +235,7 @@
 			return 0 //A resource saver: once we find someone who has to die for all antags to be dead, we can just keep checking them, cycling over everyone only when we lose our mark.
 
 		for(var/mob/Player in GLOB.alive_mob_list)
-			if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player) && Player.client && Player.mind.special_role || LAZYLEN(Player.mind.antag_datums) //Someone's still antagging but is their antagonist datum important enough to skip mulligan?
+			if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player) && Player.client && Player.mind.special_role || LAZYLEN(Player.mind.antag_datums)) //Someone's still antagging but is their antagonist datum important enough to skip mulligan?
 				for(var/datum/antagonist/antag_types in Player.mind.antag_datums)
 					if(antag_types.prevent_roundtype_conversion)
 						living_antag_player = Player //they were an important antag, they're our new mark

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -236,9 +236,14 @@
 
 		for(var/mob/Player in GLOB.alive_mob_list)
 			if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player) && Player.client)
-				if(Player.mind.special_role || LAZYLEN(Player.mind.antag_datums)) //Someone's still antaging!
-					living_antag_player = Player
-					return 0
+				if(Player.mind.special_role || LAZYLEN(Player.mind.antag_datums)) //Someone's still antaging- but is their antagonist datum important enough to skip mulligan?
+					var/no_mulligan = FALSE
+					for(var/datum/antagonist/antag_types in Player.mind.antag_datums)
+						if(antag_types.no_mulligan)
+							no_mulligan = TRUE
+					if(no_mulligan)//they were an important antag, they're our new mark
+						living_antag_player = Player
+						return 0
 
 		if(!are_special_antags_dead())
 			return FALSE

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -236,12 +236,12 @@
 
 		for(var/mob/Player in GLOB.alive_mob_list)
 			if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player) && Player.client)
-				if(Player.mind.special_role || LAZYLEN(Player.mind.antag_datums)) //Someone's still antaging- but is their antagonist datum important enough to skip mulligan?
-					var/no_mulligan = FALSE
+				if(Player.mind.special_role || LAZYLEN(Player.mind.antag_datums)) //Someone's still antaging but is their antagonist datum important enough to skip mulligan?
+					var/prevent_roundtype_conversion = FALSE
 					for(var/datum/antagonist/antag_types in Player.mind.antag_datums)
-						if(antag_types.no_mulligan)
-							no_mulligan = TRUE
-					if(no_mulligan)//they were an important antag, they're our new mark
+						if(antag_types.prevent_roundtype_conversion)
+							prevent_roundtype_conversion = TRUE
+					if(prevent_roundtype_conversion)//they were an important antag, they're our new mark
 						living_antag_player = Player
 						return 0
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -241,6 +241,7 @@
 					for(var/datum/antagonist/antag_types in Player.mind.antag_datums)
 						if(antag_types.prevent_roundtype_conversion)
 							prevent_roundtype_conversion = TRUE
+							break
 					if(prevent_roundtype_conversion)//they were an important antag, they're our new mark
 						living_antag_player = Player
 						return 0

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -4,6 +4,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/name = "Antagonist"
 	var/roundend_category = "other antagonists"				//Section of roundend report, datums with same category will be displayed together, also default header for the section
 	var/show_in_roundend = TRUE								//Set to false to hide the antagonists from roundend report
+	var/no_mulligan = FALSE					//Antagonist isn't important enough to hold up the round from a mulligan.
 	var/datum/mind/owner						//Mind that owns this datum
 	var/silent = FALSE							//Silent will prevent the gain/lose texts to show
 	var/can_coexist_with_others = TRUE			//Whether or not the person will be able to have more than one datum

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -4,7 +4,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/name = "Antagonist"
 	var/roundend_category = "other antagonists"				//Section of roundend report, datums with same category will be displayed together, also default header for the section
 	var/show_in_roundend = TRUE								//Set to false to hide the antagonists from roundend report
-	var/no_mulligan = FALSE					//Antagonist isn't important enough to hold up the round from a mulligan.
+	var/prevent_roundtype_conversion = TRUE		//If false, the roundtype will still convert with this antag active
 	var/datum/mind/owner						//Mind that owns this datum
 	var/silent = FALSE							//Silent will prevent the gain/lose texts to show
 	var/can_coexist_with_others = TRUE			//Whether or not the person will be able to have more than one datum

--- a/code/modules/antagonists/valentines/valentine.dm
+++ b/code/modules/antagonists/valentines/valentine.dm
@@ -2,6 +2,7 @@
 	name = "valentine"
 	roundend_category = "valentines" //there's going to be a ton of them so put them in separate category
 	show_in_antagpanel = FALSE
+	no_mulligan = TRUE
 	var/datum/mind/date
 
 /datum/antagonist/valentine/proc/forge_objectives()

--- a/code/modules/antagonists/valentines/valentine.dm
+++ b/code/modules/antagonists/valentines/valentine.dm
@@ -2,7 +2,7 @@
 	name = "valentine"
 	roundend_category = "valentines" //there's going to be a ton of them so put them in separate category
 	show_in_antagpanel = FALSE
-	no_mulligan = TRUE
+	prevent_roundtype_conversion = FALSE
 	var/datum/mind/date
 
 /datum/antagonist/valentine/proc/forge_objectives()


### PR DESCRIPTION
Adds a variable for antagonists: no_mulligan. if set to TRUE, the mulligan won't consider this antag as worthy enough to stop mulligan.

## Why It's Good For The Game

Everybody is a valentines, so having valentines is essentially killing mulligan when valentines is essentially some loosened escalation rules!

also fixes #42762 kinda, the other half is completed in my other pr #42770 to reduce clutter

:cl:
fix: Valentines no longer hold up mulligan!
/:cl:

