### PR TITLE
Space Dragon Now Has Event Weights Comparable to Slaughter Demon

### DIFF
--- a/code/modules/events/space_dragon.dm
+++ b/code/modules/events/space_dragon.dm
@@ -2,8 +2,8 @@
 	name = "Spawn Space Dragon"
 	typepath = /datum/round_event/ghost_role/space_dragon
 	max_occurrences = 1
-	weight = 8
-	earliest_start = 70 MINUTES
+	weight = 1
+	earliest_start = 1 HOURS
 	min_players = 20
 
 /datum/round_event/ghost_role/space_dragon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See CL

## Why It's Good For The Game

I got a few complaints about this event being on par with slaughter demon so I've adjusted it to such. Needed to be lowered anyways since the novelty of a new baddie has worn off.

If you take issue with the baddie itself post here or on the forums. If there's nothing brought up within 24 hours i'm closing this.

@IndieanaJones 

## Changelog
:cl: Dragontalesby
balance: Space Dragon can now fire a hour in but has a greatly reduced firing chance (it's now equivalent to slaughter demon event)
/:cl:
