### PR TITLE
Fixes spraycan changing opacity and paint remover not working on objects

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -654,10 +654,11 @@
 	if(isobj(target))
 		if(actually_paints)
 			target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
-			if(color_hex2num(paint_color) < 255 && istype(target, /obj/structure/window))
-				target.set_opacity(255)
-			else
-				target.set_opacity(initial(target.opacity))
+			if(istype(target, /obj/structure/window))
+				if(color_hex2num(paint_color) < 255)
+					target.set_opacity(255)
+				else
+					target.set_opacity(initial(target.opacity))
 		. = use_charges(user, 2)
 		var/fraction = min(1, . / reagents.maximum_volume)
 		reagents.reaction(target, TOUCH, fraction * volume_multiplier)

--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -78,14 +78,14 @@
 	add_fingerprint(user)
 
 
-/obj/item/paint/afterattack(turf/target, mob/user, proximity)
+/obj/item/paint/afterattack(atom/target, mob/user, proximity)
 	. = ..()
 	if(!proximity)
 		return
 	if(paintleft <= 0)
 		icon_state = "paint_empty"
 		return
-	if(!istype(target) || isspaceturf(target))
+	if(!isturf(target) || isspaceturf(target))
 		return
 	var/newcolor = "#" + item_color
 	target.add_atom_colour(newcolor, WASHABLE_COLOUR_PRIORITY)
@@ -93,12 +93,14 @@
 /obj/item/paint/paint_remover
 	gender =  PLURAL
 	name = "paint remover"
-	desc = "Used to remove color from floors and walls."
+	desc = "Used to remove color from anything."
 	icon_state = "paint_neutral"
 
-/obj/item/paint/paint_remover/afterattack(turf/target, mob/user, proximity)
+/obj/item/paint/paint_remover/afterattack(atom/target, mob/user, proximity)
 	. = ..()
 	if(!proximity)
 		return
-	if(istype(target) && target.color != initial(target.color))
+	if(!isturf(target) || !isobj(target))
+		return
+	if(target.color != initial(target.color))
 		target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)


### PR DESCRIPTION
Fixes #43353 
The paint remover change is technically a buff but it was kinda inconsistent with all other color removal sources.

----

(ed. SpaceManiac)

:cl:
fix: Spraypainting blast doors no longer makes them see-through.
balance: Paint remover now works on blast doors and the like.
/:cl: