### PR TITLE
Handle OoM errors.

### DIFF
--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -18,7 +18,14 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 		//if we got to here without silently ending, the byond bug has been fixed.
 		log_world("The bug with recursion runtimes has been fixed. Please remove the snowflake check from world/Error in [__FILE__]:[__LINE__]")
 		return //this will never happen.
-
+	
+	else if(copytext(E.name,1,18) == "Out of resources!")
+		log_world("BYOND out of memory. Restarting")
+		log_game("BYOND out of memory. Restarting")
+		TgsEndProcess()
+		Reboot(reason = 1)
+		return ..()
+	
 	if (islist(stack_trace_storage))
 		for (var/line in splittext(E.desc, "\n"))
 			if (text2ascii(line) != 32)


### PR DESCRIPTION
This works on tgs3 even though the api sleeps, this will likely not work on tgs4. in those cases the world/Reboot call will likely still bring the server back up to a functional point that an admin can do a tgs restart via the verb.

There is no point in attempting to notify clients, every attempt at doing so failed.

:cl:
add: The server will now detect out of memory related lockups and restart the server automatically.
/:cl:
