### PR TITLE
Makes tgs ran servers store DD's output to the log folder

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -30,6 +30,9 @@ GLOBAL_VAR(restart_counter)
 
 #ifndef USE_CUSTOM_ERROR_HANDLER
 	world.log = file("[GLOB.log_directory]/dd.log")
+#else
+	if (TgsAvailable())
+		world.log = file("[GLOB.log_directory]/dd.log") //not all runtimes trigger world/Error, so this is the only way to ensure we can see all of them.
 #endif
 
 	LoadVerbs(/datum/verbs/menu)


### PR DESCRIPTION
This means runtimes will go to two sources (runtimes.log is a rustg file, and i didn't want to change that to support this since the millisecond timestamps are likely to useful at some point), but it also means we can log the runtimes that don't filter thru world/Error

