### PR TITLE
Elance Rebalance

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -71,6 +71,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/list/species_exception = null	// list() of species types, if a species cannot put items in a certain slot, but species type is in list, it will be able to wear that item
 
 	var/mob/thrownby = null
+	var/targeting = 0 // Before dropping but after throwing has been started
 
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER //the icon to indicate this object is being dragged
 

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -513,6 +513,7 @@
 
 /obj/item/twohanded/spear/explosive
 	name = "explosive lance"
+	desc = "A spear with a grenade at the tip, it looks dangerous to even put down!"
 	var/obj/item/grenade/explosive = null
 
 /obj/item/twohanded/spear/explosive/Initialize(mapload, obj/item/grenade/G)
@@ -575,7 +576,7 @@
 		return TRUE //It hit the mounted grenade, not them
 
 /obj/item/twohanded/spear/explosive/fire_act(exposed_temperature, exposed_volume)
-	explosive.forceMove(get_turf(src)) 
+	explosive.forceMove(get_turf(src))
 	explosive.prime()
 	qdel(src)
 

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -565,6 +565,27 @@
 		explosive.prime()
 		qdel(src)
 
+/obj/item/twohanded/spear/explosive/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	var/obj/item/projectile/P = hitby
+	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(50))
+		owner.visible_message("<span class='danger'>[attack_text] hits [owner]'s [src], setting it off! What did they think would happen?</span>")
+		explosive.forceMove(get_turf(src))
+		explosive.prime()
+		qdel(src)
+		return TRUE //It hit the mounted grenade, not them
+
+/obj/item/twohanded/spear/explosive/fire_act(exposed_temperature, exposed_volume)
+	explosive.forceMove(get_turf(src)) 
+	explosive.prime()
+	qdel(src)
+
+/obj/item/twohanded/spear/explosive/dropped(mob/user)
+	. = ..()
+	if(loc == get_turf(src) && get_turf(src) == get_turf(user) && !src.targeting)
+		explosive.forceMove(get_turf(src))
+		explosive.prime()
+		qdel(src)
+
 // CHAINSAW
 /obj/item/twohanded/required/chainsaw
 	name = "chainsaw"

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -513,7 +513,6 @@
 
 /obj/item/twohanded/spear/explosive
 	name = "explosive lance"
-	desc = "A spear with a grenade at the tip, it looks dangerous to even put down!"
 	var/obj/item/grenade/explosive = null
 
 /obj/item/twohanded/spear/explosive/Initialize(mapload, obj/item/grenade/G)
@@ -523,7 +522,7 @@
 	G.forceMove(src)
 	explosive = G
 
-	desc = "A makeshift spear with [G] attached to it"
+	desc = "A makeshift spear with [G] attached to it, it looks dangerous to even put down!"
 	update_icon()
 
 /obj/item/twohanded/spear/explosive/suicide_act(mob/living/carbon/user)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -171,13 +171,16 @@
 
 	else if(!CHECK_BITFIELD(I.item_flags, ABSTRACT) && !I.has_trait(TRAIT_NODROP))
 		thrown_thing = I
+		I.targeting = 1
 		dropItemToGround(I)
 
 		if(has_trait(TRAIT_PACIFISM) && I.throwforce)
 			to_chat(src, "<span class='notice'>You set [I] down gently on the ground.</span>")
+			I.targeting = 0
 			return
 
 	if(thrown_thing)
+		I.targeting = 0
 		visible_message("<span class='danger'>[src] has thrown [thrown_thing].</span>")
 		log_message("has thrown [thrown_thing]", LOG_ATTACK)
 		newtonian_move(get_dir(target, src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rebalances the explosive lance by making it much riskier to use while retaining it's current rewards. Currently adds a 50% chance when shot to detonate the lance (similar to grenades but higher odds) and detonates the lance upon dropping it (intentional or unintentional, safe way to transfer is to hand it over personally or place on a table). Once I figure out how to code it it will also detonate if the wielder is ignited with the lance in hand.

## Why It's Good For The Game

The current issue with the explosive lance is that there's not much risk to using it while the rewards are significant. By making it much more unstable it both adds real downsides to the lance and fits its theme, as only a crazy person would stick an explosive on a stick.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: BuffEngineering
balance: The explosive lance will now detonate if you drop it carelessly (e.g. not placed onto a table), are lit on fire while holding it, or at a 50% chance if you are shot while holding it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
