### PR TITLE
Adding laceup shoes to curator's outfit

### DIFF
--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -22,6 +22,7 @@
 	name = "Curator"
 	jobtype = /datum/job/curator
 
+	shoes = /obj/item/clothing/shoes/laceup
 	belt = /obj/item/pda/curator
 	uniform = /obj/item/clothing/under/rank/curator
 	l_hand = /obj/item/storage/bag/books


### PR DESCRIPTION
## About The Pull Request
Adds laceup shoes to curator's outfit.
--
Old: 
![old](https://user-images.githubusercontent.com/28513509/55430634-a2e85c80-555c-11e9-98fb-bf9661adff4a.gif)
New:
![new](https://user-images.githubusercontent.com/28513509/55430644-a8de3d80-555c-11e9-8e7e-d1f5283b6881.gif)

## Why It's Good For The Game
The curator looks fancy, and should not be wearing sneakers.

## Changelog
:cl: Cyfause
code: changed some code
/:cl:
