### PR TITLE
Loot crates no longer explode after unlocking

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -169,6 +169,7 @@
 				locked = FALSE
 				cut_overlays()
 				add_overlay("securecrateg")
+				tamperproof = 0
 			else if (input == null || sanitycheck == null || length(input) != codelen)
 				to_chat(user, "<span class='notice'>You leave the crate alone.</span>")
 			else

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -169,7 +169,7 @@
 				locked = FALSE
 				cut_overlays()
 				add_overlay("securecrateg")
-				tamperproof = 0
+				tamperproof = 0 // set explosion chance to zero, so we dont accidently hit it with a multitool and instantly die
 			else if (input == null || sanitycheck == null || length(input) != codelen)
 				to_chat(user, "<span class='notice'>You leave the crate alone.</span>")
 			else


### PR DESCRIPTION
Closes #36206

:cl:
tweak: loot crates can't explode after unlocking anymore
/:cl:
Quality of life. Basicly after unlocking a loot crate people sometimes still hit it with a multitool and now that it's unlocked it doesn't intercept, so it explodes and fucking kills you