### PR TITLE
Clown and Mime items can equip to belt and back

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -147,6 +147,7 @@
 	throwforce = 0
 	hitsound = null //To prevent tap.ogg playing, as the item lacks of force
 	w_class = WEIGHT_CLASS_TINY
+	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	throw_speed = 3
 	throw_range = 7
 	attack_verb = list("HONKED")

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -175,6 +175,7 @@
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 	bitesize = 3
 	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	tastes = list("bread" = 1)
 	foodtype = GRAIN
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Here goes my first PR

A lot of equipment can be placed on the back and belt slot. Much of this equipment is job specific. Sadly, the Clown and Mime have been left out of the fun.

## Why It's Good For The Game

Why should all the other jobs have the fun of belt and back slots? Sometimes you want to mosey around the station like a honkin' cowboy, your bikehorn clipped securely to your belt. Now you can. Your trusty honkshooter is ready to go. DRAW!

Or maybe you're a Mime who wants his crusty baguette saber at his side. EN GARDE!

## Changelog
:cl:
tweak: Bike horns and baguettes can now be equipped to belt and back slots!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
