### PR TITLE
Die of Fate nat 1 roll prevents revival

### DIFF
--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -217,6 +217,7 @@
 		if(1)
 			//Dust
 			T.visible_message("<span class='userdanger'>[user] turns to dust!</span>")
+			user.hellbound = TRUE
 			user.dust()
 		if(2)
 			//Death


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds the hellbound trait to anyone unlucky enough to roll a nat 1 with the d20 of fate.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is meant to be an added insult to injury where rolling a 1 results in the worst possible outcome - not only do you get dusted, you're also unable to be revived.
This also prevents people from cheesing the dice by having someone take a blood sample before you roll it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
balance: Rolling a 1 with the d20 of fate prevents you from being revived by any means.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
