### PR TITLE
Buffs plasteel golems

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -180,7 +180,7 @@
 	C.remove_trait(TRAIT_HOLY, SPECIES_TRAIT)
 	..()
 
-//Harder to stun, deals more damage, but it's even slower
+//Harder to stun, deals more damage, massively slowpokes, but gravproof and obstructive. Basically, The Wall.
 /datum/species/golem/plasteel
 	name = "Plasteel Golem"
 	id = "plasteel golem"
@@ -196,6 +196,17 @@
 	attack_sound = 'sound/effects/meteorimpact.ogg' //hits pretty hard
 	prefix = "Plasteel"
 	special_names = null
+
+/datum/species/golem/plasteel/mob_negates_gravity()
+	return TRUE
+
+/datum/species/golem/plasteel/on_species_gain(mob/living/carbon/C, datum/species/old_species)
+	..()
+	C.add_trait(TRAIT_NOMOBSWAP, SPECIES_TRAIT) //THE WALL THE WALL THE WALL
+
+/datum/species/golem/plasteel/on_species_loss(mob/living/carbon/C)
+	C.remove_trait(TRAIT_NOMOBSWAP, SPECIES_TRAIT) //NOTHING ON ERF CAN MAKE IT FALL
+	..()
 
 //Immune to ash storms
 /datum/species/golem/titanium

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -191,7 +191,7 @@
 	punchstunthreshold = 18 //still 40% stun chance
 	speedmod = 4 //pretty fucking slow
 	meat = /obj/item/stack/ore/iron
-	info_text = "As a <span class='danger'>Plasteel Golem</span>, you are slower, but harder to stun, and hit very hard when punching."
+	info_text = "As a <span class='danger'>Plasteel Golem</span>, you are slower, but harder to stun, and hit very hard when punching. You also magnetically attach to surfaces and so don't float without gravity and cannot have positions swapped with other beings."
 	attack_verb = "smash"
 	attack_sound = 'sound/effects/meteorimpact.ogg' //hits pretty hard
 	prefix = "Plasteel"

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -197,7 +197,7 @@
 	prefix = "Plasteel"
 	special_names = null
 
-/datum/species/golem/plasteel/mob_negates_gravity()
+/datum/species/golem/plasteel/negates_gravity(mob/living/carbon/human/H)
 	return TRUE
 
 /datum/species/golem/plasteel/on_species_gain(mob/living/carbon/C, datum/species/old_species)


### PR DESCRIPTION
## About The Pull Request
Makes plasteel golems negate gravity and be obstructive (unable to swap places with another mob) so they're actually useful for some things like defense.

## Why It's Good For The Game
Plasteel golems are garbage in that their bonus is lower stun rates and higher _punching_ damage, but golems can wield melee weapons already, which are better for damaging things; and their malus is being even slower than all other golems. A gold golem with a dual-wielded spear will do about as much damage as plasteel while not being colossally slow. They're also made extremely often by clueless xenobiologists.  
This makes plasteel golems into more of a defensive golem, as they're resistant to being swapped regardless of intent, and do not care about gravity.

## Changelog
:cl: Barhandar
add: Plasteel golems have been buffed and will now stay on the ground instead of floating without gravity (like magboots). They're also cannot be swapped positions with even on help intent.
/:cl: