### PR TITLE
Tweaks blood deficiency to be less deadly by itself

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -16,7 +16,7 @@
 		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "back_pain")
 
 /datum/quirk/blooddeficiency
-	name = "Acute Blood Deficiency"
+	name = "Blood Deficiency"
 	desc = "Your body can't produce enough blood to sustain itself."
 	value = -2
 	gain_text = "<span class='danger'>You feel your vigor slowly fading away.</span>"
@@ -28,7 +28,8 @@
 	if(NOBLOOD in H.dna.species.species_traits) //can't lose blood if your species doesn't have any
 		return
 	else
-		quirk_holder.blood_volume -= 0.275
+		if (H.blood_volume > (BLOOD_VOLUME_SAFE - 25)) // just barely survivable without treatment
+			H.blood_volume -= 0.275
 
 /datum/quirk/blindness
 	name = "Blind"


### PR DESCRIPTION
:cl:
tweak: Renamed Acute Blood Deficiency to Blood Deficiency.
balance: Blood Deficiency is no longer deadly by itself if left untreated, but will still leave your blood count dangerously low.
/:cl:
I came to the conclusion that quirks that put you on a death timer are dumb and boring, one such reason being they make you unable to go AFK for any length of time but also aren't interesting to manage other than lugging around whatever medicine you need to survive every round.

Blood loss now stops just above a survivable threshold, meaning when left untreated even the smallest of wounds is potentially lethal, hence it's still 2 points. Watch out for paper cuts.

Renamed just to make it a bit shorter and less spooky.

On a relevant note, BLOOD_VOLUME_OKAY is by no definition "okay"