### PR TITLE
fixes stunbatons being invisible

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -58,11 +58,11 @@
 
 /obj/item/melee/baton/update_icon()
 	if(status)
-		icon_state = "[initial(name)]_active"
+		icon_state = "stunbaton_active"
 	else if(!cell)
-		icon_state = "[initial(name)]_nocell"
+		icon_state = "stunbaton_nocell"
 	else
-		icon_state = "[initial(name)]"
+		icon_state = "stunbaton"
 
 /obj/item/melee/baton/examine(mob/user)
 	..()

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -58,11 +58,11 @@
 
 /obj/item/melee/baton/update_icon()
 	if(status)
-		icon_state = "stunbaton_active"
+		icon_state = "[initial(icon_state)]_active"
 	else if(!cell)
-		icon_state = "stunbaton_nocell"
+		icon_state = "[initial(icon_state)]_nocell"
 	else
-		icon_state = "stunbaton"
+		icon_state = "[initial(icon_state)]"
 
 /obj/item/melee/baton/examine(mob/user)
 	..()
@@ -185,7 +185,7 @@
 /obj/item/melee/baton/cattleprod
 	name = "stunprod"
 	desc = "An improvised stun baton."
-	icon_state = "stunprod_nocell"
+	icon_state = "stunprod"
 	item_state = "prod"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'

--- a/code/game/objects/items/teleprod.dm
+++ b/code/game/objects/items/teleprod.dm
@@ -2,7 +2,7 @@
 	name = "teleprod"
 	desc = "A prod with a bluespace crystal on the end. The crystal doesn't look too fun to touch."
 	w_class = WEIGHT_CLASS_NORMAL
-	icon_state = "teleprod_nocell"
+	icon_state = "teleprod"
 	item_state = "teleprod"
 	slot_flags = null
 


### PR DESCRIPTION
Fixes #43139

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stunbatons were invisible because they were pulling from the initial name to get their icon_state, meaning that their icon_state would be something like stun baton, stun baton_active, or stun baton_nocell. I chose to do it this way instead of changing the names of the icon_states because, to my knowledge, no other sprite names have spaces in them.

If it's preferred that the sprite names get changed, let me know and I'll change those instead.

## Why It's Good For The Game

Stunbatons shouldn't be invisible.

## Changelog
:cl: Nervere
fix: Fixed stunbatons being invisible.
/:cl: