### PR TITLE
Slot machines can't refund zero balance

### DIFF
--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -157,8 +157,9 @@
 		<A href='?src=[REF(src)];spin=1'>Play!</A><BR>
 		<BR>
 		[reeltext]
-		<BR>
-		<font size='1'><A href='?src=[REF(src)];refund=1'>Refund balance</A><BR>"}
+		<BR>"}
+		if(balance > 0)
+			dat+={"<font size='1'><A href='?src=[REF(src)];refund=1'>Refund balance</A><BR>"}
 
 	var/datum/browser/popup = new(user, "slotmachine", "Slot Machine")
 	popup.set_content(dat)
@@ -174,8 +175,9 @@
 		spin(usr)
 
 	else if(href_list["refund"])
-		give_payout(balance)
-		balance = 0
+		if(balance > 0)
+			give_payout(balance)
+			balance = 0
 
 /obj/machinery/computer/slot_machine/emp_act(severity)
 	. = ..()
@@ -327,7 +329,7 @@
 /obj/machinery/computer/slot_machine/proc/dispense(amount = 0, cointype = /obj/item/coin/silver, mob/living/target, throwit = 0)
 	if(paymode == HOLOCHIP)
 		var/obj/item/holochip/H = new /obj/item/holochip(loc,amount)
-		
+
 		if(throwit && target)
 			H.throw_at(target, 3, 10)
 	else

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -159,7 +159,7 @@
 		[reeltext]
 		<BR>"}
 		if(balance > 0)
-			dat+={"<font size='1'><A href='?src=[REF(src)];refund=1'>Refund balance</A><BR>"}
+			dat+="<font size='1'><A href='?src=[REF(src)];refund=1'>Refund balance</A><BR>"
 
 	var/datum/browser/popup = new(user, "slotmachine", "Slot Machine")
 	popup.set_content(dat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #43488. Slot machines do a balance check before refunding and don't present the option to refund when the machine has 0 balance.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Simple bugfixes are always good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: JoeyJo0
fix: Slot machines can't give out 0 balance chips anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
