### PR TITLE
Removes 1-shot Stamstuns From Shotgun Ammos

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -56,7 +56,7 @@
 
 /obj/item/projectile/bullet/pellet
 	var/tile_dropoff = 0.75
-	var/tile_dropoff_s = 1.25
+	var/tile_dropoff_s = 0.5
 
 /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
@@ -65,7 +65,7 @@
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
 	damage = 3
-	stamina = 25
+	stamina = 11
 
 /obj/item/projectile/bullet/pellet/Range()
 	..()

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -5,7 +5,7 @@
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
 	damage = 5
-	stamina = 80
+	stamina = 55
 
 /obj/item/projectile/bullet/incendiary/shotgun
 	name = "incendiary slug"


### PR DESCRIPTION
:cl:
balance: rubbershot does 66 stamina  + 18 damage instead of 150 stamina + 18 damage
balance: beanbang does 55 stamina + 5 damge instead of 80 + 5 damage
/:cl:
rubber no longer 1 shot crit from <3 tiles
rubber needs 2 shots on fully healthy man to knock them down

rubber gg no re shot from grog tide is bad gameplay