### PR TITLE
[READY] Nerfs tasers (and all energy weapons capable of firing electrodes) to only have 1 electrode per engament

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -83,6 +83,7 @@
 
 /obj/item/gun/energy/can_shoot()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
+	recharge_electrodes()
 	if (istype(shot,/obj/item/ammo_casing/energy/electrode) && (num_electrodes <= 0))//If the gun has no electrode left, it can not fire an electrode
 		return FALSE
 	return !QDELETED(cell) ? (cell.charge >= shot.e_cost) : FALSE
@@ -114,7 +115,7 @@
 /obj/item/gun/energy/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	var/result
 	var/obj/item/ammo_casing/energy/AC
-	recharge_electrodes()
+	//recharge_electrodes()
 	if(can_shoot())
 		last_used = world.time
 		if(!chambered)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -22,7 +22,7 @@
 	var/dead_cell = FALSE //set to true so the gun is given an empty cell
 	var/last_used = 0 //Last time the gun was used.
 	var/max_electrodes = 1 //The maximum ammount of electrodes the gun can store.
-	var/num_electrodes = max_electrodes //The number of electordes the gun currently has.
+	var/num_electrodes = 1 //The number of electordes the gun currently has.
 	var/electrode_recharge_time = 300 //Time it takes to recharge the electrodes in deciseconds (ticks).
 
 /obj/item/gun/energy/emp_act(severity)
@@ -83,7 +83,7 @@
 
 /obj/item/gun/energy/can_shoot()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-	if (istype(shot,/obj/item/ammo_casing/energy/electrode) && (num_electrodes > 0))//If the gun has no electrode left, it can not fire an electrode
+	if (istype(shot,/obj/item/ammo_casing/energy/electrode) && (num_electrodes <= 0))//If the gun has no electrode left, it can not fire an electrode
 		return FALSE
 	return !QDELETED(cell) ? (cell.charge >= shot.e_cost) : FALSE
 
@@ -115,14 +115,16 @@
 	var/result
 	var/obj/item/ammo_casing/energy/AC
 	recharge_electrodes()
-	if(!chambered && can_shoot())
-		process_chamber()	// If the gun was drained and then recharged, load a new shot.
+	if(can_shoot())
+		last_used = world.time
+		if(!chambered)
+			process_chamber()	// If the gun was drained and then recharged, load a new shot.
 	AC = chambered
 	result = ..()
 	//Was an electrode fired?
 	if(istype(AC,/obj/item/ammo_casing/energy/electrode))
 		num_electrodes--
-		if((num_electrodes <= 0) && (ammo_type.length > 1)) //If the gun can fire something else than electrodes, switch ammo.
+		if((num_electrodes <= 0) && (ammo_type.len > 1)) //If the gun can fire something else than electrodes, switch ammo.
 			select_fire(user)
 	return result
 
@@ -131,10 +133,12 @@
 		process_chamber()	// Ditto.
 	return ..()
 
-/obj/item/gun/energy/recharge_electrodes()
-	var/time_passed = last_used - world.time
+/obj/item/gun/energy/proc/recharge_electrodes()
+	var/time_passed
+	time_passed = world.time -last_used
 	if(time_passed >= electrode_recharge_time)
 		num_electrodes = max_electrodes
+	return
 
 /obj/item/gun/energy/proc/select_fire(mob/living/user)
 	recharge_electrodes()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR represents an alternative to pull request #42930.

This pull request changes all energy weapons capable of firing electrodes in a way that they can only fire one electrode per engament. This is achieved by giving them a limited store of electrodes. Once depleted, the weapon will not be able to fire any more electrodes. If the weapon goes unused for 30 seconds, the weapon's stock of electrodes will be refilled.

If the last electrode is depleted, the weapon will automatically switch to next ammunition, the same as if the weapon had been activated in hand. For the hybrid taser, this is disable.

Potential future work would be to add additional counters to tasers. For example, some clothing, such as firesuits, could be made to grant the wearer immunity from taser shots.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The problem with tasers is that they lead to anticlimatic combat, since they deliver a 1 hit stun, which, if your opponent is bent on murder, means you are basically dead.

However, I believe that 1-hit kills have a place in game design, namely to foster paranoia among the players. Therefore, the ranged instant stun should not be excised entirely. This PR will make it so that a combat can be opened with an attempt at delivering an instant stun. However, if this attempt misses, you now have to use the taser in disabler mode, which needs 3 hits to down somebody.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: stun capable energy weapons have a limited store of electrodes (currently 1).
tweak: If a stun capable energy weapon runs out of electrodes, it has to go unused for 30 seconds to recharge its electrodes.
tweak: After the last electrode has been fired, the weapon switches to the next firing mode. (Disable in case of the taser).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
