### PR TITLE
Adds friendly life reaction to chemistry

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -519,7 +519,7 @@
 /datum/chemical_reaction/life_friendly
 	name = "Life (Friendly)"
 	id = "life_friendly"
-	required_reagents = list("strange_reagent" = 1, "synthflesh" = 1, "pax" = 1)
+	required_reagents = list("strange_reagent" = 1, "synthflesh" = 1, "sugar" = 1)
 	required_temp = 374
 
 /datum/chemical_reaction/life_friendly/on_reaction(datum/reagents/holder, created_volume)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -514,7 +514,7 @@
 	required_temp = 374
 
 /datum/chemical_reaction/life/on_reaction(datum/reagents/holder, created_volume)
-	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life") // Lol.
+	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life (hostile)") //defaults to HOSTILE_SPAWN
 
 /datum/chemical_reaction/life_friendly
 	name = "Life (Friendly)"
@@ -523,7 +523,7 @@
 	required_temp = 374
 
 /datum/chemical_reaction/life_friendly/on_reaction(datum/reagents/holder, created_volume)
-	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life (Friendly)", FRIENDLY_SPAWN)
+	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life (friendly)", FRIENDLY_SPAWN)
 
 /datum/chemical_reaction/corgium
 	name = "corgium"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -516,6 +516,15 @@
 /datum/chemical_reaction/life/on_reaction(datum/reagents/holder, created_volume)
 	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life") // Lol.
 
+/datum/chemical_reaction/life_friendly
+	name = "Life (Friendly)"
+	id = "life_friendly"
+	required_reagents = list("strange_reagent" = 1, "synthflesh" = 1, "blood" = 1, "pax" = 1)
+	required_temp = 374
+
+/datum/chemical_reaction/life_friendly/on_reaction(datum/reagents/holder, created_volume)
+	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life (Friendly)", FRIENDLY_SPAWN)
+
 /datum/chemical_reaction/corgium
 	name = "corgium"
 	id = "corgium"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -519,7 +519,7 @@
 /datum/chemical_reaction/life_friendly
 	name = "Life (Friendly)"
 	id = "life_friendly"
-	required_reagents = list("strange_reagent" = 1, "synthflesh" = 1, "blood" = 1, "pax" = 1)
+	required_reagents = list("strange_reagent" = 1, "synthflesh" = 1, "pax" = 1)
 	required_temp = 374
 
 /datum/chemical_reaction/life_friendly/on_reaction(datum/reagents/holder, created_volume)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds a version of the Life reaction that spawns friendly mobs instead of hostile ones.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Chemistry is missing some reactions that aren't just for killing or healing people. With this you can spawn non-hostile mobs, which can be useful for things like the DNA vault or cargo bounties.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
add: Added a friendly version of the Life reaction to chemistry. It has a similar recipe as the original reaction, just replace blood with sugar.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
