### PR TITLE
Ash Walker flavor text modification

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -50,7 +50,7 @@
 
 /obj/effect/mob_spawn/human/ash_walker/special(mob/living/new_spawn)
 	new_spawn.fully_replace_character_name(null,random_unique_lizard_name(gender))
-	to_chat(new_spawn, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Glory to the Necropolis!</b>")
+	to_chat(new_spawn, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Don't leave your nest undefended, protect it with your life. Glory to the Necropolis!</b>")
 
 	new_spawn.grant_language(/datum/language/draconic)
 	var/datum/language_holder/holder = new_spawn.get_language_holder()


### PR DESCRIPTION
:cl:
tweak: Ash Walkers have received a modification to their flavor text clarifying their intent to remain on lavaland and protect their nest.
/:cl:

Why:
Because Ash Walkers breaking into mining and rushing off to the station is boring, obnoxious, and only ever fun for the people doing it, usually at the expense of permanently ending several other people's rounds. Ghost roles are not your free respawn to reinvolve yourself in the round, and for a ghost role that is given pseudo antag status this is doubly true. The way I chose to phrase this isn't set in stone, I wanted something that has at least a little bit of *flavor* to it instead of blatantly just writing "DON'T GO TO THE STATION". 

Tweak was just a guess on my part, I don't really feel like this is balance because it mostly concerns how ash walkers are administrated, wherein the primary rule is "Obey your flavor text." If someone bitches and moans about my choice in CL tags I'll change it.