### PR TITLE
The Gobbetting barmaid 2: No Enter Edition

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -100480,7 +100480,7 @@ aaa
 aaf
 aaa
 aaa
-cBR
+aaa
 aaf
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -60878,16 +60878,6 @@
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"cox" = (
-/obj/machinery/door/airlock/wood{
-	doorClose = 'sound/effects/doorcreaky.ogg';
-	doorOpen = 'sound/effects/doorcreaky.ogg';
-	name = "The Gobletting Barmaid"
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/maintenance/port/aft)
 "coy" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -100490,7 +100480,7 @@ aaa
 aaf
 aaa
 aaa
-aaa
+cBR
 aaf
 aaa
 aaa
@@ -100737,7 +100727,7 @@ aaa
 aaf
 aaa
 aaa
-cox
+cBR
 cBR
 cBR
 cBR

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -60138,8 +60138,8 @@
 	},
 /area/maintenance/port/aft)
 "cnl" = (
-/obj/structure/mineral_door/wood{
-	name = "The Gobbetting Barmaid"
+/obj/machinery/door/airlock/wood{
+	name = "The Gobletting Barmaid"
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
@@ -60877,8 +60877,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "cox" = (
-/obj/structure/mineral_door/wood{
-	name = "The Gobbetting Barmaid"
+/obj/machinery/door/airlock/wood{
+	name = "The Gobletting Barmaid"
 	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -60139,6 +60139,8 @@
 /area/maintenance/port/aft)
 "cnl" = (
 /obj/machinery/door/airlock/wood{
+	doorClose = 'sound/effects/doorcreaky.ogg';
+	doorOpen = 'sound/effects/doorcreaky.ogg';
 	name = "The Gobletting Barmaid"
 	},
 /turf/open/floor/wood,
@@ -60878,6 +60880,8 @@
 /area/hallway/secondary/service)
 "cox" = (
 /obj/machinery/door/airlock/wood{
+	doorClose = 'sound/effects/doorcreaky.ogg';
+	doorOpen = 'sound/effects/doorcreaky.ogg';
 	name = "The Gobletting Barmaid"
 	},
 /turf/open/floor/wood{
@@ -100723,7 +100727,7 @@ aaa
 aaf
 aaa
 aaa
-cBR
+cox
 cBR
 cBR
 cBR

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -60141,7 +60141,7 @@
 /obj/machinery/door/airlock/wood{
 	doorClose = 'sound/effects/doorcreaky.ogg';
 	doorOpen = 'sound/effects/doorcreaky.ogg';
-	name = "The Gobletting Barmaid"
+	name = "The Gobetting Barmaid"
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
@@ -83564,6 +83564,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"mrv" = (
+/obj/machinery/door/airlock/wood{
+	doorClose = 'sound/effects/doorcreaky.ogg';
+	doorOpen = 'sound/effects/doorcreaky.ogg';
+	name = "The Gobetting Barmaid"
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/maintenance/port/aft)
 "msD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -101999,7 +102009,7 @@ cjv
 diG
 dux
 cnl
-cox
+mrv
 dux
 diI
 diK


### PR DESCRIPTION
## About The Pull Request
Replaces the wooden doors with wooden airlocks with special opening sounds.

## Why It's Good For The Game
Wooden airlocks are CRIMINALLY underused. They also look nicer than the mineral doors.


## Changelog
:cl:
tweak: Changes the wooden doors on the Meta Maint Bar with wooden airlocks. Sounds are the same.
/:cl: