### PR TITLE
Don't use megafauna in events

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -498,11 +498,11 @@ Difficulty: Medium
 	return
 	
 /mob/living/simple_animal/hostile/megafauna/dragon/space_dragon
-	name = "space dragon"
+	name = "ocean man"
 	maxHealth = 250
 	health = 250
 	faction = list("neutral")
-	desc = "A space carp turned dragon by vile magic.  Has the same ferocity of a space carp, but also a much more enabling body."
+	desc = "OCEAN MAN, TAKE ME BY THE HAND LEAD ME TO THE LAND, THAT YOU UNDERSTAND"
 	icon = 'icons/mob/spacedragon.dmi'
 	icon_state = "spacedragon"
 	icon_living = "spacedragon"


### PR DESCRIPTION
## Why It's Good For The Game

They are not at all balanced for players to control, and the fastest way to run a PVE feature into the ground to the point it isn't special and everyone wants it removed is spamming it as a PVP one.

HEADMIN AUTHORITAY says megafauna are bad

## Changelog
:cl:
add: The Space Dragon has been renamed to Ocean Man.
/:cl: