### PR TITLE
Add a fullstop to the first line of examine messages

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -265,7 +265,7 @@
 	. = "[icon2html(src, user)] [thats? "That's ":""][get_examine_name(user)]"
 
 /atom/proc/examine(mob/user)
-	to_chat(user, get_examine_string(user, TRUE))
+	to_chat(user, "[get_examine_string(user, TRUE)].")
 
 	if(desc)
 		to_chat(user, desc)


### PR DESCRIPTION
One of the really common places it's missing even though this line is in sentence format.