### PR TITLE
Allows AIs to set camera location hotkeys

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -183,7 +183,7 @@
 				cam_prev = eyeobj.loc
 				eyeobj.setLoc(cam_hotkeys[_key])
 				return
-	. = ..()
+	return ..()
 
 /mob/living/silicon/ai/Destroy()
 	GLOB.ai_list -= src

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -94,6 +94,8 @@
 	var/max_multicams = 6
 	var/display_icon_override
 
+	var/list/cam_hotkeys = new/list(9)
+
 /mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, mob/target_ai)
 	. = ..()
 	if(!target_ai) //If there is no player/brain inside.
@@ -162,6 +164,20 @@
 	builtInCamera = new (src)
 	builtInCamera.network = list("ss13")
 
+/mob/living/silicon/ai/key_down(_key, client/user)
+	switch(_key)
+		if("`")
+			view_core()
+			return
+		if("1", "2", "3", "4", "5", "6", "7", "8", "9")
+			if(client.keys_held["Ctrl"]) //do we assign a new hotkey?
+				cam_hotkeys[_key] = eyeobj.loc
+				to_chat(src, "Location saved to Camera Group [_key].")
+				return
+			if(cam_hotkeys[_key]) //if this is false, no hotkey for this slot exists.
+				eyeobj.setLoc(cam_hotkeys[_key])
+				return
+	. = ..()
 
 /mob/living/silicon/ai/Destroy()
 	GLOB.ai_list -= src

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -169,8 +169,9 @@
 	if(findtext(_key, "numpad")) //if it's a numpad number, we can convert it to just the number
 		_key = _key[7] //strings, lists, same thing really
 	switch(_key)
-		if("`" && cam_prev)
-			eyeobj.setLoc(cam_prev)
+		if("`")
+			if(cam_prev)
+				eyeobj.setLoc(cam_prev)
 			return
 		if("1", "2", "3", "4", "5", "6", "7", "8", "9")
 			_key = text2num(_key)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -169,7 +169,7 @@
 	if(findtext(_key, "numpad")) //if it's a numpad number, we can convert it to just the number
 		_key = _key[7] //strings, lists, same thing really
 	switch(_key)
-		if("`")
+		if("`" && cam_prev)
 			eyeobj.setLoc(cam_prev)
 			return
 		if("1", "2", "3", "4", "5", "6", "7", "8", "9")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -95,6 +95,7 @@
 	var/display_icon_override
 
 	var/list/cam_hotkeys = new/list(9)
+	var/cam_prev = null
 
 /mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, mob/target_ai)
 	. = ..()
@@ -165,16 +166,20 @@
 	builtInCamera.network = list("ss13")
 
 /mob/living/silicon/ai/key_down(_key, client/user)
+	if(findtext(_key, "numpad")) //if it's a numpad number, we can convert it to just the number
+		_key = _key[7] //strings, lists, same thing really
 	switch(_key)
 		if("`")
-			view_core()
+			eyeobj.setLoc(cam_prev)
 			return
 		if("1", "2", "3", "4", "5", "6", "7", "8", "9")
+			_key = text2num(_key)
 			if(client.keys_held["Ctrl"]) //do we assign a new hotkey?
 				cam_hotkeys[_key] = eyeobj.loc
 				to_chat(src, "Location saved to Camera Group [_key].")
 				return
 			if(cam_hotkeys[_key]) //if this is false, no hotkey for this slot exists.
+				cam_prev = eyeobj.loc
 				eyeobj.setLoc(cam_hotkeys[_key])
 				return
 	. = ..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -95,7 +95,7 @@
 	var/display_icon_override
 
 	var/list/cam_hotkeys = new/list(9)
-	var/cam_prev = null
+	var/cam_prev
 
 /mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, mob/target_ai)
 	. = ..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -169,7 +169,7 @@
 	if(findtext(_key, "numpad")) //if it's a numpad number, we can convert it to just the number
 		_key = _key[7] //strings, lists, same thing really
 	switch(_key)
-		if("`")
+		if("`", "0")
 			if(cam_prev)
 				eyeobj.setLoc(cam_prev)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
AIs can use CTRL and a number key to set a location to that number key, and then press it later to jump their eye back to the same location. Tilde is also set to the AI's own core.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lets the AI manage multiple areas of interest in an alternative way to using the multi-screen system.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Zxaber
add: AIs can now use CTRL and a number key (1 - 9) to assign a location to the number key, and then press the key later to jump their camera to that location. The numpad keys will work as aliases for their respective numbers.
add: The Tilde key, or zero (or numpad zero), will return you to the last point you jumped from.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Release your inner starcraft player.