### PR TITLE
Fixes an Ancient LINDA Bug

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -192,7 +192,7 @@
 			var/radiated_temperature = location.air.temperature*FIRE_SPREAD_RADIOSITY_SCALE
 			for(var/t in location.atmos_adjacent_turfs)
 				var/turf/open/T = t
-				if(T.active_hotspot)
+				if(!T.active_hotspot)
 					T.hotspot_expose(radiated_temperature, CELL_VOLUME/4)
 
 	else


### PR DESCRIPTION
Just something I noticed about a week ago with regard to LINDA. Ran it by @MrStonedOne, and he confirmed what i thought about this; the original logic is wrong for hotspot ignition.

FEA originally called `hotspot_expose` adjacent turfs that did *not* have a hotspot: https://github.com/tgstation/tgstation/blob/a4c81963883cf278e1c00f5fa50ff9cfebffcfd6/code/FEA/FEA_fire.dm#L123

The whole purpose of `hotspot_expose` is **not** to be a sort of `hotspot_act`, but rather a proc (mostly) to ignite gas and create a *new* hotspot.

This bug has been present since day 1 of LINDA.

Effects? Fires will probably ignite and spread a bit faster now

:cl: Fox McCloud
fix: Fixes a very longstanding LINDA bug where turfs adjacent to a hotspot would be less prone to igniting
/:cl:
