### PR TITLE
Allows spawnergrenade to do something with the atoms it spawns

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -379,14 +379,7 @@ GLOBAL_LIST_EMPTY(species_list)
 	var/list/spawned_mobs = new(amount)
 
 	for(var/j in 1 to amount)
-		var/atom/movable/X 
-
-		if (istype(spawn_type, /list))
-			var/mob_type = pick(spawn_type)
-			X = new mob_type(T)
-		else
-			X = new spawn_type(T)
-
+		var/atom/movable/X = new spawn_type(T)
 		if (admin_spawn)
 			X.flags_1 |= ADMIN_SPAWNED_1
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -379,7 +379,14 @@ GLOBAL_LIST_EMPTY(species_list)
 	var/list/spawned_mobs = new(amount)
 
 	for(var/j in 1 to amount)
-		var/atom/movable/X = new spawn_type(T)
+		var/atom/movable/X 
+
+		if (istype(spawn_type, /list))
+			var/mob_type = pick(spawn_type)
+			X = new mob_type(T)
+		else
+			X = new spawn_type(T)
+
 		if (admin_spawn)
 			X.flags_1 |= ADMIN_SPAWNED_1
 

--- a/code/game/objects/items/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/grenades/spawnergrenade.dm
@@ -17,9 +17,13 @@
 			C.flash_act()
 
 		// Spawn some hostile syndicate critters and spread them out
-		spawn_and_random_walk(spawner_type, T, deliveryamt, walk_chance=50, admin_spawn=((flags_1 & ADMIN_SPAWNED_1) ? TRUE : FALSE))
+		var/list/spawned = spawn_and_random_walk(spawner_type, T, deliveryamt, walk_chance=50, admin_spawn=((flags_1 & ADMIN_SPAWNED_1) ? TRUE : FALSE))
+		afterspawn(spawned)
 
 	qdel(src)
+
+/obj/item/grenade/spawnergrenade/proc/afterspawn(list/mob/spawned)
+	return
 
 /obj/item/grenade/spawnergrenade/manhacks
 	name = "viscerator delivery grenade"
@@ -41,3 +45,19 @@
 	icon_state = "holy_grenade"
 	spawner_type = /mob/living/simple_animal/hostile/poison/bees/toxin
 	deliveryamt = 10
+
+/obj/item/grenade/spawnergrenade/floorgang
+	name = "Floor Gang Beacon"
+	desc = "To be used only in dire emergencies. Summons a brigade of cleanbots ready to roll."
+	spawner_type = list(/mob/living/simple_animal/bot/cleanbot, 
+						/mob/living/simple_animal/bot/firebot,
+						/mob/living/simple_animal/bot/floorbot,
+						/mob/living/simple_animal/bot/medbot)
+	deliveryamt = 20
+
+/obj/item/grenade/spawnergrenade/floorgang/afterspawn(list/mob/spawned)
+	. = ..()
+	for(var/mob/living/simple_animal/bot/B in spawned)
+		B.locked = FALSE
+		B.open = TRUE
+		B.emag_act()

--- a/code/game/objects/items/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/grenades/spawnergrenade.dm
@@ -45,19 +45,3 @@
 	icon_state = "holy_grenade"
 	spawner_type = /mob/living/simple_animal/hostile/poison/bees/toxin
 	deliveryamt = 10
-
-/obj/item/grenade/spawnergrenade/floorgang
-	name = "Floor Gang Beacon"
-	desc = "To be used only in dire emergencies."
-	spawner_type = list(/mob/living/simple_animal/bot/cleanbot, 
-						/mob/living/simple_animal/bot/firebot,
-						/mob/living/simple_animal/bot/floorbot,
-						/mob/living/simple_animal/bot/medbot)
-	deliveryamt = 10
-
-/obj/item/grenade/spawnergrenade/floorgang/afterspawn(list/mob/spawned)
-	. = ..()
-	for(var/mob/living/simple_animal/bot/B in spawned)
-		B.locked = FALSE
-		B.open = TRUE
-		B.emag_act()

--- a/code/game/objects/items/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/grenades/spawnergrenade.dm
@@ -48,12 +48,12 @@
 
 /obj/item/grenade/spawnergrenade/floorgang
 	name = "Floor Gang Beacon"
-	desc = "To be used only in dire emergencies. Summons a brigade of cleanbots ready to roll."
+	desc = "To be used only in dire emergencies."
 	spawner_type = list(/mob/living/simple_animal/bot/cleanbot, 
 						/mob/living/simple_animal/bot/firebot,
 						/mob/living/simple_animal/bot/floorbot,
 						/mob/living/simple_animal/bot/medbot)
-	deliveryamt = 20
+	deliveryamt = 10
 
 /obj/item/grenade/spawnergrenade/floorgang/afterspawn(list/mob/spawned)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new proc to `/obj/item/grenade/spawnergrenade` called `afterspawn`, it is called after all the atoms have been spawned and gets passed a list to those. Children of spawnergrenade can override this proc to do things to the spawned atoms, for example emagging bots after spawning.

## Changelog

Add `afterspawn` proc to `/obj/item/grenade/spawnergrenade`


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
