### PR TITLE
Fixes locker bolts moving mobs not valid for insertion into lockers.

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -378,15 +378,20 @@
 	var/weld = TRUE
 	var/created = FALSE //prevents creation of more then one locker if it has multiple hits
 	var/locker_suck = TRUE
+	var/obj/structure/closet/locker_temp_instance = /obj/structure/closet/decay
+
+/obj/item/projectile/magic/locker/Initialize()
+	. = ..()
+	locker_temp_instance = new(src)
 
 /obj/item/projectile/magic/locker/prehit(atom/A)
-	if(ismob(A) && locker_suck)
-		var/mob/M = A
+	if(isliving(A) && locker_suck)
+		var/mob/living/M = A
 		if(M.anti_magic_check())
 			M.visible_message("<span class='warning'>[src] vanishes on contact with [A]!</span>")
 			qdel(src)
 			return
-		if(M.anchored)
+		if(!locker_temp_instance.insertion_allowed(M))
 			return ..()
 		M.forceMove(src)
 		return FALSE
@@ -395,7 +400,7 @@
 /obj/item/projectile/magic/locker/on_hit(target)
 	if(created)
 		return ..()
-	var/obj/structure/closet/decay/C = new(get_turf(src))
+	var/obj/structure/closet/C = new locker_temp_instance(get_turf(src))
 	if(LAZYLEN(contents))
 		for(var/atom/movable/AM in contents)
 			C.insert(AM)


### PR DESCRIPTION
Fixes issue mentioned in #43408
:cl: ShizCalev
fix: Locker bolts will no longer move mobs that aren't valid for lockering.
/:cl: