### PR TITLE
Remove NOEYES for moths because they have mutanteyes that are extra flashable for balance.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -3,7 +3,7 @@
 	id = "moth"
 	say_mod = "flutters"
 	default_color = "00FF00"
-	species_traits = list(LIPS, NOEYES)
+	species_traits = list(LIPS)
 	inherent_biotypes = list(MOB_ORGANIC, MOB_HUMANOID, MOB_BUG)
 	mutant_bodyparts = list("moth_wings")
 	default_features = list("moth_wings" = "Plain")


### PR DESCRIPTION
## About The Pull Request

Finishes #34794 by actually removing the trait.  
The intention of that PR was to balance moths (can fly until burnt, eat clothes, their dedicated counters - flyswatter and pest spray - are extremely rare) by making them get flashed extra hard; fix to NOEYES showing the overlay resulted in them becoming effectively immune to flashes, which is against the point.

## Why It's Good For The Game

Being immune to flashes on top of roundstart flight no good very bad

## Changelog
:cl: Barhandar
balance: Moths no longer simultaneously have and don't have eyes. This means they're now fully vulnerable to flashes!
/:cl:
