### PR TITLE
Gives space cleaner the ability to clean people

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1011,6 +1011,7 @@
 			var/mob/living/carbon/C = M
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
+				H.adjust_hygiene((30 * reac_volume) / (3 + reac_volume))
 				if(H.lip_style)
 					H.lip_style = null
 					H.update_body()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Space cleaner sprayed, splashed or vaporised onto someone will slightly improve their hygiene. Effective janitors can spray stinky spessmen to stave off the stench long enough for the offender to have a shower. Space cleaner will only stop you from stinking for a short time, unlike a shower which will keep you fresh for much longer.

The amount of cleanliness from a single application of space cleaner is capped, so a chemist dumping a bluespace beaker of space cleaner on their head is not going to be as effective as a shower.

## Why It's Good For The Game

Giving janitors an extra way to help the crew is probably good, especially because this additional mechanic can't be replaced by janiborgs or cleanbots.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Space cleaner improves hygiene by a small amount.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
