### PR TITLE
Lets ghosts/observers view photos from far away

### DIFF
--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -64,7 +64,7 @@
 /obj/item/photo/examine(mob/user)
 	..()
 
-	if(in_range(src, user))
+	if(in_range(src, user) || isobserver(user))
 		show(user)
 	else
 		to_chat(user, "<span class='warning'>You need to get closer to get a good look at this photo!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR lets ghosts view photos even when they're not in regular view range.

## Why It's Good For The Game

This puts photos in line with a lot of other items that have removed proximity checks for ghosts/observers.

## Changelog
:cl: Denton
tweak: Ghosts/observers can now look at photos from far away.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
