### PR TITLE
Modifies how the Assimilation pinpointer radars work

### DIFF
--- a/code/game/gamemodes/hivemind/radar.dm
+++ b/code/game/gamemodes/hivemind/radar.dm
@@ -1,6 +1,6 @@
-#define HIVEMIND_RADAR_MIN_DISTANCE 7 //Very generous, as the targets are only tracked for a few minutes.
+#define HIVEMIND_RADAR_MIN_DISTANCE 0 //Very generous, as the targets are only tracked for a few minutes.
 #define HIVEMIND_RADAR_MAX_DISTANCE 50
-#define HIVEMIND_RADAR_PING_TIME 20 //2s update time.
+#define HIVEMIND_RADAR_PING_TIME 40 //4s update time.
 
 //Modified IA/changeling pinpointer, points to the nearest person who is afflicted with the hive tracker status effect
 /datum/status_effect/agent_pinpointer/hivemind

--- a/code/modules/spells/spell_types/hivemind.dm
+++ b/code/modules/spells/spell_types/hivemind.dm
@@ -68,6 +68,7 @@
 						to_chat(user, "<span class='notice'>[target.name] was added to the Hive!</span>")
 						success = TRUE
 						hive.add_to_hive(target)
+						hive.threat_level = max(0, hive.threat_level-0.1)
 						if(ignore_mindshield)
 							to_chat(user, "<span class='warning'>We are briefly exhausted by the effort required by our enhanced assimilation abilities.</span>")
 							user.Immobilize(50)
@@ -109,6 +110,7 @@
 		return
 	hive.remove_from_hive(M)
 	hive.calc_size()
+	hive.threat_level += 0.1
 	to_chat(user, "<span class='notice'>We remove [target.name] from the hive</span>")
 	if(hive.active_one_mind)
 		var/datum/antagonist/hivevessel/woke = target.is_wokevessel()
@@ -379,7 +381,7 @@
 	if(original_body?.mind)
 		var/datum/antagonist/hivemind/hive = original_body.mind.has_antag_datum(/datum/antagonist/hivemind)
 		if(hive)
-			hive.threat_level += 0.5
+			hive.threat_level += 1
 
 
 /obj/effect/proc_holder/spell/target_hive/hive_control/on_lose(mob/user)
@@ -573,6 +575,9 @@
 		victim.Sleeping(max(80,240/(1+round(victims.len/3))))
 	for(var/mob/living/silicon/victim in victims)
 		victim.Unconscious(240)
+	var/datum/antagonist/hivemind/hive = user.mind.has_antag_datum(/datum/antagonist/hivemind)
+	if(victims.len && hive)
+		hive.threat_level += 1
 
 /obj/effect/proc_holder/spell/target_hive/hive_attack
 	name = "Medullary Failure"
@@ -594,7 +599,7 @@
 		to_chat(user, "<span class='warning'>We are unable to induce a heart attack!</span>")
 	var/datum/antagonist/hivemind/hive = user.mind.has_antag_datum(/datum/antagonist/hivemind)
 	if(hive)
-		hive.threat_level += 2
+		hive.threat_level += 4
 
 /obj/effect/proc_holder/spell/target_hive/hive_warp
 	name = "Distortion Field"
@@ -731,6 +736,7 @@
 			C.gib()
 			hive.track_bonus += TRACKER_BONUS_LARGE
 			hive.size_mod += 5
+			hive.threat_level += 1
 			gibbed = TRUE
 			found_target = TRUE
 		else if(C.IsUnconscious())
@@ -786,10 +792,11 @@
 
 	var/objective = stripped_input(user, "What objective do you want to give to your vessels?", "Objective")
 	
-	if(!objective)
+	if(!objective || !hive)
 		revert_cast()
 		return
-
+	
+	hive.threat_level += 6
 	for(var/i = 0, i < 4, i++)
 		var/mob/living/carbon/C = pick_n_take(valid_targets)
 		C.hive_awaken(objective)
@@ -843,6 +850,9 @@
 	new wall_type(get_turf(user),user)
 	for(var/dir in GLOB.alldirs)
 		new wall_type_b(get_step(user, dir),user)
+	var/datum/antagonist/hivemind/hive = user.mind.has_antag_datum(/datum/antagonist/hivemind)
+	if(hive)
+		hive.threat_level += 0.5
 
 /obj/effect/forcefield/wizard/hive
 	name = "Telekinetic Field"


### PR DESCRIPTION
just fyi this is a very long pr description for a bunch of 1 line changes

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

One of the first big updates to Assimilation changed the way outing worked, from a direct message on who assimilated the dude to a pinpointer-esque radar that shows you where they were. This PR implements two changes to this mechanic.

### 1) Increased ping time and decreased minimum range
This one is somewhat simple, there is no longer a screen-wide radius around the target where the radar no longer works, but as you no longer need to scan the edge of the radius to find out who it is, the radar updates once every four seconds instead of every two.

### 2) More powers increase the threat level
To make a very long story short, if there were multiple hosts controlling one vessel, the radar would perform a weighted pick based on two things: proximity and a threat multiplier. Proximity is self-explanatory, and the threat multiplier is a hidden variable calculated via the size of your hive plus the number of times you've used certain powers (**Threat Level**). Threat Level ranges from 0 to 20, with the multiplier maxing out at a threat level of 20.

The following abilities now count towards your threat level
* Reclaim (**+1** on gib)
* Circadian Shift (**+1**)
* Telekinetic Field (**+0.5**)
* Chaos Induction (**+6**)
* Assimilate Vessel (**-0.1**)
* Release Vessel (**+0.1**)

The following abilities have had their threat level increased
* Mind Control (now **+1**, was +0.5 to +1 when hive size based mind control was in the game)
* Medullary Failure (now **+4**, was +2)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A somewhat common complaint I've seen about the new hivemind is that it's very easy for antagonists to get dunked on by others going loud, and while it's nowhere near as bad as when mindshields revealed names, it still persists. While it'd take a lot more thought and core changes to prevent the implant gestapo snowball, this change ensures that anybody who does get implanted will be far more likely to end up tracking whoever went loud early in the first place. Laying low and assimilating people/taking out hiveminds without being detected is of the utmost importance, and a single public display of hivemind powers suddenly adds a whole new force that the hosts probably aren't ready for so early.

In addition, being tracked is now harsher, as the pinpointer's minimum range has been removed due to the jank associated with it being 7 tiles (The IAA/Ling pinpointer is 14 and requires you to actually sleuth around the area, the low timers on the assimilation pinpointers makes this impossible, but 7 tiles means you're just scanning the edge of visual range). Assimilate now also removes small amounts of threat level, while it's less than what's gained by hive size, prevents occasional uses of these powers from resulting in a permanent threat boost.

It's also because I forgot to add threat level values to the 2.0 powers, and circadian op.

**TL;DR:** you go loud, you get the pow pow

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Kierany9
balance: The hivemind radar's no longer has a minimum range, but has an increased ping time.
balance: How power use affects the hivemind radar has been tweaked as to ensure that going loud early is punished more.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
