### PR TITLE
Fix being sent back to lobby not allowing changing quirks

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -30,11 +30,5 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		quirk_points[initial(T.name)] = initial(T.value)
 
 /datum/controller/subsystem/processing/quirks/proc/AssignQuirks(mob/living/user, client/cli, spawn_effects)
-	GenerateQuirks(cli)
-	for(var/V in cli.prefs.character_quirks)
+	for(var/V in cli.prefs.all_quirks)
 		user.add_quirk(V, spawn_effects)
-
-/datum/controller/subsystem/processing/quirks/proc/GenerateQuirks(client/user)
-	if(user.prefs.character_quirks.len)
-		return
-	user.prefs.character_quirks = user.prefs.all_quirks

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -75,7 +75,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/list/negative_quirks = list()
 	var/list/neutral_quirks = list()
 	var/list/all_quirks = list()
-	var/list/character_quirks = list()
 
 		//Jobs, uses bitflags
 	var/job_civilian_high = 0


### PR DESCRIPTION
:cl:
fix: If an admin sends a ghost back to the lobby, they can now choose a different set of quirks.
/:cl:

No idea why it was coded this way but it gets in the way of testing