### PR TITLE
Fixes for asay, asay darkmode, and asay when custom asay colors enabled

### DIFF
--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -11,7 +11,7 @@
 
 	mob.log_talk(msg, LOG_ASAY)
 	msg = keywords_lookup(msg)
-	var/custom_asay_color = (CONFIG_GET(flag/allow_admin_asaycolor) && prefs.asaycolor) ? "<font color=[prefs.asaycolor]>" : "<font color='red'>"
+	var/custom_asay_color = (CONFIG_GET(flag/allow_admin_asaycolor) && prefs.asaycolor) ? "<font color=[prefs.asaycolor]>" : "<font color='#FF4500'>"
 	msg = "<span class='adminsay'><span class='prefix'>ADMIN:</span> <EM>[key_name(usr, 1)]</EM> [ADMIN_FLW(mob)]: [custom_asay_color]<span class='message linkify'>[msg]</span></span>[custom_asay_color ? "</font>":null]"
 	to_chat(GLOB.admins, msg)
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -15,7 +15,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
 	var/ooccolor = "#c43b23"
-	var/asaycolor = null
+	var/asaycolor = "#ff4500"			//This won't change the color for current admins, only incoming ones.
 	var/enable_tips = TRUE
 	var/tip_delay = 500 //tip delay in milliseconds
 

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -267,7 +267,7 @@ em						{font-style: normal;	font-weight: bold;}
 .adminobserverooc		{color: #0099cc;	font-weight: bold;}
 .adminooc				{color: #3d5bc3;	font-weight: bold;}
 
-.adminsay   			{color: #ff0000;}
+.adminsay   				{color: #ff4500;	font-weight: bold;}
 .admin					{color: #5975da;	font-weight: bold;}
 
 .name					{					font-weight: bold;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -264,7 +264,7 @@ em						{font-style: normal;	font-weight: bold;}
 .adminobserverooc		{color: #0099cc;	font-weight: bold;}
 .adminooc				{color: #700038;	font-weight: bold;}
 
-.adminsay   			{color: #ff0000;}
+.adminsay   				{color: #ff4500;	font-weight: bold;}
 .admin					{color: #4473ff;	font-weight: bold;}
 
 .name					{					font-weight: bold;}


### PR DESCRIPTION
## About The Pull Request

Fixes several annoying and unintentional things about asay.
Fixes #43370

## Changelog
:cl: Nervere
fix: Default color for when custom asay colors is not enabled is now orange, not red.
fix: Asay is now properly bolded in lightmode.
fix: Asay is now properly bolded in darkmode.
tweak: Default color for when custom asay colors is enabled is now orange, not black.
/:cl:

closes #43370