### PR TITLE
Buckler weight adjustment

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -109,7 +109,7 @@
 	resistance_flags = FLAMMABLE
 	block_chance = 30
 	transparent = FALSE
-	max_integrity = 65
+	max_integrity = 55
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/shield/riot/buckler/shatter(mob/living/carbon/human/owner)

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -110,6 +110,7 @@
 	block_chance = 30
 	transparent = FALSE
 	max_integrity = 65
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/shield/riot/buckler/shatter(mob/living/carbon/human/owner)
 	playsound(owner, 'sound/effects/bang.ogg', 50)


### PR DESCRIPTION
This is a pretty simple change, updated shields.dm to give the buckler a normal weight class and adjusted the durability slightly to offset the new portability of the buckler.

I barely see this thing used, even on xenos rounds, as you have to pretty much permanently sacrifice your spare hand to make use of it unless you've got bags of holding available. Should make it somewhat more appealing and functional without having to sacrifice an arm.

Durability nerf might not be necessary but, for the sake of getting the balance change merged, I'd rather have a slightly weaker shield that people actually use as they don't have to permanently lose an arm to carry it.