### PR TITLE
Exempts current players from the extreme pop cap

### DIFF
--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -61,7 +61,7 @@
 			hard_popcap = 0
 			popcap_value = GLOB.clients.len
 
-		if(popcap_value >= extreme_popcap && (!hard_popcap || living_player_count() >= hard_popcap))
+		if(popcap_value >= extreme_popcap && (!hard_popcap || living_player_count() >= hard_popcap) && !joined_player_list.Find(ckey))
 			log_access("Failed Login: [key] - Population cap reached")
 			return list("reason"="popcap", "desc"= "\nReason: [CONFIG_GET(string/extreme_popcap_message)]")
 

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -61,7 +61,7 @@
 			hard_popcap = 0
 			popcap_value = GLOB.clients.len
 
-		if(popcap_value >= extreme_popcap && (!hard_popcap || living_player_count() >= hard_popcap) && !joined_player_list.Find(ckey))
+		if(popcap_value >= extreme_popcap && (!hard_popcap || living_player_count() >= hard_popcap) && !GLOB.joined_player_list.Find(ckey))
 			log_access("Failed Login: [key] - Population cap reached")
 			return list("reason"="popcap", "desc"= "\nReason: [CONFIG_GET(string/extreme_popcap_message)]")
 


### PR DESCRIPTION
This will exempt anybody who was once joined into the round, this means people who were assigned at round start or latejoined. even if they later died, got gibbed, suicided, or ghosted. This does not exempt people who observed from lobby.

:cl:
tweak: Exempted byond accounts already in the round from the connected players cap, allowing them to reconnect even if the server is full. This exemption applies even if you are dead or are a ghost, but does not apply if you hit "observe" from the lobby.
/:cl: