### PR TITLE
[READY] Adds selector lists to SDQL

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -61,6 +61,10 @@
 
 	"SELECT /mob WHERE client MAP client WHERE holder MAP holder"
 
+	You can also generate a new list on the fly using a selector array. @[] will generate a list of objects based off the selector provided.
+
+	"SELECT /mob/living IN @[/area/crew_quarters/bar MAP contents]"
+
 	What if some dumbass admin spawned a bajillion spiders and you need to kill them all?
 	Oh yeah you'd rather not delete all the spiders in maintenace. Only that one room the spiders were
 	spawned in.
@@ -535,6 +539,8 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 					objs[j] = SDQL_expression(x, expression)
 					SDQL2_TICK_CHECK
 					SDQL2_HALT_CHECK
+				if(objs.len == 1 && islist(objs[1]))
+					objs = objs[1]
 
 			if ("where")
 				where_switched = TRUE
@@ -882,12 +888,18 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 
 	else if(expression[i] == "@\[")
 		var/list/search_tree = expression[++i]
+		var/already_searching = (state == SDQL2_STATE_SEARCHING) //In case we nest, don't want to break out of the searching state until we're all done.
 
-		state = SDQL2_STATE_SEARCHING
+		if(!already_searching)
+			state = SDQL2_STATE_SEARCHING
+
 		val = Search(search_tree)
 		SDQL2_STAGE_SWITCH_CHECK
 
-		state = SDQL2_STATE_EXECUTING
+		if(!already_searching)
+			state = SDQL2_STATE_EXECUTING
+		else
+			state = SDQL2_STATE_SEARCHING
 
 	else
 		val = world.SDQL_var(object, expression, i, object, superuser, src)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -63,7 +63,7 @@
 
 	You can also generate a new list on the fly using a selector array. @[] will generate a list of objects based off the selector provided.
 
-	"SELECT /mob/living IN @[/area/crew_quarters/bar MAP contents]"
+	"SELECT /mob/living IN (@[/area/crew_quarters/bar MAP contents])[1]"
 
 	What if some dumbass admin spawned a bajillion spiders and you need to kill them all?
 	Oh yeah you'd rather not delete all the spiders in maintenace. Only that one room the spiders were

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -539,8 +539,6 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 					objs[j] = SDQL_expression(x, expression)
 					SDQL2_TICK_CHECK
 					SDQL2_HALT_CHECK
-				if(length(objs) == 1 && islist(objs[1]))
-					objs = objs[1]
 
 			if ("where")
 				where_switched = TRUE

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -988,6 +988,10 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 			return null
 		start++
 		long = start < expression.len
+	else if(expression[start] == "(" && long)
+		v = query.SDQL_expression(source, expression[start + 1])
+		start++
+		long = start < expression.len
 	else if(D != null && (!long || expression[start + 1] == ".") && (expression[start] in D.vars))
 		if(D.can_vv_get(expression[start]) || superuser)
 			v = D.vars[expression[start]]

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -539,7 +539,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 					objs[j] = SDQL_expression(x, expression)
 					SDQL2_TICK_CHECK
 					SDQL2_HALT_CHECK
-				if(objs.len == 1 && islist(objs[1]))
+				if(length(objs) == 1 && islist(objs[1]))
 					objs = objs[1]
 
 			if ("where")

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -879,6 +879,16 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 				dummy[result] = assoc
 				result = dummy
 			val += result
+
+	else if(expression[i] == "@\[")
+		var/list/search_tree = expression[++i]
+
+		state = SDQL2_STATE_SEARCHING
+		val = Search(search_tree)
+		SDQL2_STAGE_SWITCH_CHECK
+
+		state = SDQL2_STATE_EXECUTING
+
 	else
 		val = world.SDQL_var(object, expression, i, object, superuser, src)
 		i = expression.len
@@ -1060,7 +1070,8 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 					"=" = list("", "="),
 					"<" = list("", "=", ">"),
 					">" = list("", "="),
-					"!" = list("", "="))
+					"!" = list("", "="),
+					"@" = list("\["))
 
 	var/word = ""
 	var/list/query_list = list()

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -19,8 +19,7 @@
 //
 //	from_item			:	'world' | expression
 //
-//	call_function		:	<function name> '(' [arguments] ')'
-//	arguments			:	expression [',' arguments]
+//	call_function		:	<function name> '(' [expression_list] ')'
 //
 //	object_type			:	<type path>
 //
@@ -30,12 +29,17 @@
 //
 //	bool_expression		:	expression comparitor expression  [bool_operator bool_expression]
 //	expression			:	( unary_expression | '(' expression ')' | value ) [binary_operator expression]
+//	expression_list		:	expression [',' expression_list]
 //	unary_expression	:	unary_operator ( unary_expression | value | '(' expression ')' )
+//
 //	comparitor			:	'=' | '==' | '!=' | '<>' | '<' | '<=' | '>' | '>='
-//	value				:	variable | string | number | 'null' | object_type
+//	value				:	variable | string | number | 'null' | object_type | array | selectors_array
 //	unary_operator		:	'!' | '-' | '~'
 //	binary_operator		:	comparitor | '+' | '-' | '/' | '*' | '&' | '|' | '^' | '%'
 //	bool_operator		:	'AND' | '&&' | 'OR' | '||'
+//
+//	array				:	'[' expression_list ']'
+//	selectors_array		:	'@[' object_selectors ']'
 //
 //	string				:	''' <some text> ''' | '"' <some text > '"'
 //	number				:	<some digits>
@@ -424,7 +428,7 @@
 
 	return i + 1
 
-//array:	'[' expression, expression, ... ']'
+//array:	'[' expression_list ']'
 /datum/SDQL_parser/proc/array(var/i, var/list/node)
 	// Arrays get turned into this: list("[", list(exp_1a = exp_1b, ...), ...), "[" is to mark the next node as an array.
 	if(copytext(token(i), 1, 2) != "\[")
@@ -624,7 +628,7 @@
 	return i + 1
 
 
-//value:	variable | string | number | 'null' | object_type
+//value:	variable | string | number | 'null' | object_type | array | selectors_array
 /datum/SDQL_parser/proc/value(i, list/node)
 	if(token(i) == "null")
 		node += "null"

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -490,6 +490,23 @@
 
 	return i + 1
 
+//selectors_array:	'@[' object_selectors ']'
+/datum/SDQL_parser/proc/selectors_array(var/i, var/list/node)
+	if(token(i) == "@\[")
+		node += token(i++)
+		if(token(i) != "]")
+			var/list/select = list()
+			i = object_selectors(i, select)
+			node[++node.len] = select
+			if(token(i) != "]")
+				parse_error("Expected ']' to close selector array, but found '[token(i)]'")
+		else
+			parse_error("Selector array expected a selector, but found nothing")
+	else
+		parse_error("Expected '@\[' but found '[token(i)]'")
+
+	return i + 1
+
 //call_function:	<function name> ['(' [arguments] ')']
 /datum/SDQL_parser/proc/call_function(i, list/node, list/arguments)
 	if(length(tokenl(i)))
@@ -626,8 +643,13 @@
 
 	else if(copytext(token(i), 1, 2) == "\[") // Start a list.
 		i = array(i, node)
+
+	else if(copytext(token(i), 1, 3) == "@\[")
+		i = selectors_array(i, node)
+
 	else if(copytext(token(i), 1, 2) == "/")
 		i = object_type(i, node)
+
 	else
 		i = variable(i, node)
 


### PR DESCRIPTION
## About The Pull Request

I've added a selector array query. It's a special construct formed like this:
```bnf
'@[' <selectors> ']'
```
The `<selectors>` is the very same way that you normally use to select datums for all of the queries.
```bnf
UPDATE <selectors> SET <assignments>
SELECT <selectors>
```

I chose `@[ ]` because it's adding an @ sign to the existing SDQL list symbols, since it still generates a list.

## Why It's Good For The Game

It adds more flexibility to SDQL, allowing admins to do more with the language. I find it very convenient in testing to really narrow down the search to say, an /area, so SDQL will only look for datums in that /area's .contents, when paired with MAP.

![query](https://user-images.githubusercontent.com/5211576/56059908-573f6b00-5d33-11e9-94c5-c423a5e9cbb4.png)
![result](https://user-images.githubusercontent.com/5211576/56059913-59092e80-5d33-11e9-9c93-d1acff71f870.png)

## Changelog
:cl: JJRcop
add: SDQL2 now features a list constructor that takes a selector query. 
tweak: (sub expressions) will work with var access, like .vars and [list indexes]
/:cl:

i stayed up too late