### PR TITLE
Changes the minimum pop requirement for the space dragon event

### DIFF
--- a/code/modules/events/space_dragon.dm
+++ b/code/modules/events/space_dragon.dm
@@ -4,7 +4,7 @@
 	max_occurrences = 1
 	weight = 8
 	earliest_start = 70 MINUTES
-	min_players = 20
+	min_players = 40
 
 /datum/round_event/ghost_role/space_dragon
 	minimum_required = 1

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -489,6 +489,7 @@ Difficulty: Medium
 	melee_damage_upper = 30
 	melee_damage_lower = 30
 	mouse_opacity = MOUSE_OPACITY_ICON
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	loot = list()
 	crusher_loot = list()
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -510,6 +510,7 @@ Difficulty: Medium
 	obj_damage = 80
 	melee_damage_upper = 35
 	melee_damage_lower = 35
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	speed = 0
 	mouse_opacity = MOUSE_OPACITY_ICON
 	loot = list()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -489,7 +489,6 @@ Difficulty: Medium
 	melee_damage_upper = 30
 	melee_damage_lower = 30
 	mouse_opacity = MOUSE_OPACITY_ICON
-	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	loot = list()
 	crusher_loot = list()
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -509,7 +509,6 @@ Difficulty: Medium
 	obj_damage = 80
 	melee_damage_upper = 35
 	melee_damage_lower = 35
-	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	speed = 0
 	mouse_opacity = MOUSE_OPACITY_ICON
 	loot = list()


### PR DESCRIPTION
## About The Pull Request
Changes the minimum pop for the space dragon event to pop up.

## Why It's Good For The Game
Every time this event pops up the crew seems to just call the shuttle, mostly being due to that the only weaponry that's on-station that can effectively fight it are shotguns. Cargo most of the time is moot and isn't able to supply autorifles. 
This mostly goes for medpop and lowpop, so it should still remain the same for highpop.

## Changelog
:cl: Vile Beggar
balance: The space dragon now requires 40 players minimum to trigger.
/:cl: