### PR TITLE
Fix welfare being given to everybody else with the same job

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -177,4 +177,3 @@
 	if(!D) //if their current mob doesn't have a bank account, likely due to them being a special role (ie nuke op)
 		return
 	D.welfare = TRUE
-	D.add_neetbux()

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -436,8 +436,6 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 						return
 					if(modify.registered_account)
 						modify.registered_account.account_job = jobdatum // this is a terrible idea and people will grief but sure whatever
-						if(modify.registered_account.welfare)
-							modify.registered_account.add_neetbux()
 
 					modify.access = ( istype(src, /obj/machinery/computer/card/centcom) ? get_centcom_access(t1) : jobdatum.get_access() )
 				if (modify)

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -5,7 +5,7 @@
 	var/list/bank_cards = list()
 	var/add_to_accounts = TRUE
 	var/account_id
-	var/welfare = TRUE
+	var/welfare = FALSE
 
 /datum/bank_account/New(newname, job)
 	if(add_to_accounts)
@@ -41,12 +41,15 @@
 	return FALSE
 
 /datum/bank_account/proc/payday(amt_of_paychecks, free = FALSE)
+	var/money_to_transfer = account_job.paycheck * amt_of_paychecks
+	if(welfare)
+		money_to_transfer += PAYCHECK_WELFARE
 	if(free)
-		adjust_money(account_job.paycheck * amt_of_paychecks)
+		adjust_money(money_to_transfer)
 	else
 		var/datum/bank_account/D = SSeconomy.get_dep_account(account_job.paycheck_department)
 		if(D)
-			if(!transfer_money(D, account_job.paycheck * amt_of_paychecks))
+			if(!transfer_money(D, money_to_transfer))
 				bank_card_talk("ERROR: Payday aborted, departmental funds insufficient.")
 				return FALSE
 			else
@@ -54,10 +57,6 @@
 				return TRUE
 	bank_card_talk("ERROR: Payday aborted, unable to contact departmental account.")
 	return FALSE
-
-
-/datum/bank_account/proc/add_neetbux()
-	account_job.paycheck += PAYCHECK_WELFARE
 
 /datum/bank_account/proc/bank_card_talk(message, force)
 	if(!message || !bank_cards.len)


### PR DESCRIPTION
Opening this PR on behalf of Goof so the other maintainers can look at it.

~~Need to examine the validity of the bug #42387 and whether this actually fixes it, the ticket specifies the following:~~

> ~~1. Spawn as NEET assistant: start with 25$ in account, 25$ payout~~
> ~~2. Respawn as assistant but without NEET: get 125$ in account, still get welfare~~

~~but the use of "Respawn" suggests to me that there may be overlap with #43319.~~

The bug is real and as far as I can tell this really fixes it.

:cl: Iamgoofball
fix: Characters with the NEET quirk no longer also give welfare to everybody else with the same job.
tweak: NEETs only receive one welfare check at roundstart rather than five.
/:cl: