### PR TITLE
Fixes adminheal not clearing heartbeat sound

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -542,6 +542,7 @@
 	if (mood)
 		mood.remove_temp_moods(admin_revive)
 	update_mobility()
+	stop_sound_channel(CHANNEL_HEARTBEAT)
 
 //proc called by revive(), to check if we can actually ressuscitate the mob (we don't want to revive him and have him instantly die again)
 /mob/living/proc/can_be_revived()


### PR DESCRIPTION
Fixes #42995
:cl:
fix: Adminhealing someone in crit will now properly clear the heartbeat sound.
/:cl:
