### PR TITLE
Adds varying cooldowns to different borg module flashes

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -223,7 +223,7 @@
 	cooldown = 40
 	
 /obj/item/assembly/flash/cyborg/tier_2
-	cooldown = 120
+	cooldown = 140
 
 /obj/item/assembly/flash/cyborg/tier_3
 	cooldown = 200

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -200,11 +200,19 @@
 
 /obj/item/assembly/flash/cyborg/attack(mob/living/M, mob/user)
 	..()
-	new /obj/effect/temp_visual/borgflash(get_turf(src))
+	if(cooldown)
+		return FALSE
+	else
+		new /obj/effect/temp_visual/borgflash(get_turf(src))
+		return 
 
 /obj/item/assembly/flash/cyborg/attack_self(mob/user)
 	..()
-	new /obj/effect/temp_visual/borgflash(get_turf(src))
+	if(cooldown)
+		return FALSE
+	else
+		new /obj/effect/temp_visual/borgflash(get_turf(src))
+		return 
 
 /obj/item/assembly/flash/cyborg/attackby(obj/item/W, mob/user, params)
 	return

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -139,6 +139,8 @@
 			M.confused += min(power, diff)
 
 /obj/item/assembly/flash/attack(mob/living/M, mob/user)
+	if(crit_fail || (world.time < last_trigger + cooldown))
+		return FALSE	
 	if(!try_use_flash(user))
 		return FALSE
 	if(iscarbon(M))
@@ -158,6 +160,8 @@
 	user.visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>", "<span class='warning'>You fail to blind [M] with the flash!</span>")
 
 /obj/item/assembly/flash/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
+	if(crit_fail || (world.time < last_trigger + cooldown))
+		return FALSE	
 	if(holder)
 		return FALSE
 	if(!AOE_flash(FALSE, 3, 5, FALSE, user))
@@ -199,18 +203,12 @@
 /obj/item/assembly/flash/cyborg
 
 /obj/item/assembly/flash/cyborg/attack(mob/living/M, mob/user)
-	if(world.time < last_trigger + cooldown)
-		return FALSE
-	else
-		new /obj/effect/temp_visual/borgflash(get_turf(src))
-		..()
+    if(..())
+        new /obj/effect/temp_visual/borgflash(get_turf(src))
 
 /obj/item/assembly/flash/cyborg/attack_self(mob/user)
-	if(world.time < last_trigger + cooldown)
-		return FALSE
-	else
-		new /obj/effect/temp_visual/borgflash(get_turf(src))
-		..()
+    if(..())
+        new /obj/effect/temp_visual/borgflash(get_turf(src))
 
 /obj/item/assembly/flash/cyborg/attackby(obj/item/W, mob/user, params)
 	return

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -211,6 +211,15 @@
 /obj/item/assembly/flash/cyborg/screwdriver_act(mob/living/user, obj/item/I)
 	return
 
+/obj/item/assembly/flash/cyborg/tier_1
+	cooldown = 4
+	
+/obj/item/assembly/flash/cyborg/tier_2
+	cooldown = 12
+
+/obj/item/assembly/flash/cyborg/tier_3
+	cooldown = 20
+
 /obj/item/assembly/flash/memorizer
 	name = "memorizer"
 	desc = "If you see this, you're not likely to remember it any time soon."

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -212,13 +212,13 @@
 	return
 
 /obj/item/assembly/flash/cyborg/tier_1
-	cooldown = 4
+	cooldown = 40
 	
 /obj/item/assembly/flash/cyborg/tier_2
-	cooldown = 12
+	cooldown = 120
 
 /obj/item/assembly/flash/cyborg/tier_3
-	cooldown = 20
+	cooldown = 200
 
 /obj/item/assembly/flash/memorizer
 	name = "memorizer"

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -199,12 +199,18 @@
 /obj/item/assembly/flash/cyborg
 
 /obj/item/assembly/flash/cyborg/attack(mob/living/M, mob/user)
-    if(..())
-        new /obj/effect/temp_visual/borgflash(get_turf(src))
+	if(world.time < last_trigger + cooldown)
+		return FALSE
+	else
+		new /obj/effect/temp_visual/borgflash(get_turf(src))
+		..()
 
 /obj/item/assembly/flash/cyborg/attack_self(mob/user)
-    if(..())
-        new /obj/effect/temp_visual/borgflash(get_turf(src))
+	if(world.time < last_trigger + cooldown)
+		return FALSE
+	else
+		new /obj/effect/temp_visual/borgflash(get_turf(src))
+		..()
 
 /obj/item/assembly/flash/cyborg/attackby(obj/item/W, mob/user, params)
 	return

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -199,20 +199,12 @@
 /obj/item/assembly/flash/cyborg
 
 /obj/item/assembly/flash/cyborg/attack(mob/living/M, mob/user)
-	..()
-	if(cooldown)
-		return FALSE
-	else
-		new /obj/effect/temp_visual/borgflash(get_turf(src))
-		return 
+    if(..())
+        new /obj/effect/temp_visual/borgflash(get_turf(src))
 
 /obj/item/assembly/flash/cyborg/attack_self(mob/user)
-	..()
-	if(cooldown)
-		return FALSE
-	else
-		new /obj/effect/temp_visual/borgflash(get_turf(src))
-		return 
+    if(..())
+        new /obj/effect/temp_visual/borgflash(get_turf(src))
 
 /obj/item/assembly/flash/cyborg/attackby(obj/item/W, mob/user, params)
 	return

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -235,7 +235,7 @@
 /obj/item/robot_module/standard
 	name = "Standard"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/tier_3,
 		/obj/item/reagent_containers/borghypo/epi,
 		/obj/item/healthanalyzer,
 		/obj/item/weldingtool/largetank/cyborg,
@@ -261,7 +261,7 @@
 /obj/item/robot_module/medical
 	name = "Medical"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/tier_2,
 		/obj/item/healthanalyzer,
 		/obj/item/reagent_containers/borghypo,
 		/obj/item/reagent_containers/glass/beaker/large,
@@ -292,7 +292,7 @@
 /obj/item/robot_module/engineering
 	name = "Engineering"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/tier_3,
 		/obj/item/borg/sight/meson,
 		/obj/item/construction/rcd/borg,
 		/obj/item/pipe_dispenser,
@@ -327,7 +327,7 @@
 /obj/item/robot_module/security
 	name = "Security"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/tier_1,
 		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/melee/baton/loaded,
 		/obj/item/gun/energy/disabler/cyborg,
@@ -359,7 +359,7 @@
 /obj/item/robot_module/peacekeeper
 	name = "Peacekeeper"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/tier_1,
 		/obj/item/cookiesynth,
 		/obj/item/harmalarm,
 		/obj/item/reagent_containers/borghypo/peace,
@@ -384,7 +384,7 @@
 /obj/item/robot_module/janitor
 	name = "Janitor"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/tier_2,
 		/obj/item/screwdriver/cyborg,
 		/obj/item/crowbar/cyborg,
 		/obj/item/stack/tile/plasteel/cyborg,
@@ -431,7 +431,7 @@
 /obj/item/robot_module/clown
 	name = "Clown"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/tier_2,
 		/obj/item/toy/crayon/rainbow,
 		/obj/item/instrument/bikehorn,
 		/obj/item/stamp/clown,
@@ -462,7 +462,7 @@
 /obj/item/robot_module/butler
 	name = "Service"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/tier_2,
 		/obj/item/reagent_containers/food/drinks/drinkingglass,
 		/obj/item/reagent_containers/food/condiment/enzyme,
 		/obj/item/pen,
@@ -516,7 +516,7 @@
 /obj/item/robot_module/miner
 	name = "Miner"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/tier_3,
 		/obj/item/borg/sight/meson,
 		/obj/item/storage/bag/ore/cyborg,
 		/obj/item/pickaxe/drill/cyborg,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Different borg modules now have different types of flashes, tiers 1 to 3. Do note, a normal flash stun lasts ~12 seconds.

**Tier 1**
_Cooldown:_ 4 seconds
_Modules:_ Security, Peacekeeper

**Tier 2**
_Cooldown:_ 14 seconds
_Modules:_ Medical, Janitor, Clown, Butler

**Tier 3**
_Cooldown:_ 20 seconds
_Modules:_ Mining, Standard, Engineering


## Why It's Good For The Game

One of the greatest flaws of a majority of the servers silicon players is their tendency to validhunt. Installing cooldowns on borg flashes will decrease their mentality of catching criminals, and force players to do their best to prevent harm. Instead of chain stunning a traitor "because they can be harmful", borgs will now have to get creative, bolting the criminal down, which gives them room for escape. 

Similarly, it will cement certain modules as more powerful in terms of stuns, due to their intended purpose. Peacekeeper and Security (updated even though its gone and should never come back) both get the shortest cooldown, as they are intended to prevent harm, which a flash is useful for. Medical, Janitor, Clown, and Butler modules all get a medium cooldown, which ends a bit after the stun for a flash expires (making chain stunning not possible). Mining, Standard, and Engineering modules, the most powerful and a valid hunters first choice, get the longest cooldown. This serves to enforce them as their intended functions, engineering fixing things, mining mining, and standard doing whatever the fuck they're intended for. 

Expanding on this, cooldowns will make the modules more equally balanced. While you might get self repairing as an engiborg, or ranged attack as mining borg, you also get a much weaker flash variant. This will make players more willing to experiment with other borg modules, as opposed to just what was considered the strongest. 

## Changelog
:cl:
add: borg flash variants tiers 1-3
balance: mining, engineering, and standard modules now have a 20 second flash cooldown
balance: medical, janitor, clown, and butler modules now have a 14 second flash cooldown
balance: peacekeeper and security modules now have a 4 second flash cooldown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
