### PR TITLE
increases the energy consuption of disabler ammo by 60%

### DIFF
--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -21,7 +21,7 @@
 /obj/item/ammo_casing/energy/disabler
 	projectile_type = /obj/item/projectile/beam/disabler
 	select_name  = "disable"
-	e_cost = 50
+	e_cost = 80
 	fire_sound = 'sound/weapons/taser2.ogg'
 	harmful = FALSE
 


### PR DESCRIPTION
:cl:
balance: disablers shots now consume 60% more power
/:cl:

the disabler (same for egun disable function) its extremly spammy 
3 hit to stun and 1 hit to slow is really fun  when you shoot 20 shots (or 40 by dual wielding) in succession