### PR TITLE
Fixes clownnames.txt file into a A-Z 

### DIFF
--- a/strings/names/clown.txt
+++ b/strings/names/clown.txt
@@ -40,7 +40,8 @@ Galton
 Giggles
 Gigglesworth
 Goose McSunny
-GrabbyShoe Giving Gerald
+Grabby
+Shoe Giving Gerald
 Grandma
 Grebble
 Greedo Shotfurst
@@ -64,7 +65,6 @@ Ladybug Honks
 Laughing Man
 Loopy Lazarus
 Mime
-Misery Marvin
 Misery Marvin
 Miss Stockings
 Mister Ostprussen

--- a/strings/names/clown.txt
+++ b/strings/names/clown.txt
@@ -1,123 +1,122 @@
+Aluminium Dave
+Baba
 Baby Cakes
+Bananium LXIX
+Bimbim
+Bingo
+Birdman From Birdland
+Bizarre Bottle
+Bizarro
 Bo Bo Sassy
 Bonker
 Bubble
 Buster Frown
+Butters The Bean
+Buttery Muffin
 Button
 Candy
+Carphunter
 Checkers
+Chuckles
+Circe The Great
+Congo Bongo
+Cool Cooper
+Crusty
+Deedum Dedah
+Delicious Dan
+Dinkster
 Dinky Doodle
+Doctor Greenthumb
+Doink
+Early Worm
+Eggy
+Emotional Oatmeal
+Fat Fingers
+Fishbreath
 Flop O'Honker
 Freckle
+Fretworks
+Galton
 Giggles
 Gigglesworth
 Goose McSunny
+GrabbyShoe Giving Gerald
+Grandma
+Grebble
+Greedo Shotfurst
+Happy Slappy
+Harvey Harvey Harvey
+Hedgerow Harry
+Hefty Hempo
+Homey
 Honkel the III
 Honker
 Honkerbelle
+Implausible Fun
+Impro
+Jazzle
+Jim From Accounting
 Jingle
+Johnny Bigshoes
 Jo Jo Bobo Bo
+King of Klowns
 Ladybug Honks
+Laughing Man
+Loopy Lazarus
+Mime
+Misery Marvin
+Misery Marvin
 Miss Stockings
+Mister Ostprussen
+Mister Redherring
+Mister Roboto
+Mister Safety Hazard
+Moinen
 Mr Shoe
+Mr Weird
+Ningelo
 Patches
 Pepinpop
 Pocket
+Pogo
+Polite Pablo
+Post Nose
 Razzle Dazzle
+Red April
+Red Dead Redemption Two
 Redshirt McBeat
+Rinso The Soapy
+Roboflop
 Ronnie Pace
+Rude Robert
+Sandwich Sam
 Scootaloo
-Mime
+Shinturner
+Shithead The Irritator
 Silly Willy
+Sir Honks-a-Lot
 Skiddle
+Slippo Supreme
 Slippy Joe
+Slipsy Dipsy
 Sparkle
 Speckles
 Sprinkledinkle
-Toodles Sharperton
-Ziggy Yoyo
-Homey
-Mr Weird
-Yanye Kest
-Weather Report
-Birdman From Birdland
-Bizarre Bottle
-Bizarro
-Bananium LXIX
-The Worst
-The Best
-The Mediocre
-Impro
-Fishbreath
-The Fun Uncle
-The Unfun Uncle
-Ningelo
-Eggy
-Loopy Lazarus
-Valid Vincent
-Emotional Oatmeal
-Delicious Dan
-Moinen
-Jim From Accounting
-Jazzle
-Deedum Dedah
-Congo Bongo
-Slippo Supreme
-Johnny Bigshoes
-Carphunter
-Mister Safety Hazard
-King of Klowns
-Uncool Ulrich
-Cool Cooper
-Butters The Bean
-Grabby
-Shoe Giving Gerald
-Yesterdays Beef
-Aluminium Dave
-Buttery Muffin
-Unimaginable Nut
-Harvey Harvey Harvey
-Mister Ostprussen
-Misery Marvin
-Twisty
-Pogo
-Happy Slappy
-Grandma
-Bingo
-Chuckles
-Doink
-Sir Honks-a-Lot
-Crusty
-Bimbim
-Greedo Shotfurst
-Tree Talker
-Circe The Great
-Mister Redherring
-Polite Pablo
-Rude Robert
-Doctor Greenthumb
-Sandwich Sam
-Red Dead Redemption Two
-Baba
-Mister Roboto
-Galton
-Dinkster
-Shithead The Irritator
-Slipsy Dipsy
-Hefty Hempo
-Laughing Man
-Post Nose
-Fat Fingers
-Rinso The Soapy
-Misery Marvin
-Red April
-Implausible Fun
-Hedgerow Harry
-Yobbo
-Roboflop
 The Amazing Farto
+The Best
+The Fun Uncle
+The Mediocre
+The Unfun Uncle
+The Worst
+Toodles Sharperton
+Tree Talker
+Twisty
+Uncool Ulrich
+Unimaginable Nut
+Valid Vincent
+Weather Report
 Widderwise
-Shinturner
-Early Worm
-Fretworks
-Grebble
+Yanye Kest
+Yesterdays Beef
+Yobbo
+Ziggy Yoyo

--- a/strings/names/clown.txt
+++ b/strings/names/clown.txt
@@ -41,7 +41,6 @@ Giggles
 Gigglesworth
 Goose McSunny
 Grabby
-Shoe Giving Gerald
 Grandma
 Grebble
 Greedo Shotfurst
@@ -58,8 +57,8 @@ Impro
 Jazzle
 Jim From Accounting
 Jingle
-Johnny Bigshoes
 Jo Jo Bobo Bo
+Johnny Bigshoes
 King of Klowns
 Ladybug Honks
 Laughing Man
@@ -93,6 +92,7 @@ Sandwich Sam
 Scootaloo
 Shinturner
 Shithead The Irritator
+Shoe Giving Gerald
 Silly Willy
 Sir Honks-a-Lot
 Skiddle


### PR DESCRIPTION
[Changlings]
Makes the names that were added A->Z, like it was before, organizing!
[Hos is ling?]
It is how names are formatted in text files as far as I know, lets keep it nice and A->Z like!
Has no in game affects, helps my brain cope a lot, thats about it! 