### PR TITLE
Fixes Janitor ERT preview and leader role spawning

### DIFF
--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -56,7 +56,7 @@
 
 /datum/ert/janitor
 	roles = list(/datum/antagonist/ert/janitor, /datum/antagonist/ert/janitor/heavy)
-	leader_role = /datum/outfit/ert/janitor/heavy
+	leader_role = /datum/antagonist/ert/janitor/heavy
 	teamsize = 4
 	opendoors = FALSE
 	rename_team = "Janitor"


### PR DESCRIPTION

## About The Pull Request

Fixes Janitor ERT runtime on `Create Antag` preview and ERT leader (heavy) spawning nude.
Fixes #43312 .

## Changelog
:cl: Menshin
fix: Janitor ERT leader now spawns properly equipped
/:cl: