### PR TITLE
Pumps, scrubbers, and canisters destroyed by explosions now release their contents.

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -43,7 +43,7 @@
 		T.assume_air(air_contents)
 		T.air_update_turf()
 
-		return ..()
+	return ..()
 
 /obj/machinery/portable_atmospherics/process_atmos()
 	if(!connected_port) // Pipe network handles reactions if connected.

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -43,8 +43,7 @@
 		T.assume_air(air_contents)
 		T.air_update_turf()
 
-
-	..()
+		return ..()
 
 /obj/machinery/portable_atmospherics/process_atmos()
 	if(!connected_port) // Pipe network handles reactions if connected.

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -33,6 +33,19 @@
 
 	return ..()
 
+/obj/machinery/portable_atmospherics/ex_act(severity, target)
+	if(severity == 1 || target == src)
+		if(resistance_flags & INDESTRUCTIBLE)
+			return //Indestructable cans shouldn't release air
+
+		//This explosion will destroy the can, release its air.
+		var/turf/T = get_turf(src)
+		T.assume_air(air_contents)
+		T.air_update_turf()
+
+
+	..()
+
 /obj/machinery/portable_atmospherics/process_atmos()
 	if(!connected_port) // Pipe network handles reactions if connected.
 		air_contents.react(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Air canisters, scrubbers, and pumps will now release their contents into the air when damaged by a large explosion, instead of silently deleting them.

## Why It's Good For The Game
Up until now, blowing up C4 planted on an air canister deleted the canister without releasing its air.  More than one traitor atmos tech has learned this the hard way.  Besides, it makes no sense.

### Balance Considerations
While this fix does give traitor atmos techs, CEs, and scientists a powerful new tool, I don't think it'll be a serious issue.
 - C4 generally isn't available outside of a few gamemodes, and will get you arrested if you're caught with it.
- Most targets can infer that a gas can with C4 on it is bad news.
- There are already ways to release a death can quickly, they just require you to be right next to it.

## Changelog
:cl:
fix: Portable atmospherics machinery now releases its air when it explodes.
/:cl: