### PR TITLE
Simple animals can only damage clowncars from the inside if they can smash walls

### DIFF
--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -42,6 +42,10 @@
 			var/mob/voreman = i
 			SSmedals.UnlockMedal(MEDAL_CLOWNCARKING,voreman.client)
 
+/obj/vehicle/sealed/car/clowncar/attack_animal(mob/living/simple_animal/M)
+	if((M.loc != src) || M.environment_smash & (ENVIRONMENT_SMASH_WALLS|ENVIRONMENT_SMASH_RWALLS))
+		return ..()
+
 /obj/vehicle/sealed/car/clowncar/mob_exit(mob/M, silent = FALSE, randomstep = FALSE)
 	. = ..()
 	UnregisterSignal(M, COMSIG_MOB_CLICKON)


### PR DESCRIPTION
Fixes #43223
:cl: ShizCalev
fix: Simple mobs can now only damage clown cars from the inside if they're able to smash through walls.
/:cl: