### PR TITLE
Afk kick tweaks

### DIFF
--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -33,12 +33,13 @@ SUBSYSTEM_DEF(server_maint)
 	for(var/I in currentrun)
 		var/client/C = I
 		//handle kicking inactive players
-		if(round_started && kick_inactive && C.is_afk(afk_period))
+		if(round_started && kick_inactive && !C.holder && C.is_afk(afk_period))
 			var/cmob = C.mob
-			if(!(isobserver(cmob) || (isdead(cmob) && C.holder)))
+			if (!isnewplayer(cmob) || !SSticker.queued_players.Find(cmob))
 				log_access("AFK: [key_name(C)]")
-				to_chat(C, "<span class='danger'>You have been inactive for more than [DisplayTimeText(afk_period)] and have been disconnected.</span>")
-				qdel(C)
+				to_chat(C, "<span class='userdanger'>You have been inactive for more than [DisplayTimeText(afk_period)] and have been disconnected.</span><br><span class='danger'You may reconnect via the button in the file menu or by <b><u><a href="byond://winset?command=.reconnect">clicking here to reconnect</a></b></u></span>")
+				QDEL_IN(C, 1) //to ensure they get our message before getting disconnected
+				continue
 
 		if (!(!C || world.time - C.connection_time < PING_BUFFER_TIME || C.inactivity >= (wait-1)))
 			winset(C, null, "command=.update_ping+[world.time+world.tick_lag*TICK_USAGE_REAL/100]")

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(server_maint)
 			var/cmob = C.mob
 			if (!isnewplayer(cmob) || !SSticker.queued_players.Find(cmob))
 				log_access("AFK: [key_name(C)]")
-				to_chat(C, "<span class='userdanger'>You have been inactive for more than [DisplayTimeText(afk_period)] and have been disconnected.</span><br><span class='danger'You may reconnect via the button in the file menu or by <b><u><a href="byond://winset?command=.reconnect">clicking here to reconnect</a></b></u></span>")
+				to_chat(C, "<span class='userdanger'>You have been inactive for more than [DisplayTimeText(afk_period)] and have been disconnected.</span><br><span class='danger'You may reconnect via the button in the file menu or by <b><u><a href='byond://winset?command=.reconnect'>clicking here to reconnect</a></b></u></span>")
 				QDEL_IN(C, 1) //to ensure they get our message before getting disconnected
 				continue
 


### PR DESCRIPTION
Currently it exempts observers and only exempts admins while they are in lobby, that makes no sense.

Now it always exempts admins (they still have the end of round lobby kick that applies to them), and people in the queue to join in lobby. 

Applies to ghosts.

Gives the player a link to rejoin in the disconnect message.

## Changelog
:cl:
del: afk kicker no longer exempts ghosts
add: afk kicker now exempts people in the lobby join queue
add: afk kicker now exempts admins
tweak: afk kicker now includes a link you can use rejoin quickly.
tweak: (Note: these all apply to the default disabled idle time kicker, not the end of round lobby kicker)
/:cl:
