### PR TITLE
Research Printing Cost Balances

### DIFF
--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -67,7 +67,7 @@
 	desc = "Essentially a handheld planet-cracker. Can drill through walls with ease as well."
 	id = "jackhammer"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 6000, MAT_GLASS = 2000, MAT_SILVER = 2000, MAT_DIAMOND = 6000)
+	materials = list(MAT_METAL = 6000, MAT_GLASS = 2000, MAT_SILVER = 2000, MAT_DIAMOND = 8000)
 	build_path = /obj/item/pickaxe/drill/jackhammer
 	category = list("Mining Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
@@ -97,7 +97,7 @@
 	desc = "A device which allows kinetic accelerators to deal more damage."
 	id = "damagemod"
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 2000, MAT_GLASS = 1500, MAT_GOLD = 1500, MAT_URANIUM = 1000)
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1500, MAT_GOLD = 3000, MAT_URANIUM = 2000)
 	build_path = /obj/item/borg/upgrade/modkit/damage
 	category = list("Mining Designs", "Cyborg Upgrade Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
@@ -107,7 +107,7 @@
 	desc = "A device which decreases the cooldown of a Kinetic Accelerator."
 	id = "cooldownmod"
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 2000, MAT_GLASS = 1500, MAT_GOLD = 1500, MAT_URANIUM = 1000)
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1500, MAT_GOLD = 3000, MAT_URANIUM = 2000)
 	build_path = /obj/item/borg/upgrade/modkit/cooldown
 	category = list("Mining Designs", "Cyborg Upgrade Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
@@ -117,7 +117,7 @@
 	desc = "A device which allows kinetic accelerators to fire at a further range."
 	id = "rangemod"
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 2000, MAT_GLASS = 1500, MAT_GOLD = 1500, MAT_URANIUM = 1000)
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1500, MAT_GOLD = 3000, MAT_URANIUM = 2000)
 	build_path = /obj/item/borg/upgrade/modkit/range
 	category = list("Mining Designs", "Cyborg Upgrade Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
@@ -127,7 +127,7 @@
 	desc = "A modification kit for Kinetic Accelerators which causes it to fire AoE blasts that destroy rock."
 	id = "hypermod"
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 8000, MAT_GLASS = 1500, MAT_SILVER = 2000, MAT_GOLD = 2000, MAT_DIAMOND = 2000)
+	materials = list(MAT_METAL = 8000, MAT_GLASS = 1500, MAT_SILVER = 2000, MAT_GOLD = 2000, MAT_DIAMOND = 1000)
 	build_path = /obj/item/borg/upgrade/modkit/aoe/turfs
 	category = list("Mining Designs", "Cyborg Upgrade Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -319,7 +319,7 @@
 	desc = "A holograpic projector used to project various warning signs."
 	id = "holosign"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000)
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000, MAT_GOLD = 500)
 	build_path = /obj/item/holosign_creator
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
@@ -408,7 +408,7 @@
 	desc = "Used to remotely scan objects and biomass for DNA and fingerprints. Can print a report of the findings."
 	id = "detective_scanner"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 5000, MAT_GLASS = 1000, MAT_GOLD = 2500, MAT_SILVER = 2000)
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 1000, MAT_GOLD = 2000, MAT_SILVER = 2000)
 	build_path = /obj/item/detective_scanner
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -72,7 +72,7 @@
 	desc = "The NT-75 Electromagnetic Power Inducer can wirelessly induce electric charge in an object, allowing you to recharge power cells without having to remove them."
 	id = "inducer"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000)
+	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_SILVER = 500)
 	build_path = /obj/item/inducer/sci
 	category = list("Power Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -211,7 +211,7 @@
 	desc = "A projector that emits high density quantum-coupled bluespace beams."
 	id = "wormholeprojector"
 	build_type = PROTOLATHE
-	materials = list(MAT_SILVER = 2000, MAT_METAL = 5000, MAT_DIAMOND = 2000, MAT_BLUESPACE = 3000)
+	materials = list(MAT_SILVER = 2000, MAT_METAL = 5000, MAT_DIAMOND = 2000, MAT_BLUESPACE = 4000)
 	build_path = /obj/item/gun/energy/wormhole_projector
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE


### PR DESCRIPTION
## About The Pull Request

Makes the KA upgrades and the sonic jackhammer more expensive, except for the AOE one to encourage miners to actually mine. The holographic projector now takes gold to make. The forensic scanner now only takes 1 sheet of gold to make. The inducer takes silver to prevent "barricade science and keep making inducers". And the "free entry into the bridge, armory and everywhere that isn't completely window-less" costs 2 full sheets now.

## Why It's Good For The Game

Mining now has to work _slightly_ more before they can take their damage upgrades and run off to die to megafauna. Also, the **wall destroyer supreme** is slightly more expensive, meaning science can't rush the armory quite as fast. Holographic projectors can kek any people if you're in maint and inducers should generally be slightly more expensive. The forensic scanner is barely used anyway so now the HoS can detective slightly better on the rare occasion that they do. Also portal gun rush armory bad.

## Changelog
:cl: Pandolphina
balance: KA Range, Damage and Cooldown upgrades and the sonic jackhammer cost more. AOE upgrade costs slightly less.
balance: The holographic projector costs more, along with the inducer and the portal gun.
balance: The forensic scanner is slightly cheaper.
/:cl:

