### PR TITLE
Fix convert_roundtype runtiming instead of failing gracefully

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -139,7 +139,7 @@
 		else
 			qdel(G)
 
-	if(!usable_modes)
+	if(!usable_modes.len)
 		message_admins("Convert_roundtype failed due to no valid modes to convert to. Please report this error to the Coders.")
 		return null
 


### PR DESCRIPTION
If the list is empty
```
runtime error: Cannot read null.protected_jobs
 - proc name: convert roundtype (/datum/game_mode/proc/convert_roundtype)
 -   source file: game_mode.dm,173
 -   usr: null
 -   src: traitor (/datum/game_mode/traitor)
 -   call stack:
 - traitor (/datum/game_mode/traitor): convert roundtype()
 - traitor (/datum/game_mode/traitor): check finished(0)
 - Ticker (/datum/controller/subsystem/ticker): fire(0)
 - Ticker (/datum/controller/subsystem/ticker): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop()
 - Master (/datum/controller/master): StartProcessing(0)
 - 
```