### PR TITLE
Pod shuttle -- Actually tested and working edition

### DIFF
--- a/_maps/shuttles/emergency_pod.dmm
+++ b/_maps/shuttles/emergency_pod.dmm
@@ -57,7 +57,10 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Shuttle Airlock"
 	},
-/obj/docking_port/mobile/emergency,
+/obj/docking_port/mobile/emergency{
+	port_direction = 2;
+	preferred_direction = 4
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_pod.dmm
+++ b/_maps/shuttles/emergency_pod.dmm
@@ -31,21 +31,12 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "h" = (
-/obj/machinery/computer/emergency_shuttle{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/space/basic,
 /area/shuttle/escape)
 "i" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dir = 8;
-	dwidth = 8;
-	height = 9;
-	name = "Emergency Pod";
-	width = 21
+/obj/machinery/light{
+	icon_state = "tube";
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -55,15 +46,51 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"k" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	icon_state = "bulb";
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"l" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/space)
+"m" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency,
+/turf/open/floor/mineral/titanium/blue,
+/area/space)
+"n" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/space)
+"o" = (
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"p" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion";
+	dir = 8
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space)
 
 (1,1,1) = {"
 a
 e
 b
-i
-a
-d
-d
+m
+p
 d
 d
 d
@@ -76,17 +103,15 @@ a
 (2,1,1) = {"
 b
 f
-g
-j
-b
-d
-d
+i
+n
+o
 d
 d
 d
 b
 f
-g
+i
 j
 b
 "}
@@ -94,10 +119,8 @@ b
 c
 f
 g
-j
-c
-d
-d
+n
+l
 d
 d
 d
@@ -111,10 +134,8 @@ c
 b
 f
 g
-j
-b
-d
-d
+n
+o
 d
 d
 d
@@ -127,27 +148,23 @@ b
 (5,1,1) = {"
 b
 b
-h
+k
+o
+o
+d
+d
+d
 b
 b
-d
-d
-d
-d
-d
-b
-b
-h
+k
 b
 b
 "}
 (6,1,1) = {"
-d
+h
 b
-c
-b
-d
-d
+l
+o
 d
 d
 d

--- a/_maps/shuttles/emergency_pod.dmm
+++ b/_maps/shuttles/emergency_pod.dmm
@@ -30,9 +30,6 @@
 "g" = (
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"h" = (
-/turf/open/space/basic,
-/area/shuttle/escape)
 "i" = (
 /obj/machinery/light{
 	icon_state = "tube";
@@ -56,41 +53,20 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"l" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/space)
 "m" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Shuttle Airlock"
 	},
 /obj/docking_port/mobile/emergency,
 /turf/open/floor/mineral/titanium/blue,
-/area/space)
-"n" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/space)
-"o" = (
-/turf/closed/wall/mineral/titanium,
-/area/space)
-"p" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 8
-	},
-/turf/closed/wall/mineral/titanium,
-/area/space)
+/area/shuttle/escape)
 
 (1,1,1) = {"
 a
 e
 b
 m
-p
+a
 d
 d
 d
@@ -104,8 +80,8 @@ a
 b
 f
 i
-n
-o
+j
+b
 d
 d
 d
@@ -119,8 +95,8 @@ b
 c
 f
 g
-n
-l
+j
+c
 d
 d
 d
@@ -134,8 +110,8 @@ c
 b
 f
 g
-n
-o
+j
+b
 d
 d
 d
@@ -149,8 +125,8 @@ b
 b
 b
 k
-o
-o
+b
+b
 d
 d
 d
@@ -161,10 +137,10 @@ b
 b
 "}
 (6,1,1) = {"
-h
+d
 b
-l
-o
+c
+b
 d
 d
 d

--- a/_maps/shuttles/emergency_pod.dmm
+++ b/_maps/shuttles/emergency_pod.dmm
@@ -1,0 +1,160 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion";
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/shuttle/escape)
+"b" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"c" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"d" = (
+/turf/open/space/basic,
+/area/space)
+"e" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Shuttle Airlock"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"f" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"g" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"h" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"i" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dir = 8;
+	dwidth = 8;
+	height = 9;
+	name = "Emergency Pod";
+	width = 21
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"j" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+a
+e
+b
+i
+a
+d
+d
+d
+d
+d
+a
+e
+b
+e
+a
+"}
+(2,1,1) = {"
+b
+f
+g
+j
+b
+d
+d
+d
+d
+d
+b
+f
+g
+j
+b
+"}
+(3,1,1) = {"
+c
+f
+g
+j
+c
+d
+d
+d
+d
+d
+c
+f
+g
+j
+c
+"}
+(4,1,1) = {"
+b
+f
+g
+j
+b
+d
+d
+d
+d
+d
+b
+f
+g
+j
+b
+"}
+(5,1,1) = {"
+b
+b
+h
+b
+b
+d
+d
+d
+d
+d
+b
+b
+h
+b
+b
+"}
+(6,1,1) = {"
+d
+b
+c
+b
+d
+d
+d
+d
+d
+d
+d
+b
+c
+b
+d
+"}

--- a/_maps/shuttles/emergency_pod.dmm
+++ b/_maps/shuttles/emergency_pod.dmm
@@ -4,7 +4,7 @@
 	icon_state = "propulsion";
 	dir = 8
 	},
-/turf/open/space/basic,
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "b" = (
 /turf/closed/wall/mineral/titanium,

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -207,7 +207,7 @@
 
 /datum/map_template/shuttle/emergency/pod
 	suffix = "pod"
-	name = "Emergency pods"
+	name = "Emergency Pods"
 	description = "We did not expect an evacuation this quickly. All we have available is two escape pods."
 	admin_notes = "For player punishment."
 	can_be_bought = FALSE

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -205,6 +205,13 @@
 	Has medical facilities."
 	credit_cost = 5000
 
+/datum/map_template/shuttle/emergency/pod
+	suffix = "pod"
+	name = "Emergency pods"
+	description = "We did not expect an evacuation this quickly. All we have available is two escape pods."
+	admin_notes = "For player punishment."
+	can_be_bought = FALSE
+
 /datum/map_template/shuttle/emergency/russiafightpit
 	suffix = "russiafightpit"
 	name = "Mother Russia Bleeds"


### PR DESCRIPTION
## About The Pull Request
Adds the Pod shuttle, an Admin spawned shuttle consisting of two large escape pods. 

## Why It's Good For The Game
This shuttle is perfect for punishing the entire crew, or making them battle to the death over who gets a seat. 

## Changelog
:cl:
add: Added the Pod Shuttle
/:cl:

Tested this time. ~~If anyone knows how to fix the flying sideways part, do tell. I figure flying sideways is not a big issue, as it's only aestethic and an already existing shuttle suffers the same issues.~~