### PR TITLE
Removes update icon in portable atmos process.

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -70,6 +70,7 @@
 	anchored = TRUE //Prevent movement
 	pixel_x = new_port.pixel_x
 	pixel_y = new_port.pixel_y
+	update_icon()
 	return TRUE
 
 /obj/machinery/portable_atmospherics/Move()

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -48,8 +48,6 @@
 /obj/machinery/portable_atmospherics/process_atmos()
 	if(!connected_port) // Pipe network handles reactions if connected.
 		air_contents.react(src)
-	else
-		update_icon()
 
 /obj/machinery/portable_atmospherics/return_air()
 	return air_contents

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -85,6 +85,7 @@
 	connected_port = null
 	pixel_x = 0
 	pixel_y = 0
+	update_icon()
 	return TRUE
 
 /obj/machinery/portable_atmospherics/portableConnectorReturnAir()


### PR DESCRIPTION
Canisters already do this manually, and other portables visuals don't care about their contents changes.