### PR TITLE
Fix heirloom bodybags being destroyed by use

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -20,7 +20,8 @@
 	var/obj/structure/closet/body_bag/R = new unfoldedbag_path(location)
 	R.open(user)
 	R.add_fingerprint(user)
-	qdel(src)
+	R.foldedbag_instance = src
+	moveToNullspace()
 
 /obj/item/bodybag/suicide_act(mob/user)
 	if(isopenturf(user.loc))
@@ -73,7 +74,8 @@
 			to_chat(A, "<span class='notice'>You suddenly feel air around you! You're free!</span>")
 	R.open(user)
 	R.add_fingerprint(user)
-	qdel(src)
+	R.foldedbag_instance = src
+	moveToNullspace()
 
 /obj/item/bodybag/bluespace/container_resist(mob/living/user)
 	if(user.incapacitated())

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -16,6 +16,12 @@
 	var/obj/item/bodybag/foldedbag_instance = null
 	var/tagged = 0 // so closet code knows to put the tag overlay back
 
+/obj/structure/closet/body_bag/Destroy()
+	// If we have a stored bag, and it's in nullspace (not in someone's hand), delete it.
+	if (foldedbag_instance && !foldedbag_instance.loc)
+		QDEL_NULL(foldedbag_instance)
+	return ..()
+
 /obj/structure/closet/body_bag/attackby(obj/item/I, mob/user, params)
 	if (istype(I, /obj/item/pen) || istype(I, /obj/item/toy/crayon))
 		if(!user.is_literate())

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -13,6 +13,7 @@
 	delivery_icon = null //unwrappable
 	anchorable = FALSE
 	var/foldedbag_path = /obj/item/bodybag
+	var/obj/item/bodybag/foldedbag_instance = null
 	var/tagged = 0 // so closet code knows to put the tag overlay back
 
 /obj/structure/closet/body_bag/attackby(obj/item/I, mob/user, params)
@@ -59,7 +60,7 @@
 		if(contents.len)
 			return 0
 		visible_message("<span class='notice'>[usr] folds up [src].</span>")
-		var/obj/item/bodybag/B = new foldedbag_path(get_turf(src))
+		var/obj/item/bodybag/B = foldedbag_instance || new foldedbag_path
 		usr.put_in_hands(B)
 		qdel(src)
 
@@ -87,7 +88,7 @@
 			to_chat(usr, "<span class='warning'>You can't recursively fold bluespace body bags!</span>" )
 			return 0
 		visible_message("<span class='notice'>[usr] folds up [src].</span>")
-		var/obj/item/bodybag/B = new foldedbag_path(get_turf(src))
+		var/obj/item/bodybag/B = foldedbag_instance || new foldedbag_path
 		usr.put_in_hands(B)
 		for(var/atom/movable/A in contents)
 			A.forceMove(B)


### PR DESCRIPTION
Fixes #42023

:cl:
fix: Heirloom bodybags no longer lose their heirloom status when deployed.
/:cl: