### PR TITLE
Remove misleading THIS_PROC_TYPE macro

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -9,19 +9,6 @@
 #define TEXT_EAST			"[EAST]"
 #define TEXT_WEST			"[WEST]"
 
-//These get to go at the top, because they're special
-//You can use these defines to get the typepath of the currently running proc/verb (yes procs + verbs are objects)
-/* eg:
-/mob/living/carbon/human/death()
-	to_chat(world, THIS_PROC_TYPE_STR) //You can only output the string versions
-Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a string with () (eg: the _WITH_ARGS defines) to make it look nicer)
-*/
-#define THIS_PROC_TYPE .....
-#define THIS_PROC_TYPE_STR "[THIS_PROC_TYPE]" //Because you can only obtain a string of THIS_PROC_TYPE using "[]", and it's nice to just +/+= strings
-#define THIS_PROC_TYPE_STR_WITH_ARGS "[THIS_PROC_TYPE]([args.Join(",")])"
-#define THIS_PROC_TYPE_WEIRD ...... //This one is WEIRD, in some cases (When used in certain defines? (eg: ASSERT)) THIS_PROC_TYPE will fail to work, but THIS_PROC_TYPE_WEIRD will work instead
-//define THIS_PROC_TYPE_WEIRD_STR "[THIS_PROC_TYPE_WEIRD]" //Included for completeness
-//define THIS_PROC_TYPE_WEIRD_STR_WITH_ARGS "[THIS_PROC_TYPE_WEIRD]([args.Join(",")])" //Ditto
 
 //Human Overlays Indexes/////////
 #define MUTATIONS_LAYER			29		//mutations. Tk headglows, cold resistance glow, etc

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -34,7 +34,7 @@
 	if(_directory)
 		directory = _directory
 	if(entries)
-		CRASH("[THIS_PROC_TYPE_WEIRD] called more than once!")
+		CRASH("/datum/controller/configuration/Load() called more than once!")
 	InitEntries()
 	LoadModes()
 	if(fexists("[directory]/config.txt") && LoadEntries("config.txt") <= 1)

--- a/code/modules/bsql/core/library.dm
+++ b/code/modules/bsql/core/library.dm
@@ -1,6 +1,6 @@
 /world/proc/_BSQL_Internal_Call(func, ...)
 	var/list/call_args = args.Copy(2)
-	BSQL_Debug("[.....]: [args[1]]([call_args.Join(", ")])")
+	BSQL_Debug("_BSQL_Internal_Call: [args[1]]([call_args.Join(", ")])")
 	. = call(_BSQL_Library_Path(), func)(arglist(call_args))
 	BSQL_Debug("Result: [. == null ? "NULL" : "\"[.]\""]")
 


### PR DESCRIPTION
`THIS_PROC_TYPE` only works when inside exactly 0 if/while/etc. blocks.
`THIS_PROC_TYPE_WEIRD` only works when inside exactly 1 if/while/etc. blocks.
These macros are therefore not really general or descriptive, and IMO should never be used.

Explanation
----

DreamMaker has a "pile of dots" syntax which is most usefully used to return a reference to the current proc, for debugging purposes, but can also resolve to the parent types of the current proc, according to these rules:

* 4 dots points to the current line.
* Each additional dot points to the parent block.
* Proc calls and operators also count as "blocks" for the purpose of this count.
  * Printing `.....` outputs `/datum/foo/bar/baz/example`, but
  * Printing `...... == /datum/foo/bar/baz/example` outputs 1.
* If the pointed-to thing is not a proc or type path, compile error.

As a result:
* 4 dots for the current line will never compile, because the current line is not a proc path.
* When not inside any `if`/`for`/`while` etc., 5 dots is the current proc.
* 6 dots will not compile if this is a proc declaration `/datum/proc/foo()` because it will resolve to the `proc` part.

Example:

```dm
/datum/foo/bar/proc/example()
	// 4 dots = current line = compile error
	// 5 dots = /datum/foo/bar/proc/baz
	// 6 dots = /datum/foo/bar/proc = compile error
	// 7 dots = /datum/foo/bar
	// 8 dots = /datum/foo
	// 9 dots = /datum
	// 10 dots = (root) = compile error ("not a prototype")

	if(A)
		if(B)
			if(C)
				// 4 dots = current line = compile error
				// 5 dots = if(C) = compile error
				// 6 dots = if(B) = compile error
				// 7 dots = if(A) = compile error
				// 8 dots = /datum/foo/bar/proc/baz
				// 9 dots = /datum/foo/bar/proc = compile error
				// 10 dots = /datum/foo/bar
				// 11 dots = /datum/foo
				// 12 dots = /datum
				// 13 dots = (root) = compile error ("not a prototype")

/datum/foo/bar/baz/example()
	// 4 dots = current line = compile error
	// 5 dots = /datum/foo/bar/baz/example
	// 6 dots = /datum/foo/bar/baz
```
