### PR TITLE
Fixes the toxins launch telescreen on Box

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -35913,6 +35913,7 @@
 	},
 /obj/machinery/computer/security/telescreen/toxins{
 	dir = 8;
+	network = list("toxins");
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -35913,7 +35913,6 @@
 	},
 /obj/machinery/computer/security/telescreen/toxins{
 	dir = 8;
-	network = list("toxins");
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel,

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -272,7 +272,7 @@
 /obj/machinery/computer/security/telescreen/toxins
 	name = "bomb test site monitor"
 	desc = "A telescreen that connects to the bomb test site's camera."
-	network = list("toxin")
+	network = list("toxins")
 
 /obj/machinery/computer/security/telescreen/engine
 	name = "engine monitor"


### PR DESCRIPTION
fixes #43410
fixes #43309 

:cl: Vile Beggar
fix: Toxins launch site telescreens now work properly again.
/:cl:
