### PR TITLE
Replace 'throw EXCEPTION' with CRASH or WARNING

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -63,7 +63,7 @@
 //Sleeping in here prevents future fires until returned.
 /datum/controller/subsystem/proc/fire(resumed = 0)
 	flags |= SS_NO_FIRE
-	throw EXCEPTION("Subsystem [src]([type]) does not fire() but did not set the SS_NO_FIRE flag. Please add the SS_NO_FIRE flag to any subsystem that doesn't fire so it doesn't get added to the processing list and waste cpu.")
+	CRASH("Subsystem [src]([type]) does not fire() but did not set the SS_NO_FIRE flag. Please add the SS_NO_FIRE flag to any subsystem that doesn't fire so it doesn't get added to the processing list and waste cpu.")
 
 /datum/controller/subsystem/Destroy()
 	dequeue()

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -447,7 +447,7 @@ SUBSYSTEM_DEF(job)
 /datum/controller/subsystem/job/proc/setup_officer_positions()
 	var/datum/job/J = SSjob.GetJob("Security Officer")
 	if(!J)
-		throw EXCEPTION("setup_officer_positions(): Security officer job is missing")
+		CRASH("setup_officer_positions(): Security officer job is missing")
 
 	var/ssc = CONFIG_GET(number/security_scaling_coeff)
 	if(ssc > 0)

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -169,7 +169,7 @@ SUBSYSTEM_DEF(shuttle)
 		WARNING("requestEvac(): There is no emergency shuttle, but the \
 			shuttle was called. Using the backup shuttle instead.")
 		if(!backup_shuttle)
-			throw EXCEPTION("requestEvac(): There is no emergency shuttle, \
+			CRASH("requestEvac(): There is no emergency shuttle, \
 			or backup shuttle! The game will be unresolvable. This is \
 			possibly a mapping error, more likely a bug with the shuttle \
 			manipulation system, or badminry. It is possible to manually \
@@ -401,7 +401,7 @@ SUBSYSTEM_DEF(shuttle)
 
 /datum/controller/subsystem/shuttle/proc/request_transit_dock(obj/docking_port/mobile/M)
 	if(!istype(M))
-		throw EXCEPTION("[M] is not a mobile docking port")
+		CRASH("[M] is not a mobile docking port")
 
 	if(M.assigned_transit)
 		return

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -54,12 +54,12 @@
 	if(stat)
 		return
 	if (!network)
-		throw EXCEPTION("No camera network")
 		user.unset_machine()
+		CRASH("No camera network")
 		return
 	if (!(islist(network)))
-		throw EXCEPTION("Camera network is not a list")
 		user.unset_machine()
+		CRASH("Camera network is not a list")
 		return
 	if(..())
 		user.unset_machine()

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -827,7 +827,7 @@ GLOBAL_LIST_EMPTY(allCasters)
 		var/mob/living/silicon/ai_user = user
 		scanned_user = "[ai_user.name] ([ai_user.job])"
 	else
-		throw EXCEPTION("Invalid user for this proc")
+		CRASH("Invalid user for this proc")
 		return
 
 /obj/machinery/newscaster/proc/print_paper()

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -1,6 +1,6 @@
 /proc/playsound(atom/source, input, vol as num, vary, extrarange as num, falloff, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE)
 	if(isarea(source))
-		throw EXCEPTION("playsound(): source is an area")
+		CRASH("playsound(): source is an area")
 		return
 
 	var/turf/turf_source = get_turf(source)

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -23,7 +23,7 @@ GLOBAL_PROTECT(protected_ranks)
 	name = init_name
 	if(!name)
 		qdel(src)
-		throw EXCEPTION("Admin rank created without name.")
+		CRASH("Admin rank created without name.")
 		return
 	if(init_rights)
 		rights = init_rights

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -39,11 +39,11 @@ GLOBAL_PROTECT(href_token)
 		return
 	if(!ckey)
 		QDEL_IN(src, 0)
-		throw EXCEPTION("Admin datum created without a ckey")
+		CRASH("Admin datum created without a ckey")
 		return
 	if(!istype(R))
 		QDEL_IN(src, 0)
-		throw EXCEPTION("Admin datum created without a rank")
+		CRASH("Admin datum created without a rank")
 		return
 	target = ckey
 	name = "[ckey]'s admin datum ([R])"

--- a/code/modules/antagonists/blob/blob/theblob.dm
+++ b/code/modules/antagonists/blob/blob/theblob.dm
@@ -300,7 +300,7 @@
 
 /obj/structure/blob/proc/change_to(type, controller)
 	if(!ispath(type))
-		throw EXCEPTION("change_to(): invalid type for blob")
+		CRASH("change_to(): invalid type for blob")
 		return
 	var/obj/structure/blob/B = new type(src.loc, controller)
 	B.creation_action()

--- a/code/modules/antagonists/changeling/cellular_emporium.dm
+++ b/code/modules/antagonists/changeling/cellular_emporium.dm
@@ -81,7 +81,7 @@
 	if(istype(our_target, /datum/cellular_emporium))
 		cellular_emporium = our_target
 	else
-		throw EXCEPTION("cellular_emporium action created with non emporium")
+		CRASH("cellular_emporium action created with non emporium")
 
 /datum/action/innate/cellular_emporium/Activate()
 	cellular_emporium.ui_interact(owner)

--- a/code/modules/antagonists/devil/devil.dm
+++ b/code/modules/antagonists/devil/devil.dm
@@ -477,7 +477,7 @@ GLOBAL_LIST_INIT(devil_suffix, list(" the Red", " the Soulless", " the Master", 
 				if(SOULVALUE >= ARCH_THRESHOLD && ascendable)
 					A.convert_to_archdevil()
 	else
-		throw EXCEPTION("Unable to find a blobstart landmark for hellish resurrection")
+		CRASH("Unable to find a blobstart landmark for hellish resurrection")
 
 
 /datum/antagonist/devil/proc/update_hud()

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -145,7 +145,7 @@
 	for(var/i in 1 to device_type)
 		var/datum/pipeline/parent = parents[i]
 		if(!parent)
-			throw EXCEPTION("Component is missing a pipenet! Rebuilding...")
+			WARNING("Component is missing a pipenet! Rebuilding...")
 			build_network()
 		parent.update = 1
 

--- a/code/modules/goonchat/jsErrorHandler.dm
+++ b/code/modules/goonchat/jsErrorHandler.dm
@@ -25,7 +25,7 @@
 		return 0
 
 	if (!(fileName in src.validFiles))
-		throw EXCEPTION("Debug log file '[fileName].[src.ext]' is not a valid path.")
+		CRASH("Debug log file '[fileName].[src.ext]' is not a valid path.")
 
 	var/logFile = file("[src.directory]/[fileName].[src.ext]")
 	var/fileSize = length(logFile)
@@ -41,10 +41,10 @@
 		return 0
 
 	if (!fexists("[src.directory]/[fileName].[src.ext]"))
-		throw EXCEPTION("Debug log file '[fileName].[src.ext]' does not exist.")
+		CRASH("Debug log file '[fileName].[src.ext]' does not exist.")
 
 	if (!(fileName in src.validFiles))
-		throw EXCEPTION("Debug log file '[fileName].[src.ext]' is not a valid path.")
+		CRASH("Debug log file '[fileName].[src.ext]' is not a valid path.")
 
 	fdel("[src.directory]/[fileName].[src.ext]")
 	return 1

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -23,7 +23,7 @@
 		return
 	template = SSmapping.shelter_templates[template_id]
 	if(!template)
-		throw EXCEPTION("Shelter template ([template_id]) not found!")
+		WARNING("Shelter template ([template_id]) not found!")
 		qdel(src)
 
 /obj/item/survivalcapsule/Destroy()

--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -69,7 +69,7 @@ Contents:
 	Mind.add_antag_datum(ninjadatum)
 
 	if(Ninja.mind != Mind)			//something has gone wrong!
-		throw EXCEPTION("Ninja created with incorrect mind")
+		CRASH("Ninja created with incorrect mind")
 
 	spawned_mobs += Ninja
 	message_admins("[ADMIN_LOOKUPFLW(Ninja)] has been made into a ninja by an event.")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -569,7 +569,7 @@
 	else if (istype(W, /obj/item/stack/cable_coil) && opened)
 		var/turf/host_turf = get_turf(src)
 		if(!host_turf)
-			throw EXCEPTION("attackby on APC when it's not on a turf")
+			CRASH("attackby on APC when it's not on a turf")
 			return
 		if (host_turf.intact)
 			to_chat(user, "<span class='warning'>You must remove the floor plating in front of the APC first!</span>")


### PR DESCRIPTION
`throw EXCEPTION` is just `CRASH` but with less debugging information.

A couple of these seemed like they're followed by logic, which throwing skips, so I guessed `WARNING` is desired there.

:cl:
code: Logs for certain kinds of errors will now include better debugging information.
/:cl: