### PR TITLE
Fixes advanced proc calls not working + various code cleaning

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -104,8 +104,8 @@ GLOBAL_LIST_EMPTY(AdminProcCallSpamPrevention)
 GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 
 /proc/WrapAdminProcCall(datum/target, procname, list/arguments)
-	if(target != GLOBAL_PROC && procname in list("Del","Destroy"))
-		to_chat(usr, "<span class='warning'>Calling [procname]() is not allowed</span>")
+	if(target != GLOBAL_PROC && procname == "Del")
+		to_chat(usr, "<span class='warning'>Calling Del() is not allowed</span>")
 		return
 
 	if(target != GLOBAL_PROC && !target.CanProcCall(procname))


### PR DESCRIPTION
## About The Pull Request

Fixes advances proccall not working as in #42937, but also handles the `target_selected` (a.k.a non global) case .
Various code cleaning while i was at it.

Closes #42937.

:cl: monster860
fix: fixes advanced proccall
/:cl: