### PR TITLE
Neuter now only targets non neutured symptoms

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -28,6 +28,7 @@
 	// NEW VARS
 	var/list/properties = list()
 	var/list/symptoms = list() // The symptoms of the disease.
+	var/list/activeSymptoms = list() //The symptoms that are not neutered
 	var/id = ""
 	var/processing = FALSE
 	var/mutable = TRUE //set to FALSE to prevent most in-game methods of altering the disease via virology
@@ -47,6 +48,7 @@
  */
 
 /datum/disease/advance/New()
+	activeSymptoms=symptoms.Copy()
 	Refresh()
 
 /datum/disease/advance/Destroy()
@@ -294,7 +296,7 @@
 	if(!mutable && !ignore_mutable)
 		return
 	if(symptoms.len)
-		var/s = safepick(symptoms)
+		var/s = safepick(activeSymptoms)
 		if(s)
 			NeuterSymptom(s)
 			Refresh(TRUE)
@@ -331,19 +333,24 @@
 
 	if(symptoms.len < (VIRUS_SYMPTOM_LIMIT - 1) + rand(-1, 1))
 		symptoms += S
+		activeSymptoms+=S
 	else
 		RemoveSymptom(pick(symptoms))
 		symptoms += S
+		activeSymptoms+=S
 
 // Simply removes the symptom.
 /datum/disease/advance/proc/RemoveSymptom(datum/symptom/S)
 	symptoms -= S
+	if(!S.neutered)
+		activeSymptoms-=S
 
 // Neuter a symptom, so it will only affect stats
 /datum/disease/advance/proc/NeuterSymptom(datum/symptom/S)
 	if(!S.neutered)
 		S.neutered = TRUE
 		S.name += " (neutered)"
+		activeSymptoms-=S
 
 /*
 

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -130,7 +130,7 @@
 
  */
 
-//
+// returns list of all non-neutered symptoms
 /datum/disease/advance/proc/CanNeuter()
 	var/notNeutered=list()
 	for(var/datum/symptom/S in symptoms)

--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -37,7 +37,6 @@
 		if(chosen_symptom)
 			var/datum/symptom/S = new chosen_symptom
 			symptoms += S
-			activeSymptoms +=S
 	Refresh()
 
 	name = "Sample #[rand(1,10000)]"

--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -37,6 +37,7 @@
 		if(chosen_symptom)
 			var/datum/symptom/S = new chosen_symptom
 			symptoms += S
+			activeSymptoms +=S
 	Refresh()
 
 	name = "Sample #[rand(1,10000)]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Creates a new function in advanced that returns a list of all non-neutered symptoms, this is then used by Neuter, so that only reasonable symptoms are neutered.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Virology already has enough 50/50's, it sucks when it can take 3/4 times to neuter the symptom you want when the only other symptom in the disease is already neutered.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Peep the Toad
add: Added new function,  canNeuter to tgstation/code/datums/diseases/advance/advance.dm that returns all non-neutered symptoms
      
tweak: Neuter now only selects the potential symptoms from a pool of non-neutered symptoms
balance: rebalanced something
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
