### PR TITLE
Prevents soviet and capitalist golems from being eligible in random golem choices

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1025,6 +1025,7 @@
 	inherent_traits = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER)
 	info_text = "As a <span class='danger'>Capitalist Golem</span>, your fist spreads the powerful industrializing light of capitalism."
 	changesource_flags = MIRROR_BADMIN
+	random_eligible = FALSE
 
 	var/last_cash = 0
 	var/cash_cooldown = 100
@@ -1068,6 +1069,7 @@
 	inherent_traits = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER)
 	info_text = "As a <span class='danger'>Soviet Golem</span>, your fist spreads the bright soviet light of communism."
 	changesource_flags = MIRROR_BADMIN
+	random_eligible = FALSE
 
 /datum/species/golem/soviet/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -509,7 +509,6 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/golem/random
 	mutationtext = "<span class='danger'>The pain subsides. You feel... rocky.</span>"
-	can_synth = FALSE
 
 /datum/reagent/mutationtoxin/abductor
 	name = "Abductor Mutation Toxin"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -509,6 +509,7 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/golem/random
 	mutationtext = "<span class='danger'>The pain subsides. You feel... rocky.</span>"
+	can_synth = FALSE
 
 /datum/reagent/mutationtoxin/abductor
 	name = "Abductor Mutation Toxin"


### PR DESCRIPTION
:cl:
tweak: Soviet and Capitalist golems no longer appear in opportunities where a random golem species was selected, primarily golem mutation toxin.
/:cl:

This PR is necessary because of the stupid conversion meme golems that immediately hijack any round they sneak their way into. Intended as an admin only feature entirely and ended up sneaking through anyways through several loopholes. This closes the last remaining loophole that I'm aware of. To briefly describe it, strange seeds can get the golem mutation toxin, which randomly chooses *any* golem race, including the soviet golem and capitalist golem. IIRC it's also available with some obscure xenobio fuckery I can't be arsed to explain. 

You could call this a nerf but it's ridiculously niche and fixing a completely unintended balance consequence so I'm not going to bother arguing about what tag this PR gets.