### PR TITLE
Ethereals don't die to their low-charge damage

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -127,7 +127,7 @@
 			H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 3)
 		if(ETHEREAL_CHARGE_NONE to ETHEREAL_CHARGE_LOWPOWER)
 			H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 2)
-			if(H.getBruteLoss() + H.getFireLoss() + H.getOxyLoss() + H.getToxLoss() < 89.5)
+			if(H.health < 10.5)
 				apply_damage(0.5, BRUTE, null, null, H)
 			brutemod = 1.75
 		if(ETHEREAL_CHARGE_LOWPOWER to ETHEREAL_CHARGE_NORMAL)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -127,7 +127,7 @@
 			H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 3)
 		if(ETHEREAL_CHARGE_NONE to ETHEREAL_CHARGE_LOWPOWER)
 			H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 2)
-			if(H.getBruteLoss() + H.getFireLoss() + H.getOxyLoss() + H.getToxLoss() < 100)
+			if(H.getBruteLoss() + H.getFireLoss() + H.getOxyLoss() + H.getToxLoss() < 89.5)
 				apply_damage(0.5, BRUTE, null, null, H)
 			brutemod = 1.75
 		if(ETHEREAL_CHARGE_LOWPOWER to ETHEREAL_CHARGE_NORMAL)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -127,7 +127,7 @@
 			H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 3)
 		if(ETHEREAL_CHARGE_NONE to ETHEREAL_CHARGE_LOWPOWER)
 			H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 2)
-			if(H.health < 10.5)
+			if(H.health > 10.5)
 				apply_damage(0.5, BRUTE, null, null, H)
 			brutemod = 1.75
 		if(ETHEREAL_CHARGE_LOWPOWER to ETHEREAL_CHARGE_NORMAL)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -127,7 +127,8 @@
 			H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 3)
 		if(ETHEREAL_CHARGE_NONE to ETHEREAL_CHARGE_LOWPOWER)
 			H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 2)
-			apply_damage(0.5, BRUTE, null, null, H)
+			if(H.getBruteLoss() + H.getFireLoss() + H.getOxyLoss() + H.getToxLoss() < 100)
+				apply_damage(0.5, BRUTE, null, null, H)
 			brutemod = 1.75
 		if(ETHEREAL_CHARGE_LOWPOWER to ETHEREAL_CHARGE_NORMAL)
 			H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This change makes it that ethereals no longer die from their own charge level depleating. They still take damage, but they won't go into crit anymore. 89.5 was just a number I found during testing, but due to moodlets I'm not sure if that's the right number. If anyone has any better suggestions let me know.

## Why It's Good For The Game

As an ethereal player, it's very annoying to know that if I ever go SSD for any substantial amount of time, that my character will be dead by the time I come back. Nobody will ever clone you so it means that you can't go AFK as this species. As someone who plays on Terry this is very obtrusive.

## Changelog
:cl:
balance: Ethereals no longer die to their own charge levels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
