### PR TITLE
Revolver Unloading Runtime Fix

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -305,7 +305,7 @@
 			var/obj/item/ammo_casing/CB
 			CB = magazine.get_round(FALSE)
 			chambered = null
-			if (CB != null)
+			if (CB)
 				CB.forceMove(drop_location())
 				CB.bounce_away(FALSE, NONE)
 				num_unloaded++

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -305,9 +305,10 @@
 			var/obj/item/ammo_casing/CB
 			CB = magazine.get_round(FALSE)
 			chambered = null
-			CB.forceMove(drop_location())
-			CB.bounce_away(FALSE, NONE)
-			num_unloaded++
+			if (CB != null)
+				CB.forceMove(drop_location())
+				CB.bounce_away(FALSE, NONE)
+				num_unloaded++
 		if (num_unloaded)
 			to_chat(user, "<span class='notice'>You unload [num_unloaded] [cartridge_wording]\s from [src].</span>")
 			playsound(user, eject_sound, eject_sound_volume, eject_sound_vary)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a weird runtime with anything that uses BOLT_TYPE_NO_BOLT. Most noticable when unloading the russian revolver.

## Why It's Good For The Game

Fixes broken shit

No CL, fixes a runtime that barely affected functionality in a somewhat uncommon situation.

Closes #42831 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
