### PR TITLE
Bans now only default to banning ip if a permaban.

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -97,16 +97,16 @@
 	<div class='inputbox'></div></label>
 	<input type='text' name='keytext' size='26' value='[player_key]'>
 	<label class='inputlabel checkbox'>IP:
-	<input type='checkbox' id='ipcheck' name='ipcheck' value='1'[player_ip ? " checked": ""]>
+	<input type='checkbox' id='ipcheck' name='ipcheck' value='1'[isnull(duration) " checked": ""]>
 	<div class='inputbox'></div></label>
 	<input type='text' name='iptext' size='18' value='[player_ip]'>
 	<label class='inputlabel checkbox'>CID:
-	<input type='checkbox' id='cidcheck' name='cidcheck' value='1'[player_cid ? " checked": ""]>
+	<input type='checkbox' id='cidcheck' name='cidcheck' value='1' checked>
 	<div class='inputbox'></div></label>
 	<input type='text' name='cidtext' size='14' value='[player_cid]'>
 	<br>
 	<label class='inputlabel checkbox'>Use IP and CID from last connection of key
-	<input type='checkbox' id='lastconn' name='lastconn' value='1'>
+	<input type='checkbox' id='lastconn' name='lastconn' value='1' [(isnull(duration) && !player_ip) || (!player_cid) ? " checked": ""]>
 	<div class='inputbox'></div></label>
 	<label class='inputlabel checkbox'>Applies to Admins
 	<input type='checkbox' id='applyadmins' name='applyadmins' value='1'[applies_to_admins ? " checked": ""]>
@@ -309,17 +309,16 @@
 		if(!player_key)
 			error_state += "Key was ticked but none was provided."
 	if(href_list["lastconn"])
-		use_last_connection = TRUE
-		if(!player_key)
-			error_state += "A key must be provided to use IP and CID from last connection."
+		if(player_key)
+			use_last_connection = TRUE
 	else
 		if(href_list["ipcheck"])
-			player_ip = href_list["iptext"]
-			if(!player_ip)
+			player_ip = href_list["iptext"] || ""
+			if(!player_ip && !use_last_connection)
 				error_state += "IP was ticked but none was provided."
 		if(href_list["cidcheck"])
-			player_cid = href_list["cidtext"]
-			if(!player_cid)
+			player_cid = href_list["cidtext"] || ""
+			if(!player_cid && !use_last_connection)
 				error_state += "CID was ticked but none was provided."
 	if(!use_last_connection && !player_ip && !player_cid && !player_key)
 		error_state += "At least a key, IP or CID must be provided."
@@ -405,13 +404,15 @@
 		if(query_create_ban_get_player.NextRow())
 			player_key = query_create_ban_get_player.item[1]
 			if(use_last_connection)
-				player_ip = query_create_ban_get_player.item[2]
-				player_cid = query_create_ban_get_player.item[3]
+				if (!isnull(player_ip))
+					player_ip = query_create_ban_get_player.item[2]
+				if (!isnull(player_cid))
+					player_cid = query_create_ban_get_player.item[3]
 		else
 			if(use_last_connection)
-				to_chat(usr, "<span class='danger'>Ban not created. [player_key]/([player_ckey]) hasn't been seen before, unable to use IP and CID from last connection.</span>")
-				qdel(query_create_ban_get_player)
-				return
+				if(alert(usr, "[player_key]/([player_ckey]) has not been seen before, unable to use IP and CID from last connection. Are you sure you want to create a ban for them?", "Unknown key", "Yes", "No", "Cancel") != "Yes")
+					qdel(query_create_ban_get_player)
+					return
 			else
 				if(alert(usr, "[player_key]/([player_ckey]) has not been seen before, are you sure you want to create a ban for them?", "Unknown key", "Yes", "No", "Cancel") != "Yes")
 					qdel(query_create_ban_get_player)

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -97,7 +97,7 @@
 	<div class='inputbox'></div></label>
 	<input type='text' name='keytext' size='26' value='[player_key]'>
 	<label class='inputlabel checkbox'>IP:
-	<input type='checkbox' id='ipcheck' name='ipcheck' value='1'[isnull(duration) " checked": ""]>
+	<input type='checkbox' id='ipcheck' name='ipcheck' value='1'[isnull(duration) ? " checked" : ""]>
 	<div class='inputbox'></div></label>
 	<input type='text' name='iptext' size='18' value='[player_ip]'>
 	<label class='inputlabel checkbox'>CID:


### PR DESCRIPTION
CID defaults to always checked.

Use IP and CID from last connection now defaults to enabled unless all the default checked values are provided. 

Use IP and CID from last connection now only fills in checked values, rather then forcing both IP and CID.

Use IP and CID from last connection no longer triggers an error if the user can not be found, instead asking the banning admin if the want to continue (same behavior as when this happens without that option checked).

The main reason behind this is that your avg 1 to 2 day ban shouldn't impact everybody on the same network, especially when it comes to colleges and shared internet. The old system worked such that ip bans were only possible on perma server bans.

Note the IP check default only applies to cases where the ban table is pre-filled by the code that opened it. I could look at tweaking the javascript to also make it check and uncheck IP as the expires box is changed between permanent.

:cl:
admin: Some tweaks to the ban interface:
add: Bans apply to computer_ids by default
add: Bans only apply to IPs by default if its a permaban.
admin: Note: The behavior of the "Use IP and CID from last connection of key" box has been changed. It now only fills in checked values, where as before it would error if CID or IP was check.
/:cl:
