### PR TITLE
Fixes alpha somatoray runtime when shooting podpeople

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -60,6 +60,7 @@
 					H.easy_randmut(NEGATIVE+MINOR_NEGATIVE)
 				else
 					H.easy_randmut(POSITIVE)
+				H.randmuti()
 				H.domutcheck()
 			else
 				H.adjustFireLoss(rand(5,15))

--- a/code/modules/projectiles/projectile/special/floral.dm
+++ b/code/modules/projectiles/projectile/special/floral.dm
@@ -6,16 +6,6 @@
 	nodamage = TRUE
 	flag = "energy"
 
-/obj/item/projectile/energy/floramut/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(iscarbon(target))
-		var/mob/living/carbon/C = target
-		if(C.dna.species.id == "pod")
-			C.randmuti()
-			C.randmut()
-			C.updateappearance()
-			C.domutcheck()
-
 /obj/item/projectile/energy/florayield
 	name = "beta somatoray"
 	icon_state = "energy2"


### PR DESCRIPTION
`randmut()` had no params which was causing a runtime. Looking into it further, this looks to have just been left-over code, since it's all duplicated in species/on_hit for them anyway.

:cl: ShizCalev
fix: Fixed runtime when shooting podpeople with a alpha somatoray
/:cl: