### PR TITLE
Changes abandoned crates to require only 2 digits to be hacked

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -7,8 +7,8 @@
 	integrity_failure = 0 //no breaking open the crate
 	var/code = null
 	var/lastattempt = null
-	var/attempts = 10
-	var/codelen = 4
+	var/attempts = 5
+	var/codelen = 2
 	tamperproof = 90
 
 /obj/structure/closet/crate/secure/loot/Initialize()


### PR DESCRIPTION
## About The Pull Request

Changes abandoned crates (the one with the hacking minigame) to give you only 5 attempts to hack it, plus lowering the amount of digits required from 4 to 2.

## Why It's Good For The Game

No one in their whole entire life has hacked these crates successfully without using a mastermind solver (and cheating is bad), there's some good loot in there if you're lucky but chances are you're not going to even bother with them to begin with due to the time it takes and the risk factor of them blowing up on you.
This changes it so that anyone with some amount of determination is able to hack open one without smashing their head against the wall repeatedly.

## Changelog
:cl: Vile Beggar
tweak: Abandoned crates now give you 5 attempts to hack them, but in return they only require 2 digits to be hacked.
/:cl: