### PR TITLE
Adds bad back quirk (makes bags give you a bad mood)

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -172,7 +172,9 @@
 	mood_change = -15
 	timeout = 900
 
-/datum/mood_event/sapped
+/datum/mood_event/back_pain
+	description = "<span class='boldwarning'>Bags never sit right on my back, this hurts like hell!</span>\n"
+	mood_change = -15
 
 //These are unused so far but I want to remember them to use them later
 /datum/mood_event/cloned_corpse

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -4,6 +4,7 @@
 	name = "Bad Back"
 	desc = "Thanks to your poor posture, backpacks and other bags never sit right on your back. More evently weighted objects are fine, though."
 	value = -2
+	mood_quirk = TRUE
 	gain_text = "<span class='danger'>Your back REALLY hurts!</span>"
 	lose_text = "<span class='notice'>Your back feels better.</span>"
 

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -1,5 +1,19 @@
 //predominantly negative traits
 
+/datum/quirk/badback
+	name = "Bad Back"
+	desc = "Thanks to your poor posture, backpacks and other bags never sit right on your back. More evently weighted objects are fine, though."
+	value = -2
+	gain_text = "<span class='danger'>Your back REALLY hurts!</span>"
+	lose_text = "<span class='notice'>Your back feels better.</span>"
+
+/datum/quirk/badback/on_process()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H.back && istype(H.back, /obj/item/storage/backpack))
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "back_pain", /datum/mood_event/back_pain)
+	else
+		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "back_pain")
+
 /datum/quirk/blooddeficiency
 	name = "Acute Blood Deficiency"
 	desc = "Your body can't produce enough blood to sustain itself."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Back pain is a -2 negative quirk that causes a _very_ bad moodlet when you wear a storage item on your back. Non storage items, like fire axes and picks, don't cause the mood.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
First, I always felt 2d spacemen had too much storage space in those bags. It'd interest me to see people sacrifice some of that space and I think it'd be a far more engaging disability then deafness or paraplegics. Maybe briefcases would even see some use for people besides launchpad traitors! Maybe fanny packs would be seen at all!
Second, I feel that quite a few items that fit on the back never get any love because you're basically gimping yourself if you don't have a backpack on there. Have you ever seen someone wear a large airtank on their back? Combat shotguns are always carried in one hand, never on the back.
Third, It slightly bugs me that everyone has a strap across their chest or a completely obstructed back. Now maybe we'll be able to read the letters on the back of the blue letterman jacket or something.
## Changelog
:cl:
rscadd: New negative quirk - back pain causes very bad mood from wearing uneven storage items on your back, but other back items like air tanks and shotguns are okay.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
Maybe I should change this thing's name to reverse hoarder or something, I dunno.