### PR TITLE
Makes unloading ballistic weapons better (Namely revolvers)

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -98,7 +98,6 @@
 			playsound(src, 'sound/weapons/bulletinsert.ogg', 60, TRUE)
 		A.update_icon()
 		update_icon()
-
 	return num_loaded
 
 /obj/item/ammo_box/attack_self(mob/user)
@@ -131,6 +130,12 @@
 		if(bullet && (bullet.BB || countempties))
 			boolets++
 	return boolets
+
+/obj/item/ammo_box/magazine/proc/ammo_list(drop_list = FALSE)
+	var/list/L = stored_ammo.Copy()
+	if(drop_list)
+		stored_ammo.Cut()
+	return L
 
 /obj/item/ammo_box/magazine/proc/empty_magazine()
 	var/turf_mag = get_turf(src)

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -22,6 +22,16 @@
 	for(var/i in 1 to rand(0, max_ammo*2))
 		rotate()
 
+/obj/item/ammo_box/magazine/internal/cylinder/ammo_list(drop_list = FALSE)
+	var/list/L = list()
+	for(var/i=1 to stored_ammo.len)
+		var/obj/item/ammo_casing/bullet = stored_ammo[i]
+		if(bullet)
+			L.Add(bullet)
+			if(drop_list)//We have to maintain the list size, to emulate a cylinder
+				stored_ammo[i] = null
+	return L
+
 /obj/item/ammo_box/magazine/internal/cylinder/give_round(obj/item/ammo_casing/R, replace_spent = 0)
 	if(!R || (caliber && R.caliber != caliber) || (!caliber && R.type != ammo_type))
 		return FALSE

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -127,7 +127,7 @@
 		chambered = magazine.get_round((bolt_type == BOLT_TYPE_NO_BOLT))
 		if (bolt_type != BOLT_TYPE_OPEN)
 			chambered.forceMove(src)
-	
+
 /obj/item/gun/ballistic/proc/rack(mob/user = null)
 	if (bolt_type == BOLT_TYPE_NO_BOLT) //If there's no bolt, nothing to rack
 		return
@@ -205,7 +205,7 @@
 				eject_magazine(user, FALSE, AM)
 			else
 				to_chat(user, "<span class='notice'>There's already a [magazine_wording] in \the [src].</span>")
-		return	
+		return
 	if (istype(A, /obj/item/ammo_casing) || istype(A, /obj/item/ammo_box))
 		if (bolt_type == BOLT_TYPE_NO_BOLT || internal_magazine)
 			if (chambered && !chambered.BB)
@@ -301,10 +301,7 @@
 			return
 	if(bolt_type == BOLT_TYPE_NO_BOLT)
 		var/num_unloaded = 0
-		while (get_ammo() > 0)
-			var/obj/item/ammo_casing/CB
-			CB = magazine.get_round(FALSE)
-			chambered = null
+		for(var/obj/item/ammo_casing/CB in get_ammo_list(TRUE, TRUE))
 			CB.forceMove(drop_location())
 			CB.bounce_away(FALSE, NONE)
 			num_unloaded++
@@ -320,7 +317,7 @@
 	if (recent_rack > world.time)
 		return
 	recent_rack = world.time + rack_delay
-	rack(user)	
+	rack(user)
 	return
 
 
@@ -342,6 +339,15 @@
 	if (magazine)
 		boolets += magazine.ammo_count()
 	return boolets
+
+/obj/item/gun/ballistic/proc/get_ammo_list(countchambered = TRUE, drop_all = FALSE)
+	var/list/rounds = list()
+	if(chambered && countchambered)
+		rounds.Add(chambered)
+		if(drop_all)
+			chambered = null
+	rounds.Add(magazine.ammo_list(drop_all))
+	return rounds
 
 #define BRAINS_BLOWN_THROW_RANGE 3
 #define BRAINS_BLOWN_THROW_SPEED 1


### PR DESCRIPTION
## About The Pull Request

Revolvers would previously use a while loop to unload all of their ammunition, within this while loop there would be direct-access attempts to an array, with assumption that that area would not be null, but was because of how the revolvers cylinder is emulated (List of nulls to max_ammo, with each new round populating the nearest empty location.)

This semi-rewrite adds the ammo_list function, which returns all ammunition being held by the gun in a list. This is then itterated through to unload each bullet. An override is made for cylinders so as to preserve the previous functionality of a list of nulls.

## Why It's Good For The Game

More efficient, and fixes a runtime

closes #42831

## Changelog
Entirely backend, so no changelog necessary.