### PR TITLE
Allows Organ Harvesters to Ignore Clothing When Emagged + Harvest Head Last

### DIFF
--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -45,16 +45,33 @@
 	harvesting = FALSE
 
 /obj/machinery/harvester/attack_hand(mob/user)
-	if(state_open)
-		close_machine()
-	else if(!harvesting)
-		open_machine()
-
-/obj/machinery/harvester/AltClick(mob/user)
 	if(harvesting || !user || !isliving(user) || state_open)
 		return
-	if(can_harvest())
+	else if(can_harvest())
 		start_harvest()
+
+/obj/machinery/harvester/MouseDrop_T(mob/target, mob/user)
+	if (!istype(target) || target.anchored || target.buckled || !Adjacent(target) || !user.canUseTopic(src, BE_CLOSE) || !state_open)
+		return
+	add_fingerprint(user)
+	if (user == target)
+		user.visible_message("[user] starts climbing into [src].", "<span class='notice'>You start climbing into [src]...</span>")
+	else
+		target.visible_message("<span class='danger'>[user] starts putting [target] into [src].</span>", "<span class='userdanger'>[user] starts putting you into [src]!</span>")
+	if (do_mob(user, target, 30))
+		if (!loc)
+			return
+		close_machine(target)
+		if (user == target)
+			user.visible_message("[user] climbs into [src].", "<span class='notice'>You climb into [src].</span>")
+		else
+			target.visible_message("<span class='danger'>[user] has placed [target] in [src].</span>", "<span class='userdanger'>[user] has placed [target] in [src].</span>")
+			log_combat(user, target, "forced", addition="into [src]")
+
+/obj/machinery/harvester/AltClick(mob/user)
+	if (!state_open && user != occupant)
+		open_machine()
+	. = ..()
 
 /obj/machinery/harvester/proc/can_harvest()
 	if(!powered(EQUIP) || state_open || !occupant || !iscarbon(occupant))

--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -84,6 +84,10 @@
 		return
 	var/mob/living/carbon/C = occupant
 	operation_order = reverseList(C.bodyparts)   //Chest and head are first in bodyparts, so we invert it to make them suffer more
+	if(operation_order.len >= 2 && istype(operation_order[operation_order.len - 1], /obj/item/bodypart/head)) // Swap head and torso, so the head is processed last
+		var/obj/item/bodypart/temp = operation_order[operation_order.len - 1]
+		operation_order[operation_order.len - 1] = operation_order[operation_order.len]
+		operation_order[operation_order.len] = temp
 	harvesting = TRUE
 	visible_message("<span class='notice'>The [name] begins warming up!</span>")
 	say("Initializing harvest protocol.")
@@ -162,6 +166,7 @@
 		return
 	obj_flags |= EMAGGED
 	allow_living = TRUE
+	allow_clothing = TRUE
 	to_chat(user, "<span class='warning'>You overload [src]'s lifesign scanners.</span>")
 
 /obj/machinery/harvester/container_resist(mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #43423.

The organ harvester will now harvest bodies that have items on them so long as it is emagged. It will also now harvest the head last, when applicable, in most cases.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ability to harvest with clothing on seems to be reasonable for an emagged harvester. Harvesting the head last is merely a flavor change, but a welcome one.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
add: Organ harvesters are now rumored to ignore abiotic items on bodies, living or dead, if the safety sensors are broken.
tweak: Organ harvesters now harvest the head last.
tweak: Organ harvesters now require bodies to be dragged onto them, with a delay similar to gibbers and disposal bins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
