### PR TITLE
Prevents law uploads to AIs that are not in a core

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -295,6 +295,18 @@ Turf and target are separate in case you want to teleport some distance from a t
 			. = pick(ais)
 	return .
 
+/proc/select_active_cored_ai(mob/user) //select from a list of active AIs that are in a core
+	var/list/ais = active_ais()
+	for(var/mob/living/silicon/ai/A in ais)
+		if(!isturf(A.loc))
+			ais -= A
+	if(ais.len)
+		if(user)
+			. = input(user,"AI signals detected:", "AI Selection", ais[1]) in ais
+		else
+			. = pick(ais)
+	return .
+
 //Returns a list of all items of interest with their name
 /proc/getpois(mobs_only=0,skip_mindless=0)
 	var/list/mobs = sortmobs()

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -21,6 +21,9 @@
 			to_chat(user, "<span class='caution'>Upload failed!</span> Unable to establish a connection to [current.name]. You're too far away!")
 			current = null
 			return
+		if(!isturf(current.loc))
+			to_chat(user, "<span class='caution'>Upload failed!</span> Unable to interface with [current.name] -- Core protocols are missing.")
+			return
 		M.install(current.laws, user)
 	else
 		return ..()
@@ -36,7 +39,7 @@
 	circuit = /obj/item/circuitboard/computer/aiupload
 
 /obj/machinery/computer/upload/ai/interact(mob/user)
-	src.current = select_active_ai(user)
+	src.current = select_active_cored_ai(user)
 
 	if (!src.current)
 		to_chat(user, "<span class='caution'>No active AIs detected!</span>")
@@ -45,8 +48,6 @@
 
 /obj/machinery/computer/upload/ai/can_upload_to(mob/living/silicon/ai/A)
 	if(!A || !isAI(A))
-		return 0
-	if(A.control_disabled)
 		return 0
 	return ..()
 

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -23,6 +23,7 @@
 			return
 		if(!isturf(current.loc))
 			to_chat(user, "<span class='caution'>Upload failed!</span> Unable to interface with [current.name] -- Core protocols are missing.")
+			current = null
 			return
 		M.install(current.laws, user)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Creates a new AI select proc called "select_active_cored_ai", which filters out AIs that are not in a core before returning what "select_active_ai" would otherwise return. Replaces the latter proc with the former in the AI Upload code.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is a two-birds solution to both situations where someone is law-spamming the AI, and situations where you _know_ someone nefarious has the boards for an Upload.

If someone is spamming the AI with nonsense laws, carding the AI will allow it some peace of mind while you deal with finding the uploader. You can core the AI momentarily, when you're ready, to reset the laws to something more coherent, and meanwhile give the AI a shell so that it can help out with tasks even if it cannot access cameras.

On the other side of things, if you know there's a traitor that has an upload, and you know they're going to upload harmful laws, the only current solutions you have are to camp an upload of your own, giving the AI Asimov every minute or so, or else killing the AI to prevent law changes (You can also send them to Lavaland, but seeing as a fix for this was merged, though it didn't work, I would consider this strategy a bug). This should only come into play if the uploader has been rather open about their intentions, or if a prior law change happened and was reverted. If the uploader in question has been stealthy about their actions, this PR shouldn't change much. Keeping an AI in a card has several downsides, and I would suspect the heads of staff would prefer the AI is able to track suspects or keep an eye on their borgs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Zxaber
balance: AIs can no longer receive law changed from uploads if the AI is not in a core.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Alternative (or addition to) #43066. Doesn't help finding the uploader, but does make their upload useless for the short-term. Technically, you could already accomplish this by simply having the wireless off, but that prevents AIs from using shells. Ideally, I'd like to allow the AI to do _something_ while it's carded besides watching the captain do whatever captains do.

One of the concerns with 43066 is that it'll affect traitors more than intended. While this PR actually does cite traitors as part of the reasoning, I don't think it'll affect most subversions. Since, carding the AI means losing all the benefits that an AI brings, I think it'll only come up if the crew resets the AI, and there's reason to suspect that it's just going to be subverted again.

Finally, full disclosure, this does affect AIs in mechs, too. However, I believe that mechs are, or should be, balanced independently from this, and there are viable ways to attack an AI-controlled mech that don't include law changes. As I've said before, any traitor roboticist that abuses this could just as well have brainwashed people into following his orders and had them pilot the mechs instead (and in fact, could order them to build the mech too, freeing the robo up for doing other things).