### PR TITLE
Fixes husked humans keeping hair

### DIFF
--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -28,14 +28,16 @@
 
 /mob/living/carbon/human/cure_husk(list/sources)
 	. = ..()
-	update_hair()
+	if(.)
+		update_hair()
 
 /mob/living/carbon/human/become_husk(source)
 	if(istype(dna.species, /datum/species/skeleton)) //skeletons shouldn't be husks.
 		cure_husk()
 		return
 	. = ..()
-	update_hair()
+	if(.)
+		update_hair()
 
 /mob/living/carbon/human/set_drugginess(amount)
 	..()

--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -28,16 +28,14 @@
 
 /mob/living/carbon/human/cure_husk(list/sources)
 	. = ..()
-	if(.)
-		update_hair()
+	update_hair()
 
 /mob/living/carbon/human/become_husk(source)
 	if(istype(dna.species, /datum/species/skeleton)) //skeletons shouldn't be husks.
 		cure_husk()
 		return
 	. = ..()
-	if(.)
-		update_hair()
+	update_hair()
 
 /mob/living/carbon/human/set_drugginess(amount)
 	..()

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -420,11 +420,13 @@
 	if(!has_trait(TRAIT_HUSK))
 		remove_trait(TRAIT_DISFIGURED, "husk")
 		update_body()
+		return TRUE
 
 /mob/living/proc/become_husk(source)
 	if(!has_trait(TRAIT_HUSK))
 		add_trait(TRAIT_DISFIGURED, "husk")
 		update_body()
+		. = TRUE
 	add_trait(TRAIT_HUSK, source)
 
 /mob/living/proc/cure_fakedeath(list/sources)


### PR DESCRIPTION
:cl: Poojawa
fix: fixed a bug where husks kept their hair if husked by fire damage or Ling succ
/:cl:

Kinda weird to have a grey corpse with bright lime hair and beard. It literally never called the proc but applied all other effects of being husked. 

I don't even know why. But removing this check allowed update_hair to be called to carry out the code in the various limb codes.

damnifino.