### PR TITLE
Makes powersinks dense when anchored 

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -38,6 +38,7 @@
 			if(mode == OPERATING)
 				STOP_PROCESSING(SSobj, src)
 			anchored = FALSE
+			density = FALSE
 
 		if(CLAMPED_OFF)
 			if(!attached)
@@ -45,12 +46,14 @@
 			if(mode == OPERATING)
 				STOP_PROCESSING(SSobj, src)
 			anchored = TRUE
+			density = TRUE
 
 		if(OPERATING)
 			if(!attached)
 				return
 			START_PROCESSING(SSobj, src)
 			anchored = TRUE
+			density = TRUE
 
 	mode = value
 	update_icon()


### PR DESCRIPTION
## About The Pull Request

Density stops powersinks from being placed under airlocks or in other odd locations, acting like a placed machine or such.

## Why It's Good For The Game

Causes annoying powersinks that are extremely hard to find for no good reason to stop existing

closes #42852

## Changelog
:cl:
tweak: powersinks now become dense when anchored, like a machine.
/:cl:


