### PR TITLE
Deflection tweaks with the MK-I Ripley in mind

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -411,6 +411,10 @@
 		var/lights_energy_drain = 2
 		use_power(lights_energy_drain)
 
+	if(!enclosed && occupant && occupant.incapacitated()) //no sides mean it's easy to just sorta fall out if you're incapacitated.
+		visible_message("<span class='warning'>[occupant] tumbles out of the cockpit!</span>")
+		go_out() //Maybe we should install seat belts?
+
 //Diagnostic HUD updates
 	diag_hud_set_mechhealth()
 	diag_hud_set_mechcell()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -411,7 +411,7 @@
 		var/lights_energy_drain = 2
 		use_power(lights_energy_drain)
 
-	if(!enclosed && occupant && occupant.incapacitated()) //no sides mean it's easy to just sorta fall out if you're incapacitated.
+	if(!enclosed && occupant?.incapacitated()) //no sides mean it's easy to just sorta fall out if you're incapacitated.
 		visible_message("<span class='warning'>[occupant] tumbles out of the cockpit!</span>", "<span class='danger'>You tumble out of the cockpit!</span>")
 		go_out() //Maybe we should install seat belts?
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -297,6 +297,12 @@
 			to_chat(user, "[src] appears to be piloting itself...")
 		else if(occupant && occupant != user) //!silicon_pilot implied
 			to_chat(user, "You can see [occupant] inside.")
+			if(ishuman(user))
+				var/mob/living/carbon/human/H = user
+				for(var/O in H.held_items)
+					if(istype(O, /obj/item/gun))
+						to_chat(user, "<span class='warning'>It looks like you can hit the pilot directly if you target the center or above.</span>")
+						break //in case user is holding two guns
 
 //processing internal damage, temperature, air regulation, alert updates, lights power use.
 /obj/mecha/process()
@@ -412,7 +418,7 @@
 		use_power(lights_energy_drain)
 
 	if(!enclosed && occupant?.incapacitated()) //no sides mean it's easy to just sorta fall out if you're incapacitated.
-		visible_message("<span class='warning'>[occupant] tumbles out of the cockpit!</span>", "<span class='danger'>You tumble out of the cockpit!</span>")
+		visible_message("<span class='warning'>[occupant] tumbles out of the cockpit!</span>")
 		go_out() //Maybe we should install seat belts?
 
 //Diagnostic HUD updates

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -412,7 +412,7 @@
 		use_power(lights_energy_drain)
 
 	if(!enclosed && occupant && occupant.incapacitated()) //no sides mean it's easy to just sorta fall out if you're incapacitated.
-		visible_message("<span class='warning'>[occupant] tumbles out of the cockpit!</span>")
+		visible_message("<span class='warning'>[occupant] tumbles out of the cockpit!</span>", "<span class='danger'>You tumble out of the cockpit!</span>")
 		go_out() //Maybe we should install seat belts?
 
 //Diagnostic HUD updates

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -113,7 +113,7 @@
 
 
 /obj/mecha/bullet_act(obj/item/projectile/Proj) //wrapper
-	if (!enclosed && occupant && !silicon_pilot) //allows bullets to hit the pilot of open-canopy mechs
+	if (!enclosed && occupant && !silicon_pilot && Proj.def_zone != BODY_ZONE_L_LEG && Proj.def_zone != BODY_ZONE_R_LEG) //allows bullets to hit the pilot of open-canopy mechs
 		occupant.bullet_act(Proj) //If the sides are open, the occupant can be hit
 		return BULLET_ACT_HIT
 	log_message("Hit by projectile. Type: [Proj.name]([Proj.flag]).", LOG_MECHA, color="red")

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -113,7 +113,7 @@
 
 
 /obj/mecha/bullet_act(obj/item/projectile/Proj) //wrapper
-	if (!enclosed && occupant && !silicon_pilot && Proj.def_zone != BODY_ZONE_L_LEG && Proj.def_zone != BODY_ZONE_R_LEG) //allows bullets to hit the pilot of open-canopy mechs
+	if (!enclosed && occupant && !silicon_pilot && !Proj.force_hit && Proj.def_zone != BODY_ZONE_L_LEG && Proj.def_zone != BODY_ZONE_R_LEG) //allows bullets to hit the pilot of open-canopy mechs
 		occupant.bullet_act(Proj) //If the sides are open, the occupant can be hit
 		return BULLET_ACT_HIT
 	log_message("Hit by projectile. Type: [Proj.name]([Proj.flag]).", LOG_MECHA, color="red")

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -113,7 +113,7 @@
 
 
 /obj/mecha/bullet_act(obj/item/projectile/Proj) //wrapper
-	if (!enclosed && occupant && !silicon_pilot && !Proj.force_hit && Proj.def_zone != BODY_ZONE_L_LEG && Proj.def_zone != BODY_ZONE_R_LEG) //allows bullets to hit the pilot of open-canopy mechs
+	if (!enclosed && occupant && !silicon_pilot && !Proj.force_hit && (Proj.def_zone == BODY_ZONE_HEAD || Proj.def_zone == BODY_ZONE_CHEST)) //allows bullets to hit the pilot of open-canopy mechs
 		occupant.bullet_act(Proj) //If the sides are open, the occupant can be hit
 		return BULLET_ACT_HIT
 	log_message("Hit by projectile. Type: [Proj.name]([Proj.flag]).", LOG_MECHA, color="red")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -47,6 +47,9 @@
 		if(mind.martial_art && !incapacitated(FALSE, TRUE) && mind.martial_art.can_use(src) && mind.martial_art.deflection_chance) //Some martial arts users can deflect projectiles!
 			if(prob(mind.martial_art.deflection_chance))
 				if((mobility_flags & MOBILITY_USE) && dna && !dna.check_mutation(HULK)) //But only if they're otherwise able to use items, and hulks can't do it
+					if(!isturf(loc)) //no deflecting if you're inside something
+						to_chat(src, "<span class='danger'>You try to deflect the projectile, but there's just not enough room!</span>")
+						return ..(P, def_zone)
 					if(mind.martial_art.deflection_chance >= 100) //if they can NEVER be hit, lets clue sec in ;)
 						visible_message("<span class='danger'>[src] deflects the projectile; [p_they()] can't be hit with ranged weapons!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
 					else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -47,9 +47,10 @@
 		if(mind.martial_art && !incapacitated(FALSE, TRUE) && mind.martial_art.can_use(src) && mind.martial_art.deflection_chance) //Some martial arts users can deflect projectiles!
 			if(prob(mind.martial_art.deflection_chance))
 				if((mobility_flags & MOBILITY_USE) && dna && !dna.check_mutation(HULK)) //But only if they're otherwise able to use items, and hulks can't do it
-					if(!isturf(loc)) //no deflecting if you're inside something
-						to_chat(src, "<span class='danger'>You try to deflect the projectile, but there's just not enough room!</span>")
-						return ..(P, def_zone)
+					if(!isturf(loc)) //if we're inside something and still got hit
+						P.force_hit = TRUE //The thing we're in passed the bullet to us. Pass it back, and tell it to take the damage.
+						loc.bullet_act(P)
+						return BULLET_ACT_HIT
 					if(mind.martial_art.deflection_chance >= 100) //if they can NEVER be hit, lets clue sec in ;)
 						visible_message("<span class='danger'>[src] deflects the projectile; [p_they()] can't be hit with ranged weapons!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
 					else
@@ -68,6 +69,10 @@
 				visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", \
 								"<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")
 				// Find a turf near or on the original location to bounce to
+				if(!isturf(loc)) //if we're inside something and still got hit
+					P.force_hit = TRUE //The thing we're in passed the bullet to us. Pass it back, and tell it to take the damage.
+					loc.bullet_act(P)
+					return BULLET_ACT_HIT
 				if(P.starting)
 					var/new_x = P.starting.x + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)
 					var/new_y = P.starting.y + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -69,7 +69,7 @@
 				visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", \
 								"<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")
 				// Find a turf near or on the original location to bounce to
-				if(!isturf(loc)) //if we're inside something and still got hit
+				if(!isturf(loc)) //Open canopy mech (ripley) check. if we're inside something and still got hit
 					P.force_hit = TRUE //The thing we're in passed the bullet to us. Pass it back, and tell it to take the damage.
 					loc.bullet_act(P)
 					return BULLET_ACT_HIT

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -45,6 +45,7 @@
 	var/ricochets = 0
 	var/ricochets_max = 2
 	var/ricochet_chance = 30
+	var/force_hit = FALSE //If the object being hit can pass ths damage on to something else, it should not do it for this bullet.
 
 	//Hitscan
 	var/hitscan = FALSE		//Whether this is hitscan. If it is, speed is basically ignored.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes Sleeping Carp users unable to deflect shots while inside an object (specifically not on turf).
Allows firearms users to specifically target a MK-I by aiming for legs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The new Ripley was never designed to be a combat mech, which is why the bullets are passed onto the user. This had unintentional consequences when paired with Sleeping Carp. This change prevents Carp from being used if the user is inside _any_ object, though I can't think of an existing case where bullet damage is passed from the container to the occupant except with the MK-I.

I also added the ability to target the legs of a MK-I to intentionally hit it and not the pilot.

Finally, if the user is incapacitated and is in an open-canopy mech, they'll fall out now. This is mostly because the user can get stunlocked by things like electrode turrets, but only if they're in a MK-I.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Zxaber
balance: Deflecting shots while inside a MK-I Ripley (or inside anything else, for that matter) will cause the shots to deflect back into the container.
balance: Firing at a MK-I Ripley while aiming for the head or chest will still hit the pilot, but aiming for the arms or legs will now intentionally hit the mech.
tweak: Being incapacitated in an open-canopy mech will now lead to you falling out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
