### PR TITLE
Ends the Great Clown Shoes Debate of 2019

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -62,10 +62,6 @@
   mood_change = -8
   timeout = 2400
 
-/datum/mood_event/noshoes
-	description = "<span class='warning'>I am a disgrace to comedy everywhere!</span>\n"
-	mood_change = -5
-
 /datum/mood_event/tased
 	description = "<span class='warning'>There's no \"z\" in \"taser\". It's in the zap.</span>\n"
 	mood_change = -3

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -104,3 +104,7 @@
 /datum/mood_event/religiously_comforted
 	description = "<span class='nicegreen'>You are comforted by the presence of a holy person.</span>"
 	mood_change = 3
+
+/datum/mood_event/clownshoes
+	description = "<span class='nicegreen'>The shoes are a clown's legacy, I never want to take them off!</span>\n"
+	mood_change = 5

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -85,16 +85,17 @@
 
 /obj/item/clothing/shoes/clown_shoes/equipped(mob/user, slot)
 	. = ..()
-	if(slot == SLOT_SHOES && enabled_waddle)
-		waddle = user.AddComponent(/datum/component/waddling)
-	if(user.mind && user.mind.assigned_role == "Clown")
-		SEND_SIGNAL(user, COMSIG_CLEAR_MOOD_EVENT, "noshoes")
+	if(slot == SLOT_SHOES)
+		if(enabled_waddle)
+			waddle = user.AddComponent(/datum/component/waddling)
+		if(user.mind && user.mind.assigned_role == "Clown")
+			SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "clownshoes", /datum/mood_event/clownshoes)
 
 /obj/item/clothing/shoes/clown_shoes/dropped(mob/user)
 	. = ..()
 	QDEL_NULL(waddle)
 	if(user.mind && user.mind.assigned_role == "Clown")
-		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "noshoes", /datum/mood_event/noshoes)
+		SEND_SIGNAL(user, COMSIG_CLEAR_MOOD_EVENT, "clownshoes")
 
 /obj/item/clothing/shoes/clown_shoes/CtrlClick(mob/living/user)
 	if(!isliving(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Clowns now get a mood boost from wearing their shoes instead of a debuff from not doing so

Fixes moodlet being applied if you're holding the shoes in your hands

## Why It's Good For The Game
I support what the original was trying to do, punishing clowns that remove their shoes to not deal with the slowdown, which is often seen as powergaming to bypass the quirks that come with the job, similar to mimes talking. 
It comes, however, at the expense of people being creative with alternate costumes and stifling creativity goes against the spirit of the job even more so.

The mood boost is very sizable for something that's never going to expire so I feel like it's equally desirable to keep the shoes on without directly punishing people for using other costumes. 
Also, this means clowns are going to generally be happier than the average crewmember, which is just so fitting!

## Changelog
:cl:
tweak: Clowns now get a mood boost from wearing clown shoes, but no longer feel sad when they are not.
fix: Wearing shoes means on your FEET!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
