### PR TITLE
Fixes wheelchairs [TESTMERGE ME :)]

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -14,7 +14,7 @@
 	icon = 'icons/obj/objects.dmi'
 	anchored = TRUE
 	can_buckle = TRUE
-	buckle_lying = TRUE
+	buckle_lying = 90
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
 	integrity_failure = 30

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -413,7 +413,7 @@
 	buildstack = /obj/item/stack/sheet/mineral/silver
 	smooth = SMOOTH_FALSE
 	can_buckle = 1
-	buckle_lying = 1
+	buckle_lying = -1
 	buckle_requires_restraints = 1
 	var/mob/living/carbon/human/patient = null
 	var/obj/machinery/computer/operating/computer = null

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -505,9 +505,6 @@
 	return
 
 /turf/handle_fall(mob/faller, forced)
-	if(isliving(faller))
-		var/mob/living/L = faller
-		L.lying = pick(90, 270)
 	if(!forced)
 		return
 	if(has_gravity(src))

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -754,7 +754,6 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "bed"
 	can_buckle = 1
-	buckle_lying = 1
 
 	var/static/list/injected_reagents = list("corazone")
 

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
@@ -3,7 +3,7 @@
 	var/minimum_temperature_difference = 20
 	var/thermal_conductivity = WINDOW_HEAT_TRANSFER_COEFFICIENT
 	color = "#404040"
-	buckle_lying = 1
+	buckle_lying = -1
 	var/icon_temperature = T20C //stop small changes in temperature causing icon refresh
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1068,13 +1068,14 @@
 	var/canstand_involuntary = conscious && !stat_softcrit && !knockdown && !chokehold && !paralyzed && (ignore_legs || has_legs) && !(buckled && buckled.buckle_lying)
 	var/canstand = canstand_involuntary && !resting
 
-	var/should_be_lying = canstand
+	var/should_be_lying = !canstand
 	if(buckled)
 		if(buckled.buckle_lying != -1)
 			should_be_lying = buckled.buckle_lying
 	
 	if(should_be_lying)
 		mobility_flags &= ~(MOBILITY_UI | MOBILITY_PULL | MOBILITY_STAND)
+		lying = 0
 		if(buckled)
 			if(buckled.buckle_lying != -1)
 				lying = buckled.buckle_lying

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1075,7 +1075,6 @@
 	
 	if(should_be_lying)
 		mobility_flags &= ~(MOBILITY_UI | MOBILITY_PULL | MOBILITY_STAND)
-		lying = 0
 		if(buckled)
 			if(buckled.buckle_lying != -1)
 				lying = buckled.buckle_lying

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1068,26 +1068,26 @@
 	var/canstand_involuntary = conscious && !stat_softcrit && !knockdown && !chokehold && !paralyzed && (ignore_legs || has_legs) && !(buckled && buckled.buckle_lying)
 	var/canstand = canstand_involuntary && !resting
 
-	if(canstand)
-		mobility_flags |= MOBILITY_STAND
-		lying = 0
+	var/should_be_lying = canstand
+	if(buckled)
+		if(buckled.buckle_lying != -1)
+			should_be_lying = buckled.buckle_lying
+	
+	if(should_be_lying)
+		mobility_flags &= ~(MOBILITY_UI | MOBILITY_PULL | MOBILITY_STAND)
+		if(buckled)
+			if(buckled.buckle_lying != -1)
+				lying = buckled.buckle_lying
+		if(!lying) //force them on the ground
+			lying = pick(90, 270)
+	else
 		if(!restrained)
 			mobility_flags |= (MOBILITY_UI | MOBILITY_PULL)
 		else
 			mobility_flags &= ~(MOBILITY_UI | MOBILITY_PULL)
-	else
-		mobility_flags &= ~(MOBILITY_UI | MOBILITY_PULL)
-
-		var/should_be_lying = (buckled && (buckled.buckle_lying != -1)) ? buckled.buckle_lying : TRUE //make lying match buckle_lying if it's not -1, else lay down
-
-		if(should_be_lying)
-			mobility_flags &= ~MOBILITY_STAND
-			if(!lying) //force them on the ground
-				lying = pick(90, 270)
-		else
-			mobility_flags |= MOBILITY_STAND //important to add this back, otherwise projectiles will pass through the mob while they're upright.
-			if(lying) //stand them back up
-				lying = 0
+		mobility_flags |= MOBILITY_STAND
+		lying = 0
+			
 
 	var/canitem = !paralyzed && !stun && conscious && !chokehold && !restrained && has_arms
 	if(canitem)


### PR DESCRIPTION
## Changelog
:cl:
fix: Buckle objects can now properly specify lying angle
fix: Wheelchairs and other such vehicles let you use UIs even if your legs don't work
fix: You can now pull objects while in a wheelchair even if your legs don't work
fix: You no longer have a chance of sleeping upside down in a bed
tweak: No longer randomises lying direction a second time on fall
/:cl:

code: simplified can_stand code

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

fixes #41703