### PR TITLE
fixes printing saved mutations

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -354,7 +354,10 @@
 			for(var/datum/mutation/human/HM in stored_mutations)
 				var/i = stored_mutations.Find(HM)
 				temp_html += "<tr><td><a href='?src=[REF(src)];task=inspectstorage;num=[i]'>[HM.name]</a></td>"
-				temp_html += "<td><a href='?src=[REF(src)];task=exportdiskmut;path=[HM.type]'>Export</a></td>"
+				if(diskette)
+					temp_html += "<td><a href='?src=[REF(src)];task=exportdiskmut;path=[HM.type]'>Export</a></td>"
+				else
+					temp_html += "<td><td><span class='linkOff'>Export</span></td>"
 				temp_html += "<td><a href='?src=[REF(src)];task=deletemut;num=[i]'>Delete</a></td>"
 				if(combine == HM.type)
 					temp_html += "<td><span class='linkOff'>Combine</span></td></tr>"
@@ -367,7 +370,6 @@
 				var/obj/item/chromosome/CM = stored_chromosomes[i]
 				temp_html += "<td><a href='?src=[REF(src)];task=ejectchromosome;num=[i]'>[CM.name]</a></td><br>"
 			temp_html += "</table>"
-
 		else
 			temp_html += status
 			temp_html += buttons
@@ -883,7 +885,9 @@
 /obj/machinery/computer/scan_consolenew/proc/get_valid_mutation(mutation)
 	var/mob/living/carbon/C = get_viable_occupant()
 	if(C)
-		return C.dna.get_mutation(mutation)
+		var/datum/mutation/human/HM = C.dna.get_mutation(mutation)
+		if(HM)
+			return HM
 	for(var/datum/mutation/human/A in stored_mutations)
 		if(A.type == mutation)
 			return A


### PR DESCRIPTION
fixes #42816 
Optimization gone wrong
:cl:
fix: You can now print mutators and stuff again from storage if the occupant doesnt have it
/:cl:

No PRB please, my fault
