### PR TITLE
[ready]secway + atv nerfs

### DIFF
--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -82,7 +82,7 @@
 		smoke.set_up(0, src)
 		smoke.start()
 
-/obj/ridden/atv/bullet_act(obj/item/projectile/P)
+/obj/vehicle/ridden/atv/bullet_act(obj/item/projectile/P)
 	if(prob(50))
 		for(var/mob/M in buckled_mobs)
 			M.bullet_act(P)

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -3,8 +3,8 @@
 	name = "all-terrain vehicle"
 	desc = "An all-terrain vehicle built for traversing rough terrain with ease. One of the few old-Earth technologies that are still relevant on most planet-bound outposts."
 	icon_state = "atv"
-	max_integrity = 200
-	armor = list("melee" = 50, "bullet" = 30, "laser" = 20, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
+	max_integrity = 150
+	armor = list("melee" = 50, "bullet" = 25, "laser" = 20, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
 	key_type = /obj/item/key
 	var/static/mutable_appearance/atvcover
 
@@ -81,6 +81,13 @@
 		var/datum/effect_system/smoke_spread/smoke = new
 		smoke.set_up(0, src)
 		smoke.start()
+
+/obj/ridden/atv/bullet_act(obj/item/projectile/P)
+	if(prob(50))
+		for(var/mob/M in buckled_mobs)
+			M.bullet_act(P)
+		return TRUE
+	. = ..()
 
 /obj/vehicle/ridden/atv/Destroy()
 	STOP_PROCESSING(SSobj,src)

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -9,7 +9,6 @@
 	var/static/mutable_appearance/atvcover
 
 /obj/vehicle/ridden/atv/Initialize()
-	START_PROCESSING(SSobj,src)
 	. = ..()
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 	D.vehicle_move_delay = 1.5
@@ -73,23 +72,31 @@
 				if(obj_integrity == max_integrity)
 					to_chat(user, "<span class='notice'>It looks to be fully repaired now.</span>")
 		return TRUE
-	else
-		return ..()
+	..()
+
+/obj/vehicle/ridden/atv/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
+	. = ..()
+	if(obj_integrity <= 0)
+		explosion(src, -1, 0, 2, 4, flame_range = 3)
+	if(. && (obj_integrity > 0) && obj_integrity < (max_integrity * 0.5))
+		START_PROCESSING(SSobj, src)
 
 /obj/vehicle/ridden/atv/process()
-	if(obj_integrity < 100 && prob(20))
-		var/datum/effect_system/smoke_spread/smoke = new
-		smoke.set_up(0, src)
-		smoke.start()
+	if(obj_integrity >= (max_integrity * 0.5) || obj_integrity <= 0)
+		return PROCESS_KILL
+	if(!prob(80))
+		return
+	var/datum/effect_system/smoke_spread/smoke = new
+	smoke.set_up(0, src)
+	smoke.start()
 
 /obj/vehicle/ridden/atv/bullet_act(obj/item/projectile/P)
 	if(prob(50))
 		for(var/mob/M in buckled_mobs)
 			M.bullet_act(P)
 		return TRUE
-	. = ..()
+	return ..()
 
 /obj/vehicle/ridden/atv/Destroy()
 	STOP_PROCESSING(SSobj,src)
-	explosion(src, -1, 0, 2, 4, flame_range = 3)
 	return ..()

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -68,7 +68,7 @@
 	if(W.tool_behaviour == TOOL_WELDER && user.a_intent != INTENT_HARM)
 		if(obj_integrity < max_integrity)
 			if(W.use_tool(src, user, 0, volume=50, amount=1))
-				user.visible_message("<span class='notice'>[user] repairs some damage to [name].</span>", "<span class='notice'>You repair some damage to [src].</span>")
+				user.visible_message("<span class='notice'>[user] repairs some damage to [name].</span>", "<span class='notice'>You repair some damage to \the [src].</span>")
 				obj_integrity += min(10, max_integrity-obj_integrity)
 				if(obj_integrity == max_integrity)
 					to_chat(user, "<span class='notice'>It looks to be fully repaired now.</span>")
@@ -80,9 +80,9 @@
 	return ..()
 
 /obj/vehicle/ridden/atv/process()
-	if(obj_integrity >= integrity_failure || obj_integrity <= 0)
+	if(obj_integrity >= integrity_failure)
 		return PROCESS_KILL
-	if(!prob(80))
+	if(prob(20))
 		return
 	var/datum/effect_system/smoke_spread/smoke = new
 	smoke.set_up(0, src)

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -76,8 +76,6 @@
 
 /obj/vehicle/ridden/atv/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
 	. = ..()
-	if(obj_integrity <= 0)
-		explosion(src, -1, 0, 2, 4, flame_range = 3)
 	if(. && (obj_integrity > 0) && obj_integrity < (max_integrity * 0.5))
 		START_PROCESSING(SSobj, src)
 
@@ -98,5 +96,7 @@
 	return ..()
 
 /obj/vehicle/ridden/atv/Destroy()
+	if(obj_integrity <= 0)
+		explosion(src, -1, 0, 2, 4, flame_range = 3)
 	STOP_PROCESSING(SSobj,src)
 	return ..()

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -6,6 +6,7 @@
 	max_integrity = 150
 	armor = list("melee" = 50, "bullet" = 25, "laser" = 20, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
 	key_type = /obj/item/key
+	integrity_failure = 70
 	var/static/mutable_appearance/atvcover
 
 /obj/vehicle/ridden/atv/Initialize()
@@ -72,15 +73,15 @@
 				if(obj_integrity == max_integrity)
 					to_chat(user, "<span class='notice'>It looks to be fully repaired now.</span>")
 		return TRUE
-	..()
+	return ..()
 
 /obj/vehicle/ridden/atv/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
 	. = ..()
-	if(. && (obj_integrity > 0) && obj_integrity < (max_integrity * 0.5))
+	if(. && (obj_integrity > 0) && obj_integrity < integrity_failure)
 		START_PROCESSING(SSobj, src)
 
 /obj/vehicle/ridden/atv/process()
-	if(obj_integrity >= (max_integrity * 0.5) || obj_integrity <= 0)
+	if(obj_integrity >= integrity_failure || obj_integrity <= 0)
 		return PROCESS_KILL
 	if(!prob(80))
 		return
@@ -89,14 +90,16 @@
 	smoke.start()
 
 /obj/vehicle/ridden/atv/bullet_act(obj/item/projectile/P)
-	if(prob(50))
+	if(prob(50) && buckled_mobs)
 		for(var/mob/M in buckled_mobs)
 			M.bullet_act(P)
 		return TRUE
 	return ..()
 
+/obj/vehicle/ridden/atv/obj_destruction()
+	explosion(src, -1, 0, 2, 4, flame_range = 3)
+	return ..()
+
 /obj/vehicle/ridden/atv/Destroy()
-	if(obj_integrity <= 0)
-		explosion(src, -1, 0, 2, 4, flame_range = 3)
 	STOP_PROCESSING(SSobj,src)
 	return ..()

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -75,10 +75,9 @@
 		return TRUE
 	return ..()
 
-/obj/vehicle/ridden/atv/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
-	. = ..()
-	if(. && (obj_integrity > 0) && obj_integrity < integrity_failure)
-		START_PROCESSING(SSobj, src)
+/obj/vehicle/ridden/secway/obj_break()
+	START_PROCESSING(SSobj, src)
+	return ..()
 
 /obj/vehicle/ridden/atv/process()
 	if(obj_integrity >= integrity_failure || obj_integrity <= 0)

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -4,7 +4,7 @@
 	desc = "A brave security cyborg gave its life to help you look like a complete tool."
 	icon_state = "secway"
 	max_integrity = 100
-	armor = list("melee" = 20, "bullet" = 30, "laser" = 10, "energy" = 0, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
+	armor = list("melee" = 20, "bullet" = 15, "laser" = 10, "energy" = 0, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
 	key_type = /obj/item/key/security
 
 /obj/vehicle/ridden/secway/Initialize()
@@ -36,3 +36,11 @@
 	STOP_PROCESSING(SSobj,src)
 	explosion(src, -1, 0, 2, 4, flame_range = 3)
 	return ..()
+
+
+/obj/ridden/secway/bullet_act(obj/item/projectile/P)
+	if(prob(70))
+		for(var/mob/M in buckled_mobs)
+			M.bullet_act(P)
+		return TRUE
+	. = ..()

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -3,10 +3,36 @@
 	name = "secway"
 	desc = "A brave security cyborg gave its life to help you look like a complete tool."
 	icon_state = "secway"
+	max_integrity = 100
+	armor = list("melee" = 20, "bullet" = 30, "laser" = 10, "energy" = 0, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
 	key_type = /obj/item/key/security
 
 /obj/vehicle/ridden/secway/Initialize()
 	. = ..()
+	START_PROCESSING(SSobj,src)
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 	D.vehicle_move_delay = 1.5
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 4), TEXT_EAST = list(0, 4), TEXT_WEST = list( 0, 4)))
+
+/obj/vehicle/ridden/secway/process()
+	if(obj_integrity < 50 && prob(20))
+		var/datum/effect_system/smoke_spread/smoke = new
+		smoke.set_up(0, src)
+		smoke.start()
+
+/obj/vehicle/ridden/secway/attackby(obj/item/W as obj, mob/user as mob, params)
+	if(W.tool_behaviour == TOOL_WELDER && user.a_intent != INTENT_HARM)
+		if(obj_integrity < max_integrity)
+			if(W.use_tool(src, user, 0, volume=50, amount=1))
+				user.visible_message("<span class='notice'>[user] repairs some damage to [name].</span>", "<span class='notice'>You repair some damage to [src].</span>")
+				obj_integrity += min(10, max_integrity-obj_integrity)
+				if(obj_integrity == max_integrity)
+					to_chat(user, "<span class='notice'>It looks to be fully repaired now.</span>")
+		return TRUE
+	else
+		return ..()
+
+/obj/vehicle/ridden/secway/Destroy()
+	STOP_PROCESSING(SSobj,src)
+	explosion(src, -1, 0, 2, 4, flame_range = 3)
+	return ..()

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -19,9 +19,9 @@
 	return ..()
 
 /obj/vehicle/ridden/secway/process()
-	if(obj_integrity >= integrity_failure || obj_integrity <= 0)
+	if(obj_integrity >= integrity_failure)
 		return PROCESS_KILL
-	if(!prob(80))
+	if(prob(20))
 		return
 	var/datum/effect_system/smoke_spread/smoke = new
 	smoke.set_up(0, src)
@@ -31,7 +31,7 @@
 	if(W.tool_behaviour == TOOL_WELDER && user.a_intent != INTENT_HARM)
 		if(obj_integrity < max_integrity)
 			if(W.use_tool(src, user, 0, volume = 50, amount = 1))
-				user.visible_message("<span class='notice'>[user] repairs some damage to [name].</span>", "<span class='notice'>You repair some damage to [src].</span>")
+				user.visible_message("<span class='notice'>[user] repairs some damage to [name].</span>", "<span class='notice'>You repair some damage to \the [src].</span>")
 				obj_integrity += min(10, max_integrity-obj_integrity)
 				if(obj_integrity == max_integrity)
 					to_chat(user, "<span class='notice'>It looks to be fully repaired now.</span>")

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -9,18 +9,27 @@
 
 /obj/vehicle/ridden/secway/Initialize()
 	. = ..()
-	START_PROCESSING(SSobj,src)
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 	D.vehicle_move_delay = 1.5
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 4), TEXT_EAST = list(0, 4), TEXT_WEST = list( 0, 4)))
 
-/obj/vehicle/ridden/secway/process()
-	if(obj_integrity < 50 && prob(20))
-		var/datum/effect_system/smoke_spread/smoke = new
-		smoke.set_up(0, src)
-		smoke.start()
+/obj/vehicle/ridden/secway/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
+	. = ..()
+	if(obj_integrity <= 0)
+		explosion(src, -1, 0, 2, 4, flame_range = 3)
+	if(. && (obj_integrity > 0) && obj_integrity < (max_integrity * 0.5))
+		START_PROCESSING(SSobj, src)
 
-/obj/vehicle/ridden/secway/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/vehicle/ridden/secway/process()
+	if(obj_integrity >= (max_integrity * 0.5) || obj_integrity <= 0)
+		return PROCESS_KILL
+	if(!prob(80))
+		return
+	var/datum/effect_system/smoke_spread/smoke = new
+	smoke.set_up(0, src)
+	smoke.start()
+
+/obj/vehicle/ridden/secway/attackby(obj/item/W, mob/user, params)
 	if(W.tool_behaviour == TOOL_WELDER && user.a_intent != INTENT_HARM)
 		if(obj_integrity < max_integrity)
 			if(W.use_tool(src, user, 0, volume=50, amount=1))
@@ -29,14 +38,11 @@
 				if(obj_integrity == max_integrity)
 					to_chat(user, "<span class='notice'>It looks to be fully repaired now.</span>")
 		return TRUE
-	else
-		return ..()
+	..()
 
 /obj/vehicle/ridden/secway/Destroy()
 	STOP_PROCESSING(SSobj,src)
-	explosion(src, -1, 0, 2, 4, flame_range = 3)
 	return ..()
-
 
 /obj/vehicle/ridden/secway/bullet_act(obj/item/projectile/P)
 	if(prob(60))

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -14,10 +14,9 @@
 	D.vehicle_move_delay = 1.5
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 4), TEXT_EAST = list(0, 4), TEXT_WEST = list( 0, 4)))
 
-/obj/vehicle/ridden/secway/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
-	. = ..()
-	if(. && (obj_integrity > 0) && obj_integrity < integrity_failure)
-		START_PROCESSING(SSobj, src)
+/obj/vehicle/ridden/secway/obj_break()
+	START_PROCESSING(SSobj, src)
+	return ..()
 
 /obj/vehicle/ridden/secway/process()
 	if(obj_integrity >= integrity_failure || obj_integrity <= 0)

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -15,8 +15,6 @@
 
 /obj/vehicle/ridden/secway/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
 	. = ..()
-	if(obj_integrity <= 0)
-		explosion(src, -1, 0, 2, 4, flame_range = 3)
 	if(. && (obj_integrity > 0) && obj_integrity < (max_integrity * 0.5))
 		START_PROCESSING(SSobj, src)
 
@@ -41,6 +39,8 @@
 	..()
 
 /obj/vehicle/ridden/secway/Destroy()
+	if(obj_integrity <= 0)
+		explosion(src, -1, 0, 2, 4, flame_range = 3)
 	STOP_PROCESSING(SSobj,src)
 	return ..()
 

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -38,7 +38,7 @@
 	return ..()
 
 
-/obj/ridden/secway/bullet_act(obj/item/projectile/P)
+/obj/vehicle/ridden/secway/bullet_act(obj/item/projectile/P)
 	if(prob(70))
 		for(var/mob/M in buckled_mobs)
 			M.bullet_act(P)

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -39,7 +39,7 @@
 
 
 /obj/vehicle/ridden/secway/bullet_act(obj/item/projectile/P)
-	if(prob(70))
+	if(prob(60))
 		for(var/mob/M in buckled_mobs)
 			M.bullet_act(P)
 		return TRUE


### PR DESCRIPTION
:cl:
balance: NT has now equipped all secways and atvs with new cheap lithium cells. It may cause explosions if they take too much damage
balance: secway and atv have less health
balance: you can repair vehicles with a welder
fix: you might hit the driver while straigh shooting 
/:cl:

@4dplanner 