### PR TITLE
Trees now have the plants faction

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -12,6 +12,7 @@
 	response_help = "brushes"
 	response_disarm = "pushes"
 	response_harm = "hits"
+	faction = list("plants")
 	speed = 1
 	maxHealth = 250
 	health = 250
@@ -69,3 +70,4 @@
 	icon_gib = "festivus_pole"
 	loot = list(/obj/item/stack/rods)
 	speak_emote = list("polls")
+	faction = list()


### PR DESCRIPTION
closes #43017 

consistency i guess, i just think that the plants faction is one of the most diverse groupings of mobs who will not attack eachother. tomatoes to trees to podpeople, even kudzu respects it. i think that's pretty neat

and if wood golems are plants faction then why aren't trees huh