### PR TITLE
Catastrophic vent clog event uses random reagents

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -71,7 +71,7 @@
 	earliest_start = 45 MINUTES
 
 /datum/round_event/vent_clog/catastrophic
-	randomProbability = 30
+	randomProbability = 100
 	reagentsAmount = 250
 
 /datum/round_event_control/vent_clog/beer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The catastrophic vent clogging event now uses completely random reagents.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Considering how rare it is, the catastrophic vent clog event always feels kind of underwhelming compared to the threatening version. With completely random reagents, it'll be a lot more unpredictable. You might get flour, or you might get plasma.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The catastrophic vent clogging event now uses completely random reagents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
