### PR TITLE
Improves cloning logging

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -292,7 +292,7 @@
 
 		else if(mob_occupant && (mob_occupant.cloneloss <= (100 - heal_level)))
 			connected_message("Cloning Process Complete.")
-			log_cloning("[key_name(mob_occupant)] completed cloning cycle - [src] at [AREACOORD(src)].")
+			log_cloning("[key_name(mob_occupant)] completed cloning cycle in [src] at [AREACOORD(src)].")
 			if(internal_radio)
 				SPEAK("The cloning cycle of [mob_occupant.real_name] is complete.")
 

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -237,20 +237,20 @@
 
 	if(!is_operational()) //Autoeject if power is lost
 		if(mob_occupant)
-			log_cloning("[mob_occupant] ejected from [src] at [AREACOORD(src)] due to power loss.")
+			log_cloning("[key_name(mob_occupant)] ejected from [src] at [AREACOORD(src)] due to power loss.")
 			go_out()
 			connected_message("Clone Ejected: Loss of power.")
 
 	else if(mob_occupant && (mob_occupant.loc == src))
 		if(SSeconomy.full_ancap)
 			if(!current_insurance)
-				log_cloning("[mob_occupant] ejected from [src] at [AREACOORD(src)] due to invalid bank account.")
+				log_cloning("[key_name(mob_occupant)] ejected from [src] at [AREACOORD(src)] due to invalid bank account.")
 				go_out()
 				connected_message("Clone Ejected: No bank account.")
 				if(internal_radio)
 					SPEAK("The cloning of [mob_occupant.real_name] has been terminated due to no bank account to draw payment from.")
 			else if(!current_insurance.adjust_money(-fair_market_price))
-				log_cloning("[mob_occupant] ejected from [src] at [AREACOORD(src)] due to insufficient funds.")
+				log_cloning("[key_name(mob_occupant)] ejected from [src] at [AREACOORD(src)] due to insufficient funds.")
 				go_out()
 				connected_message("Clone Ejected: Out of Money.")
 				if(internal_radio)
@@ -264,7 +264,7 @@
 			if(internal_radio)
 				SPEAK("The cloning of [mob_occupant.real_name] has been \
 					aborted due to unrecoverable tissue failure.")
-			log_cloning("[mob_occupant] ejected from [src] at [AREACOORD(src)] after suiciding.")
+			log_cloning("[key_name(mob_occupant)] ejected from [src] at [AREACOORD(src)] after suiciding.")
 			go_out()
 
 		else if(mob_occupant && mob_occupant.cloneloss > (100 - heal_level))
@@ -292,7 +292,7 @@
 
 		else if(mob_occupant && (mob_occupant.cloneloss <= (100 - heal_level)))
 			connected_message("Cloning Process Complete.")
-			log_cloning("[mob_occupant] completed cloning cycle - [src] at [AREACOORD(src)].")
+			log_cloning("[key_name(mob_occupant)] completed cloning cycle - [src] at [AREACOORD(src)].")
 			if(internal_radio)
 				SPEAK("The cloning cycle of [mob_occupant.real_name] is complete.")
 
@@ -352,7 +352,8 @@
 			to_chat(user, "<span class='danger'>Error: Pod has no occupant.</span>")
 			return
 		else
-			log_cloning("[user] manually ejected [mob_occupant] from [src] at [AREACOORD(src)].")
+			add_fingerprint(user)
+			log_cloning("[key_name(user)] manually ejected [key_name(mob_occupant)] from [src] at [AREACOORD(src)].")
 			log_combat(user, mob_occupant, "ejected", W, "from [src]")
 			connected_message("Emergency Ejection")
 			SPEAK("An emergency ejection of [clonemind.name] has occurred. Survival not guaranteed.")
@@ -366,7 +367,8 @@
 		return
 	to_chat(user, "<span class='warning'>You corrupt the genetic compiler.</span>")
 	malfunction()
-	log_cloning("[user] emagged [src] at [AREACOORD(src)], causing it to malfunction.")
+	add_fingerprint(user)
+	log_cloning("[key_name(user)] emagged [src] at [AREACOORD(src)], causing it to malfunction.")
 	log_combat(user, src, "emagged", null, occupant ? "[occupant] inside, killing them via malfunction." : null)
 
 //Put messages in the connected computer's temp var for display.
@@ -436,7 +438,7 @@
 		to_chat(mob_occupant, "<span class='warning'><b>Agony blazes across your consciousness as your body is torn apart.</b><br><i>Is this what dying is like? Yes it is.</i></span>")
 		playsound(src, 'sound/machines/warning-buzzer.ogg', 50)
 		SEND_SOUND(mob_occupant, sound('sound/hallucinations/veryfar_noise.ogg',0,1,50))
-		log_cloning("[mob_occupant] destroyed within [src] at [AREACOORD(src)] due to malfunction.")
+		log_cloning("[key_name(mob_occupant)] destroyed within [src] at [AREACOORD(src)] due to malfunction.")
 		QDEL_IN(mob_occupant, 40)
 
 /obj/machinery/clonepod/relaymove(mob/user)
@@ -451,7 +453,7 @@
 	if (!(. & EMP_PROTECT_SELF))
 		var/mob/living/mob_occupant = occupant
 		if(mob_occupant && prob(100/(severity*efficiency)))
-			log_cloning("[mob_occupant] ejected from [src] at [AREACOORD(src)] due to EMP pulse.")
+			log_cloning("[key_name(mob_occupant)] ejected from [src] at [AREACOORD(src)] due to EMP pulse.")
 			connected_message(Gibberish("EMP-caused Accidental Ejection", 0))
 			SPEAK(Gibberish("Exposure to electromagnetic fields has caused the ejection of [mob_occupant.real_name] prematurely." ,0))
 			go_out()

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -487,7 +487,7 @@
 						active_record = null
 					menu = 1
 					success = TRUE
-					log_cloning("[key_name(usr)] initiated cloning of [key_name(C.fields["mindref"])] - [src] at [AREACOORD(src)]. Pod: [pod] at [AREACOORD(pod)].")
+					log_cloning("[key_name(usr)] initiated cloning of [key_name(C.fields["mindref"])] via [src] at [AREACOORD(src)]. Pod: [pod] at [AREACOORD(pod)].")
 				if(result &	CLONING_DELETE_RECORD)
 					if(active_record == C)
 						active_record = null

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -602,5 +602,5 @@
 	else
 		scantemp = "Subject successfully scanned."
 	records += R
-	log_cloning("[usr ? key_name(usr) : "Autoprocess"] added the record of [key_name(mob_occupant)] to [src] at [AREACOORD(src)].")
+	log_cloning("[M ? key_name(M) : "Autoprocess"] added the record of [key_name(mob_occupant)] to [src] at [AREACOORD(src)].")
 	playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -63,7 +63,7 @@
 				. = pod
 
 /proc/grow_clone_from_record(obj/machinery/clonepod/pod, datum/data/record/R)
-	return pod.growclone(R.fields["name"], R.fields["UI"], R.fields["SE"], R.fields["mind"], R.fields["last_death"], R.fields["mrace"], R.fields["features"], R.fields["factions"], R.fields["quirks"], R.fields["bank_account"], R.fields["traumas"])
+	return pod.growclone(R.fields["name"], R.fields["UI"], R.fields["SE"], R.fields["mindref"], R.fields["last_death"], R.fields["mrace"], R.fields["features"], R.fields["factions"], R.fields["quirks"], R.fields["bank_account"], R.fields["traumas"])
 
 /obj/machinery/computer/cloning/process()
 	if(!(scanner && LAZYLEN(pods) && autoprocess))
@@ -73,7 +73,7 @@
 		scan_occupant(scanner.occupant)
 
 	for(var/datum/data/record/R in records)
-		var/obj/machinery/clonepod/pod = GetAvailableEfficientPod(R.fields["mind"])
+		var/obj/machinery/clonepod/pod = GetAvailableEfficientPod(R.fields["mindref"])
 
 		if(!pod)
 			return
@@ -84,7 +84,7 @@
 		var/result = grow_clone_from_record(pod, R)
 		if(result & CLONING_SUCCESS)
 			temp = "[R.fields["name"]] => <font class='good'>Cloning cycle in progress...</font>"
-			log_cloning("Cloning of [R.fields["name"]] automatically started via autoprocess - [src] at [AREACOORD(src)]. Pod: [pod] at [AREACOORD(pod)].")
+			log_cloning("Cloning of [key_name(active_record.fields["mindref"])] automatically started via autoprocess - [src] at [AREACOORD(src)]. Pod: [pod] at [AREACOORD(pod)].")
 		if(result & CLONING_DELETE_RECORD)
 			records -= R
 
@@ -354,7 +354,7 @@
 		say("Initiating scan...")
 
 		spawn(20)
-			scan_occupant(scanner.occupant)
+			scan_occupant(scanner.occupant, usr)
 
 			loading = FALSE
 			updateUsrDialog()
@@ -400,7 +400,7 @@
 
 
 		else if (menu == 4)
-			log_cloning("[usr] deleted [active_record.fields["name"]]'s cloning records from [src] at [AREACOORD(src)].")
+			log_cloning("[key_name(usr)] deleted [key_name(active_record.fields["mindref"])]'s cloning records from [src] at [AREACOORD(src)].")
 			temp = "[active_record.fields["name"]] => Record deleted."
 			records.Remove(active_record)
 			active_record = null
@@ -433,7 +433,7 @@
 				if(include_se)
 					overwrite_field_if_available(active_record, diskette, "SE")
 
-				log_cloning("[usr] uploaded [active_record.fields["name"]]'s cloning records to [src] at [AREACOORD(src)] via [diskette].")
+				log_cloning("[key_name(usr)] uploaded [key_name(active_record.fields["mindref"])]'s cloning records to [src] at [AREACOORD(src)] via [diskette].")
 				temp = "Load successful."
 				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 
@@ -449,7 +449,7 @@
 					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 					return
 
-				log_cloning("[usr] added [active_record.fields["name"]]'s cloning records to [diskette] via [src] at [AREACOORD(src)].")
+				log_cloning("[key_name(usr)] added [key_name(active_record.fields["mindref"])]'s cloning records to [diskette] via [src] at [AREACOORD(src)].")
 				diskette.fields = active_record.fields.Copy()
 				diskette.name = "data disk - '[diskette.fields["name"]]'"
 				temp = "Save successful."
@@ -487,7 +487,7 @@
 						active_record = null
 					menu = 1
 					success = TRUE
-					log_cloning("[usr] initiated cloning of [C.fields["name"]] - [src] at [AREACOORD(src)]. Pod: [pod] at [AREACOORD(pod)].")
+					log_cloning("[key_name(usr)] initiated cloning of [key_name(C.fields["mindref"])] - [src] at [AREACOORD(src)]. Pod: [pod] at [AREACOORD(pod)].")
 				if(result &	CLONING_DELETE_RECORD)
 					if(active_record == C)
 						active_record = null
@@ -510,7 +510,7 @@
 	updateUsrDialog()
 	return
 
-/obj/machinery/computer/cloning/proc/scan_occupant(occupant)
+/obj/machinery/computer/cloning/proc/scan_occupant(occupant, mob/M)
 	var/mob/living/mob_occupant = get_mob_or_brainmob(occupant)
 	var/datum/dna/dna
 	var/datum/bank_account/has_bank_account
@@ -583,7 +583,7 @@
 		R.fields["traumas"] = B.get_traumas()
 
 	R.fields["bank_account"] = has_bank_account
-	R.fields["mind"] = "[REF(mob_occupant.mind)]"
+	R.fields["mindref"] = "[REF(mob_occupant.mind)]"
 	R.fields["last_death"] = mob_occupant.stat == DEAD ? mob_occupant.mind.last_death : -1
 
    //Add an implant if needed
@@ -602,4 +602,5 @@
 	else
 		scantemp = "Subject successfully scanned."
 	records += R
+	log_cloning("[usr ? key_name(usr) : "Autoprocess"] added the record of [key_name(mob_occupant)] to [src] at [AREACOORD(src)].")
 	playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50)

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -44,6 +44,7 @@
 				factions = B.data["quirks"]
 				contains_sample = TRUE
 				visible_message("<span class='notice'>The [src] is injected with a fresh blood sample.</span>")
+				log_cloning("[key_name(mind)]'s cloning record was added to [src] at [AREACOORD(src)].")
 			else
 				visible_message("<span class='warning'>The [src] rejects the sample!</span>")
 
@@ -117,6 +118,7 @@
 			new V(podman)
 		podman.hardset_dna(null,null,podman.real_name,blood_type, new /datum/species/pod,features)//Discard SE's and UI's, podman cloning is inaccurate, and always make them a podman
 		podman.set_cloned_appearance()
+		log_cloning("[key_name(mind)] cloned as a podman via [src] in [parent] at [AREACOORD(parent)].")
 
 	else //else, one packet of seeds. maybe two
 		var/seed_count = 1


### PR DESCRIPTION
Forgot to log keys as well.
Also noticed that cloning was writing the occupant's mind ref to the field "mind" on the record instead of "mindref". Corrected that.

:cl: ShizCalev
admin: Improved some cloning logging.
fix: Emagging a cloning pod will now leave fingerprints.
fix: Ejecting someone while they're being cloned will now leave fingerprints.
/:cl: