### PR TITLE
Reorganizes, adds new chaplain religions

### DIFF
--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -63,7 +63,7 @@
 		if("hinduism")
 			B.name = "The Vedas"
 		if("homosexuality")
-			B.name = "Guys Gone Wild"	
+			B.name = pick("Guys Gone Wild","Coming Out of The Closet")
 		if("imperium")
 			B.name = "Uplifting Primer"
 		if("islam")

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -54,7 +54,7 @@
 			B.name = pick("The Holy Bible","The Dead Sea Scrolls")
 		if("buddhism")
 			B.name = "The Sutras"
-		if("clownism","honkmother","honk","honkism")	
+		if("clownism","honkmother","honk","honkism","comedy")	
 			B.name = pick("The Holy Joke Book", "Just a Prank", "Hymns to the Honkmother")
 		if("chaos")
 			B.name = "The Book of Lorgar"
@@ -70,6 +70,8 @@
 			B.name = "Quran"	
 		if("judaism")
 			B.name = "The Torah"
+		if("lampism")
+			B.name = "Fluorescent Incandescence" 
 		if("lol", "wtf", "gay", "penis", "ass", "poo", "badmin", "shitmin", "deadmin", "cock", "cocks", "meme", "memes")
 			B.name = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition","F.A.T.A.L. Rulebook")
 			H.adjustBrainLoss(100) // starts off retarded as fuck
@@ -77,7 +79,9 @@
 			B.name = pick("Going Bananas", "Bananas Out For Harambe")
 		if("mormonism")
 			B.name = "The Book of Mormon"
-		if("rastafarian","rasta")
+		if("pastafarianism")
+			B.name = "ASDF"
+		if("rastafarianism","rasta")
 			B.name = "The Holy Piby"
 		if("satanism")
 			B.name = "The Unholy Bible"
@@ -85,6 +89,8 @@
 			B.name = pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition")
 		if("scientology")
 			B.name = pick("The Biography of L. Ron Hubbard","Dianetics")
+		if("subgenius")
+			B.name = "Book of the SubGenius"
 		if("toolboxia","greytide")
 			B.name = "Toolbox Manifesto"
 		if("weeaboo","kawaii")

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -94,7 +94,7 @@
 		if("toolboxia","greytide")
 			B.name = "Toolbox Manifesto"
 		if("weeaboo","kawaii")
-			B.name = pick("Fanfiction Compendium","Japanese for Dummies")
+			B.name = pick("Fanfiction Compendium","Japanese for Dummies","The Manganomicon","Establishing Your O.T.P")
 		else
 			B.name = "The Holy Book of [new_religion]"
 

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -80,7 +80,7 @@
 		if("mormonism")
 			B.name = "The Book of Mormon"
 		if("pastafarianism")
-			B.name = "ASDF"
+			B.name = "The Gospel of the Flying Spaghetti Monster"
 		if("rastafarianism","rasta")
 			B.name = "The Holy Piby"
 		if("satanism")

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -92,7 +92,7 @@
 		if("subgenius")
 			B.name = "Book of the SubGenius"
 		if("toolboxia","greytide")
-			B.name = "Toolbox Manifesto"
+			B.name = pick("Toolbox Manifesto","iGlove Assistants")
 		if("weeaboo","kawaii")
 			B.name = pick("Fanfiction Compendium","Japanese for Dummies","The Manganomicon","Establishing Your O.T.P")
 		else

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -52,27 +52,43 @@
 	switch(lowertext(new_religion))
 		if("christianity") // DEFAULT_RELIGION
 			B.name = pick("The Holy Bible","The Dead Sea Scrolls")
-		if("satanism")
-			B.name = "The Unholy Bible"
-		if("cthulhu")
-			B.name = "The Necronomicon"
-		if("islam")
-			B.name = "Quran"
-		if("scientology")
-			B.name = pick("The Biography of L. Ron Hubbard","Dianetics")
+		if("buddhism")
+			B.name = "The Sutras"
+		if("clownism","honkmother","honk","honkism")	
+			B.name = pick("The Holy Joke Book", "Just a Prank", "Hymns to the Honkmother")
 		if("chaos")
 			B.name = "The Book of Lorgar"
+		if("cthulhu")
+			B.name = "The Necronomicon"
+		if("hinduism")
+			B.name = "The Vedas"
+		if("homosexuality")
+			B.name = "Guys Gone Wild"	
 		if("imperium")
 			B.name = "Uplifting Primer"
-		if("toolboxia")
-			B.name = "Toolbox Manifesto"
-		if("homosexuality")
-			B.name = "Guys Gone Wild"
+		if("islam")
+			B.name = "Quran"	
+		if("judaism")
+			B.name = "The Torah"
 		if("lol", "wtf", "gay", "penis", "ass", "poo", "badmin", "shitmin", "deadmin", "cock", "cocks", "meme", "memes")
-			B.name = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition")
+			B.name = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition","F.A.T.A.L. Rulebook")
 			H.adjustBrainLoss(100) // starts off retarded as fuck
+		if("monkeyism","apism","gorillism","primatism")
+			B.name = "Going Bananas", "Bananas Out For Harambe"
+		if("mormonism")
+			B.name = "The Book of Mormon"
+		if("rastafarian","rasta")
+			B.name = "The Holy Piby"
+		if("satanism")
+			B.name = "The Unholy Bible"
 		if("science")
 			B.name = pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition")
+		if("scientology")
+			B.name = pick("The Biography of L. Ron Hubbard","Dianetics")
+		if("toolboxia","greytide")
+			B.name = "Toolbox Manifesto"
+		if("weeaboo","kawaii")
+			B.name = "Fanfiction Compendium","Japanese for Dummies"
 		else
 			B.name = "The Holy Book of [new_religion]"
 

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -74,7 +74,7 @@
 			B.name = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition","F.A.T.A.L. Rulebook")
 			H.adjustBrainLoss(100) // starts off retarded as fuck
 		if("monkeyism","apism","gorillism","primatism")
-			B.name = "Going Bananas", "Bananas Out For Harambe"
+			B.name = pick("Going Bananas", "Bananas Out For Harambe")
 		if("mormonism")
 			B.name = "The Book of Mormon"
 		if("rastafarian","rasta")
@@ -88,7 +88,7 @@
 		if("toolboxia","greytide")
 			B.name = "Toolbox Manifesto"
 		if("weeaboo","kawaii")
-			B.name = "Fanfiction Compendium","Japanese for Dummies"
+			B.name = pick("Fanfiction Compendium","Japanese for Dummies")
 		else
 			B.name = "The Holy Book of [new_religion]"
 


### PR DESCRIPTION
## About The Pull Request
This pull request alphabetizes the religion list (with the default religion at the top), and adds a number of new religions, including world religions, small religions and made up ones that I've seen in-game by roleplaying chaplains.

## Why It's Good For The Game
Variety is always nice, and the addition of new religions sets the groundwork for other ideas I have to flesh out in-game religions.

## Changelog
:cl:
add: Added several new religions to the Nanotrasen-approved faith list, including Judaism, Rastafarianism, and Honkism
/:cl:
