### PR TITLE
Escapes the quotes in the shell call

### DIFF
--- a/code/__HELPERS/shell.dm
+++ b/code/__HELPERS/shell.dm
@@ -25,7 +25,10 @@
 			shelleo_ids[shelleo_id] = TRUE
 		out_file = "[SHELLEO_NAME][shelleo_id][SHELLEO_OUT]"
 		err_file = "[SHELLEO_NAME][shelleo_id][SHELLEO_ERR]"
-		errorcode = shell("[interpreter] \"[command]\" > [out_file] 2> [err_file]")
+		if(world.system_type == UNIX)
+			errorcode = shell("[interpreter] \"[replacetext(command, "\"", "\\\"")]\" > [out_file] 2> [err_file]")
+		else
+			errorcode = shell("[interpreter] \"[command]\" > [out_file] 2> [err_file]")
 		if(fexists(out_file))
 			stdout = file2text(out_file)
 			fdel(out_file)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Escapes the quotes in the shell call so that the command does not get butchered when passed to execve
Before:
`shell("sh -c \"echo fuck me\"")`
would become
`[pid 13257] execve("/usr/bin/sh", ["sh", "-c", "echo fuck me"], 0x55a364d22e60 /* 64 vars */ <unfinished ...>`

instead,

`shell("sh -c \"echo \"fuck me\"\"")`
becomes
`[pid 14261] execve("/usr/bin/sh", ["sh", "-c", "echo fuck", "me"], 0x5628f8f15e60 /* 64 vars */ <unfinished ...>`
This PR escapes the quotes for linux, because on hippie the youtube-dl library wouldn't work, and this was part of the cause. I do not know if the same issue happens with window, so I applied the fix only if the system type of the server is linux.


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Any downstream that hosts on linux will benefit from this.
## Changelog
:cl: Carbonhell
server: youtube-dl works again for linux based servers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Big thanks to @PJB3005 !