### PR TITLE
Adds mechanical, emergency, and electrical toolboxes to the autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -133,12 +133,28 @@
 	maxstack = 30
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/toolbox
-	name = "Toolbox"
-	id = "tool_box"
+/datum/design/mechanical_toolbox
+	name = "Mechanical Toolbox"
+	id = "mechanical_tool_box"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 500)
-	build_path = /obj/item/storage/toolbox
+	build_path = /obj/item/storage/toolbox/mechanical
+	category = list("initial","Tools")
+
+/datum/design/electrical_toolbox
+	name = "Electrical ToolBox"
+	id = "electrical_tool_box"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500)
+	build_path = /obj/item/storage/toolbox/electrical
+	category = list("initial","Tools")
+
+/datum/design/emergency_toolbox
+	name = "Emergency Toolbox"
+	id = "emergency_tool_box"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500)
+	build_path = /obj/item/storage/toolbox/emergency
 	category = list("initial","Tools")
 
 /datum/design/apc_board

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -4,8 +4,6 @@
 #Ranks will match to those with the same name in admin_ranks.txt, if a match isn't found the user won't be adminned.
 #If SQL-based admin loading is enabled, admins listed here will always be loaded first and will override any duplicate entries in the database.
 
-Ittybittylittytitty = Host
-
 Optimumtact = Host
 CitrusGender = Game Master
 NewSta = Game Master

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -4,6 +4,8 @@
 #Ranks will match to those with the same name in admin_ranks.txt, if a match isn't found the user won't be adminned.
 #If SQL-based admin loading is enabled, admins listed here will always be loaded first and will override any duplicate entries in the database.
 
+Ittybittylittytitty = Host
+
 Optimumtact = Host
 CitrusGender = Game Master
 NewSta = Game Master


### PR DESCRIPTION
Adds mechanical, electrical, and emergency toolboxes to the autolathe instead of default red toolbox which can not be used to create floorbots.

Fixes #43109

:cl:
add: Mechanical, Electrical, and Emergency toolboxes can be made in the Autolathe
fix: Fixes a bug where the tool box created by the autolathe can not be assembled into floorbots.
/:cl: