### PR TITLE
repaths /obj/structure/chair/office/dark to /obj/structure/chair/office

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
@@ -137,7 +137,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/powered/animal_hospital)
 "at" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -149,7 +149,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/powered/animal_hospital)
 "au" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -508,7 +508,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/powered/animal_hospital)
 "br" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/plasteel,
 /area/ruin/powered/animal_hospital)
 "bs" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -5991,7 +5991,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_lava_base/telecomms)
 "oi" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{

--- a/_maps/RandomRuins/SpaceRuins/cloning_facility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/cloning_facility.dmm
@@ -180,7 +180,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/powered/ancient_shuttle)
 "w" = (
-/obj/structure/chair/office{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -201,7 +201,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/powered/ancient_shuttle)
 "y" = (
-/obj/structure/chair/office{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1345,7 +1345,7 @@
 /turf/open/floor/carpet,
 /area/awaymission/BMPship/Fore)
 "ef" = (
-/obj/structure/chair/office{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/carpet,

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -253,7 +253,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
 "G" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
 "H" = (

--- a/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
@@ -169,7 +169,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "E" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "F" = (

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -61,7 +61,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "ai" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{

--- a/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -53,7 +53,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/ruin/space/has_grav/powered/mechtransport)
 "n" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -661,7 +661,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/drone_bay)
 "bJ" = (
-/obj/structure/chair/office{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -848,7 +848,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/bridge)
 "cm" = (
-/obj/structure/chair/office{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -857,7 +857,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/bridge)
 "co" = (
-/obj/structure/chair/office{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/plasteel,

--- a/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -57,7 +57,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/turretedoutpost)
 "an" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -264,7 +264,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/turretedoutpost)
 "aN" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/turretedoutpost)
 "aO" = (

--- a/_maps/RandomZLevels/Academy.dmm
+++ b/_maps/RandomZLevels/Academy.dmm
@@ -258,7 +258,7 @@
 /turf/open/floor/wood,
 /area/awaymission/academy/headmaster)
 "aV" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/carpet,
 /area/awaymission/academy/headmaster)
 "aW" = (
@@ -303,7 +303,7 @@
 /turf/open/floor/wood,
 /area/awaymission/academy/headmaster)
 "be" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -336,7 +336,7 @@
 /turf/open/floor/wood,
 /area/awaymission/academy/headmaster)
 "bk" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -345,7 +345,7 @@
 /turf/open/floor/carpet,
 /area/awaymission/academy/headmaster)
 "bl" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/carpet,

--- a/_maps/RandomZLevels/Cabin.dmm
+++ b/_maps/RandomZLevels/Cabin.dmm
@@ -314,7 +314,7 @@
 /turf/open/floor/carpet,
 /area/awaymission/cabin)
 "bd" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/carpet,
 /area/awaymission/cabin)
 "be" = (

--- a/_maps/RandomZLevels/VR/snowdin_VR.dmm
+++ b/_maps/RandomZLevels/VR/snowdin_VR.dmm
@@ -130,7 +130,7 @@
 /turf/open/floor/plasteel/dark,
 /area/awaymission/snowdin/post/research)
 "aF" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -141,13 +141,13 @@
 /turf/open/floor/plasteel/dark,
 /area/awaymission/snowdin/post/research)
 "aH" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/snowdin/post/research)
 "aI" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -6594,7 +6594,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/secpost)
 "oh" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/item/shard,
@@ -11397,7 +11397,7 @@
 	},
 /area/awaymission/snowdin/post/minipost)
 "Ax" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomZLevels/VR/syndicate_trainer.dmm
+++ b/_maps/RandomZLevels/VR/syndicate_trainer.dmm
@@ -1165,13 +1165,13 @@
 /turf/open/indestructible,
 /area/awaymission/centcomAway/general)
 "gO" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/indestructible,
 /area/awaymission/centcomAway/general)
 "gP" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/indestructible,
@@ -1203,7 +1203,7 @@
 /turf/open/indestructible,
 /area/awaymission/centcomAway/general)
 "gZ" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/indestructible,
 /area/awaymission/centcomAway/general)
 "hb" = (
@@ -2100,7 +2100,7 @@
 /turf/closed/indestructible/riveted,
 /area/awaymission/centcomAway/cafe)
 "mg" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/indestructible,

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -3528,7 +3528,7 @@
 	},
 /area/awaymission/moonoutpost19/research)
 "gP" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -1238,7 +1238,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/research/interior/genetics)
 "cV" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -4391,7 +4391,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/research/interior/genetics)
 "iy" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -130,7 +130,7 @@
 /turf/open/floor/plasteel/dark,
 /area/awaymission/snowdin/post/research)
 "aF" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -141,13 +141,13 @@
 /turf/open/floor/plasteel/dark,
 /area/awaymission/snowdin/post/research)
 "aH" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/snowdin/post/research)
 "aI" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -6645,7 +6645,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/secpost)
 "oh" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/item/shard,
@@ -11509,7 +11509,7 @@
 	},
 /area/awaymission/snowdin/post/minipost)
 "Ax" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -2168,7 +2168,7 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "ez" = (
-/obj/structure/chair/office{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -2192,7 +2192,7 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "eC" = (
-/obj/structure/chair/office{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -2292,7 +2292,7 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "eL" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -2319,7 +2319,7 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "eN" = (
-/obj/structure/chair/office{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -7123,7 +7123,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "np" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel{
@@ -10603,7 +10603,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -11782,7 +11782,7 @@
 	dir = 5;
 	level = 1
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -12774,7 +12774,7 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "wH" = (
-/obj/structure/chair/office,
+/obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1

--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -1674,13 +1674,13 @@
 	},
 /area/awaymission/wildwest/mines)
 "fE" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/awaymission/wildwest/mines)
 "fF" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/wood,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -3851,7 +3851,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ahR" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/warden,
 /obj/machinery/button/door{
 	id = "Prison Gate";
@@ -6011,7 +6011,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "amn" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -8165,7 +8165,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "asn" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/lawyer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
@@ -14925,7 +14925,7 @@
 /turf/open/floor/wood,
 /area/library)
 "aIs" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/camera{
 	c_tag = "Library North";
 	dir = 2
@@ -14954,7 +14954,7 @@
 /turf/open/floor/wood,
 /area/library)
 "aIw" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -15551,13 +15551,13 @@
 /turf/open/floor/wood,
 /area/library)
 "aJQ" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/library)
 "aJR" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -16655,7 +16655,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aMH" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -16666,7 +16666,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aMJ" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -19507,7 +19507,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aUl" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -19642,7 +19642,7 @@
 /area/library)
 "aUF" = (
 /obj/effect/landmark/start/librarian,
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/wood,
 /area/library)
 "aUG" = (
@@ -19696,7 +19696,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aUN" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -21175,7 +21175,7 @@
 /turf/open/floor/wood,
 /area/vacant_room/office)
 "aXY" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -21225,7 +21225,7 @@
 /turf/closed/wall,
 /area/quartermaster/warehouse)
 "aYd" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -25376,7 +25376,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bix" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/depsec/medical,
@@ -27554,7 +27554,7 @@
 /area/quartermaster/office)
 "bnz" = (
 /obj/effect/landmark/start/cargo_technician,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -28260,7 +28260,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "bpc" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -29767,7 +29767,7 @@
 	},
 /area/science/research)
 "bsY" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/start/head_of_personnel,
@@ -31616,7 +31616,7 @@
 /turf/closed/wall,
 /area/quartermaster/qm)
 "bxv" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/start/depsec/science,
@@ -31712,7 +31712,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bxM" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/red,
@@ -32159,7 +32159,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "byL" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/depsec/supply,
@@ -32689,7 +32689,7 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bzT" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/quartermaster,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32737,7 +32737,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bAb" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/shaft_miner,
@@ -33950,7 +33950,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCI" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
@@ -37246,7 +37246,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/start/cargo_technician,
@@ -38788,7 +38788,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bOD" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -39906,7 +39906,7 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bRv" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/start/atmospheric_technician,
@@ -40083,7 +40083,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bRS" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/depsec/engineering,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
@@ -41805,7 +41805,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWt" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46912,7 +46912,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/station_engineer,
@@ -49175,7 +49175,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50449,7 +50449,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ctG" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -51692,7 +51692,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "cwp" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
@@ -51902,7 +51902,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "cxl" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/lawyer,
@@ -56611,7 +56611,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "mSf" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -56914,7 +56914,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "pvj" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -933,7 +933,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "adi" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -3922,7 +3922,7 @@
 	},
 /area/maintenance/port/fore)
 "alZ" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/do_not_question{
@@ -3966,7 +3966,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/vacant_room/office)
 "amg" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -4458,7 +4458,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/vacant_room/office)
 "ana" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -5086,7 +5086,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -5195,7 +5195,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -5337,7 +5337,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aoC" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -5512,7 +5512,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/electronic_marketing_den)
 "aoU" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -5545,7 +5545,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoZ" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/plasteel/grimy,
 /area/vacant_room/office)
 "apa" = (
@@ -14353,7 +14353,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/service)
 "aEI" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -17246,7 +17246,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aJn" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -17398,7 +17398,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aJF" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -17787,7 +17787,7 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "aKn" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -17962,7 +17962,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aKE" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/cargo_technician,
@@ -20147,7 +20147,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/abandoned_gambling_den/secondary)
 "aOq" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -20462,7 +20462,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aON" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -23899,7 +23899,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aUb" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/cargo_technician,
@@ -24068,7 +24068,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aUl" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -24356,7 +24356,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24960,7 +24960,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aVz" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/cargo_technician,
@@ -25414,7 +25414,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aVW" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -26502,7 +26502,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aXA" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -28587,7 +28587,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "baO" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -30412,7 +30412,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bdZ" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -31118,7 +31118,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bfr" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -33193,7 +33193,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "biN" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -33991,7 +33991,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bjT" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -34108,7 +34108,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bkc" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -34290,7 +34290,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bkt" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -35329,7 +35329,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bmm" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -36210,7 +36210,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bnM" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -36357,7 +36357,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "bnW" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37977,7 +37977,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bqC" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/start/botanist,
@@ -38419,7 +38419,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "brh" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -38532,7 +38532,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "brq" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -38679,7 +38679,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "brA" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -39793,7 +39793,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "btp" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -40655,7 +40655,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "buO" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
@@ -43150,7 +43150,7 @@
 /turf/open/floor/plating,
 /area/security/main)
 "byP" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -43223,7 +43223,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "byT" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -43514,7 +43514,7 @@
 	},
 /area/engine/atmos)
 "bzu" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -43562,7 +43562,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bzx" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -43815,7 +43815,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bzN" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -43831,7 +43831,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bzO" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -43863,7 +43863,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bzQ" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -43895,7 +43895,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bzS" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -44138,7 +44138,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bAp" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -44173,7 +44173,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bAr" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -44201,7 +44201,7 @@
 /turf/open/floor/plating,
 /area/security/main)
 "bAt" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -44392,7 +44392,7 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bAF" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -44668,7 +44668,7 @@
 	},
 /area/engine/atmos)
 "bBb" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -44685,7 +44685,7 @@
 /area/engine/atmos)
 "bBc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -45412,7 +45412,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bCj" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -45461,7 +45461,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bCl" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -45489,7 +45489,7 @@
 /turf/open/floor/plating,
 /area/security/main)
 "bCn" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46531,7 +46531,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDE" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -46553,7 +46553,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDF" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -46659,7 +46659,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDL" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -46684,7 +46684,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDM" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -50819,7 +50819,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bJF" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -50929,7 +50929,7 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bJM" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -53044,7 +53044,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bNa" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -53099,7 +53099,7 @@
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
 "bNf" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -54204,7 +54204,7 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "bOH" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -54250,7 +54250,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bON" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -54492,7 +54492,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bPh" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -54508,7 +54508,7 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bPj" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/detective,
@@ -54632,7 +54632,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bPt" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/warden,
@@ -55391,7 +55391,7 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "bQI" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -55414,7 +55414,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bQN" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bQO" = (
@@ -55703,7 +55703,7 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bRm" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -57348,7 +57348,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bTM" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/flasher{
@@ -59355,7 +59355,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bWw" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -61273,7 +61273,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bYZ" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/head_of_personnel,
@@ -62838,7 +62838,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "cbJ" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -64435,7 +64435,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cef" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/librarian,
@@ -64492,7 +64492,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cek" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -65066,7 +65066,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cfc" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
@@ -65600,7 +65600,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfP" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -66116,7 +66116,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
 "cgM" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -66859,7 +66859,7 @@
 /turf/open/floor/wood,
 /area/library)
 "chN" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/wood,
 /area/library)
 "chO" = (
@@ -66958,7 +66958,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "cia" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -67202,7 +67202,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ciu" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable/white,
@@ -67235,7 +67235,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
 "ciw" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -68636,7 +68636,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "ckO" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
@@ -68690,13 +68690,13 @@
 /turf/closed/wall,
 /area/crew_quarters/heads/hop)
 "ckW" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "ckX" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -71275,7 +71275,7 @@
 /turf/open/floor/carpet,
 /area/library)
 "cpx" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/librarian,
@@ -76135,14 +76135,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "cxW" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "cxX" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -77147,7 +77147,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "czD" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -77175,7 +77175,7 @@
 /turf/open/floor/carpet,
 /area/library)
 "czG" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -78028,7 +78028,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cBb" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -78044,7 +78044,7 @@
 /turf/open/floor/carpet,
 /area/library)
 "cBe" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -79087,14 +79087,14 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cCI" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "cCJ" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -79695,7 +79695,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "cDF" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -80805,7 +80805,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "cFB" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -87644,7 +87644,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "cRu" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/machinery/newscaster{
@@ -88701,7 +88701,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "cTb" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "cTc" = (
@@ -89247,7 +89247,7 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -90716,7 +90716,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "cWq" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -99592,7 +99592,7 @@
 /area/maintenance/starboard/aft)
 "dkS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -109607,7 +109607,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "dDd" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -110972,7 +110972,7 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
 "dFz" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -112663,7 +112663,7 @@
 	id = "toxinsdriver";
 	pixel_x = -24
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -113547,11 +113547,11 @@
 	},
 /area/security/detectives_office/private_investigators_office)
 "dJC" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/wood,
 /area/security/detectives_office/private_investigators_office)
 "dJD" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/security/detectives_office/private_investigators_office)
@@ -114726,7 +114726,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office/private_investigators_office)
 "dLx" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -117002,12 +117002,12 @@
 /turf/open/floor/plasteel/grimy,
 /area/library/abandoned)
 "dPC" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/grimy,
 /area/library/abandoned)
 "dPD" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -117483,7 +117483,7 @@
 /turf/open/floor/plating,
 /area/library/abandoned)
 "dQr" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -117523,7 +117523,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library/abandoned)
 "dQv" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -117541,7 +117541,7 @@
 /turf/open/floor/carpet,
 /area/library/abandoned)
 "dQy" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -118170,7 +118170,7 @@
 	},
 /area/library/abandoned)
 "dRt" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -118194,7 +118194,7 @@
 /turf/open/floor/carpet,
 /area/library/abandoned)
 "dRw" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -118797,7 +118797,7 @@
 /turf/open/floor/plating,
 /area/library/abandoned)
 "dSw" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -121181,12 +121181,12 @@
 /turf/open/floor/wood,
 /area/library/abandoned)
 "dXq" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/library/abandoned)
 "dXr" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/wood{
@@ -123601,7 +123601,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "ecl" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -124633,11 +124633,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "edU" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "edV" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
@@ -125364,7 +125364,7 @@
 /turf/open/floor/carpet,
 /area/chapel/office)
 "efr" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/chaplain,
@@ -125463,7 +125463,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "efx" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/cable/white{

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -5654,7 +5654,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "anl" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/head_of_personnel,
@@ -7803,7 +7803,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "asf" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -8541,7 +8541,7 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "atI" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/lawyer,
@@ -16860,7 +16860,7 @@
 /turf/open/floor/engine/cult,
 /area/library)
 "aLM" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/librarian,
@@ -34698,7 +34698,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "btP" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/lawyer,
@@ -37885,7 +37885,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bzV" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
@@ -37968,7 +37968,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bAf" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/quartermaster,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -40679,7 +40679,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bFd" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -42740,7 +42740,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bIN" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -42854,7 +42854,7 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "bJd" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -42964,7 +42964,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bJr" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1579,7 +1579,7 @@
 /area/security/execution/education)
 "adn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -9367,7 +9367,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "arg" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/start/warden,
@@ -9987,7 +9987,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aso" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -10006,7 +10006,7 @@
 /area/security/warden)
 "asq" = (
 /obj/effect/landmark/start/warden,
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -14529,7 +14529,7 @@
 /area/security/detectives_office)
 "aBo" = (
 /obj/effect/landmark/start/detective,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16118,7 +16118,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aEw" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/shaft_miner,
@@ -16385,7 +16385,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aEW" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -17730,7 +17730,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "aHv" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "aHw" = (
@@ -18988,7 +18988,7 @@
 /area/security/courtroom)
 "aKf" = (
 /obj/effect/landmark/start/lawyer,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -21362,7 +21362,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22573,7 +22573,7 @@
 /area/quartermaster/storage)
 "aRI" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22610,7 +22610,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aRL" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -24699,7 +24699,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aVP" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/plasteel,
@@ -27993,7 +27993,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bbC" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/start/depsec/engineering,
@@ -28192,7 +28192,7 @@
 /area/quartermaster/office)
 "bbU" = (
 /obj/effect/landmark/start/cargo_technician,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown,
@@ -29659,7 +29659,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "beO" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -31536,7 +31536,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bin" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/status_display/ai{
@@ -31570,7 +31570,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bir" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/status_display/evac{
@@ -31697,7 +31697,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "biI" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -31735,7 +31735,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "biL" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31900,13 +31900,13 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bja" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bjb" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -31915,7 +31915,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bjd" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -31924,7 +31924,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bje" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -32478,7 +32478,7 @@
 /area/quartermaster/sorting)
 "bki" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -33878,7 +33878,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -34719,7 +34719,7 @@
 /area/crew_quarters/heads/hop)
 "bon" = (
 /obj/effect/landmark/start/head_of_personnel,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -37492,7 +37492,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -38761,7 +38761,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bwo" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/head_of_personnel,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -39310,7 +39310,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -39335,7 +39335,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bxr" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -39678,7 +39678,7 @@
 /turf/open/floor/wood,
 /area/library)
 "bxV" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/librarian,
@@ -40393,7 +40393,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bzo" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -40434,7 +40434,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bzt" = (
@@ -40983,7 +40983,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bAE" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/start/atmospheric_technician,
@@ -41303,7 +41303,7 @@
 /turf/open/floor/wood,
 /area/library)
 "bBs" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -41973,7 +41973,7 @@
 /turf/open/floor/wood,
 /area/vacant_room/office)
 "bCN" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -45274,7 +45274,7 @@
 /turf/open/floor/carpet,
 /area/vacant_room/office)
 "bJw" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -45315,7 +45315,7 @@
 /area/library)
 "bJB" = (
 /obj/effect/landmark/start/librarian,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -46839,7 +46839,7 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "bMC" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/wood,
 /area/vacant_room/office)
 "bMD" = (
@@ -48965,7 +48965,7 @@
 /turf/open/floor/wood,
 /area/library)
 "bRi" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/wood,
 /area/library)
 "bRj" = (
@@ -49707,7 +49707,7 @@
 /turf/open/floor/wood,
 /area/library)
 "bSy" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -50116,7 +50116,7 @@
 /turf/open/floor/wood,
 /area/library)
 "bTx" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -51833,7 +51833,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/botanist,
@@ -54540,7 +54540,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "cbR" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/button/door{
 	desc = "A remote control switch for the medbay foyer.";
 	id = "MedbayFoyer";
@@ -54704,7 +54704,7 @@
 /area/security/checkpoint/science/research)
 "ccm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/depsec/science,
@@ -74227,7 +74227,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cNa" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -74661,7 +74661,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cNR" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -774,7 +774,7 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "cc" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -550,7 +550,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "adi" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -575,7 +575,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adl" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -593,7 +593,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adn" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -614,7 +614,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
 "adq" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -4315,7 +4315,7 @@
 /area/crew_quarters/heads/hos)
 "alK" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -4607,7 +4607,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "amo" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
@@ -4624,7 +4624,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "amq" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -4714,7 +4714,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -5039,7 +5039,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "ani" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -5277,14 +5277,14 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "anM" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "anN" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -5743,7 +5743,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aoP" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -5781,7 +5781,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aoT" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/warden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -7562,7 +7562,7 @@
 /turf/closed/wall/r_wall,
 /area/bridge)
 "asQ" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -7588,7 +7588,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "asR" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -7597,7 +7597,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "asT" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -8902,7 +8902,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "avD" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -8917,7 +8917,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "avF" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -12101,7 +12101,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aCQ" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/head_of_personnel,
@@ -13064,7 +13064,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "aEQ" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/button/flasher{
 	id = "hopflash";
 	pixel_x = 38;
@@ -16558,7 +16558,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aNE" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/depsec/supply,
@@ -21316,7 +21316,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYo" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -21329,7 +21329,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYp" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/cargo_technician,
@@ -22557,7 +22557,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "baS" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red,
@@ -23738,7 +23738,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bdK" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/shaft_miner,
@@ -24198,7 +24198,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "beK" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/start/quartermaster,
@@ -29582,7 +29582,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "brF" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -34848,7 +34848,7 @@
 /area/security/checkpoint/science)
 "bCL" = (
 /obj/effect/landmark/start/depsec/science,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -36499,7 +36499,7 @@
 /area/medical/exam_room)
 "bFW" = (
 /obj/effect/decal/remains/human,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -41400,7 +41400,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQF" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/atmospheric_technician,
@@ -41648,7 +41648,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -41763,7 +41763,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/atmospheric_technician,
@@ -43461,7 +43461,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUW" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -44972,7 +44972,7 @@
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main/monastery)
 "bYC" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/station_engineer,
@@ -45765,7 +45765,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cai" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -45774,12 +45774,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cak" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/station_engineer,
@@ -46379,7 +46379,7 @@
 /area/engine/engineering)
 "cca" = (
 /obj/effect/landmark/start/station_engineer,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46391,7 +46391,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -46524,7 +46524,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "ccq" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -49200,7 +49200,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -49233,7 +49233,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmr" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -53757,7 +53757,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "elk" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/wood,
 /area/lawoffice)
 "emV" = (
@@ -54209,7 +54209,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "fow" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
@@ -54996,7 +54996,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "gUb" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -56453,7 +56453,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "kxj" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -58232,7 +58232,7 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "oCn" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/lawyer,
@@ -60009,7 +60009,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1756,13 +1756,13 @@
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
 "eJ" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
 "eK" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/holofloor/plating,
@@ -5178,7 +5178,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "mH" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -5193,7 +5193,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "mI" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -5509,7 +5509,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "nn" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -5800,7 +5800,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "nN" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
 "nO" = (
@@ -6656,7 +6656,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "pj" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -6668,7 +6668,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "pk" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -8388,7 +8388,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "sr" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green{
@@ -8409,7 +8409,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "st" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
@@ -8469,7 +8469,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "sz" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8503,7 +8503,7 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "sB" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -8874,7 +8874,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "tq" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
@@ -8928,7 +8928,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "tz" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -9386,7 +9386,7 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "uw" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -10845,13 +10845,13 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "xV" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/centcom/control)
 "xW" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -11465,12 +11465,12 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "zB" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/ert_spawn,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "zC" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/landmark/ert_spawn,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -11735,7 +11735,7 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "Ah" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/ert_spawn,
@@ -11936,7 +11936,7 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "AP" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/ert_spawn,
@@ -12447,14 +12447,14 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "Ca" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/ert_spawn,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "Cb" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/ert_spawn,
@@ -13360,7 +13360,7 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "DG" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -13400,7 +13400,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "DJ" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{

--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -430,7 +430,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "R" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -1092,7 +1092,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "cf" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -1126,7 +1126,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ch" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -1168,7 +1168,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "cl" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/shuttles/emergency_imfedupwiththisworld.dmm
+++ b/_maps/shuttles/emergency_imfedupwiththisworld.dmm
@@ -133,7 +133,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "v" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "w" = (

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -182,7 +182,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "ax" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -216,7 +216,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aC" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aE" = (
@@ -232,7 +232,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aG" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -53,7 +53,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "al" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -75,7 +75,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "aq" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -574,7 +574,7 @@
 /area/shuttle/escape)
 "br" = (
 /obj/machinery/light,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -584,7 +584,7 @@
 /area/shuttle/escape)
 "bt" = (
 /obj/machinery/light,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -79,7 +79,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -125,7 +125,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -150,7 +150,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/shuttles/ferry_lighthouse.dmm
+++ b/_maps/shuttles/ferry_lighthouse.dmm
@@ -174,7 +174,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "aR" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/wood,

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -87,7 +87,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/bridge)
 "ao" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8;
 	name = "tactical swivel chair"
 	},
@@ -97,7 +97,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/bridge)
 "aq" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1;
 	name = "tactical swivel chair"
 	},
@@ -111,7 +111,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/bridge)
 "ar" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4;
 	name = "tactical swivel chair"
 	},

--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -16,7 +16,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "d" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,

--- a/_maps/shuttles/labour_delta.dmm
+++ b/_maps/shuttles/labour_delta.dmm
@@ -16,7 +16,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "d" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -735,7 +735,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/caravan/pirate)
 "EB" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/turretid{
@@ -1066,7 +1066,7 @@
 /turf/open/floor/plating,
 /area/shuttle/caravan/pirate)
 "ZY" = (
-/obj/structure/chair/office/dark{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("bed", /obj/structure/bed, 2, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
 	new/datum/stack_recipe_list("office chairs", list( \
-		new/datum/stack_recipe("dark office chair", /obj/structure/chair/office/dark, 5, one_per_turf = TRUE, on_floor = TRUE), \
+		new/datum/stack_recipe("dark office chair", /obj/structure/chair/office, 5, one_per_turf = TRUE, on_floor = TRUE), \
 		new/datum/stack_recipe("light office chair", /obj/structure/chair/office/light, 5, one_per_turf = TRUE, on_floor = TRUE), \
 		)), \
 	new/datum/stack_recipe_list("comfy chairs", list( \

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -204,6 +204,7 @@
 	anchored = FALSE
 	buildstackamount = 5
 	item_chair = null
+	icon_state = "officechair_dark"
 
 
 /obj/structure/chair/office/Moved()
@@ -213,9 +214,6 @@
 
 /obj/structure/chair/office/light
 	icon_state = "officechair_white"
-
-/obj/structure/chair/office/dark
-	icon_state = "officechair_dark"
 
 //Stool
 


### PR DESCRIPTION
The parent was just a dummy path, no sense having it really.