### PR TITLE
Fix runtime when setting up a sec character before atoms initialize

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -57,7 +57,8 @@
 	fire_delay = shot.delay
 
 /obj/item/gun/energy/Destroy()
-	QDEL_NULL(cell)
+	if (cell)
+		QDEL_NULL(cell)
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 


### PR DESCRIPTION
Destroy QDEL_NULLs `cell` but `cell` hasn't been set because Initialize hasn't run yet.

fixes #43211
```
runtime error: bad del
 - proc name: qdel (/proc/qdel)
 -   source file: garbage.dm,255
 -   usr: [REDACTED] (/mob/dead/new_player)
 -   src: null
 -   usr.loc: the plating (8,174,1) (/turf/open/floor/plating)
 -   call stack:
 - qdel(null, 0)
 - the disabler (/obj/item/gun/energy/disabler): Destroy(0)
 - the disabler (/obj/item/gun/energy/disabler): Destroy(0)
 - qdel(the disabler (/obj/item/gun/energy/disabler), 0)
 - [REDACTED] (/mob/living/carbon/human/dummy): equip to slot if possible(the disabler (/obj/item/gun/energy/disabler), 17, 1, 1, 0, 1)
 - [REDACTED] (/mob/living/carbon/human/dummy): equip to slot or del(the disabler (/obj/item/gun/energy/disabler), 17)
 - Security Officer (/datum/outfit/job/security): equip([REDACTED] (/mob/living/carbon/human/dummy), 1)
 - [REDACTED] (/mob/living/carbon/human/dummy): equipOutfit(/datum/outfit/job/security (/datum/outfit/job/security), 1)
 - /datum/job/officer (/datum/job/officer): equip([REDACTED] (/mob/living/carbon/human/dummy), 1, 1, 0, null, [REDACTED] (/client))
 - /datum/preferences (/datum/preferences): update preview icon()
 - /datum/preferences (/datum/preferences): ShowChoices([REDACTED] (/mob/dead/new_player))
 - [REDACTED] (/mob/dead/new_player): Topic("src=\[mob_51];show_preferences...", /list (/list))
 - [REDACTED] (/client): Topic("src=\[mob_51];show_preferences...", /list (/list), [REDACTED] (/mob/dead/new_player))
 - [REDACTED] (/client): Topic("src=\[mob_51];show_preferences...", /list (/list), [REDACTED] (/mob/dead/new_player))
```