### PR TITLE
[WIP] Space Dragon Fixes +Ghost Notification

### DIFF
--- a/code/modules/events/space_dragon.dm
+++ b/code/modules/events/space_dragon.dm
@@ -10,10 +10,6 @@
 	minimum_required = 1
 	role_name = "Space Dragon"
 	fakeable = TRUE
-
-/datum/round_event/ghost_role/space_dragon/announce(fake)
-	priority_announce("It appears a lifeform with magical traces is approaching [station_name()], please stand-by.", "Lifesign Alert")
-
 	
 /datum/round_event/ghost_role/space_dragon/spawn_role()
 	var/list/candidates = get_candidates(ROLE_ALIEN, null, ROLE_ALIEN)
@@ -41,6 +37,7 @@
 	message_admins("[ADMIN_LOOKUPFLW(S)] has been made into a Space Dragon by an event.")
 	log_game("[key_name(S)] was spawned as a Space Dragon by an event.")
 	announce_to_ghosts(S)
+	priority_announce("It appears a lifeform with magical traces is approaching [station_name()], please stand-by.", "Lifesign Alert")
 	spawned_mobs += S
 	return SUCCESSFUL_SPAWN
 

--- a/code/modules/events/space_dragon.dm
+++ b/code/modules/events/space_dragon.dm
@@ -9,7 +9,7 @@
 /datum/round_event/ghost_role/space_dragon
 	minimum_required = 1
 	role_name = "Space Dragon"
-	fakeable = FALSE
+	fakeable = TRUE
 
 /datum/round_event/ghost_role/space_dragon/announce(fake)
 	priority_announce("It appears a lifeform with magical traces is approaching [station_name()], please stand-by.", "Lifesign Alert")

--- a/code/modules/events/space_dragon.dm
+++ b/code/modules/events/space_dragon.dm
@@ -40,6 +40,7 @@
 	playsound(S, 'sound/magic/ethereal_exit.ogg', 50, 1, -1)
 	message_admins("[ADMIN_LOOKUPFLW(S)] has been made into a Space Dragon by an event.")
 	log_game("[key_name(S)] was spawned as a Space Dragon by an event.")
+	announce_to_ghosts(S)
 	spawned_mobs += S
 	return SUCCESSFUL_SPAWN
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -510,7 +510,7 @@ Difficulty: Medium
 	obj_damage = 80
 	melee_damage_upper = 35
 	melee_damage_lower = 35
-	speed = 0
+	speed = 1
 	mouse_opacity = MOUSE_OPACITY_ICON
 	loot = list()
 	crusher_loot = list()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -510,7 +510,7 @@ Difficulty: Medium
 	obj_damage = 80
 	melee_damage_upper = 35
 	melee_damage_lower = 35
-	speed = 1
+	speed = 0
 	mouse_opacity = MOUSE_OPACITY_ICON
 	loot = list()
 	crusher_loot = list()


### PR DESCRIPTION
## About The Pull Request

Fixes #42779 , adds ghost notification for the Space Dragon.

## Why It's Good For The Game

Just adds bug fix for the announcement and ghost notification.

## Changelog
:cl:
add: Space Dragon notification for ghosts to spectate it
fix: Space Dragon announcement playing when no Space Dragon spawns
/:cl:

Alright, as of now, no balance changes will be made with this PR.  If you have a good idea to add to SD though, feel free to comment.