### PR TITLE
[Possibly Ready] Reworks the ebow to shoot faster and hit softer

### DIFF
--- a/_maps/RandomZLevels/VR/mining_VR.dmm
+++ b/_maps/RandomZLevels/VR/mining_VR.dmm
@@ -529,7 +529,7 @@
 	},
 /area/awaymission/vr/miner)
 "JW" = (
-/obj/item/gun/energy/kinetic_accelerator/crossbow,
+/obj/item/gun/energy/crossbow,
 /turf/open/floor/bronze{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -10,8 +10,8 @@
 			new /obj/item/encryptionkey/syndicate(src) // 2 tc
 			new /obj/item/storage/box/syndie_kit/space(src) //4 tc
 			new /obj/item/grenade/syndieminibomb/concussion/frag(src) // ~2 tc each?
-			new /obj/item/grenade/syndieminibomb/concussion/frag(src) 
-			
+			new /obj/item/grenade/syndieminibomb/concussion/frag(src)
+
 		if("bloodyspai") // 27 tc now this is more right
 			new /obj/item/clothing/under/chameleon(src) // 2 tc since it's not the full set
 			new /obj/item/clothing/mask/chameleon(src) // Goes with above
@@ -27,13 +27,13 @@
 			new /obj/item/chameleon(src) // 7 tc
 
 		if("stealth") // 31 tc
-			new /obj/item/gun/energy/kinetic_accelerator/crossbow(src)
+			new /obj/item/gun/energy/crossbow(src)
 			new /obj/item/pen/sleepy(src)
 			new /obj/item/healthanalyzer/rad_laser(src)
 			new /obj/item/chameleon(src)
 			new /obj/item/soap/syndie(src)
 			new /obj/item/clothing/glasses/thermal/syndi(src)
-			
+
 		if("guns") // 28 tc now
 			new /obj/item/gun/ballistic/revolver(src)
 			new /obj/item/ammo_box/a357(src)
@@ -109,7 +109,7 @@
 			new /obj/item/grenade/plastic/c4 (src) // 1 tc
 			new /obj/item/grenade/plastic/c4 (src) // 1 tc
 			new /obj/item/card/emag(src) // 6 tc
-			
+
 /obj/item/storage/box/syndicate/bundle_B/PopulateContents()
 	switch (pickweight(list( "bond" = 2, "ninja" = 1, "darklord" = 1, "white_whale_holy_grail" = 2, "mad_scientist" = 2, "bee" = 2, "mr_freeze" = 2)))
 		if("bond") // 29 tc
@@ -120,7 +120,7 @@
 			new /obj/item/clothing/under/chameleon(src)
 			new /obj/item/card/id/syndicate(src)
 			new /obj/item/reagent_containers/syringe/stimulants(src)
-			
+
 		if("ninja") // 33 tc worth
 			new /obj/item/katana(src) // Unique , hard to tell how much tc this is worth. 8 tc?
 			new /obj/item/implanter/adrenalin(src) // 8 tc
@@ -128,8 +128,8 @@
 				new /obj/item/throwing_star(src) // ~5 tc for all 6
 			new /obj/item/storage/belt/chameleon(src) // Unique but worth at least 2 tc
 			new /obj/item/card/id/syndicate(src) // 2 tc
-			new /obj/item/chameleon(src) // 7 tc	
-			
+			new /obj/item/chameleon(src) // 7 tc
+
 		if("darklord") //20 tc + tk + summon item close enough for now
 			new /obj/item/twohanded/dualsaber(src)
 			new /obj/item/dnainjector/telemut/darkbundle(src)
@@ -137,14 +137,14 @@
 			new /obj/item/card/id/syndicate(src)
 			new /obj/item/clothing/shoes/chameleon/noslip(src) //because slipping while being a dark lord sucks
 			new /obj/item/book/granter/spell/summonitem(src)
-			
+
 		if("white_whale_holy_grail") //Unique items that don't appear anywhere else
 			new /obj/item/pneumatic_cannon/speargun(src)
 			new /obj/item/storage/backpack/magspear_quiver(src)
 			new /obj/item/clothing/suit/space/hardsuit/carp(src)
 			new /obj/item/clothing/mask/gas/carp(src)
 			new /obj/item/grenade/spawnergrenade/spesscarp(src)
-			
+
 		if("mad_scientist") // ~26 tc
 			new /obj/item/clothing/suit/toggle/labcoat/mad(src) // 0 tc
 			new /obj/item/clothing/shoes/jackboots(src) // 0 tc
@@ -157,7 +157,7 @@
 			new /obj/item/assembly/signaler(src) // 0 tc
 			new /obj/item/assembly/signaler(src) // 0 tc
 			new /obj/item/storage/toolbox/syndicate(src) // 1 tc
-			
+
 		if("bee") // ~25 tc
 			new /obj/item/paper/fluff/bee_objectives(src) // 0 tc (motivation)
 			new /obj/item/clothing/suit/hooded/bee_costume(src) // 0 tc
@@ -165,7 +165,7 @@
 			new /obj/item/storage/belt/fannypack/yellow(src) // 0 tc
 			new /obj/item/storage/box/syndie_kit/bee_grenades(src) // 15 tc
 			new /obj/item/reagent_containers/glass/bottle/beesease(src) // 10 tc?
-			
+
 		if("mr_freeze")
 			new /obj/item/clothing/glasses/cold(src)
 			new /obj/item/clothing/gloves/color/black(src)
@@ -179,7 +179,7 @@
 			new /obj/item/dnainjector/geladikinesis(src)
 			new /obj/item/dnainjector/cryokinesis(src)
 			new /obj/item/gun/energy/temperature/security(src)
-			
+
 /obj/item/storage/box/syndie_kit
 	name = "box"
 	desc = "A sleek, sturdy box."
@@ -263,11 +263,11 @@
 	if(prob(50))
 		new /obj/item/clothing/suit/space/syndicate/black/red(src) // Black and red is so in right now
 		new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
-		
+
 	else
 		new /obj/item/clothing/head/helmet/space/syndicate(src)
 		new /obj/item/clothing/suit/space/syndicate(src)
-		
+
 /obj/item/storage/box/syndie_kit/emp
 	name = "EMP kit"
 

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -183,7 +183,7 @@
 		qdel(briefcase_item)
 	for(var/i = 3 to 0 step -1)
 		SEND_SIGNAL(sec_briefcase, COMSIG_TRY_STORAGE_INSERT, new /obj/item/stack/spacecash/c1000, null, TRUE, TRUE)
-	SEND_SIGNAL(sec_briefcase, COMSIG_TRY_STORAGE_INSERT, new /obj/item/gun/energy/kinetic_accelerator/crossbow, null, TRUE, TRUE)
+	SEND_SIGNAL(sec_briefcase, COMSIG_TRY_STORAGE_INSERT, new /obj/item/gun/energy/crossbow, null, TRUE, TRUE)
 	SEND_SIGNAL(sec_briefcase, COMSIG_TRY_STORAGE_INSERT, new /obj/item/gun/ballistic/revolver/mateba, null, TRUE, TRUE)
 	SEND_SIGNAL(sec_briefcase, COMSIG_TRY_STORAGE_INSERT, new /obj/item/ammo_box/a357, null, TRUE, TRUE)
 	SEND_SIGNAL(sec_briefcase, COMSIG_TRY_STORAGE_INSERT, new /obj/item/grenade/plastic/x4, null, TRUE, TRUE)
@@ -426,7 +426,7 @@
 
 /datum/outfit/debug //Debug objs plus hardsuit
 	name = "Debug outfit"
-	uniform = /obj/item/clothing/under/patriotsuit 
+	uniform = /obj/item/clothing/under/patriotsuit
 	suit = /obj/item/clothing/suit/space/hardsuit/syndi/elite
 	shoes = /obj/item/clothing/shoes/magboots/advance
 	suit_store = /obj/item/tank/internals/oxygen

--- a/code/modules/projectiles/ammunition/energy/ebow.dm
+++ b/code/modules/projectiles/ammunition/energy/ebow.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/energy/bolt
 	projectile_type = /obj/item/projectile/energy/bolt
 	select_name = "bolt"
-	e_cost = 500
+	e_cost = 100
 	fire_sound = 'sound/weapons/genhit.ogg'
 
 /obj/item/ammo_casing/energy/bolt/halloween
@@ -10,3 +10,4 @@
 /obj/item/ammo_casing/energy/bolt/large
 	projectile_type = /obj/item/projectile/energy/bolt/large
 	select_name = "heavy bolt"
+	e_cost = 200

--- a/code/modules/projectiles/ammunition/energy/ebow.dm
+++ b/code/modules/projectiles/ammunition/energy/ebow.dm
@@ -10,4 +10,3 @@
 /obj/item/ammo_casing/energy/bolt/large
 	projectile_type = /obj/item/projectile/energy/bolt/large
 	select_name = "heavy bolt"
-	e_cost = 100

--- a/code/modules/projectiles/ammunition/energy/ebow.dm
+++ b/code/modules/projectiles/ammunition/energy/ebow.dm
@@ -10,4 +10,4 @@
 /obj/item/ammo_casing/energy/bolt/large
 	projectile_type = /obj/item/projectile/energy/bolt/large
 	select_name = "heavy bolt"
-	e_cost = 200
+	e_cost = 100

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -88,7 +88,6 @@
 	damtype = TOX
 	attack_verb = list("poisoned", "jabbed")
 	w_class = WEIGHT_CLASS_SMALL
-	cell_type = /obj/item/stock_parts/cell{charge = 1000; maxcharge = 1000}
 	materials = list(MAT_METAL=4000)
 	suppressed = TRUE
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
@@ -109,7 +108,6 @@
 	desc = "A reverse engineered weapon using syndicate technology."
 	icon_state = "crossbowlarge"
 	w_class = WEIGHT_CLASS_NORMAL
-	cell_type = /obj/item/stock_parts/cell{charge = 2000; maxcharge = 2000}
 	materials = list(MAT_METAL=4000)
 	suppressed = null
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -94,7 +94,7 @@
 	weapon_weight = WEAPON_LIGHT
 	obj_flags = 0
 	can_flashlight = FALSE
-	selfcharge = 1
+	selfcharge = TRUE
 
 /obj/item/gun/energy/crossbow/halloween
 	name = "candy corn crossbow"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -79,35 +79,37 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/mindflayer)
 	ammo_x_offset = 2
 
-/obj/item/gun/energy/kinetic_accelerator/crossbow
+/obj/item/gun/energy/crossbow
 	name = "mini energy crossbow"
 	desc = "A weapon favored by syndicate stealth specialists."
 	icon_state = "crossbow"
 	item_state = "crossbow"
+	force = 4
+	damtype = TOX
+	attack_verb = list(""poisoned", "jabbed")
 	w_class = WEIGHT_CLASS_SMALL
-	materials = list(MAT_METAL=2000)
+	cell_type = /obj/item/stock_parts/cell{charge = 1000; maxcharge = 1000}
+	materials = list(MAT_METAL=4000)
 	suppressed = TRUE
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
 	weapon_weight = WEAPON_LIGHT
 	obj_flags = 0
-	overheat_time = 20
-	holds_charge = TRUE
-	unique_frequency = TRUE
 	can_flashlight = FALSE
-	max_mod_capacity = 0
+	selfcharge = 1
 
-/obj/item/gun/energy/kinetic_accelerator/crossbow/halloween
+/obj/item/gun/energy/crossbow/halloween
 	name = "candy corn crossbow"
 	desc = "A weapon favored by Syndicate trick-or-treaters."
 	icon_state = "crossbow_halloween"
 	item_state = "crossbow"
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/halloween)
 
-/obj/item/gun/energy/kinetic_accelerator/crossbow/large
+/obj/item/gun/energy/crossbow/large
 	name = "energy crossbow"
 	desc = "A reverse engineered weapon using syndicate technology."
 	icon_state = "crossbowlarge"
 	w_class = WEIGHT_CLASS_NORMAL
+	cell_type = /obj/item/stock_parts/cell{charge = 2000; maxcharge = 2000}
 	materials = list(MAT_METAL=4000)
 	suppressed = null
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -86,7 +86,7 @@
 	item_state = "crossbow"
 	force = 4
 	damtype = TOX
-	attack_verb = list(""poisoned", "jabbed")
+	attack_verb = list("poisoned", "jabbed")
 	w_class = WEIGHT_CLASS_SMALL
 	cell_type = /obj/item/stock_parts/cell{charge = 1000; maxcharge = 1000}
 	materials = list(MAT_METAL=4000)

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,10 +1,10 @@
 /obj/item/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 12
+	damage = 15
 	damage_type = TOX
 	nodamage = 0
-	stamina = 21
+	stamina = 25
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 15
+	damage = 13
 	damage_type = TOX
 	nodamage = 0
 	stamina = 25

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,17 +1,15 @@
 /obj/item/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 15
+	damage = 10
 	damage_type = TOX
 	nodamage = 0
-	stamina = 50
-	eyeblur = 10
-	knockdown = 10
-	slur = 5
+	stamina = 20
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"
 	icon_state = "candy_corn"
 
 /obj/item/projectile/energy/bolt/large
-	damage = 40
+	damage = 25
+	stamina = 10

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,10 +1,10 @@
 /obj/item/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 10
+	damage = 12
 	damage_type = TOX
 	nodamage = 0
-	stamina = 20
+	stamina = 21
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"
@@ -12,4 +12,4 @@
 
 /obj/item/projectile/energy/bolt/large
 	damage = 25
-	stamina = 10
+	stamina = 20

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -290,7 +290,7 @@
 	id = "largecrossbow"
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 1500, MAT_URANIUM = 1500, MAT_SILVER = 1500)
-	build_path = /obj/item/gun/energy/kinetic_accelerator/crossbow/large
+	build_path = /obj/item/gun/energy/crossbow/large
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_INIT(summoned_guns, list(
 	/obj/item/pneumatic_cannon/speargun,
 	/obj/item/gun/ballistic/automatic/mini_uzi,
 	/obj/item/gun/energy/lasercannon,
-	/obj/item/gun/energy/kinetic_accelerator/crossbow/large,
+	/obj/item/gun/energy/crossbow/large,
 	/obj/item/gun/energy/e_gun/nuclear,
 	/obj/item/gun/ballistic/automatic/proto,
 	/obj/item/gun/ballistic/automatic/c20r,

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -181,7 +181,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndicate/bundle_A
 	cost = 20
 	exclude_modes = list(/datum/game_mode/nuclear)
-	
+
 /datum/uplink_item/bundles_TC/bundle_B
 	name = "Syndi-kit Special"
 	desc = "Syndicate Bundles, also known as Syndi-Kits, are specialized groups of items that arrive in a plain box. \
@@ -545,11 +545,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A short bow mounted across a tiller in miniature. \
 	Small enough to fit into a pocket or slip into a bag unnoticed. \
 	It will synthesize and fire bolts tipped with a debilitating \
-	toxin that will damage and disorient targets, causing them to \
-	slur as if inebriated. It can produce an infinite number \
-	of bolts, but takes time to automatically recharge after each shot."
-	item = /obj/item/gun/energy/kinetic_accelerator/crossbow
-	cost = 10
+	toxin that will damage and weaken targets; It can store up to ten \
+	bolts, and recharges them over time."
+	item = /obj/item/gun/energy/crossbow
+	cost = 11
 	surplus = 50
 	exclude_modes = list(/datum/game_mode/nuclear)
 
@@ -1547,7 +1546,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 20
 	restricted_roles = list("Assistant")
 	surplus = 0
-	
+
 /datum/uplink_item/role_restricted/oldtoolboxclean
 	name = "Ancient Toolbox"
 	desc = "An iconic toolbox design notorious with Assistants everywhere, this design was especially made to become more robust the more telecrystals it has inside it! Tools and insulated gloves included."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -550,7 +550,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/gun/energy/crossbow
 	cost = 10
 	surplus = 50
-	limited_stock = 1
 	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/origami_kit

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -548,8 +548,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	toxin that will damage and weaken targets; It can store up to ten \
 	bolts, and recharges them over time."
 	item = /obj/item/gun/energy/crossbow
-	cost = 11
+	cost = 10
 	surplus = 50
+	limited_stock = 1
 	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/origami_kit


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ebow stores up to ten shots very similarly to the captain's laser now, except it's the energy crossbow. Projectiles do 13 toxin, 25 stamina, and don't have many of the disorienting effects it previously did. You can only buy one per uplink, and it does pathetic toxin damage on melee hit just for fluff.
## Why It's Good For The Game
I said I was going to change the ebow after the stun change, and, well, I did. Ebow's always been a very strong weapon thanks to its unlimited ammo supply an, well, the ebow dealing 65 damage total counting stam, giving every disorienting status, being silent, and causing vomiting was probably a bit too much to be reasonable to survive if you get hit with one bolt, especially since you won't dodge the next shot out of infinity- and since stuns were changed because one hit and you're done is unfair, I think "2 hits and you're basically screwed on dodging the second hit" was kind of dumb. Infinite ammo is enough of an edge over other traitor weapons. I always liked the ebow as a middleground among lethal and non lethal, highlighting how violent syndies really are. This should accentuate this (though if you're just trying to get someone down, this will deal just 50%  more damage in doing so as the current ebow does, and you probably won't have to shoot them again to keep due to the strength of stamina damage if you need them alive). This will give a reasonable chance to dodge or fight back, dealing less stamina damage than a disabler but being far quieter. What I think is the most important change, though, is that this makes the ebow less spammable- though it still recharges over time, you have motivation to hold your fire- if you run out, waiting for it to recharge mid combat is an awful idea. It charges fast enough for most planned assasinations, but if you're running out of maint and picking off one person a minute you're bound to run into issues, unless of course you have very good aim. This should dissuade ebow murderbone while keeping it a very solid pick for anyone with more nuanced plans.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: the energy crossbow now charges up ten shots at once like it used to four years ago. Each shot does 25 stamina and 13 toxin, but recharges over time and can be fired more rapidly. 
/:cl:

