### PR TITLE
Adds ghost notification for powersinks, lets observers jump to active sinks

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -102,7 +102,9 @@
 				"<span class='italics'>You hear a click.</span>")
 			message_admins("Power sink activated by [ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(src)]")
 			log_game("Power sink activated by [key_name(user)] at [AREACOORD(src)]")
+			notify_ghosts("\A [src] has been activated at [get_area(src)]!", source = src, action = NOTIFY_ORBIT)
 			set_mode(OPERATING)
+			GLOB.poi_list |= src
 
 		if(OPERATING)
 			user.visible_message( \
@@ -114,6 +116,7 @@
 /obj/item/powersink/process()
 	if(!attached)
 		set_mode(DISCONNECTED)
+		GLOB.poi_list -= src
 		return
 
 	var/datum/powernet/PN = attached.powernet


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds active powersinks to the "haunt" menu and plays a ghost notification every time one is activated.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes it easier for ghosts (and admemes) to find out about powersinks. Same as with bombs, C4 and so on.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
tweak: Ghosts now get notified about activated powersinks. Active powersinks appear in the "haunt" menu too.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
