### PR TITLE
Fixes wabbajack runtime

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -241,17 +241,17 @@
 			new_mob = new path(M.loc)
 
 		if("humanoid")
+			new_mob = new /mob/living/carbon/human(M.loc)
+
 			if(prob(50))
-				new_mob = new /mob/living/carbon/human(M.loc)
-			else
-				var/chooseable_races = list()
+				var/list/chooseable_races = list()
 				for(var/speciestype in subtypesof(/datum/species))
 					var/datum/species/S = speciestype
 					if(initial(S.changesource_flags) & WABBAJACK)
 						chooseable_races += speciestype
 
-				var/hooman = pick(chooseable_races)
-				new_mob =new hooman(M.loc)
+				if(chooseable_races.len)
+					new_mob.set_species(pick(chooseable_races))
 
 			var/datum/preferences/A = new()	//Randomize appearance for the human
 			A.copy_to(new_mob, icon_updates=0)


### PR DESCRIPTION
Was trying to spawn a new datum instead of setting the mob's species.

caused by #42523

:cl: ShizCalev
fix: Fixed a runtime with wabbajack / bolt of change causing the person that was hit to go invisible and be unable to do anything.
/:cl: