### PR TITLE
Jordie proofs the codebase

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -243,7 +243,7 @@ This prevents nesting levels from getting deeper then they need to be.
 
 * Queries must never specify the database, be it in code, or in text files in the repo.
 
-* Primary keys are inharently immutable and your must never do anything to change the primary key of a row. This includes preserving auto increment numbers of rows when copying data to a table in a conversion script. No amount of bitching about gaps in ids will save you from this policy.
+* Primary keys are inherently immutable and your must never do anything to change the primary key of a row. This includes preserving auto increment numbers of rows when copying data to a table in a conversion script. No amount of bitching about gaps in ids will save you from this policy.
 
 ### Mapping Standards
 * TGM Format & Map Merge

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -243,7 +243,7 @@ This prevents nesting levels from getting deeper then they need to be.
 
 * Queries must never specify the database, be it in code, or in text files in the repo.
 
-* Primary keys are inherently immutable and your must never do anything to change the primary key of a row. This includes preserving auto increment numbers of rows when copying data to a table in a conversion script. No amount of bitching about gaps in ids will save you from this policy.
+* Primary keys are inherently immutable and your must never do anything to change the primary key of a row or entity. This includes preserving auto increment numbers of rows when copying data to a table in a conversion script. No amount of bitching about gaps in ids or out of order ids will save you from this policy.
 
 ### Mapping Standards
 * TGM Format & Map Merge

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -243,6 +243,8 @@ This prevents nesting levels from getting deeper then they need to be.
 
 * Queries must never specify the database, be it in code, or in text files in the repo.
 
+* Primary keys are inharently immutable and your must never do anything to change the primary key of a row. This includes preserving auto increment numbers of rows when copying data to a table in a conversion script. No amount of bitching about gaps in ids will save you from this policy.
+
 ### Mapping Standards
 * TGM Format & Map Merge
 	* All new maps submitted to the repo through a pull request must be in TGM format (unless there is a valid reason present to have it in the default BYOND format.) This is done using the [Map Merge](https://github.com/tgstation/tgstation/wiki/Map-Merger) utility included in the repo to convert the file to TGM format.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -243,7 +243,7 @@ This prevents nesting levels from getting deeper then they need to be.
 
 * Queries must never specify the database, be it in code, or in text files in the repo.
 
-* Primary keys are inherently immutable and your must never do anything to change the primary key of a row or entity. This includes preserving auto increment numbers of rows when copying data to a table in a conversion script. No amount of bitching about gaps in ids or out of order ids will save you from this policy.
+* Primary keys are inherently immutable and you must never do anything to change the primary key of a row or entity. This includes preserving auto increment numbers of rows when copying data to a table in a conversion script. No amount of bitching about gaps in ids or out of order ids will save you from this policy.
 
 ### Mapping Standards
 * TGM Format & Map Merge


### PR DESCRIPTION
Some unbanned legacy bans came back as active bans because the db conversion script jordie had me run back during the ban panel rewrite didn't account for erro being erro and setting `unbanned` to `2` in some cases for reasons we don't understand or care about.

Normally I could easily fix this by having mysql give me a list of every id in the old ban table with unbanned set to `2`, and shunting that as a subquery to an update statement to unban those bans. but jordie, complaining about weird gaps in ordering and id numbers, intentionally reset and reassigned the id numbers of all bans during the conversion.

Its at this point that I decided we should never reshuffle ids arounds for bullshit reasons.