### PR TITLE
Makes money briefcases cost 3TC in the uplink, up from 1TC

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1760,7 +1760,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			and services at lucrative prices. The briefcase also feels a little heavier to hold; it has been \
 			manufactured to pack a little bit more of a punch if your client needs some convincing."
 	item = /obj/item/storage/secure/briefcase/syndie
-	cost = 1
+	cost = 3
 	restricted = TRUE
 
 /datum/uplink_item/badass/syndiecards


### PR DESCRIPTION
## About The Pull Request

Makes cash briefcases cost 3 TC, thats all.

## Why It's Good For The Game

They're far too cheap for how much you can do with 5000 credits.


:cl:
balance: Cash briefcases now cost 3TC, up from 1TC.
/:cl:
