### PR TITLE
Running slowly is the same as walking.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -11,9 +11,6 @@
 #define MOVE_INTENT_WALK "walk"
 #define MOVE_INTENT_RUN  "run"
 
-//Walking Speed Threshold for slips and stuff. If you move slower than this, you are considered walking, regardless of intent.
-#define MOVE_WALK_THRESHOLD 4 // Roundstart with shoes in walk-intent your move-delay reads as 4.
-
 //Blood levels
 #define BLOOD_VOLUME_MAXIMUM		2000
 #define BLOOD_VOLUME_SLIME_SPLIT	1120

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -11,6 +11,9 @@
 #define MOVE_INTENT_WALK "walk"
 #define MOVE_INTENT_RUN  "run"
 
+//Walking Speed Threshold for slips and stuff. If you move slower than this, you are considered walking, regardless of intent.
+#define MOVE_WALK_THRESHOLD 4 // Roundstart with shoes in walk-intent your move-delay reads as 4.
+
 //Blood levels
 #define BLOOD_VOLUME_MAXIMUM		2000
 #define BLOOD_VOLUME_SLIME_SPLIT	1120

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -27,7 +27,7 @@
 		if(H.has_trait(TRAIT_PIERCEIMMUNE))
 			return
 
-		if((flags & CALTROP_IGNORE_WALKERS) && H.real_move_delay < MOVE_WALK_THRESHOLD)
+		if((flags & CALTROP_IGNORE_WALKERS) && H.real_move_delay < CONFIG_GET(number/movedelay/walk_delay))
 			return
 
 		var/picked_def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -27,7 +27,7 @@
 		if(H.has_trait(TRAIT_PIERCEIMMUNE))
 			return
 
-		if((flags & CALTROP_IGNORE_WALKERS) && H.m_intent == MOVE_INTENT_WALK)
+		if((flags & CALTROP_IGNORE_WALKERS) && H.real_move_delay < MOVE_WALK_THRESHOLD)
 			return
 
 		var/picked_def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)

--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -28,7 +28,7 @@
 		var/mob/living/carbon/C = LM
 		if(!C.get_bodypart(BODY_ZONE_L_LEG) && !C.get_bodypart(BODY_ZONE_R_LEG))
 			return
-		if(ishuman(C) && C.real_move_delay < MOVE_WALK_THRESHOLD)
+		if(ishuman(C) && C.real_move_delay < CONFIG_GET(number/movedelay/walk_delay))
 			v /= 2
 			e -= 5
 	steps++

--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -14,7 +14,7 @@
 	var/turf/open/T = get_turf(parent)
 	if(!istype(T))
 		return
-	
+
 	var/mob/living/LM = parent
 	var/v = volume
 	var/e = e_range
@@ -23,27 +23,27 @@
 			return
 		playsound(T, 'sound/effects/footstep/crawl1.ogg', 15 * v) //play crawling sound
 		return
-	
+
 	if(iscarbon(LM))
 		var/mob/living/carbon/C = LM
 		if(!C.get_bodypart(BODY_ZONE_L_LEG) && !C.get_bodypart(BODY_ZONE_R_LEG))
 			return
-		if(ishuman(C) && C.m_intent == MOVE_INTENT_WALK)
+		if(ishuman(C) && C.real_move_delay < MOVE_WALK_THRESHOLD)
 			v /= 2
 			e -= 5
 	steps++
-	
+
 	if(steps >= 6)
 		steps = 0
-	
+
 	if(steps % 2)
 		return
-	
+
 	if(!LM.has_gravity(T) && steps != 0) // don't need to step as often when you hop around
 		return
-		
+
 	//begin playsound shenanigans//
-	
+
 	//for barefooted non-clawed mobs like monkeys
 	if(isbarefoot(LM))
 		playsound(T, pick(GLOB.barefootstep[T.barefootstep][1]),
@@ -51,19 +51,19 @@
 			TRUE,
 			GLOB.barefootstep[T.barefootstep][3] + e)
 		return
-	
+
 	//for xenomorphs, dogs, and other clawed mobs
 	if(isclawfoot(LM))
 		if(isalienadult(LM)) //xenos are stealthy and get quieter footsteps
 			v /= 3
 			e -= 5
-		
+
 		playsound(T, pick(GLOB.clawfootstep[T.clawfootstep][1]),
 				GLOB.clawfootstep[T.clawfootstep][2] * v,
 				TRUE,
 				GLOB.clawfootstep[T.clawfootstep][3] + e)
 		return
-	
+
 	//for megafauna and other large and imtimidating mobs such as the bloodminer
 	if(isheavyfoot(LM))
 		playsound(T, pick(GLOB.heavyfootstep[T.heavyfootstep][1]),
@@ -71,12 +71,12 @@
 				TRUE,
 				GLOB.heavyfootstep[T.heavyfootstep][3] + e)
 		return
-	
+
 	//for slimes
-	if(isslime(LM)) 
+	if(isslime(LM))
 		playsound(T, 'sound/effects/footstep/slime1.ogg', 15 * v)
 		return
-		
+
 	//for (simple) humanoid mobs (clowns, russians, pirates, etc.)
 	if(isshoefoot(LM))
 		if(!ishuman(LM))
@@ -88,13 +88,13 @@
 		if(ishuman(LM)) //for proper humans, they're special
 			var/mob/living/carbon/human/H = LM
 			var/feetCover = (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))
-			
+
 			if(H.shoes || feetCover) //are we wearing shoes
 				playsound(T, pick(GLOB.footstep[T.footstep][1]),
 					GLOB.footstep[T.footstep][2] * v,
 					TRUE,
 					GLOB.footstep[T.footstep][3] + e)
-			
+
 			if((!H.shoes && !feetCover)) //are we NOT wearing shoes
 				if(H.dna.species.special_step_sounds)
 					playsound(T, pick(H.dna.species.special_step_sounds), 50, TRUE)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -2,6 +2,8 @@
 	layer = OBJ_LAYER
 	var/last_move = null
 	var/last_move_time = 0
+	var/last_moved = 0
+	var/real_move_delay = 0
 	var/anchored = FALSE
 	var/move_resist = MOVE_RESIST_DEFAULT
 	var/move_force = MOVE_FORCE_DEFAULT
@@ -221,6 +223,8 @@
 	var/area/newarea = get_area(newloc)
 	loc = newloc
 	. = TRUE
+	real_move_delay = world.time - last_moved
+	last_moved = world.time
 	oldloc.Exited(src, newloc)
 	if(oldarea != newarea)
 		oldarea.Exited(src, newloc)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -164,7 +164,7 @@
 
 	if(istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		if (M.real_move_delay < MOVE_WALK_THRESHOLD && anchored)
+		if (M.real_move_delay < CONFIG_GET(number/movedelay/walk_delay) && anchored)
 			flash()
 
 /obj/machinery/flasher/portable/attackby(obj/item/W, mob/user, params)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -164,7 +164,7 @@
 
 	if(istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		if (M.m_intent != MOVE_INTENT_WALK && anchored)
+		if (M.real_move_delay < MOVE_WALK_THRESHOLD && anchored)
 			flash()
 
 /obj/machinery/flasher/portable/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/effects/alien_acid.dm
+++ b/code/game/objects/effects/alien_acid.dm
@@ -57,7 +57,7 @@
 		var/mob/living/L = AM
 		if(L.movement_type & FLYING)
 			return
-		if(L.m_intent != MOVE_INTENT_WALK && prob(40))
+		if(L.real_move_delay < MOVE_WALK_THRESHOLD && prob(40))
 			var/acid_used = min(acid_level*0.05, 20)
 			if(L.acid_act(10, acid_used, "feet"))
 				acid_level = max(0, acid_level - acid_used*10)

--- a/code/game/objects/effects/alien_acid.dm
+++ b/code/game/objects/effects/alien_acid.dm
@@ -57,7 +57,7 @@
 		var/mob/living/L = AM
 		if(L.movement_type & FLYING)
 			return
-		if(L.real_move_delay < MOVE_WALK_THRESHOLD && prob(40))
+		if(L.real_move_delay < CONFIG_GET(number/movedelay/walk_delay) && prob(40))
 			var/acid_used = min(acid_level*0.05, 20)
 			if(L.acid_act(10, acid_used, "feet"))
 				acid_level = max(0, acid_level - acid_used*10)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -400,7 +400,7 @@
 /obj/item/toy/snappop/Crossed(H as mob|obj)
 	if(ishuman(H) || issilicon(H)) //i guess carp and shit shouldn't set them off
 		var/mob/living/carbon/M = H
-		if(issilicon(H) || M.m_intent == MOVE_INTENT_RUN)
+		if(issilicon(H) || M.real_move_delay < MOVE_WALK_THRESHOLD)
 			to_chat(M, "<span class='danger'>You step on the snap pop!</span>")
 			pop_burst(2, 0)
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -400,7 +400,7 @@
 /obj/item/toy/snappop/Crossed(H as mob|obj)
 	if(ishuman(H) || issilicon(H)) //i guess carp and shit shouldn't set them off
 		var/mob/living/carbon/M = H
-		if(issilicon(H) || M.real_move_delay < MOVE_WALK_THRESHOLD)
+		if(issilicon(H) || M.real_move_delay < CONFIG_GET(number/movedelay/walk_delay))
 			to_chat(M, "<span class='danger'>You step on the snap pop!</span>")
 			pop_burst(2, 0)
 

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -64,7 +64,7 @@
 		return 1
 	if(iscarbon(mover))
 		var/mob/living/carbon/C = mover
-		if(allow_walk && C.m_intent == MOVE_INTENT_WALK)
+		if(allow_walk && C.real_move_delay >= MOVE_WALK_THRESHOLD)
 			return 1
 
 /obj/structure/holosign/barrier/wetsign

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -64,7 +64,7 @@
 		return 1
 	if(iscarbon(mover))
 		var/mob/living/carbon/C = mover
-		if(allow_walk && C.real_move_delay >= MOVE_WALK_THRESHOLD)
+		if(allow_walk && C.real_move_delay >= CONFIG_GET(number/movedelay/walk_delay))
 			return 1
 
 /obj/structure/holosign/barrier/wetsign

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -228,7 +228,7 @@
 		else
 			if(!(C.mobility_flags & MOBILITY_STAND) || !(C.status_flags & CANKNOCKDOWN)) // can't slip unbuckled mob if they're lying or can't fall.
 				return 0
-			if(C.m_intent == MOVE_INTENT_WALK && (lube&NO_SLIP_WHEN_WALKING))
+			if(C.real_move_delay >= MOVE_WALK_THRESHOLD && (lube&NO_SLIP_WHEN_WALKING))
 				return 0
 		if(!(lube&SLIDE_ICE))
 			to_chat(C, "<span class='notice'>You slipped[ O ? " on the [O.name]" : ""]!</span>")

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -228,7 +228,7 @@
 		else
 			if(!(C.mobility_flags & MOBILITY_STAND) || !(C.status_flags & CANKNOCKDOWN)) // can't slip unbuckled mob if they're lying or can't fall.
 				return 0
-			if(C.real_move_delay >= MOVE_WALK_THRESHOLD && (lube&NO_SLIP_WHEN_WALKING))
+			if(C.real_move_delay >= CONFIG_GET(number/movedelay/walk_delay) && (lube&NO_SLIP_WHEN_WALKING))
 				return 0
 		if(!(lube&SLIDE_ICE))
 			to_chat(C, "<span class='notice'>You slipped[ O ? " on the [O.name]" : ""]!</span>")

--- a/code/modules/antagonists/clockcult/clock_structures/trap_triggers/pressure_sensor.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/trap_triggers/pressure_sensor.dm
@@ -18,7 +18,7 @@
 /obj/structure/destructible/clockwork/trap/trigger/pressure_sensor/Crossed(atom/movable/AM)
 	if(isliving(AM) && !is_servant_of_ratvar(AM))
 		var/mob/living/L = AM
-		if(L.stat || L.m_intent == MOVE_INTENT_WALK || !(L.mobility_flags & MOBILITY_STAND))
+		if(L.stat || L.real_move_delay >= MOVE_WALK_THRESHOLD || !(L.mobility_flags & MOBILITY_STAND))
 			return
 		audible_message("<i>*click*</i>")
 		playsound(src, 'sound/items/screwdriver2.ogg', 50, TRUE)

--- a/code/modules/antagonists/clockcult/clock_structures/trap_triggers/pressure_sensor.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/trap_triggers/pressure_sensor.dm
@@ -18,7 +18,7 @@
 /obj/structure/destructible/clockwork/trap/trigger/pressure_sensor/Crossed(atom/movable/AM)
 	if(isliving(AM) && !is_servant_of_ratvar(AM))
 		var/mob/living/L = AM
-		if(L.stat || L.real_move_delay >= MOVE_WALK_THRESHOLD || !(L.mobility_flags & MOBILITY_STAND))
+		if(L.stat || L.real_move_delay >= CONFIG_GET(number/movedelay/walk_delay) || !(L.mobility_flags & MOBILITY_STAND))
 			return
 		audible_message("<i>*click*</i>")
 		playsound(src, 'sound/items/screwdriver2.ogg', 50, TRUE)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -105,7 +105,7 @@
 			if(!(MM.movement_type & FLYING))
 				if(ishuman(AM))
 					var/mob/living/carbon/H = AM
-					if(H.m_intent == MOVE_INTENT_RUN)
+					if(H.real_move_delay < MOVE_WALK_THRESHOLD)
 						triggered(H)
 						H.visible_message("<span class='warning'>[H] accidentally steps on [src].</span>", \
 										  "<span class='warning'>You accidentally step on [src]</span>")

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -105,7 +105,7 @@
 			if(!(MM.movement_type & FLYING))
 				if(ishuman(AM))
 					var/mob/living/carbon/H = AM
-					if(H.real_move_delay < MOVE_WALK_THRESHOLD)
+					if(H.real_move_delay < CONFIG_GET(number/movedelay/walk_delay))
 						triggered(H)
 						H.visible_message("<span class='warning'>[H] accidentally steps on [src].</span>", \
 										  "<span class='warning'>You accidentally step on [src]</span>")

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -39,5 +39,5 @@
 			set_nutrition(NUTRITION_LEVEL_FED - 1)	//just less than feeling vigorous
 		else if(nutrition && stat != DEAD)
 			adjust_nutrition(-(HUNGER_FACTOR/10))
-			if(m_intent == MOVE_INTENT_RUN)
+			if(real_move_delay >= MOVE_WALK_THRESHOLD)
 				adjust_nutrition(-(HUNGER_FACTOR/10))

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -9,8 +9,8 @@
 			. += 6 - 3*get_num_arms() //crawling is harder with fewer arms
 		if(legcuffed)
 			. += legcuffed.slowdown
-	if(m_intent == MOVE_INTENT_WALK && . < MOVE_WALK_THRESHOLD)
-		. = MOVE_WALK_THRESHOLD
+	if(m_intent == MOVE_INTENT_WALK && . < CONFIG_GET(number/movedelay/walk_delay))
+		. = CONFIG_GET(number/movedelay/walk_delay)
 
 /mob/living/carbon/slip(knockdown_amount, obj/O, lube, paralyze, force_drop)
 	if(movement_type & FLYING)
@@ -41,5 +41,5 @@
 			set_nutrition(NUTRITION_LEVEL_FED - 1)	//just less than feeling vigorous
 		else if(nutrition && stat != DEAD)
 			adjust_nutrition(-(HUNGER_FACTOR/10))
-			if(real_move_delay >= MOVE_WALK_THRESHOLD)
+			if(real_move_delay >= CONFIG_GET(number/movedelay/walk_delay))
 				adjust_nutrition(-(HUNGER_FACTOR/10))

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -9,6 +9,8 @@
 			. += 6 - 3*get_num_arms() //crawling is harder with fewer arms
 		if(legcuffed)
 			. += legcuffed.slowdown
+	if(m_intent == MOVE_INTENT_WALK && . < MOVE_WALK_THRESHOLD)
+		. = MOVE_WALK_THRESHOLD
 
 /mob/living/carbon/slip(knockdown_amount, obj/O, lube, paralyze, force_drop)
 	if(movement_type & FLYING)


### PR DESCRIPTION
:cl:
:tweak: Certain objects and effects that were psychically able to tell whether
you have the intent to walk or run, are now triggered instead by whether
you're actually walking or running.
/:cl:

This means that as long as you are moving at or slower than walking
speed that you will not slip on wet floors or trigger portable flashers.

Limping slowly in run-intent no longer triggers run-intent stuff.
Moving really fast while in walk-intent should **NOT** trigger run-intent stuff.