### PR TITLE
Revert "Replaces the singularity with a supermatter on Donutstation"

### DIFF
--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -23,31 +23,44 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aaf" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aag" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"aah" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"aah" = (
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aai" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -67,6 +80,28 @@
 	dir = 8
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"aaj" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/sign/poster/contraband/power{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aak" = (
 /turf/closed/wall,
 /area/medical/morgue)
@@ -94,15 +129,19 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "aan" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"aao" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aap" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -139,41 +178,57 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aat" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	icon_state = "scrub_map_on-1";
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aau" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "aav" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"aax" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"aaw" = (
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"aaz" = (
-/obj/machinery/atmospherics/components/binary/pump/on/layer3{
-	dir = 1;
-	name = "Cold Loop Access"
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Engine Containment North";
+	network = list("ss13","Engine","Engineering")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"aax" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"aay" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
+"aaz" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "aaA" = (
 /obj/structure/falsewall{
 	name = "suspicious wall"
@@ -206,6 +261,17 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"aaE" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "aaF" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -214,22 +280,16 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "aaG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/field/generator{
+	anchored = 1;
+	state = 2
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "aaH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/camera{
-	c_tag = "Engine - Internal Topleft";
-	dir = 4;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/space/basic,
+/area/engine/engineering)
 "aaI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -803,16 +863,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "abY" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room";
-	req_access_txt = "10"
-	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "abZ" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -877,10 +932,22 @@
 "ack" = (
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/fitness/recreation)
+"acl" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "acm" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
+"acn" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aco" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -936,8 +1003,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -1036,20 +1103,10 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "acM" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/space,
+/area/engine/engineering)
 "acN" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -2174,6 +2231,18 @@
 /obj/structure/closet/crate/hydroponics,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"afx" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "afy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -2227,8 +2296,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -2709,9 +2778,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "agG" = (
@@ -2899,6 +2965,19 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"ahb" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ahc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -3052,6 +3131,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -3276,9 +3358,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -3935,6 +4014,21 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"ajw" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - North Containment Arm";
+	dir = 2;
+	network = list("ss13","Engine","Engineering")
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "ajx" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -4364,6 +4458,12 @@
 "akp" = (
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"akq" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "akr" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -4475,9 +4575,6 @@
 	icon_state = "pipe-j1s";
 	name = "sorting disposal pipe (Bar)";
 	sortType = 19
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -4718,19 +4815,32 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "alc" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 4
+/obj/structure/lattice,
+/turf/open/space,
+/area/engine/engineering)
+"ald" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/closed/wall,
+/area/maintenance/fore)
 "ale" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"alf" = (
+/obj/machinery/power/emitter{
+	icon_state = "emitter";
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "alg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -4740,21 +4850,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"alh" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "alj" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Engine_Shutter"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/obj/item/disk/holodisk/donutstation/enginewars,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "alk" = (
 /turf/closed/wall,
 /area/storage/tools)
@@ -4807,24 +4927,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "alr" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/plasma/reinforced{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "als" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "alu" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -4835,10 +4948,21 @@
 /area/crew_quarters/bar)
 "alv" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "alw" = (
 /obj/machinery/vr_sleeper,
 /obj/effect/turf_decal/tile/neutral{
@@ -4857,32 +4981,15 @@
 /area/security/warden)
 "aly" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Engine_Shutter"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"alz" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"alz" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/the_singularitygen,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "alA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -4896,6 +5003,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"alB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "alC" = (
 /obj/machinery/teleport/station,
 /obj/effect/turf_decal/tile/neutral,
@@ -4919,16 +5032,11 @@
 /area/teleporter)
 "alD" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Engine_Shutter"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/obj/item/screwdriver,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "alE" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "robo1"
@@ -4991,20 +5099,39 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"alM" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+"alL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/obj/item/wrench,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"alM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "alN" = (
-/obj/structure/lattice,
+/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "enginepashutter";
+	name = "particle accelerator shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "alO" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/computer/cargo,
@@ -5031,18 +5158,63 @@
 "alP" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"alS" = (
-/obj/structure/table/reinforced,
-/obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = 5
-	},
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/meson/engine,
-/obj/machinery/light{
+"alQ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "enginepashutter";
+	name = "particle accelerator shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"alR" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"alS" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"alT" = (
+/obj/machinery/door/airlock/external{
+	name = "External Engine Access Airlock";
+	req_access_txt = "32"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"alU" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "alV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -5069,9 +5241,6 @@
 	icon_state = "pipe-j1s";
 	name = "sorting disposal pipe (Kitchen)";
 	sortType = 20
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -5284,25 +5453,23 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "amt" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer1,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "amu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Engine - Internal Topright";
-	dir = 8;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "amv" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/tile/green{
@@ -5327,6 +5494,20 @@
 "amx" = (
 /turf/open/floor/plating,
 /area/engine/engineering)
+"amy" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"amz" = (
+/obj/structure/particle_accelerator/particle_emitter/right{
+	icon_state = "emitter_right";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "amA" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -5337,31 +5518,21 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "amB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "amC" = (
-/obj/machinery/suit_storage_unit/open,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+/obj/structure/particle_accelerator/particle_emitter/left{
+	icon_state = "emitter_left";
+	dir = 1
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Engine - External Airlock";
-	dir = 4;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "amD" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -5395,12 +5566,27 @@
 /area/crew_quarters/kitchen)
 "amH" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"amI" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"amJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "amK" = (
 /obj/machinery/door/airlock{
 	name = "Mass Driver";
@@ -5412,36 +5598,27 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "amL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "amM" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "amN" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "amO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -5467,14 +5644,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
-"amS" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/binary/pump/layer1{
-	dir = 1;
-	name = "Gas to Port"
+"amR" = (
+/obj/machinery/power/emitter{
+	icon_state = "emitter";
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
+"amS" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "amT" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -5741,10 +5929,15 @@
 	},
 /area/crew_quarters/kitchen)
 "anw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/machinery/door/airlock/external{
+	name = "External Engine Access Airlock";
+	req_access_txt = "32"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -5752,13 +5945,30 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"any" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "anz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"anA" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -5788,28 +5998,29 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"anF" = (
-/obj/machinery/light{
-	dir = 1
+"anE" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/engine/supermatter";
-	dir = 1;
-	name = "Supermatter APC";
-	pixel_x = 0;
-	pixel_y = 28
+/turf/open/space/basic,
+/area/space/nearstation)
+"anF" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/turf/open/space/basic,
+/area/space/nearstation)
 "anG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Engineering Maintenance Access";
-	req_access_txt = "10"
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "anH" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -5820,6 +6031,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"anI" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "anJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -5856,17 +6074,29 @@
 	},
 /area/engine/atmos)
 "anN" = (
-/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"anO" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"anP" = (
+/turf/open/floor/circuit,
 /area/engine/engineering)
 "anQ" = (
 /obj/structure/sign/warning/docking{
@@ -5947,6 +6177,18 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"aoc" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "aod" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -6087,17 +6329,8 @@
 /area/maintenance/starboard)
 "aoq" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aor" = (
@@ -6119,6 +6352,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"aou" = (
+/obj/machinery/vending/engivend,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aov" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -6144,21 +6391,17 @@
 /area/hydroponics)
 "aoy" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/disposal/bin,
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aoz" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -6261,7 +6504,20 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
+"aoI" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Arm Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aoJ" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -6288,6 +6544,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aoL" = (
+/obj/machinery/particle_accelerator/control_box,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aoM" = (
 /obj/machinery/camera{
 	c_tag = "Research - Main 4";
@@ -6340,6 +6603,24 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/science)
+"aoQ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aoR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -6354,6 +6635,28 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"aoS" = (
+/obj/item/stack/sheet/plasteel{
+	amount = 10;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/rglass{
+	amount = 30;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	dir = 1
+	},
+/area/engine/engineering)
 "aoT" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -6374,10 +6677,19 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aoU" = (
-/obj/machinery/suit_storage_unit/ce,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aoV" = (
 /obj/structure/dresser,
 /turf/open/floor/wood,
@@ -6406,20 +6718,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "apa" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/filingcabinet/chestdrawer,
-/mob/living/simple_animal/parrot/Poly,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "apb" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -6466,27 +6769,34 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "apf" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/modular_computer/console/preset/engineering,
+/obj/machinery/requests_console{
+	announcementConsole = 0;
+	department = "Engineering";
+	departmentType = 4;
+	name = "Engineering RC";
+	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "apg" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aph" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "api" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -6544,17 +6854,55 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"apn" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor{
-	id = "Secure Storage";
-	name = "Engineering Secure Storage"
+"apm" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/bot{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"apn" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/turf_decal/stripes/line,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"apo" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/closet/crate/solarpanel_small,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "app" = (
-/obj/structure/closet/crate/solarpanel_small,
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/crowbar,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel{
+	dir = 1
+	},
 /area/engine/engineering)
 "apq" = (
 /obj/effect/landmark/start/station_engineer,
@@ -6577,6 +6925,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"aps" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Engine Containment West";
+	dir = 4;
+	network = list("ss13","Engine","Engineering")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "apt" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -6585,22 +6950,24 @@
 	},
 /area/crew_quarters/kitchen)
 "apu" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/structure/table,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "apv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table,
+/obj/effect/turf_decal/delivery,
+/obj/item/storage/box/lights/mixed,
+/obj/item/storage/box/lights/mixed{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "apw" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -6609,51 +6976,54 @@
 	},
 /area/crew_quarters/kitchen)
 "apx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/effect/turf_decal/delivery,
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"apy" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit,
 /area/engine/engineering)
 "apz" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"apA" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"apB" = (
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/machinery/light_switch{
-	pixel_x = 28;
-	pixel_y = -8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
-"apC" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/camera{
-	c_tag = "Engineering - Job Equipment";
-	dir = 2;
-	network = list("ss13","Engineering","Engine")
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"apC" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -6676,18 +7046,56 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "apG" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/layer1{
-	dir = 1
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/engine/supermatter)
+/turf/open/floor/plating,
+/area/engine/engineering)
+"apH" = (
+/obj/structure/table,
+/obj/item/airlock_painter{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment,
+/obj/item/airlock_painter,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"apI" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "apJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"apK" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "apL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -6698,17 +7106,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "apM" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "apN" = (
@@ -6721,9 +7120,18 @@
 "apO" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/chief)
+"apP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "apQ" = (
-/obj/structure/table,
-/obj/item/stack/rods/fifty,
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "apR" = (
@@ -6779,11 +7187,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "apY" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -6836,9 +7243,6 @@
 	icon_state = "pipe-j1s";
 	name = "sorting disposal pipe (Theatre)";
 	sortType = 18
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -6986,16 +7390,20 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aqs" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/cable_coil,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"aqt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"aqu" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aqv" = (
 /obj/structure/grille,
@@ -7280,6 +7688,23 @@
 /obj/machinery/status_display,
 /turf/closed/wall/r_wall,
 /area/teleporter)
+"ara" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Engine Containment East";
+	dir = 8;
+	network = list("ss13","Engine","Engineering")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "arb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -7546,10 +7971,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "arB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/machinery/field/generator,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"arC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "arD" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -7567,21 +7999,24 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "arE" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/table,
+/obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/fifty,
 /obj/item/stack/sheet/glass/fifty,
-/obj/structure/window/reinforced{
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/gps,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Tank Storage";
-	dir = 1;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "arF" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -7604,6 +8039,36 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tools)
+"arH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	icon_state = "pipe-j1s";
+	name = "sorting disposal pipe (Atmospherics)";
+	sortType = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"arI" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "arJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -7627,9 +8092,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "arL" = (
@@ -7643,6 +8105,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"arN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "arO" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -8104,6 +8582,24 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"asI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	icon_state = "pipe-j1s";
+	name = "sorting disposal pipe (Custodial)";
+	sortType = 22
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "asJ" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
@@ -8689,9 +9185,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aua" = (
@@ -8721,9 +9214,11 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Waste to Filter"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Engine"
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"auc" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -9946,7 +10441,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "awL" = (
@@ -10479,6 +10973,10 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"axW" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "axX" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 1;
@@ -10695,11 +11193,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Lockdown"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ayu" = (
@@ -11392,6 +11885,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"azT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "azU" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -11399,16 +11898,43 @@
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "azV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"azW" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"azX" = (
+/obj/machinery/computer/security/telescreen{
+	name = "Engine Monitor";
+	network = list("Engine");
+	pixel_y = 32
+	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Right SMES Bank";
+	network = list("ss13","Engineering")
+	},
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/turf/open/floor/plating,
+/area/engine/engineering)
+"azY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "azZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -11430,6 +11956,13 @@
 	dir = 9
 	},
 /area/science/research)
+"aAb" = (
+/obj/machinery/field/generator,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aAc" = (
 /turf/closed/wall,
 /area/maintenance/aft)
@@ -11507,23 +12040,17 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aAm" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/computer/station_alert{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aAn" = (
 /turf/closed/wall,
@@ -11648,9 +12175,6 @@
 	icon_state = "pipe-j1s";
 	name = "sorting disposal pipe (Head of Personnel)";
 	sortType = 15
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -12187,7 +12711,19 @@
 "aBH" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
+"aBI" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "aBJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -12197,6 +12733,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"aBK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aBL" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
@@ -12880,6 +13432,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aDi" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aDj" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -12962,12 +13523,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/hallway/primary/central)
 "aDr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aDs" = (
@@ -13006,6 +13562,15 @@
 /obj/item/folder/red,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"aDu" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "aDv" = (
 /obj/structure/closet/crate,
 /obj/item/kitchen/fork,
@@ -13129,9 +13694,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aDM" = (
@@ -13143,6 +13705,19 @@
 	},
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
+"aDN" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - West Containment Arm";
+	dir = 4;
+	network = list("ss13","Engine","Engineering")
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "aDO" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
@@ -13572,9 +14147,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14648,6 +15220,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"aGJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "aGK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -14753,9 +15332,9 @@
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "aGV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/radiation,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aGW" = (
@@ -14771,9 +15350,6 @@
 	name = "sorting disposal pipe (Research)";
 	sortType = 0;
 	sortTypes = list(12,24,25)
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14989,6 +15565,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"aHr" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aHs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -15048,12 +15633,6 @@
 	name = "sorting disposal pipe (Research Director)";
 	sortType = 13
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHx" = (
@@ -15094,11 +15673,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "aHD" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "aHE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -15212,6 +15797,42 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"aHR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "enginepashutter";
+	name = "particle accelerator shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"aHS" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "enginepashutter";
+	name = "particle accelerator shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aHT" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -15219,6 +15840,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"aHU" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "enginepashutter";
+	name = "particle accelerator shutters"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aHV" = (
 /obj/machinery/vending/medical{
 	pixel_x = -2
@@ -15325,6 +15967,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
+"aIm" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "enginepashutter";
+	name = "particle accelerator shutters"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aIn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -15344,12 +16003,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "aIq" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3{
-	icon_state = "pipe11-3";
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aIr" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -15357,6 +16018,19 @@
 /obj/effect/landmark/start/depsec/science,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"aIs" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - East Containment Arm";
+	dir = 8;
+	network = list("ss13","Engine","Engineering")
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "aIt" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
@@ -15498,6 +16172,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"aIH" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aII" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall,
@@ -15579,30 +16262,21 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "aIS" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/grille,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Chief Engineer";
-	req_access_txt = "56"
-	},
+/obj/structure/window/reinforced,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "aIT" = (
 /obj/machinery/disposal/bin,
@@ -15767,9 +16441,6 @@
 	name = "sorting disposal pipe (Xenobiology)";
 	sortType = 28
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJl" = (
@@ -15778,9 +16449,6 @@
 /obj/structure/disposalpipe/sorting/mail{
 	name = "sorting disposal pipe (Medical)";
 	sortType = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -15803,9 +16471,6 @@
 /obj/structure/disposalpipe/sorting/mail{
 	name = "sorting disposal pipe (Genetics)";
 	sortType = 23
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -16514,15 +17179,11 @@
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "aKQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer1,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "aKR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -17338,6 +17999,24 @@
 "aMQ" = (
 /turf/closed/wall,
 /area/janitor)
+"aMR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "enginepashutter";
+	name = "particle accelerator shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aMS" = (
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/engine/cult,
@@ -17399,16 +18078,20 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aNb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Particle Accelerator";
+	dir = 8;
+	network = list("ss13","Engine","Engineering")
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/turf/open/floor/plating,
+/area/engine/engineering)
+"aNc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/obj/item/toy/figure/engineer,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aNd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -17570,22 +18253,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aNt" = (
-/obj/machinery/button/door{
-	desc = "A remote control-switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_x = -24;
-	pixel_y = -5;
-	req_access_txt = "10"
+/obj/machinery/computer/apc_control{
+	icon_state = "computer";
+	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_x = -24;
-	pixel_y = 5;
-	req_access_txt = "24"
-	},
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -17595,13 +18267,15 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/item/radio/intercom{
+	pixel_x = -28
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/machinery/computer/security/telescreen{
+	name = "Telecomms/Engineering Monitor";
+	network = list("Telecom","Engine","Engineering");
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "aNu" = (
 /obj/machinery/teleport/hub,
@@ -17744,12 +18418,11 @@
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/ai)
 "aNK" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -17794,6 +18467,27 @@
 	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"aNP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "enginepashutter";
+	name = "particle accelerator shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aNQ" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -17810,6 +18504,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"aNR" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Particle Accelerator Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aNS" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/structure/cable/yellow{
@@ -17819,20 +18530,24 @@
 /area/medical/cryo)
 "aNT" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Engine Lockdown";
-	name = "Engine Island Lockdown"
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "enginepashutter";
+	name = "particle accelerator shutters"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aNU" = (
@@ -18447,10 +19162,6 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Lockdown"
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aPr" = (
@@ -18461,11 +19172,6 @@
 /obj/machinery/door/window/southleft{
 	name = "Atmospherics Desk";
 	req_access_txt = "24"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Lockdown"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -18502,10 +19208,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4;
 	icon_state = "manifoldlayer"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Lockdown"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -18864,9 +19566,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aQg" = (
-/obj/machinery/door/window/northright{
-	name = "Engineering Storage";
-	req_access_txt = "10"
+/obj/structure/table,
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -18928,15 +19632,14 @@
 /turf/closed/wall,
 /area/quartermaster/warehouse)
 "aQn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/rack,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/item/clothing/head/welding,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQo" = (
@@ -19127,7 +19830,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/atmospheric_technician,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aQH" = (
@@ -19249,6 +19951,16 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/solar/aft)
+"aQW" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aQX" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -19397,6 +20109,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"aRm" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Arm Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aRn" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -19430,9 +20152,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRq" = (
@@ -19464,24 +20183,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aRs" = (
-/obj/effect/landmark/start/station_engineer,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/structure/rack,
+/obj/item/clothing/glasses/meson{
+	pixel_x = -2;
+	pixel_y = -2
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRt" = (
@@ -19523,8 +20234,24 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aRx" = (
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Arm Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
+"aRy" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "aRz" = (
 /obj/structure/bed,
 /obj/effect/landmark/start/virologist,
@@ -19536,12 +20263,67 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aRD" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12"
+"aRB" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Arm Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
+"aRC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/hallway/primary/central)
+"aRD" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"aRE" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"aRF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"aRG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "aRH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -19602,6 +20384,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"aRN" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "aRO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -19629,10 +20417,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aRS" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1,
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
-/area/engine/supermatter)
+/area/engine/engineering)
 "aRT" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -19702,20 +20491,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aSc" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 4;
-	state = 2
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Containment Access";
+	req_access_txt = "10"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	c_tag = "Engine - Emitters Left";
-	dir = 4;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aSd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -19840,6 +20624,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"aSp" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "aSq" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
@@ -20248,8 +21038,11 @@
 	name = "Service Door";
 	req_one_access_txt = "35;28"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "aTp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -20344,6 +21137,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"aTw" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aTx" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -20445,60 +21247,60 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "aTH" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/poddoor/preopen{
-	id = "Engine Lockdown";
-	name = "Engine Island Lockdown"
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "enginepashutter";
+	name = "particle accelerator shutters"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aTI" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
-"aTJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/item/flashlight/lamp,
+/obj/machinery/button/door{
+	id = "enginesecurestorage";
+	name = "Secure Storage Control";
+	pixel_x = -8;
+	pixel_y = 24;
+	req_access_txt = "56"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/door/window/northright{
-	name = "Engineering Delivery Access";
-	req_access_txt = "10"
+/obj/machinery/button/door{
+	id = "enginepashutter";
+	name = "Particle Accelerator Shutter Control";
+	pixel_x = 2;
+	pixel_y = 24;
+	req_access_txt = "56"
 	},
 /turf/open/floor/plasteel,
+/area/crew_quarters/heads/chief)
+"aTJ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor{
+	id = "enginesecurestorage";
+	name = "Secure Storage"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aTK" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -20520,25 +21322,27 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aTL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+/obj/machinery/power/apc/highcap/ten_k{
+	dir = 8;
+	name = "Engine Room APC";
+	areastring = "/area/engine/engineering";
+	pixel_x = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-4"
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTM" = (
-/obj/machinery/button/door{
-	desc = "A remote control-switch for secure storage.";
-	id = "Secure Storage";
-	name = "Engineering Secure Storage";
-	pixel_x = -24;
-	pixel_y = 5;
-	req_access_txt = "11"
+/obj/machinery/computer/card/minor/ce{
+	icon_state = "computer";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20547,70 +21351,93 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for the engine security doors.";
-	id = "Engine Lockdown";
-	name = "Engine Lockdown";
-	pixel_x = -24;
-	pixel_y = -5;
-	req_access_txt = "10"
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 3;
+	name = "Chief Engineer RC";
+	pixel_x = -32
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "aTN" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility,
-/obj/item/wrench,
-/obj/item/weldingtool,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"aTP" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"aTQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"aTR" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Storage";
+	req_access_txt = "32"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aTQ" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTS" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -20631,11 +21458,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aTU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/window/northleft{
-	name = "Engineering Storage";
-	req_access_txt = "10"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -20647,8 +21471,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "aTW" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTX" = (
 /obj/structure/table/glass,
@@ -20847,11 +21673,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aUq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1{
-	dir = 4
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Engine Containment South";
+	dir = 1;
+	network = list("ss13","Engine","Engineering")
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aUr" = (
 /obj/machinery/biogenerator,
 /obj/effect/decal/cleanable/dirt,
@@ -20908,9 +21742,6 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	icon_state = "pipe-y";
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -21127,12 +21958,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aUO" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+"aUN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/vending/engivend,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"aUO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aUP" = (
@@ -21157,42 +22004,90 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "aUS" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"aUT" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"aUT" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aUU" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aUV" = (
-/obj/machinery/computer/card/minor/ce{
-	icon_state = "computer";
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 3;
-	name = "Chief Engineer RC";
-	pixel_x = 0;
-	pixel_y = -32
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/clothing/glasses/meson{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
+"aUW" = (
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
+/area/engine/engineering)
+"aUX" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"aUY" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aUZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -21370,22 +22265,16 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aVq" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/engine/engineering";
-	dir = 1;
-	name = "Engineering APC";
-	pixel_x = 0;
-	pixel_y = 28
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aVr" = (
@@ -21502,50 +22391,57 @@
 /area/science/lab)
 "aVB" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/obj/item/paper/monitorkey,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/chief)
+"aVC" = (
+/obj/machinery/computer/station_alert{
+	icon_state = "computer";
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/chief)
+"aVD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
-"aVC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/keycard_auth{
+	pixel_x = -24;
+	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/noticeboard{
-	dir = 4;
-	pixel_x = -27
-	},
-/obj/item/paper/monitorkey,
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/chief";
-	dir = 2;
-	name = "CE Office APC";
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
-"aVD" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "aVE" = (
@@ -21681,9 +22577,6 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aVP" = (
@@ -21705,6 +22598,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aVR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aVS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -21923,9 +22828,6 @@
 	sortType = 0;
 	sortTypes = list(7,8)
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aWi" = (
@@ -21935,9 +22837,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -21981,9 +22880,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -23344,6 +24240,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aYC" = (
@@ -23573,14 +24470,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "aZd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aZe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -23666,9 +24568,6 @@
 	icon_state = "pipe-j1";
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZn" = (
@@ -23679,9 +24578,6 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -24346,9 +25242,6 @@
 	c_tag = "Atmospherics - Front Desk";
 	dir = 1;
 	network = list("ss13","Atmospherics")
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -25175,6 +26068,37 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"bch" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"bci" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bcj" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/structure/closet/crate/goldcrate,
@@ -25216,6 +26140,23 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
+"bco" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bcp" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/machinery/ore_silo,
@@ -25248,6 +26189,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"bcr" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"bcs" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Arm Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "bct" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
@@ -25267,6 +26231,21 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/nuke_storage)
+"bcv" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bcw" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -25540,7 +26519,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bcX" = (
@@ -26997,6 +27975,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"bfR" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;35"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "bfS" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -27015,6 +27999,21 @@
 	},
 /turf/open/floor/plating,
 /area/hydroponics)
+"bfU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "bfV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -27031,12 +28030,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bfW" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/structure/chair/office/light{
+	dir = 8
 	},
-/obj/item/pen,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/landmark/start/chief_engineer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bfX" = (
@@ -27164,7 +28174,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bgk" = (
@@ -27195,6 +28204,25 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/main)
+"bgn" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bgo" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -28359,15 +29387,17 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "biF" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 4;
-	state = 2
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "biG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -28387,13 +29417,16 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "biI" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/camera{
-	c_tag = "Engineering - Engine Airlock";
-	dir = 8;
-	network = list("ss13","Engineering","Engine")
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "biJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -28684,6 +29717,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bjh" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "bji" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -28789,6 +29828,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bjr" = (
@@ -29060,9 +30100,6 @@
 	icon_state = "pipe-j1s";
 	name = "sorting disposal pipe (Recycling)";
 	sortType = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -29773,17 +30810,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "blb" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "blc" = (
 /obj/structure/table,
@@ -29816,7 +30849,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "blf" = (
@@ -30213,6 +31245,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"blT" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "blU" = (
 /obj/machinery/computer/security{
 	dir = 4
@@ -31425,26 +32466,41 @@
 /area/science/explab)
 "bnY" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8
+	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "bnZ" = (
-/obj/machinery/computer/apc_control{
-	icon_state = "computer";
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen/ce{
-	dir = 1;
-	network = list("Engine","Telecom");
-	pixel_y = -30
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/chief";
+	dir = 2;
+	name = "Chief Engineer's Office APC";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "boa" = (
 /obj/effect/turf_decal/tile/bar,
@@ -31463,14 +32519,30 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "bob" = (
-/obj/machinery/computer/station_alert{
-	icon_state = "computer";
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_y = -28
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/ce,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
+"boc" = (
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "bod" = (
 /obj/structure/table,
@@ -31529,9 +32601,6 @@
 	codes_txt = "patrol;next_patrol=TOPMID";
 	location = "TOPLEFT";
 	name = "navigation beacon (TOPLEFT)"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -31702,10 +32771,54 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"boA" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+"box" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = 32
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"boy" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = -32
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"boz" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = -32
+	},
 /turf/open/floor/plating,
-/area/engine/supermatter)
+/area/maintenance/starboard/fore)
+"boA" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
+"boB" = (
+/obj/structure/particle_accelerator/particle_emitter/center{
+	icon_state = "emitter_center";
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "boC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -31737,35 +32850,57 @@
 	},
 /area/hallway/secondary/entry)
 "boG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/flashlight/lamp,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
-"boH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
+"boH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/sign/warning/enginesafety{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "boI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer's Office";
+	req_access_txt = "56"
 	},
-/obj/structure/window/reinforced{
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "boJ" = (
 /obj/structure/grille,
@@ -31821,11 +32956,32 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "boO" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"boP" = (
+/obj/structure/particle_accelerator/power_box{
+	icon_state = "power_box";
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "boQ" = (
 /obj/structure/cable/yellow{
@@ -31833,32 +32989,50 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"boS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+"boR" = (
+/obj/effect/landmark/start/station_engineer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
-"boT" = (
+/area/engine/engineering)
+"boS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/computer/atmos_alert{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
+"boT" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "boU" = (
-/obj/machinery/suit_storage_unit/open,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "boV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -31952,7 +33126,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bpe" = (
@@ -31963,6 +33136,7 @@
 /obj/structure/sign/departments/custodian{
 	pixel_y = -32
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bpf" = (
@@ -31972,7 +33146,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/janitor)
 "bpg" = (
@@ -32098,6 +33271,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bpt" = (
@@ -32133,9 +33307,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"bpx" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bpy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -32320,6 +33506,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"bpQ" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bpR" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Gravity Generator Main 1";
@@ -32365,9 +33566,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -33280,7 +34478,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "brx" = (
@@ -33370,9 +34567,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1{
-	dir = 9
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "brE" = (
@@ -33393,7 +34587,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -33769,9 +34963,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bsp" = (
@@ -33791,9 +34982,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -34029,9 +35217,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bsI" = (
@@ -34048,9 +35233,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -34194,6 +35376,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bsU" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bsV" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/neutral,
@@ -34205,9 +35396,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -34347,9 +35535,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "btg" = (
@@ -34363,9 +35548,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bth" = (
@@ -34378,9 +35560,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment{
 	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -34413,9 +35592,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "btl" = (
@@ -34428,9 +35604,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "btm" = (
@@ -34441,9 +35614,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "btn" = (
@@ -35140,6 +36310,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"buD" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "buE" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -35152,6 +36339,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"buF" = (
+/obj/structure/particle_accelerator/fuel_chamber{
+	icon_state = "fuel_chamber";
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "buG" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -35195,6 +36392,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"buJ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/camera/emp_proof/motion{
+	c_tag = "Engineering - External Engine Containment Northwest";
+	dir = 8;
+	network = list("Engine")
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "buK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -36051,16 +37260,43 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"bwt" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/camera/emp_proof/motion{
+	c_tag = "Engineering - External Engine Containment Northeast";
+	dir = 4;
+	network = list("Engine")
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"bwu" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/camera/emp_proof/motion{
+	c_tag = "Engineering - External Engine Containment Southwest";
+	network = list("Engine")
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bwv" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "bww" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/obj/machinery/camera/emp_proof/motion{
+	c_tag = "Engineering - External Engine Containment Southeast";
+	network = list("Engine")
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bwx" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/structure/light_construct/small{
@@ -36294,32 +37530,42 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bwU" = (
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"bwV" = (
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"bwW" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"bwX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"bwV" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/hallway/primary/central)
 "bwY" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -37062,6 +38308,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"byr" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "bys" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -37188,9 +38447,6 @@
 	},
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "byG" = (
@@ -37773,18 +39029,23 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "bzK" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/structure/table,
+/obj/effect/turf_decal/delivery,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bzL" = (
@@ -37871,6 +39132,18 @@
 /obj/machinery/door/window/eastleft,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
+"bzT" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bzU" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -38050,6 +39323,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"bAq" = (
+/obj/structure/particle_accelerator/end_cap{
+	icon_state = "end_cap";
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bAr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -38124,6 +39407,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"bAB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"bAC" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bAD" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -38131,10 +39432,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bAE" = (
-/obj/machinery/camera{
-	c_tag = "Engineering - Material Storage";
+/obj/machinery/light,
+/obj/machinery/firealarm{
 	dir = 1;
-	network = list("ss13","Engineering","Engine")
+	pixel_y = -26
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -38184,9 +39489,6 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bAL" = (
@@ -38201,9 +39503,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -38234,11 +39533,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"bAO" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bAP" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -38487,6 +39792,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"bBm" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bBn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -38781,9 +40096,6 @@
 /obj/structure/disposalpipe/sorting/mail{
 	name = "sorting disposal pipe (Robotics)";
 	sortType = 14
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -39331,6 +40643,18 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"bCF" = (
+/obj/machinery/computer/security/telescreen{
+	name = "Engine Monitor";
+	network = list("Engine");
+	pixel_y = 32
+	},
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bCG" = (
 /obj/structure/table,
 /obj/machinery/smartfridge/disks{
@@ -39338,6 +40662,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"bCH" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bCI" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -39361,9 +40704,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -39506,6 +40846,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"bCX" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bCY" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1;
@@ -39642,16 +41000,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDl" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/loading_area{
+	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bDm" = (
@@ -39673,6 +41025,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"bDo" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bDp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -39687,9 +41045,6 @@
 	codes_txt = "patrol;next_patrol=RIGHTMID";
 	location = "RIGHTTOP";
 	name = "navigation beacon (RIGHTTOP)"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -39719,9 +41074,6 @@
 	location = "LEFTTOP";
 	name = "navigation beacon (LEFTTOP)"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDt" = (
@@ -39740,9 +41092,6 @@
 	location = "LEFTMID";
 	name = "navigation beacon (LEFTMID)"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDu" = (
@@ -39750,9 +41099,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDv" = (
@@ -39834,9 +41180,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDE" = (
@@ -39853,9 +41196,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -39956,11 +41296,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	icon_state = "pipe-j1s";
-	name = "sorting disposal pipe (Custodial)";
-	sortType = 22
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -39988,6 +41325,16 @@
 	dir = 10
 	},
 /area/science/research)
+"bDR" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bDS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -40078,6 +41425,16 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"bDZ" = (
+/obj/machinery/computer/station_alert,
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bEa" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -40242,16 +41599,10 @@
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "bEr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bEs" = (
@@ -40587,9 +41938,6 @@
 	name = "sorting disposal pipe (Quartermaster)";
 	sortType = 3
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bEU" = (
@@ -40607,16 +41955,29 @@
 	name = "sorting disposal pipe (Cargo)";
 	sortType = 2
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bEV" = (
 /obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/yellow,
-/obj/item/stamp/ce,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/item/toy/figure/ce,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bEW" = (
@@ -40664,6 +42025,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bFa" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Arm Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bFb" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/disposalpipe/segment,
@@ -40907,9 +42279,6 @@
 	icon_state = "pipe-j2";
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bFv" = (
@@ -40981,6 +42350,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"bFB" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bFC" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -41121,11 +42499,15 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bFN" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Containment Access";
+	req_access_txt = "10"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "bFO" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/brig";
@@ -41453,6 +42835,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"bGu" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/janitor)
 "bGv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -41471,7 +42857,7 @@
 "bGw" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -41488,9 +42874,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -41512,9 +42895,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -41775,6 +43155,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"bGR" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Material Storage";
+	network = list("ss13","Engineering")
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bGS" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -41805,9 +43196,6 @@
 	name = "sorting disposal pipe (Chief Medical Director)";
 	sortType = 10
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bGU" = (
@@ -41818,6 +43206,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"bGV" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bGW" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -41883,9 +43275,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bHc" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/bot{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -41939,9 +43339,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bHi" = (
@@ -42086,9 +43483,6 @@
 	sortType = 21
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bHt" = (
@@ -42126,9 +43520,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bHw" = (
@@ -42183,6 +43574,9 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
+"bHB" = (
+/turf/closed/wall/r_wall,
+/area/vacant_room/commissary)
 "bHC" = (
 /obj/machinery/door/airlock{
 	name = "Lounge"
@@ -42444,6 +43838,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"bIb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bIc" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -42614,6 +44020,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"bIu" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "bIv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -42823,6 +44236,26 @@
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"bIZ" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "bJa" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -42918,6 +44351,25 @@
 	},
 /turf/open/floor/carpet,
 /area/bridge)
+"bJl" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "bJm" = (
 /obj/machinery/computer/shuttle/labor{
 	icon_state = "computer";
@@ -43093,26 +44545,34 @@
 /area/ai_monitored/turret_protected/ai)
 "bJF" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Chief Engineer's Office";
+	network = list("ss13","Engineering")
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/airalarm{
+	pixel_y = 25
 	},
+/mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"bJG" = (
+/obj/machinery/field/generator,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Secure Storage";
+	network = list("ss13","Engineering")
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bJH" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -43122,6 +44582,15 @@
 /obj/item/pen,
 /turf/open/floor/carpet,
 /area/bridge)
+"bJI" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Entrance";
+	dir = 1;
+	network = list("ss13","Engineering")
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bJJ" = (
 /obj/machinery/telecomms/server/presets/common,
 /obj/machinery/light{
@@ -44223,6 +45692,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/bridge)
+"bLT" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/closed/wall,
+/area/maintenance/fore)
 "bLU" = (
 /obj/effect/landmark/event_spawn,
 /mob/living/carbon/monkey,
@@ -45882,9 +47357,6 @@
 	dir = 8
 	},
 /obj/item/clothing/head/cone,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bOS" = (
@@ -45985,9 +47457,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -46318,9 +47787,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bPB" = (
@@ -46404,122 +47870,246 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bPF" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/bot{
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bPG" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3,
-/obj/machinery/camera{
-	c_tag = "Engine -External Midright";
-	dir = 4;
-	network = list("ss13","Engineering","Engine")
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "bPH" = (
-/obj/structure/tank_dispenser,
-/obj/effect/turf_decal/bot{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"bPI" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"bPJ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"bPK" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/emitter{
+	icon_state = "emitter";
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"bPL" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "bPM" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"bPO" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
+"bPN" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"bPP" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3,
-/obj/machinery/camera{
-	c_tag = "Engine -External Midleft";
-	dir = 8;
-	network = list("ss13","Engineering","Engine")
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"bPT" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Engine - Freezer Ports";
-	dir = 4;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"bPV" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"bPW" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"bPO" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Arm Access";
+	req_access_txt = "10"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"bPY" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/flashlight,
-/obj/item/pipe_dispenser,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
+"bPP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"bPQ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"bPR" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/camera{
-	c_tag = "Engine - SMES";
-	dir = 8;
-	network = list("ss13","Engineering","Engine")
+/turf/open/space/basic,
+/area/space/nearstation)
+"bPS" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"bQa" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"bPT" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"bPU" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
+"bPV" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
+"bPW" = (
+/obj/machinery/power/emitter,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"bPX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "Engine_Shutter";
-	name = "Collector Shutter Toggle";
-	pixel_y = 28;
-	req_access_txt = "10"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"bPY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"bPZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
+"bQa" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "bQb" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -46528,6 +48118,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"bQc" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/closed/wall,
+/area/maintenance/port/aft)
 "bQd" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -47097,6 +48693,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"bRr" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bRs" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -47407,6 +49010,16 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/engine/atmos)
+"bRW" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Arm Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bRX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -47425,7 +49038,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "bRZ" = (
 /obj/structure/rack,
 /obj/item/poster/random_official,
@@ -47438,7 +49051,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "bSa" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/crate,
@@ -47451,7 +49064,7 @@
 "bSb" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "bSc" = (
 /obj/machinery/door/poddoor{
 	id = "toxinsdriver";
@@ -47471,7 +49084,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/scythe,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "bSe" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -47484,10 +49097,36 @@
 	initial_gas_mix = "n2o=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
+"bSg" = (
+/obj/machinery/power/terminal{
+	icon_state = "term";
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "bSh" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"bSi" = (
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/port/aft";
+	dir = 1;
+	name = "Port Aft Maintenance APC";
+	pixel_y = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "bSj" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
@@ -47565,9 +49204,6 @@
 /area/maintenance/starboard/fore)
 "bSr" = (
 /obj/structure/grille/broken,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "bSs" = (
@@ -47579,6 +49215,15 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"bSu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "bSv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -47710,10 +49355,28 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "bSK" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Arm Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
+"bSL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Containment Access";
+	req_access_txt = "10"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "bSM" = (
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbine";
@@ -48906,6 +50569,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"bVm" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Arm Access";
+	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "bVn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -49089,6 +50765,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"bVI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "bVJ" = (
 /obj/item/storage/firstaid/regular,
 /obj/structure/rack,
@@ -49596,12 +51287,27 @@
 	dir = 4
 	},
 /area/chapel/main)
+"bWT" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "bWU" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "bWV" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -49883,6 +51589,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"bXM" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "bXN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50054,6 +51772,38 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"bYo" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
+"bYp" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Arm Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"bYq" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "External Arm Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bYr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -50412,6 +52162,24 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"bZd" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"bZe" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/circuit,
+/area/engine/engineering)
 "bZf" = (
 /obj/structure/closet/cardboard,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -50631,6 +52399,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/janitor)
+"bZB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/build{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bZC" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -50932,6 +52716,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -50980,7 +52767,7 @@
 	},
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "caj" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -51009,14 +52796,14 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "can" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/closet,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "cao" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -51036,7 +52823,7 @@
 	name = "4maintenance loot spawner"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "car" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -51155,6 +52942,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"caE" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "caF" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -51163,6 +52954,22 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"caG" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "caH" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
@@ -51208,10 +53015,20 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "caM" = (
-/obj/structure/chair/office/light{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/landmark/start/chief_engineer,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "caN" = (
@@ -51229,6 +53046,9 @@
 "caO" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j1";
 	dir = 4
@@ -51239,12 +53059,6 @@
 	name = "navigation beacon (BOTTOMMID)"
 	},
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "caP" = (
@@ -51369,6 +53183,12 @@
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"cbf" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cbg" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -51477,6 +53297,25 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"cbw" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"cbx" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cby" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -51485,7 +53324,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "cbz" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	icon_state = "computer";
@@ -51517,7 +53356,7 @@
 	},
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "cbD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -51734,7 +53573,7 @@
 	req_one_access_txt = "12;35;28;25"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "cbU" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -51743,7 +53582,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "cbV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/brig{
@@ -51763,7 +53602,7 @@
 "cbX" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "cbY" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -52583,6 +54422,21 @@
 	initial_gas_mix = "o2=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
+"cdO" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	dir = 1;
+	freq = 1400;
+	location = "Engineering";
+	name = "navigation beacon (Engineering Delivery)"
+	},
+/obj/machinery/door/window/northright{
+	name = "Engineering Delivery Access";
+	req_access_txt = "10"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cdP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -52997,9 +54851,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ceF" = (
@@ -53013,9 +54864,6 @@
 	sortType = 29
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ceG" = (
@@ -53033,18 +54881,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ceI" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
 	icon_state = "pipe-j2s";
@@ -53052,16 +54888,23 @@
 	sortType = 0;
 	sortTypes = list(4,5)
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1{
-	dir = 9
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ceI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -53164,121 +55007,20 @@
 	dir = 1
 	},
 /area/science/xenobiology)
-"cgH" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cid" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cxa" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"cDf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Suit Storage";
-	dir = 8;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cIZ" = (
 /turf/closed/wall,
 /area/crew_quarters/fitness/locker_room)
-"cLX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "cOZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Engine_Shutter"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cYx" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cZN" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer3{
-	dir = 8;
-	icon_state = "manifold-3"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"ddt" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"dmV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "dns" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -53297,77 +55039,11 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"dzE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"dEx" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"dNx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"dZW" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"ecC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/hatch{
-	name = "Supermatter External Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"emg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "esU" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"eyM" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/layer1{
-	icon_state = "filter_off_f_map-1";
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "ezL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -53389,188 +55065,24 @@
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"eLG" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible/layer1,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"eMa" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "eRe" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"fdn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"feu" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer3,
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/camera{
-	c_tag = "Engine - Internal Bottomleft";
-	dir = 4;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"fkV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"fpn" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/camera{
-	c_tag = "Engine - Internal Bottomright";
-	dir = 8;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"fpA" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer1,
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"fvY" = (
-/obj/effect/turf_decal/tile/yellow{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"fzV" = (
-/obj/machinery/power/emitter,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Secure Storage";
-	dir = 8;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"fOk" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"fVo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"fVB" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gst" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/crew_quarters/fitness/locker_room)
-"gwx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"gxl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"gBq" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engine -External Top";
-	dir = 1;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "gGG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -53587,43 +55099,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"gJo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
-"gNI" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"hfx" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer3{
-	dir = 8;
-	icon_state = "manifold-3"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"hmG" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Gas to Mix"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
 "hnd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53639,51 +55114,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"hrD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"htE" = (
-/obj/structure/reflector/single/anchored{
-	icon_state = "reflector_map";
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
 "htS" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
-"hvP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hEk" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "hGn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -53704,160 +55140,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hKe" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 8;
-	state = 2
-	},
-/obj/structure/cable/yellow{
+"iJC" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"hKj" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"hNP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	icon_state = "pipe-j1s";
-	name = "sorting disposal pipe (Atmospherics)";
-	sortType = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hVt" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer3{
-	icon_state = "manifold-3";
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"hYI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ifH" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"ifP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"iGD" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer1,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"iJC" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/machinery/meter,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"iLN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/hatch{
-	name = "Supermatter External Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"iMs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"iOg" = (
-/obj/structure/closet/radiation,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"iUF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"jqp" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "jro" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light/small{
@@ -53865,31 +55158,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"jvP" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"jws" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"jxP" = (
-/obj/machinery/power/supermatter_crystal/engine,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "jzE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -53912,58 +55180,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jHA" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"jHY" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"jVA" = (
-/obj/structure/closet/secure_closet/engineering_welding,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jZv" = (
-/obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kcd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "kow" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room";
-	req_access_txt = "10"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"kuo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1{
-	dir = 4
-	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/circuit/airless,
+/area/engine/engineering)
 "kLE" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/fitness/locker_room";
@@ -53976,28 +55209,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"lhs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"ljD" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "ljF" = (
 /obj/machinery/shower{
 	dir = 1
@@ -54005,14 +55216,6 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"lyr" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "lDQ" = (
 /obj/machinery/rnd/production/techfab/department/engineering,
 /turf/open/floor/plasteel,
@@ -54021,13 +55224,6 @@
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"lKk" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	icon_state = "freezer";
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
 "lLE" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -54043,31 +55239,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mgs" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"mjA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "mjC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54078,403 +55249,31 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"moO" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_access_txt = "10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "Engineering Lockdown"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"mpC" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"mCI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"mHo" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"mHD" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"mPw" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
-"mUy" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"mXC" = (
-/obj/structure/rack,
-/obj/item/storage/box/lights/mixed,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/twohanded/rcl/pre_loaded,
-/obj/item/twohanded/rcl/pre_loaded,
-/obj/item/crowbar/large,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"mXY" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"mZS" = (
-/obj/structure/girder,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"naO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "njx" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"nnE" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/layer1{
-	dir = 4;
-	filter_data = null;
-	filter_type = "n2";
-	icon_state = "filter_off_f_map-1"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"nrD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"nsr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/layer1{
-	icon_state = "filter_off_f_map-1";
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"ntF" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "nuq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"nyL" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"nEo" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"nIf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"nNJ" = (
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"nQr" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3,
-/obj/machinery/camera{
-	c_tag = "Engine -External Topright";
-	dir = 4;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"oex" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/binary/pump/layer1{
-	dir = 1;
-	name = "Atmos to Gas"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"ofx" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	dir = 1;
-	freq = 1400;
-	location = "Engineering";
-	name = "navigation beacon (Engineering Delivery)"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"ohU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"okf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"omp" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
-	icon_state = "pipe11-3";
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "omI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"ozE" = (
-/obj/structure/reflector/single/anchored{
-	icon_state = "reflector_map";
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"oAP" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"oIG" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"oNF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"oOL" = (
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"oPe" = (
-/turf/closed/wall/r_wall,
-/area/lawoffice)
-"oWa" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"pgT" = (
-/obj/machinery/atmospherics/components/binary/pump/layer3{
-	dir = 8;
-	name = "Port to Gas"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"piG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "plI" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"poI" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"ppV" = (
-/turf/closed/wall/r_wall,
-/area/hydroponics)
-"ptm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"pyl" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "pBI" = (
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"pGQ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"pIz" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3,
-/obj/machinery/camera{
-	c_tag = "Engine -External Topleft";
-	dir = 8;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"pLg" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pWc" = (
 /obj/machinery/camera/motion{
 	c_tag = "Secure - Captain's Office External";
@@ -54483,34 +55282,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"qlL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"qxF" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	icon_state = "freezer";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
 "qxZ" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = 32
@@ -54527,24 +55298,6 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"qyT" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera{
-	c_tag = "Engine -External Bottomright";
-	dir = 4;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"qBm" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
 "qBt" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -54563,316 +55316,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"qOX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer3,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "rfC" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "Secure - Captain's Private Quarters External";
 	dir = 4;
 	network = list("AISat")
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"riR" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
-"rmC" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"rny" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"rta" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ruT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"rDY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rJs" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"rLt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Engine_Shutter"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"seX" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"sgW" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"sjE" = (
-/obj/structure/reflector/box/anchored,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"skl" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"sky" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 8;
-	state = 2
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Engine -Emitters Right";
-	dir = 8;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"snk" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"son" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"srD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4;
-	icon_state = "manifoldlayer"
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"stN" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"sxr" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"szT" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"sEf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"sMe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"sTg" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"sTI" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"sYx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"tlY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"tmV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Engine_Shutter"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"tnz" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3,
-/turf/open/space/basic,
-/area/space/nearstation)
-"toE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"tqz" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer1,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"tHJ" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera{
-	c_tag = "Engine -External Bottomleft";
-	dir = 8;
-	network = list("ss13","Engineering","Engine")
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -54886,19 +55335,6 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"tTb" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "tVl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54911,48 +55347,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"ueN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ugT" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"upM" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"uqn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "uIo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54966,114 +55360,16 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"uQa" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer3{
-	icon_state = "manifold-3";
-	dir = 4
-	},
+"vws" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"uQd" = (
-/turf/closed/wall/r_wall,
-/area/hallway/primary/central)
-"uQL" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"uTy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"uXm" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/layer3{
-	icon_state = "connector_map-3";
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"vbr" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
-	icon_state = "pipe11-3";
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"vdQ" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"viK" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
-/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"vjt" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer3{
-	dir = 8;
-	icon_state = "manifold-3"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"vmg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"vtD" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "vxP" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -55092,34 +55388,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"vAo" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
-	icon_state = "pipe11-3";
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"vFq" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4;
-	icon_state = "manifoldlayer"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"vLE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/layer1{
-	icon_state = "filter_off_f_map-1";
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "vMB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -55145,188 +55413,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vQd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"vUd" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Gas"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"wlc" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"wll" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Engineering - Tank Storage";
-	dir = 1;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"wmo" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4;
-	icon_state = "manifoldlayer"
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital/layer1{
-	name = "Output to SPACE"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"wok" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"wIe" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"wLF" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Input Toggle"
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/machinery/airalarm/engine{
-	dir = 4;
-	pixel_x = -23
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"wMf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/modular_computer/console/preset/engineering{
-	icon_state = "console";
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"wQC" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"wUt" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Output Toggle"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"wVS" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"wZF" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel/dark,
-/area/engine/supermatter)
-"xaP" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
-	icon_state = "pipe11-3";
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"xdQ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"xec" = (
-/obj/structure/noticeboard{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "xhI" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen/coldroom)
-"xiu" = (
-/obj/machinery/shieldgen,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"xpX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "xyz" = (
 /obj/machinery/atmospherics/pipe/manifold/dark/visible{
 	dir = 1
@@ -55337,18 +55426,6 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"xGM" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Main Airlock";
-	dir = 2;
-	network = list("ss13","Engineering","Engine")
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xOq" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light/small{
@@ -55357,51 +55434,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
-"xRV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
-"xWi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"ybh" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"yjo" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"ykD" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "yma" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -82803,13 +82835,13 @@ bTt
 azH
 aqa
 bWY
-stN
-sMe
-sMe
-sMe
-sMe
-xWi
-sMe
+aoi
+aRg
+aRg
+aRg
+aRg
+bYC
+aRg
 bOR
 bOY
 azH
@@ -83060,7 +83092,7 @@ bMq
 azH
 bba
 aBx
-aUi
+bba
 aBx
 bYK
 aBx
@@ -83317,7 +83349,7 @@ bYC
 aRg
 aKz
 aBx
-aUi
+bba
 bRm
 aoh
 aoh
@@ -84300,7 +84332,7 @@ ask
 adb
 adb
 adb
-xec
+adb
 acy
 agX
 aJt
@@ -85076,24 +85108,24 @@ axE
 ahV
 aHw
 aDL
-hvP
+bFw
 bBJ
-rta
-rta
-rta
-rta
-ueN
-rta
+btc
+btc
+btc
+btc
+afy
+btc
 bDt
-rta
-sEf
-rta
+btc
+cew
+btc
 bDu
-rta
-hvP
+btc
+bFw
 aJk
-rta
-ueN
+btc
+afy
 aJl
 aJm
 bGL
@@ -85329,7 +85361,7 @@ axE
 axG
 bso
 aGX
-rta
+btc
 aRp
 bgS
 axm
@@ -85837,8 +85869,8 @@ acP
 arA
 awO
 bso
-rta
-ueN
+btc
+afy
 bth
 axm
 axF
@@ -85865,9 +85897,9 @@ aLs
 bvC
 aLs
 aLn
-aaT
+azH
 cbT
-aaT
+azH
 cbX
 axL
 bPx
@@ -86092,7 +86124,7 @@ acf
 acP
 awO
 bso
-rta
+btc
 btg
 axm
 bPv
@@ -86121,13 +86153,13 @@ aLs
 aLR
 aLs
 aLs
-aZb
-bQr
-aRA
-aaT
-aaT
-aaT
-aaT
+bfR
+aBx
+cbf
+azH
+azH
+azH
+azH
 bHE
 bHk
 axm
@@ -86380,9 +86412,9 @@ aLs
 aLS
 aLn
 can
-aRA
-aaT
-bKd
+cbf
+azH
+bSi
 caq
 afa
 afa
@@ -86636,10 +86668,10 @@ byz
 aLs
 aOs
 aLn
-bQj
-aRA
+bQe
+aHJ
 aTo
-bQr
+aTj
 bSb
 afa
 akx
@@ -86649,7 +86681,7 @@ aoA
 aoE
 azE
 azR
-rDY
+btt
 aUv
 bGr
 bGU
@@ -86860,7 +86892,7 @@ asP
 bli
 bfC
 bso
-hYI
+bsP
 axh
 bxA
 bxC
@@ -86893,10 +86925,10 @@ aLn
 aLn
 aLn
 aLn
-bQg
-bmo
-aaT
-bQr
+bRd
+bYA
+azH
+aBx
 aBH
 afa
 bUo
@@ -86907,8 +86939,8 @@ aoF
 aoE
 azE
 azR
-rDY
-iMs
+btt
+btj
 aAv
 all
 alq
@@ -87146,12 +87178,12 @@ aLn
 aLn
 aLn
 cai
-bQr
+aBx
 bRZ
 bRZ
 bRY
 bWU
-aRA
+cbf
 afa
 afa
 afa
@@ -87401,13 +87433,13 @@ aMS
 aLP
 aLn
 cam
-bLB
+cbx
 cby
-vtD
+aLo
 cbC
-vtD
-anx
-vtD
+aLo
+bYx
+aLo
 cbU
 afa
 akn
@@ -87422,7 +87454,7 @@ bCE
 aoF
 aQz
 aAd
-vmg
+bna
 ark
 akl
 akW
@@ -87657,15 +87689,15 @@ aLJ
 aLU
 aKC
 aLn
-aRA
-aaT
-aaT
+cbf
+azH
+azH
 acL
 aoH
-aaT
-aaT
+azH
+azH
 bSd
-amM
+akq
 bfT
 aTB
 bCy
@@ -87909,13 +87941,13 @@ bHI
 bvs
 bOx
 bvx
-aLn
-aLn
-aLn
-aLn
-aLn
-aRA
-aaT
+aad
+aad
+aad
+aad
+aad
+cbf
+azH
 aaa
 aaa
 aaa
@@ -88166,13 +88198,13 @@ aLm
 aLm
 aLm
 aLm
-aaT
-cxa
-vtD
-anx
-vtD
-aRv
-aaT
+aad
+aRN
+aDN
+aSp
+aad
+cbf
+azH
 aaa
 aaa
 aaa
@@ -88193,7 +88225,7 @@ alZ
 buw
 aQA
 aAd
-rDY
+btt
 bAL
 aDj
 alV
@@ -88414,26 +88446,26 @@ avj
 aLl
 aCz
 bQr
-rmC
+amM
 ahW
 boe
 boe
-lyr
 boe
 boe
-nyL
 boe
-vtD
-aRv
-aaT
-aaT
-aaT
-aaT
-aaT
+boe
+byr
+bFa
+bIu
+bSg
+bZe
+bYp
+cbw
+azH
 aaa
-aaa
-aaa
-aaa
+aau
+aau
+aau
 afa
 bCG
 aku
@@ -88671,7 +88703,7 @@ aCC
 aCz
 aCz
 bQr
-aRA
+bQr
 aaT
 aaT
 aaT
@@ -88679,14 +88711,14 @@ aaT
 aaT
 aaT
 aaT
-aaT
-aaT
-aaT
-aaT
-aaa
-aaa
-aaa
-aau
+bLT
+aad
+aad
+bSu
+aad
+aad
+bQc
+azH
 aaa
 aaa
 aaa
@@ -88708,7 +88740,7 @@ bux
 aoF
 aQz
 aAr
-vmg
+bna
 axf
 alV
 bwA
@@ -88927,32 +88959,32 @@ aCz
 aCz
 aCz
 bQr
-yjo
-aRv
+bCh
+bQr
 aBG
 aau
 aaa
 aaa
 aaa
 aaa
+aaa
+any
+amI
+aad
+bSu
+aad
+anA
+anE
+aau
 aau
 aaa
 aaa
 aaa
-aau
 aaa
 aaa
 aaa
 aau
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aau
 aaa
 afa
 buI
@@ -88965,7 +88997,7 @@ buy
 bzV
 bCA
 aAr
-vmg
+bna
 axf
 alF
 alF
@@ -89172,19 +89204,19 @@ arA
 bxX
 afC
 aae
-aTr
+aaE
 acx
-vtD
-vtD
+bQr
+bQr
 bSr
-vtD
-vtD
-aRu
+bQr
+bQr
+bQr
 bSt
 aBC
 bQr
-cxa
-aRv
+bQr
+bQr
 aBE
 aBF
 aaa
@@ -89192,15 +89224,15 @@ aaa
 aaa
 aaa
 aaa
-aau
-aaa
-aaa
 aaa
 aau
+bPG
+aad
+bVm
+aad
+bPG
 aaa
 aaa
-aaa
-aau
 aaa
 aaa
 aaa
@@ -89222,7 +89254,7 @@ aqG
 aoD
 bCB
 aAr
-vmg
+bna
 awZ
 bZJ
 amP
@@ -89430,36 +89462,36 @@ abP
 bot
 axb
 aaT
-bfS
+afx
 bQr
 bCh
 aaT
 bSa
 bQr
-amM
-vtD
-mHD
-vtD
-aRv
+bQr
+bQr
+bCh
+bQr
+bQr
 aBE
 aBF
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aau
 aaa
 aaa
 aaa
+aaa
+adF
+anD
+box
+bPN
+bPO
+bVI
+bSK
+bPN
+box
+anD
+anB
 aau
-aaa
-aaa
-aaa
-aau
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -89470,9 +89502,9 @@ aaa
 aaa
 afa
 afa
-ppV
-apO
-apO
+aad
+aad
+aad
 apO
 apO
 apO
@@ -89480,7 +89512,7 @@ apO
 apO
 azE
 bCJ
-iMs
+btj
 aDl
 aDo
 aPp
@@ -89687,7 +89719,7 @@ aff
 apV
 aaT
 aaT
-bfS
+afx
 bQr
 aaT
 aaT
@@ -89703,24 +89735,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aau
-aau
-aau
-aau
-aau
-aau
-aau
-aau
-aau
-aau
-aau
-aaa
-aaa
-aaa
-aaa
-aaa
+adF
+anD
+anz
+aad
+aad
+bFN
+aad
+aad
+aad
+bFN
+aad
+aad
+amO
+anD
+anB
 aaa
 aaa
 aaa
@@ -89728,16 +89757,19 @@ aaa
 aaa
 aaa
 aaa
-apO
+aaa
+aaa
+aad
+aou
 aoU
-mPw
+apO
 aNt
 aTM
 aVC
 apO
 apO
 buC
-ptm
+afC
 afF
 aDo
 aPq
@@ -89944,64 +89976,64 @@ arK
 awV
 aaT
 bQr
-bfS
+afx
 bQr
 aaT
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aau
 aaa
 aaa
 aau
-vAo
-tnz
-tnz
-tnz
-tnz
-tnz
+aaa
+aaa
+aaa
+aaa
+aaa
+adF
+buJ
+aad
+aad
+aad
+aaf
 bPP
-tnz
-xaP
-aau
+alh
+aps
+bIZ
+bPP
+aax
+aad
+aad
+aad
+bwu
+anB
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-apO
+aad
+aad
+aad
+aad
+aad
+bZB
 aoy
-xRV
+apO
 aVB
 bfW
 aVD
 bnZ
 apO
 anH
-hNP
-awb
-fvY
+bna
+aDl
+aDp
 aPr
 aQG
-ifH
-fVo
-gwx
+asr
+aRJ
+asr
 bbR
 bbR
 bbR
@@ -90201,64 +90233,64 @@ bAK
 awV
 aaT
 aBC
-blN
+ahb
 aWS
 aaT
 aau
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aau
 aaa
 aau
-amH
-dZW
-dZW
-boA
-boA
-boA
-dZW
-dZW
-amH
+aaa
+aaa
 aau
 aaa
 aaa
 aaa
 aaa
+adF
+anz
+aad
+aad
+aaf
+amu
+aat
+bPT
+apg
+apg
+apg
+bPT
+aan
+amu
+aax
+aad
+aad
+amO
+anB
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-apO
+adF
+alT
+bBm
+anw
+bDo
+bPJ
+aoq
 apa
-xRV
+apO
 aTI
 bEV
 caM
 aUV
 apO
 bPB
-vmg
+bna
 aDl
 aDp
 aPt
 aQH
 asr
 aRJ
-ohU
+asr
 bbX
 bbX
 bbX
@@ -90454,61 +90486,61 @@ aty
 byq
 ark
 ark
-vmg
+bna
 bnq
 aaT
 bQr
-bfS
+afx
 aaT
 aaT
 aau
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aau
 aaa
 aaa
 aaa
 aaa
 aau
-aau
-aau
-aau
-aau
-amH
-dZW
+aaa
+aaa
+aaa
+aaa
+ahP
+aad
+aad
+aaf
+aat
+amy
+aav
 bPT
 apg
 apg
-lKk
-qxF
-dZW
-amH
+apg
+bPT
+aav
+amy
+aan
+aax
+aad
+aad
+ahP
 aau
-aau
-aau
-aau
-aau
-aau
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-apO
+ahP
+aad
+aad
+aad
+bDZ
+azW
+azY
 apz
-xRV
+apO
 bJF
 boG
 boS
 bob
 apO
 anH
-vmg
+bna
 aDl
 aDq
 aPv
@@ -90711,11 +90743,11 @@ aty
 ard
 anH
 ark
-dNx
+boi
 awV
 aaT
 bQr
-bfS
+afx
 aaT
 aaT
 aaT
@@ -90724,55 +90756,55 @@ aaa
 aaa
 aaa
 aaa
+aau
 aaa
 aaa
-aau
-aau
-aau
-aau
-vAo
-tnz
-tnz
-tnz
-vbr
-dZW
+aaa
+adF
+anz
+aad
+aaf
+aat
+aay
+alf
+amN
 aHD
 iJC
-oAP
-vdQ
+iJC
+iJC
 bPV
-dZW
-omp
-tnz
-tnz
-xaP
-tHJ
-aug
+amR
+amJ
+apI
+aan
+aax
+aad
+bPQ
 aau
 aau
-aau
-aau
+ahP
 aau
 aad
-aad
-aad
+bCF
+bFB
+azW
+aor
+apA
 apO
-apO
-riR
 aIS
 boI
 bnY
-apO
+boc
 apO
 anH
-vmg
+bna
 aDl
 aDq
 aPw
 aQN
 aQT
 aRM
-ohU
+asr
 bcP
 bgy
 bgy
@@ -90968,68 +91000,68 @@ aMn
 aMp
 arv
 awF
-vmg
+bna
 arx
 aaT
 arw
 ahu
-bLB
-aRu
+ahW
+alR
 aaT
 aaT
 aaT
 aaa
 aaa
 aaa
-aaa
-aau
-aau
-vAo
-tnz
-pIz
-vbr
-dZW
-dZW
-dZW
-dZW
-dZW
-dZW
-vUd
-aRx
-hmG
-dZW
-dZW
-dZW
-dZW
-dZW
-aIq
-dZW
-aug
 aau
 aaa
 aaa
 aaa
-aaa
+ahP
 aad
+aad
+aao
+aav
+aaz
+aaG
+aaH
+aaH
+aaH
+aaG
+aaH
+aaH
+aaH
+aaG
+aaz
+acn
+aIq
+bSL
+bPR
+anD
+anD
+anz
+aau
+aad
+apK
 eRe
 aUT
-jVA
-apv
+aor
+apB
 aTL
 aTO
 boO
 apQ
 apY
 aad
-anH
-vmg
+aDg
+bna
 aWV
 acj
 aPx
 aQO
 aRh
 aYA
-uTy
+aRh
 bcU
 acj
 acj
@@ -91225,7 +91257,7 @@ auG
 auG
 aAn
 ans
-vmg
+bna
 awV
 aeu
 aeu
@@ -91233,55 +91265,55 @@ bok
 aeu
 amM
 anx
-aRu
-aaT
-aau
-aau
-aau
-aau
-aau
-vAo
-vbr
-dZW
-dZW
-dZW
-dZW
-aav
-aav
-aaH
-tlY
-xpX
-vFq
-xpX
-vFq
-jvP
-cZN
-vjt
-aaz
-hfx
-feu
-dZW
-aug
+aoc
+ald
+amH
+amI
+aaa
 aau
 aaa
 aaa
-aaa
-aaa
+aau
+ahP
 aad
+aaf
+aat
+aav
+aaz
+aaH
+aaH
+acM
+aaH
+alc
+aaH
+acM
+aaH
+aaH
+aaz
+apg
+aad
+aad
+aad
+aad
+aad
+alN
+alQ
+aHR
+bCX
 bHc
-gxl
-naO
+aor
+aor
 aTU
-fdn
-aor
-aor
 apq
+aor
+bzT
+aor
 aqs
 aad
-anH
-vmg
-aWV
-acj
+aDh
+arH
+awb
+axW
 bjq
 bps
 bps
@@ -91482,7 +91514,7 @@ bPj
 bRI
 bFf
 aww
-dNx
+boi
 awW
 aeu
 arz
@@ -91490,52 +91522,52 @@ boC
 aeu
 aeu
 aeu
-aRA
-aaT
-aaa
-aaa
-aaa
-aaa
-aau
+aoI
+aad
+aad
+any
 amH
-dZW
-dZW
+amH
+amH
+amH
+amH
+anF
 aSc
 biF
-dZW
-dZW
-dZW
-lhs
+bjh
+bjh
+blT
+aaH
 acM
-mXY
-hVt
-snk
-uQa
-dEx
-pgT
-pgT
-seX
-ykD
-wmo
+aaH
+aaH
+alc
+aaH
+aaH
+acM
+aaH
+aaz
+apg
+aad
 aRS
 apG
-aau
-aaa
-aaa
-aaa
-aaa
-aad
+amx
+amx
+amx
+bGV
+aHS
+aMR
 bPF
 aDr
-aor
+apH
 aQg
 aQn
 aGV
-aor
-aor
+arI
+bAC
 bAE
-aad
-aDg
+bwW
+bwX
 ceH
 ceJ
 acj
@@ -91746,54 +91778,54 @@ axd
 boC
 bsM
 btr
-aeu
-aRA
-aaT
-aaa
-aaa
-aaa
-aaa
-aau
-amH
-dZW
+bHB
+apy
+azT
+aad
+aad
+aad
+aad
+aad
+aad
+aad
 aRx
-mHo
+aad
 aah
 alM
-nIf
+alM
 kow
-dmV
-hEk
-dZW
+aaH
+aaH
+aaH
 alj
 aly
 alD
-dZW
-uXm
-uXm
-wVS
-eyM
+aaH
+aaH
+aaH
+aaz
+apg
 amt
-dZW
-aug
-aau
-aaa
-aaa
-aaa
-aaa
-aad
+amx
+amz
+amx
+amx
+amx
+amx
+amx
+aNP
 bPH
-cDf
+aor
 apu
-apv
-wok
+boR
+aor
 aor
 aAm
-wMf
+aad
 boT
 aad
-aDh
-vmg
+bjp
+bna
 aDl
 acj
 bSI
@@ -91804,7 +91836,7 @@ bpw
 bcW
 bpw
 bgj
-iUF
+bgj
 bhg
 bhk
 bif
@@ -92003,53 +92035,53 @@ aBB
 bqh
 bsW
 bCx
-aeu
-aRA
-aaT
-aaa
-aaa
-aaa
-aaa
-aau
-amH
-dZW
-aRx
-aRx
-aRx
-poI
-nEo
-dZW
+bHB
+ajw
+aBI
+aGJ
+aGJ
+aGJ
+aGJ
+aGJ
+aGJ
+bcs
+bfU
+aad
+aaw
+alM
+alM
+kow
 aaG
 alc
-dZW
+alc
 alr
 alz
-alz
-jqp
-dZW
-dZW
+aNc
+alc
+alc
+aaG
 bQa
 aUq
 aUS
-dZW
-dZW
-dZW
-dZW
-aaa
-aaa
-aaa
-aad
-aad
-aad
-aad
-aad
-wok
+aph
+boB
+boP
+buF
+bAq
+bAO
+aph
+aNR
+bPI
+aUX
+bRr
+caG
+bsU
 jZv
-aad
-aad
-aad
-aad
-aDh
+aBK
+bpx
+bAB
+bpQ
+buD
 caO
 awK
 ayt
@@ -92260,54 +92292,54 @@ axd
 boC
 bti
 bDN
-aeu
-aRA
-aaT
-aaa
-aaa
-aaa
-aaa
-aau
-amH
-dZW
-aRx
-ozE
-aRx
-poI
-aRx
-dZW
-son
-wIe
-dZW
+bHB
+aRy
+anP
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aRB
+aad
+aaj
+alM
+alM
+kow
+aaH
+aaH
+aaH
 als
-als
-als
-mpC
-wLF
-rJs
-qOX
-nsr
-iGD
-dZW
+alB
+alL
+aaH
+aaH
+aaH
+aaz
+apg
+amw
+amx
 amC
 boU
-dZW
+aoL
 aph
-aph
-aph
+aqu
+amx
 aNT
 aZd
-oOL
+aor
 apv
 bwU
-wok
-jHY
+aor
+aor
+bJI
 aad
-ugT
-ybh
+boT
 aad
 bjp
-qlL
+aeo
 bDk
 cdQ
 bDm
@@ -92318,7 +92350,7 @@ asJ
 acj
 atg
 atC
-srD
+atC
 auN
 avl
 avK
@@ -92518,43 +92550,43 @@ boC
 aeu
 aeu
 aeu
-aRA
-aaT
-aau
-aau
-aau
-aau
-aau
-gBq
-dZW
+aRm
+aad
+aad
+anA
+amH
+amH
+amH
+amH
+amH
 anF
-mZS
-sjE
-poI
-aRx
+aSc
+biF
+bjh
+bjh
 boA
-aav
-mgs
-boA
-nNJ
-jxP
-nNJ
-cLX
-nNJ
-skl
-tTb
-sTI
-oex
-ecC
+aaH
+acM
+aaH
+aaH
+alc
+aaH
+aaH
+acM
+aaH
+aaz
+apg
+aad
+aRS
 azV
 aNb
-iLN
-mjA
-mjA
-mjA
+amx
+amx
+bGV
+aHU
 aTH
-viK
-piG
+aZd
+aor
 apx
 bzK
 aRs
@@ -92562,8 +92594,8 @@ apM
 bwV
 aoq
 bEr
-moO
-mUy
+aad
+aDh
 ceI
 afF
 acj
@@ -92774,53 +92806,53 @@ aeu
 bok
 aeu
 aZp
-vtD
+aDu
 aag
-aaT
+ald
+amH
+anE
 aaa
-aaa
+aau
 aaa
 aaa
 aau
-amH
-dZW
-poI
-htE
-aRx
-poI
-aRx
-dZW
-rny
-eMa
-dZW
-sYx
-sYx
-sYx
-pyl
-wUt
-rJs
-mCI
-vLE
-tqz
-dZW
-wZF
-iOg
-dZW
+ahP
+aad
+aan
+aax
+aav
+aaz
+aaH
+aaH
+aaH
+aaH
+alc
+aaH
+aaH
+aaH
+aaH
+aaz
+apg
+aad
+aad
+aad
+aad
+aad
 alN
-alN
-alN
-aNT
+alQ
+aIm
+aoQ
 biI
-emg
-apv
-apf
-okf
-jHY
-aad
-xGM
+aor
+aor
+bzT
+apq
+aor
+aor
+aor
 bDl
-aad
-bjp
+cdO
+cdP
 aeo
 aDl
 acj
@@ -92832,7 +92864,7 @@ asK
 ayL
 ati
 atE
-aue
+auc
 auR
 avw
 avN
@@ -93038,46 +93070,46 @@ aaa
 aaa
 aaa
 aaa
-aau
-amH
-dZW
-poI
-aRx
-aRx
-poI
-nEo
-dZW
+aaa
+aaa
+aaa
+ahP
+aad
+aad
+aao
+aav
+aaz
 aaG
-alc
-dZW
-ntF
-cid
-cid
-pGQ
-dZW
-dZW
-kuo
-aUq
-aUS
-dZW
-dZW
-dZW
-dZW
-aaa
-aaa
-aaa
+aaH
+aaH
+aaH
+aaG
+aaH
+aaH
+aaH
+aaG
+aaz
+acl
+aIH
+bSL
+bPS
+anD
+anD
+anB
+aau
 aad
-aad
-aad
-aad
+bCH
+vws
+aHr
+aor
 aVq
 boH
-oIG
+aos
+aos
+aos
+aqt
 aad
-aad
-aad
-aad
-aDh
+aDi
 aeo
 aDn
 aMP
@@ -93295,46 +93327,46 @@ aaa
 aaa
 aaa
 aaa
-aau
-amH
-dZW
-mHo
-qBm
-dzE
+aaa
+aaa
+aaa
+amO
+anB
+aad
 aan
 aax
 abY
 amB
 amN
-dZW
+bPU
 cOZ
-tmV
-rLt
-dZW
-fpA
+cOZ
+cOZ
+bPZ
+amN
 amS
 aKQ
-nnE
-szT
-dZW
-aug
-aau
-aaa
-aaa
-aaa
-aaa
+aaf
+aat
 aad
+bPQ
+aau
+aau
+ahP
+aau
+aad
+azX
 blb
 anN
 aNK
 aUU
-hrD
-aor
-aor
-aor
+aad
 aTJ
-ofx
-cdP
+aTJ
+aTJ
+aTJ
+aad
+bIb
 aeo
 axf
 aMQ
@@ -93546,52 +93578,52 @@ bfS
 aaT
 aaT
 aau
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aau
-amH
-dZW
-dZW
-sky
-hKe
-dZW
-dZW
-dZW
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+ahP
+aad
+aad
+aan
+aax
 amL
-cYx
+aav
 bPW
-cgH
-fVB
-gNI
-hKj
-uqn
-uqn
-eLG
-toE
-ddt
-boA
-aug
+apg
+apg
+apg
+bPT
+aav
+bPK
+aaf
+aat
+aad
+aad
+ahP
 aau
-aaa
-aaa
-aaa
-aaa
-jHA
+aau
+ahP
+aad
+aad
+aad
 apf
-aor
-aor
-aor
-ruT
+anN
+aTP
+bDR
+aad
 arB
-aor
-aor
+arC
+arC
 arE
 aad
-uQL
+awI
 aeo
 axf
 aMQ
@@ -93803,55 +93835,55 @@ bqm
 aXF
 aaT
 aau
-aau
-aau
-aau
-aau
-aau
-aau
-aau
-omp
-xaP
-dZW
-dZW
-dZW
-dZW
-aav
-aav
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+amO
+anB
+aad
+aad
+aan
 amu
-vQd
-vQd
-jws
-ifP
-kcd
-xdQ
+aax
+bPT
+apg
+apg
+apg
+bPT
 aaf
-aaf
+anO
 aat
-ljD
-fpn
-dZW
-aug
+aad
+aad
+adF
+anz
 aau
 aaa
-aaa
-aaa
-aaa
+amO
+alT
+alU
 anw
-apf
+aQW
 aTN
 aTQ
-apq
-upM
-pLg
-mXC
-aor
-wll
+aUW
+aad
+apF
+amx
+apS
+apT
 aad
 bPC
-aeo
+asI
 bpe
-aMQ
+bGu
 bGw
 aMU
 aMU
@@ -94066,50 +94098,50 @@ aaa
 aaa
 aaa
 aaa
-aau
-aau
-omp
-tnz
-nQr
-xaP
-dZW
-dZW
-dZW
-dZW
-dZW
-dZW
+aaa
+aaa
+aaa
+aaa
+aaa
+amO
+bwt
+aad
+aad
+aad
+aan
+bPX
 alv
-poI
-aRx
-dZW
-dZW
-dZW
-dZW
-dZW
+ara
+bJl
+bPX
+aat
+aad
+aad
+aad
 bww
-dZW
-aug
-aau
+anz
 aaa
 aaa
 aaa
 aaa
-amw
-apf
-aor
-aor
-aor
-aor
-aor
-aor
-apq
-oWa
+aad
+aad
+aad
+aad
+aUN
+aTR
+aUY
+aad
+bJG
+apF
+apT
+apT
 aad
 jzE
 bDO
 bpd
 bpf
-gJo
+bpi
 bpi
 bpi
 bpm
@@ -94324,42 +94356,42 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 aau
-aau
-aau
-aau
-omp
-tnz
-tnz
-tnz
-xaP
-dZW
+amO
+anD
+anB
+aad
+aad
 bFN
-fOk
-sgW
-sTg
-aRx
-dZW
-vAo
-tnz
-tnz
-vbr
-qyT
-aug
-aau
-aau
-aau
-aau
+aad
+aad
+aad
+bFN
+aad
+aad
+adF
+anD
+anz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aau
 aad
 apC
 aUO
 aTS
-aos
-aos
-aos
-aos
-wQC
+apm
+aad
+apF
+aAb
+apT
 aad
 aad
 bHF
@@ -94584,38 +94616,38 @@ aaa
 aaa
 aaa
 aaa
-aau
-aau
-aau
-aau
-aau
-amH
-dZW
+aaa
+aaa
+aaa
+aaa
+amO
+anD
+boy
 bPY
 bPO
-bPO
+bWT
 bSK
 alS
-dZW
-amH
-aau
-aau
-aau
-aau
-aau
+anD
+anD
+anz
+aaa
 aau
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aau
 aad
 anG
+caE
+aTU
+apn
 aad
 aad
-apn
-apn
-apn
-apn
+aad
 aad
 aad
 aze
@@ -94845,16 +94877,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aau
-amH
-dZW
-dZW
-boA
-boA
-boA
-dZW
-dZW
-amH
+bPG
+aad
+bVm
+aad
+bPG
+aau
+aau
 aau
 aaa
 aaa
@@ -94866,15 +94898,15 @@ aaa
 aaa
 aaa
 aad
-amx
-aad
+bGR
+apP
 aTW
-amx
-amx
-amx
-amx
-xiu
+apo
 aad
+aau
+aau
+aau
+axc
 bHt
 bCL
 bDP
@@ -95102,36 +95134,36 @@ aaa
 aaa
 aaa
 aaa
-aau
-omp
-tnz
-tnz
-tnz
-tnz
-tnz
+aaa
+aaa
+aaa
 bPG
-tnz
-vbr
-aau
+aad
+bSu
+aad
+bPG
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+anX
+anX
+anX
+anX
+anX
 aaa
 aaa
 aaa
 aad
-amx
-aad
-apF
+anI
+aVR
+aoS
 app
-amx
-apS
-sxr
-xiu
 aad
+aaa
+aaa
+aau
+axc
 bHu
 aeo
 axf
@@ -95351,24 +95383,6 @@ aMG
 aMD
 aME
 aMv
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aau
-aau
-aau
-aau
-aau
-aau
-aau
-aau
-aau
-aau
 aau
 aaa
 aaa
@@ -95378,17 +95392,35 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+bPG
+aad
+bSu
+aad
+bPG
+aaa
+aaa
+aau
+anX
+anX
+bzJ
+bcy
+bzM
+anX
+anX
+aau
 aaa
 aad
-amx
-aad
-apT
-apF
-apF
-apF
-xiu
 aad
 aad
+aad
+aad
+aad
+aaa
+aau
+aRC
+aRG
 awI
 bjP
 bov
@@ -95617,34 +95649,34 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+bPG
+aad
+bSu
+aad
+bPG
+aaa
+aaa
+anX
+anX
+bck
+bct
+bct
+bct
+bck
+anX
+anX
+aaa
+aaa
+aaa
+aau
+aau
 aau
 aaa
 aaa
-aaa
 aau
-aaa
-aaa
-aaa
-aau
-aaa
-aaa
-anX
-anX
-anX
-anX
-anX
-aaa
-aaa
-aaa
-aad
-amx
-aad
-apT
-apT
-fzV
-apF
-xiu
-aad
+aRE
 aze
 bAN
 bDE
@@ -95874,34 +95906,34 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+bPG
+aad
+bSu
+aad
+bPG
+aaa
 aau
+anX
+aTy
+aOf
+bcf
+bJR
+btn
+but
+bcE
+anX
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
 aau
-aaa
-aaa
-aaa
-aau
-aaa
-anX
-anX
-bzJ
-bcy
-bzM
-anX
-anX
-aaa
-aaa
-aad
-amx
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aRC
+aRF
 aIX
 bHv
 awU
@@ -96131,32 +96163,32 @@ aaa
 aaa
 aaa
 aaa
-aau
-aaa
-aaa
 aaa
 aau
-aaa
-aaa
-aaa
-aau
-anX
-anX
-bck
-bct
-bct
-bct
-bck
-anX
-anX
-aaa
+bPG
 aad
-amx
-amx
-amx
-amx
-amx
-amx
+bSu
+aad
+bPG
+aaa
+aau
+anX
+bbC
+bbD
+bzL
+bLY
+bct
+bcl
+bbF
+anX
+aaa
+aau
+aaa
+aau
+aau
+aaa
+aaa
+aaa
 aRD
 aze
 awO
@@ -96388,33 +96420,33 @@ aaa
 aaa
 aaa
 aaa
-aau
 aaa
 aaa
-aaa
-aau
-aaa
-aaa
+bPG
+aad
+bSu
+aad
+bPG
 aaa
 aau
 anX
-aTy
-aOf
-bcf
-bJR
-btn
-but
-bcE
+bcj
+bcl
+bct
+bcn
+bct
+bcl
+bOe
 anX
-oPe
-oPe
-oPe
-oPe
-oPe
-oPe
-oPe
-amx
-uQd
+acZ
+acZ
+acZ
+acZ
+acZ
+acZ
+acZ
+aau
+axc
 awI
 ark
 aZm
@@ -96645,23 +96677,23 @@ aaa
 aaa
 aaa
 aaa
-aau
 aaa
+anA
+anE
+aad
+bSu
+aad
+any
+amI
 aaa
-aaa
-aau
-aaa
-aaa
-aaa
-aau
 anX
-bbC
-bbD
-bzL
-bLY
-bct
+anX
+bcp
 bcl
-bbF
+bcn
+bcl
+bcx
+anX
 anX
 acZ
 aQy
@@ -96669,9 +96701,9 @@ btM
 btO
 atN
 aQw
-oPe
-uQd
-uQd
+acZ
+axc
+axc
 bPz
 ceD
 ceF
@@ -96902,24 +96934,24 @@ aaa
 aaa
 aau
 aau
-aau
+aaa
+bPG
+aad
+aad
+bSu
+aad
+aad
+bPG
 aaa
 aaa
-aaa
-aau
-aaa
-aaa
-aaa
-aau
 anX
-bcj
-bcl
-bct
-bcn
-bct
-bcl
-bOe
 anX
+anX
+bcu
+anX
+anX
+anX
+acZ
 aeG
 bbG
 btN
@@ -97160,23 +97192,23 @@ alk
 aRY
 aSb
 aSa
+bPG
+aad
+anP
+bXM
+azT
+aad
+bPG
 aaa
 aaa
 aaa
-aau
+aaa
+bch
+bcv
+bch
 aaa
 aaa
-aaa
-aau
-anX
-anX
-bcp
-bcl
-bcn
-bcl
-bcx
-anX
-anX
+acZ
 aeR
 ats
 bLZ
@@ -97185,8 +97217,8 @@ btT
 acZ
 cbY
 awI
-fkV
-rta
+btG
+btc
 aVO
 aWi
 aAe
@@ -97417,22 +97449,22 @@ alk
 aTt
 aTu
 aSa
-aaa
-aaa
-aaa
+bPG
+aad
+aRN
+aIs
+bYo
+aad
+bPG
 aau
 aaa
-aau
-aau
-aau
-aau
-anX
-anX
-anX
-bcu
-anX
-anX
-anX
+aSa
+arN
+bci
+bgn
+bco
+bcr
+aSa
 acZ
 acZ
 atJ
@@ -97442,7 +97474,7 @@ aQv
 bub
 aze
 awO
-vmg
+bna
 ark
 axf
 aqz
@@ -97674,11 +97706,11 @@ alk
 aRZ
 bBo
 aSa
+bPL
 aSa
+bRW
 aSa
-aSa
-aSa
-aSa
+bYq
 aSa
 bQd
 aSb
@@ -97698,8 +97730,8 @@ aQu
 aQx
 aze
 awO
-fkV
-hYI
+btG
+bsP
 awU
 bfJ
 aqz
@@ -97933,9 +97965,9 @@ aSg
 aSj
 cad
 aSj
-aSj
-aSj
-aSj
+aTw
+boz
+bZd
 cah
 caj
 cak
@@ -97955,7 +97987,7 @@ arA
 arA
 buH
 btc
-oNF
+bsP
 azf
 azg
 aqz
@@ -98172,10 +98204,10 @@ aaZ
 bsG
 abO
 btf
-rta
-rta
+btc
+btc
 bPA
-iMs
+btj
 bFt
 axe
 arj
@@ -98434,7 +98466,7 @@ brv
 cet
 bDp
 bFu
-wlc
+bte
 arA
 arA
 arD
@@ -98692,10 +98724,10 @@ bDU
 axu
 axx
 btl
-rta
-rta
+btc
+btc
 btm
-wlc
+bte
 arA
 bHg
 vMB
@@ -98953,12 +98985,12 @@ axu
 axu
 axx
 btk
-nrD
+afq
 bHh
-rta
-rta
-rta
-rta
+btc
+btc
+btc
+btc
 aAA
 cew
 btq


### PR DESCRIPTION
Reverts tgstation/tgstation#43246

Why: This SM design requires careful study to start understanding. Even when made to work (hard, considering the mislabeled pipes and unintuitive/retarded piping) it has these issues:

- No chamber bypass

- Cooling loop bypass is badly placed, wrongly named, and doesn't work because it doesn't bypass the loop

- The cooling loop is so hilariously easy to sabotage, it's not even funny. Just weld a wall in maint, be quick with a firesuit and you're able to take it out.

- How do engineers fix a damaged cooling loop? Where's the airlock? Having to break walls is bad design. Fuck modifying loop, I suppose.

- Straightpiping the cooling loop; A brilliant idea. Not one you should use for the map. That's taking the modding out of the SM.

- All of these pipe layer manifolds look hilariously bad

- Why have you made this entrance a chokepoint? Bad idea to have all access to the SM restricted to a single door. This is a major reason as to why the pipes are layered and mangled like this.

- There's no freezer bypass pump, meaning you cannot prevent gas flowing through the freezers several times. There's an argument to be made about increased efficiency due to less bottlenecking, but again, we shouldn't be optimizing roundstart engine placements.

- Why are you even lowering and raising the pipe layers all over the place? Only the freezers are locked on level 2, there's fuckall reason to have it divert for the filters, the SM chamber vents, the cooling loop etc.


- This all but prevents additional emitters without significately modifying the room.

- Where are the cameras?  the air alarm and chamber pumps are out of the AIs reach.

- The air injector starts out off, and since there isn't a way to go out and turn it on.....

- The entire room is the same area: SM Engine. This causes the air alarm to be horrible to use. If you do the normal thing and set vents and scrubbers 1 2 3 to the proper settings, you'll end up with a depressurized engi, only half setup SM and a nasty temper.

- The freezer loop is redundant. The only gas that passes by there is the n2 cans, and due to the straightpiping (which is required for this engine to function, it seems) the only reason the gas loop wraps around the SM chamber is the freezers. There is no way to properly use the freezer loop as a secondary emergency cooling loop as the only way the gas would cycle past the freezers is through the cooling loop. 

- The two suit storage units in the airlock between the SM and the space bridge start out empty.

- The cooling loop pipes being underneath tables is SEVERELY annoying.

- Layer manifolds start out invisible

- Some of the gas meters start out not working

- And finally, the retarded placement of the air supply pipes makes modifying the atmos inlet come into direct conflict with the air supply loop. I understand you wanted to avoid the sin of wall pipes, but two pipes on the same layer in the same direction on the same tile is a far greater sin.


All in all, the SM design is absolutely retarded, the pipe placement looks horrid, barely works, it's easy to sabotage and the pipes themselves are broken. How this got merged is a mystery to me. This SM cannot wait for a PR fixing the SM, as it makes the main power source for this map inoperable. God have mercy if you're a new engi and have to try to make this work.