### PR TITLE
Aligned Grid Check code with Power Failure

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -1,5 +1,10 @@
 #define BP_MAX_ROOM_SIZE 300
 
+GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/engine/engineering, \
+															    /area/engine/supermatter, \
+															    /area/engine/atmospherics_engine, \
+															    /area/ai_monitored/turret_protected/ai))
+
 // Gets an atmos isolated contained space
 // Returns an associative list of turf|dirs pairs
 // The dirs are connected turfs in the same space

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -5,28 +5,16 @@
 			continue
 		S.charge = 0
 		S.output_level = 0
-		S.output_attempt = 0
+		S.output_attempt = FALSE
 		S.update_icon()
 		S.power_change()
 
-	var/list/skipped_areas = list(/area/engine/engineering, /area/engine/supermatter, /area/engine/atmospherics_engine, /area/ai_monitored/turret_protected/ai)
-
-	for(var/area/A in world)
-		if( !A.requires_power || A.always_unpowered )
+	for(var/area/A in GLOB.the_station_areas)
+		if(!A.requires_power || A.always_unpowered )
+			continue
+		if(GLOB.typecache_powerfailure_safe_areas[A.type])
 			continue
 
-		var/skip = 0
-		for(var/area_type in skipped_areas)
-			if(istype(A,area_type))
-				skip = 1
-				break
-		if(A.contents)
-			for(var/atom/AT in A.contents)
-				if(!is_station_level(AT.z)) //Only check one, it's enough.
-					skip = 1
-				break
-		if(skip)
-			continue
 		A.power_light = FALSE
 		A.power_equip = FALSE
 		A.power_environ = FALSE
@@ -35,13 +23,7 @@
 	for(var/obj/machinery/power/apc/C in GLOB.apcs_list)
 		if(C.cell && is_station_level(C.z))
 			var/area/A = C.area
-
-			var/skip = 0
-			for(var/area_type in skipped_areas)
-				if(istype(A,area_type))
-					skip = 1
-					break
-			if(skip)
+			if(GLOB.typecache_powerfailure_safe_areas[A.type])
 				continue
 
 			C.cell.charge = 0
@@ -58,11 +40,13 @@
 			continue
 		S.charge = S.capacity
 		S.output_level = S.output_level_max
-		S.output_attempt = 1
+		S.output_attempt = TRUE
 		S.update_icon()
 		S.power_change()
-	for(var/area/A in world)
-		if(!istype(A, /area/space) && !istype(A, /area/shuttle))
+	for(var/area/A in GLOB.the_station_areas)
+		if(!A.requires_power || A.always_unpowered)
+			continue
+		if(!istype(A, /area/shuttle))
 			A.power_light = TRUE
 			A.power_equip = TRUE
 			A.power_environ = TRUE
@@ -76,7 +60,7 @@
 			continue
 		S.charge = S.capacity
 		S.output_level = S.output_level_max
-		S.output_attempt = 1
+		S.output_attempt = TRUE
 		S.update_icon()
 		S.power_change()
 

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -16,4 +16,8 @@
 	for(var/P in GLOB.apcs_list)
 		var/obj/machinery/power/apc/C = P
 		if(C.cell && is_station_level(C.z))
+			var/area/A = C.area
+			if(GLOB.typecache_powerfailure_safe_areas[A.type])
+				continue
+
 			C.energy_fail(rand(30,120))


### PR DESCRIPTION
## About The Pull Request

Aligned `grid_check()` event code with the `power_failure()` one. Some light code cleaning too.
Fixes #43049.

## Changelog
:cl: Menshin
fix: engineering APCs shouldn't be reset on Grid Check event anymore.
/:cl: