### PR TITLE
lowers the max radstorm duration to 1000 from 1500 ticks

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -9,7 +9,7 @@
 	weather_message = "<span class='userdanger'><i>You feel waves of heat wash over you! Find shelter!</i></span>"
 	weather_overlay = "ash_storm"
 	weather_duration_lower = 600
-	weather_duration_upper = 1500
+	weather_duration_upper = 1000
 	weather_color = "green"
 	weather_sound = 'sound/misc/bloblarm.ogg'
 


### PR DESCRIPTION
:cl:
balance: lowers the max radstorm duration to 1000 from 1500 ticks
/:cl:
boring event that lasts painfully long and no one likes it
