### PR TITLE
Adds Firefighter Helmets to Autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -44,6 +44,14 @@
 	build_path = /obj/item/extinguisher/mini
 	category = list("initial","Tools")
 
+/datum/design/firefighterhelmet
+	name = "Firefighter Helmet"
+	id = "firefighterhelmet"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 150, MAT_GLASS = 40)
+	build_path = /obj/item/clothing/head/hardhat/red
+	category = list("initial","Tools")
+
 /datum/design/multitool
 	name = "Multitool"
 	id = "multitool"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Firefighter Helmests (red hardhats) to the list of items Autolathes can print.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
With emergency fire lockers regularly looted and the recent addition of firebots which require this type of hardhat, making it printable reduces competition over them and having to hunt down a non-looted locker.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds Firefighter Helmets to Autolathes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
