### PR TITLE
[READY][TESTED]Plasmeme Gulag

### DIFF
--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -30,7 +30,8 @@ The console is located at computer/gulag_teleporter.dm
 		/obj/item/clothing/head/helmet/space/plasmaman,
 		/obj/item/tank/internals,
 		/obj/item/clothing/mask/breath,
-		/obj/item/clothing/mask/gas))
+		/obj/item/clothing/mask/gas,
+		/obj/item/restraints/handcuffs))
 
 /obj/machinery/gulag_teleporter/Initialize()
 	. = ..()
@@ -138,9 +139,6 @@ The console is located at computer/gulag_teleporter.dm
 	for(var/obj/item/W in mob_occupant)
 		if(!is_type_in_typecache(W, telegulag_required_items))
 			if(mob_occupant.temporarilyRemoveItemFromInventory(W))
-				if(istype(W, /obj/item/restraints/handcuffs))
-					W.forceMove(get_turf(src))
-					continue
 				if(linked_reclaimer)
 					linked_reclaimer.stored_items[mob_occupant] += W
 					linked_reclaimer.contents += W

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -136,16 +136,17 @@ The console is located at computer/gulag_teleporter.dm
 		linked_reclaimer.stored_items[occupant] = list()
 	var/mob/living/mob_occupant = occupant
 	for(var/obj/item/W in mob_occupant)
-		if(!is_type_in_typecache(W, telegulag_required_items) && mob_occupant.temporarilyRemoveItemFromInventory(W))
-			if(istype(W, /obj/item/restraints/handcuffs))
-				W.forceMove(get_turf(src))
-				continue
-			if(linked_reclaimer)
-				linked_reclaimer.stored_items[mob_occupant] += W
-				linked_reclaimer.contents += W
-				W.forceMove(linked_reclaimer)
-			else
-				W.forceMove(src)
+		if(!is_type_in_typecache(W, telegulag_required_items))
+			if(mob_occupant.temporarilyRemoveItemFromInventory(W))
+				if(istype(W, /obj/item/restraints/handcuffs))
+					W.forceMove(get_turf(src))
+					continue
+				if(linked_reclaimer)
+					linked_reclaimer.stored_items[mob_occupant] += W
+					linked_reclaimer.contents += W
+					W.forceMove(linked_reclaimer)
+				else
+					W.forceMove(src)
 
 /obj/machinery/gulag_teleporter/proc/handle_prisoner(obj/item/id, datum/data/record/R)
 	if(!ishuman(occupant))

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -30,8 +30,7 @@ The console is located at computer/gulag_teleporter.dm
 		/obj/item/clothing/head/helmet/space/plasmaman,
 		/obj/item/tank/internals,
 		/obj/item/clothing/mask/breath,
-		/obj/item/clothing/mask/gas,
-		/obj/item/restraints/handcuffs))
+		/obj/item/clothing/mask/gas))
 
 /obj/machinery/gulag_teleporter/Initialize()
 	. = ..()
@@ -139,6 +138,9 @@ The console is located at computer/gulag_teleporter.dm
 	for(var/obj/item/W in mob_occupant)
 		if(!is_type_in_typecache(W, telegulag_required_items))
 			if(mob_occupant.temporarilyRemoveItemFromInventory(W))
+				if(istype(W, /obj/item/restraints/handcuffs))
+					W.forceMove(get_turf(src))
+					continue
 				if(linked_reclaimer)
 					linked_reclaimer.stored_items[mob_occupant] += W
 					linked_reclaimer.contents += W


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
```
//visibly unequips I but it is NOT MOVED AND REMAINS IN SRC
//item MUST BE FORCEMOVE'D OR QDEL'D
/mob/proc/temporarilyRemoveItemFromInventory(obj/item/I, force = FALSE, idrop = TRUE)
return doUnEquip(I, force, null, TRUE, idrop)
```

If I read this correctly, when you call this it just unequip. Since it returns true to being able to get removed, but returns false because it is on the plasmeme list, the item never get forcemoved, just removed.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Plasmemes can now go to gulag

## Changelog
🆑
fix: Benevolent Nanotrasen makes gulag available for everyone! (Plasmamen retain their equipment and don't die.)
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Web-pr. Will test tonight, but will leave here for feedback
Edit: Fixes #42472 