### PR TITLE
Fixes jaunting mobs squeeking things.

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -60,6 +60,8 @@
 			var/obj/item/projectile/P = AM
 			if(P.original != parent)
 				return
+	if(istype(AM, /obj/effect/dummy/phased_mob)) //don't squeek if they're in a phased/jaunting container.
+		return
 	var/atom/current_parent = parent
 	if(isturf(current_parent.loc))
 		play_squeak()


### PR DESCRIPTION
Fixes #42885

:cl: ShizCalev
fix: Jaunting mobs will no longer cause mice/ducks/ect to squeek when moving over them.
/:cl:
