### PR TITLE
player list is now only updated at the end of the login

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -1,56 +1,62 @@
 /mob/Login()
 	GLOB.player_list |= src
-	lastKnownIP	= client.address
-	computer_id	= client.computer_id
-	log_access("Mob Login: [key_name(src)] was assigned to a [type]")
-	world.update_status()
-	client.screen = list()				//remove hud items just in case
-	client.images = list()
+	//If any of this fails we need to unassign from the player list
+	try
+		lastKnownIP	= client.address
+		computer_id	= client.computer_id
+		log_access("Mob Login: [key_name(src)] was assigned to a [type]")
+		world.update_status()
+		client.screen = list()				//remove hud items just in case
+		client.images = list()
 
-	if(!hud_used)
-		create_mob_hud()
-	if(hud_used)
-		hud_used.show_hud(hud_used.hud_version)
-		hud_used.update_ui_style(ui_style2icon(client.prefs.UI_style))
+		if(!hud_used)
+			create_mob_hud()
+		if(hud_used)
+			hud_used.show_hud(hud_used.hud_version)
+			hud_used.update_ui_style(ui_style2icon(client.prefs.UI_style))
 
-	next_move = 1
+		next_move = 1
 
-	..()
-	if (client && key != client.key)
-		key = client.key
-	reset_perspective(loc)
+		..()
+		if (client && key != client.key)
+			key = client.key
+		reset_perspective(loc)
 
-	if(loc)
-		loc.on_log(TRUE)
+		if(loc)
+			loc.on_log(TRUE)
 
-	//readd this mob's HUDs (antag, med, etc)
-	reload_huds()
+		//readd this mob's HUDs (antag, med, etc)
+		reload_huds()
 
-	reload_fullscreen() // Reload any fullscreen overlays this mob has.
+		reload_fullscreen() // Reload any fullscreen overlays this mob has.
 
-	add_click_catcher()
+		add_click_catcher()
 
-	sync_mind()
+		sync_mind()
 
-	//Reload alternate appearances
-	for(var/v in GLOB.active_alternate_appearances)
-		if(!v)
-			continue
-		var/datum/atom_hud/alternate_appearance/AA = v
-		AA.onNewMob(src)
+		//Reload alternate appearances
+		for(var/v in GLOB.active_alternate_appearances)
+			if(!v)
+				continue
+			var/datum/atom_hud/alternate_appearance/AA = v
+			AA.onNewMob(src)
 
-	update_client_colour()
-	update_mouse_pointer()
-	if(client)
-		client.change_view(CONFIG_GET(string/default_view)) // Resets the client.view in case it was changed.
+		update_client_colour()
+		update_mouse_pointer()
+		if(client)
+			client.change_view(CONFIG_GET(string/default_view)) // Resets the client.view in case it was changed.
 
-		if(client.player_details.player_actions.len)
-			for(var/datum/action/A in client.player_details.player_actions)
-				A.Grant(src)
-		
-		for(var/foo in client.player_details.post_login_callbacks)
-			var/datum/callback/CB = foo
-			CB.Invoke()
-		log_played_names(client.ckey,name,real_name)
+			if(client.player_details.player_actions.len)
+				for(var/datum/action/A in client.player_details.player_actions)
+					A.Grant(src)
+			
+			for(var/foo in client.player_details.post_login_callbacks)
+				var/datum/callback/CB = foo
+				CB.Invoke()
+			log_played_names(client.ckey,name,real_name)
 
-	log_message("Client [key_name(src)] has taken ownership of mob [src]([src.type])", LOG_OWNERSHIP)
+		log_message("Client [key_name(src)] has taken ownership of mob [src]([src.type])", LOG_OWNERSHIP)
+	catch(var/exception/e)
+		//Stop null runtimes breaking everything, sigh
+		GLOB.player_list -= src
+		throw e //woop


### PR DESCRIPTION
Client is removed from the player list is login fails due to an exception

If a runtime occurs during the login proc because the client has gone
again, then logout is never called and it seems like this leads to nulls
in the player list

We catch runtimes, remove the mob from the player list and then
rethrow

https://tgstation13.org/parsed-logs/sybil/data/logs/2019/03/18/round-104032/runtime.log

will show this pattern quite clearly, when it's available publically