### PR TITLE
Fixes syndicate mob block chance

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -133,10 +133,9 @@
 
 /mob/living/simple_animal/hostile/syndicate/melee/bullet_act(obj/item/projectile/Proj)
 	if(prob(projectile_deflect_chance))
-		return ..()
-	else
 		visible_message("<span class='danger'>[src] blocks [Proj] with its shield!</span>")
 		return BULLET_ACT_BLOCK
+	return ..()
 
 /mob/living/simple_animal/hostile/syndicate/melee/sword/space
 	icon_state = "syndicate_space_sword"


### PR DESCRIPTION
:cl:
fix: Shield-less syndicate mobs no longer block projectiles
/:cl:

The logic was written backwards from the way the chance variables are set (shieldless mobs have 0, shield mobs have 50)