### PR TITLE
unassblasts mass blasters

### DIFF
--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -20,6 +20,8 @@
 	var/atom/target = get_edge_target_turf(src, dir)
 	for(var/atom/movable/O in loc)
 		if(!O.anchored || ismecha(O))	//Mechs need their launch platforms.
+			if(ismob(O) && !isliving(O))
+				continue
 			O_limit++
 			if(O_limit >= 20)
 				audible_message("<span class='notice'>[src] lets out a screech, it doesn't seem to be able to handle the load.</span>")


### PR DESCRIPTION
Fixes #43404
:cl: ShizCalev
fix: Mass drivers will no longer launch ghosts & camera mobs (AI cameras, xenobio cameras, ect)
/:cl: