### PR TITLE
Makes regular Sandwich more nutritional than grilled cheese

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_sandwichtoast.dm
+++ b/code/modules/food_and_drinks/food/snacks_sandwichtoast.dm
@@ -5,7 +5,7 @@
 	icon_state = "sandwich"
 	trash = /obj/item/trash/plate
 	bonus_reagents = list("nutriment" = 1, "vitamin" = 1)
-	list_reagents = list("nutriment" = 6, "vitamin" = 1)
+	list_reagents = list("nutriment" = 7, "vitamin" = 1)
 	cooked_type = /obj/item/reagent_containers/food/snacks/toastedsandwich
 	tastes = list("meat" = 2, "cheese" = 1, "bread" = 2, "lettuce" = 1)
 	foodtype = GRAIN | VEGETABLES
@@ -28,7 +28,7 @@
 	icon_state = "toastedsandwich"
 	trash = /obj/item/trash/plate
 	bonus_reagents = list("nutriment" = 1, "vitamin" = 1)
-	list_reagents = list("nutriment" = 7, "vitamin" = 1)
+	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 	tastes = list("toast" = 1, "cheese" = 1)
 	foodtype = GRAIN | DAIRY
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This makes the regular sandwich option, with meat and lettuce, more nutritional than grilled cheese. This makes it more realistic since meat and lettuce is better than just cheese and bread. Old Nutritional values were:
Grilled Cheese: Nutrition: 7, Vitamin: 1
Sandwich: Nutrition: 6, Vitamin 1

New values are:
Grilled Cheese: Nutrition 6, Vitamin 1
Sandwich: Nutrition 7, Vitamin 1
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds more realism and makes more sense because grilled cheese is for poor people
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: swapped nutrition values for sandwich and grilled cheese
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
