### PR TITLE
paraplegic vehicle fixes

### DIFF
--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -120,6 +120,7 @@
 	if(!canmove)
 		return
 	vehicle_move(direction)
+	return TRUE
 
 /obj/vehicle/proc/vehicle_move(direction)
 	if(lastmove + movedelay > world.time)

--- a/code/modules/vehicles/bicycle.dm
+++ b/code/modules/vehicles/bicycle.dm
@@ -2,7 +2,8 @@
 	name = "bicycle"
 	desc = "Keep away from electricity."
 	icon_state = "bicycle"
-	
+	fall_off_if_missing_arms = TRUE
+
 /obj/vehicle/ridden/bicycle/Initialize()
 	. = ..()
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)

--- a/code/modules/vehicles/cars/car.dm
+++ b/code/modules/vehicles/cars/car.dm
@@ -30,6 +30,7 @@
 		return
 	last_enginesound_time = world.time
 	playsound(src, engine_sound, 100, TRUE)
+	return TRUE
 
 /obj/vehicle/sealed/car/MouseDrop_T(atom/dropping, mob/M)
 	if(M.stat || M.restrained())

--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -9,6 +9,7 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	can_buckle = TRUE
 	legs_required = 0
+	arms_required = 0
 
 /obj/vehicle/ridden/lavaboat/Initialize()
 	. = ..()

--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -8,6 +8,7 @@
 	icon = 'icons/obj/lavaland/dragonboat.dmi'
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	can_buckle = TRUE
+	legs_required = 0
 
 /obj/vehicle/ridden/lavaboat/Initialize()
 	. = ..()

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -5,7 +5,8 @@
 	buckle_lying = FALSE
 	default_driver_move = FALSE
 	var/legs_required = 2
-	var/arms_requires = 0	//why not?
+	var/arms_required = 1	//why not?
+	var/fall_off_if_missing_arms = FALSE //heh...
 
 /obj/vehicle/ridden/Initialize()
 	. = ..()
@@ -60,6 +61,25 @@
 	if(key_type && !is_key(inserted_key))
 		to_chat(user, "<span class='warning'>[src] has no key inserted!</span>")
 		return FALSE
+	if(legs_required)
+		var/how_many_legs = user.get_num_legs()
+		if(how_many_legs < legs_required)
+			to_chat(user, "<span class='warning'>You can't seem to manage that with[how_many_legs ? " your leg[how_many_legs > 1 ? "s" : null]" : "out legs"]...</span>")
+			return FALSE
+	if(arms_required)
+		var/how_many_arms = user.get_num_arms()
+		if(how_many_arms < arms_required)
+			if(fall_off_if_missing_arms)
+				unbuckle_mob(user, TRUE)
+				user.visible_message("<span class='danger'>[user] falls off of \the [src].",\
+				"<span class='danger'>You fall of \the [src] while trying to operate it without [arms_required ? "both arms":"an arm"]!</span>")
+				if(isliving(user))
+					var/mob/living/L = user
+					L.Stun(30)
+				return FALSE
+
+			to_chat(user, "<span class='warning'>You can't seem to manage that with[how_many_arms ? " your arm[how_many_arms > 1 ? "s" : null]" : "out arms"]...</span>")
+			return FALSE
 	var/datum/component/riding/R = GetComponent(/datum/component/riding)
 	R.handle_ride(user, direction)
 	return ..()

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -3,6 +3,7 @@
 	desc = "A fun way to get around."
 	icon_state = "scooter"
 	are_legs_exposed = TRUE
+	fall_off_if_missing_arms = TRUE
 
 /obj/vehicle/ridden/scooter/Initialize()
 	. = ..()
@@ -32,19 +33,21 @@
 		else
 			buckled_mob.pixel_y = -4
 
-/obj/vehicle/ridden/scooter/buckle_mob(mob/living/M, force = 0, check_loc = 1)
+/obj/vehicle/ridden/scooter/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)
 	if(!istype(M))
-		return 0
-	if(M.get_num_legs() < 2 && M.get_num_arms() <= 0)
-		to_chat(M, "<span class='warning'>Your limbless body can't ride \the [src].</span>")
-		return 0
-	. = ..()
+		return FALSE
+	if(M.get_num_legs() < legs_required && M.get_num_arms() < arms_required)
+		to_chat(M, "<span class='warning'>You don't think it'd be a good idea trying to ride \the [src]...</span>")
+		return FALSE
+	return ..()
 
 /obj/vehicle/ridden/scooter/skateboard
 	name = "skateboard"
 	desc = "An unfinished scooter which can only barely be called a skateboard. It's still rideable, but probably unsafe. Looks like you'll need to add a few rods to make handlebars. Alt-click to adjust speed."
 	icon_state = "skateboard"
 	density = FALSE
+	arms_required = 0
+	fall_off_if_missing_arms = FALSE
 	var/adjusted_speed = FALSE
 
 /obj/vehicle/ridden/scooter/skateboard/Initialize()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -37,8 +37,8 @@
 /obj/vehicle/ridden/wheelchair/driver_move(mob/living/user, direction)
 	var/mob/living/carbon/human/H = user
 	if(istype(H))
-		if(!H.get_num_arms() && canmove)
-			to_chat(H, "<span class='warning'>You can't move the wheels without arms!</span>")
+		if(canmove && (H.get_num_arms() < arms_required))
+			to_chat(H, "<span class='warning'>You don't have enough arms to operate the wheels!</span>")
 			canmove = FALSE
 			addtimer(VARSET_CALLBACK(src, canmove , TRUE), 20)
 			return FALSE
@@ -46,7 +46,7 @@
 		//1.5 (movespeed as of this change) multiplied by 6.7 gets ABOUT 10 (rounded), the old constant for the wheelchair that gets divided by how many arms they have
 		//if that made no sense this simply makes the wheelchair speed change along with movement speed delay
 		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 6.7) / min(H.get_num_arms(), 2)
-	..()
+	return ..()
 
 /obj/vehicle/ridden/wheelchair/Moved()
 	. = ..()
@@ -108,4 +108,4 @@
 	if(istype(H))
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
 		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 6.7) / H.get_num_arms()
-	..()
+	return ..()


### PR DESCRIPTION
:cl: ShizCalev
fix: Paraplegics/mobs missing legs can no longer operate vehicles which require legs to operate (ie bicycles, skateboards, ATVs, ect) if they lost the limbs while still buckled in.
tweak: Mobs with no arms will now fall off bikes & scooters when trying to move.
tweak: Badmins can now edit limb requirements of vehicles.
/:cl: