### PR TITLE
Internet midi respects start and end times

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -67,7 +67,7 @@
 	if(istext(web_sound_input))
 		var/web_sound_url = ""
 		var/stop_web_sounds = FALSE
-		var/pitch
+		var/list/music_extra_data = list("pitch", "seek")
 		if(length(web_sound_input))
 
 			web_sound_input = trim(web_sound_input)
@@ -95,6 +95,7 @@
 					var/webpage_url = title
 					if (data["webpage_url"])
 						webpage_url = "<a href=\"[data["webpage_url"]]\">[title]</a>"
+					music_extra_data["seek"] = data["start_time"]
 
 					var/res = alert(usr, "Show the title of and link to this song to the players?\n[title]",, "No", "Yes", "Cancel")
 					switch(res)
@@ -126,7 +127,7 @@
 				var/client/C = M.client
 				if((C.prefs.toggles & SOUND_MIDI) && C.chatOutput && !C.chatOutput.broken && C.chatOutput.loaded)
 					if(!stop_web_sounds)
-						C.chatOutput.sendMusic(web_sound_url, pitch)
+						C.chatOutput.sendMusic(web_sound_url, music_extra_data)
 					else
 						C.chatOutput.stopMusic()
 

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -67,7 +67,7 @@
 	if(istext(web_sound_input))
 		var/web_sound_url = ""
 		var/stop_web_sounds = FALSE
-		var/list/music_extra_data = list("pitch", "seek")
+		var/list/music_extra_data = list("pitch", "start", "end")
 		if(length(web_sound_input))
 
 			web_sound_input = trim(web_sound_input)
@@ -95,7 +95,8 @@
 					var/webpage_url = title
 					if (data["webpage_url"])
 						webpage_url = "<a href=\"[data["webpage_url"]]\">[title]</a>"
-					music_extra_data["seek"] = data["start_time"]
+					music_extra_data["start"] = data["start_time"]
+					music_extra_data["end"] = data["end_time"]
 
 					var/res = alert(usr, "Show the title of and link to this song to the players?\n[title]",, "No", "Yes", "Cancel")
 					switch(res)

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -67,7 +67,7 @@
 	if(istext(web_sound_input))
 		var/web_sound_url = ""
 		var/stop_web_sounds = FALSE
-		var/list/music_extra_data = list("pitch", "start", "end")
+		var/list/music_extra_data = list()
 		if(length(web_sound_input))
 
 			web_sound_input = trim(web_sound_input)

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -120,9 +120,10 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 		return
 	var/list/music_data = list("adminMusic" = url_encode(url_encode(music)))
 
-	if(extra_data && extra_data.len)
+	if(extra_data?.len)
 		music_data["musicRate"] = extra_data["pitch"]
-		music_data["musicSeek"] = extra_data["seek"]
+		music_data["musicSeek"] = extra_data["start"]
+		music_data["musicHalt"] = extra_data["end"]
 
 	ehjax_send(data = music_data)
 

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -115,12 +115,15 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 		data = json_encode(data)
 	C << output("[data]", "[window]:ehjaxCallback")
 
-/datum/chatOutput/proc/sendMusic(music, pitch)
+/datum/chatOutput/proc/sendMusic(music, list/extra_data)
 	if(!findtext(music, GLOB.is_http_protocol))
 		return
 	var/list/music_data = list("adminMusic" = url_encode(url_encode(music)))
-	if(pitch)
-		music_data["musicRate"] = pitch
+
+	if(extra_data && extra_data.len)
+		music_data["musicRate"] = extra_data["pitch"]
+		music_data["musicSeek"] = extra_data["seek"]
+
 	ehjax_send(data = music_data)
 
 /datum/chatOutput/proc/stopMusic()

--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -65,6 +65,7 @@ var opts = {
 	'volumeUpdateDelay': 5000, //Time from when the volume updates to data being sent to the server
 	'volumeUpdating': false, //True if volume update function set to fire
 	'updatedVolume': 0, //The volume level that is sent to the server
+	'musicStartAt': 0, //The position the music starts playing
 	
 	'defaultMusicVolume': 25,
 
@@ -552,6 +553,11 @@ function ehjaxCallback(data) {
 				} else {
 					$('#adminMusic').prop('defaultPlaybackRate', 1.0);
 				}
+				if (data.musicSeek) {
+					opts.musicStartAt = Number(data.musicSeek) || 0;
+				} else {
+					opts.musicStartAt = 0;
+				}
 				$('#adminMusic').prop('src', adminMusic);
 				$('#adminMusic').trigger("play");
 			}
@@ -582,6 +588,12 @@ function sendVolumeUpdate() {
 	opts.volumeUpdating = false;
 	if(opts.updatedVolume) {
 		runByond('?_src_=chat&proc=setMusicVolume&param[volume]='+opts.updatedVolume);
+	}
+}
+
+function adminMusicCanPlay(event) {
+	if ($('#adminMusic').prop('duration') === Infinity || (opts.musicStartAt <= $('#adminMusic').prop('duration'))) {
+		$('#adminMusic').prop('currentTime', opts.musicStartAt);
 	}
 }
 
@@ -1062,6 +1074,8 @@ $(function() {
 			opts.volumeUpdating = true;
 		}
 	});
+
+	$('#adminMusic').on('canplay', adminMusicCanPlay);
 
 	$('#toggleCombine').click(function(e) {
 		opts.messageCombining = !opts.messageCombining;


### PR DESCRIPTION
I was looking through [my rounds](https://sb.atlantaned.space/me) on statbus because I really wanted to find this dumb song that an admin played a while back, that I couldn't find anymore. I still haven't found it, but I did find this

[![screenshot_20190305_131352](https://user-images.githubusercontent.com/5211576/53827193-87cc0200-3f48-11e9-87ce-bfdb58d73745.png)](https://sb.atlantaned.space/rounds/82772/played_url)

So I thought "hm, I know that the admin midi definitely does not work like that", so I checked the logs of that round

[![cobby_struggling_with_memes](https://user-images.githubusercontent.com/5211576/53827326-c6fa5300-3f48-11e9-8aa4-d6171c5fb454.png)](https://tgstation13.org/parsed-logs/basil/data/logs/2018/01/30/round-82772/game.html)

Well @ExcessiveUseOfCobblestone, now it does!

Also, later on in the PR's life, I found that youtube-dl parses end_time too, so I supported that cause it's cool.

:cl: JJRcop
admin: Play Internet Sound now respects start (like &t=xxx or &start=xxx) and end times (like &end=xxx). This allows admins to choose a snippet of media to play, like for example pick a song out of an hour long album compilation.
/:cl: