### PR TITLE
Fix the wizard hardsuit not being antimagic

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -423,7 +423,7 @@
 
 /obj/item/clothing/suit/space/hardsuit/wizard/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, FALSE, _blocks_self = FALSE)
+	AddComponent(/datum/component/anti_magic, TRUE, FALSE, INFINITY, FALSE)
 
 
 	//Medical hardsuit


### PR DESCRIPTION
`AddComponent` can't take keyword arguments:

```dm
[00:08:50] Runtime in ,: bad arg name '_blocks_self'
  proc name: AddComponent (/datum/proc/AddComponent)
  usr: SpaceManiac/(Joe Bine)
  usr.loc: (Primary Tool Storage (53, 56, 2))
  src: the gem-encrusted hardsuit (/obj/item/clothing/suit/space/hardsuit/wizard)
  src.loc: the floor (53,56,2) (/turf/open/floor/plasteel)
  call stack:
  the gem-encrusted hardsuit (/obj/item/clothing/suit/space/hardsuit/wizard): AddComponent(/datum/component/anti_magic (/datum/component/anti_magic), 1, 0, null)
  the gem-encrusted hardsuit (/obj/item/clothing/suit/space/hardsuit/wizard): Initialize(0)
  Atoms (/datum/controller/subsystem/atoms): InitAtom(the gem-encrusted hardsuit (/obj/item/clothing/suit/space/hardsuit/wizard), /list (/list))
  the gem-encrusted hardsuit (/obj/item/clothing/suit/space/hardsuit/wizard): New(0)
  spacemaniac\'s admin datum (!l... (/datum/admins): Topic("src=%5B0x21000ffe%5D%3Badmin_t...", /list (/list))
  SpaceManiac (/client): Topic("src=%5B0x21000ffe%5D%3Badmin_t...", /list (/list), spacemaniac\'s admin datum (!l... (/datum/admins))
  SpaceManiac (/client): Topic("src=%5B0x21000ffe%5D%3Badmin_t...", /list (/list), spacemaniac\'s admin datum (!l... (/datum/admins))
```

:cl:
fix: The wizard hardsuit now correctly grants magic resistance.
/:cl: