### PR TITLE
Tweaks the powerfist

### DIFF
--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -79,9 +79,19 @@
         return
     T.assume_air(gasused)
     T.air_update_turf()
-    if(gasused.total_moles() < (gasperfist * fisto_setting))
+    if(gasused.total_moles() == 0)
+        to_chat(user, "<span class='warning'>\The [src]'s tank is empty!</span>")
+        target.apply_damage(force / 5, BRUTE)
+        playsound(loc, 'sound/weapons/punch1.ogg', 50, 1)
+        target.visible_message("<span class='danger'>[user]'s powerfist lets out a dull thunk as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
+            "<span class='userdanger'>[user]'s punches you!</span>")
+        return
+    if(gasused.total_moles() < gasperfist * fisto_setting)
         to_chat(user, "<span class='warning'>\The [src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
-        playsound(loc, 'sound/effects/refill.ogg', 50, 1)
+        playsound(loc, 'sound/weapons/punch4.ogg', 50, 1)
+        target.apply_damage(force / 2, BRUTE)
+        target.visible_message("<span class='danger'>[user]'s powerfist lets out a weak hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
+            "<span class='userdanger'>[user]'s punch strikes with force!</span>")
         return
     target.apply_damage(force * fisto_setting, BRUTE)
     target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
@@ -92,7 +102,7 @@
 
     var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
 
-    target.throw_at(throw_target, 5 * fisto_setting, fisto_setting)
+    target.throw_at(throw_target, 5 * fisto_setting, 0.5 + (fisto_setting / 2))
 
     log_combat(user, target, "power fisted", src)
 

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -87,7 +87,7 @@
 
 	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
 
-	target.throw_at(throw_target, 5 * fisto_setting, 0.2)
+	target.throw_at(throw_target, 5 * fisto_setting, 1.5)
 
 	log_combat(user, target, "power fisted", src)
 

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -79,9 +79,9 @@
         return
     T.assume_air(gasused)
     T.air_update_turf()
-    if(gasused.total_moles() == 0)
+    if(!gasused)
         to_chat(user, "<span class='warning'>\The [src]'s tank is empty!</span>")
-        target.apply_damage(force / 5, BRUTE)
+        target.apply_damage((force / 5), BRUTE)
         playsound(loc, 'sound/weapons/punch1.ogg', 50, 1)
         target.visible_message("<span class='danger'>[user]'s powerfist lets out a dull thunk as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
             "<span class='userdanger'>[user]'s punches you!</span>")
@@ -89,7 +89,7 @@
     if(gasused.total_moles() < gasperfist * fisto_setting)
         to_chat(user, "<span class='warning'>\The [src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
         playsound(loc, 'sound/weapons/punch4.ogg', 50, 1)
-        target.apply_damage(force / 2, BRUTE)
+        target.apply_damage((force / 2), BRUTE)
         target.visible_message("<span class='danger'>[user]'s powerfist lets out a weak hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
             "<span class='userdanger'>[user]'s punch strikes with force!</span>")
         return

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -50,7 +50,6 @@
 		if(tank)
 			updateTank(tank, 1, user)
 
-
 /obj/item/melee/powerfist/proc/updateTank(obj/item/tank/internals/thetank, removing = 0, mob/living/carbon/human/user)
 	if(removing)
 		if(!tank)
@@ -71,26 +70,32 @@
 
 
 /obj/item/melee/powerfist/attack(mob/living/target, mob/living/user)
-	if(!tank)
-		to_chat(user, "<span class='warning'>\The [src] can't operate without a source of gas!</span>")
-		return
-	if(tank && !tank.air_contents.remove(gasperfist * fisto_setting))
-		to_chat(user, "<span class='warning'>\The [src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
-		playsound(loc, 'sound/effects/refill.ogg', 50, 1)
-		return
-	target.apply_damage(force * fisto_setting, BRUTE)
-	target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
-		"<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
-	new /obj/effect/temp_visual/kinetic_blast(target.loc)
-	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
-	playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
+    if(!tank)
+        to_chat(user, "<span class='warning'>\The [src] can't operate without a source of gas!</span>")
+        return
+    var/datum/gas_mixture/gasused = tank.air_contents.remove(gasperfist * fisto_setting)
+    var/turf/T = get_turf(src)
+    if(!T)
+        return
+    T.assume_air(gasused)
+    T.air_update_turf()
+    if(gasused.total_moles() < (gasperfist * fisto_setting))
+        to_chat(user, "<span class='warning'>\The [src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
+        playsound(loc, 'sound/effects/refill.ogg', 50, 1)
+        return
+    target.apply_damage(force * fisto_setting, BRUTE)
+    target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
+        "<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
+    new /obj/effect/temp_visual/kinetic_blast(target.loc)
+    playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
+    playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
 
-	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
+    var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
 
-	target.throw_at(throw_target, 5 * fisto_setting, 1.5)
+    target.throw_at(throw_target, 5 * fisto_setting, fisto_setting)
 
-	log_combat(user, target, "power fisted", src)
+    log_combat(user, target, "power fisted", src)
 
-	user.changeNext_move(CLICK_CD_MELEE * click_delay)
+    user.changeNext_move(CLICK_CD_MELEE * click_delay)
 
-	return
+    return


### PR DESCRIPTION


## About The Pull Request

Changes the powerfist to not have a throw speed that normal walking people can match, rather actually flinging the person hit rather hard. Throw speed is based on the fist's setting. Also makes the powerfist leak its contents, based on the gas it contains and the settings.
(first, small, PR, be gentle)

## Why It's Good For The Game

Makes it so the puncher can't literally collide with people they punched, knocking themselves over, or other such shenanigans. Also makes the powerfist a lot more unique beyond just 'punches hard when you add gas', and clarifies some messages.

The launch speed might be a bit strong, and might warrant an up to the TC price. If I should do that, whack me with a stick about it.

## Changelog
:cl: Unit2E & JMoldy

balance: the powerfist now punches people away at high velocity depending on setting.
add: the powerfist now leaks the gas it uses onto the tile you're on.
tweak: Adds weak punch variations for empty and near-empty punching.


/:cl: