### PR TITLE
Update canister icons when connected to a port

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -366,20 +366,22 @@
 	if(timing && valve_timer < world.time)
 		valve_open = !valve_open
 		timing = FALSE
-	if(!valve_open)
+	if(valve_open)
+		var/turf/T = get_turf(src)
+		pump.airs[1] = air_contents
+		pump.airs[2] = holding ? holding.air_contents : T.return_air()
+		pump.target_pressure = release_pressure
+
+		pump.process_atmos() // Pump gas.
+		if(!holding)
+			air_update_turf() // Update the environment if needed.
+	else
 		pump.airs[1] = null
 		pump.airs[2] = null
-		return
 
-	var/turf/T = get_turf(src)
-	pump.airs[1] = air_contents
-	pump.airs[2] = holding ? holding.air_contents : T.return_air()
-	pump.target_pressure = release_pressure
+	if(connected_port || valve_open)
+		update_icon()
 
-	pump.process_atmos() // Pump gas.
-	if(!holding)
-		air_update_turf() // Update the environment if needed.
-	update_icon()
 
 /obj/machinery/portable_atmospherics/canister/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 															datum/tgui/master_ui = null, datum/ui_state/state = GLOB.physical_state)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -379,9 +379,7 @@
 		pump.airs[1] = null
 		pump.airs[2] = null
 
-	if(connected_port || valve_open)
-		update_icon()
-
+	update_icon()
 
 /obj/machinery/portable_atmospherics/canister/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 															datum/tgui/master_ui = null, datum/ui_state/state = GLOB.physical_state)


### PR DESCRIPTION
## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/43500.
I found that when the valve of a canister was closed, the `.../canister/process_atmos` proc would never reach its `update_icon` call. I've fixed that by removing the early return and having a single update_icon call at the end run when necessary.

## Changelog
:cl:
fix: Fixed canister pressure indicators not updating when canisters are attached to a connector
/:cl:
