### PR TITLE
Fixes mop bucket sprite not updating properly after filling with a bucket

### DIFF
--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -21,7 +21,8 @@
 			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 			update_icon()
 	else
-		return ..()
+		. = ..()
+		update_icon()
 
 /obj/structure/mopbucket/update_icon()
 	cut_overlays()


### PR DESCRIPTION
## About The Pull Request

The mop bucket wasn't updating its sprite properly when filled with a bucket, and would update when you got your mop wet. This fixes that.

## Why It's Good For The Game

Minor fix but still a fix

No CL because it's a ridiculously minor fix

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
