### PR TITLE
galaxy brain hivemind bugfixes

### DIFF
--- a/code/game/gamemodes/hivemind/radar.dm
+++ b/code/game/gamemodes/hivemind/radar.dm
@@ -66,7 +66,7 @@
 	if(.)
 		tracked_by = hunter
 		if(isnum(set_duration))
-			duration = set_duration
+			duration = world.time + set_duration
 
 //Screen alert
 /obj/screen/alert/status_effect/agent_pinpointer/hivemind

--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -86,13 +86,13 @@
 			to_chat(owner, "<big><span class='assimilator'>Our true power, the One Mind, is finally within reach.</span></big>")
 
 /datum/antagonist/hivemind/proc/add_track_bonus(datum/antagonist/hivemind/enemy, bonus)
-	if(individual_track_bonus[enemy])
+	if(!individual_track_bonus[enemy])
 		individual_track_bonus[enemy] = bonus
 	else
 		individual_track_bonus[enemy] += bonus
 
 /datum/antagonist/hivemind/proc/get_track_bonus(datum/antagonist/hivemind/enemy)
-	if(individual_track_bonus[enemy])
+	if(!individual_track_bonus[enemy])
 		. = 0
 	else
 		. = individual_track_bonus[enemy]
@@ -153,12 +153,12 @@
 	if(C == real_C) //Mind control check
 		real_C2.apply_status_effect(STATUS_EFFECT_HIVE_TRACKER, real_C, hive_C.get_track_bonus(hive_C2))
 		real_C.apply_status_effect(STATUS_EFFECT_HIVE_RADAR)
-		to_chat(real_C, "<span class='assimilator'>We detect a surge of psionic energy from a far away vessel before they disappear from the hive. Whatever happened, there's a good chance they're after us now.</span>")
+		to_chat(real_C2, "<span class='assimilator'>We detect a surge of psionic energy from a far away vessel before they disappear from the hive. Whatever happened, there's a good chance they're after us now.</span>")
 	if(C2 == real_C2)
 		real_C.apply_status_effect(STATUS_EFFECT_HIVE_TRACKER, real_C2, hive_C2.get_track_bonus(hive_C))
 		real_C2.apply_status_effect(STATUS_EFFECT_HIVE_RADAR)
 		user_warning += " and we've managed to pinpoint their location"
-	to_chat(C2, "<span class='userdanger'>[user_warning]!</span>")
+	to_chat(real_C, "<span class='userdanger'>[user_warning]!</span>")
 
 /datum/antagonist/hivemind/proc/destroy_hive()
 	hivemembers = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes the broken radars (again). the duration of a status effect, unless set on creation, is world.time+duration  [(See here)](https://github.com/tgstation/tgstation/blob/9d28bd7244844dba26ca213aca64f1295fc2eeeb/code/datums/status_effects/status_effect.dm#L28) and not just duration, which was causing them to expire instantly.

flips a couple of backwards conditionals (set to zero if can't find anything instead of can find anything), flips the receivers of a couple of messages (tested ingame, it was backwards).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

it makes the mode work better

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Kierany9
fix: The hivemind radar works again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
