### PR TITLE
Adds a new minor gas reaction.

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -24,6 +24,7 @@
 #define STIMULUM_ABSOLUTE_DROP				0.00000335
 #define REACTION_OPPRESSION_THRESHOLD		5
 #define NOBLIUM_FORMATION_ENERGY			2e9 	//1 Mole of Noblium takes the planck energy to condense.
+#define STIM_BALL_GAS_AMOUNT				5
 //Research point amounts
 #define NOBLIUM_RESEARCH_AMOUNT				1000
 #define BZ_RESEARCH_SCALE					4

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -488,7 +488,6 @@
 	var/pluox_used = min(STIM_BALL_GAS_AMOUNT/cached_gases[/datum/gas/plasma][MOLES],cached_gases[/datum/gas/pluoxium][MOLES])
 	var/energy_released = stim_used*STIMULUM_HEAT_SCALE//Stimulum has a lot of stored energy, and breaking it up releases some of it
 	location.fire_nuclear_particle(ball_shot_angle)
-	to_chat(world,"Fired ball at [ball_shot_angle]")
 	cached_gases[/datum/gas/carbon_dioxide][MOLES] += 4*pluox_used
 	cached_gases[/datum/gas/nitrogen][MOLES] += 8*stim_used
 	cached_gases[/datum/gas/pluoxium][MOLES] -= pluox_used

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -308,7 +308,7 @@
 		/datum/gas/oxygen = 20,
 		/datum/gas/nitrogen = 20,
 		/datum/gas/nitrous_oxide = 5,
-		"TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST*400
+		"TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST*60
 	)
 
 /datum/gas_reaction/nitrylformation/react(datum/gas_mixture/air)
@@ -459,3 +459,43 @@
 	//Possibly burning a bit of organic matter through maillard reaction, so a *tiny* bit more heat would be understandable
 	air.temperature += cleaned_air * 0.002
 	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, cleaned_air*MIASMA_RESEARCH_AMOUNT)//Turns out the burning of miasma is kinda interesting to scientists
+
+/datum/gas_reaction/stim_ball
+	priority = 7
+	name ="Stimulum Energy Ball"
+	id = "stimball"
+
+/datum/gas_reaction/stim_ball/init_reqs()
+	min_requirements = list(
+		/datum/gas/pluoxium = STIM_BALL_GAS_AMOUNT,
+		/datum/gas/stimulum = STIM_BALL_GAS_AMOUNT,
+		/datum/gas/nitryl = MINIMUM_MOLE_COUNT,
+		/datum/gas/plasma = MINIMUM_MOLE_COUNT,
+		"TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST
+	)
+/datum/gas_reaction/stim_ball/react(datum/gas_mixture/air, datum/holder)
+	var/list/cached_gases = air.gases
+	var/turf/open/location
+	var/old_heat_capacity = air.heat_capacity()
+	if(istype(holder,/datum/pipeline)) //Find the tile the reaction is occuring on, or a random part of the network if it's a pipenet.
+		var/datum/pipeline/pipenet = holder
+		location = get_turf(pick(pipenet.members))
+	else
+		location = get_turf(holder)
+	air.assert_gases(/datum/gas/water_vapor,/datum/gas/nitryl,/datum/gas/carbon_dioxide,/datum/gas/nitrogen)
+	var/ball_shot_angle = 180*cos(cached_gases[/datum/gas/water_vapor][MOLES]/cached_gases[/datum/gas/nitryl][MOLES])+180
+	var/stim_used = min(STIM_BALL_GAS_AMOUNT/cached_gases[/datum/gas/plasma][MOLES],cached_gases[/datum/gas/stimulum][MOLES])
+	var/pluox_used = min(STIM_BALL_GAS_AMOUNT/cached_gases[/datum/gas/plasma][MOLES],cached_gases[/datum/gas/pluoxium][MOLES])
+	var/energy_released = stim_used*STIMULUM_HEAT_SCALE//Stimulum has a lot of stored energy, and breaking it up releases some of it
+	location.fire_nuclear_particle(ball_shot_angle)
+	to_chat(world,"Fired ball at [ball_shot_angle]")
+	cached_gases[/datum/gas/carbon_dioxide][MOLES] += 4*pluox_used
+	cached_gases[/datum/gas/nitrogen][MOLES] += 8*stim_used
+	cached_gases[/datum/gas/pluoxium][MOLES] -= pluox_used
+	cached_gases[/datum/gas/stimulum][MOLES] -= stim_used
+	cached_gases[/datum/gas/plasma][MOLES] *= 0.5 //Consumes half the plasma each time.
+	if(energy_released)
+		var/new_heat_capacity = air.heat_capacity()
+		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
+			air.temperature = (air.temperature*old_heat_capacity + energy_released)/new_heat_capacity
+		return REACTING

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -496,5 +496,5 @@
 	if(energy_released)
 		var/new_heat_capacity = air.heat_capacity()
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
-			air.temperature = (air.temperature*old_heat_capacity + energy_released)/new_heat_capacity
+			air.temperature = CLAMP((air.temperature*old_heat_capacity + energy_released)/new_heat_capacity,TCMB,INFINITY)
 		return REACTING

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -146,30 +146,6 @@
 	filled = 1
 
 
-/obj/machinery/portable_atmospherics/canister/fusion_test
-	name = "Fusion Test Canister"
-	desc = "This should never be spawned in game."
-	icon_state = "green"
-/obj/machinery/portable_atmospherics/canister/fusion_test/create_gas()
-	air_contents.add_gases(/datum/gas/tritium,/datum/gas/plasma,/datum/gas/carbon_dioxide,/datum/gas/nitrous_oxide)
-	air_contents.gases[/datum/gas/tritium][MOLES] = 10
-	air_contents.gases[/datum/gas/plasma][MOLES] = 500
-	air_contents.gases[/datum/gas/carbon_dioxide][MOLES] = 500
-	air_contents.gases[/datum/gas/nitrous_oxide][MOLES] = 100
-	air_contents.temperature = 9999
-
-/obj/machinery/portable_atmospherics/canister/fusion_test_2
-	name = "Fusion Test Canister"
-	desc = "This should never be spawned in game."
-	icon_state = "green"
-/obj/machinery/portable_atmospherics/canister/fusion_test_2/create_gas()
-	air_contents.add_gases(/datum/gas/tritium,/datum/gas/plasma,/datum/gas/carbon_dioxide,/datum/gas/nitrous_oxide)
-	air_contents.gases[/datum/gas/tritium][MOLES] = 10
-	air_contents.gases[/datum/gas/plasma][MOLES] = 15000
-	air_contents.gases[/datum/gas/carbon_dioxide][MOLES] = 1500
-	air_contents.gases[/datum/gas/nitrous_oxide][MOLES] = 100
-	air_contents.temperature = 9999
-
 
 /obj/machinery/portable_atmospherics/canister/proc/get_time_left()
 	if(timing)

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -25,7 +25,6 @@
 	add_atom_colour(particle_colors[our_color], FIXED_COLOUR_PRIORITY)
 	set_light(4, 3, particle_colors[our_color]) //Range of 4, brightness of 3 - Same range as a flashlight
 
-/atom/proc/fire_nuclear_particle() //used by fusion to fire random nuclear particles. Fires one particle in a random direction.
-	var/angle = rand(0,360)
+/atom/proc/fire_nuclear_particle(angle = rand(0,360)) //used by fusion to fire random nuclear particles. Fires one particle in a random direction.
 	var/obj/item/projectile/energy/nuclear_particle/P = new /obj/item/projectile/energy/nuclear_particle(src)
 	P.fire(angle)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new small reaction for some of the endgame gases. You can combine hot Stimulum and Pluoxium(with some nitryl to catalyze and plasma as fuel), and it will release a high power radioactive energy ball like the ones released by fusion. The angle of the shot is also dependent on the concentrations of water vapor and nitryl within the reaction, so you can modify those amounts to aim which way the ball is shot for those elaborate atmos snipes. Also significantly lowers the heat requirements of Nitryl, as it was way too high and now there's more motivation to obtain it.

Deletes the fusion test canisters that I forgot to take out of the code earlier.

## Why It's Good For The Game

Atmos is still lacking in reactions that produce meaningful effects in the world, this is an example of a fun, small one that's pretty versatile and adds slightly more incentive to acquiring late game gases. The reaction itself is very flexible, and allows a couple cool possibilities. 
Possible things you can try with this:
- Atmosia Gatling Gun
- Using it with a TTV for a portable weapon
- Have it going in distro to have random energy blasts shoot around the station

## Changelog
:cl:
add: New Gas Reaction, Stimulum Energy Balls. Combine 100 degree Pluoxium, Stimulum and small amounts of Plasma and Nitryl to shoot off a deadly radioactive energy ball.
add: The reaction will consume the plasma, pluoxium and stimulum and release small amounts of heat. The presence of water vapor will change the direction in which it shoots. See if you can figure out how to aim it.
tweak: Nitryl now forms at 22,000 degrees, a significantly lower temperature.
fix: fixed a few things
del: Removed some old left-behind fusion test canisters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
