### PR TITLE
Fixes reversed Cross check in turf/enter, signal now only send when the atom actually crosses something.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -371,9 +371,9 @@
 // Make sure you know what you're doing if you call this, this is intended to only be called by byond directly.
 // You probably want CanPass()
 /atom/movable/Cross(atom/movable/AM)
-	. = TRUE
-	SEND_SIGNAL(src, COMSIG_MOVABLE_CROSS, AM)
-	return CanPass(AM, AM.loc, TRUE)
+	if(CanPass(AM, AM.loc, TRUE))
+		SEND_SIGNAL(src, COMSIG_MOVABLE_CROSS, AM)
+		return TRUE
 
 //oldloc = old location on atom, inserted when forceMove is called and ONLY when forceMove is called!
 /atom/movable/Crossed(atom/movable/AM, oldloc)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -219,7 +219,7 @@
 			if(i == mover || i == mover.loc) // Multi tile objects and moving out of other objects
 				continue
 			var/atom/movable/thing = i
-			if(!thing.Cross(mover))
+			if(!mover.Cross(thing))
 				if(QDELETED(mover))		//Mover deleted from Cross/CanPass, do not proceed.
 					return FALSE
 				if(CHECK_BITFIELD(mover.movement_type, UNSTOPPABLE))


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed a reversed check when a mob moves that resulted the signal indicating they crossed something never being sent.
/:cl: