### PR TITLE
Fix several incorrect keyword argument calls

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -194,7 +194,7 @@
 	.=..()
 	opentime = 0
 
-/datum/browser/modal/open()
+/datum/browser/modal/open(use_onclose)
 	set waitfor = 0
 	opentime = world.time
 

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -357,7 +357,7 @@
 		var/new_staminaloss = owner.getStaminaLoss()
 		if(new_staminaloss < last_staminaloss)
 			var/heal_amount = (new_staminaloss - last_staminaloss) * 10
-			owner.adjustStaminaLoss(heal_amount, updating_stamina = FALSE)
+			owner.adjustStaminaLoss(heal_amount, updating_health = FALSE)
 			new_staminaloss = owner.getStaminaLoss()
 			needs_health_update = TRUE
 		last_staminaloss = new_staminaloss

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -357,7 +357,7 @@
 		var/new_staminaloss = owner.getStaminaLoss()
 		if(new_staminaloss < last_staminaloss)
 			var/heal_amount = (new_staminaloss - last_staminaloss) * 10
-			owner.adjustStaminaLoss(heal_amount, updating_health = FALSE)
+			owner.adjustStaminaLoss(heal_amount, updating_stamina = FALSE)
 			new_staminaloss = owner.getStaminaLoss()
 			needs_health_update = TRUE
 		last_staminaloss = new_staminaloss

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -662,8 +662,9 @@ Code:
 				active_bot.bot_control(command= href_list["op"], user= usr)
 
 	if(href_list["mule"]) //MULEbots are special snowflakes, and need different args due to how they work.
-
-		active_bot.bot_control(command= href_list["mule"], user= usr, pda= 1)
+		var/mob/living/simple_animal/bot/mulebot/mule = active_bot
+		if (istype(mule))
+			mule.bot_control(command=href_list["mule"], user=usr, pda=TRUE)
 
 	if(!host_pda)
 		return

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -504,7 +504,7 @@
 		output += ruler
 	var/datum/browser/browser = new(usr, "Note panel", "Manage player notes", 1000, 500)
 	var/datum/asset/notes_assets = get_asset_datum(/datum/asset/simple/notes)
-	notes_assets.send(src)
+	notes_assets.send(usr.client)
 	browser.set_content(jointext(output, ""))
 	browser.open()
 

--- a/code/modules/mob/living/carbon/alien/damage_procs.dm
+++ b/code/modules/mob/living/carbon/alien/damage_procs.dm
@@ -6,8 +6,8 @@
 	return FALSE
 
 //aliens are immune to stamina damage.
-/mob/living/carbon/alien/adjustStaminaLoss(amount, updating_stamina = 1)
+/mob/living/carbon/alien/adjustStaminaLoss(amount, updating_health = 1)
 	return
 
-/mob/living/carbon/alien/setStaminaLoss(amount, updating_stamina = 1)
+/mob/living/carbon/alien/setStaminaLoss(amount, updating_health = 1)
 	return

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -103,12 +103,12 @@
 		heal_overall_damage(0, 0, abs(amount), null, updating_health)
 	return amount
 
-/mob/living/carbon/setStaminaLoss(amount, updating = TRUE, forced = FALSE)
+/mob/living/carbon/setStaminaLoss(amount, updating_health = TRUE, forced = FALSE)
 	var/current = getStaminaLoss()
 	var/diff = amount - current
 	if(!diff)
 		return
-	adjustStaminaLoss(diff, updating, forced)
+	adjustStaminaLoss(diff, updating_health, forced)
 
 ////////////////////////////////////////////
 

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -85,7 +85,7 @@
 
 	return not_handled
 
-/mob/living/carbon/doUnEquip(obj/item/I)
+/mob/living/carbon/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE)
 	. = ..() //Sets the default return value to what the parent returns.
 	if(!. || !I) //We don't want to set anything to null if the parent returned 0.
 		return

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -258,7 +258,7 @@
 		update_stamina()
 
 // damage ONE external organ, organ gets randomly selected from damaged ones.
-/mob/living/proc/take_bodypart_damage(brute = 0, burn = 0, stamina = 0, updating_health = TRUE, required_status)
+/mob/living/proc/take_bodypart_damage(brute = 0, burn = 0, stamina = 0, updating_health = TRUE, required_status, check_armor = FALSE)
 	adjustBruteLoss(brute, FALSE) //zero as argument for no instant health update
 	adjustFireLoss(burn, FALSE)
 	adjustStaminaLoss(stamina, FALSE)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -242,10 +242,10 @@
 /mob/living/proc/getStaminaLoss()
 	return staminaloss
 
-/mob/living/proc/adjustStaminaLoss(amount, updating_stamina = TRUE, forced = FALSE)
+/mob/living/proc/adjustStaminaLoss(amount, updating_health = TRUE, forced = FALSE)
 	return
 
-/mob/living/proc/setStaminaLoss(amount, updating_stamina = TRUE, forced = FALSE)
+/mob/living/proc/setStaminaLoss(amount, updating_health = TRUE, forced = FALSE)
 	return
 
 // heal ONE external organ, organ gets randomly selected from damaged ones.

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -388,8 +388,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	else
 		. = ..()
 
-/mob/living/whisper(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null)
-	say("#[message]", bubble_type, spans, sanitize, language)
+/mob/living/whisper(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
+	say("#[message]", bubble_type, spans, sanitize, language, ignore_spam, forced)
 
 /mob/living/get_language_holder(shadow=TRUE)
 	if(mind && shadow)

--- a/code/modules/mob/living/silicon/damage_procs.dm
+++ b/code/modules/mob/living/silicon/damage_procs.dm
@@ -29,10 +29,10 @@
 /mob/living/silicon/setCloneLoss(amount, updating_health = TRUE, forced = FALSE)
 	return FALSE
 
-/mob/living/silicon/adjustStaminaLoss(amount, updating_stamina = 1)//immune to stamina damage.
+/mob/living/silicon/adjustStaminaLoss(amount, updating_health = TRUE)//immune to stamina damage.
 	return FALSE
 
-/mob/living/silicon/setStaminaLoss(amount, updating_stamina = 1)
+/mob/living/silicon/setStaminaLoss(amount, updating_health = TRUE)
 	return FALSE
 
 /mob/living/silicon/adjustBrainLoss(amount)

--- a/code/modules/mob/living/silicon/pai/pai_defense.dm
+++ b/code/modules/mob/living/silicon/pai/pai_defense.dm
@@ -114,7 +114,7 @@
 /mob/living/silicon/pai/setBrainLoss()
 	return FALSE
 
-/mob/living/silicon/pai/setStaminaLoss()
+/mob/living/silicon/pai/setStaminaLoss(amount, updating_health = TRUE)
 	return FALSE
 
 /mob/living/silicon/pai/setToxLoss()

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -217,7 +217,7 @@
 			bot_control(action, usr) // Kill this later.
 			. = TRUE
 
-/mob/living/simple_animal/bot/mulebot/bot_control(command, mob/user, pda = 0)
+/mob/living/simple_animal/bot/mulebot/bot_control(command, mob/user, pda = FALSE)
 	if(pda && wires.is_cut(WIRE_RX)) // MULE wireless is controlled by wires.
 		return
 

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -161,7 +161,7 @@
 		M.visible_message("<span class='warning'>[M] tips over [src].</span>",
 			"<span class='notice'>You tip over [src].</span>")
 		to_chat(src, "<span class='userdanger'>You are tipped over by [M]!</span>")
-		Paralyze(60,ignore_canknockdown = TRUE)
+		Paralyze(60, ignore_canstun = TRUE)
 		icon_state = icon_dead
 		spawn(rand(20,50))
 			if(!stat && M)

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -100,7 +100,7 @@
 /obj/item/paper/contract/infernal/suicide_act(mob/user)
 	if(signed && (user == target.current) && istype(user, /mob/living/carbon/human/))
 		var/mob/living/carbon/human/H = user
-		H.forcesay("OH GREAT INFERNO!  I DEMAND YOU COLLECT YOUR BOUNTY IMMEDIATELY!", forced = "infernal contract suicide")
+		H.say("OH GREAT INFERNO!  I DEMAND YOU COLLECT YOUR BOUNTY IMMEDIATELY!", forced = "infernal contract suicide")
 		H.visible_message("<span class='suicide'>[H] holds up a contract claiming [user.p_their()] soul, then immediately catches fire.  It looks like [user.p_theyre()] trying to commit suicide!</span>")
 		H.adjust_fire_stacks(20)
 		H.IgniteMob()


### PR DESCRIPTION
:cl:
fix: Cow tipping now properly stuns the cow.
fix: Suiciding with the infernal contract now properly causes the victim to yell out.
fix: Accessing the notes panel within the first few seconds of connecting no longer risks broken styling.
/:cl:

`updateStaminaLoss`/`setStaminaLoss` were a mixture of `updating_health` and `updating_stamina` depending on type. For uniformity with all other set/updateXLoss it's now `updating_health` everywhere.