### PR TITLE
Changes the pAI 'Loudness Booster' to allow instrument selection.

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -289,10 +289,7 @@
 /datum/action/item_action/synthswitch/Trigger()
 	if(istype(target, /obj/item/instrument/piano_synth))
 		var/obj/item/instrument/piano_synth/synth = target
-		var/chosen = input("Choose the type of instrument you want to use", "Instrument Selection", "piano") as null|anything in synth.insTypes
-		if(!synth.insTypes[chosen])
-			return
-		return synth.changeInstrument(chosen)
+		return synth.selectInstrument()
 	return ..()
 
 /datum/action/item_action/vortex_recall

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -73,6 +73,12 @@
 	song.instrumentDir = name
 	song.instrumentExt = insTypes[name]
 
+/obj/item/instrument/piano_synth/proc/selectInstrument() // Moved here so it can be used by the action and PAI software panel without copypasta
+	var/chosen = input("Choose the type of instrument you want to use", "Instrument Selection", song.instrumentDir) as null|anything in insTypes
+	if(!insTypes[chosen])
+		return
+	return changeInstrument(chosen)
+
 /obj/item/instrument/guitar
 	name = "guitar"
 	desc = "It's made of wood and has bronze strings."

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -53,7 +53,7 @@
 
 	var/obj/item/integrated_signaler/signaler // AI's signaller
 
-	var/obj/item/instrument/recorder/internal_instrument
+	var/obj/item/instrument/piano_synth/internal_instrument
 
 	var/holoform = FALSE
 	var/canholo = TRUE

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -269,7 +269,10 @@
 				cable = new /obj/item/pai_cable(T)
 				T.visible_message("<span class='warning'>A port on [src] opens to reveal [cable], which promptly falls to the floor.</span>", "<span class='italics'>You hear the soft click of something light and hard falling to the ground.</span>")
 		if("loudness")
-			internal_instrument.interact(src)
+			if(subscreen == 1) // Open Instrument
+				internal_instrument.interact(src)
+			if(subscreen == 2) // Change Instrument type
+				internal_instrument.selectInstrument()
 
 	//updateUsrDialog()		We only need to account for the single mob this is intended for, and he will *always* be able to call this window
 	paiInterface()		 // So we'll just call the update directly rather than doing some default checks
@@ -634,4 +637,7 @@
 /mob/living/silicon/pai/proc/softwareLoudness()
 	if(!internal_instrument)
 		internal_instrument = new(src)
-	return "<h3>Sound Synthetizer</h3>"
+	var/dat = "<h3>Sound Synthetizer</h3>"
+	dat += "<a href='byond://?src=[REF(src)];software=loudness;sub=1'>Open Synthetizer Interface</a><br>"
+	dat += "<a href='byond://?src=[REF(src)];software=loudness;sub=2'>Choose Instrument Type</a>"
+	return dat


### PR DESCRIPTION
## About The Pull Request

Changes the instrument used internally by the Loudness Booster pAI software to a piano_synth from the previous boring recorder.
Software interface has been slightly changed to allow changing the instrument type.
Instrument selection code has been moved to it's own proc so the action-button and pAI interface can both use it without copypasta, and the dialog now shows the current instrument as selected in the menu.

Tested locally and seems to work fine.

Yay, first pull request ever.

## Why It's Good For The Game

One round I was playing music as a pAI while in the ownership of a traitor.
She wanted a different instrument, but I could not choose one.
So I fixed it.

## Changelog
:cl:
tweak: Nanotrasen has released a software update for pAI's that allows them to synthesize various musical instruments.
/:cl:
