### PR TITLE
fixes slippery oil never initalizing, moves some AddComponent()'s in Initialize() to ComponentInitialize()

### DIFF
--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -70,7 +70,7 @@
 	light_color = "#ffff00"
 	var/next_trombone_allowed = 0
 
-/obj/item/melee/transforming/energy/sword/bananium/Initialize()
+/obj/item/melee/transforming/energy/sword/bananium/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/slippery, 60, GALOSHES_DONT_HELP)
 	GET_COMPONENT(slipper, /datum/component/slippery)
@@ -127,7 +127,7 @@
 	on_throwforce = 0
 	on_throw_speed = 1
 
-/obj/item/shield/energy/bananium/Initialize()
+/obj/item/shield/energy/bananium/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/slippery, 60, GALOSHES_DONT_HELP)
 	GET_COMPONENT(slipper, /datum/component/slippery)
@@ -176,7 +176,6 @@
 
 /obj/item/grown/bananapeel/bombanana/Initialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, det_time)
 	bomb = new /obj/item/grenade/syndieminibomb(src)
 	bomb.det_time = det_time
 	if(iscarbon(loc))
@@ -184,6 +183,10 @@
 		var/mob/living/carbon/C = loc
 		C.throw_mode_on()
 	bomb.preprime(loc, null, FALSE)
+
+/obj/item/grown/bananapeel/bombanana/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/slippery, det_time)
 
 /obj/item/grown/bananapeel/bombanana/Destroy()
 	. = ..()

--- a/code/game/objects/effects/decals/cleanable/robots.dm
+++ b/code/game/objects/effects/decals/cleanable/robots.dm
@@ -61,4 +61,5 @@
 /obj/effect/decal/cleanable/oil/slippery
 
 /obj/effect/decal/cleanable/oil/slippery/Initialize()
+	. = ..()
 	AddComponent(/datum/component/slippery, 80, (NO_SLIP_WHEN_WALKING | SLIDE))

--- a/code/game/objects/effects/decals/cleanable/robots.dm
+++ b/code/game/objects/effects/decals/cleanable/robots.dm
@@ -60,6 +60,6 @@
 
 /obj/effect/decal/cleanable/oil/slippery
 
-/obj/effect/decal/cleanable/oil/slippery/Initialize()
+/obj/effect/decal/cleanable/oil/slippery/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/slippery, 80, (NO_SLIP_WHEN_WALKING | SLIDE))

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -22,15 +22,14 @@
 	/turf/open/space/transit,
 	/turf/open/chasm,
 	/turf/open/lava))
+	var/slippery_foam = TRUE
 
 /obj/effect/particle_effect/foam/firefighting
 	name = "firefighting foam"
 	lifetime = 20 //doesn't last as long as normal foam
 	amount = 0 //no spread
+	slippery_foam = FALSE
 	var/absorbed_plasma = 0
-
-/obj/effect/particle_effect/foam/firefighting/MakeSlippery()
-	return
 
 /obj/effect/particle_effect/foam/firefighting/process()
 	..()
@@ -73,9 +72,7 @@
 	name = "aluminium foam"
 	metal = ALUMINUM_FOAM
 	icon_state = "mfoam"
-
-/obj/effect/particle_effect/foam/metal/MakeSlippery()
-	return
+	slippery_foam = FALSE
 
 /obj/effect/particle_effect/foam/metal/smart
 	name = "smart foam"
@@ -93,13 +90,14 @@
 
 /obj/effect/particle_effect/foam/Initialize()
 	. = ..()
-	MakeSlippery()
 	create_reagents(1000) //limited by the size of the reagent holder anyway.
 	START_PROCESSING(SSfastprocess, src)
 	playsound(src, 'sound/effects/bubbles2.ogg', 80, 1, -3)
 
-/obj/effect/particle_effect/foam/proc/MakeSlippery()
-	AddComponent(/datum/component/slippery, 100)
+/obj/effect/particle_effect/foam/ComponentInitialize()
+	. = ..()
+	if(slippery_foam)
+		AddComponent(/datum/component/slippery, 100)
 
 /obj/effect/particle_effect/foam/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -28,7 +28,7 @@
 	force_string = "robust... against germs"
 	var/uses = 100
 
-/obj/item/soap/Initialize()
+/obj/item/soap/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/slippery, 80)
 

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -7,7 +7,7 @@
 	desc = "A portable microcomputer by Thinktronic Systems, LTD. The surface is coated with polytetrafluoroethylene and banana drippings."
 	ttone = "honk"
 
-/obj/item/pda/clown/Initialize()
+/obj/item/pda/clown/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/slippery, 120, NO_SLIP_WHEN_WALKING, CALLBACK(src, .proc/AfterSlip))
 

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -125,6 +125,6 @@
 	name = "synthesized banana peel"
 	desc = "A synthetic banana peel."
 
-/obj/item/grown/bananapeel/specialpeel/Initialize(AM)
+/obj/item/grown/bananapeel/specialpeel/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/slippery, 40)


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed an issue causing slippery oil to be noninteractive.
/:cl:
