### PR TITLE
Allows Mecha Clamps to open Firelocks and unpowered Airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1037,7 +1037,7 @@
 	else if(locked)
 		to_chat(user, "<span class='warning'>The airlock's bolts prevent it from being forced!</span>")
 	else if( !welded && !operating)
-		if(istype(I, /obj/item/twohanded/fireaxe)) //being fireaxe'd (maybe)
+		if(istype(I, /obj/item/twohanded/fireaxe)) //being fireaxe'd
 			var/obj/item/twohanded/fireaxe/F = I
 			if(!F.wielded)
 				to_chat(user, "<span class='warning'>You need to be wielding the fire axe to do that!</span>")

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1037,12 +1037,14 @@
 	else if(locked)
 		to_chat(user, "<span class='warning'>The airlock's bolts prevent it from being forced!</span>")
 	else if( !welded && !operating)
-		if(!beingcrowbarred) //being fireaxe'd
-			var/obj/item/twohanded/fireaxe/F = I
-			if(F.wielded)
-				INVOKE_ASYNC(src, (density ? .proc/open : .proc/close), 2)
-			else
+		if(!beingcrowbarred) //being fireaxe'd (maybe)
+			var/obj/item/twohanded/fireaxe/F = null
+			if(istype(I, /obj/item/twohanded/fireaxe))
+				F = I
+			if(F && !F.wielded)
 				to_chat(user, "<span class='warning'>You need to be wielding the fire axe to do that!</span>")
+			else
+				INVOKE_ASYNC(src, (density ? .proc/open : .proc/close), 2)
 		else
 			INVOKE_ASYNC(src, (density ? .proc/open : .proc/close), 2)
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1037,16 +1037,12 @@
 	else if(locked)
 		to_chat(user, "<span class='warning'>The airlock's bolts prevent it from being forced!</span>")
 	else if( !welded && !operating)
-		if(!beingcrowbarred) //being fireaxe'd (maybe)
-			var/obj/item/twohanded/fireaxe/F = null
-			if(istype(I, /obj/item/twohanded/fireaxe))
-				F = I
-			if(F && !F.wielded)
+		if(istype(I, /obj/item/twohanded/fireaxe)) //being fireaxe'd (maybe)
+			var/obj/item/twohanded/fireaxe/F = I
+			if(!F.wielded)
 				to_chat(user, "<span class='warning'>You need to be wielding the fire axe to do that!</span>")
-			else
-				INVOKE_ASYNC(src, (density ? .proc/open : .proc/close), 2)
-		else
-			INVOKE_ASYNC(src, (density ? .proc/open : .proc/close), 2)
+				return
+		INVOKE_ASYNC(src, (density ? .proc/open : .proc/close), 2)
 
 	if(istype(I, /obj/item/crowbar/power))
 		if(isElectrified())

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -34,6 +34,14 @@
 		return
 	if(isobj(target))
 		var/obj/O = target
+		if(istype(O, /obj/machinery/door/firedoor))
+			var/obj/machinery/door/firedoor/D = O
+			D.try_to_crowbar(src,chassis.occupant)
+			return
+		if(istype(O, /obj/machinery/door/airlock/))
+			var/obj/machinery/door/airlock/D = O
+			D.try_to_crowbar(src,chassis.occupant)
+			return
 		if(!O.anchored)
 			if(cargo_holder.cargo.len < cargo_holder.cargo_capacity)
 				chassis.visible_message("[chassis] lifts [target] and starts to load it into cargo compartment.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This change lets the mecha clamp call the try_to_crowbar proc of firelocks and airlocks. If a standard crowbar will open it, so will the clamp.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows Firefighters the ability to actually reach a fire to fight it. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Zxaber
tweak: The Mecha Hydraulic Clamp can now open firelocks and unpowered airlocks 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

I know it seems weird that a giant mech clamp doesn't have the same strength as the jaws of life, but I _really_ don't want to give such griefing power to mechs that are so easy to produce.