### PR TITLE
EZ-CLEAN Buff

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1052,8 +1052,8 @@
 /datum/reagent/space_cleaner/ez_clean/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	..()
 	if((method == TOUCH || method == VAPOR) && !issilicon(M))
-		M.adjustBruteLoss(1)
-		M.adjustFireLoss(1)
+		M.adjustBruteLoss(1.5)
+		M.adjustFireLoss(1.5)
 
 /datum/reagent/cryptobiolin
 	name = "Cryptobiolin"


### PR DESCRIPTION
REAL PR NOT APRIL FOOLS I SWEAR

## About The Pull Request

Buffs the damage of EZ-CLEAN nades by 1.5. This is enough to take someone in perfect health to just barely on the edge of not in crit. It previously did 70 damage but now does 105.

## Why It's Good For The Game

EZ-CLEAN grenades were garbage before, if you were unlucky enough to spend some time sitting in it it did nothing compared to even a bad hellfoam mix. This makes them actually viable as a powerful crowd control solution.

## Changelog
:cl:
balance: EZ-CLEAN grenades now deal 1.5x the damage.
/:cl:

 Being able to get 9 of them total might be a problem, so it might be worth increasing the TC cost to 7. Feedback below.