### PR TITLE
Fixes some inconsistencies in genetics

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -19,16 +19,17 @@
 	text_lose_indication = "<span class='notice'>Your sense of smell goes back to normal.</span>"
 	power = /obj/effect/proc_holder/spell/targeted/olfaction
 	instability = 30
+	synchronizer_coeff = 1
 	var/reek = 200
 
 /datum/mutation/human/olfaction/on_life()
 	var/hygiene_now = owner.hygiene
 
 	if(hygiene_now < 100 && prob(5))
-		owner.adjust_disgust(rand(3,5))
+		owner.adjust_disgust(GET_MUTATION_SYNCHRONIZER(src) * (rand(3,5)))
 	if(hygiene_now < HYGIENE_LEVEL_DIRTY && prob(50))
 		to_chat(owner,"<span class='danger'>You get a whiff of your stench and feel sick!</span>")
-		owner.adjust_disgust(rand(5,10))
+		owner.adjust_disgust(GET_MUTATION_SYNCHRONIZER(src) * rand(5,10))
 
 	if(hygiene_now < HYGIENE_LEVEL_NORMAL && reek >= HYGIENE_LEVEL_NORMAL)
 		to_chat(owner,"<span class='warning'>Your inhumanly strong nose picks up a faint odor. Maybe you should shower soon.</span>")

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -267,6 +267,9 @@
 	text_lose_indication = "<span class'notice'>The space around you settles back to normal.</span>"
 	difficulty = 18//high so it's hard to unlock and abuse
 	instability = 10
+	synchronizer_coeff = 1
+	energy_coeff = 1
+	power_coeff = 1
 	var/warpchance = 0
 
 /datum/mutation/human/badblink/on_life()
@@ -278,13 +281,13 @@
 		"<span class='warning'>[owner]'s torso starts folding inside out until it vanishes from reality, taking [owner] with it.</span>",
 		"<span class='warning'>One moment, you see [owner]. The next, [owner] is gone.</span>")
 		owner.visible_message(warpmessage, "<span class='userdanger'>You feel a wave of nausea as you fall through reality!</span>")
-		var/warpdistance = rand(10,15)
+		var/warpdistance = rand(10,15) * GET_MUTATION_POWER(src)
 		do_teleport(owner, get_turf(owner), warpdistance, channel = TELEPORT_CHANNEL_FREE)
-		owner.adjust_disgust((warpchance * warpdistance))
+		owner.adjust_disgust(GET_MUTATION_SYNCHRONIZER(src) * (warpchance * warpdistance))
 		warpchance = 0
 		owner.visible_message("<span class='danger'>[owner] appears out of nowhere!</span>")
 	else
-		warpchance += 0.25
+		warpchance += 0.25 * GET_MUTATION_ENERGY(src)
 
 /datum/mutation/human/acidflesh
 	name = "Acidic Flesh"

--- a/code/datums/mutations/cold.dm
+++ b/code/datums/mutations/cold.dm
@@ -5,6 +5,7 @@
 	text_gain_indication = "<span class='notice'>Your hand feels cold.</span>"
 	instability = 10
 	difficulty = 10
+	synchronizer_coeff = 1
 	power = /obj/effect/proc_holder/spell/targeted/conjure_item/snow
 
 /obj/effect/proc_holder/spell/targeted/conjure_item/snow
@@ -23,6 +24,7 @@
 	text_gain_indication = "<span class='notice'>Your hand feels cold.</span>"
 	instability = 20
 	difficulty = 12
+	synchronizer_coeff = 1
 	power = /obj/effect/proc_holder/spell/aimed/cryo
 
 /obj/effect/proc_holder/spell/aimed/cryo

--- a/code/datums/mutations/radioactive.dm
+++ b/code/datums/mutations/radioactive.dm
@@ -6,10 +6,11 @@
 	time_coeff = 5
 	instability = 5
 	difficulty = 8
+	power = 1
 
 
 /datum/mutation/human/radioactive/on_life()
-	radiation_pulse(owner, 20)
+	radiation_pulse(owner, 20 * GET_MUTATION_POWER(src))
 
 /datum/mutation/human/radioactive/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
 	..()

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -716,7 +716,7 @@
 						I.name = "[HM.name] activator"
 						I.damage_coeff = connected.damage_coeff*4
 						I.research = TRUE
-						injectorready = world.time + INJECTOR_TIMEOUT
+						injectorready = world.time + INJECTOR_TIMEOUT * (1 - 0.1 * connected.precision_coeff) //precision_coeff being the manipulator rating
 		if("mutator")
 			if(injectorready < world.time)
 				var/mutation = text2path(href_list["path"])
@@ -728,7 +728,7 @@
 						I.doitanyway = TRUE
 						I.name = "[HM.name] injector"
 						I.damage_coeff = connected.damage_coeff
-						injectorready = world.time + INJECTOR_TIMEOUT*5
+						injectorready = world.time + INJECTOR_TIMEOUT*5 * (1 - 0.1 * connected.precision_coeff)
 		if("nullify")
 			if(viable_occupant)
 				var/datum/mutation/human/A = viable_occupant.dna.get_mutation(current_mutation)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1275,7 +1275,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				target_table = locate(/obj/structure/table) in target_shove_turf.contents
 				target_disposal_bin = locate(/obj/machinery/disposal/bin) in target_shove_turf.contents
 				shove_blocked = TRUE
-			
+
 		if(target.IsKnockdown() && !target.IsParalyzed())
 			target.Paralyze(SHOVE_CHAIN_PARALYZE)
 			target.visible_message("<span class='danger'>[user.name] kicks [target.name] onto their side!</span>",

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -32,7 +32,7 @@
 			lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
 	M.update_tint()
 	owner.update_sight()
-	if(M.has_dna())
+	if(M.has_dna() && ishuman(M))
 		M.dna.species.handle_body(M) //updates eye icon
 
 /obj/item/organ/eyes/Remove(mob/living/carbon/M, special = 0)
@@ -348,4 +348,4 @@
 	desc = "These eyes seem to have a large range, but might be cumbersome with glasses."
 	eye_icon_state = "snail_eyes"
 	icon_state = "snail_eyeballs"
-	
+


### PR DESCRIPTION
Adds chromosome interactions to a few mutations that should have it, but were simply not added.
Makes upgraded parts affect printing speed. Every tier decreases cooldown by 10%
Kind of off-topic, but fixes a runtime I caused when adding unique icons for species eyes
:cl: Time-Green
tweak: Chromosomes interact with more mutations
tweak: The DNA console printing speed is now affected by better parts
fix: Monkeys no longer runtime with transformations
/:cl:

I'd say no PRB since theyre my fault, but I'm not even sure if it would go up or go down
