### PR TITLE
Fixes defective clones not losing cloning pod traits

### DIFF
--- a/code/game/machinery/exp_cloner.dm
+++ b/code/game/machinery/exp_cloner.dm
@@ -42,11 +42,11 @@
 	icon_state = "pod_1"
 	//Get the clone body ready
 	maim_clone(H)
-	H.add_trait(TRAIT_STABLEHEART, "cloning")
-	H.add_trait(TRAIT_EMOTEMUTE, "cloning")
-	H.add_trait(TRAIT_MUTE, "cloning")
-	H.add_trait(TRAIT_NOBREATH, "cloning")
-	H.add_trait(TRAIT_NOCRITDAMAGE, "cloning")
+	H.add_trait(TRAIT_STABLEHEART, CLONING_POD_TRAIT)
+	H.add_trait(TRAIT_EMOTEMUTE, CLONING_POD_TRAIT)
+	H.add_trait(TRAIT_MUTE, CLONING_POD_TRAIT)
+	H.add_trait(TRAIT_NOBREATH, CLONING_POD_TRAIT)
+	H.add_trait(TRAIT_NOCRITDAMAGE, CLONING_POD_TRAIT)
 	H.Unconscious(80)
 
 	var/list/candidates = pollCandidatesForMob("Do you want to play as [clonename]'s defective clone?", null, null, null, 100, H)


### PR DESCRIPTION
:cl:
fix: Defective clones will no longer be permanently mute
/:cl:

Fixes #42543

These traits are supposed to be removed here
https://github.com/tgstation/tgstation/blob/9dfa7a6d58bbf19311d3ed5e2bb6aa040b523404/code/game/machinery/cloning.dm#L385-L389

however the hardcoded string didn't match the define
https://github.com/tgstation/tgstation/blob/3e1781a44a8ace8e03a0a1eaf62e61425b21b7e8/code/__DEFINES/traits.dm#L128