### PR TITLE
Slot Machines Now Accept Holocredits via Multitool

### DIFF
--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -84,7 +84,7 @@
 /obj/machinery/computer/slot_machine/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/coin))
 		var/obj/item/coin/C = I
-		if(paymode = COIN)
+		if(paymode == COIN)
 			if(prob(2))
 				if(!user.transferItemToLoc(C, drop_location()))
 					return
@@ -102,10 +102,10 @@
 		else
 			to_chat(user, "<span class='warning'>This machine is only accepting holochips!</span>")
 	else if(istype(I, /obj/item/holochip))
-		if(paymode = HOLOCHIP)
+		if(paymode == HOLOCHIP)
+			var/obj/item/holochip/H = I
 			if(!user.temporarilyRemoveItemFromInventory(H))
 				return
-			var/obj/item/holochip/H = I
 			to_chat(user, "<span class='notice'>You insert [H.credits] holocredits into [src]'s!</span>")
 			balance += H.credits
 			qdel(H)
@@ -115,7 +115,7 @@
 		if(balance > 0)
 			visible_message("<b>[src]</b> says, 'ERROR! Please empty the machine balance before altering paymode'") //Prevents converting coins into holocredits and vice versa
 		else
-			if(paymode = HOLOCHIP)
+			if(paymode == HOLOCHIP)
 				paymode = COIN
 				visible_message("<b>[src]</b> says, 'This machine now works with COINS!'")
 			else
@@ -258,8 +258,8 @@
 		jackpots += 1
 		balance += money - give_payout(JACKPOT)
 		money = 0
-		if(payout = HOLOCHIP)
-			var/obj/item/holochip/H = new obj/item/holochip(loc,JACKPOT)
+		if(paymode == HOLOCHIP)
+			var/obj/item/holochip/H = new /obj/item/holochip(loc,JACKPOT)
 		else
 			for(var/i = 0, i < 5, i++)
 				var/cointype = pick(subtypesof(/obj/item/coin))
@@ -308,7 +308,7 @@
 	balance += surplus
 
 /obj/machinery/computer/slot_machine/proc/give_payout(amount)
-	if(paymode = HOLOCHIP)
+	if(paymode == HOLOCHIP)
 		var/cointype = /obj/item/holochip
 	else
 		var/cointype = obj_flags & EMAGGED ? /obj/item/coin/iron : /obj/item/coin/silver
@@ -324,8 +324,8 @@
 	return amount
 
 /obj/machinery/computer/slot_machine/proc/dispense(amount = 0, cointype = /obj/item/coin/silver, mob/living/target, throwit = 0)
-	if(paymode = HOLOCHIP)
-		var/obj/item/holochip/H = new obj/item/holochip(loc,amount)
+	if(paymode == HOLOCHIP)
+		var/obj/item/holochip/H = new /obj/item/holochip(loc,amount)
 		
 		if(throwit && target)
 			H.throw_at(target, 3, 10)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -28,7 +28,7 @@
 	var/working = 0
 	var/balance = 0 //How much money is in the machine, ready to be CONSUMED.
 	var/jackpots = 0
-	var/paymode = HOLOCHIP //It is a config
+	var/paymode = HOLOCHIP //toggles between HOLOCHIP/COIN, defined above
 	var/cointype = /obj/item/coin/iron //default cointype
 	var/list/coinvalues = list()
 	var/list/reels = list(list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -260,7 +260,7 @@
 		balance += money - give_payout(JACKPOT)
 		money = 0
 		if(paymode == HOLOCHIP)
-			var/obj/item/holochip/H = new /obj/item/holochip(loc,JACKPOT)
+			new /obj/item/holochip(loc,JACKPOT)
 		else
 			for(var/i = 0, i < 5, i++)
 				cointype = pick(subtypesof(/obj/item/coin))

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -29,6 +29,7 @@
 	var/balance = 0 //How much money is in the machine, ready to be CONSUMED.
 	var/jackpots = 0
 	var/paymode = HOLOCHIP //It is a config
+	var/cointype = /obj/item/coin/iron //default cointype
 	var/list/coinvalues = list()
 	var/list/reels = list(list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0)
 	var/list/symbols = list(SEVEN = 1, "<font color='orange'>&</font>" = 2, "<font color='yellow'>@</font>" = 2, "<font color='green'>$</font>" = 2, "<font color='blue'>?</font>" = 2, "<font color='grey'>#</font>" = 2, "<font color='white'>!</font>" = 2, "<font color='fuchsia'>%</font>" = 2) //if people are winning too much, multiply every number in this list by 2 and see if they are still winning too much.
@@ -48,7 +49,7 @@
 
 	toggle_reel_spin(0)
 
-	for(var/cointype in typesof(/obj/item/coin))
+	for(cointype in typesof(/obj/item/coin))
 		var/obj/item/coin/C = cointype
 		coinvalues["[cointype]"] = initial(C.value)
 
@@ -262,7 +263,7 @@
 			var/obj/item/holochip/H = new /obj/item/holochip(loc,JACKPOT)
 		else
 			for(var/i = 0, i < 5, i++)
-				var/cointype = pick(subtypesof(/obj/item/coin))
+				cointype = pick(subtypesof(/obj/item/coin))
 				var/obj/item/coin/C = new cointype(loc)
 				random_step(C, 2, 50)
 
@@ -309,9 +310,9 @@
 
 /obj/machinery/computer/slot_machine/proc/give_payout(amount)
 	if(paymode == HOLOCHIP)
-		var/cointype = /obj/item/holochip
+		cointype = /obj/item/holochip
 	else
-		var/cointype = obj_flags & EMAGGED ? /obj/item/coin/iron : /obj/item/coin/silver
+		cointype = obj_flags & EMAGGED ? /obj/item/coin/iron : /obj/item/coin/silver
 
 	if(!(obj_flags & EMAGGED))
 		amount = dispense(amount, cointype, null, 0)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -112,7 +112,7 @@
 			qdel(H)
 		else
 			to_chat(user, "<span class='warning'>This machine is only accepting coins!</span>")
-	else if(I.tool_behavior == TOOL_MULTITOOL)
+	else if(I.tool_behaviour == TOOL_MULTITOOL)
 		if(balance > 0)
 			visible_message("<b>[src]</b> says, 'ERROR! Please empty the machine balance before altering paymode'") //Prevents converting coins into holocredits and vice versa
 		else

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -112,7 +112,7 @@
 			qdel(H)
 		else
 			to_chat(user, "<span class='warning'>This machine is only accepting coins!</span>")
-	else if(istype(I, /obj/item/multitool))
+	else if(I.tool_behavior == TOOL_MULTITOOL)
 		if(balance > 0)
 			visible_message("<b>[src]</b> says, 'ERROR! Please empty the machine balance before altering paymode'") //Prevents converting coins into holocredits and vice versa
 		else

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -11,6 +11,8 @@
 #define SPIN_TIME 65 //As always, deciseconds.
 #define REEL_DEACTIVATE_DELAY 7
 #define SEVEN "<font color='red'>7</font>"
+#define HOLOCHIP 1
+#define COIN 2
 
 /obj/machinery/computer/slot_machine
 	name = "slot machine"
@@ -26,6 +28,7 @@
 	var/working = 0
 	var/balance = 0 //How much money is in the machine, ready to be CONSUMED.
 	var/jackpots = 0
+	var/paymode = HOLOCHIP //It is a config
 	var/list/coinvalues = list()
 	var/list/reels = list(list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0, list("", "", "") = 0)
 	var/list/symbols = list(SEVEN = 1, "<font color='orange'>&</font>" = 2, "<font color='yellow'>@</font>" = 2, "<font color='green'>$</font>" = 2, "<font color='blue'>?</font>" = 2, "<font color='grey'>#</font>" = 2, "<font color='white'>!</font>" = 2, "<font color='fuchsia'>%</font>" = 2) //if people are winning too much, multiply every number in this list by 2 and see if they are still winning too much.
@@ -51,7 +54,7 @@
 
 /obj/machinery/computer/slot_machine/Destroy()
 	if(balance)
-		give_coins(balance)
+		give_payout(balance)
 	return ..()
 
 /obj/machinery/computer/slot_machine/process()
@@ -81,20 +84,43 @@
 /obj/machinery/computer/slot_machine/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/coin))
 		var/obj/item/coin/C = I
-		if(prob(2))
-			if(!user.transferItemToLoc(C, drop_location()))
-				return
-			C.throw_at(user, 3, 10)
-			if(prob(10))
-				balance = max(balance - SPIN_PRICE, 0)
-			to_chat(user, "<span class='warning'>[src] spits your coin back out!</span>")
+		if(paymode = COIN)
+			if(prob(2))
+				if(!user.transferItemToLoc(C, drop_location()))
+					return
+				C.throw_at(user, 3, 10)
+				if(prob(10))
+					balance = max(balance - SPIN_PRICE, 0)
+				to_chat(user, "<span class='warning'>[src] spits your coin back out!</span>")
 
+			else
+				if(!user.temporarilyRemoveItemFromInventory(C))
+					return
+				to_chat(user, "<span class='notice'>You insert a [C.cmineral] coin into [src]'s slot!</span>")
+				balance += C.value
+				qdel(C)
 		else
-			if(!user.temporarilyRemoveItemFromInventory(C))
+			to_chat(user, "<span class='warning'>This machine is only accepting holochips!</span>")
+	else if(istype(I, /obj/item/holochip))
+		if(paymode = HOLOCHIP)
+			if(!user.temporarilyRemoveItemFromInventory(H))
 				return
-			to_chat(user, "<span class='notice'>You insert a [C.cmineral] coin into [src]'s slot!</span>")
-			balance += C.value
-			qdel(C)
+			var/obj/item/holochip/H = I
+			to_chat(user, "<span class='notice'>You insert [H.credits] holocredits into [src]'s!</span>")
+			balance += H.credits
+			qdel(H)
+		else
+			to_chat(user, "<span class='warning'>This machine is only accepting coins!</span>")
+	else if(istype(I, /obj/item/screwdriver))
+		if(balance > 0)
+			visible_message("<b>[src]</b> says, 'ERROR! Please empty the machine balance before altering paymode'") //Prevents converting coins into holocredits and vice versa
+		else
+			if(paymode = HOLOCHIP)
+				paymode = COIN
+				visible_message("<b>[src]</b> says, 'This machine now works with COINS!'")
+			else
+				paymode = HOLOCHIP
+				visible_message("<b>[src]</b> says, 'This machine now works with HOLOCHIPS!'")
 	else
 		return ..()
 
@@ -147,7 +173,7 @@
 		spin(usr)
 
 	else if(href_list["refund"])
-		give_coins(balance)
+		give_payout(balance)
 		balance = 0
 
 /obj/machinery/computer/slot_machine/emp_act(severity)
@@ -161,7 +187,7 @@
 	var/severity_ascending = 4 - severity
 	money = max(rand(money - (200 * severity_ascending), money + (200 * severity_ascending)), 0)
 	balance = max(rand(balance - (50 * severity_ascending), balance + (50 * severity_ascending)), 0)
-	money -= max(0, give_coins(min(rand(-50, 100 * severity_ascending)), money)) //This starts at -50 because it shouldn't always dispense coins yo
+	money -= max(0, give_payout(min(rand(-50, 100 * severity_ascending)), money)) //This starts at -50 because it shouldn't always dispense coins yo
 	spin()
 
 /obj/machinery/computer/slot_machine/proc/spin(mob/user)
@@ -227,23 +253,25 @@
 	var/linelength = get_lines()
 
 	if(reels[1][2] + reels[2][2] + reels[3][2] + reels[4][2] + reels[5][2] == "[SEVEN][SEVEN][SEVEN][SEVEN][SEVEN]")
-		visible_message("<b>[src]</b> says, 'JACKPOT! You win [money] credits worth of coins!'")
+		visible_message("<b>[src]</b> says, 'JACKPOT! You win [money] credits!'")
 		priority_announce("Congratulations to [user ? user.real_name : usrname] for winning the jackpot at the slot machine in [get_area(src)]!")
 		jackpots += 1
-		balance += money - give_coins(JACKPOT)
+		balance += money - give_payout(JACKPOT)
 		money = 0
-
-		for(var/i = 0, i < 5, i++)
-			var/cointype = pick(subtypesof(/obj/item/coin))
-			var/obj/item/coin/C = new cointype(loc)
-			random_step(C, 2, 50)
+		if(payout = HOLOCHIP)
+			var/obj/item/holochip/H = new obj/item/holochip(loc,JACKPOT)
+		else
+			for(var/i = 0, i < 5, i++)
+				var/cointype = pick(subtypesof(/obj/item/coin))
+				var/obj/item/coin/C = new cointype(loc)
+				random_step(C, 2, 50)
 
 	else if(linelength == 5)
-		visible_message("<b>[src]</b> says, 'Big Winner! You win a thousand credits worth of coins!'")
+		visible_message("<b>[src]</b> says, 'Big Winner! You win a thousand credits!'")
 		give_money(BIG_PRIZE)
 
 	else if(linelength == 4)
-		visible_message("<b>[src]</b> says, 'Winner! You win four hundred credits worth of coins!'")
+		visible_message("<b>[src]</b> says, 'Winner! You win four hundred credits!'")
 		give_money(SMALL_PRIZE)
 
 	else if(linelength == 3)
@@ -275,12 +303,15 @@
 
 /obj/machinery/computer/slot_machine/proc/give_money(amount)
 	var/amount_to_give = money >= amount ? amount : money
-	var/surplus = amount_to_give - give_coins(amount_to_give)
+	var/surplus = amount_to_give - give_payout(amount_to_give)
 	money = max(0, money - amount)
 	balance += surplus
 
-/obj/machinery/computer/slot_machine/proc/give_coins(amount)
-	var/cointype = obj_flags & EMAGGED ? /obj/item/coin/iron : /obj/item/coin/silver
+/obj/machinery/computer/slot_machine/proc/give_payout(amount)
+	if(paymode = HOLOCHIP)
+		var/cointype = /obj/item/holochip
+	else
+		var/cointype = obj_flags & EMAGGED ? /obj/item/coin/iron : /obj/item/coin/silver
 
 	if(!(obj_flags & EMAGGED))
 		amount = dispense(amount, cointype, null, 0)
@@ -293,16 +324,21 @@
 	return amount
 
 /obj/machinery/computer/slot_machine/proc/dispense(amount = 0, cointype = /obj/item/coin/silver, mob/living/target, throwit = 0)
-	var/value = coinvalues["[cointype]"]
-
-
-	while(amount >= value)
-		var/obj/item/coin/C = new cointype(loc) //DOUBLE THE PAIN
-		amount -= value
+	if(paymode = HOLOCHIP)
+		var/obj/item/holochip/H = new obj/item/holochip(loc,amount)
+		
 		if(throwit && target)
-			C.throw_at(target, 3, 10)
-		else
-			random_step(C, 2, 40)
+			H.throw_at(target, 3, 10)
+	else
+		var/value = coinvalues["[cointype]"]
+
+		while(amount >= value)
+			var/obj/item/coin/C = new cointype(loc) //DOUBLE THE PAIN
+			amount -= value
+			if(throwit && target)
+				C.throw_at(target, 3, 10)
+			else
+				random_step(C, 2, 40)
 
 	return amount
 
@@ -312,3 +348,5 @@
 #undef BIG_PRIZE
 #undef SMALL_PRIZE
 #undef SPIN_PRICE
+#undef HOLOCHIP
+#undef COIN

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -112,7 +112,7 @@
 			qdel(H)
 		else
 			to_chat(user, "<span class='warning'>This machine is only accepting coins!</span>")
-	else if(istype(I, /obj/item/screwdriver))
+	else if(istype(I, /obj/item/multitool))
 		if(balance > 0)
 			visible_message("<b>[src]</b> says, 'ERROR! Please empty the machine balance before altering paymode'") //Prevents converting coins into holocredits and vice versa
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Since I am messing around with money related code, I decided to take a look in the slotmachine codes.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
There are more ways to lose money via gambling. Otherwise you would need to forge/find coins to play something that exists in the game

## Changelog
:cl:
refactor: Slot Machines can now accept holocredits (Switch mode back and forth with a multitool. Default is Holocredit.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
I wanted to put in the changelog "If you get rich in real life you get rich in real life" but that is too vague to tell what this PR is doing
