### PR TITLE
Roundstart Engine Selection (WIP)

### DIFF
--- a/_maps/templates/engine_singularity.dmm
+++ b/_maps/templates/engine_singularity.dmm
@@ -1,0 +1,15 @@
+"a" = (/turf/template_noop,/area/template_noop)
+"b" = (/turf/closed/indestructible/riveted,/area/template_noop)
+
+(1,1,1) = {"
+aaaaaaaaaa
+abaaaaaaba
+aaaaaaaaaa
+aaaaaaaaaa
+aaaabbaaaa
+aaaabbaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+abaaaaaaba
+aaaaaaaaaa
+"}

--- a/_maps/templates/engine_supermatter.dmm
+++ b/_maps/templates/engine_supermatter.dmm
@@ -1,0 +1,15 @@
+"a" = (/turf/template_noop,/area/template_noop)
+"b" = (/turf/closed/indestructible/riveted,/area/template_noop)
+
+(1,1,1) = {"
+baaaaaaaab
+aaaaaaaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+baaaaaaaab
+"}

--- a/_maps/templates/engine_teg.dmm
+++ b/_maps/templates/engine_teg.dmm
@@ -1,0 +1,15 @@
+"a" = (/turf/template_noop,/area/template_noop)
+"b" = (/turf/closed/indestructible/riveted,/area/template_noop)
+
+(1,1,1) = {"
+aaaaaaaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+aaaabbaaaa
+aaaabbaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+"}

--- a/_maps/templates/engine_tesla.dmm
+++ b/_maps/templates/engine_tesla.dmm
@@ -1,0 +1,15 @@
+"a" = (/turf/template_noop,/area/template_noop)
+"b" = (/turf/closed/indestructible/riveted,/area/template_noop)
+
+(1,1,1) = {"
+aaaaaaaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+aaabaabaaa
+aaaaaaaaaa
+aaaaaaaaaa
+aaabaabaaa
+aaaaaaaaaa
+aaaaaaaaaa
+aaaaaaaaaa
+"}

--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -31,6 +31,7 @@ GLOBAL_LIST_EMPTY(tdomeobserve)
 GLOBAL_LIST_EMPTY(tdomeadmin)
 GLOBAL_LIST_EMPTY(prisonwarped)	//list of players already warped
 GLOBAL_LIST_EMPTY(blobstart) //stationloving objects, blobs, santa, respawning devils
+GLOBAL_LIST_EMPTY(enginestart) //spawn location for round-start engine
 GLOBAL_LIST_EMPTY(secequipment) //sec equipment lockers that scale with the number of sec players
 GLOBAL_LIST_EMPTY(deathsquadspawn)
 GLOBAL_LIST_EMPTY(emergencyresponseteamspawn)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -17,6 +17,7 @@ SUBSYSTEM_DEF(mapping)
 
 	var/list/shuttle_templates = list()
 	var/list/shelter_templates = list()
+	var/list/engine_templates = list()
 
 	var/list/areas_in_z = list()
 
@@ -155,6 +156,7 @@ SUBSYSTEM_DEF(mapping)
 	lava_ruins_templates = SSmapping.lava_ruins_templates
 	shuttle_templates = SSmapping.shuttle_templates
 	shelter_templates = SSmapping.shelter_templates
+	engine_templates = SSmapping.engine_templates
 	unused_turfs = SSmapping.unused_turfs
 	turf_reservations = SSmapping.turf_reservations
 	used_turfs = SSmapping.used_turfs
@@ -333,6 +335,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	preloadRuinTemplates()
 	preloadShuttleTemplates()
 	preloadShelterTemplates()
+	preloadEngineTemplates()
 
 /datum/controller/subsystem/mapping/proc/preloadRuinTemplates()
 	// Still supporting bans by filename
@@ -381,6 +384,16 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 
 		shelter_templates[S.shelter_id] = S
 		map_templates[S.shelter_id] = S
+
+/datum/controller/subsystem/mapping/proc/preloadEngineTemplates()
+	for(var/item in subtypesof(/datum/map_template/engine))
+		var/datum/map_template/engine/engine_type = item
+		if(!(initial(engine_type.mappath)))
+			continue
+		var/datum/map_template/engine/S = new engine_type()
+
+		engine_templates[S.engine_id] = S
+		map_templates[S.engine_id] = S
 
 //Manual loading of away missions.
 /client/proc/admin_away()

--- a/code/game/objects/items/engine_selector.dm
+++ b/code/game/objects/items/engine_selector.dm
@@ -1,0 +1,83 @@
+#define STATION_ENGINE_WARP_TIME_LIMIT 3000
+
+/obj/item/engine_selector
+	name = "engine selector beacon"
+	icon = 'icons/obj/items_and_weapons.dmi'
+	icon_state = "blueprints"
+	desc = "A beacon used by the station's Engineering department to warp in an engine of their choice."
+	var/used = FALSE
+	var/response_timer_id = null
+	var/engine_turf //location of the enginewarp landmark
+	var/datum/map_template/engine/template
+
+/obj/item/engine_selector/Initialize()
+	. = ..()
+	response_timer_id = addtimer(CALLBACK(src, .proc/force_engine_placement), STATION_ENGINE_WARP_TIME_LIMIT)
+
+/obj/item/engine_selector/attack_self(mob/user)
+	if(used)
+		to_chat(user, "An engine has already been warped onto the station!")
+		return
+	find_placement()
+	generate_options(user)
+
+/obj/item/engine_selector/proc/find_placement()
+	if(GLOB.enginestart.len > 0)
+		engine_turf = get_turf(pick(GLOB.enginestart))
+	else
+		CRASH("No valid engine markers for placement.")
+
+/obj/item/engine_selector/proc/generate_options(mob/living/M)
+	var/choice = input(M,"Which engine would you like to warp in?","Select an Engine") as null|anything in SSmapping.engine_templates
+	if(!choice || !M.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+		return
+
+	used = TRUE
+	template = SSmapping.engine_templates[choice]
+	template.load(engine_turf, centered = TRUE)
+
+/obj/item/engine_selector/proc/force_engine_placement()//place the engine after x minutes if nobody has actually bothered to place one
+	if(!used)
+		find_placement()
+		var/spinthewheel = pick(SSmapping.engine_templates)
+		template = SSmapping.engine_templates[spinthewheel]
+		template.load(engine_turf, centered = TRUE)
+		used = TRUE
+
+//engine templates
+/datum/map_template/engine
+	name = "big bobg"
+	var/engine_id = "yas"
+
+/datum/map_template/engine/singularity
+	name = "Singularity Containment Prefab"
+	engine_id = "engine_singularity"
+	mappath = "_maps/templates/engine_singularity.dmm"
+
+/datum/map_template/engine/tesla
+	name = "Tesla Containment Prefab"
+	engine_id = "engine_tesla"
+	mappath = "_maps/templates/engine_tesla.dmm"
+
+/datum/map_template/engine/supermatter
+	name = "Supermatter Containment Prefab"
+	engine_id = "engine_supermatter"
+	mappath = "_maps/templates/engine_supermatter.dmm"
+
+/datum/map_template/engine/teg
+	name = "TEG Prefab"
+	engine_id = "engine_teg"
+	mappath = "_maps/templates/engine_teg.dmm"
+
+
+//landmark used to mark where to spawn the engine
+/obj/effect/landmark/enginewarp
+	name = "enginewarp location"
+	icon_state = "blob_start"
+
+/obj/effect/landmark/enginewarp/Initialize(mapload)
+	..()
+	GLOB.enginestart += loc
+	return INITIALIZE_HINT_QDEL
+
+#undef STATION_ENGINE_WARP_TIME_LIMIT

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -801,6 +801,7 @@
 #include "code\game\objects\items\dna_injector.dm"
 #include "code\game\objects\items\documents.dm"
 #include "code\game\objects\items\eightball.dm"
+#include "code\game\objects\items\engine_selector.dm"
 #include "code\game\objects\items\etherealdiscoball.dm"
 #include "code\game\objects\items\extinguisher.dm"
 #include "code\game\objects\items\flamethrower.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
The main idea behind this PR is to turn every roundstart engine area into a blank workspace and give Engineering the ability to warp in a prefab of an engine of their choice. Prefabs will have the basic setup for the selected engine along with some extra supplies to do whatever with. If an engine is not selected via the beacon tool within a reasonable roundstart time, a random one will be selected and warped in automatically.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
More variety to choose from when playing as an Engineer and might encourage people to learn the lesser-used engines (TEG, mostly) or learn why the supermatter eventually replaced the singularity. 

## Changelog
:cl: MMMiracles
add: Engineering now starts without an engine but with the ability to spawn one in.
add: The CE's office spawns with an engine beacon and a plethora of prefabs to choose from for the station engine.
add: Not choosing an engine for the station without a reasonable amount of time will have one randomly selected and warped in for the station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

todo stuff:
- [ ] Make the engine warp look fancier/maybe deadlier if you're under it
- [ ] Proper naming in the engine selector rather than the template's pathtype.
- [ ] The actual mapping of the engines
- [ ] Remapping Box/Meta/Donut to suite this new design.


The main reason I handle the engine checking and spawning through the beacon item itself is so maps that aren't set up to use it don't run into any issues until their updated. I only plan on updating Box/Meta/Donutstation with this, as having to remap every engineering section and give proper fitting universal templates is gonna be enough of pain as is.
