### PR TITLE
Shoulder Holsters Now Accept Mini-Eguns

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -558,6 +558,7 @@
 		/obj/item/gun/ballistic/automatic/pistol,
 		/obj/item/gun/ballistic/revolver,
 		/obj/item/ammo_box,
+		/obj/item/gun/energy/e_gun/mini
 		))
 
 /obj/item/storage/belt/holster/full/PopulateContents()


### PR DESCRIPTION
## About The Pull Request

Fixes #43191 

## Why It's Good For The Game

They're small enough to be pistols, should logically fit in the holster.

## Changelog
:cl: Pandolphina
fix: Miniature energy guns can fit in the holster
/:cl:

