### PR TITLE
If both the extreme and hard caps are active, extreme popcap applies to connected players, not living players.

### DIFF
--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -48,9 +48,19 @@
 
 	//Population Cap Checking
 	var/extreme_popcap = CONFIG_GET(number/extreme_popcap)
-	if(!real_bans_only && extreme_popcap && living_player_count() >= extreme_popcap && !admin)
-		log_access("Failed Login: [key] - Population cap reached")
-		return list("reason"="popcap", "desc"= "\nReason: [CONFIG_GET(string/extreme_popcap_message)]")
+	if(!real_bans_only && extreme_popcap)
+		var/hard_popcap = CONFIG_GET(number/hard_popcap)
+
+		var/popcap_value = living_player_count()
+		if (hard_popcap)
+			popcap_value = GLOB.clients.len
+		if (!GLOB.enter_allowed || length(SSticker.queued_players) || !SSticker.HasRoundStarted())
+			hard_popcap = 0
+			popcap_value = GLOB.clients.len
+
+		if(!real_bans_only && extreme_popcap && popcap_value >= extreme_popcap && !admin && (!hard_popcap || living_player_count() >= hard_popcap))
+			log_access("Failed Login: [key] - Population cap reached")
+			return list("reason"="popcap", "desc"= "\nReason: [CONFIG_GET(string/extreme_popcap_message)]")
 
 	if(CONFIG_GET(flag/sql_enabled))
 		if(!SSdbcore.Connect())

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -58,7 +58,7 @@
 			hard_popcap = 0
 			popcap_value = GLOB.clients.len
 
-		if(!real_bans_only && extreme_popcap && popcap_value >= extreme_popcap && !admin && (!hard_popcap || living_player_count() >= hard_popcap))
+		if(popcap_value >= extreme_popcap && !admin && (!hard_popcap || living_player_count() >= hard_popcap))
 			log_access("Failed Login: [key] - Population cap reached")
 			return list("reason"="popcap", "desc"= "\nReason: [CONFIG_GET(string/extreme_popcap_message)]")
 

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -24,9 +24,12 @@
 
 	if(GLOB.admin_datums[ckey] || GLOB.deadmins[ckey])
 		admin = TRUE
+	
+	var/client/C = GLOB.directory[ckey]
+
 
 	//Whitelist
-	if(CONFIG_GET(flag/usewhitelist))
+	if(!real_bans_only && !C && CONFIG_GET(flag/usewhitelist))
 		if(!check_whitelist(ckey))
 			if (admin)
 				log_admin("The admin [key] has been allowed to bypass the whitelist")
@@ -38,7 +41,7 @@
 				return list("reason"="whitelist", "desc" = "\nReason: You are not on the white list for this server")
 
 	//Guest Checking
-	if(!real_bans_only && IsGuestKey(key))
+	if(!real_bans_only && !C && IsGuestKey(key))
 		if (CONFIG_GET(flag/guest_ban))
 			log_access("Failed Login: [key] - Guests not allowed")
 			return list("reason"="guest", "desc"="\nReason: Guests not allowed. Please sign in with a byond account.")
@@ -48,7 +51,7 @@
 
 	//Population Cap Checking
 	var/extreme_popcap = CONFIG_GET(number/extreme_popcap)
-	if(!real_bans_only && extreme_popcap)
+	if(!real_bans_only && !C && extreme_popcap && !admin)
 		var/hard_popcap = CONFIG_GET(number/hard_popcap)
 
 		var/popcap_value = living_player_count()
@@ -58,7 +61,7 @@
 			hard_popcap = 0
 			popcap_value = GLOB.clients.len
 
-		if(popcap_value >= extreme_popcap && !admin && (!hard_popcap || living_player_count() >= hard_popcap))
+		if(popcap_value >= extreme_popcap && (!hard_popcap || living_player_count() >= hard_popcap))
 			log_access("Failed Login: [key] - Population cap reached")
 			return list("reason"="popcap", "desc"= "\nReason: [CONFIG_GET(string/extreme_popcap_message)]")
 
@@ -106,7 +109,6 @@
 			bannedckey = ban["ckey"]
 
 		var/newmatch = FALSE
-		var/client/C = GLOB.directory[ckey]
 		var/list/cachedban = SSstickyban.cache[bannedckey]
 		//rogue ban in the process of being reverted.
 		if (cachedban && (cachedban["reverting"] || cachedban["timeout"]))


### PR DESCRIPTION
I also have it using the connected players, and not the living players, if the amount of living players can not increase (queue active, entering disabled, round hasn't started, etc).
I also have it allowing the connection if the hard cap is active but has not been hit.
