### PR TITLE
Brings back transformer borgs

### DIFF
--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -57,7 +57,7 @@
 			R.SetLockdown(!R.lockcharge) // Toggle
 		if(WIRE_RESET_MODULE)
 			if(R.has_module())
-				R.visible_message("[R]'s module servos twitch.", "Your module display flickers.")
+				R.ResetModule()
 
 /datum/wires/robot/on_cut(wire, mend)
 	var/mob/living/silicon/robot/R = holder


### PR DESCRIPTION
2 years ago a terrible mistake was made that left every cyborg main weeping, cyborgs lost their ability to have activators put onto their reset wire effectively giving them the ability to change forms whenever they desire with the help of a voice command. Today I am here to remedy that and let them return to their former glory. For too long the cyborg main has been the eternal cuck of the station, unable to do anything but follow the ai and be mocked by the crew when they are the wrong module.

Those days will soon be a thing of the past, 