### PR TITLE
[WIP] Xenobio Skeleton Simplemob Rework

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/skeleton.dm
@@ -206,6 +206,7 @@
 		if(S.mind) //Ensures only skeletons can control the grave warden. (Including more at once)
 			add_control_flags(S, VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_PERMISSION)
 			remove_action_type_from_mob(/datum/action/vehicle/sealed/DumpKidnappedMobs, S)
+			remove_action_type_from_mob(/datum/action/vehicle/sealed/remove_key, S)
 			return
 	add_control_flags(M, VEHICLE_CONTROL_KIDNAPPED)
 	

--- a/code/modules/mob/living/simple_animal/hostile/skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/skeleton.dm
@@ -137,15 +137,6 @@
 	GW = new
 	GW.Grant(src)
 
-/mob/living/simple_animal/hostile/skeleton/robust/AttackingTarget()
-	if(istype(target, /obj/vehicle/sealed/car/grave_warden))
-		return
-	. = ..()
-	if(. && ishuman(target))
-		var/mob/living/carbon/human/H = target
-		if(H.stat == DEAD)
-			convert(H)
-
 /mob/living/simple_animal/hostile/skeleton/robust/death(gibbed)
 	var/obj/effect/decal/remains/human/skelebones = new (src.loc)
 	..()
@@ -168,18 +159,6 @@
 			to_chat(src, "<span class='notice'>Without your bones, your spirit eases up and ascends.</span>")
 			qdel(src)
 			
-/mob/living/simple_animal/hostile/skeleton/robust/proc/convert(mob/living/carbon/L)
-	if(!L)
-		return
-	visible_message(
-		"<span class='danger'>[src] rips out [L]'s skeleton!</span>",
-		"<span class='userdanger'>You free the skeleton from inside [L]!</span>")
-	var/mob/living/simple_animal/hostile/skeleton/robust/newskele = new (L.loc)
-	newskele.faction = faction.Copy()
-	if(L.mind)
-		L.mind.transfer_to(newskele)
-	L.gib()
-
 /obj/vehicle/sealed/car/grave_warden
 	name = "grave warden"
 	desc = "A pile of skeletons somehow forming one large skeleton."

--- a/code/modules/mob/living/simple_animal/hostile/skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/skeleton.dm
@@ -26,7 +26,7 @@
 	unsuitable_atmos_damage = 10
 	robust_searching = 1
 	stat_attack = UNCONSCIOUS
-	gold_core_spawnable = HOSTILE_SPAWN
+	gold_core_spawnable = NO_SPAWN
 	faction = list("skeleton")
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
@@ -45,7 +45,6 @@
 	maxHealth = 55
 	health = 55
 	weather_immunities = list("snow")
-	gold_core_spawnable = NO_SPAWN
 	melee_damage_lower = 17
 	melee_damage_upper = 20
 	deathmessage = "collapses into a pile of bones, its gear falling to the floor!"
@@ -65,7 +64,6 @@
 	health = 150
 	weather_immunities = list("snow")
 	speed = 2
-	gold_core_spawnable = NO_SPAWN
 	speak_chance = 1
 	speak = list("THE GODS WILL IT!","DEUS VULT!","REMOVE KABAB!")
 	force_threshold = 10 //trying to simulate actually having armor
@@ -100,6 +98,7 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 20
 	light_color = LIGHT_COLOR_PURPLE
+	gold_core_spawnable = HOSTILE_SPAWN
 	attacktext = "slashes"
 	attack_sound = 'sound/hallucinations/growl1.ogg'
 	deathmessage = "collapses into a pile of bones, their suit dissolving among the plasma!"
@@ -122,3 +121,162 @@
 /mob/living/simple_animal/hostile/skeleton/plasmaminer/Initialize()
 	. = ..()
 	set_light(2)
+	
+/mob/living/simple_animal/hostile/skeleton/robust
+	name = "robust skeleton"
+	desc = "A real bonefied skeleton, and this one seems to have a bone to pick with you."
+	del_on_death = 0
+	icon_dead = null
+	loot = list()
+	gold_core_spawnable = HOSTILE_SPAWN
+	var/datum/action/innate/skeleton/robust/grave_warden/GW
+	var/gravewardened = 0
+	
+/mob/living/simple_animal/hostile/skeleton/robust/Initialize()
+	. = ..()
+	GW = new
+	GW.Grant(src)
+
+/mob/living/simple_animal/hostile/skeleton/robust/AttackingTarget()
+	if(istype(target, /obj/vehicle/sealed/car/grave_warden))
+		return
+	. = ..()
+	if(. && ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(H.stat == DEAD)
+			convert(H)
+
+/mob/living/simple_animal/hostile/skeleton/robust/death(gibbed)
+	var/obj/effect/decal/remains/human/skelebones = new (src.loc)
+	..()
+	if(health > 0)
+		return
+	else
+		if(!gibbed && skelebones.loc)
+			sleep(300)
+			if(skelebones.loc)
+				INVOKE_ASYNC(src, .proc/revive, 1, 1)
+				src.loc = skelebones.loc
+				qdel(skelebones)
+				visible_message(
+					"<span class='danger'>[src] re-forms from the pile of bones!</span>",
+					"<span class='userdanger'>You rise again!</span>")
+			else
+				to_chat(src, "<span class='notice'>Without your bones, your spirit eases up and ascends.</span>")
+				qdel(src)
+		else
+			to_chat(src, "<span class='notice'>Without your bones, your spirit eases up and ascends.</span>")
+			qdel(src)
+			
+/mob/living/simple_animal/hostile/skeleton/robust/proc/convert(mob/living/carbon/L)
+	if(!L)
+		return
+	visible_message(
+		"<span class='danger'>[src] rips out [L]'s skeleton!</span>",
+		"<span class='userdanger'>You free the skeleton from inside [L]!</span>")
+	var/mob/living/simple_animal/hostile/skeleton/robust/newskele = new (L.loc)
+	newskele.faction = faction.Copy()
+	if(L.mind)
+		L.mind.transfer_to(newskele)
+	L.gib()
+
+/obj/vehicle/sealed/car/grave_warden
+	name = "grave warden"
+	desc = "A pile of skeletons somehow forming one large skeleton."
+	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
+	icon_state = "legion"
+	max_integrity = 600
+	obj_integrity = 600
+	armor = list("melee" = 70, "bullet" = 40, "laser" = 40, "energy" = 0, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
+	enter_delay = 20
+	max_occupants = 200
+	movedelay = 3
+	car_traits = CAN_KIDNAP
+	key_type = null
+	key_type_exact = FALSE
+	engine_sound = 'sound/magic/RATTLEMEBONES2.ogg'
+	
+/obj/vehicle/sealed/car/grave_warden/Initialize(mapload)
+	. = ..()
+	src.transform *= 2
+	
+/obj/vehicle/sealed/car/grave_warden/auto_assign_occupant_flags(mob/M)
+	if(istype(M, /mob/living/simple_animal/hostile/skeleton))
+		var/mob/living/simple_animal/hostile/skeleton/S = M
+		if(S.mind) //Ensures only skeletons can control the grave warden. (Including more at once)
+			add_control_flags(S, VEHICLE_CONTROL_DRIVE|VEHICLE_CONTROL_PERMISSION)
+			remove_action_type_from_mob(/datum/action/vehicle/sealed/DumpKidnappedMobs, S)
+			return
+	add_control_flags(M, VEHICLE_CONTROL_KIDNAPPED)
+	
+/obj/vehicle/sealed/car/grave_warden/Bump(atom/movable/M)
+	. = ..()
+	if(isliving(M))
+		if(ismegafauna(M))
+			return
+		var/mob/living/L = M
+		if(ishuman(L))
+			var/mob/living/carbon/human/H = L
+			H.visible_message("<span class='danger'>[H] screams as the they are pulled into [src], flesh being flung as their skeleton becomes intermeshed!</span>")
+			var/mob/living/simple_animal/hostile/skeleton/robust/newskele = new (H.loc)
+			if(H.mind)
+				H.mind.transfer_to(newskele)
+			H.gib()
+			newskele.gravewardened = 1
+			mob_forced_enter(newskele)
+			obj_integrity += 100
+			return
+		L.visible_message("<span class='warning'>[src] pulls [L] into itself!</span>")
+		mob_forced_enter(L)
+	if(istype(M, /obj/machinery/door))
+		var/obj/machinery/door/D = M
+		D.take_damage(20)
+	
+/obj/vehicle/sealed/car/grave_warden/mob_try_exit(mob/M, mob/user, silent = FALSE)
+	if(M == user && (occupants[M] & VEHICLE_CONTROL_KIDNAPPED))
+		to_chat(user, "<span class='notice'>You wiggle around in [src] and try to release yourself.</span>")
+		if(!do_after(user, escape_time, target = src))
+			return FALSE
+		mob_exit(M, silent)
+		return TRUE
+	mob_exit(M, silent)
+	return TRUE
+	
+/obj/vehicle/sealed/car/grave_warden/attack_hand(mob/living/user)
+	src.Bump(user)
+	return
+	
+/datum/action/innate/skeleton/robust/grave_warden
+	name = "Summon Grave Warden"
+	desc = "Form the grave warden, and become one with death."
+	check_flags = AB_CHECK_CONSCIOUS
+	button_icon_state = null
+
+/datum/action/innate/skeleton/robust/grave_warden/Activate()
+	var/mob/living/simple_animal/hostile/skeleton/robust/S = owner
+	if(S.gravewardened == 1)
+		to_chat(owner, "<span class='danger'>You have already formed a grave warden!</span>")
+		return 0
+	var/skele_amount = 0
+	var/static/list/skele_check_angles = list(EAST, WEST, NORTH, SOUTH)
+	for(var/i in skele_check_angles)
+		var/turf/T = get_turf(get_step(S, i))
+		for(var/mob/living/simple_animal/hostile/skeleton/robust/L in T)
+			if(S.Adjacent(L))
+				skele_amount = skele_amount + 1
+	if(skele_amount >= 4)
+		var/obj/vehicle/sealed/car/grave_warden/G = new (S.loc)
+		for(var/i in skele_check_angles)
+			var/turf/T = get_turf(get_step(S, i))
+			for(var/mob/living/simple_animal/hostile/skeleton/robust/L in T)
+				L.gravewardened = 1
+				G.mob_forced_enter(L)
+		S.gravewardened = 1
+		G.mob_forced_enter(S)
+		S.visible_message(
+		"<span class='danger'>The skeletons mesh together, and form the Grave Warden!</span>",
+		"<span class='userdanger'>You mesh together with your fellow skeletons, and form the Grave Warden!</span>")
+	else
+		to_chat(owner, "<span class='danger'>You lack the needed skeletons!  You need 5 in a plus position!</span>")
+		skele_amount = 0
+		return 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ever make some gold slime core mobs as a xenobiologist?  Did you ever generate some really cool skeletons, only to realize there's no reason to make them sentient but to make them suffer, and there's no good drops to get from them either?  Well, today's PR solves that issue by removing the skeleton simplemobs (not the plasma miners) from the gold slime pool, and adding an entirely new new mob in its stead.

Now, instead of having reanimated skeletons and ice skeletons, both of which were useless when compared to the many other options a xenobiologist has, the gold cores now can spawn in a robust skeleton, who looks identical to the reanimated skeleton and has the same base stats as the reanimated skeleton as well, but contains new features to make the mob worthwhile.   Your robust skeleton comes with the following features:

- Even though you have that crappy health pool, damage, and speed stat inherited from your regular counterpart, death doesn't get you down easy.  Rather, you'll find yourself getting up only a short while after death!  Unless gibbed, you will still spawn remains on death, but revive from those remains after a short time has passed!  However, if your remains are cleaned up or otherwise removed, you'll find that your death is quite permanent.

- So, now you have your skeleton band, and life doesn't suck so much anyone now that killing you takes a bit of elbow work, but you're still a bunch of crappy simple mobs at the end of the day, right?  Well, while your simple mob status might not be fixable, you'll find you're not JUST some crappy simple mob.  If 5 skeletons can come together, they can merge and form a GRAVE WARDEN.  The Grave Warden is a larger  being made out of skeletons, and all the skeletons a part of the mix get to control it!  It's pretty resistant to damage but not fast, and can damage doors (but not broken airlocks) by colliding into them. 

 What makes the Grave Warden special is that colliding into a humanoid species tears out their skeleton and adds them to the Grave Warden as well, healing it slightly, and since they are now a skeleton, also gives them shared control.  Other mobs (excluding megafauna) also get added to the Grave Warden on collision, but cannot control it.  When the Grave Warden is killed, it explodes akin to a clown car and releases all the mobs and skeletons inside.  Mind you, skeletons and mobs can get out of the Grave Warden akin to getting out of a clown car as well, so if the Grave Warden needs to bust in somewhere, it'll need to get everyone to stop and unload the troops, but that likely won't be easy.  Hectic skeleton fun for everyone!

## Why It's Good For The Game

Right now, compared to what else xenobiologists have to make sentient, there's no reason to make a skeleton sentient at all other than short-lived memes.  With this change, there's an actual reason to make sentient skeletons for both crew (bodyguard who requires extra steps to kill) and traitors (unleashing a grave warden onto the unsuspecting crew).

## Changelog
:cl:
tweak: Xenobiologists have noted that captive gold spawn skeletons having been putting their heads together recently...
add: Fear the Grave Warden!
/:cl:

EDIT: New feature considered: skeletons having hands.  Please discuss your thoughts below.
