### PR TITLE
Fix blood brothers causing the whole end-round report to be bold

### DIFF
--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 		var/objective_count = 1
 		for(var/datum/objective/objective in objectives)
 			if(objective.check_completion())
-				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='greentext'><B>Success!</span>"
+				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='greentext'>Success!</span>"
 			else
 				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
 				win = FALSE

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -109,7 +109,7 @@
 	var/objective_count = 1
 	for(var/datum/objective/objective in objectives)
 		if(objective.check_completion())
-			parts += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='greentext'><B>Success!</span>"
+			parts += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='greentext'>Success!</span>"
 		else
 			parts += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
 			win = FALSE

--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -34,17 +34,17 @@
 	if(!istype(A))
 		return
 	if(loc == summoner)
-		to_chat(src, "<span class='danger'><B>You must be manifested to create bombs!</span></B>")
+		to_chat(src, "<span class='danger'><B>You must be manifested to create bombs!</B></span>")
 		return
 	if(isobj(A) && Adjacent(A))
 		if(bomb_cooldown <= world.time && !stat)
 			var/obj/guardian_bomb/B = new /obj/guardian_bomb(get_turf(A))
-			to_chat(src, "<span class='danger'><B>Success! Bomb armed!</span></B>")
+			to_chat(src, "<span class='danger'><B>Success! Bomb armed!</B></span>")
 			bomb_cooldown = world.time + 200
 			B.spawner = src
 			B.disguise(A)
 		else
-			to_chat(src, "<span class='danger'><B>Your powers are on cooldown! You must wait 20 seconds between bombs.</span></B>")
+			to_chat(src, "<span class='danger'><B>Your powers are on cooldown! You must wait 20 seconds between bombs.</B></span>")
 
 /obj/guardian_bomb
 	name = "bomb"
@@ -64,14 +64,14 @@
 
 /obj/guardian_bomb/proc/disable()
 	stored_obj.forceMove(get_turf(src))
-	to_chat(spawner, "<span class='danger'><B>Failure! Your trap didn't catch anyone this time.</span></B>")
+	to_chat(spawner, "<span class='danger'><B>Failure! Your trap didn't catch anyone this time.</B></span>")
 	qdel(src)
 
 /obj/guardian_bomb/proc/detonate(mob/living/user)
 	if(isliving(user))
 		if(user != spawner && user != spawner.summoner && !spawner.hasmatchingsummoner(user))
-			to_chat(user, "<span class='danger'><B>[src] was boobytrapped!</span></B>")
-			to_chat(spawner, "<span class='danger'><B>Success! Your trap caught [user]</span></B>")
+			to_chat(user, "<span class='danger'><B>[src] was boobytrapped!</B></span>")
+			to_chat(spawner, "<span class='danger'><B>Success! Your trap caught [user]</B></span>")
 			var/turf/T = get_turf(src)
 			stored_obj.forceMove(T)
 			playsound(T,'sound/effects/explosion2.ogg', 200, 1)


### PR DESCRIPTION
:cl:
fix: Blood brothers succeeding at some objective no longer bolds the entire rest of the round-end report.
/:cl: