### PR TITLE
Riot armor buff

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -122,7 +122,7 @@
 	blocks_shove_knockdown = TRUE
 	strip_delay = 80
 	equip_delay_other = 60
-	slowdown = 1
+	slowdown = 0.5
 
 /obj/item/clothing/suit/armor/bone
 	name = "bone armor"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Halves the value of riot armor slowdown. Because of how slowdown works, if you are running at full speed (1.5 movement delay) this changes it from a 40% slowdown to a 25% slowdown.

## Why It's Good For The Game

40% slowdown was a lot more than I intended.

## Changelog
:cl:
balance: Riot armor slows you down less.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
