### PR TITLE
fixes large ebows insane dmg

### DIFF
--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -14,4 +14,4 @@
 	icon_state = "candy_corn"
 
 /obj/item/projectile/energy/bolt/large
-	damage = 40
+	damage = 20


### PR DESCRIPTION
:cl: Tlaltecuhtli 
balance: large ebows do 20 damage instead of 40
/:cl:
@actioninja said it wasnt intended