### PR TITLE
fixes grammar error in void magnet

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -520,7 +520,7 @@
 		. = ..()
 
 /obj/effect/immortality_talisman/void
-	vanish_description = "dragged into the void"
+	vanish_description = "is dragged into the void"
 
 //Shared Bag
 


### PR DESCRIPTION
:cl:
spellcheck: fixes spelling error in void magent
/:cl: