### PR TITLE
Database backed stickybans.

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,6 +1,6 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 4.7; The query to update the schema revision table is:
+The latest database version is 5.1; The query to update the schema revision table is:
 
 INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 1);
 or
@@ -10,7 +10,7 @@ In any query remember to add a prefix to the table names if you use one.
 
 ----------------------------------------------------
 
-Version 5.1, 23 Dec 2018, by MrStonedOne
+Version 5.1, 25 Feb 2018, by MrStonedOne
 Added four tables to enable storing of stickybans in the database since byond can lose them, and to enable disabling stickybans for a round without depending on a crash free round. Existing stickybans are automagically imported to the tables.
 
 CREATE TABLE `stickyban` (
@@ -24,7 +24,8 @@ CREATE TABLE `stickyban` (
 CREATE TABLE `stickyban_matched_ckey` (
 	`stickyban` VARCHAR(32) NOT NULL,
 	`matched_ckey` VARCHAR(32) NOT NULL,
-	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`first_matched` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`last_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	`exempt` TINYINT(1) NOT NULL DEFAULT '0',
 	PRIMARY KEY (`stickyban`, `matched_ckey`)
 ) ENGINE=InnoDB;
@@ -32,14 +33,16 @@ CREATE TABLE `stickyban_matched_ckey` (
 CREATE TABLE `stickyban_matched_ip` (
 	`stickyban` VARCHAR(32) NOT NULL,
 	`matched_ip` INT UNSIGNED NOT NULL,
-	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`first_matched` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`last_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	PRIMARY KEY (`stickyban`, `matched_ip`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `stickyban_matched_cid` (
 	`stickyban` VARCHAR(32) NOT NULL,
-	`matched_cid` INT UNSIGNED NOT NULL,
-	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`matched_cid` VARCHAR(32) NOT NULL,
+	`first_matched` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`last_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	PRIMARY KEY (`stickyban`, `matched_cid`)
 ) ENGINE=InnoDB;
 

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -2,11 +2,46 @@ Any time you make a change to the schema files, remember to increment the databa
 
 The latest database version is 4.7; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 0);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 1);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 0);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 1);
 
 In any query remember to add a prefix to the table names if you use one.
+
+----------------------------------------------------
+
+Version 5.1, 23 Dec 2018, by MrStonedOne
+Added four tables to enable storing of stickybans in the database since byond can lose them, and to enable disabling stickybans for a round without depending on a crash free round. Existing stickybans are automagically imported to the tables.
+
+CREATE TABLE `stickyban` (
+	`ckey` VARCHAR(32) NOT NULL,
+	`reason` VARCHAR(2048) NOT NULL,
+	`banning_admin` VARCHAR(32) NOT NULL,
+	`datetime` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (`ckey`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `stickyban_matched_ckey` (
+	`stickyban` VARCHAR(32) NOT NULL,
+	`matched_ckey` VARCHAR(32) NOT NULL,
+	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`exempt` TINYINT(1) NOT NULL DEFAULT '0',
+	PRIMARY KEY (`stickyban`, `matched_ckey`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `stickyban_matched_ip` (
+	`stickyban` VARCHAR(32) NOT NULL,
+	`matched_ip` INT UNSIGNED NOT NULL,
+	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (`stickyban`, `matched_ip`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `stickyban_matched_cid` (
+	`stickyban` VARCHAR(32) NOT NULL,
+	`matched_cid` INT UNSIGNED NOT NULL,
+	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (`stickyban`, `matched_cid`)
+) ENGINE=InnoDB;
 
 ----------------------------------------------------
 
@@ -88,8 +123,7 @@ Added table `role_time_log` and triggers `role_timeTlogupdate`, `role_timeTlogin
 
 CREATE TABLE `role_time_log` ( `id` BIGINT NOT NULL AUTO_INCREMENT , `ckey` VARCHAR(32) NOT NULL , `job` VARCHAR(128) NOT NULL , `delta` INT NOT NULL , `datetime` TIMESTAMP on update CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP , PRIMARY KEY (`id`), INDEX (`ckey`), INDEX (`job`), INDEX (`datetime`)) ENGINE = InnoDB;
 
-DELIMITER
-$$
+DELIMITER $$
 CREATE TRIGGER `role_timeTlogupdate` AFTER UPDATE ON `role_time` FOR EACH ROW BEGIN INSERT into role_time_log (ckey, job, delta) VALUES (NEW.CKEY, NEW.job, NEW.minutes-OLD.minutes);
 END
 $$
@@ -99,7 +133,7 @@ $$
 CREATE TRIGGER `role_timeTlogdelete` AFTER DELETE  ON `role_time` FOR EACH ROW BEGIN INSERT into role_time_log (ckey, job, delta) VALUES (OLD.ckey, OLD.job, 0-OLD.minutes);
 END
 $$
-
+DELIMITER ;
 ----------------------------------------------------
 
 Version 4.2, 17 April 2018, by Jordie0608

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -465,10 +465,10 @@ $$
 DELIMITER ;
 
 --
--- Table structure for table `SS13_stickyban`
+-- Table structure for table `stickyban`
 --
-DROP TABLE IF EXISTS `SS13_stickyban`;
-CREATE TABLE `SS13_stickyban` (
+DROP TABLE IF EXISTS `stickyban`;
+CREATE TABLE `stickyban` (
 	`ckey` VARCHAR(32) NOT NULL,
 	`reason` VARCHAR(2048) NOT NULL,
 	`banning_admin` VARCHAR(32) NOT NULL,
@@ -477,13 +477,14 @@ CREATE TABLE `SS13_stickyban` (
 ) ENGINE=InnoDB;
 
 --
--- Table structure for table `ss13_stickyban_matched_ckey`
+-- Table structure for table `stickyban_matched_ckey`
 --
-DROP TABLE IF EXISTS `ss13_stickyban_matched_ckey`;
+DROP TABLE IF EXISTS `stickyban_matched_ckey`;
 CREATE TABLE `ss13_stickyban_matched_ckey` (
 	`stickyban` VARCHAR(32) NOT NULL,
 	`matched_ckey` VARCHAR(32) NOT NULL,
-	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`first_matched` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`last_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	`exempt` TINYINT(1) NOT NULL DEFAULT '0',
 	PRIMARY KEY (`stickyban`, `matched_ckey`)
 ) ENGINE=InnoDB;
@@ -495,18 +496,20 @@ DROP TABLE IF EXISTS `ss13_stickyban_matched_ip`;
 CREATE TABLE `ss13_stickyban_matched_ip` (
 	`stickyban` VARCHAR(32) NOT NULL,
 	`matched_ip` INT UNSIGNED NOT NULL,
-	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`first_matched` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`last_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	PRIMARY KEY (`stickyban`, `matched_ip`)
 ) ENGINE=InnoDB;
 
 --
--- Table structure for table `ss13_stickyban_matched_cid`
+-- Table structure for table `stickyban_matched_cid`
 --
-DROP TABLE IF EXISTS `ss13_stickyban_matched_cid`;
-CREATE TABLE `ss13_stickyban_matched_cid` (
+DROP TABLE IF EXISTS `stickyban_matched_cid`;
+CREATE TABLE `stickyban_matched_cid` (
 	`stickyban` VARCHAR(32) NOT NULL,
-	`matched_cid` INT UNSIGNED NOT NULL,
-	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`matched_cid` VARCHAR(32) NOT NULL,
+	`first_matched` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`last_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	PRIMARY KEY (`stickyban`, `matched_cid`)
 ) ENGINE=InnoDB;
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -462,6 +462,54 @@ $$
 CREATE TRIGGER `role_timeTlogdelete` AFTER DELETE ON `role_time` FOR EACH ROW BEGIN INSERT into role_time_log (ckey, job, delta) VALUES (OLD.ckey, OLD.job, 0-OLD.minutes);
 END
 $$
+DELIMITER ;
+
+--
+-- Table structure for table `SS13_stickyban`
+--
+DROP TABLE IF EXISTS `SS13_stickyban`;
+CREATE TABLE `SS13_stickyban` (
+	`ckey` VARCHAR(32) NOT NULL,
+	`reason` VARCHAR(2048) NOT NULL,
+	`banning_admin` VARCHAR(32) NOT NULL,
+	`datetime` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (`ckey`)
+) ENGINE=InnoDB;
+
+--
+-- Table structure for table `ss13_stickyban_matched_ckey`
+--
+DROP TABLE IF EXISTS `ss13_stickyban_matched_ckey`;
+CREATE TABLE `ss13_stickyban_matched_ckey` (
+	`stickyban` VARCHAR(32) NOT NULL,
+	`matched_ckey` VARCHAR(32) NOT NULL,
+	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`exempt` TINYINT(1) NOT NULL DEFAULT '0',
+	PRIMARY KEY (`stickyban`, `matched_ckey`)
+) ENGINE=InnoDB;
+
+--
+-- Table structure for table `ss13_stickyban_matched_ip`
+--
+DROP TABLE IF EXISTS `ss13_stickyban_matched_ip`;
+CREATE TABLE `ss13_stickyban_matched_ip` (
+	`stickyban` VARCHAR(32) NOT NULL,
+	`matched_ip` INT UNSIGNED NOT NULL,
+	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (`stickyban`, `matched_ip`)
+) ENGINE=InnoDB;
+
+--
+-- Table structure for table `ss13_stickyban_matched_cid`
+--
+DROP TABLE IF EXISTS `ss13_stickyban_matched_cid`;
+CREATE TABLE `ss13_stickyban_matched_cid` (
+	`stickyban` VARCHAR(32) NOT NULL,
+	`matched_cid` INT UNSIGNED NOT NULL,
+	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (`stickyban`, `matched_cid`)
+) ENGINE=InnoDB;
+
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -477,10 +477,10 @@ CREATE TABLE `SS13_stickyban` (
 ) ENGINE=InnoDB;
 
 --
--- Table structure for table `ss13_stickyban_matched_ckey`
+-- Table structure for table `SS13_stickyban_matched_ckey`
 --
-DROP TABLE IF EXISTS `ss13_stickyban_matched_ckey`;
-CREATE TABLE `ss13_stickyban_matched_ckey` (
+DROP TABLE IF EXISTS `SS13_stickyban_matched_ckey`;
+CREATE TABLE `SS13_stickyban_matched_ckey` (
 	`stickyban` VARCHAR(32) NOT NULL,
 	`matched_ckey` VARCHAR(32) NOT NULL,
 	`first_matched` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -490,10 +490,10 @@ CREATE TABLE `ss13_stickyban_matched_ckey` (
 ) ENGINE=InnoDB;
 
 --
--- Table structure for table `ss13_stickyban_matched_ip`
+-- Table structure for table `SS13_stickyban_matched_ip`
 --
-DROP TABLE IF EXISTS `ss13_stickyban_matched_ip`;
-CREATE TABLE `ss13_stickyban_matched_ip` (
+DROP TABLE IF EXISTS `SS13_stickyban_matched_ip`;
+CREATE TABLE `SS13_stickyban_matched_ip` (
 	`stickyban` VARCHAR(32) NOT NULL,
 	`matched_ip` INT UNSIGNED NOT NULL,
 	`first_matched` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -502,10 +502,10 @@ CREATE TABLE `ss13_stickyban_matched_ip` (
 ) ENGINE=InnoDB;
 
 --
--- Table structure for table `ss13_stickyban_matched_cid`
+-- Table structure for table `SS13_stickyban_matched_cid`
 --
-DROP TABLE IF EXISTS `ss13_stickyban_matched_cid`;
-CREATE TABLE `ss13_stickyban_matched_cid` (
+DROP TABLE IF EXISTS `SS13_stickyban_matched_cid`;
+CREATE TABLE `SS13_stickyban_matched_cid` (
 	`stickyban` VARCHAR(32) NOT NULL,
 	`matched_cid` VARCHAR(32) NOT NULL,
 	`first_matched` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -483,7 +483,8 @@ DROP TABLE IF EXISTS `ss13_stickyban_matched_ckey`;
 CREATE TABLE `ss13_stickyban_matched_ckey` (
 	`stickyban` VARCHAR(32) NOT NULL,
 	`matched_ckey` VARCHAR(32) NOT NULL,
-	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`first_matched` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`last_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	`exempt` TINYINT(1) NOT NULL DEFAULT '0',
 	PRIMARY KEY (`stickyban`, `matched_ckey`)
 ) ENGINE=InnoDB;
@@ -495,7 +496,8 @@ DROP TABLE IF EXISTS `ss13_stickyban_matched_ip`;
 CREATE TABLE `ss13_stickyban_matched_ip` (
 	`stickyban` VARCHAR(32) NOT NULL,
 	`matched_ip` INT UNSIGNED NOT NULL,
-	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`first_matched` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`last_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	PRIMARY KEY (`stickyban`, `matched_ip`)
 ) ENGINE=InnoDB;
 
@@ -505,8 +507,9 @@ CREATE TABLE `ss13_stickyban_matched_ip` (
 DROP TABLE IF EXISTS `ss13_stickyban_matched_cid`;
 CREATE TABLE `ss13_stickyban_matched_cid` (
 	`stickyban` VARCHAR(32) NOT NULL,
-	`matched_cid` INT UNSIGNED NOT NULL,
-	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`matched_cid` VARCHAR(32) NOT NULL,
+	`first_matched` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`last_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	PRIMARY KEY (`stickyban`, `matched_cid`)
 ) ENGINE=InnoDB;
 

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -462,6 +462,55 @@ $$
 CREATE TRIGGER `SS13_role_timeTlogdelete` AFTER DELETE ON `SS13_role_time` FOR EACH ROW BEGIN INSERT into SS13_role_time_log (ckey, job, delta) VALUES (OLD.ckey, OLD.job, 0-OLD.minutes);
 END
 $$
+DELIMITER ;
+
+--
+-- Table structure for table `SS13_stickyban`
+--
+DROP TABLE IF EXISTS `SS13_stickyban`;
+CREATE TABLE `SS13_stickyban` (
+	`ckey` VARCHAR(32) NOT NULL,
+	`reason` VARCHAR(2048) NOT NULL,
+	`banning_admin` VARCHAR(32) NOT NULL,
+	`datetime` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (`ckey`)
+) ENGINE=InnoDB;
+
+--
+-- Table structure for table `ss13_stickyban_matched_ckey`
+--
+DROP TABLE IF EXISTS `ss13_stickyban_matched_ckey`;
+CREATE TABLE `ss13_stickyban_matched_ckey` (
+	`stickyban` VARCHAR(32) NOT NULL,
+	`matched_ckey` VARCHAR(32) NOT NULL,
+	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`exempt` TINYINT(1) NOT NULL DEFAULT '0',
+	PRIMARY KEY (`stickyban`, `matched_ckey`)
+) ENGINE=InnoDB;
+
+--
+-- Table structure for table `ss13_stickyban_matched_ip`
+--
+DROP TABLE IF EXISTS `ss13_stickyban_matched_ip`;
+CREATE TABLE `ss13_stickyban_matched_ip` (
+	`stickyban` VARCHAR(32) NOT NULL,
+	`matched_ip` INT UNSIGNED NOT NULL,
+	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (`stickyban`, `matched_ip`)
+) ENGINE=InnoDB;
+
+--
+-- Table structure for table `ss13_stickyban_matched_cid`
+--
+DROP TABLE IF EXISTS `ss13_stickyban_matched_cid`;
+CREATE TABLE `ss13_stickyban_matched_cid` (
+	`stickyban` VARCHAR(32) NOT NULL,
+	`matched_cid` INT UNSIGNED NOT NULL,
+	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (`stickyban`, `matched_cid`)
+) ENGINE=InnoDB;
+
+
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;

--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -83,4 +83,4 @@
 #define SPAM_TRIGGER_AUTOMUTE	10	//Number of identical messages required before the spam-prevention will automute you
 
 #define STICKYBAN_DB_CACHE_TIME 10 SECONDS
-#define STICKYBAN_ROGUE_CHECK_TIME 5 SECONDS
+#define STICKYBAN_ROGUE_CHECK_TIME 5

--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -81,3 +81,6 @@
 
 #define SPAM_TRIGGER_WARNING	5	//Number of identical messages required before the spam-prevention will warn you to stfu
 #define SPAM_TRIGGER_AUTOMUTE	10	//Number of identical messages required before the spam-prevention will automute you
+
+#define STICKYBAN_DB_CACHE_TIME 10 SECONDS
+#define STICKYBAN_ROGUE_CHECK_TIME 5 SECONDS

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -1,7 +1,8 @@
 //Update this whenever the db schema changes
 //make sure you add an update to the schema_version stable in the db changelog
 #define DB_MAJOR_VERSION 5
-#define DB_MINOR_VERSION 0
+#define DB_MINOR_VERSION 1
+
 
 //Timing subsystem
 //Don't run if there is an identical unique timer active

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -177,6 +177,27 @@ SUBSYSTEM_DEF(dbcore)
 		return FALSE
 	return new /datum/DBQuery(sql_query, connection)
 
+/datum/controller/subsystem/dbcore/proc/QuerySelect(list/querys, warn = FALSE, qdel = FALSE)
+	if (!islist(querys))
+		if (!istype(querys, /datum/DBQuery))
+			CRASH("Invalid query passed to QuerySelect: [querys]")
+		querys = list(querys)
+
+	for (var/thing in querys)
+		var/datum/DBQuery/query = thing
+		if (warn)
+			INVOKE_ASYNC(query, /datum/DBQuery.proc/warn_execute)
+		else
+			INVOKE_ASYNC(query, /datum/DBQuery.proc/Execute)
+
+	for (var/thing in querys)
+		var/datum/DBQuery/query = thing
+		UNTIL(!query.in_progress)
+		if (qdel)
+			qdel(query)
+
+
+
 /*
 Takes a list of rows (each row being an associated list of column => value) and inserts them via a single mass query.
 Rows missing columns present in other rows will resolve to SQL NULL

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -9,6 +9,9 @@ SUBSYSTEM_DEF(server_maint)
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 	var/list/currentrun
 
+/datum/controller/subsystem/server_maint/PreInit()
+	world.hub_password = "" //quickly! before the hubbies see us.
+
 /datum/controller/subsystem/server_maint/Initialize(timeofday)
 	if (CONFIG_GET(flag/hub))
 		world.update_hub_visibility(TRUE)

--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -1,34 +1,82 @@
 SUBSYSTEM_DEF(stickyban)
-	name = "Sticky Ban"
+	name = "PRISM"
 	init_order = INIT_ORDER_STICKY_BAN
 	flags = SS_NO_FIRE
 
 	var/list/cache = list()
+	var/list/dbcache = list()
+	var/list/confirmed_exempt = list()
+	var/dbcacheexpire = 0
+
 
 /datum/controller/subsystem/stickyban/Initialize(timeofday)
-	var/list/bannedkeys = world.GetConfig("ban")
+	var/list/bannedkeys = sticky_banned_ckeys()
 	//sanitize the sticky ban list
 	for (var/bannedkey in bannedkeys)
 		var/ckey = ckey(bannedkey)
-		var/list/ban = stickyban2list(world.GetConfig("ban", bannedkey))
+		var/list/ban = get_stickyban_from_ckey(bannedkey)
 
-		//byond stores sticky bans by key, that can end up confusing things
-		//i also remove it here so that if any stickybans cause a runtime, they just stop existing
-		world.SetConfig("ban", bannedkey, null)
+		//byond stores sticky bans by key, that's lame
+		if (ckey != bannedkey)
+			world.SetConfig("ban", bannedkey, null)
 
 		if (!ban["ckey"])
 			ban["ckey"] = ckey
 
-		//storing these can break things and isn't needed for sticky ban tracking
-		ban -= "IP"
-		ban -= "computer_id"
-
 		ban["matches_this_round"] = list()
 		ban["existing_user_matches_this_round"] = list()
 		ban["admin_matches_this_round"] = list()
+		ban["pending_matches_this_round"] = list()
+
 		cache[ckey] = ban
-	
+
 	for (var/bannedckey in cache)
 		world.SetConfig("ban", bannedckey, list2stickyban(cache[bannedckey]))
 
+
+	if (!CONFIG_GET(flag/ban_legacy_system) && (SSdbcore.Connect() || length(SSstickyban.dbcache)))
+		for (var/oldban in (world.GetConfig("ban") - bannedkeys))
+			world.SetConfig("ban", oldban, null) //remove bans that no longer exist.
 	return ..()
+
+/datum/controller/subsystem/stickyban/proc/Populatedbcache()
+	var/newdbcache = list() //so if we runtime or the db connection dies we don't kill the existing cache
+
+	var/datum/DBQuery/query_stickybans = SSdbcore.NewQuery("SELECT ckey, reason, banning_admin, datetime FROM [format_table_name("stickyban")] ORDERED BY ckey")
+	if (!query_stickybans.warn_execute())
+		return
+
+	var/datum/DBQuery/query_stickyban_matches = SSdbcore.NewQuery("SELECT stickyban, matched_ckey, first_matched, exempt FROM [format_table_name("stickyban_matrched_ckey")]")
+	if (!query_stickyban_matches.warn_execute())
+		return
+	query_stickyban_matches.SetConversion(4, SSdbcore.NUMBER_CONV) //read exempt as a number, not a string
+
+	while (query_stickybans.NextRow())
+		var/list/ban = list()
+
+		ban["ckey"] = query_stickybans.item[1]
+		ban["reason"] = query_stickybans.item[2]
+		ban["banning_admin"] = query_stickybans.item[3]
+		ban["datetime"] = query_stickybans.item[4]
+
+		newdbcache["[query_stickybans.item[1]]"] = ban
+
+
+	while (query_stickyban_matches.NextRow())
+		var/list/match = list()
+
+		match["stickyban"] = query_stickyban_matches.item[1]
+		match["matched_ckey"] = query_stickyban_matches.item[2]
+		match["first_matched"] = query_stickyban_matches.item[3]
+		match["exempt"] = query_stickyban_matches.item[4]
+
+		var/ban = newdbcache[match["stickyban"]]
+		if (!ban)
+			continue
+		var/keys = ban["keys"]
+		if (!keys)
+			keys = ban["keys"] = list()
+		keys[match["matched_ckey"]] = match
+
+	dbcache = newdbcache
+	dbcacheexpire = world.time+STICKYBAN_DB_CACHE_TIME

--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -14,7 +14,7 @@ SUBSYSTEM_DEF(stickyban)
 	//sanitize the sticky ban list
 
 	//delete db bans that no longer exist in the database and add new legacy bans to the database
-	if (!CONFIG_GET(flag/ban_legacy_system) && (SSdbcore.Connect() || length(SSstickyban.dbcache)))
+	if (SSdbcore.Connect() || length(SSstickyban.dbcache))
 		for (var/oldban in (world.GetConfig("ban") - bannedkeys))
 			var/ckey = ckey(oldban)
 			if (ckey != oldban && (ckey in bannedkeys))
@@ -61,7 +61,6 @@ SUBSYSTEM_DEF(stickyban)
 	var/datum/DBQuery/query_stickyban_matches = SSdbcore.NewQuery("SELECT stickyban, matched_ckey, first_matched, exempt FROM [format_table_name("stickyban_matched_ckey")] ORDER BY first_matched")
 	if (!query_stickyban_matches.warn_execute())
 		return
-	query_stickyban_matches.SetConversion(4, SSdbcore.NUMBER_CONV) //read exempt as a number, not a string
 
 	while (query_stickybans.NextRow())
 		var/list/ban = list()
@@ -82,7 +81,7 @@ SUBSYSTEM_DEF(stickyban)
 		match["stickyban"] = query_stickyban_matches.item[1]
 		match["matched_ckey"] = query_stickyban_matches.item[2]
 		match["first_matched"] = query_stickyban_matches.item[3]
-		match["exempt"] = query_stickyban_matches.item[4]
+		match["exempt"] = text2num(query_stickyban_matches.item[4])
 
 		var/ban = newdbcache[query_stickyban_matches.item[1]]
 		if (!ban)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -20,6 +20,8 @@ GLOBAL_VAR(restart_counter)
 
 	config.Load(params[OVERRIDE_CONFIG_DIRECTORY_PARAMETER])
 
+	load_admins()
+
 	//SetupLogs depends on the RoundID, so lets check
 	//DB schema and set RoundID if we can
 	SSdbcore.CheckSchemaVersion()
@@ -30,7 +32,6 @@ GLOBAL_VAR(restart_counter)
 	world.log = file("[GLOB.log_directory]/dd.log")
 #endif
 
-	load_admins()
 	LoadVerbs(/datum/verbs/menu)
 	if(CONFIG_GET(flag/usewhitelist))
 		load_whitelist()

--- a/code/modules/admin/stickyban.dm
+++ b/code/modules/admin/stickyban.dm
@@ -399,7 +399,7 @@
 	if (!length(.))
 		return null
 
-/proc/stickyban2list(var/ban)
+/proc/stickyban2list(ban)
 	if (!ban)
 		return null
 	. = params2list(ban)
@@ -413,9 +413,10 @@
 	.["type"] = splittext(.["type"], ",")
 	.["IP"] = splittext(.["IP"], ",")
 	.["computer_id"] = splittext(.["computer_id"], ",")
+	. -= "fromdb"
 
 
-/proc/list2stickyban(var/list/ban)
+/proc/list2stickyban(list/ban)
 	if (!ban || !islist(ban))
 		return null
 	. = ban.Copy()
@@ -425,7 +426,6 @@
 		.["type"] = jointext(.["type"], ",")
 
 	. -= "reverting"
-	. -= "fromdb"
 	. -= "matches_this_round"
 	. -= "existing_user_matches_this_round"
 	. -= "admin_matches_this_round"

--- a/code/modules/admin/stickyban.dm
+++ b/code/modules/admin/stickyban.dm
@@ -386,7 +386,7 @@
 			SSstickyban.Populatedbcache()
 		if (SSstickyban.dbcacheexpire)
 			. = SSstickyban.dbcache[ckey]
-			//reset the cache incase its a newer ban (but only if we didn't update the cache
+			//reset the cache incase its a newer ban (but only if we didn't update the cache recently)
 			if (!. && SSstickyban.dbcacheexpire != world.time+STICKYBAN_DB_CACHE_TIME)
 				SSstickyban.dbcacheexpire = 1
 				SSstickyban.Populatedbcache()
@@ -434,6 +434,10 @@
 	. = ban.Copy()
 	if (.["keys"])
 		.["keys"] = jointext(.["keys"], ",")
+	if (.["IP"])
+		.["IP"] = jointext(.["IP"], ",")
+	if (.["computer_id"])
+		.["computer_id"] = jointext(.["computer_id"], ",")
 	if (.["whitelist"])
 		.["whitelist"] = jointext(.["whitelist"], ",")
 	if (.["type"])

--- a/code/modules/admin/stickyban.dm
+++ b/code/modules/admin/stickyban.dm
@@ -35,7 +35,7 @@
 			world.SetConfig("ban",ckey,list2stickyban(ban))
 			SSstickyban.cache[ckey] = ban
 
-			if(!CONFIG_GET(flag/ban_legacy_system) && SSdbcore.Connect())
+			if(SSdbcore.Connect())
 				var/datum/DBQuery/query_create_stickyban = SSdbcore.NewQuery("INSERT INTO [format_table_name("stickyban")] (ckey, reason, banning_admin) VALUES ('[sanitizeSQL(ckey)]', '[sanitizeSQL(ban["message"])]', '[sanitizeSQL(usr.ckey)]')")
 				query_create_stickyban.warn_execute()
 
@@ -59,7 +59,7 @@
 			world.SetConfig("ban",ckey, null)
 			SSstickyban.cache -= ckey
 
-			if (!CONFIG_GET(flag/ban_legacy_system) && SSdbcore.Connect())
+			if (SSdbcore.Connect())
 				var/datum/DBQuery/query_remove_stickyban = SSdbcore.NewQuery("DELETE FROM [format_table_name("stickyban")] WHERE ckey = '[sanitizeSQL(ckey)]'")
 				query_remove_stickyban.warn_execute()
 				var/datum/DBQuery/query_remove_stickyban_alts = SSdbcore.NewQuery("DELETE FROM [format_table_name("stickyban_matched_ckey")] WHERE stickyban = '[sanitizeSQL(ckey)]'")
@@ -105,7 +105,7 @@
 
 			SSstickyban.cache[ckey] = ban
 
-			if (!CONFIG_GET(flag/ban_legacy_system) && SSdbcore.Connect())
+			if (SSdbcore.Connect())
 				var/datum/DBQuery/query_remove_stickyban_alt = SSdbcore.NewQuery("DELETE FROM [format_table_name("stickyban_matched_ckey")] WHERE stickyban = '[sanitizeSQL(ckey)]' AND matched_ckey = '[sanitizeSQL(alt)]'")
 				query_remove_stickyban_alt.warn_execute()
 
@@ -135,7 +135,7 @@
 
 			SSstickyban.cache[ckey] = ban
 
-			if (!CONFIG_GET(flag/ban_legacy_system) && SSdbcore.Connect())
+			if (SSdbcore.Connect())
 				var/datum/DBQuery/query_edit_stickyban = SSdbcore.NewQuery("UPDATE [format_table_name("stickyban")] SET reason = '[sanitizeSQL(reason)]' WHERE ckey = '[sanitizeSQL(ckey)]'")
 				query_edit_stickyban.warn_execute()
 
@@ -181,7 +181,7 @@
 
 			SSstickyban.cache[ckey] = ban
 
-			if (!CONFIG_GET(flag/ban_legacy_system) && SSdbcore.Connect())
+			if (!SSdbcore.Connect())
 				var/datum/DBQuery/query_exempt_stickyban_alt = SSdbcore.NewQuery("UPDATE [format_table_name("stickyban_matched_ckey")] SET exempt = 1 WHERE stickyban = '[sanitizeSQL(ckey)]' AND matched_ckey = '[sanitizeSQL(alt)]'")
 				query_exempt_stickyban_alt.warn_execute()
 
@@ -227,7 +227,7 @@
 
 			SSstickyban.cache[ckey] = ban
 
-			if (!CONFIG_GET(flag/ban_legacy_system) && SSdbcore.Connect())
+			if (SSdbcore.Connect())
 
 				var/datum/DBQuery/query_unexempt_stickyban_alt = SSdbcore.NewQuery("UPDATE [format_table_name("stickyban_matched_ckey")] SET exempt = 0 WHERE stickyban = '[sanitizeSQL(ckey)]' AND matched_ckey = '[sanitizeSQL(alt)]'")
 				query_unexempt_stickyban_alt.warn_execute()
@@ -238,7 +238,7 @@
 		if ("timeout")
 			if (!data["ckey"])
 				return
-			if (CONFIG_GET(flag/ban_legacy_system) || !SSdbcore.Connect())
+			if (!SSdbcore.Connect())
 				to_chat(usr, "<span class='adminnotice'>No database connection!</span>")
 				return
 
@@ -265,7 +265,7 @@
 		if ("untimeout")
 			if (!data["ckey"])
 				return
-			if (CONFIG_GET(flag/ban_legacy_system) || !SSdbcore.Connect())
+			if (!SSdbcore.Connect())
 				to_chat(usr, "<span class='adminnotice'>No database connection!</span>")
 				return
 			var/ckey = data["ckey"]
@@ -319,7 +319,7 @@
 	if (!ban)
 		return
 	var/timeout
-	if (!CONFIG_GET(flag/ban_legacy_system) && SSdbcore.Connect())
+	if (SSdbcore.Connect())
 		timeout = "<a href='?_src_=holder;[HrefToken()];stickyban=[(ban["timeout"] ? "untimeout" : "timeout")]&ckey=[ckey]'>\[[(ban["timeout"] ? "untimeout" : "timeout" )]\]</a>"
 	. = list({"
 		<a href='?_src_=holder;[HrefToken()];stickyban=remove&ckey=[ckey]'>\[-\]</a>
@@ -368,7 +368,7 @@
 	usr << browse(html,"window=stickybans;size=700x400")
 
 /proc/sticky_banned_ckeys()
-	if (!CONFIG_GET(flag/ban_legacy_system) && (SSdbcore.Connect() || length(SSstickyban.dbcache)))
+	if (SSdbcore.Connect() || length(SSstickyban.dbcache))
 		if (SSstickyban.dbcacheexpire < world.time)
 			SSstickyban.Populatedbcache()
 		if (SSstickyban.dbcacheexpire)
@@ -381,7 +381,7 @@
 	. = list()
 	if (!ckey)
 		return null
-	if (!CONFIG_GET(flag/ban_legacy_system) && (SSdbcore.Connect() || length(SSstickyban.dbcache)))
+	if (SSdbcore.Connect() || length(SSstickyban.dbcache))
 		if (SSstickyban.dbcacheexpire < world.time)
 			SSstickyban.Populatedbcache()
 		if (SSstickyban.dbcacheexpire)

--- a/code/modules/admin/stickyban.dm
+++ b/code/modules/admin/stickyban.dm
@@ -445,10 +445,6 @@
 	. -= "admin_matches_this_round"
 	. -= "pending_matches_this_round"
 
-	//storing these can sometimes cause sticky bans to start matching everybody
-	//	and isn't even needed for sticky ban matching, as the hub tracks these separately
-	. -= "IP"
-	. -= "computer_id"
 
 	. = list2params(.)
 

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -158,7 +158,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 				var/list/row = src.connectionHistory[i]
 				if (!row || row.len < 3 || (!row["ckey"] || !row["compid"] || !row["ip"])) //Passed malformed history object
 					return
-				if (world.IsBanned(row["ckey"], row["compid"], row["ip"], real_bans_only=TRUE))
+				if (world.IsBanned(row["ckey"], row["ip"], row["compid"], real_bans_only=TRUE))
 					found = row
 					break
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -7,6 +7,7 @@
 	area = /area/space
 	view = "15x15"
 	hub = "Exadv1.spacestation13"
+	hub_password = "kMZy3U5jJHSiBQjr"
 	name = "/tg/ Station 13"
 	fps = 20
 #ifdef FIND_REF_NO_CHECK_TICK


### PR DESCRIPTION
Stickybans are stored in the database.

Because byond has to keep its own list, most of this is about ferrying info between the database and byond, and keeping them synced up. Because of this, this system will properly convert existing file stickybans to database stickybans during first init. This system also plays nicely with file stickybans existing on both servers (ish): seen key matches will be merged together in the database, but the reason, date, and admin, will be taken from the first server to introduce the stickyban to the database.

This has further protections from rogue bans, but byond fixed those. I'm keeping them in anyways because they will be helpful if this ever becomes an issue again. They are: Enforcement of matches on already connected users are delayed for 5 seconds to see if the match will turnout to be fucked. Confirmed fucked stickybans will be disabled for the round.

This fixes a bug that kept stickybans from properly doing hub backed matching on servers that were not currently on the hub.

This adds a button to whitelist a ckey from a given stickyban, this uses an internal and undocumented byond stickyban field.

This adds a button to allow admins to disable the stickyban for the current server for the current round. Called putting the ban on "Time out".

Todo: 

- [ ] add ip/cid match information to the stickybanpanel (requires tgui2, will do in another pr)
- [x] test it on the rebased codebase.
- [x] fix undeleted queries.

Note: I added a query select proc for executing a list of queries at once and returning once all of them finish. It works like callback selects in that it does not wait for the previous one to finish before starting the next one, instead starting all of them than waiting for all of them to finish.
