### PR TITLE
Fix weird padding issues on Character Setup screen

### DIFF
--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -2,6 +2,7 @@
 /mob/living/carbon/human/dummy
 	real_name = "Test Dummy"
 	status_flags = GODMODE|CANPUSH
+	mouse_drag_pointer = MOUSE_INACTIVE_POINTER
 	var/in_use = FALSE
 
 INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -2,21 +2,21 @@ macro "default"
 
 
 menu "menu"
-	elem 
+	elem
 		name = "&File"
 		command = ""
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = "&Quick screenshot\tF2"
 		command = ".screenshot auto"
 		category = "&File"
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = "&Save screenshot as...\tShift+F2"
 		command = ".screenshot"
 		category = "&File"
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = ""
 		command = ""
 		category = "&File"
@@ -26,21 +26,21 @@ menu "menu"
 		command = ".reconnect"
 		category = "&File"
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = "&Quit\tAlt-F4"
 		command = ".quit"
 		category = "&File"
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = "&Help"
 		command = ""
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = "&Admin Help\tF1"
 		command = "adminhelp"
 		category = "&Help"
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = "&Hotkeys"
 		command = "hotkeys-help"
 		category = "&Help"
@@ -255,7 +255,7 @@ window "preferences_window"
 	elem "preferences_window"
 		type = MAIN
 		pos = 372,0
-		size = 1120x1000
+		size = 1280x1000
 		anchor1 = none
 		anchor2 = none
 		background-color = none
@@ -264,17 +264,17 @@ window "preferences_window"
 		statusbar = false
 	elem "preferences_browser"
 		type = BROWSER
-		pos = -8,-8
-		size = 896x1008
+		pos = 0,0
+		size = 960x1000
 		anchor1 = 0,0
-		anchor2 = 90,100
+		anchor2 = 75,100
 		background-color = none
 		saved-params = ""
 	elem "character_preview_map"
 		type = MAP
-		pos = 887,0
-		size = 313x1000
-		anchor1 = 90,0
+		pos = 960,0
+		size = 320x1000
+		anchor1 = 75,0
 		anchor2 = 100,100
 		right-click = true
 		saved-params = "zoom;letterbox;zoom-mode"


### PR DESCRIPTION
Why kevinz thought -8,-8 was a suitable position for the browser window is beyond me. I [complained about this](https://github.com/tgstation/tgstation/pull/41978#issuecomment-449598249) at the time but only just got around to fixing it myself.

## Before
![image](https://user-images.githubusercontent.com/222630/55704172-61a6e100-5990-11e9-82b7-5575e8ffd954.png)

## After 
![image](https://user-images.githubusercontent.com/222630/55703882-b39b3700-598f-11e9-9538-99bba38cf827.png)

:cl:
fix: Stuff in the Character Setup screen is no longer way too close to the edge of the window.
/:cl:

<details>
<summary>Bugged screenshot I happened to catch that clearly shows the dead zone between the browser control and the hidden pixels off to the right</summary>

![image](https://user-images.githubusercontent.com/222630/55704039-155ba100-5990-11e9-9043-afd011f2b12c.png)

</details>