### PR TITLE
Disembowelment now only works if you are dead/in critical 

### DIFF
--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -446,6 +446,11 @@
 	max_stamina_damage = 100
 	var/obj/item/cavity_item
 
+/obj/item/bodypart/chest/can_dismember(obj/item/I)
+	if(health <= crit_threshold)
+		return FALSE
+	return ..()
+
 /obj/item/bodypart/chest/Destroy()
 	QDEL_NULL(cavity_item)
 	return ..()

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -447,7 +447,7 @@
 	var/obj/item/cavity_item
 
 /obj/item/bodypart/chest/can_dismember(obj/item/I)
-	if(health <= crit_threshold)
+	if(!((owner.stat == DEAD) || owner.InFullCritical()))
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disembowelment now only works if a mob is either dead or in critical condition, as opposed to the complete RNG it used to be (RNG now limited to those two health states). 

## Why It's Good For The Game

Its not fair or fun to have your organs removed in one hit by a rando with an esword. Disembowelment results in you dying a short time later, with no chance of defibrillation. 

## Changelog
:cl: wesoda25
balance: disembowelment no longer works on mobs that aren't dead or in critical condition
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

also thanks to imsxz and 4dplanner with helping me on this