### PR TITLE
Fixes hivemind hosts retaining powers on death/while dead and no longer displays objective status for One Mind vessels

### DIFF
--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -163,6 +163,8 @@
 /datum/antagonist/hivemind/proc/destroy_hive()
 	hivemembers = list()
 	calc_size()
+	for(var/power in upgrade_tiers)
+		owner.RemoveSpell(power)
 
 /datum/antagonist/hivemind/antag_panel_data()
 	return "Vessels Assimilated: [hive_size] (+[size_mod])"

--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -164,6 +164,8 @@
 	hivemembers = list()
 	calc_size()
 	for(var/power in upgrade_tiers)
+		if(upgrade_tiers[power] == 0)
+			continue
 		owner.RemoveSpell(power)
 
 /datum/antagonist/hivemind/antag_panel_data()

--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -164,7 +164,7 @@
 	hivemembers = list()
 	calc_size()
 	for(var/power in upgrade_tiers)
-		if(upgrade_tiers[power] == 0)
+		if(!upgrade_tiers[power])
 			continue
 		owner.RemoveSpell(power)
 

--- a/code/modules/antagonists/hivemind/vessel.dm
+++ b/code/modules/antagonists/hivemind/vessel.dm
@@ -77,3 +77,16 @@
 /datum/antagonist/hivevessel/farewell()
 	to_chat(owner, "<span class='assimilator'>Your mind closes up once more...</span>")
 	to_chat(owner, "<big><span class='warning'><b>You feel the weight of your objectives disappear! You no longer have to obey them.</b></span></big>")
+	
+/datum/antagonist/hivevessel/roundend_report()
+	if(!owner)
+		CRASH("antagonist datum without owner")
+		
+	if(one_mind)
+		return printplayer(owner)
+	
+	var/list/report = list()
+	report += printplayer(owner)
+	if(objectives.len)
+		report += printobjectives(objectives)
+	return report.Join("<br>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does what it says in the title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fixes bugs and reduces roundend screen clutter

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Kierany9
fix: Fixed Hivemind Hosts retaining powers on death and while dead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
