### PR TITLE
Radiation suit lockers in atmos, moves pipe dispensers

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -55592,6 +55592,10 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"eTd" = (
+/obj/machinery/pipedispenser/disposal,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "eUr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
@@ -55807,6 +55811,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"gwp" = (
+/obj/machinery/pipedispenser,
+/turf/open/floor/plasteel,
+/area/construction)
 "gwQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -72172,7 +72180,7 @@ bgj
 bgj
 bjc
 cAF
-cAF
+eTd
 bja
 aaa
 aaa
@@ -85814,7 +85822,7 @@ bJm
 bFa
 bHO
 bCs
-cCd
+gwp
 cCd
 aYg
 cjL

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -36454,9 +36454,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bIH" = (
-/obj/machinery/pipedispenser/disposal,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36857,10 +36860,14 @@
 /turf/closed/wall/r_wall,
 /area/medical/medbay/central)
 "bJF" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/space_heater,
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bJG" = (
@@ -38172,7 +38179,10 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bMR" = (
-/obj/machinery/pipedispenser,
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMS" = (
@@ -42396,10 +42406,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXR" = (
-/obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXS" = (
@@ -43972,6 +43982,9 @@
 /area/maintenance/port/aft)
 "cbz" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cbA" = (
@@ -43979,17 +43992,15 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cbB" = (
-/obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cbC" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cbD" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4468,7 +4468,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aij" = (
-/obj/item/vending_refill/coffee,
+/obj/machinery/pipedispenser/disposal,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -6451,6 +6451,7 @@
 	dir = 9
 	},
 /obj/item/bot_assembly/cleanbot,
+/obj/item/vending_refill/coffee,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "alI" = (
@@ -7637,7 +7638,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "anM" = (
-/obj/machinery/space_heater,
+/obj/machinery/pipedispenser,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "anN" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -48209,10 +48209,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPr" = (
-/obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPs" = (
@@ -50654,10 +50654,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "bUA" = (
-/obj/machinery/pipedispenser,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUB" = (
@@ -50667,19 +50667,19 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/machinery/pipedispenser/disposal,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUC" = (
 /obj/item/radio/intercom{
 	pixel_y = 28
 	},
-/obj/machinery/pipedispenser/disposal/transit_tube,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUD" = (
@@ -51248,6 +51248,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -41382,7 +41382,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQH" = (
-/obj/machinery/pipedispenser,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQI" = (
@@ -41390,10 +41393,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQJ" = (
-/obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQK" = (
@@ -41761,7 +41764,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRv" = (
-/obj/machinery/pipedispenser/disposal,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -41769,6 +41771,10 @@
 	c_tag = "Atmospherics Central";
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRw" = (
@@ -42089,10 +42095,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bSe" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSf" = (
@@ -97948,7 +97950,7 @@ bOS
 bPQ
 bQH
 bRv
-bSe
+bQH
 bPQ
 bTL
 uRj

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -43640,6 +43640,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
+/obj/machinery/pipedispenser,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bVv" = (
@@ -59794,9 +59795,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "srZ" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
+/obj/machinery/pipedispenser/disposal,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ssx" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

~~The atmos hardsuit radiation protection is raised to 75, making it equal to the engineering hardsuit in everything except sprite.~~

Atmos will get radsuit lockers, so they don't die when they inevitably screw up fusion.

Pipe dispensers are removed as only noobs use these.

Metastation space heaters are moved to the top, same layout as boxstation.

## Why It's Good For The Game

~~The current atmos hardsuit has only 25 radiation protection, which is low compared to the engineering hardsuit, which has 75. As atmos can experiment with fusion, I don't see a reason to keep the rad protection on atmos hardsuits lower than that of engineering.~~

Continuing the argument that atmos can experiment with fusion, experiments can quickly turn lethal when not properly protected with a radsuit. These were only accessible to the engineers, who had to work on the engine. That's why atmos needs radsuit lockers.

In exchange for this, I removed the pipe dispensers, as they take up a lot of space. Meta and Pubby get an additional atmos locker, so there are enough RPDs for everyone.

## Changelog
:cl: JoeyJo0
add: Radsuit lockers in atmos
tweak: Pipe dispensers are now moved to maintenance locations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
