### PR TITLE
Fixes hitting air alarms with your ID when unlocking them

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -735,6 +735,7 @@
 				return
 			else if(istype(W, /obj/item/card/id) || istype(W, /obj/item/pda))// trying to unlock the interface with an ID card
 				togglelock(user)
+				return
 			else if(panel_open && is_wire_tool(W))
 				wires.interact(user)
 				return


### PR DESCRIPTION


:cl: ShizCalev
fix: You'll no longer hit an air alarm with your ID when unlocking it.
/:cl: