### PR TITLE
Fix chem dispensers starting with an extra power cell

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -9,7 +9,6 @@
 	interaction_flags_machine = INTERACT_MACHINE_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OFFLINE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	circuit = /obj/item/circuitboard/machine/chem_dispenser
-	var/cell_type = /obj/item/stock_parts/cell/high
 	var/obj/item/stock_parts/cell/cell
 	var/powerefficiency = 0.1
 	var/amount = 30
@@ -70,7 +69,6 @@
 
 /obj/machinery/chem_dispenser/Initialize()
 	. = ..()
-	cell = new cell_type
 	dispensable_reagents = sortList(dispensable_reagents)
 	update_icon()
 


### PR DESCRIPTION
Fixes #43508.

:cl:
fix: Disassembling a chem dispenser for the first time will no longer always yield a fully-charged cell.
/:cl: