### PR TITLE
Captain now requires playtime as another head role

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -13,6 +13,7 @@
 	minimal_player_age = 14
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
+	exp_type_department = EXP_TYPE_COMMAND
 
 	outfit = /datum/outfit/job/captain
 


### PR DESCRIPTION
By default (assuming the department based exp lockout config is enabled), hos requires 5 hours as security. but the captain only requires 3 hours as crew?

Seems silly. 

@iamgoofball I wonder if banned accounts still get notifications.

Somebody with more time than me: make the config for these use a keyed list for per-job overrides, rather than a flat head override.

Somebody else with more time than me: make a config that allows readying for time restricted roles anyways, but only at low priority.

## Changelog
:cl:
tweak: Unlocking the captain role now uses the department based job unlock system, to unlock captain, you must acquire the required play time (default 3 hours) as head of staff, rather than as any crew member.
/:cl: