### PR TITLE
On second thought; lets just let the extreme popcap be what it is.

### DIFF
--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -52,16 +52,8 @@
 	//Population Cap Checking
 	var/extreme_popcap = CONFIG_GET(number/extreme_popcap)
 	if(!real_bans_only && !C && extreme_popcap && !admin)
-		var/hard_popcap = CONFIG_GET(number/hard_popcap)
-
-		var/popcap_value = living_player_count()
-		if (hard_popcap)
-			popcap_value = GLOB.clients.len
-		if (!GLOB.enter_allowed || length(SSticker.queued_players) || !SSticker.HasRoundStarted())
-			hard_popcap = 0
-			popcap_value = GLOB.clients.len
-
-		if(popcap_value >= extreme_popcap && (!hard_popcap || living_player_count() >= hard_popcap) && !GLOB.joined_player_list.Find(ckey))
+		var/popcap_value = GLOB.clients.len
+		if(popcap_value >= extreme_popcap && !GLOB.joined_player_list.Find(ckey))
 			log_access("Failed Login: [key] - Population cap reached")
 			return list("reason"="popcap", "desc"= "\nReason: [CONFIG_GET(string/extreme_popcap_message)]")
 


### PR DESCRIPTION
Last pr, i changed it from always looking at living player count, to only looking at living player count in certain situations. These situations came up often enough that it was subverting the intent of the extreme popcap and in some cases allowing 20 players extra on bagil.

It still exempts anybody currently in the round (even dead) reconnecting after disconnecting, except people who observed from lobby.
## Changelog
:cl:
fix: Fixed the connection cap being silly about what connections it counted towards the limit. 
/:cl:
