### PR TITLE
Add a type annotation to represent proc paths

### DIFF
--- a/code/__DEFINES/procpath.dm
+++ b/code/__DEFINES/procpath.dm
@@ -1,0 +1,24 @@
+/// Represents a proc or verb path.
+///
+/// Despite having no DM-defined static type, proc paths have some variables,
+/// listed below. These are not modifiable, but for a given procpath P,
+/// `new P(null, "Name", "Desc")` can be used to create a new procpath with the
+/// same code but new `name` and `desc` values. The other variables cannot be
+/// changed in this way.
+///
+/// This type exists only to act as an annotation, providing reasonable static
+/// typing for procpaths. Previously, types like `/atom/verb` were used, with
+/// the `name` and `desc` vars of `/atom` thus being accessible. Proc and verb
+/// paths will fail `istype` and `ispath` checks against `/procpath`.
+/procpath
+	// Although these variables are effectively const, if they are marked const
+	// below, their accesses are optimized away.
+
+	/// A text string of the verb's name.
+	var/name as text
+	/// The verb's help text or description.
+	var/desc as text
+	/// The category or tab the verb will appear in.
+	var/category as text
+	/// Only clients/mobs with `see_invisibility` higher can use the verb.
+	var/invisibility as num

--- a/code/datums/verbs.dm
+++ b/code/datums/verbs.dm
@@ -11,7 +11,7 @@
 
 //do things for each entry in Generate_list
 //return value sets Generate_list[verbpath]
-/datum/verbs/proc/HandleVerb(list/entry, atom/verb/verbpath, ...)
+/datum/verbs/proc/HandleVerb(list/entry, procpath/verbpath, ...)
 	return entry
 
 /datum/verbs/New()
@@ -82,7 +82,7 @@
 				. += childlist
 
 	for (var/thing in verblist)
-		var/atom/verb/verbpath = thing
+		var/procpath/verbpath = thing
 		if (!verbpath)
 			stack_trace("Bad VERB in [type] verblist: [english_list(verblist)]")
 		var/list/entry = list()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -382,7 +382,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		for (var/child in entries)
 			winset(src, "[child]", "[entries[child]]")
 			if (!ispath(child, /datum/verbs/menu))
-				var/atom/verb/verbpath = child
+				var/procpath/verbpath = child
 				if (copytext(verbpath.name,1,2) != "@")
 					new child(src)
 

--- a/interface/menu.dm
+++ b/interface/menu.dm
@@ -65,10 +65,10 @@ GLOBAL_LIST_EMPTY(menulist)
 
 
 /datum/verbs/menu/Icon/Load_checked(client/C) //So we can be lazy, we invoke the "checked" menu item on menu load.
-	var/atom/verb/verbpath = Get_checked(C)
+	var/procpath/verbpath = Get_checked(C)
 	if (!verbpath || !(verbpath in typesof("[type]/verb")))
 		return
-	
+
 	if (copytext(verbpath.name,1,2) == "@")
 		winset(C, null, list2params(list("command" = copytext(verbpath.name,2))))
 	else

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -74,6 +74,7 @@
 #include "code\__DEFINES\pinpointers.dm"
 #include "code\__DEFINES\pipe_construction.dm"
 #include "code\__DEFINES\preferences.dm"
+#include "code\__DEFINES\procpath.dm"
 #include "code\__DEFINES\profile.dm"
 #include "code\__DEFINES\qdel.dm"
 #include "code\__DEFINES\radiation.dm"


### PR DESCRIPTION
`/atom/verb` is kind of a meaningless type annotation, the `.name` var is being pulled from the `/atom` part and not the `/verb` part, let's define a typepath which accurately represents what vars are available on procpaths.

Open to thoughts.