### PR TITLE
Removes the flavortext from polymorphed drones

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -78,6 +78,7 @@
 	default_storage = null
 	default_hatmask = null
 	picked = TRUE
+	flavortext = null
 
 /mob/living/simple_animal/drone/polymorphed/Initialize()
 	. = ..()


### PR DESCRIPTION
Fixes #43311 
Dunno if this is really needed, but it seems some people got confused by it. This PR removes the flavor text that normal drones would get, for polymorphed drones.

:cl: Vile Beggar
fix: Polymorphed drones no longer have normal drone flavortext.
/:cl: