### PR TITLE
Fixes limb damage cap formula

### DIFF
--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -174,9 +174,8 @@
 	var/total_damage = brute + burn
 
 	if(total_damage > can_inflict)
-		var/excess = total_damage - can_inflict
-		brute = round(brute * (excess / total_damage),DAMAGE_PRECISION)
-		burn = round(burn * (excess / total_damage),DAMAGE_PRECISION)
+		brute = round(brute * (can_inflict / total_damage),DAMAGE_PRECISION)
+		burn = round(burn * (can_inflict / total_damage),DAMAGE_PRECISION)
 
 	brute_dam += brute
 	burn_dam += burn


### PR DESCRIPTION
:cl:
fix: Fixed a bug that caused limbs to take incorrect damage amounts when damage exceeded the limb's damage cap
/:cl:
Closes #43079
Fixes #42909

Pretty self explanatory I hope because I suck at explaining math