### PR TITLE
Elances no longer explode when thrown

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -521,7 +521,6 @@
 		G = new /obj/item/grenade/iedcasing() //For admin-spawned explosive lances
 	G.forceMove(src)
 	explosive = G
-
 	desc = "A makeshift spear with [G] attached to it"
 	update_icon()
 
@@ -540,14 +539,6 @@
 
 /obj/item/twohanded/spear/explosive/update_icon()	
 	icon_state = "spearbomb[wielded]"
-
- //THIS MIGHT BE UNBALANCED SO I DUNNO // it totally is.
-/obj/item/twohanded/spear/explosive/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-	. = ..()
-	if(!.) //not caught
-		explosive.forceMove(get_turf(src))
-		explosive.prime()
-		qdel(src)
 
 /obj/item/twohanded/spear/explosive/AltClick(mob/user)
 	if(user.canUseTopic(src, BE_CLOSE))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR stops elances from exploding when they're thrown.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Elances can be used to straight up delete players with close to no risk to you. With this change, they're harder to use (melee range) and come with the substantial risk of killing you as well.

IMO this would be a decent test merge candidate so that people can see if they're still used to take down threats like wizards or nuke ops.

Closes: #42993
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
balance: Explosive lances no longer explode when thrown (but still do with melee attacks).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
