### PR TITLE
add more salt to the game

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -243,9 +243,9 @@
 
 /obj/item/reagent_containers/food/drinks/dry_ramen
 	name = "cup ramen"
-	desc = "Just add 5ml of water, self heats! A taste that reminds you of your school years."
+	desc = "Just add 5ml of water, self heats! A taste that reminds you of your school years. Now new with salty flavour!"
 	icon_state = "ramen"
-	list_reagents = list("dry_ramen" = 15)
+	list_reagents = list("dry_ramen" = 15, "sodiumchloride" = 3)
 	foodtype = GRAIN
 	isGlass = FALSE
 	custom_price = 38


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds salt to the map beyond the few salt-shakers publically available. 

## Why It's Good For The Game

Useful if chemistry blew up, is extremely incompetent and territorial or the traitor CMO killed everyone and is now spreading some AIDS you literally can't cure because salt is rarer than gold. Use pure or turn into saline-glucose solution. Also makes Charcoal ghetto-craftable allowing to deal with Toxins damage after you breathe in a healthy dose of Plasma.
tl;dr more options for ghettochem

## Changelog
:cl: Terranaut

add: Added 3u of Sodium Chloride to the Cup Ramen purchasable from vending machines

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
