### PR TITLE
Fixes 10mm rifle mags and sniper mags not reporting ammo/updating material values.

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -7,6 +7,7 @@
 	max_ammo = 10
 
 /obj/item/ammo_box/magazine/m10mm/rifle/update_icon()
+	..()
 	if(ammo_count())
 		icon_state = "75-8"
 	else

--- a/code/modules/projectiles/boxes_magazines/external/sniper.dm
+++ b/code/modules/projectiles/boxes_magazines/external/sniper.dm
@@ -6,6 +6,7 @@
 	caliber = ".50"
 
 /obj/item/ammo_box/magazine/sniper_rounds/update_icon()
+	..()
 	if(ammo_count())
 		icon_state = "[initial(icon_state)]-ammo"
 	else


### PR DESCRIPTION
Fixes #42929
:cl: ShizCalev
fix: Fixed 10mm rifle mags and sniper mags not reporting ammo/updating material values.
/:cl:
