### PR TITLE
Renames check_weakness() on /datum/species to check_species_weakness()

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -788,7 +788,7 @@
 /mob/living/carbon/human/check_weakness(obj/item/weapon, mob/living/attacker)
 	. = ..()
 	if (dna && dna.species)
-		. += dna.species.check_weakness(weapon, attacker)
+		. += dna.species.check_species_weakness(weapon, attacker)
 
 /mob/living/carbon/human/is_literate()
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -962,8 +962,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 /datum/species/proc/get_spans()
 	return list()
 
-/datum/species/proc/check_weakness(obj/item, mob/living/attacker)
-	return FALSE
+/datum/species/proc/check_species_weakness(obj/item, mob/living/attacker)
+	return 0 //This is not a boolean, it's the multiplier for the damage that the user takes from the item.It is added onto the check_weakness value of the mob, and then the force of the item is multiplied by this value
 
 ////////
 	//LIFE//

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -30,7 +30,7 @@
 						"<span class='userdanger'>You throw up on the floor!</span>")
 	..()
 
-/datum/species/fly/check_weakness(obj/item/weapon, mob/living/attacker)
+/datum/species/fly/check_species_weakness(obj/item/weapon, mob/living/attacker)
 	if(istype(weapon, /obj/item/melee/flyswatter))
 		return 29 //Flyswatters deal 30x damage to flypeople.
 	return 0

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -49,7 +49,7 @@
 		H.adjustToxLoss(3)
 		H.reagents.remove_reagent(chem.id, REAGENTS_METABOLISM)
 
-/datum/species/moth/check_weakness(obj/item/weapon, mob/living/attacker)
+/datum/species/moth/check_species_weakness(obj/item/weapon, mob/living/attacker)
 	if(istype(weapon, /obj/item/melee/flyswatter))
 		return 9 //flyswatters deal 10x damage to moths
 	return 0

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -58,9 +58,9 @@
 		C.adjust_fire_stacks(6)
 		C.IgniteMob()
 
-/datum/species/vampire/check_weakness(obj/item/weapon, mob/living/attacker)
+/datum/species/vampire/check_species_weakness(obj/item/weapon, mob/living/attacker)
 	if(istype(weapon, /obj/item/nullrod/whip))
-		return 1 //Vampire killer.
+		return 1 //Whips deal 2x damage to vampires. Vampire killer.
 	return 0
 
 /obj/item/organ/tongue/vampire

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -930,7 +930,7 @@
 /mob/living/proc/check_weakness(obj/item/weapon, mob/living/attacker)
 	if(mind && mind.has_antag_datum(/datum/antagonist/devil))
 		return check_devil_bane_multiplier(weapon, attacker)
-	return 1
+	return 1 //This is not a boolean, it's the multiplier for the damage the weapon does.
 
 /mob/living/proc/check_acedia()
 	if(mind && mind.has_objective(/datum/objective/sintouched/acedia))


### PR DESCRIPTION
So there I was, merging mirror PRs like I do, when I notice this:
![image](https://user-images.githubusercontent.com/20558591/54693783-7decf600-4b27-11e9-8726-d86b1717aa22.png)

I think to myself: "why is this not a boolean?" and I look at the /tg/ PR, just to see this:
![image](https://user-images.githubusercontent.com/20558591/54693893-a8d74a00-4b27-11e9-9625-3f7b698fbc80.png)

It is at this point that I think that that's incredibly dumb, and I look into how check_weakness works, and find this:
![image](https://user-images.githubusercontent.com/20558591/54693943-c4daeb80-4b27-11e9-925a-11166b4b710a.png)

Now I get confused, and wonder: "why on god's green earth does it multiply the force with the weakness, if the default weakness is 0?"
The answer to that question is that there's two different check_weakness procs, one on a mob level, and one on a species level. And of course, the mob proc returns the value that it should multiply the force with, whereas the species proc returns the value it should multiply with, minus 1, since the species check_weakness is added on top of the normal check_weakness which just returns the value it should multiply with.

To summarize: 
There's two check_weakness procs, the return result of which could be (and have been) confused with booleans. Not only that, but the return values for the two identically named procs need to be different to achieve the same thing.

Renames check_weakness on the species side to check_species_weakness, since they don't get confused with each other then, and adds a comment to the default return value to make sure they're not confused with booleans in the future.