### PR TITLE
Fixes inter-server crosshop with only 1 configured server

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -77,7 +77,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 			verbs -= /mob/dead/proc/server_hop
 			to_chat(src, "<span class='notice'>Server Hop has been disabled.</span>")
 		if(1)
-			pick = csa[0]
+			pick = csa[1]
 		else
 			pick = input(src, "Pick a server to jump to", "Server Hop") as null|anything in csa
 


### PR DESCRIPTION
Lists start at one. Thanks Lummox.
🆑
fix: Duo-server links can now hop between each other properly.
/🆑