### PR TITLE
Buffs rad collector point production by multiplying the conversion rate by 50x but also nerfs them by capping rad collector output to 5k per process cycle

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -65,7 +65,7 @@
 			loaded_tank.air_contents.assert_gas(/datum/gas/carbon_dioxide)
 			loaded_tank.air_contents.gases[/datum/gas/carbon_dioxide][MOLES] += gasdrained*2
 			loaded_tank.air_contents.garbage_collect()
-			var/bitcoins_mined = min(RAD_COLLECTOR_OUTPUT * RAD_COLLECTOR_CONVERSION_RATE, RAD_COLLECTOR_MINING_CONVERSION_CAP)
+			var/bitcoins_mined = min(RAD_COLLECTOR_OUTPUT * RAD_COLLECTOR_MINING_CONVERSION_RATE, RAD_COLLECTOR_MINING_CONVERSION_CAP)
 			var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_ENG)
 			if(D)
 				D.adjust_money(bitcoins_mined)


### PR DESCRIPTION
This PR basically does exactly as it says on the tin. Some time between just last year and last week, supermatters were nerfed with their power production being cut down to a mere tenth of what it was when I first made the PR that made rad collectors capable of producing both tritium and research points. But the conversion rate was never actually adjusted, which means that even though the intended baseline for rad collectors with a roundstart supermatter setup is supposed to be 7 research points per minute/process cycle per rad collector, it ended up being a laughable .7 instead. This means that the setup I use that's supposed to be capable of producing well over 5k research points per rad collector only produces a laughable 500 points per rad collector. However, this PR goes a little beyond just making the point production match up with what it's actually supposed to be, as it increases the baseline to 5x of the original intended amount. This means that you only need to be approximately 0.2x as autistic as was originally necessary to speedrun RND with the supermatter and rad collectors alone, and also means that the new baseline for a newbie/standard supermatter setup has been increased from 7ppm/prc to 35ppm/prc, bringing the total amount of research points the most basic setup can produce to a total of 210 points per minute across all six rad collectors. This PR also adds a cap for the point production mode of rad collectors, which is seated at a solid 5k points per process cycle, this is to prevent people from completing RND in under 15 minutes from roundstart with the supermatter alone.

:cl:
balance: The rad collector point production conversion rate has been multiplied by 50x. The new baseline for rad collector point production with a very basic supermatter setup is 35 points per minute per rad collector. Protip for those that actually look at the changelog: Radiation collectors turn plasma into tritium, meaning you can premix oxygen into plasma tanks to instantly start producing research points on demand.
balance: Rad collector point production is now capped at 5k points per process cycle, since it's no longer a herculean effort to achieve that level of point production.
/:cl:
