### PR TITLE
Move stat() to procs per tab so we can find the lag

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -552,56 +552,56 @@
 			stat(null, "[ETA] [SSshuttle.emergency.getTimerStr()]")
 
 /mob/proc/stat_mc()
-			var/turf/T = get_turf(client.eye)
-			stat("Location:", COORD(T))
-			stat("CPU:", "[world.cpu]")
-			stat("Instances:", "[num2text(world.contents.len, 10)]")
-			stat("World Time:", "[world.time]")
-			GLOB.stat_entry()
-			config.stat_entry()
-			stat(null)
-			if(Master)
-				Master.stat_entry()
-			else
-				stat("Master Controller:", "ERROR")
-			if(Failsafe)
-				Failsafe.stat_entry()
-			else
-				stat("Failsafe Controller:", "ERROR")
-			if(Master)
-				stat(null)
-				for(var/datum/controller/subsystem/SS in Master.subsystems)
-					SS.stat_entry()
-			GLOB.cameranet.stat_entry()
+	var/turf/T = get_turf(client.eye)
+	stat("Location:", COORD(T))
+	stat("CPU:", "[world.cpu]")
+	stat("Instances:", "[num2text(world.contents.len, 10)]")
+	stat("World Time:", "[world.time]")
+	GLOB.stat_entry()
+	config.stat_entry()
+	stat(null)
+	if(Master)
+		Master.stat_entry()
+	else
+		stat("Master Controller:", "ERROR")
+	if(Failsafe)
+		Failsafe.stat_entry()
+	else
+		stat("Failsafe Controller:", "ERROR")
+	if(Master)
+		stat(null)
+		for(var/datum/controller/subsystem/SS in Master.subsystems)
+			SS.stat_entry()
+	GLOB.cameranet.stat_entry()
 			
 /mob/proc/stat_tickets()
 	GLOB.ahelp_tickets.stat_entry()
 
 /mob/proc/stat_sdql2()
-				stat("Access Global SDQL2 List", GLOB.sdql2_vv_statobj)
-				for(var/i in GLOB.sdql2_queries)
-					var/datum/SDQL2_query/Q = i
-					Q.generate_stat()
+	stat("Access Global SDQL2 List", GLOB.sdql2_vv_statobj)
+	for(var/i in GLOB.sdql2_queries)
+		var/datum/SDQL2_query/Q = i
+		Q.generate_stat()
 
 /mob/proc/stat_turf_contents()
-		if(!TurfAdjacent(listed_turf))
-			listed_turf = null
-		else
-			statpanel(listed_turf.name, null, listed_turf)
-			var/list/overrides = list()
-			for(var/image/I in client.images)
-				if(I.loc && I.loc.loc == listed_turf && I.override)
-					overrides += I.loc
-			for(var/atom/A in listed_turf)
-				if(!A.mouse_opacity)
-					continue
-				if(A.invisibility > see_invisible)
-					continue
-				if(overrides.len && (A in overrides))
-					continue
-				if(A.IsObscured())
-					continue
-				statpanel(listed_turf.name, null, A)
+	if(!TurfAdjacent(listed_turf))
+		listed_turf = null
+	else
+		statpanel(listed_turf.name, null, listed_turf)
+		var/list/overrides = list()
+		for(var/image/I in client.images)
+			if(I.loc && I.loc.loc == listed_turf && I.override)
+				overrides += I.loc
+		for(var/atom/A in listed_turf)
+			if(!A.mouse_opacity)
+				continue
+			if(A.invisibility > see_invisible)
+				continue
+			if(overrides.len && (A in overrides))
+				continue
+			if(A.IsObscured())
+				continue
+			statpanel(listed_turf.name, null, A)
 
 /mob/proc/stat_spells()
 	if(mind)
@@ -609,13 +609,13 @@
 	add_spells_to_statpanel(mob_spell_list)
 
 /mob/proc/stat_adminpanels()
-		if(statpanel("MC"))
-			stat_mc()
-		if(statpanel("Tickets"))
-			stat_tickets()
-		if(length(GLOB.sdql2_queries))
-			if(statpanel("SDQL2"))
-				stat_sdql2()
+	if(statpanel("MC"))
+		stat_mc()
+	if(statpanel("Tickets"))
+		stat_tickets()
+	if(length(GLOB.sdql2_queries))
+		if(statpanel("SDQL2"))
+			stat_sdql2()
 
 /mob/proc/add_spells_to_statpanel(list/spells)
 	for(var/obj/effect/proc_holder/spell/S in spells)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -525,24 +525,33 @@
 	..()
 
 	if(statpanel("Status"))
-		if (client)
-			stat(null, "Ping: [round(client.lastping, 1)]ms (Average: [round(client.avgping, 1)]ms)")
-		stat(null, "Map: [SSmapping.config?.map_name || "Loading..."]")
-		var/datum/map_config/cached = SSmapping.next_map_config
-		if(cached)
-			stat(null, "Next Map: [cached.map_name]")
-		stat(null, "Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]")
-		stat(null, "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]")
-		stat(null, "Round Time: [worldtime2text()]")
-		stat(null, "Station Time: [station_time_timestamp()]")
-		stat(null, "Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)")
-		if(SSshuttle.emergency)
-			var/ETA = SSshuttle.emergency.getModeStr()
-			if(ETA)
-				stat(null, "[ETA] [SSshuttle.emergency.getTimerStr()]")
+		stat_status()
 
 	if(client && client.holder)
-		if(statpanel("MC"))
+		stat_adminpanels()
+
+
+	if(listed_turf && client)
+		stat_turf_contents()
+
+/mob/proc/stat_status()
+	if (client)
+		stat(null, "Ping: [round(client.lastping, 1)]ms (Average: [round(client.avgping, 1)]ms)")
+	stat(null, "Map: [SSmapping.config?.map_name || "Loading..."]")
+	var/datum/map_config/cached = SSmapping.next_map_config
+	if(cached)
+		stat(null, "Next Map: [cached.map_name]")
+	stat(null, "Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]")
+	stat(null, "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]")
+	stat(null, "Round Time: [worldtime2text()]")
+	stat(null, "Station Time: [station_time_timestamp()]")
+	stat(null, "Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)")
+	if(SSshuttle.emergency)
+		var/ETA = SSshuttle.emergency.getModeStr()
+		if(ETA)
+			stat(null, "[ETA] [SSshuttle.emergency.getTimerStr()]")
+
+/mob/proc/stat_mc()
 			var/turf/T = get_turf(client.eye)
 			stat("Location:", COORD(T))
 			stat("CPU:", "[world.cpu]")
@@ -564,16 +573,17 @@
 				for(var/datum/controller/subsystem/SS in Master.subsystems)
 					SS.stat_entry()
 			GLOB.cameranet.stat_entry()
-		if(statpanel("Tickets"))
-			GLOB.ahelp_tickets.stat_entry()
-		if(length(GLOB.sdql2_queries))
-			if(statpanel("SDQL2"))
+			
+/mob/proc/stat_tickets()
+	GLOB.ahelp_tickets.stat_entry()
+
+/mob/proc/stat_sdql2()
 				stat("Access Global SDQL2 List", GLOB.sdql2_vv_statobj)
 				for(var/i in GLOB.sdql2_queries)
 					var/datum/SDQL2_query/Q = i
 					Q.generate_stat()
 
-	if(listed_turf && client)
+/mob/proc/stat_turf_contents()
 		if(!TurfAdjacent(listed_turf))
 			listed_turf = null
 		else
@@ -593,10 +603,19 @@
 					continue
 				statpanel(listed_turf.name, null, A)
 
-
+/mob/proc/stat_spells()
 	if(mind)
 		add_spells_to_statpanel(mind.spell_list)
 	add_spells_to_statpanel(mob_spell_list)
+
+/mob/proc/stat_adminpanels()
+		if(statpanel("MC"))
+			stat_mc()
+		if(statpanel("Tickets"))
+			stat_tickets()
+		if(length(GLOB.sdql2_queries))
+			if(statpanel("SDQL2"))
+				stat_sdql2
 
 /mob/proc/add_spells_to_statpanel(list/spells)
 	for(var/obj/effect/proc_holder/spell/S in spells)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -615,7 +615,7 @@
 			stat_tickets()
 		if(length(GLOB.sdql2_queries))
 			if(statpanel("SDQL2"))
-				stat_sdql2
+				stat_sdql2()
 
 /mob/proc/add_spells_to_statpanel(list/spells)
 	for(var/obj/effect/proc_holder/spell/S in spells)


### PR DESCRIPTION
Stat is 6th for self and 20th for total on the profiler.

gas_mixture/share was called 5 times as much, and has about the same cost.

gas_mixture/react was called 15 times as much, and has nearly half the cost.

I have a feeling on what it is, but this will allow us to get hard stats about how costly each tab is to update, as well as how many updates they each see.