### PR TITLE
Fixes the CHECK_MULTIPLE_BITFIELDS macro

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -12,7 +12,7 @@
 
 
 //check if all bitflags specified are present
-#define CHECK_MULTIPLE_BITFIELDS(flagvar, flags) ((flagvar & (flags)) == (flags))
+#define CHECK_MULTIPLE_BITFIELDS(flagvar, flags) (((flagvar) & (flags)) == (flags))
 
 GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768))
 

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -12,7 +12,7 @@
 
 
 //check if all bitflags specified are present
-#define CHECK_MULTIPLE_BITFIELDS(flagvar, flags) ((flagvar & (flags)) == flags)
+#define CHECK_MULTIPLE_BITFIELDS(flagvar, flags) ((flagvar & (flags)) == (flags))
 
 GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768))
 


### PR DESCRIPTION
## About The Pull Request

Found by TGMC people, the CHECK_MULTIPLE_BITFIELDS macro wasn't parenthesing the == rvalue, so

`CHECK_MULTIPLE_BITFIELDS(var, flag1 | flag 2)`

 would come as
`(var & (flag 1 | flag 2)) == flag 1 | flag2`

instead of
`(var & (flag 1 | flag 2)) == (flag 1 | flag2)`

making the check always pass when a second flag was checked.

Only `/datum/component/footstep/proc/play_footstep()` was using it in that way though and it doesn't seems it was impacting it much.