### PR TITLE
Adds KDevelop and Kate to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,6 +202,10 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 #GitHub Atom
 .atom-build.json
 
+#KDevelop and Kate
+*.kdev4*
+*.kate-swp
+
 #extra map stuff
 /_maps/**/backup/
 /_maps/templates.dm


### PR DESCRIPTION
Added the following to .gitignore
```gitignore
*.kdev4*
*.kate-swp
```

I've already got both of these in my ~/.config/git/ignore file, but this may be helpful to others.
Since I've already got it in my global gitignore file, I am not affected whether this is merged or not. This change was made in the interest in other people who use or want to use KDevelop and have not set this up in their global git ignore file.