### PR TITLE
Adds DRAGnets to pubby & delta armories

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -62862,6 +62862,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/item/gun/energy/e_gun/dragnet,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "cbL" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -60587,6 +60587,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"ulV" = (
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/item/gun/energy/e_gun/dragnet,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ulY" = (
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -85240,8 +85246,8 @@ aik
 aiM
 ajh
 ajR
+ulV
 akN
-aiM
 amj
 amX
 anH


### PR DESCRIPTION
They were missing, which lead to certain things (ie ED209's) being completely inconstructible on those maps.

:cl: ShizCalev
tweak: Added DRAGnet's to the armory on Delta & Pubby.
/:cl: