### PR TITLE
Corrects ED-209 tablecrafting recipe

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -142,7 +142,7 @@
 				/obj/item/bodypart/r_leg/robot = 1,
 				/obj/item/stack/sheet/metal = 1,
 				/obj/item/stack/cable_coil = 1,
-				/obj/item/gun/energy/disabler = 1,
+				/obj/item/gun/energy/e_gun/dragnet = 1,
 				/obj/item/stock_parts/cell = 1,
 				/obj/item/assembly/prox_sensor = 1)
 	tools = list(TOOL_WELDER, TOOL_SCREWDRIVER)


### PR DESCRIPTION
Mistake from #42930
:cl: ShizCalev
fix: ED-209 tablecrafting recipe has been corrected to use a DRAGNet
/:cl: