### PR TITLE
makes the medical hardsuit faster

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -445,7 +445,7 @@
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/storage/firstaid, /obj/item/healthanalyzer, /obj/item/stack/medical)
 	armor = list("melee" = 30, "bullet" = 5, "laser" = 10, "energy" = 5, "bomb" = 10, "bio" = 100, "rad" = 60, "fire" = 60, "acid" = 75)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/medical
-	slowdown = 0
+	slowdown = 0.5
 
 	//Research Director hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/rd

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -445,6 +445,7 @@
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/storage/firstaid, /obj/item/healthanalyzer, /obj/item/stack/medical)
 	armor = list("melee" = 30, "bullet" = 5, "laser" = 10, "energy" = 5, "bomb" = 10, "bio" = 100, "rad" = 60, "fire" = 60, "acid" = 75)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/medical
+	slowdown = 0
 
 	//Research Director hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/rd


### PR DESCRIPTION
## About The Pull Request
Changes the medical hardsuit's slowdown from 1 to 0.5

## Why It's Good For The Game
Medical hardsuit is the worst one, doesnt even have any flash protection, doesnt have any cool protection thing like sci bomb protection or atmos fireproofness, its description says that its made of lightweight materials to allow easier movement too, and also if you want to save someones life you probably would like to do it as fast as possible and not go in a slow hardsuit

## Changelog
:cl:
balance: Medical Hardsuit is faster
/:cl: