### PR TITLE
Rigged Cell Devastation Range

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -111,7 +111,7 @@
 	var/turf/T = get_turf(src.loc)
 	if (charge==0)
 		return
-	var/devastation_range = -1 //round(charge/11000)
+	var/devastation_range = CLAMP(round(sqrt(charge)/120),0,2)
 	var/heavy_impact_range = round(sqrt(charge)/60)
 	var/light_impact_range = round(sqrt(charge)/30)
 	var/flash_range = light_impact_range


### PR DESCRIPTION
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR allows plasma-rigged power cells to explode with a devastation range (no less than zero, never more than 2).

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I feel that this is a reasonable idea because there's A: an established pattern to plasma cell explosion size, following the square root of charge divided by integer multiples of 30, and B: precedent in the form of prior code which gave plasma cells devastation ranges (that got reverted because it didn't take upper bounds into account, allowing for maxcaps, while this code cannot produce a bomb as good as a singletank).

## Changelog
:cl:
balance: rebalanced something
code: changed some code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
