### PR TITLE
[s]Temp workaround for admins matching stickybans because of a byond bug.

### DIFF
--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -10,11 +10,15 @@ SUBSYSTEM_DEF(stickyban)
 
 
 /datum/controller/subsystem/stickyban/Initialize(timeofday)
+	if (length(stickybanadminexemptions))
+		restore_stickybans()
 	var/list/bannedkeys = sticky_banned_ckeys()
 	//sanitize the sticky ban list
 
 	//delete db bans that no longer exist in the database and add new legacy bans to the database
 	if (SSdbcore.Connect() || length(SSstickyban.dbcache))
+		if (length(stickybanadminexemptions))
+			restore_stickybans()
 		for (var/oldban in (world.GetConfig("ban") - bannedkeys))
 			var/ckey = ckey(oldban)
 			if (ckey != oldban && (ckey in bannedkeys))
@@ -29,6 +33,8 @@ SUBSYSTEM_DEF(stickyban)
 				bannedkeys += ckey
 			world.SetConfig("ban", oldban, null)
 
+	if (length(stickybanadminexemptions)) //the previous loop can sleep
+		restore_stickybans()
 
 	for (var/bannedkey in bannedkeys)
 		var/ckey = ckey(bannedkey)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -240,6 +240,10 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 
 
 	. = ..()	//calls mob.Login()
+	if (length(stickybanadminexemptions))
+		stickybanadminexemptions -= ckey
+		if (!length(stickybanadminexemptions))
+			restore_stickybans()
 
 	if (byond_version >= 512)
 		if (!byond_build || byond_build < 1386)


### PR DESCRIPTION
Temp testmergable and hacky workaround for the byond bug with stickybans causing the admin whitelist code to not get called.

How does it work? when an admin is connecting, just before byond asks the hub about the current stickybans, we remove all of the stickybans from byond's database. later, when either 5 seconds have passed, or the admin's client/New is called, we restore the stickybans we deleted earlier.

This uses a stack and overriding timers to properly handle cases where multiple admins are joining within the same window.

Lummox said he will look into this bug on monday now that its impacting one of our admins.