### PR TITLE
Fixes regenerative core only working below CRIT_THRESHOLD instead of at it.

### DIFF
--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -63,7 +63,7 @@
 
 /obj/item/organ/regenerative_core/on_life()
 	..()
-	if(owner.health < owner.crit_threshold)
+	if(owner.health <= owner.crit_threshold)
 		ui_action_click()
 
 /obj/item/organ/regenerative_core/afterattack(atom/target, mob/user, proximity_flag)


### PR DESCRIPTION
:cl: ShizCalev
fix: Corrected a minor issue where the regenerative core would trigger at -1 HP instead of at 0HP.
/:cl:
