### PR TITLE
Fix incorrect APC pixel offsets in maps

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -236,7 +236,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 8;
 	name = "Chemistry APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -583,7 +583,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 1;
 	name = "Cargo Bay APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/dirt,
@@ -1297,7 +1297,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 1;
 	name = "Virology APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -1329,7 +1329,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 2;
 	name = "Experimentation Lab APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -3184,7 +3184,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 2;
 	name = "Dormitories APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -3348,7 +3348,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 8;
 	name = "Primary Hallway APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4084,7 +4084,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 1;
 	name = "Engineering APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -5003,7 +5003,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 2;
 	name = "Bar APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/bar)
@@ -5480,7 +5480,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 1;
 	name = "Arrival Hallway APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -6032,7 +6032,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 2;
 	name = "Telecommunications APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -296,7 +296,7 @@
 	equipment = 0;
 	lighting = 0;
 	name = "Starboard Solar APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -599,7 +599,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Worn-out APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -3802,7 +3802,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Worn-out APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
@@ -3826,7 +3826,7 @@
 	areastring = "/area/ruin/space/derelict/atmospherics";
 	dir = 1;
 	name = "Worn-out APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -4143,7 +4143,7 @@
 	equipment = 0;
 	lighting = 0;
 	name = "Worn-out APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/se_solar)

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -333,7 +333,7 @@
 	equipment = 0;
 	lighting = 0;
 	name = "Worn-out APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -814,7 +814,7 @@
 	start_charge = 0;
 	dir = 4;
 	name = "Power Storage APC";
-	pixel_x = 23;
+	pixel_x = 24;
 	pixel_y = 2
 	},
 /obj/structure/cable{
@@ -925,7 +925,7 @@
 	start_charge = 0;
 	dir = 2;
 	name = "Tradepost APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -98,7 +98,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Tiny Freighter APC";
-	pixel_x = -24;
+	pixel_x = -25;
 	req_access = null;
 	start_charge = 0
 	},
@@ -244,7 +244,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Tiny Freighter APC";
-	pixel_x = -24;
+	pixel_x = -25;
 	req_access = null;
 	start_charge = 0
 	},

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -499,7 +499,7 @@
 	dir = 1;
 	environ = 0;
 	equipment = 3;
-	pixel_y = 32;
+	pixel_y = 23;
 	req_access = null
 	},
 /turf/open/floor/carpet,
@@ -877,7 +877,7 @@
 	dir = 1;
 	environ = 0;
 	equipment = 3;
-	pixel_y = 32;
+	pixel_y = 23;
 	req_access = null
 	},
 /turf/open/floor/plating,
@@ -1198,7 +1198,7 @@
 	},
 /obj/machinery/power/apc/unlocked{
 	dir = 1;
-	pixel_y = 28;
+	pixel_y = 23;
 	req_access = null
 	},
 /obj/effect/turf_decal/tile/bar,

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -144,7 +144,7 @@
 /obj/machinery/power/apc/away{
 	dir = 2;
 	name = "Recycling APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/crusher)
@@ -694,7 +694,7 @@
 /obj/machinery/power/apc/away{
 	dir = 2;
 	name = "Kitchen APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
@@ -1762,7 +1762,7 @@
 /obj/machinery/power/apc/away{
 	dir = 2;
 	name = "Main Area APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -2172,7 +2172,7 @@
 /obj/machinery/power/apc/away{
 	dir = 1;
 	name = "Airlock Control APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -175,7 +175,7 @@
 	dir = 1;
 	name = "Worn-out APC";
 	pixel_x = 1;
-	pixel_y = 26
+	pixel_y = 23
 	},
 /obj/machinery/light{
 	dir = 1

--- a/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
@@ -47,7 +47,7 @@
 	dir = 1;
 	name = "Worn-out APC";
 	pixel_x = 1;
-	pixel_y = 26
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -1444,7 +1444,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Charlie Security APC";
-	pixel_x = -24;
+	pixel_x = -25;
 	start_charge = 0
 	},
 /obj/effect/turf_decal/tile/red{
@@ -2281,7 +2281,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Delta Main Corridor APC";
-	pixel_y = 24;
+	pixel_y = 23;
 	start_charge = 0
 	},
 /turf/open/floor/plating,
@@ -2577,7 +2577,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Charlie Hydroponics APC";
-	pixel_y = 24;
+	pixel_y = 23;
 	start_charge = 0
 	},
 /obj/structure/cable{
@@ -2614,7 +2614,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Charlie Kitchen APC";
-	pixel_y = -24;
+	pixel_y = -23;
 	start_charge = 0
 	},
 /obj/structure/cable{
@@ -4352,7 +4352,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Delta Prototype Lab APC";
-	pixel_y = 24;
+	pixel_y = 23;
 	start_charge = 0
 	},
 /obj/structure/cable{

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -233,7 +233,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Crew Quarters APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/onehalf/dorms_med)
@@ -324,7 +324,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Mining Drone Bay APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -603,7 +603,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Hallway APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/onehalf/hallway)
@@ -781,7 +781,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Bridge APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/bridge)

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -483,7 +483,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Guest Room APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -531,7 +531,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Guest Room APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -579,7 +579,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Guest Room APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -627,7 +627,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Guest Room APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -1070,7 +1070,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Guest Room APC";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -1131,7 +1131,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Guest Room APC";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -1460,7 +1460,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Laundry APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -1653,7 +1653,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Kitchen APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -2494,7 +2494,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Staff Room APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -2866,7 +2866,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Power Storage APC";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -3041,7 +3041,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Security APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3088,7 +3088,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Pool APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3137,7 +3137,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Dock APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -4875,7 +4875,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Custodial APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{

--- a/_maps/RandomZLevels/Academy.dmm
+++ b/_maps/RandomZLevels/Academy.dmm
@@ -48,7 +48,7 @@
 	dir = 1;
 	environ = 3;
 	equipment = 3;
-	pixel_y = 32;
+	pixel_y = 23;
 	req_access = null
 	},
 /turf/open/floor/carpet,
@@ -1284,7 +1284,7 @@
 	dir = 1;
 	environ = 3;
 	equipment = 3;
-	pixel_y = 32;
+	pixel_y = 23;
 	req_access = null
 	},
 /turf/open/floor/plasteel/grimy,
@@ -2539,7 +2539,7 @@
 	dir = 1;
 	environ = 3;
 	equipment = 3;
-	pixel_y = 32;
+	pixel_y = 23;
 	req_access = null
 	},
 /turf/open/floor/plasteel,
@@ -3571,7 +3571,7 @@
 	dir = 1;
 	environ = 3;
 	equipment = 3;
-	pixel_y = 32;
+	pixel_y = 23;
 	req_access = null
 	},
 /obj/structure/cable{
@@ -3915,7 +3915,7 @@
 "lp" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	pixel_y = 32
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"

--- a/_maps/RandomZLevels/Cabin.dmm
+++ b/_maps/RandomZLevels/Cabin.dmm
@@ -105,7 +105,8 @@
 "av" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "cabin APC"
+	name = "cabin APC";
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"

--- a/_maps/RandomZLevels/VR/snowdin_VR.dmm
+++ b/_maps/RandomZLevels/VR/snowdin_VR.dmm
@@ -641,7 +641,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Dorms APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -804,7 +804,7 @@
 	dir = 1;
 	name = "Kitchen APC";
 	pixel_x = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -1853,7 +1853,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Gateway APC";
-	pixel_y = -24;
+	pixel_y = -23;
 	req_access = 150
 	},
 /obj/structure/cable/yellow{
@@ -1870,7 +1870,7 @@
 	dir = 1;
 	name = "Research Center APC";
 	pixel_x = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1899,7 +1899,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Mess Hall APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -2503,7 +2503,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Outpost Hallway APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -3046,7 +3046,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Garage APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -4824,7 +4824,7 @@
 	dir = 1;
 	name = "Custodials APC";
 	pixel_x = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -6249,7 +6249,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Engineering APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -6552,7 +6552,7 @@
 	dir = 1;
 	name = "Security Outpost APC";
 	pixel_x = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -6749,7 +6749,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Hydroponics APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -8237,7 +8237,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Main Outpost APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -8924,7 +8924,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Main Outpost APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -9940,7 +9940,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Main Outpost APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
@@ -11706,7 +11706,7 @@
 	dir = 1;
 	name = "Recon Post APC";
 	pixel_x = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -14081,7 +14081,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Robotics APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -14591,7 +14591,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Main Outpost APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14605,7 +14605,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Mechbay APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -15358,7 +15358,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Mining Post APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -1410,7 +1410,7 @@
 	dir = 2;
 	locked = 1;
 	name = "Worn-out APC";
-	pixel_y = -25;
+	pixel_y = -23;
 	req_access = null;
 	req_access_txt = "150";
 	start_charge = 0
@@ -3413,7 +3413,7 @@
 	dir = 4;
 	locked = 0;
 	name = "Worn-out APC";
-	pixel_x = 25;
+	pixel_x = 24;
 	req_access = null;
 	start_charge = 100
 	},
@@ -4980,7 +4980,7 @@
 	dir = 1;
 	locked = 0;
 	name = "Worn-out APC";
-	pixel_y = 25;
+	pixel_y = 23;
 	req_access = null;
 	start_charge = 100
 	},

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -412,7 +412,7 @@
 	auto_name = 1;
 	dir = 4;
 	name = "Engineering APC";
-	pixel_x = 27;
+	pixel_x = 24;
 	pixel_y = 2
 	},
 /turf/open/floor/plating,
@@ -4457,7 +4457,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Security APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -5903,7 +5903,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Medbay APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plating,
 /area/awaymission/research/interior/medbay)
@@ -5925,7 +5925,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Escape APC";
-	pixel_y = -24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -641,7 +641,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Dorms APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -804,7 +804,7 @@
 	dir = 1;
 	name = "Kitchen APC";
 	pixel_x = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -1853,7 +1853,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Gateway APC";
-	pixel_y = -24;
+	pixel_y = -23;
 	req_access = 150
 	},
 /obj/structure/cable/yellow{
@@ -1870,7 +1870,7 @@
 	dir = 1;
 	name = "Research Center APC";
 	pixel_x = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1899,7 +1899,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Mess Hall APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -2503,7 +2503,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Outpost Hallway APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -3058,7 +3058,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Garage APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -4840,7 +4840,7 @@
 	dir = 1;
 	name = "Custodials APC";
 	pixel_x = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -6300,7 +6300,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Engineering APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -6603,7 +6603,7 @@
 	dir = 1;
 	name = "Security Outpost APC";
 	pixel_x = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -6800,7 +6800,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Hydroponics APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -8333,7 +8333,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Main Outpost APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -9032,7 +9032,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Main Outpost APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -10048,7 +10048,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Main Outpost APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
@@ -11832,7 +11832,7 @@
 	dir = 1;
 	name = "Recon Post APC";
 	pixel_x = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -14226,7 +14226,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Robotics APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -14740,7 +14740,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Main Outpost APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14754,7 +14754,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Mechbay APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -15510,7 +15510,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Mining Post APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -2549,7 +2549,7 @@
 	dir = 2;
 	locked = 0;
 	name = "Hydroponics APC";
-	pixel_y = -25;
+	pixel_y = -23;
 	req_access = null;
 	start_charge = 100
 	},
@@ -5013,7 +5013,7 @@
 	dir = 1;
 	locked = 0;
 	name = "UO45 Bar APC";
-	pixel_y = 25;
+	pixel_y = 23;
 	req_access = null;
 	start_charge = 100
 	},
@@ -6161,7 +6161,7 @@
 	dir = 2;
 	locked = 0;
 	name = "UO45 Research Division APC";
-	pixel_y = -25;
+	pixel_y = -23;
 	req_access = null;
 	start_charge = 100
 	},
@@ -6719,7 +6719,7 @@
 	dir = 2;
 	locked = 0;
 	name = "UO45 Gateway APC";
-	pixel_y = -25;
+	pixel_y = -23;
 	req_access = null;
 	start_charge = 100
 	},
@@ -10227,7 +10227,7 @@
 	dir = 2;
 	locked = 0;
 	name = "UO45 Mining APC";
-	pixel_y = -25;
+	pixel_y = -23;
 	req_access = null;
 	start_charge = 100
 	},

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1757,7 +1757,7 @@
 	dir = 8;
 	areastring = "/area/crew_quarters/heads/hos";
 	name = "Head of Security's Office APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -2964,7 +2964,7 @@
 	dir = 2;
 	name = "Prisoner Transfer Centre";
 	areastring = "/area/security/execution/transfer";
-	pixel_y = -27
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
@@ -3595,7 +3595,7 @@
 	dir = 8;
 	name = "Brig Control APC";
 	areastring = "/area/security/warden";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -4708,7 +4708,7 @@
 	dir = 1;
 	name = "Brig APC";
 	areastring = "/area/security/brig";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -5815,7 +5815,7 @@
 	dir = 8;
 	name = "Courtroom APC";
 	areastring = "/area/security/courtroom";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -6938,7 +6938,7 @@
 	dir = 2;
 	name = "Fitness Room APC";
 	areastring = "/area/crew_quarters/fitness";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -7139,7 +7139,7 @@
 	dir = 1;
 	name = "Fore Maintenance APC";
 	areastring = "/area/maintenance/fore/secondary";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7445,7 +7445,7 @@
 	dir = 2;
 	name = "Dormitory APC";
 	areastring = "/area/crew_quarters/dorms";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -7656,7 +7656,7 @@
 	name = "Port Bow Maintenance APC";
 	areastring = "/area/maintenance/port/fore";
 	pixel_x = -1;
-	pixel_y = 26
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -7686,7 +7686,7 @@
 	dir = 8;
 	name = "Labor Shuttle Dock APC";
 	areastring = "/area/security/processing";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -7849,7 +7849,7 @@
 	dir = 1;
 	name = "Starboard Bow Maintenance APC";
 	areastring = "/area/maintenance/starboard/fore";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -9478,7 +9478,7 @@
 	dir = 1;
 	name = "Electrical Maintenance APC";
 	areastring = "/area/maintenance/department/electrical";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -9619,7 +9619,7 @@
 	dir = 1;
 	name = "Fore Maintenance APC";
 	areastring = "/area/maintenance/fore";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -10743,7 +10743,7 @@
 	dir = 1;
 	name = "EVA Storage APC";
 	areastring = "/area/ai_monitored/storage/eva";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -11344,7 +11344,7 @@
 	name = "Security Checkpoint APC";
 	areastring = "/area/security/checkpoint/auxiliary";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11494,7 +11494,7 @@
 	dir = 4;
 	name = "Garden APC";
 	areastring = "/area/hydroponics/garden";
-	pixel_x = 27;
+	pixel_x = 24;
 	pixel_y = 2
 	},
 /obj/structure/cable{
@@ -11612,7 +11612,7 @@
 	name = "Primary Tool Storage APC";
 	areastring = "/area/storage/primary";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -11795,7 +11795,7 @@
 	dir = 8;
 	name = "Gateway APC";
 	areastring = "/area/gateway";
-	pixel_x = -24;
+	pixel_x = -25;
 	pixel_y = -1
 	},
 /obj/structure/cable{
@@ -12077,7 +12077,7 @@
 	dir = 1;
 	name = "Vault APC";
 	areastring = "/area/ai_monitored/nuke_storage";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -13077,7 +13077,7 @@
 	dir = 2;
 	name = "Chapel APC";
 	areastring = "/area/chapel/main";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -13451,7 +13451,7 @@
 	dir = 4;
 	name = "Dormitory Bathrooms APC";
 	areastring = "/area/crew_quarters/toilet";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -13575,7 +13575,7 @@
 	dir = 2;
 	name = "Chapel Office APC";
 	areastring = "/area/chapel/office";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14780,7 +14780,7 @@
 	dir = 2;
 	name = "Bar APC";
 	areastring = "/area/crew_quarters/bar";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14831,7 +14831,7 @@
 	dir = 2;
 	name = "Kitchen APC";
 	areastring = "/area/crew_quarters/kitchen";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14892,7 +14892,7 @@
 	dir = 2;
 	name = "Hydroponics APC";
 	areastring = "/area/hydroponics";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -15678,7 +15678,7 @@
 	dir = 8;
 	name = "Auxillary Base Construction APC";
 	areastring = "/area/construction/mining/aux_base";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -16260,7 +16260,7 @@
 	name = "Port Hall APC";
 	areastring = "/area/hallway/primary/port";
 	dir = 1;
-	pixel_y = 26
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -18653,7 +18653,7 @@
 	dir = 1;
 	name = "Auxiliary Tool Storage APC";
 	areastring = "/area/storage/tools";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -19851,7 +19851,7 @@
 	dir = 8;
 	name = "Fore Primary Hallway APC";
 	areastring = "/area/hallway/primary/fore";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -20416,7 +20416,7 @@
 	dir = 1;
 	name = "Art Storage";
 	areastring = "/area/storage/art";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20457,7 +20457,7 @@
 	dir = 1;
 	name = "Port Emergency Storage APC";
 	areastring = "/area/storage/emergency/port";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -20719,7 +20719,7 @@
 	dir = 2;
 	name = "Bridge APC";
 	areastring = "/area/bridge";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /obj/machinery/light,
@@ -21191,7 +21191,7 @@
 	dir = 8;
 	name = "Port Maintenance APC";
 	areastring = "/area/maintenance/port";
-	pixel_x = -27;
+	pixel_x = -25;
 	pixel_y = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -21477,7 +21477,7 @@
 	dir = 2;
 	name = "Central Hall APC";
 	areastring = "/area/hallway/primary/central";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue,
@@ -22298,7 +22298,7 @@
 	dir = 4;
 	name = "Locker Restrooms APC";
 	areastring = "/area/crew_quarters/toilet/locker";
-	pixel_x = 27;
+	pixel_x = 24;
 	pixel_y = 2
 	},
 /obj/structure/cable{
@@ -22548,7 +22548,7 @@
 	dir = 1;
 	name = "Captain's Office APC";
 	areastring = "/area/crew_quarters/heads/captain";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -22646,7 +22646,7 @@
 	dir = 8;
 	name = "Vacant Office APC";
 	areastring = "/area/vacant_room/office";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -23478,7 +23478,7 @@
 	dir = 8;
 	name = "Disposal APC";
 	areastring = "/area/maintenance/disposal";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -23566,7 +23566,7 @@
 	dir = 2;
 	name = "Upload APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -24008,7 +24008,7 @@
 	dir = 1;
 	name = "Locker Room APC";
 	areastring = "/area/crew_quarters/locker";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -24078,7 +24078,7 @@
 	name = "Cargo Bay APC";
 	areastring = "/area/quartermaster/storage";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -24265,7 +24265,7 @@
 	dir = 2;
 	name = "Starboard Primary Hallway APC";
 	areastring = "/area/hallway/primary/starboard";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
@@ -24450,7 +24450,7 @@
 	dir = 4;
 	name = "Mech Bay APC";
 	areastring = "/area/science/robotics/mechbay";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -24713,7 +24713,7 @@
 	dir = 1;
 	name = "Chemistry APC";
 	areastring = "/area/medical/chemistry";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -24870,7 +24870,7 @@
 	dir = 1;
 	name = "Morgue APC";
 	areastring = "/area/medical/morgue";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -26627,7 +26627,7 @@
 	dir = 1;
 	name = "Starboard Emergency Storage APC";
 	areastring = "/area/storage/emergency/starboard";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -28477,7 +28477,7 @@
 	dir = 1;
 	name = "Genetics APC";
 	areastring = "/area/medical/genetics";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -30056,7 +30056,7 @@
 	dir = 8;
 	name = "Teleporter APC";
 	areastring = "/area/teleporter";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -30215,7 +30215,7 @@
 	name = "Cargo Office APC";
 	areastring = "/area/quartermaster/office";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -32039,7 +32039,7 @@
 	dir = 1;
 	name = "Quartermaster APC";
 	areastring = "/area/quartermaster/qm";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -32095,7 +32095,7 @@
 	dir = 1;
 	name = "Mining Dock APC";
 	areastring = "/area/quartermaster/miningdock";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -32502,7 +32502,7 @@
 	dir = 1;
 	name = "Server Room APC";
 	areastring = "/area/science/server";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -32860,7 +32860,7 @@
 	name = "Cargo Security APC";
 	areastring = "/area/security/checkpoint/supply";
 	pixel_x = 1;
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -33638,7 +33638,7 @@
 	dir = 2;
 	name = "Science Security APC";
 	areastring = "/area/security/checkpoint/science";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -34308,7 +34308,7 @@
 	dir = 1;
 	name = "Tech Storage APC";
 	areastring = "/area/storage/tech";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -34327,7 +34327,7 @@
 	dir = 4;
 	name = "Treatment Center APC";
 	areastring = "/area/medical/sleeper";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -34995,7 +34995,7 @@
 	dir = 8;
 	name = "Custodial Closet APC";
 	areastring = "/area/janitor";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -35326,7 +35326,7 @@
 	dir = 4;
 	name = "Toxins Lab APC";
 	areastring = "/area/science/mixing";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -36084,7 +36084,7 @@
 	dir = 8;
 	name = "Aft Maintenance APC";
 	areastring = "/area/maintenance/aft";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -37384,7 +37384,7 @@
 	dir = 1;
 	name = "CM Office APC";
 	areastring = "/area/crew_quarters/heads/cmo";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -37563,7 +37563,7 @@
 	areastring = "/area/science/mixing/chamber";
 	dir = 8;
 	name = "Toxins Chamber APC";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -37721,7 +37721,7 @@
 	name = "Delivery Office APC";
 	areastring = "/area/quartermaster/sorting";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -38889,7 +38889,7 @@
 	dir = 8;
 	name = "Engineering Security APC";
 	areastring = "/area/security/checkpoint/engineering";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -39168,7 +39168,7 @@
 	dir = 4;
 	name = "Testing Lab APC";
 	areastring = "/area/science/misc_lab";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -40520,7 +40520,7 @@
 	dir = 1;
 	name = "Virology APC";
 	areastring = "/area/medical/virology";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -41126,7 +41126,7 @@
 	dir = 2;
 	name = "Telecomms Monitoring APC";
 	areastring = "/area/tcommsat/computer";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -41875,7 +41875,7 @@
 	dir = 1;
 	name = "Telecomms Server APC";
 	areastring = "/area/tcommsat/server";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -43092,7 +43092,7 @@
 	dir = 8;
 	name = "Atmospherics APC";
 	areastring = "/area/engine/atmos";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -43932,7 +43932,7 @@
 	dir = 8;
 	name = "Engineering Foyer APC";
 	areastring = "/area/engine/break_room";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -45629,7 +45629,7 @@
 	dir = 2;
 	name = "Incinerator APC";
 	areastring = "/area/maintenance/disposal/incinerator";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -46498,7 +46498,7 @@
 	dir = 1;
 	name = "Engineering APC";
 	areastring = "/area/engine/engineering";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -46809,7 +46809,7 @@
 	dir = 4;
 	name = "Port Quarter Solar APC";
 	areastring = "/area/maintenance/solars/port/aft";
-	pixel_x = 23;
+	pixel_x = 24;
 	pixel_y = 2
 	},
 /obj/machinery/camera{
@@ -47446,7 +47446,7 @@
 	dir = 8;
 	name = "Starboard Quarter Solar APC";
 	areastring = "/area/maintenance/solars/starboard/aft";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/structure/cable{
@@ -49250,7 +49250,7 @@
 	dir = 2;
 	name = "SMES room APC";
 	areastring = "/area/engine/engine_smes";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -50564,7 +50564,7 @@
 	dir = 4;
 	name = "MiniSat Foyer APC";
 	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	pixel_x = 27
+	pixel_x = 24
 	},
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
@@ -50982,7 +50982,7 @@
 	dir = 8;
 	name = "MiniSat Atmospherics APC";
 	areastring = "/area/ai_monitored/turret_protected/aisat/atmos";
-	pixel_x = -27
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -51108,7 +51108,7 @@
 	dir = 4;
 	name = "MiniSat Service Bay APC";
 	areastring = "/area/ai_monitored/turret_protected/aisat/service";
-	pixel_x = 27
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -51558,7 +51558,7 @@
 	dir = 4;
 	name = "MiniSat Chamber Hallway APC";
 	areastring = "/area/ai_monitored/turret_protected/aisat/hallway";
-	pixel_x = 27
+	pixel_x = 24
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
@@ -51823,7 +51823,7 @@
 	dir = 2;
 	name = "AI Chamber APC";
 	areastring = "/area/ai_monitored/turret_protected/ai";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/machinery/flasher{
 	id = "AI";
@@ -52564,7 +52564,7 @@
 	dir = 2;
 	name = "Head of Personnel APC";
 	areastring = "/area/crew_quarters/heads/hop";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -54761,7 +54761,7 @@
 	dir = 1;
 	name = "Central Maintenance APC";
 	areastring = "/area/maintenance/central";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -54798,7 +54798,7 @@
 	dir = 4;
 	name = "Starboard Maintenance APC";
 	areastring = "/area/maintenance/starboard";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -55244,7 +55244,7 @@
 	dir = 8;
 	name = "Central Maintenance APC";
 	areastring = "/area/maintenance/central/secondary";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -55308,7 +55308,7 @@
 	dir = 4;
 	name = "Morgue Maintenance APC";
 	areastring = "/area/maintenance/department/medical/morgue";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -55865,7 +55865,7 @@
 	dir = 4;
 	name = "Research Lab APC";
 	areastring = "/area/science/lab";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -55903,7 +55903,7 @@
 	dir = 4;
 	name = "Cargo Warehouse APC";
 	areastring = "/area/quartermaster/warehouse";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -56044,7 +56044,7 @@
 	areastring = "/area/hallway/secondary/service";
 	dir = 1;
 	name = "Service Hall APC";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
@@ -56073,7 +56073,7 @@
 	dir = 1;
 	name = "Law Office APC";
 	areastring = "/area/lawoffice";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -57223,7 +57223,7 @@
 	areastring = "/area/vacant_room/commissary";
 	dir = 4;
 	name = "Vacant Commissary APC";
-	pixel_x = 27;
+	pixel_x = 24;
 	pixel_y = 2
 	},
 /obj/structure/cable{
@@ -57679,7 +57679,7 @@
 	areastring = "/area/security/detectives_office";
 	dir = 8;
 	name = "Detective's Office APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -57912,7 +57912,7 @@
 	dir = 4;
 	name = "Experimentation Lab APC";
 	areastring = "/area/science/explab";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -925,7 +925,7 @@
 	dir = 2;
 	name = "Starboard Bow Solar APC";
 	areastring = "/area/maintenance/solars/starboard/fore";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -1548,7 +1548,7 @@
 	dir = 8;
 	name = "Auxiliary Construction APC";
 	areastring = "/area/construction/mining/aux_base";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2700,7 +2700,7 @@
 	dir = 1;
 	name = "Arrivals Hallway APC";
 	areastring = "/area/hallway/secondary/entry";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3993,7 +3993,7 @@
 	dir = 8;
 	name = "Customs Desk APC";
 	areastring = "/area/security/checkpoint/customs";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -4152,7 +4152,7 @@
 	areastring = "/area/security/checkpoint";
 	dir = 4;
 	name = "Security Checkpoint APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -4689,7 +4689,7 @@
 	dir = 1;
 	name = "Starboard Bow Maintenance APC";
 	areastring = "/area/maintenance/starboard/fore";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/bar,
@@ -6155,7 +6155,7 @@
 	dir = 2;
 	name = "Auxiliary Office APC";
 	areastring = "/area/vacant_room/office";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white,
@@ -6645,7 +6645,7 @@
 	dir = 2;
 	name = "Electronics Marketing APC";
 	areastring = "/area/crew_quarters/electronic_marketing_den";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/electronic_marketing_den)
@@ -9017,7 +9017,7 @@
 	dir = 2;
 	name = "Disposal APC";
 	areastring = "/area/maintenance/disposal";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -9407,7 +9407,7 @@
 	dir = 1;
 	name = "Custodial Closet APC";
 	areastring = "/area/janitor";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -10791,7 +10791,7 @@
 	dir = 2;
 	name = "Auxiliary Restrooms APC";
 	areastring = "/area/crew_quarters/toilet/auxiliary";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/auxiliary)
@@ -11270,7 +11270,7 @@
 	dir = 2;
 	name = "Port Bow Maintenance APC";
 	areastring = "/area/maintenance/port/fore";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/structure/cable/white,
 /obj/effect/turf_decal/tile/neutral,
@@ -13493,7 +13493,7 @@
 	dir = 4;
 	name = "Cargo Warehouse APC";
 	areastring = "/area/quartermaster/warehouse";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -14288,7 +14288,7 @@
 	dir = 4;
 	name = "Atmospherics Engine APC";
 	areastring = "/area/engine/atmospherics_engine";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -14432,7 +14432,7 @@
 	dir = 1;
 	name = "Bar APC";
 	areastring = "/area/crew_quarters/bar";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -14615,7 +14615,7 @@
 	dir = 8;
 	name = "Port Primary Hallway APC";
 	areastring = "/area/hallway/primary/fore";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -14983,7 +14983,7 @@
 	dir = 2;
 	name = "Abandoned Garden APC";
 	areastring = "/area/hydroponics/garden/abandoned";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -16760,7 +16760,7 @@
 	dir = 1;
 	name = "Turbine Generator APC";
 	areastring = "/area/maintenance/disposal/incinerator";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -17414,7 +17414,7 @@
 	dir = 2;
 	name = "Port Bow Solar APC";
 	areastring = "/area/maintenance/solars/port/fore";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -18737,7 +18737,7 @@
 	dir = 8;
 	name = "Security Post - Cargo APC";
 	areastring = "/area/security/checkpoint/supply";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -19252,7 +19252,7 @@
 	areastring = "/area/crew_quarters/abandoned_gambling_den/secondary";
 	dir = 1;
 	name = "Abandoned Gambling Den APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood{
@@ -19342,7 +19342,7 @@
 	dir = 1;
 	name = "Atrium APC";
 	areastring = "/area/crew_quarters/bar/atrium";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/machinery/camera{
 	c_tag = "Theatre Stage";
@@ -20244,7 +20244,7 @@
 	dir = 1;
 	name = "Theatre Backstage APC";
 	areastring = "/area/crew_quarters/theatre";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -20450,7 +20450,7 @@
 	dir = 8;
 	name = "Delivery Office APC";
 	areastring = "/area/quartermaster/sorting";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -22592,7 +22592,7 @@
 	dir = 8;
 	name = "Cargo Bay APC";
 	areastring = "/area/quartermaster/storage";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/structure/disposalpipe/segment{
@@ -22744,7 +22744,7 @@
 	dir = 1;
 	name = "Quartermaster's Office APC";
 	areastring = "/area/quartermaster/qm";
-	pixel_y = 28
+	pixel_y = 23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/brown{
@@ -23807,7 +23807,7 @@
 	dir = 1;
 	name = "Cargo Office APC";
 	areastring = "/area/quartermaster/office";
-	pixel_y = 28
+	pixel_y = 23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -25686,7 +25686,7 @@
 	dir = 2;
 	name = "Education Chamber APC";
 	areastring = "/area/security/execution/education";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 4
@@ -26027,7 +26027,7 @@
 	dir = 8;
 	name = "Service Hall APC";
 	areastring = "/area/hallway/secondary/service";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -28802,7 +28802,7 @@
 	name = "Prison Wing APC";
 	areastring = "/area/security/prison";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -30957,7 +30957,7 @@
 	dir = 2;
 	name = "Kitchen APC";
 	areastring = "/area/crew_quarters/kitchen";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -32189,7 +32189,7 @@
 	dir = 1;
 	name = "Atmospherics APC";
 	areastring = "/area/engine/atmos";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -35135,7 +35135,7 @@
 	dir = 4;
 	name = "Mining Dock APC";
 	areastring = "/area/quartermaster/miningoffice";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Mining Office";
@@ -36192,7 +36192,7 @@
 	dir = 8;
 	name = "Security Office APC";
 	areastring = "/area/security/main";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
@@ -36903,7 +36903,7 @@
 	dir = 1;
 	name = "Central Primary Hallway APC";
 	areastring = "/area/hallway/primary/central";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -40370,7 +40370,7 @@
 	dir = 4;
 	name = "Port Primary Hallway APC";
 	areastring = "/area/hallway/primary/port";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -40724,7 +40724,7 @@
 	dir = 2;
 	name = "Head of Security's Office APC";
 	areastring = "/area/crew_quarters/heads/hos";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/structure/cable/white,
 /obj/effect/turf_decal/tile/neutral{
@@ -41392,7 +41392,7 @@
 	dir = 2;
 	name = "Security Transferring APC";
 	areastring = "/area/security/execution/transfer";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -42984,7 +42984,7 @@
 	dir = 4;
 	name = "Vault APC";
 	areastring = "/area/security/nuke_storage";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45891,7 +45891,7 @@
 	dir = 1;
 	name = "Engineering Foyer APC";
 	areastring = "/area/engine/break_room";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
@@ -47657,7 +47657,7 @@
 	dir = 8;
 	name = "Primary Tool Storage APC";
 	areastring = "/area/storage/primary";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/structure/cable/white{
@@ -49058,7 +49058,7 @@
 	dir = 2;
 	name = "Bridge APC";
 	areastring = "/area/bridge";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -49936,7 +49936,7 @@
 	dir = 8;
 	name = "Technology Storage APC";
 	areastring = "/area/storage/tech";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -50500,7 +50500,7 @@
 	dir = 1;
 	name = "Detective's Office APC";
 	areastring = "/area/security/detectives_office";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/item/taperecorder,
 /obj/item/restraints/handcuffs,
@@ -50891,7 +50891,7 @@
 	dir = 1;
 	name = "AI Chamber APC";
 	areastring = "/area/ai_monitored/turret_protected/ai";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -51474,7 +51474,7 @@
 	dir = 1;
 	name = "Council Chambers APC";
 	areastring = "/area/bridge/meeting_room/council";
-	pixel_y = 26
+	pixel_y = 23
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room/council)
@@ -52158,7 +52158,7 @@
 	dir = 1;
 	name = "Transit Tube Access APC";
 	areastring = "/area/engine/transit_tube";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/neutral{
@@ -52764,7 +52764,7 @@
 	dir = 1;
 	name = "Telecomms Monitoring APC";
 	areastring = "/area/tcommsat/computer";
-	pixel_y = 28
+	pixel_y = 23
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/cable/white{
@@ -52958,7 +52958,7 @@
 	dir = 1;
 	name = "Auxiliary Tool Storage APC";
 	areastring = "/area/storage/tools";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -55499,7 +55499,7 @@
 	dir = 2;
 	name = "Captain's Office APC";
 	areastring = "/area/crew_quarters/heads/captain";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/white,
 /turf/open/floor/wood,
@@ -56861,7 +56861,7 @@
 	dir = 4;
 	name = "Warden's Office APC";
 	areastring = "/area/security/warden";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Warden's Office";
@@ -57666,7 +57666,7 @@
 	dir = 1;
 	name = "Security Post - Engineering APC";
 	areastring = "/area/security/checkpoint/engineering";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -60704,7 +60704,7 @@
 	dir = 2;
 	name = "AI Satellite Exterior APC";
 	areastring = "/area/aisat";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -60879,7 +60879,7 @@
 	dir = 2;
 	name = "Chief Engineer's APC";
 	areastring = "/area/crew_quarters/heads/chief";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -61545,7 +61545,7 @@
 	dir = 2;
 	name = "Starboard Primary Hallway APC";
 	areastring = "/area/hallway/primary/starboard";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -61866,7 +61866,7 @@
 	dir = 2;
 	name = "MiniSat APC";
 	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	pixel_y = -27
+	pixel_y = -23
 	},
 /obj/structure/cable/white,
 /obj/effect/turf_decal/stripes/line{
@@ -62852,7 +62852,7 @@
 	dir = 2;
 	name = "Armoury APC";
 	areastring = "/area/ai_monitored/security/armory";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/camera{
 	c_tag = "Armory - Interior";
@@ -64571,7 +64571,7 @@
 	dir = 4;
 	name = "HoP Office APC";
 	areastring = "/area/crew_quarters/heads/hop";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -64593,7 +64593,7 @@
 	dir = 8;
 	name = "Telecomms Server Room APC";
 	areastring = "/area/tcommsat/server";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/cable/white,
 /obj/effect/turf_decal/tile/neutral{
@@ -65246,7 +65246,7 @@
 	dir = 1;
 	name = "Brig APC";
 	areastring = "/area/security/brig";
-	pixel_y = 28
+	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65905,7 +65905,7 @@
 	dir = 2;
 	name = "Captain's Quarters APC";
 	areastring = "/area/crew_quarters/heads/captain/private";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/white,
 /turf/open/floor/plasteel/grimy,
@@ -67209,7 +67209,7 @@
 	dir = 8;
 	name = "Law Office APC";
 	areastring = "/area/lawoffice";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/effect/landmark/start/lawyer,
@@ -68579,7 +68579,7 @@
 	dir = 4;
 	name = "Engine Room APC";
 	areastring = "/area/engine/engineering";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -69603,7 +69603,7 @@
 	dir = 1;
 	name = "Teleporter APC";
 	areastring = "/area/teleporter";
-	pixel_y = 28
+	pixel_y = 23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -70140,7 +70140,7 @@
 	dir = 2;
 	name = "AI Upload Access APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
-	pixel_y = -27
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -70935,7 +70935,7 @@
 	dir = 8;
 	name = "Shooting Range APC";
 	areastring = "/area/security/range";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
@@ -71229,7 +71229,7 @@
 	dir = 8;
 	name = "Library APC";
 	areastring = "/area/library";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/structure/cable/white{
@@ -71565,7 +71565,7 @@
 	dir = 4;
 	name = "Courtroom APC";
 	areastring = "/area/security/courtroom";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -72834,7 +72834,7 @@
 	dir = 1;
 	name = "Command Hall APC";
 	areastring = "/area/hallway/secondary/command";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -74209,7 +74209,7 @@
 	dir = 2;
 	name = "Starboard Maintenance APC";
 	areastring = "/area/maintenance/starboard";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/structure/cable/white,
 /turf/open/floor/plating,
@@ -75328,7 +75328,7 @@
 	dir = 1;
 	name = "E.V.A. Storage APC";
 	areastring = "/area/ai_monitored/storage/eva";
-	pixel_y = 26
+	pixel_y = 23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -75485,7 +75485,7 @@
 	dir = 1;
 	name = "Gateway APC";
 	areastring = "/area/gateway";
-	pixel_y = 28
+	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -77683,7 +77683,7 @@
 	dir = 4;
 	name = "Lockerroom APC";
 	areastring = "/area/crew_quarters/locker";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -78474,7 +78474,7 @@
 	dir = 1;
 	name = "Primary Restroom APC";
 	areastring = "/area/crew_quarters/toilet/restrooms";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -79211,7 +79211,7 @@
 	dir = 8;
 	name = "Corporate Lounge APC";
 	areastring = "/area/bridge/showroom/corporate";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
@@ -79994,7 +79994,7 @@
 	dir = 4;
 	name = "Engineering Storage APC";
 	areastring = "/area/engine/storage";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -84977,7 +84977,7 @@
 	dir = 2;
 	name = "Dormitories APC";
 	areastring = "/area/crew_quarters/dorms";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -86539,7 +86539,7 @@
 	dir = 8;
 	name = "Medbay Storage APC";
 	areastring = "/area/medical/storage";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Storage";
@@ -87008,7 +87008,7 @@
 	dir = 4;
 	name = "Auxiliary Power APC";
 	areastring = "/area/maintenance/department/electrical";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
@@ -90896,7 +90896,7 @@
 	dir = 8;
 	name = "Recreation Area APC";
 	areastring = "/area/crew_quarters/fitness/recreation";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -91355,7 +91355,7 @@
 	dir = 8;
 	name = "Security Post - Science APC";
 	areastring = "/area/security/checkpoint/science/research";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -92654,7 +92654,7 @@
 	dir = 8;
 	name = "Security Post - Medical APC";
 	areastring = "/area/security/checkpoint/medical";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -93679,7 +93679,7 @@
 	dir = 1;
 	name = "Chemistry Lab APC";
 	areastring = "/area/medical/chemistry";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -94167,7 +94167,7 @@
 	dir = 1;
 	name = "Port Maintenance APC";
 	areastring = "/area/maintenance/port";
-	pixel_y = 28
+	pixel_y = 23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
@@ -94525,7 +94525,7 @@
 	dir = 4;
 	name = "Xenobiology Lab APC";
 	areastring = "/area/science/xenobiology";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/item/storage/box/monkeycubes,
@@ -96162,7 +96162,7 @@
 	dir = 8;
 	name = "Research and Development Lab APC";
 	areastring = "/area/science/lab";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -96605,7 +96605,7 @@
 	dir = 1;
 	name = "Abandoned Gambling Den APC";
 	areastring = "/area/crew_quarters/abandoned_gambling_den";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
@@ -99463,7 +99463,7 @@
 	name = "Abandoned Medical Lab APC";
 	areastring = "/area/medical/abandoned";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /turf/open/floor/plating,
 /area/medical/abandoned)
@@ -100590,7 +100590,7 @@
 	dir = 1;
 	name = "Mech Bay APC";
 	areastring = "/area/science/robotics/mechbay";
-	pixel_y = 28
+	pixel_y = 23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -100728,7 +100728,7 @@
 	dir = 1;
 	name = "Cloning Lab APC";
 	areastring = "/area/medical/genetics/cloning";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/item/folder/white,
 /obj/item/book/manual/wiki/medical_cloning,
@@ -103144,7 +103144,7 @@
 	dir = 2;
 	name = "Testing Range APC";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -103341,7 +103341,7 @@
 	dir = 8;
 	name = "Research Director's Office APC";
 	areastring = "/area/crew_quarters/heads/hor";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/cable/white,
 /obj/structure/disposalpipe/segment,
@@ -104208,7 +104208,7 @@
 	dir = 8;
 	name = "Medbay APC";
 	areastring = "/area/medical/medbay/central";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -105869,7 +105869,7 @@
 	dir = 4;
 	name = "Genetics Lab APC";
 	areastring = "/area/medical/genetics";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -107100,7 +107100,7 @@
 	dir = 2;
 	name = "Surgery APC";
 	areastring = "/area/medical/surgery";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Surgery";
@@ -107180,7 +107180,7 @@
 	areastring = "/area/maintenance/starboard/aft";
 	dir = 4;
 	name = "Starboard Quarter Maintenance APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -107204,7 +107204,7 @@
 	dir = 2;
 	name = "Auxiliary Construction Zone APC";
 	areastring = "/area/hallway/secondary/construction";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
@@ -107921,7 +107921,7 @@
 	dir = 4;
 	name = "Chief Medical Officer's Office APC";
 	areastring = "/area/crew_quarters/heads/cmo";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chief Medical Officer's Office";
@@ -108101,7 +108101,7 @@
 	dir = 8;
 	name = "Toxins Lab APC";
 	areastring = "/area/science/mixing";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -109251,7 +109251,7 @@
 	dir = 4;
 	name = "Aft Primary Hallway APC";
 	areastring = "/area/hallway/primary/aft";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -109598,7 +109598,7 @@
 	dir = 2;
 	name = "Starboard Quarter Solar APC";
 	areastring = "/area/maintenance/solars/starboard/aft";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -110834,7 +110834,7 @@
 	dir = 1;
 	name = "Abandoned Theatre APC";
 	areastring = "/area/crew_quarters/theatre/abandoned";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
@@ -111170,7 +111170,7 @@
 	dir = 8;
 	name = "Research Division Server Room APC";
 	areastring = "/area/science/server";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/machinery/light_switch{
 	pixel_x = -28;
@@ -111305,7 +111305,7 @@
 	dir = 8;
 	name = "Robotics Lab APC";
 	areastring = "/area/science/robotics/lab";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -112614,7 +112614,7 @@
 	dir = 8;
 	name = "Private Investigator's Office APC";
 	areastring = "/area/security/detectives_office/private_investigators_office";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /turf/open/floor/plating,
@@ -113050,7 +113050,7 @@
 	dir = 4;
 	name = "Research Division APC";
 	areastring = "/area/science/research";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -113177,7 +113177,7 @@
 	dir = 2;
 	name = "Morgue APC";
 	areastring = "/area/medical/morgue";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /turf/open/floor/plating,
 /area/medical/morgue)
@@ -113297,7 +113297,7 @@
 	dir = 2;
 	name = "Morgue Maintenance APC";
 	areastring = "/area/maintenance/department/medical/morgue";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -113829,7 +113829,7 @@
 	dir = 4;
 	name = "Toxins Storage APC";
 	areastring = "/area/science/storage";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/white,
 /obj/effect/turf_decal/bot,
@@ -115286,7 +115286,7 @@
 	name = "Aft Maintenance APC";
 	areastring = "/area/maintenance/aft";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -117080,7 +117080,7 @@
 	dir = 1;
 	name = "Port Quarter Maintenance APC";
 	areastring = "/area/maintenance/port/aft";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -117215,7 +117215,7 @@
 	areastring = "/area/security/checkpoint/customs/auxiliary";
 	dir = 8;
 	name = "Departures Customs APC";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/machinery/camera{
@@ -119164,7 +119164,7 @@
 	dir = 8;
 	name = "Abandoned Library APC";
 	areastring = "/area/library/abandoned";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /turf/open/floor/wood{
@@ -119333,7 +119333,7 @@
 	dir = 1;
 	name = "Departure Lounge APC";
 	areastring = "/area/hallway/secondary/exit/departure_lounge";
-	pixel_y = 28
+	pixel_y = 23
 	},
 /obj/machinery/camera{
 	c_tag = "Departures - Fore";
@@ -119915,7 +119915,7 @@
 	dir = 4;
 	name = "Virology Satellite APC";
 	areastring = "/area/medical/virology";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -122443,7 +122443,7 @@
 	dir = 8;
 	name = "Chapel APC";
 	areastring = "/area/chapel/main";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/structure/cable/white{
@@ -123616,7 +123616,7 @@
 	dir = 2;
 	name = "Port Quarter Solar APC";
 	areastring = "/area/maintenance/solars/port/aft";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -124904,7 +124904,7 @@
 	dir = 1;
 	name = "Chapel Quarters APC";
 	areastring = "/area/chapel/office";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -125414,7 +125414,7 @@
 	areastring = "/area/security/checkpoint/escape";
 	dir = 8;
 	name = "Departures Checkpoint APC";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/item/crowbar,
@@ -126866,7 +126866,7 @@
 	areastring = "/area/science/mixing/chamber";
 	dir = 4;
 	name = "Toxins Chamber APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -128189,7 +128189,7 @@
 	areastring = "/area/vacant_room/commissary";
 	dir = 8;
 	name = "Vacant Commissary APC";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/structure/cable/white{
@@ -128412,7 +128412,7 @@
 	dir = 1;
 	name = "Gravity Generator APC";
 	areastring = "/area/engine/gravity_generator";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -128659,7 +128659,7 @@
 	areastring = "/area/science/research/abandoned";
 	dir = 1;
 	name = "Abandoned Research Lab APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/white{
 	icon_state = "0-2"

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -1287,7 +1287,7 @@
 	areastring = "/area/science/lab";
 	dir = 1;
 	name = "Research Lab APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -1454,7 +1454,7 @@
 	areastring = "/area/science/mixing";
 	dir = 1;
 	name = "Toxins Mixing APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -3106,7 +3106,7 @@
 	areastring = "/area/crew_quarters/heads/captain/private";
 	dir = 1;
 	name = "Captain's Private Quarters APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -3837,7 +3837,7 @@
 	areastring = "/area/science/explab";
 	dir = 1;
 	name = "Experimentation APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -4131,7 +4131,7 @@
 	areastring = "/area/security/prison";
 	dir = 8;
 	name = "Prison APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -4391,7 +4391,7 @@
 	areastring = "/area/hydroponics";
 	dir = 1;
 	name = "Hydroponics APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -4423,7 +4423,7 @@
 	areastring = "/area/science/research";
 	dir = 2;
 	name = "Science Main APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -5098,7 +5098,7 @@
 	areastring = "/area/crew_quarters/heads/captain";
 	dir = 1;
 	name = "Captain's Office APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -5310,7 +5310,7 @@
 	areastring = "/area/teleporter";
 	dir = 1;
 	name = "Teleporter APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
@@ -6036,7 +6036,7 @@
 	areastring = "/area/maintenance/fore";
 	dir = 1;
 	name = "Fore Maintenance APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -6945,7 +6945,7 @@
 	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	dir = 1;
 	name = "Departures APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -8720,7 +8720,7 @@
 	areastring = "/area/security/checkpoint";
 	dir = 8;
 	name = "Docks Checkpoint APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
@@ -9396,7 +9396,7 @@
 	areastring = "/area/janitor";
 	dir = 8;
 	name = "Custodial Closet APC";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -15287,7 +15287,7 @@
 	areastring = "/area/medical/sleeper";
 	dir = 1;
 	name = "Sleepers APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -15301,7 +15301,7 @@
 	areastring = "/area/medical/cryo";
 	dir = 1;
 	name = "Cryogenics APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -16325,7 +16325,7 @@
 	areastring = "/area/crew_quarters/dorms";
 	dir = 2;
 	name = "Sleeping Quarters APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -17219,7 +17219,7 @@
 	areastring = "/area/ai_monitored/turret_protected/aisat/service";
 	dir = 8;
 	name = "MiniSat Service APC";
-	pixel_x = -27
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -18014,7 +18014,7 @@
 	areastring = "/area/chapel/main";
 	dir = 8;
 	name = "Chapel Main APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -19004,7 +19004,7 @@
 	areastring = "/area/engine/atmos";
 	dir = 8;
 	name = "Atmospherics APC";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -19901,7 +19901,7 @@
 	areastring = "/area/ai_monitored/storage/eva";
 	dir = 1;
 	name = "EVA APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -19965,7 +19965,7 @@
 	areastring = "/area/storage/tools";
 	dir = 1;
 	name = "Aux Tool Storage APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -20022,7 +20022,7 @@
 	areastring = "/area/library/lounge";
 	dir = 2;
 	name = "Lounge APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -20052,7 +20052,7 @@
 	areastring = "/area/lawoffice";
 	dir = 2;
 	name = "Lawyer's Office APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
@@ -20959,7 +20959,7 @@
 	areastring = "/area/engine/engineering";
 	dir = 1;
 	name = "Engineering APC";
-	pixel_y = 28
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -21540,7 +21540,7 @@
 	areastring = "/area/security/warden";
 	dir = 1;
 	name = "Warden's Office APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -21583,7 +21583,7 @@
 	areastring = "/area/security/processing";
 	dir = 1;
 	name = "Labor Processing APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -21777,7 +21777,7 @@
 	areastring = "/area/security/main";
 	dir = 1;
 	name = "Security Office APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -22314,7 +22314,7 @@
 	areastring = "/area/medical/chemistry";
 	dir = 8;
 	name = "Chemistry APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/white,
@@ -22399,7 +22399,7 @@
 	areastring = "/area/crew_quarters/heads/cmo";
 	dir = 8;
 	name = "CMO's Office APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -22438,7 +22438,7 @@
 	areastring = "/area/medical/medbay/central";
 	dir = 1;
 	name = "Medical Main APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -22459,7 +22459,7 @@
 	areastring = "/area/medical/surgery";
 	dir = 1;
 	name = "Surgery APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -22924,7 +22924,7 @@
 	areastring = "/area/security/courtroom";
 	dir = 8;
 	name = "Courtroom APC";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/effect/decal/cleanable/cobweb,
@@ -24425,7 +24425,7 @@
 	areastring = "/area/ai_monitored/nuke_storage";
 	dir = 1;
 	name = "Vault APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
@@ -26237,7 +26237,7 @@
 	areastring = "/area/quartermaster/warehouse";
 	dir = 1;
 	name = "Cargo Warehouse APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -26727,7 +26727,7 @@
 	areastring = "/area/crew_quarters/theatre";
 	dir = 2;
 	name = "Theatre APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -27044,7 +27044,7 @@
 	areastring = "/area/quartermaster/miningdock";
 	dir = 1;
 	name = "Mining Dock APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -27373,7 +27373,7 @@
 	areastring = "/area/medical/virology";
 	dir = 2;
 	name = "Virology APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/item/paper_bin{
@@ -27825,7 +27825,7 @@
 	areastring = "/area/solar/aft";
 	dir = 8;
 	name = "Aft Solar APC";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/structure/cable/yellow{
@@ -29838,7 +29838,7 @@
 	areastring = "/area/security/detectives_office";
 	dir = 1;
 	name = "Detective's Office APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -29888,7 +29888,7 @@
 	areastring = "/area/security/checkpoint/science";
 	dir = 2;
 	name = "Science Checkpoint APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
@@ -31891,7 +31891,7 @@
 	areastring = "/area/crew_quarters/bar";
 	dir = 1;
 	name = "Bar APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -31998,7 +31998,7 @@
 	areastring = "/area/medical/storage";
 	dir = 8;
 	name = "Medical Storage APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -33007,7 +33007,7 @@
 	areastring = "/area/crew_quarters/kitchen";
 	dir = 1;
 	name = "Kitchen APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -34421,7 +34421,7 @@
 	areastring = "/area/crew_quarters/heads/hop";
 	dir = 1;
 	name = "Head of Personnel's Office APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -35563,7 +35563,7 @@
 	cell_type = null;
 	dir = 1;
 	name = "Abandoned Bar APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -35643,7 +35643,7 @@
 	areastring = "/area/maintenance/disposal";
 	dir = 8;
 	name = "Waste Disposal APC";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /turf/open/floor/plating,
@@ -36217,7 +36217,7 @@
 	areastring = "/area/crew_quarters/fitness";
 	dir = 8;
 	name = "Fitness APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -36229,7 +36229,7 @@
 	areastring = "/area/crew_quarters/fitness/recreation";
 	dir = 8;
 	name = "Dormatories APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -37138,7 +37138,7 @@
 	areastring = "/area/tcommsat/server";
 	dir = 2;
 	name = "Telecomms Servers APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38079,7 +38079,7 @@
 	areastring = "/area/quartermaster/office";
 	dir = 8;
 	name = "Cargo Main APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -39933,7 +39933,7 @@
 	areastring = "/area/chapel/office";
 	dir = 8;
 	name = "Chapel Office APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
@@ -40605,7 +40605,7 @@
 	areastring = "/area/security/brig";
 	dir = 2;
 	name = "Brig APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -40634,7 +40634,7 @@
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	dir = 2;
 	name = "AI Upload APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/circuit,
@@ -42203,7 +42203,7 @@
 	areastring = "/area/tcommsat/computer";
 	dir = 8;
 	name = "Telecomms Lounge APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -44880,7 +44880,7 @@
 	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
 	dir = 4;
 	name = "MiniSat Main APC";
-	pixel_x = 27
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -45348,7 +45348,7 @@
 	areastring = "/area/gateway";
 	dir = 2;
 	name = "Gateway APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
@@ -50313,7 +50313,7 @@
 	dir = 2;
 	name = "AI Chamber APC";
 	areastring = "/area/ai_monitored/turret_protected/ai";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/machinery/flasher{
 	id = "AI";
@@ -50379,7 +50379,7 @@
 	areastring = "/area/library";
 	dir = 8;
 	name = "Library APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -51093,7 +51093,7 @@
 	areastring = "/area/medical/genetics/cloning";
 	dir = 2;
 	name = "Cloning Bay APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/item/toy/figure/geneticist,
@@ -51733,7 +51733,7 @@
 	cell_type = null;
 	dir = 8;
 	name = "Construction APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -52030,7 +52030,7 @@
 	areastring = "/area/ai_monitored/security/armory";
 	dir = 8;
 	name = "Armory APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
@@ -53715,7 +53715,7 @@
 	areastring = "/area/crew_quarters/heads/chief";
 	dir = 2;
 	name = "CE Office APC";
-	pixel_y = -28
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/dark,
@@ -53968,7 +53968,7 @@
 	areastring = "/area/engine/engine_room";
 	dir = 2;
 	name = "Engine Room APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -392,7 +392,7 @@
 	areastring = "/area/maintenance/disposal/incinerator";
 	dir = 1;
 	name = "Incinerator APC";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -1443,7 +1443,7 @@
 	dir = 1;
 	name = "Prisoner Education Chamber APC";
 	areastring = "/area/security/execution/education";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -2547,7 +2547,7 @@
 	name = "Prison Wing APC";
 	areastring = "/area/security/prison";
 	pixel_x = 1;
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3465,7 +3465,7 @@
 	dir = 1;
 	name = "Recreation Area APC";
 	areastring = "/area/crew_quarters/fitness/recreation";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -4107,7 +4107,7 @@
 	name = "Armory APC";
 	areastring = "/area/ai_monitored/security/armory";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -6770,7 +6770,7 @@
 	dir = 8;
 	name = "Brig Control APC";
 	areastring = "/area/security/warden";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/showroomfloor,
@@ -8206,7 +8206,7 @@
 	dir = 2;
 	name = "Disposal APC";
 	areastring = "/area/maintenance/disposal";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/stripes/line{
@@ -12497,7 +12497,7 @@
 	name = "Brig APC";
 	areastring = "/area/security/brig";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/machinery/button/flasher{
@@ -13019,7 +13019,7 @@
 	dir = 1;
 	name = "Vault APC";
 	areastring = "/area/security/nuke_storage";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -13451,7 +13451,7 @@
 	dir = 1;
 	name = "Mining APC";
 	areastring = "/area/quartermaster/miningoffice";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -13875,7 +13875,7 @@
 	dir = 1;
 	name = "Fore Maintenance APC";
 	areastring = "/area/maintenance/fore";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -14639,7 +14639,7 @@
 	dir = 1;
 	name = "Dormitories APC";
 	areastring = "/area/crew_quarters/dorms";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -15130,7 +15130,7 @@
 	dir = 8;
 	name = "Detective APC";
 	areastring = "/area/security/detectives_office";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -16195,7 +16195,7 @@
 	dir = 4;
 	name = "Warehouse APC";
 	areastring = "/area/quartermaster/warehouse";
-	pixel_x = 27
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -16464,7 +16464,7 @@
 	dir = 2;
 	name = "Restrooms APC";
 	areastring = "/area/crew_quarters/toilet/restrooms";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -17039,7 +17039,7 @@
 	dir = 2;
 	name = "Fore Primary Hallway APC";
 	areastring = "/area/hallway/primary/fore";
-	pixel_y = -27
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/machinery/light,
@@ -18193,7 +18193,7 @@
 	dir = 2;
 	name = "Storage Wing APC";
 	areastring = "/area/construction/storage_wing";
-	pixel_y = -27
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -18534,7 +18534,7 @@
 	dir = 1;
 	name = "Law Office APC";
 	areastring = "/area/lawoffice";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -20624,7 +20624,7 @@
 	dir = 1;
 	name = "Quartermaster's Office APC";
 	areastring = "/area/quartermaster/qm";
-	pixel_y = 30
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -21153,7 +21153,7 @@
 	dir = 4;
 	name = "Garden APC";
 	areastring = "/area/hydroponics/garden";
-	pixel_x = 27;
+	pixel_x = 24;
 	pixel_y = 2
 	},
 /obj/structure/cable/yellow{
@@ -21181,7 +21181,7 @@
 	dir = 8;
 	name = "Engine Room APC";
 	areastring = "/area/engine/engineering";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -22004,7 +22004,7 @@
 	dir = 2;
 	name = "Upload APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -23080,7 +23080,7 @@
 	dir = 2;
 	name = "Auxillary Base Construction APC";
 	areastring = "/area/construction/mining/aux_base";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -23422,7 +23422,7 @@
 	name = "Locker Room APC";
 	areastring = "/area/crew_quarters/locker";
 	pixel_x = -1;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/neutral{
@@ -23834,7 +23834,7 @@
 	name = "Security Post - Cargo Bay APC";
 	areastring = "/area/security/checkpoint/supply";
 	pixel_x = 1;
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -24000,7 +24000,7 @@
 	dir = 2;
 	name = "AI Upload Access APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload_foyer";
-	pixel_y = -27
+	pixel_y = -23
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -24130,7 +24130,7 @@
 	name = "Courtroom APC";
 	areastring = "/area/security/courtroom";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -26080,7 +26080,7 @@
 	dir = 4;
 	name = "CE Office APC";
 	areastring = "/area/crew_quarters/heads/chief";
-	pixel_x = 28
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -26589,7 +26589,7 @@
 	dir = 8;
 	name = "Tech Storage APC";
 	areastring = "/area/storage/tech";
-	pixel_x = -27
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -27226,7 +27226,7 @@
 	name = "Cargo Bay APC";
 	areastring = "/area/quartermaster/storage";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/machinery/light,
@@ -27655,7 +27655,7 @@
 	dir = 1;
 	name = "Auxiliary Tool Storage APC";
 	areastring = "/area/storage/tools";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -28139,7 +28139,7 @@
 	dir = 8;
 	name = "Cargo Office APC";
 	areastring = "/area/quartermaster/office";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -28595,7 +28595,7 @@
 	dir = 8;
 	name = "Engineering Security APC";
 	areastring = "/area/security/checkpoint/engineering";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -28704,7 +28704,7 @@
 	dir = 1;
 	name = "Customs APC";
 	areastring = "/area/security/checkpoint/customs";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -29570,7 +29570,7 @@
 	dir = 1;
 	name = "AI Chamber APC";
 	areastring = "/area/ai_monitored/turret_protected/ai";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -30866,7 +30866,7 @@
 	dir = 4;
 	name = "Central Maintenance APC";
 	areastring = "/area/maintenance/central";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
@@ -31287,7 +31287,7 @@
 	dir = 1;
 	name = "Starboard Hallway APC";
 	areastring = "/area/hallway/primary/starboard";
-	pixel_y = 26
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -31836,7 +31836,7 @@
 	areastring = "/area/vacant_room/commissary";
 	dir = 4;
 	name = "Vacant Commissary APC";
-	pixel_x = 27;
+	pixel_x = 24;
 	pixel_y = 2
 	},
 /obj/structure/cable/yellow,
@@ -32570,7 +32570,7 @@
 	dir = 4;
 	name = "Delivery Office APC";
 	areastring = "/area/quartermaster/sorting";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -34342,7 +34342,7 @@
 	dir = 4;
 	name = "MiniSat Antechamber APC";
 	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	pixel_x = 29
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -34587,7 +34587,7 @@
 	name = "Port Hallway APC";
 	areastring = "/area/hallway/primary/port";
 	pixel_x = -1;
-	pixel_y = 26
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -34740,7 +34740,7 @@
 	dir = 8;
 	name = "Bridge APC";
 	areastring = "/area/bridge";
-	pixel_x = -27
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow,
 /obj/machinery/camera{
@@ -36067,7 +36067,7 @@
 	dir = 8;
 	name = "Captain's Quarters APC";
 	areastring = "/area/crew_quarters/heads/captain/private";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -36520,7 +36520,7 @@
 	dir = 2;
 	name = "MiniSat Exterior APC";
 	areastring = "/area/aisat";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -36634,7 +36634,7 @@
 	dir = 2;
 	name = "MiniSat Foyer APC";
 	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
-	pixel_y = -29
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/machinery/camera/motion{
@@ -37532,7 +37532,7 @@
 	dir = 1;
 	name = "Head of Personnel APC";
 	areastring = "/area/crew_quarters/heads/hop";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
@@ -39123,7 +39123,7 @@
 	dir = 1;
 	name = "Bar APC";
 	areastring = "/area/crew_quarters/bar";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -39649,7 +39649,7 @@
 	dir = 2;
 	name = "Port Maintenance APC";
 	areastring = "/area/maintenance/port";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -40028,7 +40028,7 @@
 	dir = 1;
 	name = "Theatre APC";
 	areastring = "/area/crew_quarters/theatre";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -40063,7 +40063,7 @@
 	dir = 2;
 	name = "MiniSat Maint APC";
 	areastring = "/area/ai_monitored/storage/satellite";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -40207,7 +40207,7 @@
 	dir = 1;
 	name = "Atmospherics APC";
 	areastring = "/area/engine/atmos";
-	pixel_y = 28
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -40441,7 +40441,7 @@
 	dir = 4;
 	name = "Telecomms Control Room APC";
 	areastring = "/area/tcommsat/computer";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/machinery/computer/telecomms/server{
 	dir = 8;
@@ -42000,7 +42000,7 @@
 	dir = 2;
 	name = "Auxiliary Restrooms APC";
 	areastring = "/area/crew_quarters/toilet/auxiliary";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -42238,7 +42238,7 @@
 	dir = 1;
 	name = "Command Hallway APC";
 	areastring = "/area/hallway/secondary/command";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -44795,7 +44795,7 @@
 	dir = 4;
 	name = "Gateway APC";
 	areastring = "/area/gateway";
-	pixel_x = 28
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -46146,7 +46146,7 @@
 	dir = 8;
 	name = "E.V.A. Storage APC";
 	areastring = "/area/ai_monitored/storage/eva";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -46721,7 +46721,7 @@
 	dir = 4;
 	name = "Telecomms Server Room APC";
 	areastring = "/area/tcommsat/server";
-	pixel_x = 25
+	pixel_x = 24
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -47452,7 +47452,7 @@
 	dir = 8;
 	name = "Telecomms Storage APC";
 	areastring = "/area/storage/tcom";
-	pixel_x = -28
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -47851,7 +47851,7 @@
 	dir = 4;
 	name = "Nanotrasen Corporate Showroom APC";
 	areastring = "/area/bridge/showroom/corporate";
-	pixel_x = 28
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -49329,7 +49329,7 @@
 	dir = 2;
 	name = "Kitchen APC";
 	areastring = "/area/crew_quarters/kitchen";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/cafeteria{
@@ -49967,7 +49967,7 @@
 	name = "Starboard Maintenance APC";
 	areastring = "/area/maintenance/starboard";
 	pixel_x = -1;
-	pixel_y = 26
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -50349,7 +50349,7 @@
 	dir = 1;
 	name = "Central Primary Hallway APC";
 	areastring = "/area/hallway/primary/central";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -50774,7 +50774,7 @@
 	dir = 8;
 	name = "Port Quarter Solar APC";
 	areastring = "/area/maintenance/solars/port/aft";
-	pixel_x = -26;
+	pixel_x = -25;
 	pixel_y = 3
 	},
 /obj/structure/cable/yellow{
@@ -52890,7 +52890,7 @@
 	dir = 8;
 	name = "Medical Security Checkpoint APC";
 	areastring = "/area/security/checkpoint/medical";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/machinery/airalarm{
 	pixel_y = 28
@@ -54838,7 +54838,7 @@
 	dir = 2;
 	name = "Hydroponics APC";
 	areastring = "/area/hydroponics";
-	pixel_y = -28
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/stripes/line{
@@ -55211,7 +55211,7 @@
 	dir = 2;
 	name = "Medbay Storage APC";
 	areastring = "/area/medical/storage";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/blue{
@@ -56380,7 +56380,7 @@
 	dir = 1;
 	name = "Sleeper Room APC";
 	areastring = "/area/medical/sleeper";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -56746,7 +56746,7 @@
 	dir = 8;
 	name = "Security Post - Research Division APC";
 	areastring = "/area/security/checkpoint/science/research";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red{
@@ -57786,7 +57786,7 @@
 	dir = 1;
 	name = "Medbay Central APC";
 	areastring = "/area/medical/medbay/central";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -58044,7 +58044,7 @@
 	dir = 1;
 	name = "Research Division APC";
 	areastring = "/area/science/research";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -60213,7 +60213,7 @@
 	dir = 1;
 	name = "Cryogenics APC";
 	areastring = "/area/medical/cryo";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -60887,7 +60887,7 @@
 	dir = 4;
 	name = "Surgery APC";
 	areastring = "/area/medical/surgery";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -61054,7 +61054,7 @@
 	dir = 4;
 	name = "CMO's Office APC";
 	areastring = "/area/crew_quarters/heads/cmo";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -61911,7 +61911,7 @@
 	dir = 8;
 	name = "Chemistry APC";
 	areastring = "/area/medical/chemistry";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/closet/secure_closet/chemical{
 	pixel_x = -3
@@ -62014,7 +62014,7 @@
 	dir = 2;
 	name = "Research Lab APC";
 	areastring = "/area/science/lab";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/structure/table,
@@ -62263,7 +62263,7 @@
 	dir = 2;
 	name = "Experimentation Lab APC";
 	areastring = "/area/science/explab";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/white,
@@ -63547,7 +63547,7 @@
 	dir = 1;
 	name = "Toxins Storage APC";
 	areastring = "/area/science/storage";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -64019,7 +64019,7 @@
 	dir = 1;
 	name = "Port Quarter Maintenance APC";
 	areastring = "/area/maintenance/port/aft";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -64037,7 +64037,7 @@
 	dir = 8;
 	name = "Patient Room A APC";
 	areastring = "/area/medical/patients_rooms/room_a";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -64199,7 +64199,7 @@
 	dir = 1;
 	name = "Genetics Lab APC";
 	areastring = "/area/medical/genetics";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -65171,7 +65171,7 @@
 	dir = 8;
 	name = "Patient Room B APC";
 	areastring = "/area/medical/patients_rooms/room_b";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -65496,7 +65496,7 @@
 	dir = 2;
 	name = "RD Office APC";
 	areastring = "/area/crew_quarters/heads/hor";
-	pixel_y = -27
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/machinery/light_switch{
@@ -67070,7 +67070,7 @@
 	dir = 4;
 	name = "Medbay Aft APC";
 	areastring = "/area/medical/medbay/aft";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -67333,7 +67333,7 @@
 	dir = 4;
 	name = "Mech Bay APC";
 	areastring = "/area/science/robotics/mechbay";
-	pixel_x = 28
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -68331,7 +68331,7 @@
 	dir = 4;
 	name = "Toxins Lab APC";
 	areastring = "/area/science/mixing";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -68610,7 +68610,7 @@
 	dir = 1;
 	name = "Robotics Lab APC";
 	areastring = "/area/science/robotics/lab";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -68809,7 +68809,7 @@
 	dir = 1;
 	name = "Virology APC";
 	areastring = "/area/medical/virology";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -69119,7 +69119,7 @@
 	dir = 4;
 	name = "Morgue APC";
 	areastring = "/area/medical/morgue";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -69779,7 +69779,7 @@
 	areastring = "/area/science/mixing/chamber";
 	dir = 4;
 	name = "Toxins Chamber APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -71502,7 +71502,7 @@
 	dir = 1;
 	name = "Research Division Server Room APC";
 	areastring = "/area/science/server";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -72811,7 +72811,7 @@
 	dir = 1;
 	name = "Departure Lounge APC";
 	areastring = "/area/hallway/secondary/exit/departure_lounge";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -73476,7 +73476,7 @@
 	dir = 1;
 	name = "Starboard Quarter Solar APC";
 	areastring = "/area/maintenance/solars/starboard/aft";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -75062,7 +75062,7 @@
 	lighting = 3;
 	name = "Chapel Office APC";
 	areastring = "/area/chapel/office";
-	pixel_y = -25
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -78393,7 +78393,7 @@
 	dir = 1;
 	name = "Xenobiology APC";
 	areastring = "/area/science/xenobiology";
-	pixel_y = 27
+	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -79220,7 +79220,7 @@
 	dir = 4;
 	name = "Test Chamber Maintenance APC";
 	areastring = "/area/maintenance/department/science/xenobiology";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
@@ -80602,7 +80602,7 @@
 	dir = 2;
 	name = "Tool Storage APC";
 	areastring = "/area/storage/primary";
-	pixel_y = -27
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/item/wrench,
@@ -81506,7 +81506,7 @@
 	dir = 4;
 	name = "Port Bow Maintenance APC";
 	areastring = "/area/maintenance/port/fore";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -81717,7 +81717,7 @@
 	dir = 2;
 	name = "Starboard Bow Maintenance APC";
 	areastring = "/area/maintenance/starboard/fore";
-	pixel_y = -28
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -81941,7 +81941,7 @@
 	dir = 2;
 	name = "Starboard Quarter Maintenance APC";
 	areastring = "/area/maintenance/starboard/aft";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83365,7 +83365,7 @@
 	areastring = "/area/hallway/secondary/service";
 	dir = 1;
 	name = "Service Hall APC";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/machinery/airalarm{
 	dir = 8;

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -530,7 +530,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Labor Camp APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1077,7 +1077,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Mining Station Starboard Wing APC";
-	pixel_x = -27;
+	pixel_x = -25;
 	pixel_y = 2
 	},
 /obj/structure/cable{
@@ -1167,7 +1167,7 @@
 	dir = 1;
 	name = "Mining Communications APC";
 	pixel_x = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -1616,7 +1616,7 @@
 	dir = 1;
 	name = "Mining Station Port Wing APC";
 	pixel_x = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -145,7 +145,7 @@
 	dir = 1;
 	name = "AI Chamber APC";
 	areastring = "/area/ai_monitored/turret_protected/ai";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
@@ -569,7 +569,7 @@
 	dir = 8;
 	name = "MiniSat Antechamber APC";
 	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/grimy,
@@ -1239,7 +1239,7 @@
 	dir = 8;
 	name = "MiniSat Port Maintenance APC";
 	areastring = "/area/ai_monitored/turret_protected/AIsatextAP";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -2412,7 +2412,7 @@
 	dir = 1;
 	name = "Prison Wing APC";
 	pixel_x = 1;
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -3449,7 +3449,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Security Office APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -3743,7 +3743,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Crematorium APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
@@ -4918,7 +4918,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Brig Control APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -5395,7 +5395,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Head of Security's Office APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -5941,7 +5941,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Fore Maintenance APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -6613,7 +6613,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Vault APC";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -6642,7 +6642,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Gateway APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -9407,7 +9407,7 @@
 	dir = 1;
 	name = "Fitness Room APC";
 	areastring = "/area/crew_quarters/fitness/recreation";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -9941,7 +9941,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Captain's Office APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -10249,7 +10249,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Solar APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
@@ -10830,7 +10830,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Fore Primary Hallway APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -11408,7 +11408,7 @@
 	dir = 1;
 	name = "Upload APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -12364,7 +12364,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Tool Storage APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -14547,7 +14547,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Dormitory Bathrooms APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -14991,7 +14991,7 @@
 	dir = 1;
 	name = "Departure Lounge APC";
 	areastring = "/area/hallway/secondary/exit/departure_lounge";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -15799,7 +15799,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Teleporter APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -16099,7 +16099,7 @@
 	dir = 4;
 	name = "Cargo Warehouse APC";
 	areastring = "/area/quartermaster/warehouse";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -16347,7 +16347,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Cafeteria APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/cafeteria)
@@ -16374,7 +16374,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Auxiliary Restrooms APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/item/soap/nanotrasen,
 /obj/machinery/shower{
@@ -17325,7 +17325,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Bar Maintenance APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -17456,7 +17456,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Security Post - Cargo APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/closet/secure_closet/security/cargo,
 /obj/effect/turf_decal/tile/red{
@@ -17930,7 +17930,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "EVA Storage APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel,
 /area/storage/eva)
@@ -18038,7 +18038,7 @@
 /obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 4;
 	name = "Delivery Office APC";
-	pixel_x = 28
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -20144,7 +20144,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Kitchen APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
@@ -20667,7 +20667,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Bar APC";
-	pixel_x = 27
+	pixel_x = 24
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
@@ -22124,7 +22124,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Custodial Closet APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -22367,7 +22367,7 @@
 	name = "Cargo Office APC";
 	areastring = "/area/quartermaster/office";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -22415,7 +22415,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Cargo Bay APC";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -22582,7 +22582,7 @@
 	dir = 2;
 	name = "Security Checkpoint APC";
 	pixel_x = 1;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -23695,7 +23695,7 @@
 	dir = 8;
 	name = "Quartermaster APC";
 	areastring = "/area/quartermaster/qm";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -23786,7 +23786,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Starboard Solar APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -24482,7 +24482,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Mech Bay APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -24999,7 +24999,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Mining Dock APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -25809,7 +25809,7 @@
 	dir = 2;
 	name = "Lounge APC";
 	areastring = "/area/crew_quarters/lounge";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/grimy,
@@ -26152,7 +26152,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Morgue APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -26531,7 +26531,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Emergency Storage APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -26912,7 +26912,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Robotics Lab APC";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -29263,7 +29263,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Medbay APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -30096,7 +30096,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Research Lab APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -31325,7 +31325,7 @@
 /obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Research Division APC";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -32553,7 +32553,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Chemistry APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -34262,7 +34262,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Toxins Lab APC";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -34419,7 +34419,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Genetics APC";
-	pixel_x = 27
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -35177,7 +35177,7 @@
 	dir = 4;
 	name = "CMO's Office APC";
 	areastring = "/area/crew_quarters/heads/cmo";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -37011,7 +37011,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Virology APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -37391,7 +37391,7 @@
 	areastring = "/area/science/mixing/chamber";
 	dir = 4;
 	name = "Toxins Chamber APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -38818,7 +38818,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Surgery APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -38900,7 +38900,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Atmospherics APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -42785,7 +42785,7 @@
 	dir = 2;
 	name = "Tech Storage APC";
 	areastring = "/area/storage/tech";
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /obj/structure/closet/crate/solarpanel_small,
@@ -43101,7 +43101,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Engineering Foyer APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -43774,7 +43774,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "CE Office APC";
-	pixel_x = 28
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -43866,7 +43866,7 @@
 	dir = 8;
 	name = "Engineering Security APC";
 	areastring = "/area/security/checkpoint/engineering";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -44519,7 +44519,7 @@
 	dir = 8;
 	name = "Engine Room APC";
 	areastring = "/area/engine/engine_smes";
-	pixel_x = -26
+	pixel_x = -25
 	},
 /obj/structure/cable,
 /obj/item/stack/sheet/metal/fifty,
@@ -45404,7 +45404,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Incinerator APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/machinery/airalarm/unlocked{
 	dir = 2;
@@ -47465,7 +47465,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Monastery APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -49153,7 +49153,7 @@
 	dir = 1;
 	name = "Telecomms Monitoring APC";
 	areastring = "/area/tcommsat/computer";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -49652,7 +49652,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Dormitory APC";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -49672,7 +49672,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Dormitory Maintenance APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable,
 /obj/machinery/light/small,
@@ -51426,7 +51426,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Garden APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -51998,7 +51998,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Monastery Maintenance APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -57656,7 +57656,7 @@
 	dir = 8;
 	name = "Auxillary Base Construction APC";
 	areastring = "/area/construction/mining/aux_base";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -58880,7 +58880,7 @@
 	areastring = "/area/lawoffice";
 	dir = 8;
 	name = "Law Office APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -59724,7 +59724,7 @@
 /obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 8;
 	name = "Engineering APC";
-	pixel_x = -28
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -61704,7 +61704,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Brig Maintenance APC";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -62090,7 +62090,7 @@
 	layer = 4;
 	name = "Telecomms Server APC";
 	areastring = "/area/tcommsat/server";
-	pixel_y = 24
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"

--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -75,7 +75,7 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/structure/cable{
@@ -115,7 +115,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Gravity Generator APC";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -399,7 +399,7 @@
 "bj" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -506,7 +506,7 @@
 "bB" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -547,7 +547,7 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -629,7 +629,7 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -964,7 +964,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
@@ -995,7 +995,7 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -66,7 +66,7 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/closet/secure_closet/engineering_electrical{
 	locked = 0
@@ -112,7 +112,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Gravity Generator APC";
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -542,7 +542,7 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -652,7 +652,7 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -1046,7 +1046,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
@@ -1093,7 +1093,7 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -1660,7 +1660,7 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -25
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -2146,7 +2146,7 @@
 "fS" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -2280,7 +2280,7 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/machinery/airalarm/unlocked{
 	pixel_x = 32
@@ -2503,7 +2503,7 @@
 "hD" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -2558,7 +2558,7 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -7952,7 +7952,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Commander's Office APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal/fifty,
@@ -11994,7 +11994,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Briefing Area APC";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12693,7 +12693,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Briefing Room APC";
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1

--- a/_maps/shuttles/fugitive_hunter_space_cop.dmm
+++ b/_maps/shuttles/fugitive_hunter_space_cop.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "bY" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -786,7 +786,7 @@
 	aidisabled = 1;
 	dir = 1;
 	name = "Pirate Corvette APC";
-	pixel_y = 24;
+	pixel_y = 23;
 	req_access = null
 	},
 /obj/structure/reagent_dispensers/watertank,

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -717,7 +717,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Pirate Cutter APC";
-	pixel_x = -24;
+	pixel_x = -25;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,

--- a/_maps/shuttles/ruin_syndicate_dropship.dmm
+++ b/_maps/shuttles/ruin_syndicate_dropship.dmm
@@ -105,7 +105,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 8;
 	name = "Syndicate Drop Ship APC";
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,

--- a/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
+++ b/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
@@ -68,7 +68,7 @@
 /obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 8;
 	name = "Syndicate Fighter APC";
-	pixel_x = -24;
+	pixel_x = -25;
 	req_access = null;
 	req_access_txt = "150"
 	},

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -383,7 +383,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Hospital Ship Crew Quarters APC";
-	pixel_y = 24;
+	pixel_y = 23;
 	req_access = null
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -1047,7 +1047,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Hospital Ship Medbay APC";
-	pixel_y = 24;
+	pixel_y = 23;
 	req_access = null
 	},
 /turf/open/floor/plasteel/white,
@@ -2135,7 +2135,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Hospital Ship Bridge APC";
-	pixel_y = 24;
+	pixel_y = 23;
 	req_access = null
 	},
 /obj/effect/turf_decal/tile/blue{

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -183,7 +183,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Frigate Bar APC";
-	pixel_x = -24;
+	pixel_x = -25;
 	req_access = null
 	},
 /obj/structure/spider/stickyweb,
@@ -478,7 +478,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Frigate Crew Quarters APC";
-	pixel_y = 24;
+	pixel_y = 23;
 	req_access = null
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -1229,7 +1229,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Frigate Bridge APC";
-	pixel_x = -24;
+	pixel_x = -25;
 	req_access = null
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -2271,7 +2271,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Frigate Cargo APC";
-	pixel_x = -24;
+	pixel_x = -25;
 	req_access = null
 	},
 /turf/open/floor/plasteel,

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -1219,7 +1219,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Salvage Ship Bar APC";
-	pixel_y = 24;
+	pixel_y = 23;
 	req_access = null
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -1418,7 +1418,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Salvage Ship Bridge APC";
-	pixel_y = 24;
+	pixel_y = 23;
 	req_access = null
 	},
 /obj/item/camera{
@@ -1936,7 +1936,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Salvage Ship Cargo APC";
-	pixel_x = -24;
+	pixel_x = -25;
 	req_access = null
 	},
 /obj/structure/cable{

--- a/tools/mapmerge2/map_scripts/apc_pixel_offsets.txt
+++ b/tools/mapmerge2/map_scripts/apc_pixel_offsets.txt
@@ -1,0 +1,4 @@
+/obj/machinery/power/apc/@SUBTYPES{dir = 1} : @OLD{@OLD; pixel_y = 23}
+/obj/machinery/power/apc/@SUBTYPES{dir = 2} : @OLD{@OLD; pixel_y = -23}
+/obj/machinery/power/apc/@SUBTYPES{dir = 4} : @OLD{@OLD; pixel_x = 24}
+/obj/machinery/power/apc/@SUBTYPES{dir = 8} : @OLD{@OLD; pixel_x = -25}

--- a/tools/mapmerge2/update_paths.py
+++ b/tools/mapmerge2/update_paths.py
@@ -23,14 +23,14 @@ Old paths properties:
 """
 
 default_map_directory = "../../_maps"
-replacement_re = re.compile('\s*([^{]*)\s*(\{(.*)\})?')
+replacement_re = re.compile(r'\s*(?P<path>[^{]*)\s*(\{(?P<props>.*)\})?')
 
 #urgent todo: replace with actual parser, this is slow as janitor in crit
-split_re = re.compile('((?:[A-Za-z0-9_\-$]+)\s*=\s*(?:"(?:.+?)"|[^";]*)|@OLD)')
+split_re = re.compile(r'((?:[A-Za-z0-9_\-$]+)\s*=\s*(?:"(?:.+?)"|[^";]*)|@OLD)')
 
 
 def props_to_string(props):
-    return "{{{0}}}".format(";".join([k+" = "+props[k] for k in props]))
+    return "{{{}}}".format(";".join([f"{k} = {v}" for k, v in props.items()]))
 
 
 def string_to_props(propstring, verbose = False):
@@ -48,8 +48,8 @@ def string_to_props(propstring, verbose = False):
 def parse_rep_string(replacement_string, verbose = False):
     # translates /blah/blah {meme = "test",} into path,prop dictionary tuple
     match = re.match(replacement_re, replacement_string)
-    path = match.group(1)
-    props = match.group(3)
+    path = match['path']
+    props = match['props']
     if props:
         prop_dict = string_to_props(props, verbose)
     else:
@@ -65,9 +65,18 @@ def update_path(dmm_data, replacement_string, verbose=False):
         new_path, new_path_props = parse_rep_string(replacement_def, verbose)
         new_paths.append((new_path, new_path_props))
 
+    subtypes = ""
+    if old_path.endswith("/@SUBTYPES"):
+        old_path = old_path[:-len("/@SUBTYPES")]
+        if verbose:
+            print("Looking for subtypes of", old_path)
+        subtypes = r"(?:/\w+)*"
+
+    replacement_pattern = re.compile(rf"(?P<path>{re.escape(old_path)}{subtypes})\s*(:?{{(?P<props>.*)}})?$")
+
     def replace_def(match):
-        if match.group(2):
-            old_props = string_to_props(match.group(2), verbose)
+        if match['props']:
+            old_props = string_to_props(match['props'], verbose)
         else:
             old_props = dict()
         for filter_prop in old_path_props:
@@ -83,7 +92,10 @@ def update_path(dmm_data, replacement_string, verbose=False):
             print("Found match : {0}".format(match.group(0)))
         out_paths = []
         for new_path, new_props in new_paths:
-            out = new_path
+            if new_path == "@OLD":
+                out = match.group('path')
+            else:
+                out = new_path
             out_props = dict()
             for prop_name, prop_value in new_props.items():
                 if prop_name == "@OLD":
@@ -106,10 +118,9 @@ def update_path(dmm_data, replacement_string, verbose=False):
         return out_paths
 
     def get_result(element):
-        p = re.compile("{0}\s*({{(.*)}})?$".format(re.escape(old_path)))
-        match = p.match(element)
+        match = replacement_pattern.match(element)
         if match:
-            return replace_def(match) # = re.sub(p,replace_def,element)
+            return replace_def(match)
         else:
             return [element]
 
@@ -141,10 +152,12 @@ def update_all_maps(map_directory, updates, verbose=False):
 
 def main(args):
     if args.inline:
+        print("Using replacement:", args.update_source)
         updates = [args.update_source]
     else:
         with open(args.update_source) as f:
             updates = [line for line in f if line and not line.startswith("#") and not line.isspace()]
+        print(f"Using {len(updates)} replacements from file:", args.update_source)
 
     if args.map:
         update_map(args.map, updates, verbose=args.verbose)


### PR DESCRIPTION
We have code to complain about these:

https://github.com/tgstation/tgstation/blob/8054bc34db6702a94e5c1f0c053da6ec0ea1a86b/code/modules/power/apc.dm#L169-L184

So we should fix them.

Includes improvements to `update_paths.py` and a script for it.