### PR TITLE
Removes References to Disney's Star Wars™ Franchise

### DIFF
--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -70,7 +70,7 @@
 	//initialize things that are normally initialized after map load
 	parsed.initTemplateBounds()
 	smooth_zlevel(world.maxz)
-	log_game("Z-level [name] loaded at at [x],[y],[world.maxz]")
+	log_game("Z-level [name] loaded at [x],[y],[world.maxz]")
 
 	return level
 
@@ -100,7 +100,7 @@
 	//initialize things that are normally initialized after map load
 	parsed.initTemplateBounds()
 
-	log_game("[name] loaded at at [T.x],[T.y],[T.z]")
+	log_game("[name] loaded at [T.x],[T.y],[T.z]")
 	return bounds
 
 /datum/map_template/proc/get_affected_turfs(turf/T, centered = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
We previously abused Disney's copyright of "at at":

```
[2019-04-01 01:22:51.609] GAME: Blood-Drunk Miner loaded at at 194,162,5
[2019-04-01 01:22:51.621] GAME: Summoning Ritual loaded at at 67,166,5
[2019-04-01 01:22:51.639] GAME: Ruin of Envy loaded at at 91,109,5
[2019-04-01 01:22:51.680] GAME: Biodome Beach loaded at at 149,60,5
[2019-04-01 01:22:51.954] GAME: Syndicate Listening Station loaded at at 48,177,4
[2019-04-01 01:22:51.980] GAME: Whiteship Dock loaded at at 146,84,10
[2019-04-01 01:22:52.045] GAME: Derelict 5 loaded at at 26,150,8
[2019-04-01 01:22:52.077] GAME: Authorship loaded at at 126,154,6
[2019-04-01 01:22:52.140] GAME: Hilbert Research Facility loaded at at 30,106,7
[2019-04-01 01:22:52.225] GAME: DK Excavator 453 loaded at at 145,135,6
```

I've removed it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Won't get sued.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
spellcheck: Removed unlawful reference to Disney's Star Wars franchise in map logging.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
