### PR TITLE
Reset dizziness to 0 when adminhealing

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -529,6 +529,7 @@
 	bodytemperature = BODYTEMP_NORMAL
 	set_blindness(0)
 	set_blurriness(0)
+	set_dizziness(0)
 	set_eye_damage(0)
 	cure_nearsighted()
 	cure_blind()

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -15,6 +15,9 @@
 /mob/proc/Dizzy(amount)
 	dizziness = max(dizziness,amount,0)
 
+/mob/proc/set_dizziness(amount)
+	dizziness = max(amount, 0)
+
 /////////////////////////////////// EYE DAMAGE ////////////////////////////////////
 
 /mob/proc/damage_eyes(amount)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix for #42996 
Added dizziness reset code to status_procs.dm and calls this when adminhealing in living.dm

## Why It's Good For The Game

Bugfix

## Changelog
:cl: dvanbale
fix: Removes dizziness when adminhealing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
