### PR TITLE
Adds functionality to let some mutations transfer on cloning

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -329,8 +329,8 @@
 	return dna
 
 
-/mob/living/carbon/human/proc/hardset_dna(ui, list/mutation_index, newreal_name, newblood_type, datum/species/mrace, newfeatures)
-
+/mob/living/carbon/human/proc/hardset_dna(ui, list/mutation_index, newreal_name, newblood_type, datum/species/mrace, newfeatures, list/mutations, force_transfer_mutations)
+//Do not use force_transfer_mutations for stuff like cloners without some precautions, otherwise some conditional mutations could break (timers, drill hat etc)
 	if(newfeatures)
 		dna.features = newfeatures
 
@@ -360,6 +360,11 @@
 		update_body_parts()
 		update_mutations_overlay()
 
+	if(LAZYLEN(mutations))
+		for(var/M in mutations)
+			var/datum/mutation/human/HM = M
+			if(HM.allow_transfer || force_transfer_mutations)
+				dna.force_give(HM.class, copymut = new HM.type (HM)) //using force_give since it may include exotic mutations that otherwise wont be handled properly
 
 /mob/living/carbon/proc/create_dna()
 	dna = new /datum/dna(src)

--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -28,6 +28,7 @@
 	var/scrambled = FALSE //Wheter we can read it if it's active. To avoid cheesing with mutagen
 	var/class           //Decides player accesibility, sorta
 	var/list/conflicts //any mutations that might conflict. put mutation typepath defines in here. make sure to enter it both ways (so that A conflicts with B, and B with A)
+	var/allow_transfer  //Do we transfer upon cloning?
 	//MUT_NORMAL - A mutation that can be activated and deactived by completing a sequence
 	//MUT_EXTRA - A mutation that is in the mutations tab, and can be given and taken away through though the DNA console. Has a 0 before it's name in the mutation section of the dna console
 	//MUT_OTHER Cannot be interacted with by players through normal means. I.E. wizards mutate


### PR DESCRIPTION
Someone asked me about it and I decided to code it since it'll probably be useful for later.

This doesn't change anything gameplay wise.
This lets you make a specific mutation transfer through cloning, useful for mutations that you dont want people to get rid of at all.

:cl:
code: Adds tools to make mutations transfer through cloning
/:cl:
