### PR TITLE
Standardizes cable colors

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/DJstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation.dmm
@@ -54,43 +54,43 @@
 /turf/open/floor/plating,
 /area/ruin/space/djstation)
 "an" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/power/smes/magical{
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit.";
 	name = "power storage unit"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/ruin/space/djstation)
 "ao" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/djstation)
 "ap" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	name = "Worn-out APC";
 	pixel_y = -24
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
 /area/ruin/space/djstation)
 "aq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/item/storage/box/lights/mixed,
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/ruin/space/djstation)
 "ar" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -42,7 +42,7 @@
 	id = "derelictsolar";
 	name = "Derelict Solar Array"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/airless,
@@ -54,10 +54,10 @@
 "aj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
 /turf/template_noop,
 /area/solar/derelict_starboard)
@@ -84,10 +84,10 @@
 "am" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "2-4"
 	},
 /turf/template_noop,
 /area/solar/derelict_starboard)
@@ -180,28 +180,28 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "aB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "aC" = (
 /obj/machinery/power/smes,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "aD" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/power/solar_control{
 	id = "derelictsolar";
 	name = "Primary Solar Control";
 	track = 0
 	},
 /obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "aF" = (
@@ -215,13 +215,13 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "aH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -236,11 +236,11 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "aJ" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
@@ -263,7 +263,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/solar_control)
 "aN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -298,14 +298,14 @@
 	name = "Starboard Solar APC";
 	pixel_x = -24
 	},
-/obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "aU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -331,23 +331,23 @@
 /obj/machinery/computer/monitor/secret{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "ba" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "bb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -382,7 +382,7 @@
 	name = "Starboard Solar Access";
 	req_access_txt = "10"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -405,7 +405,7 @@
 /area/ruin/space/derelict/bridge/ai_upload)
 "bm" = (
 /obj/machinery/door/window,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -435,7 +435,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
 "br" = (
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/open/floor/plasteel,
@@ -491,7 +491,7 @@
 	},
 /area/ruin/space/derelict/solar_control)
 "bC" = (
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/open/floor/plasteel{
@@ -601,13 +601,13 @@
 	name = "Worn-out APC";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/ai_upload)
 "bX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
@@ -636,7 +636,7 @@
 	},
 /area/space/nearstation)
 "cc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
@@ -646,19 +646,19 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/ai_upload)
 "ce" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/bridge/ai_upload)
 "cf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/bridge/ai_upload)
 "cg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/closed/wall/r_wall,
@@ -670,13 +670,13 @@
 /turf/closed/wall/r_wall,
 /area/template_noop)
 "cj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/bridge/ai_upload)
 "ck" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
@@ -714,7 +714,7 @@
 	},
 /area/ruin/space/derelict/gravity_generator)
 "cr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/closed/wall,
@@ -724,7 +724,7 @@
 /area/ruin/space/derelict/bridge/access)
 "ct" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -788,7 +788,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "cF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -810,28 +810,28 @@
 /turf/template_noop,
 /area/template_noop)
 "cJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/closed/wall,
 /area/ruin/space/derelict/bridge/access)
 "cK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "cM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "cN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -840,17 +840,19 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/gravity_generator)
 "cP" = (
-/obj/item/stack/cable_coil/cut/red,
+/obj/item/stack/cable_coil/cut/yellow{
+	amount = 2
+	},
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged4"
 	},
 /area/ruin/space/derelict/gravity_generator)
 "cQ" = (
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	name = "Worn-out APC";
 	pixel_y = -24
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "cR" = (
@@ -887,7 +889,7 @@
 	name = "E.V.A.";
 	req_access_txt = "18"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -901,7 +903,7 @@
 /area/ruin/space/derelict/bridge/access)
 "cX" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -945,29 +947,29 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "df" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/item/wallframe/apc,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/gravity_generator)
 "dg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/gravity_generator)
 "dh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/gravity_generator)
 "di" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/frame/machine,
@@ -988,37 +990,37 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "dm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/bridge/access)
 "dn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "do" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "dp" = (
 /obj/machinery/door/airlock/public/glass,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "dq" = (
 /obj/item/reagent_containers/food/drinks/beer,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -1035,7 +1037,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/gravity_generator)
 "dt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
@@ -1069,7 +1071,7 @@
 /area/ruin/space/derelict/bridge/access)
 "dy" = (
 /obj/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -1090,7 +1092,7 @@
 	name = "Engineering Access";
 	req_access_txt = "10"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -1120,7 +1122,7 @@
 /area/ruin/space/derelict/bridge)
 "dH" = (
 /obj/structure/frame/computer,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
@@ -1185,14 +1187,16 @@
 	},
 /area/ruin/space/derelict/singularity_engine)
 "dR" = (
-/obj/item/stack/cable_coil/cut/red,
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/item/stack/cable_coil/cut/yellow{
+	amount = 2
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "dS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
@@ -1202,13 +1206,13 @@
 	name = "Engineering Access";
 	req_access_txt = "10"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/gravity_generator)
 "dU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -1228,7 +1232,7 @@
 	},
 /area/ruin/space/derelict/singularity_engine)
 "dY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -1319,7 +1323,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "ep" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced,
@@ -1405,16 +1409,16 @@
 	},
 /area/ruin/space/derelict/singularity_engine)
 "eH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "eI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -1423,13 +1427,13 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/access)
 "eK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1439,7 +1443,7 @@
 /turf/template_noop,
 /area/ruin/space/derelict/singularity_engine)
 "eM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -1466,7 +1470,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge)
 "eR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -1739,7 +1743,7 @@
 /area/ruin/space/derelict/singularity_engine)
 "fK" = (
 /obj/machinery/door/window,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -1791,7 +1795,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/bridge/access)
 "fT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/airless,
@@ -1835,7 +1839,7 @@
 /turf/closed/wall,
 /area/ruin/space/derelict/hallway/primary)
 "ga" = (
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/open/floor/plasteel/airless{
@@ -1843,7 +1847,7 @@
 	},
 /area/ruin/space/derelict/hallway/primary)
 "gb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless{
@@ -1851,28 +1855,28 @@
 	},
 /area/ruin/space/derelict/hallway/primary)
 "gc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "gd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/bridge/access)
 "ge" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/access)
 "gf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/airless,
@@ -1901,7 +1905,7 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/hallway/primary)
 "gl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
@@ -1953,13 +1957,13 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "gx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/primary)
 "gy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
@@ -1974,11 +1978,11 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "gB" = (
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	name = "Worn-out APC";
 	pixel_y = -24
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/access)
 "gC" = (
@@ -2072,7 +2076,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "gU" = (
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/open/floor/plating/airless,
@@ -2096,7 +2100,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "ha" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/airless,
@@ -2441,7 +2445,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "ip" = (
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/open/floor/plasteel/airless{
@@ -2529,7 +2533,7 @@
 /turf/open/floor/plasteel/airless/white,
 /area/ruin/unpowered/no_grav)
 "iF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/airless{
@@ -2682,7 +2686,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "jc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/airless,
@@ -2692,13 +2696,13 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/arrival)
 "jf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/airless/white,
 /area/ruin/space/derelict/medical)
 "jg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/window/reinforced{
@@ -2707,19 +2711,19 @@
 /turf/open/floor/plasteel/airless/white,
 /area/ruin/space/derelict/medical)
 "jh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless/white,
 /area/ruin/space/derelict/medical)
 "ji" = (
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/open/floor/plasteel/airless/white,
 /area/ruin/space/derelict/medical)
 "jj" = (
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/open/floor/plasteel/airless{
@@ -2805,7 +2809,7 @@
 	name = "Worn-out APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/airless,
@@ -2834,7 +2838,7 @@
 /turf/open/floor/plasteel/airless/white,
 /area/ruin/space/derelict/medical)
 "jD" = (
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/open/floor/plasteel/airless{
@@ -2884,14 +2888,14 @@
 /area/ruin/space/derelict/medical/chapel)
 "jM" = (
 /obj/machinery/door/window,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/medical/chapel)
 "jN" = (
 /obj/machinery/door/window/southleft,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/airless/white,
@@ -2901,16 +2905,16 @@
 /turf/open/floor/plasteel/airless/white,
 /area/ruin/space/derelict/medical)
 "jP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "jQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/research{
@@ -2920,13 +2924,13 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "jR" = (
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "jS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
@@ -2962,7 +2966,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "jX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/airless{
@@ -2985,13 +2989,13 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "kb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/unpowered/no_grav)
 "kc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless,
@@ -3010,20 +3014,20 @@
 /area/ruin/unpowered/no_grav)
 "kf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/unpowered/no_grav)
 "kg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/window/fulltile,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "kh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/research{
@@ -3033,19 +3037,19 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/arrival)
 "ki" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/arrival)
 "kj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/arrival)
 "kk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -3057,7 +3061,9 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/medical/chapel)
 "km" = (
-/obj/item/stack/cable_coil/cut/red,
+/obj/item/stack/cable_coil/cut/yellow{
+	amount = 2
+	},
 /turf/open/floor/plasteel/airless{
 	icon_state = "floorscorched1"
 	},
@@ -3092,7 +3098,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/arrival)
 "ku" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless{
@@ -3105,37 +3111,37 @@
 	dir = 4;
 	icon_state = "right"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "kx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "ky" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "kz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "kA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/airless,
@@ -3153,25 +3159,25 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "kE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "kG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary)
 "kH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/airless,
@@ -3221,7 +3227,7 @@
 	name = "Security";
 	req_access_txt = "1"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/airless,
@@ -3314,7 +3320,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary/port)
 "lj" = (
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/open/floor/plasteel/airless,
@@ -3410,7 +3416,7 @@
 /turf/template_noop,
 /area/ruin/space/derelict/hallway/primary/port)
 "lB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced,
@@ -3494,7 +3500,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/atmospherics)
 "lQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/airless,
@@ -3555,7 +3561,9 @@
 /area/ruin/space/derelict/atmospherics)
 "mb" = (
 /obj/structure/lattice,
-/obj/item/stack/cable_coil/cut/red,
+/obj/item/stack/cable_coil/cut/yellow{
+	amount = 2
+	},
 /turf/template_noop,
 /area/ruin/space/derelict/hallway/primary/port)
 "mc" = (
@@ -3690,7 +3698,9 @@
 /turf/template_noop,
 /area/ruin/space/derelict/atmospherics)
 "mA" = (
-/obj/item/stack/cable_coil/cut/red,
+/obj/item/stack/cable_coil/cut/yellow{
+	amount = 2
+	},
 /turf/template_noop,
 /area/ruin/space/derelict/hallway/primary/port)
 "mB" = (
@@ -3701,7 +3711,7 @@
 /area/ruin/space/derelict/hallway/secondary)
 "mC" = (
 /obj/item/wirecutters,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/airless,
@@ -3730,7 +3740,7 @@
 	},
 /area/ruin/space/derelict/hallway/primary/port)
 "mI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/airless,
@@ -3795,15 +3805,15 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "mX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Worn-out APC";
 	pixel_x = -24
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "mY" = (
@@ -3828,19 +3838,19 @@
 	name = "Worn-out APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "nd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "ne" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -3852,7 +3862,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -3861,7 +3871,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "ng" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -3870,7 +3880,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "nh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -3879,7 +3889,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "ni" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -3888,7 +3898,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "nj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -3897,7 +3907,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "nk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -3909,7 +3919,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -3918,16 +3928,16 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "nm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "nn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/airless,
@@ -3996,7 +4006,7 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/se_solar)
 "nC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -4017,7 +4027,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/secondary)
 "nF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -4038,22 +4048,22 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/se_solar)
 "nJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/se_solar)
 "nK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/se_solar)
 "nL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -4109,10 +4119,10 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/item/drone_shell/dusty,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/item/drone_shell/dusty,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/se_solar)
 "nV" = (
@@ -4123,20 +4133,19 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/se_solar)
 "nY" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable,
 /obj/machinery/power/solar_control{
 	dir = 1;
 	id = "derelictsolar";
 	name = "Primary Solar Control";
 	track = 0
 	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/se_solar)
 "nZ" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
 	dir = 8;
 	environ = 0;
@@ -4145,6 +4154,7 @@
 	name = "Worn-out APC";
 	pixel_x = -24
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/se_solar)
 "oa" = (
@@ -4199,10 +4209,10 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/se_solar)
 "ok" = (
+/obj/machinery/door/airlock/external,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/se_solar)
 "ol" = (
@@ -4211,14 +4221,14 @@
 /turf/template_noop,
 /area/solar/derelict_aft)
 "om" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/solar/derelict_aft)
 "on" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
@@ -4228,14 +4238,14 @@
 /turf/open/floor/plasteel/airless,
 /area/solar/derelict_aft)
 "oo" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/solar/derelict_aft)
 "op" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
@@ -4282,16 +4292,16 @@
 /turf/template_noop,
 /area/solar/derelict_aft)
 "ou" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/solar/derelict_aft)
 "ov" = (
@@ -4344,20 +4354,13 @@
 	},
 /turf/template_noop,
 /area/solar/derelict_aft)
-"oB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/solar/derelict_aft)
 "oC" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
 /turf/template_noop,
 /area/solar/derelict_aft)
@@ -4444,7 +4447,7 @@
 /turf/closed/wall,
 /area/ruin/space/derelict/hallway/primary/port)
 "KT" = (
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/open/floor/plating/airless,
@@ -4461,9 +4464,35 @@
 "Lv" = (
 /turf/closed/wall,
 /area/space/nearstation)
+"My" = (
+/obj/structure/lattice,
+/obj/item/stack/cable_coil/cut/yellow{
+	amount = 2
+	},
+/turf/template_noop,
+/area/space/nearstation)
+"MQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/derelict/se_solar)
 "Oj" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/bridge/access)
+"ON" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/template_noop,
+/area/solar/derelict_aft)
 "OT" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/hallway/primary/port)
@@ -10138,7 +10167,7 @@ nB
 nI
 ZB
 ZB
-ld
+My
 nV
 nV
 nB
@@ -10258,7 +10287,7 @@ aa
 aa
 aa
 on
-os
+ON
 ox
 aa
 on
@@ -10371,7 +10400,7 @@ nB
 aa
 aa
 on
-os
+ON
 ox
 aa
 on
@@ -10488,7 +10517,7 @@ ot
 aa
 aa
 aa
-oB
+ot
 aa
 aa
 vf
@@ -10714,7 +10743,7 @@ ot
 aa
 aa
 aa
-oB
+ot
 aa
 aa
 ZB
@@ -10814,8 +10843,8 @@ mI
 nC
 nF
 nL
-nP
-nP
+MQ
+MQ
 nZ
 nR
 nR

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -8,14 +8,17 @@
 	anchored = 1;
 	power = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
 "ac" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -26,11 +29,11 @@
 	anchored = 1;
 	power = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
@@ -40,11 +43,11 @@
 	anchored = 1;
 	power = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
@@ -54,8 +57,11 @@
 	anchored = 1;
 	power = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
@@ -72,13 +78,6 @@
 "aj" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid,
-/area/ruin/space/has_grav/abandonedzoo)
-"ak" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
 "al" = (
 /obj/structure/flora/ausbushes/genericbush,
@@ -185,12 +184,15 @@
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/abandonedzoo)
 "aD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "Bio Containment";
 	req_one_access_txt = "47"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
@@ -200,58 +202,24 @@
 	anchored = 1;
 	power = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
-"aF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/abandonedzoo)
 "aG" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/item/gun/energy/floragun,
 /turf/open/floor/plasteel/dark/side,
-/area/ruin/space/has_grav/abandonedzoo)
-"aH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/abandonedzoo)
 "aI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/med_data/laptop{
 	dir = 8;
 	pixel_y = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
@@ -261,14 +229,11 @@
 	anchored = 1;
 	power = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
@@ -279,13 +244,10 @@
 /turf/template_noop,
 /area/space/nearstation)
 "aL" = (
-/turf/open/floor/plasteel/dark/side,
-/area/ruin/space/has_grav/abandonedzoo)
-"aM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aN" = (
 /obj/structure/table/reinforced,
@@ -324,6 +286,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aS" = (
@@ -335,21 +300,15 @@
 	name = "Worn-out APC";
 	pixel_x = -24
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/structure/rack,
 /obj/item/melee/baton/cattleprod,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aT" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/rack,
 /obj/item/clothing/suit/space/hardsuit/medical,
 /obj/item/tank/internals/emergency_oxygen/double,
@@ -408,6 +367,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bb" = (
@@ -426,27 +388,8 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/abandonedzoo)
-"bc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/abandonedzoo)
 "bd" = (
 /obj/machinery/power/terminal,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -461,6 +404,9 @@
 /area/ruin/space/has_grav/abandonedzoo)
 "be" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bf" = (
@@ -468,15 +414,20 @@
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit.";
 	name = "power storage unit"
 	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bg" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bh" = (
@@ -528,15 +479,11 @@
 	anchored = 1;
 	power = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
@@ -546,41 +493,29 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
-"bq" = (
-/obj/item/stack/cable_coil/cut/red,
-/obj/item/stack/tile/plasteel{
-	pixel_x = 3;
-	pixel_y = -4
-	},
-/obj/item/wirecutters,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/abandonedzoo)
 "br" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/shieldwallgen,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
 "bt" = (
-/obj/structure/cable{
+/obj/machinery/shieldwallgen,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/shieldwallgen,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
 "bu" = (
@@ -712,6 +647,7 @@
 /area/ruin/space/has_grav/abandonedzoo)
 "bN" = (
 /obj/structure/grille/broken,
+/obj/item/stack/cable_coil/cut/yellow,
 /obj/item/shard{
 	icon_state = "small"
 	},
@@ -725,18 +661,6 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/space/nearstation)
-"bQ" = (
-/obj/machinery/shieldwallgen{
-	active = 2;
-	anchored = 1;
-	power = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/abandonedzoo)
 "bR" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -745,11 +669,13 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable,
 /obj/machinery/shieldwallgen,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
 "bT" = (
@@ -774,6 +700,52 @@
 "bX" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
+"eY" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/ruin/space/has_grav/abandonedzoo)
+"fM" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/abandonedzoo)
+"jz" = (
+/obj/machinery/shieldwallgen{
+	active = 2;
+	anchored = 1;
+	power = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/abandonedzoo)
+"kj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/abandonedzoo)
 "lo" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -791,29 +763,187 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/abandonedzoo)
+"nQ" = (
+/obj/machinery/shieldwallgen{
+	active = 2;
+	anchored = 1;
+	power = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/abandonedzoo)
+"oK" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/abandonedzoo)
+"rY" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/stack/cable_coil/cut/yellow,
+/obj/item/stack/tile/plasteel{
+	pixel_x = 3;
+	pixel_y = -4
+	},
+/obj/item/wirecutters,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/abandonedzoo)
+"sC" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/ruin/space/has_grav/abandonedzoo)
+"tP" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/abandonedzoo)
+"wF" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Bio-Research Station"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/abandonedzoo)
+"AX" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Bio Containment";
+	req_one_access_txt = "47"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/ruin/space/has_grav/abandonedzoo)
+"Ck" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/abandonedzoo)
+"Hx" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Bio Containment";
+	req_one_access_txt = "47"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/ruin/space/has_grav/abandonedzoo)
 "KN" = (
 /turf/template_noop,
 /area/space/nearstation)
+"Ld" = (
+/obj/machinery/shieldwallgen{
+	active = 2;
+	anchored = 1;
+	power = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/abandonedzoo)
+"VW" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Bio Containment";
+	req_one_access_txt = "47"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/ruin/space/has_grav/abandonedzoo)
 
 (1,1,1) = {"
 ab
-ag
-ag
-ag
-ag
-ab
+kj
+kj
+kj
+kj
+jz
 aa
 aa
 aa
 aa
 aa
 aa
-ab
-ag
-ag
-ag
-ag
-ab
+ae
+kj
+kj
+kj
+kj
+nQ
 aa
 "}
 (2,1,1) = {"
@@ -847,10 +977,10 @@ aD
 aL
 aR
 aL
-aL
+eY
 aR
 aL
-aD
+VW
 bv
 bv
 bJ
@@ -868,7 +998,7 @@ ac
 at
 at
 bb
-bb
+wF
 at
 at
 ac
@@ -888,8 +1018,8 @@ ar
 ac
 at
 aS
-ay
-ay
+Ck
+oK
 be
 at
 ac
@@ -902,23 +1032,23 @@ aa
 "}
 (6,1,1) = {"
 ad
-ak
-ak
-ak
-ak
+kj
+kj
+kj
+kj
 aE
-aM
+at
 aT
-bc
+ay
 bd
 bf
-aM
+at
 bo
-ak
-ak
-ak
-ak
-bQ
+kj
+kj
+kj
+kj
+Ld
 aa
 "}
 (7,1,1) = {"
@@ -927,14 +1057,14 @@ aa
 aa
 at
 at
-aF
+at
 at
 aU
 ay
-ay
+fM
 bg
 at
-aF
+at
 by
 bF
 bK
@@ -952,7 +1082,7 @@ aG
 aN
 aV
 ay
-ay
+tP
 bh
 bm
 bp
@@ -969,14 +1099,14 @@ aa
 aa
 ag
 ay
-aH
+ay
 aO
 ay
 ay
+tP
 ay
 ay
 ay
-aH
 ay
 bG
 bL
@@ -990,14 +1120,14 @@ aa
 aa
 ag
 ay
-aH
 ay
 ay
 ay
 ay
+tP
 ay
 ay
-bq
+ay
 ay
 bG
 bM
@@ -1015,7 +1145,7 @@ aI
 aP
 aW
 ay
-ay
+tP
 bi
 bn
 br
@@ -1032,14 +1162,14 @@ aa
 aa
 at
 at
-aF
+at
 at
 aX
 ay
-ay
+tP
 bj
 at
-aF
+at
 at
 at
 aa
@@ -1049,22 +1179,22 @@ aa
 "}
 (13,1,1) = {"
 ae
-ak
-ak
-ak
-ak
+kj
+kj
+kj
+kj
 aJ
 at
 aY
 ay
-ay
+tP
 bk
 at
 bs
-ak
-ak
-ak
-ak
+kj
+kj
+kj
+kj
 bS
 aa
 "}
@@ -1078,7 +1208,7 @@ ac
 at
 aZ
 ay
-ay
+tP
 bl
 at
 ac
@@ -1099,7 +1229,7 @@ ac
 at
 at
 bb
-bb
+wF
 at
 at
 ac
@@ -1116,14 +1246,14 @@ an
 aq
 au
 am
-aD
+Hx
 aL
 ba
 aL
+sC
+rY
 aL
-ba
-aL
-aD
+AX
 bD
 bB
 bX
@@ -1154,11 +1284,11 @@ aa
 "}
 (18,1,1) = {"
 af
-ak
-ak
-ak
-ak
-af
+kj
+kj
+kj
+kj
+Ld
 aa
 aa
 aa
@@ -1166,8 +1296,8 @@ aa
 aa
 aa
 bt
-ag
-ag
+kj
+kj
 bN
 bP
 KN

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -58,7 +58,7 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
 "an" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -70,7 +70,7 @@
 	name = "Cargo Bay APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
@@ -102,7 +102,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "au" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -295,7 +295,7 @@
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "bb" = (
 /obj/machinery/power/smes,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
@@ -303,17 +303,17 @@
 "bc" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell/hyper,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "bd" = (
 /obj/machinery/power/smes,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
@@ -455,7 +455,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "bs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -801,10 +801,10 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "bZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
@@ -817,7 +817,7 @@
 	pixel_x = 23;
 	pixel_y = 2
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
@@ -850,7 +850,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -915,7 +915,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost)
 "cj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -927,7 +927,7 @@
 	name = "Tradepost APC";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
@@ -967,14 +967,14 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "cp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "cq" = (
 /obj/structure/barricade/wooden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -985,19 +985,19 @@
 	req_access_txt = "10"
 	},
 /obj/structure/barricade/wooden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "cs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
 "ct" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -1028,10 +1028,10 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -1042,7 +1042,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1053,14 +1053,14 @@
 	id = "bigderelictcheckpoint";
 	name = "checkpoint security doors"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost)
 "cz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1071,13 +1071,13 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost)
 "cB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -1154,13 +1154,13 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
 "cI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/janitorialcart,
@@ -1172,7 +1172,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/mop,
@@ -1189,7 +1189,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1205,7 +1205,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1217,7 +1217,7 @@
 	name = "gelatinous floor"
 	},
 /obj/structure/glowshroom/single,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1228,10 +1228,10 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -1390,7 +1390,7 @@
 	name = "gelatinous floor"
 	},
 /obj/machinery/light,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
@@ -1406,7 +1406,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1427,7 +1427,7 @@
 	desc = "A pried-open airlock. Scratch marks mark the sidings of the door.";
 	name = "pried-open airlock"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -1444,7 +1444,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -1539,7 +1539,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -1659,7 +1659,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -1743,7 +1743,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -1793,7 +1793,7 @@
 	icon_state = "trails_1";
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -1958,7 +1958,7 @@
 	icon_state = "trails_1";
 	name = "dried blood trail"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -2020,7 +2020,7 @@
 	name = "Cargo Storage APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
@@ -2077,7 +2077,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
 "eu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -2123,7 +2123,7 @@
 	icon_state = "trails_1";
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -2186,7 +2186,7 @@
 	icon_state = "trails_1";
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
@@ -2202,7 +2202,7 @@
 	icon_state = "trails_1";
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -2213,7 +2213,7 @@
 	icon_state = "trails_1";
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1006,24 +1006,9 @@
 /area/awaymission/BMPship/Aft)
 "do" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
-/area/awaymission/BMPship/Aft)
-"dp" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/awaymission/BMPship/Aft)
 "dq" = (
 /obj/item/multitool,
@@ -1314,25 +1299,10 @@
 /turf/open/floor/plating,
 /area/awaymission/BMPship/Aft)
 "eb" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/terminal{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/awaymission/BMPship/Aft)
-"ec" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/awaymission/BMPship/Aft)
 "ed" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
@@ -1452,15 +1422,6 @@
 /obj/item/storage/belt/utility/full,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/BMPship/Aft)
-"eu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/BMPship/Aft)
@@ -1639,15 +1600,6 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/awaymission/BMPship/Aft)
-"eR" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/awaymission/BMPship/Aft)
 "eS" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -5294,12 +5246,12 @@ aa
 aa
 ac
 cX
-dp
-eu
-ec
-eu
-eu
-eR
+fr
+cX
+cX
+cX
+cX
+cX
 cX
 fr
 fH

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -2804,17 +2804,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "gj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/cable/yellow{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage/power)
 "gk" = (
@@ -2867,13 +2867,13 @@
 /area/ruin/space/has_grav/deepstorage/power)
 "gt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage/power)
 "gu" = (
@@ -2928,10 +2928,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage/power)
 "gB" = (
@@ -2989,16 +2989,16 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "gK" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -3008,17 +3008,17 @@
 	name = "RTG Observation";
 	req_access_txt = "200"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "gM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/cable/yellow{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage/power)
 "gN" = (
@@ -3053,7 +3053,7 @@
 /area/ruin/space/has_grav/deepstorage)
 "gR" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -3101,10 +3101,10 @@
 /area/ruin/space/has_grav/deepstorage/power)
 "gX" = (
 /obj/machinery/power/rtg/advanced,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "gY" = (
@@ -3116,13 +3116,13 @@
 /area/ruin/space/has_grav/deepstorage/power)
 "gZ" = (
 /obj/machinery/power/rtg/advanced,
-/obj/structure/cable/yellow,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "ha" = (
 /obj/machinery/power/rtg/advanced,
 /obj/machinery/light/small,
-/obj/structure/cable/yellow,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "hb" = (

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -245,7 +245,7 @@
 	pixel_x = 24;
 	start_charge = 0
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -297,7 +297,7 @@
 /area/ruin/space/has_grav/ancientstation)
 "aU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -529,7 +529,7 @@
 /area/ruin/space/has_grav/ancientstation/betanorth)
 "bx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -618,7 +618,7 @@
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/ancientstation)
 "bP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -630,7 +630,7 @@
 /area/ruin/space/has_grav/ancientstation)
 "bQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -777,7 +777,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/powered)
 "cl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -891,17 +891,17 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-25"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/strong,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/strong,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "cA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -912,7 +912,7 @@
 "cB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/science,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -920,16 +920,16 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "cC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/range,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/range,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "cD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -937,7 +937,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "cE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -946,8 +946,8 @@
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "cF" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/range,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/range,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "cG" = (
@@ -999,7 +999,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation)
 "cO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1070,13 +1070,13 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "cY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "cZ" = (
@@ -1085,8 +1085,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "da" = (
@@ -1104,8 +1104,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/hivebot/range,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/range,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "dc" = (
@@ -1122,8 +1122,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/hivebot/range,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/range,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "de" = (
@@ -1140,14 +1140,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/mob/living/simple_animal/hostile/hivebot/strong,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/strong,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "dg" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/strong,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/strong,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "dh" = (
@@ -1178,7 +1178,7 @@
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/ancientstation/engi)
 "dm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1283,7 +1283,7 @@
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/ancientstation/sec)
 "dw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1361,17 +1361,17 @@
 /area/template_noop)
 "dK" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/template_noop,
 /area/template_noop)
 "dL" = (
 /obj/machinery/power/solar,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating/airless,
@@ -1438,7 +1438,7 @@
 "dS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -1490,7 +1490,7 @@
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/ancientstation/sec)
 "dW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1528,7 +1528,6 @@
 /area/ruin/space/has_grav/ancientstation/rnd)
 "ec" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/strong,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -1538,12 +1537,13 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/mob/living/simple_animal/hostile/hivebot/strong,
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "ed" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "ee" = (
@@ -1552,8 +1552,8 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "ef" = (
@@ -1569,7 +1569,7 @@
 /area/ruin/space/has_grav/ancientstation/betanorth)
 "ei" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/template_noop,
@@ -1666,7 +1666,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "et" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1714,7 +1714,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/sec)
 "ey" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1777,14 +1777,14 @@
 	},
 /area/ruin/space/has_grav/ancientstation/betanorth)
 "eI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/solar,
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "eJ" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating/airless,
@@ -1834,7 +1834,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/engi)
 "eO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1888,7 +1888,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "eU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1915,27 +1915,27 @@
 /area/ruin/space/has_grav/ancientstation/sec)
 "eW" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "eX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "eY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "eZ" = (
@@ -1967,7 +1967,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -1976,7 +1976,7 @@
 /obj/machinery/power/smes/engineering{
 	charge = 0
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1993,7 +1993,7 @@
 /area/ruin/space/has_grav/ancientstation/engi)
 "fg" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2108,7 +2108,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/sec)
 "ft" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2131,8 +2131,8 @@
 /area/ruin/space/has_grav/ancientstation/rnd)
 "fw" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/strong,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/strong,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "fx" = (
@@ -2177,7 +2177,7 @@
 /area/ruin/space/has_grav/ancientstation/engi)
 "fE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2235,7 +2235,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/sec)
 "fL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2275,7 +2275,7 @@
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "fQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -2287,19 +2287,19 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "fR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "fS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "fT" = (
@@ -2360,18 +2360,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/ancientstation/betanorth)
 "ga" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/ancientstation/betanorth)
@@ -2390,10 +2390,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/template_noop,
@@ -2403,7 +2403,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/template_noop,
@@ -2413,13 +2413,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/template_noop,
@@ -2436,7 +2436,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -2446,7 +2446,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -2457,10 +2457,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -2468,19 +2468,19 @@
 "gj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "gk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2495,14 +2495,14 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "gm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -2511,10 +2511,10 @@
 /area/ruin/space/has_grav/ancientstation/engi)
 "gn" = (
 /obj/effect/spawner/structure/window/hollow/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2526,13 +2526,13 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/powered)
 "go" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2543,7 +2543,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation)
 "gp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2552,7 +2552,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation)
 "gq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -2563,7 +2563,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
 "gr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2580,10 +2580,10 @@
 	pixel_y = 24;
 	start_charge = 0
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2592,7 +2592,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "gt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2603,7 +2603,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
 "gu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2617,16 +2617,16 @@
 	pixel_y = -24;
 	start_charge = 0
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "gw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2638,7 +2638,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
 "gx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -2646,7 +2646,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
 "gy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -2657,7 +2657,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation)
 "gz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2669,10 +2669,10 @@
 /area/ruin/space/has_grav/ancientstation)
 "gA" = (
 /obj/effect/spawner/structure/window/hollow/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2684,11 +2684,11 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/sec)
 "gB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2699,7 +2699,7 @@
 /area/ruin/space/has_grav/ancientstation/sec)
 "gC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2710,7 +2710,7 @@
 /area/ruin/space/has_grav/ancientstation/sec)
 "gD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -2724,10 +2724,10 @@
 /area/ruin/space/has_grav/ancientstation/sec)
 "gE" = (
 /obj/effect/spawner/structure/window/hollow/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2736,7 +2736,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/sec)
 "gF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2746,7 +2746,7 @@
 /area/space/nearstation)
 "gG" = (
 /obj/effect/spawner/structure/window/hollow/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2756,7 +2756,7 @@
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "gH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2766,10 +2766,10 @@
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "gI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2779,7 +2779,7 @@
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "gJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -2789,13 +2789,13 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "gK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2813,7 +2813,7 @@
 	pixel_x = 24;
 	start_charge = 0
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -2906,14 +2906,14 @@
 /area/ruin/space/has_grav/ancientstation/engi)
 "gW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/engi)
 "gX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3004,7 +3004,7 @@
 /area/ruin/space/has_grav/ancientstation/engi)
 "hl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -3018,7 +3018,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "hn" = (
@@ -3031,7 +3031,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/engi)
 "ho" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3044,7 +3044,7 @@
 /area/ruin/space/has_grav/ancientstation/engi)
 "hq" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3136,7 +3136,7 @@
 /area/ruin/space/has_grav/ancientstation/sec)
 "hC" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3155,8 +3155,8 @@
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "hE" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "hF" = (
@@ -3241,14 +3241,14 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/ancientstation/betanorth)
 "hM" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "hN" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/template_noop,
@@ -3260,7 +3260,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/oil,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
@@ -3285,7 +3285,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/engi)
 "hQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3382,7 +3382,7 @@
 /area/ruin/space/has_grav/ancientstation/rnd)
 "ib" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/template_noop,
@@ -3428,7 +3428,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/engi)
 "ig" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3439,7 +3439,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/engi)
 "ih" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3518,8 +3518,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/hivebot/range,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/range,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "ir" = (
@@ -3683,7 +3683,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/sec)
 "iC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3691,8 +3691,8 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "iD" = (
@@ -3872,7 +3872,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -3882,10 +3882,10 @@
 	charge = 0;
 	name = "backup power storage unit"
 	},
-/obj/structure/cable{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "iW" = (
@@ -3974,11 +3974,11 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/cable/yellow,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "jj" = (
@@ -3990,7 +3990,7 @@
 	name = "Backup Generator Room"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -4068,8 +4068,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "ju" = (
@@ -4095,8 +4095,8 @@
 "jw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "jx" = (
@@ -4107,8 +4107,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "jy" = (
@@ -4157,7 +4157,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "jE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4168,7 +4168,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation)
 "jF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4199,7 +4199,7 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-25"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4207,17 +4207,17 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "jK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "jL" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4225,7 +4225,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "jM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4247,7 +4247,7 @@
 /turf/template_noop,
 /area/space/nearstation)
 "jR" = (
-/obj/structure/cable/yellow,
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "jS" = (
@@ -4281,7 +4281,7 @@
 	name = "Prototype Laboratory";
 	req_access_txt = "200"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white/side,
@@ -4355,14 +4355,14 @@
 	pixel_y = 24;
 	start_charge = 0
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation/proto)
 "kh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/white,
@@ -4719,9 +4719,9 @@
 	pixel_x = 24;
 	start_charge = 0
 	},
-/obj/structure/cable,
 /obj/item/storage/backpack/old,
 /obj/item/storage/backpack/old,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
 "kZ" = (
@@ -4927,7 +4927,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -4938,8 +4938,8 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "qB" = (
@@ -4952,7 +4952,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "rv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -5022,7 +5022,7 @@
 /area/ruin/space/has_grav/ancientstation/rnd)
 "Af" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5102,18 +5102,18 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "LY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation)
 "MS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -5171,7 +5171,7 @@
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "Pl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/solar_assembly,
@@ -5242,12 +5242,12 @@
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "XJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "Yc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -5257,7 +5257,7 @@
 "Yi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -3,35 +3,35 @@
 /turf/template_noop,
 /area/template_noop)
 "ab" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/space/nearstation)
 "ac" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/space/nearstation)
 "ad" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/space/nearstation)
 "ae" = (
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/space/nearstation)
 "af" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/lattice/catwalk,
@@ -45,7 +45,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/onehalf/dorms_med)
 "ai" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
@@ -85,7 +85,7 @@
 /area/ruin/space/has_grav/onehalf/dorms_med)
 "aq" = (
 /obj/machinery/door/airlock/external,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -174,7 +174,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/dorms_med)
 "aD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
@@ -216,13 +216,13 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/onehalf/dorms_med)
 "aL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/onehalf/dorms_med)
 "aM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/closet/crate/medical,
@@ -282,7 +282,7 @@
 /turf/template_noop,
 /area/space/nearstation)
 "aT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/airless{
@@ -296,7 +296,7 @@
 /area/ruin/space/has_grav/onehalf/hallway)
 "aV" = (
 /obj/machinery/door/airlock/medical/glass,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -306,10 +306,10 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/dorms_med)
 "aX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -318,7 +318,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/drone_bay)
 "aY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -425,7 +425,7 @@
 /obj/structure/disposalpipe/broken{
 	dir = 4
 	},
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/open/floor/plating/airless{
@@ -436,10 +436,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/airless{
@@ -450,7 +450,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless{
@@ -461,7 +461,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless,
@@ -470,10 +470,10 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless{
@@ -484,10 +484,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/airless,
@@ -496,7 +496,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless,
@@ -506,7 +506,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/public/glass,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -515,7 +515,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -599,12 +599,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Hallway APC";
 	pixel_y = -24
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/onehalf/hallway)
 "bA" = (
@@ -775,7 +775,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/bridge)
 "cf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -786,7 +786,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/bridge)
 "cg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/table/reinforced,
@@ -863,10 +863,10 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/bridge)
 "cp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/table/reinforced,
@@ -875,13 +875,13 @@
 /area/ruin/space/has_grav/onehalf/bridge)
 "cq" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -931,19 +931,19 @@
 /area/ruin/space/has_grav/onehalf/bridge)
 "cy" = (
 /obj/machinery/power/solar_control,
-/obj/structure/cable,
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/bridge)
 "cz" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge_onehalf";
 	name = "bridge blast door"
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/onehalf/bridge)
 "cA" = (
@@ -1006,7 +1006,7 @@
 /area/ruin/space/has_grav/onehalf/bridge)
 "cK" = (
 /obj/structure/lattice,
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/template_noop,
@@ -1060,28 +1060,28 @@
 /area/ruin/space/has_grav/onehalf/bridge)
 "cV" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge_onehalf";
 	name = "bridge blast door"
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/onehalf/bridge)
 "cW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/space/nearstation)
 "cX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/airless{
@@ -1111,7 +1111,7 @@
 /area/ruin/space/has_grav/onehalf/bridge)
 "dc" = (
 /obj/structure/grille/broken,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless{
@@ -1127,10 +1127,10 @@
 /area/ruin/space/has_grav/onehalf/hallway)
 "de" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -1141,10 +1141,10 @@
 /area/ruin/space/has_grav/onehalf/bridge)
 "df" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -1155,10 +1155,10 @@
 /area/ruin/space/has_grav/onehalf/bridge)
 "dg" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -1173,7 +1173,7 @@
 /turf/template_noop,
 /area/space/nearstation)
 "di" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/shard{
@@ -1183,10 +1183,10 @@
 /turf/template_noop,
 /area/space/nearstation)
 "dj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/item/stack/rods,
@@ -1194,17 +1194,17 @@
 /turf/template_noop,
 /area/space/nearstation)
 "dk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/space/nearstation)
 "dl" = (
-/obj/item/stack/cable_coil/cut/red{
+/obj/item/stack/cable_coil/cut/yellow{
 	amount = 2
 	},
 /turf/template_noop,

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -12,54 +12,54 @@
 /area/space/nearstation)
 "ad" = (
 /obj/machinery/power/solar,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "ae" = (
 /obj/machinery/power/solar,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "af" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "ag" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "ah" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "ai" = (
 /obj/machinery/power/tracker,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "aj" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
@@ -67,13 +67,13 @@
 "ak" = (
 /obj/machinery/power/solar,
 /obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "al" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/airless,
@@ -485,13 +485,13 @@
 	name = "Guest Room APC";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/guestroom/room_3)
 "bO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -533,13 +533,13 @@
 	name = "Guest Room APC";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/guestroom/room_4)
 "bU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -581,13 +581,13 @@
 	name = "Guest Room APC";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/guestroom/room_5)
 "ca" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -629,13 +629,13 @@
 	name = "Guest Room APC";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
 "cg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -669,7 +669,7 @@
 	id_tag = "a3";
 	name = "Guest Room A3"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -684,7 +684,7 @@
 	id_tag = "a4";
 	name = "Guest Room A4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -699,7 +699,7 @@
 	id_tag = "a5";
 	name = "Guest Room A5"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -714,7 +714,7 @@
 	id_tag = "a6";
 	name = "Guest Room A6"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -756,7 +756,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "cy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -839,7 +839,7 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel)
 "cI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -848,7 +848,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "cJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -861,7 +861,7 @@
 	name = "Hotel Maintenance";
 	req_access_txt = "201"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -870,7 +870,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "cL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -879,20 +879,20 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "cM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "cN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -902,7 +902,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "cO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -911,7 +911,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "cP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -920,7 +920,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "cQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -931,7 +931,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "cS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -985,7 +985,7 @@
 	id_tag = "a2";
 	name = "Guest Room A2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1003,7 +1003,7 @@
 	id_tag = "a1";
 	name = "Guest Room A1"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1035,7 +1035,7 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Hotel Staff Storage"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -1072,13 +1072,13 @@
 	name = "Guest Room APC";
 	pixel_y = 25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/guestroom/room_2)
 "do" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1133,13 +1133,13 @@
 	name = "Guest Room APC";
 	pixel_y = 25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/guestroom/room_1)
 "dw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1171,7 +1171,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/hotel/workroom)
 "dB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1269,14 +1269,14 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/hotel/workroom)
 "dW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/hotel/workroom)
 "dX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1285,7 +1285,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/hotel/workroom)
 "dY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1294,7 +1294,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/hotel/workroom)
 "dZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1401,7 +1401,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/hotel/workroom)
 "eq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1502,23 +1502,23 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel)
 "eI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "eJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "eK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -1623,7 +1623,7 @@
 /area/ruin/space/has_grav/hotel/dock)
 "fd" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1632,7 +1632,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "fe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2023,7 +2023,7 @@
 /area/ruin/space/has_grav/hotel/dock)
 "gj" = (
 /obj/effect/decal/cleanable/oil,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2333,7 +2333,7 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel)
 "hf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2496,7 +2496,7 @@
 	name = "Staff Room APC";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /mob/living/simple_animal/bot/medbot{
@@ -2595,7 +2595,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/hotel/dock)
 "hP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2604,10 +2604,10 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "hQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -2616,7 +2616,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "hR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -2624,7 +2624,7 @@
 /area/ruin/space/has_grav/hotel)
 "hS" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2704,7 +2704,7 @@
 	name = "Power Storage";
 	req_access_txt = "200,201"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2744,7 +2744,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "ik" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2754,7 +2754,7 @@
 /area/ruin/space/has_grav/hotel)
 "il" = (
 /obj/machinery/door/airlock/public/glass,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -2764,7 +2764,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel/dock)
 "im" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2785,13 +2785,13 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel/dock)
 "ip" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "iq" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
@@ -2814,10 +2814,10 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/power)
 "it" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2830,7 +2830,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/power)
 "iu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/fire{
@@ -2848,7 +2848,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/power)
 "iv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
@@ -2868,7 +2868,7 @@
 	name = "Power Storage APC";
 	pixel_y = 25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -2925,7 +2925,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "iE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -2934,7 +2934,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel)
 "iF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -2959,7 +2959,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/power)
 "iI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2989,7 +2989,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel)
 "iN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -3000,7 +3000,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel)
 "iP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
@@ -3043,10 +3043,10 @@
 	name = "Security APC";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3055,14 +3055,14 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/security)
 "iV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "iW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3072,7 +3072,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "iY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
@@ -3090,10 +3090,10 @@
 	name = "Pool APC";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3102,7 +3102,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/pool)
 "ja" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3111,7 +3111,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel)
 "jb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -3120,7 +3120,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "jc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -3173,7 +3173,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/power)
 "jj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3296,7 +3296,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -3308,7 +3308,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/power)
 "jB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -3509,7 +3509,7 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel/power)
 "kc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -3525,23 +3525,23 @@
 /area/ruin/space/has_grav/hotel/power)
 "kd" = (
 /obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/power)
 "ke" = (
 /obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/power)
 "kf" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/binary/valve/on{
@@ -3618,7 +3618,7 @@
 /area/ruin/space/has_grav/hotel/pool)
 "kq" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -3632,10 +3632,10 @@
 /area/ruin/space/has_grav/hotel/power)
 "kr" = (
 /obj/machinery/power/smes/engineering,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/sign/warning/electricshock{
@@ -3649,7 +3649,7 @@
 /area/ruin/space/has_grav/hotel/power)
 "ks" = (
 /obj/machinery/power/smes/engineering,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -3659,7 +3659,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/power)
 "kt" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3673,10 +3673,10 @@
 /obj/machinery/power/solar_control{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -3686,7 +3686,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/power)
 "kv" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/vacuum{
@@ -3699,7 +3699,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/power)
 "kw" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -3825,7 +3825,7 @@
 /area/ruin/space/has_grav/hotel/power)
 "kJ" = (
 /obj/machinery/door/airlock/external/glass,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -3979,7 +3979,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -4217,7 +4217,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "lD" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4226,7 +4226,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "lE" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4281,10 +4281,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ruin/space/has_grav/hotel/pool)
 "lJ" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating/airless,
@@ -4412,46 +4412,46 @@
 /area/ruin/space/has_grav/hotel/security)
 "lV" = (
 /obj/machinery/power/solar,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "lW" = (
 /obj/machinery/power/solar,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "lX" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "lY" = (
 /obj/machinery/power/solar,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "lZ" = (
 /obj/machinery/power/solar,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating/airless,
@@ -4478,7 +4478,6 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel/custodial)
 "me" = (
-/mob/living/simple_animal/bot/cleanbot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -4489,6 +4488,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/custodial)
 "mf" = (
@@ -4708,7 +4708,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/custodial)
 "mw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4731,7 +4731,7 @@
 	name = "Custodial Closet";
 	req_access_txt = "200,201"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4740,7 +4740,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/custodial)
 "my" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -4877,7 +4877,6 @@
 	name = "Custodial APC";
 	pixel_y = -24
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -4888,6 +4887,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/custodial)
 "mK" = (
@@ -4917,7 +4917,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
 "mP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -4927,43 +4927,43 @@
 	name = "Hotel Staff Room";
 	req_access_txt = "200"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/hotel/workroom)
 "mR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "mS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "mT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "mU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel)
 "mV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/carpet,
@@ -4974,7 +4974,7 @@
 /area/ruin/space/has_grav/hotel/pool)
 "sN" = (
 /obj/machinery/door/airlock/external/glass,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -70,33 +70,33 @@
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "aaj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "aak" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison)
 "aal" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison)
 "aam" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -179,7 +179,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aav" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -291,7 +291,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "aaL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced{
@@ -336,7 +336,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "aaQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -396,7 +396,7 @@
 /area/security/prison)
 "aaY" = (
 /obj/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -530,7 +530,7 @@
 /area/crew_quarters/heads/hos)
 "abr" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -540,10 +540,10 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "abs" = (
+/obj/machinery/power/tracker,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/tracker,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
 "abt" = (
@@ -631,7 +631,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "abE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -870,7 +870,7 @@
 /area/crew_quarters/heads/hos)
 "abU" = (
 /obj/machinery/computer/card/minor/hos,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -893,10 +893,10 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "abX" = (
+/obj/machinery/power/tracker,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/tracker,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
 "abY" = (
@@ -904,10 +904,10 @@
 /turf/open/space,
 /area/space/nearstation)
 "abZ" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/fore)
 "aca" = (
@@ -962,7 +962,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -1014,7 +1014,7 @@
 	name = "Armory APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -1062,7 +1062,7 @@
 /area/crew_quarters/heads/hos)
 "act" = (
 /obj/machinery/holopad,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -1084,10 +1084,10 @@
 /turf/open/space,
 /area/space/nearstation)
 "acx" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
 "acy" = (
@@ -1214,7 +1214,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "acJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1326,7 +1326,7 @@
 /turf/open/floor/plating,
 /area/security/main)
 "acV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
@@ -1404,7 +1404,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ade" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -1420,7 +1420,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "adg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/button/door{
@@ -1435,7 +1435,7 @@
 "adh" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/carpet,
@@ -1522,24 +1522,24 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "ado" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "adp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/carpet,
@@ -1561,7 +1561,7 @@
 /turf/open/floor/plating,
 /area/security/main)
 "ads" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
@@ -1576,40 +1576,40 @@
 /turf/open/space,
 /area/solar/starboard/fore)
 "adu" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/space/basic,
 /area/solar/port/fore)
 "adv" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/space/basic,
 /area/solar/port/fore)
 "adw" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/turf/open/space/basic,
 /area/solar/port/fore)
 "adx" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/fore)
 "ady" = (
@@ -1617,6 +1617,7 @@
 /turf/open/space,
 /area/solar/port/fore)
 "adz" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1626,17 +1627,16 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/fore)
 "adA" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/fore)
 "adB" = (
@@ -1716,7 +1716,7 @@
 	name = "Long-Term Cell 1";
 	req_access_txt = "2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1747,7 +1747,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "adM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
@@ -1759,11 +1759,11 @@
 	name = "Head of Security's Office APC";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/carpet,
@@ -1775,14 +1775,14 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "adP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/carpet,
@@ -1797,67 +1797,67 @@
 /turf/closed/wall/r_wall,
 /area/security/main)
 "adS" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/space/basic,
 /area/solar/starboard/fore)
 "adT" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/space/basic,
 /area/solar/starboard/fore)
 "adU" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
 "adV" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/turf/open/space/basic,
 /area/solar/starboard/fore)
 "adW" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/space,
 /area/solar/starboard/fore)
 "adX" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
 "adY" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/space,
 /area/solar/starboard/fore)
 "adZ" = (
@@ -2043,7 +2043,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aep" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2082,7 +2082,7 @@
 	areastring = "/area/security/prison";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -2095,7 +2095,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aes" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/suit_storage_unit/security,
@@ -2112,7 +2112,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "aeu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/suit_storage_unit/security,
@@ -2139,7 +2139,7 @@
 "aex" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "aey" = (
@@ -2147,7 +2147,7 @@
 	name = "Head of Security";
 	req_access_txt = "58"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -2190,7 +2190,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -2199,7 +2199,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -2209,13 +2209,13 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -2283,7 +2283,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2296,7 +2296,7 @@
 /area/security/execution/transfer)
 "aeM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -2311,7 +2311,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -2326,7 +2326,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -2338,7 +2338,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2354,7 +2354,7 @@
 /area/security/prison)
 "aeQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -2366,7 +2366,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "aeS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2375,24 +2375,24 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aeT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aeU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aeV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2429,7 +2429,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aeX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -2439,7 +2439,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "aeY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/southleft{
@@ -2453,10 +2453,10 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "aeZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -2546,7 +2546,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "afj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -2617,7 +2617,7 @@
 /turf/open/space/basic,
 /area/space)
 "afq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -2673,7 +2673,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2717,10 +2717,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2890,7 +2890,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "afX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/head_of_security,
@@ -3007,7 +3007,7 @@
 	name = "Prison Wing";
 	req_access_txt = "2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -3058,16 +3058,16 @@
 	name = "Armory";
 	req_access_txt = "3"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -3176,7 +3176,7 @@
 /area/security/main)
 "agC" = (
 /obj/machinery/holopad,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -3200,7 +3200,7 @@
 /area/security/main)
 "agF" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/sign/warning/securearea{
@@ -3304,7 +3304,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -3320,13 +3320,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "agR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -3339,7 +3339,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "agT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -3353,13 +3353,13 @@
 "agV" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "agW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -3414,7 +3414,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -3597,7 +3597,7 @@
 	areastring = "/area/security/warden";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -3618,26 +3618,26 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "ahx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ahy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ahz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -3649,7 +3649,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3664,7 +3664,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3676,7 +3676,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -3700,13 +3700,13 @@
 	name = "Brig Control";
 	req_access_txt = "3"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3715,7 +3715,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ahF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -3730,10 +3730,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3745,7 +3745,7 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3754,7 +3754,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -3770,7 +3770,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3782,10 +3782,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/chair,
@@ -3794,7 +3794,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3803,13 +3803,13 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3824,7 +3824,7 @@
 	areastring = "/area/security/main";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3845,7 +3845,7 @@
 /area/security/brig)
 "ahQ" = (
 /obj/structure/closet/secure_closet/warden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -3870,10 +3870,10 @@
 /area/security/warden)
 "ahS" = (
 /obj/structure/table,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -3967,7 +3967,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aib" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -3977,7 +3977,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aic" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -4012,7 +4012,7 @@
 /area/security/warden)
 "aif" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -4062,7 +4062,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aik" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -4187,7 +4187,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -4197,7 +4197,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -4226,7 +4226,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aix" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -4252,7 +4252,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aiz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -4322,7 +4322,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aiI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/sign/warning/electricshock{
@@ -4333,10 +4333,10 @@
 /area/security/warden)
 "aiJ" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -4359,21 +4359,21 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aiK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/security/warden)
 "aiL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -4387,7 +4387,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aiN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -4464,7 +4464,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "aiZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4476,7 +4476,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aja" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4527,7 +4527,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -4540,7 +4540,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -4627,10 +4627,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "ajq" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/fore)
 "ajr" = (
@@ -4710,7 +4710,7 @@
 	areastring = "/area/security/brig";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4725,7 +4725,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -4764,7 +4764,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "ajD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -4830,7 +4830,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -4958,7 +4958,7 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -31
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -4985,10 +4985,10 @@
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "ajX" = (
@@ -5020,7 +5020,7 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "akc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5029,14 +5029,14 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "akd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ake" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5051,7 +5051,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -5065,7 +5065,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -5079,10 +5079,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5091,10 +5091,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aki" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5107,7 +5107,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5212,7 +5212,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aks" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -5325,7 +5325,7 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "akK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5340,10 +5340,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "akM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/cable,
@@ -5352,10 +5352,10 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "akN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5367,7 +5367,7 @@
 	id = "Cell 1";
 	name = "Cell 1"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -5377,10 +5377,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5388,7 +5388,7 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "akQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/closed/wall,
@@ -5398,7 +5398,7 @@
 	id = "Cell 2";
 	name = "Cell 2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -5408,10 +5408,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5423,7 +5423,7 @@
 	id = "Cell 3";
 	name = "Cell 3"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -5437,19 +5437,19 @@
 	name = "Brig Desk";
 	req_access_txt = "1"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "akV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -5462,7 +5462,7 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -5481,7 +5481,7 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -5496,16 +5496,16 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/closed/wall,
 /area/security/brig)
 "akZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5514,10 +5514,10 @@
 /area/security/brig)
 "ala" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -5570,22 +5570,22 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "alg" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
 "alh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
@@ -5625,7 +5625,7 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "als" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5650,7 +5650,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "alv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -5703,7 +5703,7 @@
 	pixel_x = -26;
 	pixel_y = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/button/flasher{
@@ -5800,10 +5800,10 @@
 /area/security/courtroom)
 "alK" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5817,7 +5817,7 @@
 	areastring = "/area/security/courtroom";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5902,7 +5902,7 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ame" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -5913,7 +5913,7 @@
 "amf" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/flasher{
@@ -5989,7 +5989,7 @@
 	pixel_y = 5;
 	req_access_txt = "63"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -6053,13 +6053,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "amv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
@@ -6080,12 +6080,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "amz" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/terminal,
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
@@ -6155,7 +6155,7 @@
 	name = "Prisoner Processing";
 	req_access_txt = "2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -6182,7 +6182,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "amQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/cable,
@@ -6194,10 +6194,10 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "amR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -6208,7 +6208,7 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "amS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall,
@@ -6223,10 +6223,10 @@
 	name = "Brig Desk";
 	req_access_txt = "1"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -6236,7 +6236,7 @@
 	id = "briggate";
 	name = "security blast door"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -6254,7 +6254,7 @@
 	name = "Brig Desk";
 	req_access_txt = "1"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -6326,7 +6326,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "anc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -6350,7 +6350,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ang" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -6367,17 +6367,17 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "anh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "ani" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -6469,7 +6469,7 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "anv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6526,7 +6526,7 @@
 /turf/open/floor/plating,
 /area/security/courtroom)
 "anD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -6562,7 +6562,7 @@
 	name = "Port Bow Solar Access";
 	req_access_txt = "10"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -6749,7 +6749,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aol" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -6800,7 +6800,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -6813,7 +6813,7 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aou" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/camera{
@@ -6925,7 +6925,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "aoI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -6940,7 +6940,7 @@
 	areastring = "/area/crew_quarters/fitness";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6985,12 +6985,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "aoO" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/terminal,
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
@@ -7062,7 +7062,7 @@
 	name = "Security Maintenance";
 	req_access_txt = "2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -7132,7 +7132,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "apr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -7169,7 +7169,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "apu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7185,7 +7185,7 @@
 	name = "Fitness Maintenance";
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -7225,16 +7225,16 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "apz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "apA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -7251,7 +7251,7 @@
 	c_tag = "Fore Starboard Solars";
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes,
@@ -7320,7 +7320,7 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "apS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -7429,10 +7429,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aqj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7447,7 +7447,7 @@
 	areastring = "/area/crew_quarters/dorms";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7459,10 +7459,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -7471,10 +7471,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aqm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7561,7 +7561,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aqw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -7658,7 +7658,7 @@
 	pixel_x = -1;
 	pixel_y = 26
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -7689,7 +7689,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -7781,7 +7781,7 @@
 /area/crew_quarters/dorms)
 "arl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -7836,10 +7836,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -7851,7 +7851,7 @@
 	areastring = "/area/maintenance/starboard/fore";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -7930,7 +7930,7 @@
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "arH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
@@ -7939,7 +7939,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
@@ -7948,10 +7948,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
@@ -7968,7 +7968,7 @@
 	},
 /area/maintenance/port/fore)
 "arL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
@@ -8067,7 +8067,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "asc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8082,7 +8082,7 @@
 /turf/closed/wall,
 /area/crew_quarters/dorms)
 "ase" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8120,7 +8120,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "ash" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -8132,10 +8132,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8251,7 +8251,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "asw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -8326,7 +8326,7 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "asK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8352,7 +8352,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -8399,7 +8399,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -8532,7 +8532,7 @@
 	pixel_y = -23
 	},
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
@@ -8550,7 +8550,7 @@
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "atr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8633,14 +8633,14 @@
 /area/maintenance/department/electrical)
 "atG" = (
 /obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "atH" = (
 /obj/machinery/computer/mech_bay_power_console,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/circuit,
@@ -8687,7 +8687,7 @@
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "atN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8832,7 +8832,7 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "auj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8866,10 +8866,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aum" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -8883,7 +8883,7 @@
 /turf/closed/wall,
 /area/crew_quarters/dorms)
 "auo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -8917,7 +8917,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "aus" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9019,13 +9019,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -9035,13 +9035,13 @@
 	req_access_txt = "12"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -9054,17 +9054,17 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "auK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "auL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -9074,7 +9074,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -9123,7 +9123,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "auT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -9236,7 +9236,7 @@
 /area/crew_quarters/dorms)
 "avh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -9247,7 +9247,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -9318,7 +9318,7 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "avq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -9332,7 +9332,7 @@
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "avs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -9410,7 +9410,7 @@
 /area/crew_quarters/fitness)
 "avB" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -9437,7 +9437,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "maint3"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -9480,7 +9480,7 @@
 	areastring = "/area/maintenance/department/electrical";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -9492,7 +9492,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "avN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -9621,7 +9621,7 @@
 	areastring = "/area/maintenance/fore";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9630,13 +9630,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "awe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9654,7 +9654,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "awg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -9667,14 +9667,14 @@
 /area/maintenance/fore)
 "awh" = (
 /obj/effect/landmark/blobstart,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -9687,7 +9687,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -9708,7 +9708,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "awl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -9801,7 +9801,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "awx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9821,7 +9821,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "awA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -9878,7 +9878,7 @@
 	pixel_x = -28;
 	pixel_y = -6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -9901,7 +9901,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "awM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9910,13 +9910,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "awN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -9928,7 +9928,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "awP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9937,7 +9937,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "awQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -9951,10 +9951,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "awR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9969,7 +9969,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "awT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
@@ -10026,7 +10026,7 @@
 	},
 /area/hallway/secondary/entry)
 "axa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -10035,7 +10035,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "axb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10163,7 +10163,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10172,7 +10172,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "axs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10184,7 +10184,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10196,10 +10196,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10212,10 +10212,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10224,10 +10224,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "axw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -10239,7 +10239,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10370,14 +10370,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "axR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -10397,10 +10397,10 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "axT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -10413,7 +10413,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
 "axV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -10463,10 +10463,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "ayc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -10488,14 +10488,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ayg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ayh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10505,7 +10505,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ayi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -10565,7 +10565,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -10603,7 +10603,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10623,27 +10623,27 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
 "ayA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ayB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ayC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -10651,10 +10651,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ayD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10665,11 +10665,11 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/fore)
 "ayF" = (
-/obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ayG" = (
@@ -10677,14 +10677,14 @@
 /area/gateway)
 "ayH" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ayI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/sign/warning/securearea{
@@ -10745,7 +10745,7 @@
 	areastring = "/area/ai_monitored/storage/eva";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
@@ -10770,7 +10770,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/sign/warning/securearea{
@@ -10870,7 +10870,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "azd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -10942,7 +10942,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "azl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -10985,10 +10985,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "azs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -11004,7 +11004,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "azu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -11064,7 +11064,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "azD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -11073,7 +11073,7 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "azE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11164,10 +11164,10 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "azO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -11176,7 +11176,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "azQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -11201,10 +11201,10 @@
 	name = "EVA Storage";
 	req_access_txt = "18"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11220,10 +11220,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "azU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11248,7 +11248,7 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -11297,7 +11297,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aAe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11336,7 +11336,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aAj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/power/apc{
@@ -11351,7 +11351,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aAk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -11367,7 +11367,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "aAl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11388,7 +11388,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -11405,7 +11405,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "aAn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -11435,7 +11435,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "aAp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -11477,7 +11477,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "maint2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -11497,7 +11497,7 @@
 	pixel_x = 27;
 	pixel_y = 2
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -11510,7 +11510,7 @@
 /obj/machinery/power/smes{
 	charge = 0
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -11520,17 +11520,17 @@
 	dir = 1;
 	name = "backup power monitoring console"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "aAA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/closed/wall,
@@ -11539,7 +11539,7 @@
 /obj/machinery/power/smes{
 	charge = 0
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -11590,7 +11590,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aAJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -11614,7 +11614,7 @@
 	pixel_x = 1;
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11623,10 +11623,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aAN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11649,7 +11649,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aAR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11676,7 +11676,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aAV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -11716,7 +11716,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aAZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -11781,7 +11781,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11798,7 +11798,7 @@
 	pixel_x = -24;
 	pixel_y = -1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11882,14 +11882,14 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aBs" = (
-/obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
 "aBt" = (
@@ -11952,7 +11952,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -12008,7 +12008,7 @@
 	name = "Tool Storage Maintenance";
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12033,10 +12033,10 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aBP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -12079,7 +12079,7 @@
 	areastring = "/area/ai_monitored/nuke_storage";
 	pixel_y = 25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12146,7 +12146,7 @@
 /area/gateway)
 "aBZ" = (
 /obj/machinery/gateway,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/bot_white,
@@ -12169,7 +12169,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aCb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/item/pen{
@@ -12208,7 +12208,7 @@
 "aCe" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/item/bikehorn/rubberducky,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -12222,7 +12222,7 @@
 	},
 /area/crew_quarters/theatre)
 "aCg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -12234,8 +12234,8 @@
 	},
 /area/crew_quarters/theatre)
 "aCi" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
 "aCj" = (
@@ -12252,7 +12252,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -12292,7 +12292,7 @@
 	c_tag = "Arrivals North";
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -12329,7 +12329,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aCt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -12369,14 +12369,14 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCA" = (
 /obj/structure/grille/broken,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/window{
@@ -12406,7 +12406,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "maint1"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12448,7 +12448,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12595,7 +12595,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aDd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12726,7 +12726,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aDt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12759,7 +12759,7 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "aDx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window{
@@ -12785,7 +12785,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aDA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -12806,7 +12806,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aDD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12890,7 +12890,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -12912,7 +12912,7 @@
 /area/crew_quarters/toilet)
 "aDQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -12941,14 +12941,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "aDT" = (
 /obj/machinery/light/small,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -12957,7 +12957,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -12991,7 +12991,7 @@
 	},
 /area/crew_quarters/theatre)
 "aDZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -13003,10 +13003,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -13042,17 +13042,17 @@
 	},
 /area/crew_quarters/theatre)
 "aEd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13061,7 +13061,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13079,7 +13079,7 @@
 	areastring = "/area/chapel/main";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -13152,7 +13152,7 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "aEA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -13171,7 +13171,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -13184,10 +13184,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aED" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -13280,7 +13280,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aEO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit,
@@ -13335,7 +13335,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "aET" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13526,7 +13526,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13535,7 +13535,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -13551,7 +13551,7 @@
 /turf/closed/wall,
 /area/library)
 "aFv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -13736,7 +13736,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aFR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -13763,7 +13763,7 @@
 /area/storage/primary)
 "aFV" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/meter,
@@ -13819,7 +13819,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aGc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/camera/motion{
@@ -13834,7 +13834,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aGd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -14024,20 +14024,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14047,10 +14047,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -14063,7 +14063,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -14079,7 +14079,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -14111,7 +14111,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -14142,10 +14142,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14157,7 +14157,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14169,7 +14169,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14178,7 +14178,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -14199,13 +14199,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14221,7 +14221,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -14231,7 +14231,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14240,11 +14240,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -14253,7 +14253,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14372,7 +14372,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "aHh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -14391,7 +14391,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -20
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -14438,7 +14438,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/filingcabinet/chestdrawer,
@@ -14552,7 +14552,7 @@
 /obj/machinery/door/airlock/vault{
 	req_access_txt = "53"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -14840,7 +14840,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aIj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -14860,10 +14860,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aIl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -14879,7 +14879,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14894,7 +14894,7 @@
 	areastring = "/area/hydroponics";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14904,7 +14904,7 @@
 /area/maintenance/starboard/fore)
 "aIo" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -15177,7 +15177,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aJa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -15193,14 +15193,14 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aJd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "aJe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -15614,7 +15614,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aJZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -15632,24 +15632,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aKb" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "aKc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Gateway Access";
 	req_access_txt = "62"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -15671,7 +15660,7 @@
 	},
 /area/chapel/main)
 "aKf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -15680,7 +15669,7 @@
 	areastring = "/area/construction/mining/aux_base";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -15754,41 +15743,41 @@
 /turf/open/floor/plating,
 /area/storage/primary)
 "aKt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "aKu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "aKv" = (
-/obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "aKw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/door/firedoor,
@@ -15805,7 +15794,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "aKx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -15813,7 +15802,7 @@
 /area/hallway/primary/port)
 "aKy" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -16110,7 +16099,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
 "aLk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -16139,7 +16128,7 @@
 /area/hallway/primary/port)
 "aLn" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16152,7 +16141,7 @@
 /turf/closed/wall,
 /area/chapel/office)
 "aLp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16253,7 +16242,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -16326,7 +16315,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aLP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16705,7 +16694,7 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "aMQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -16714,7 +16703,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aMR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -16732,7 +16721,7 @@
 /area/hallway/primary/port)
 "aMU" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -16742,7 +16731,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aMV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -16815,28 +16804,28 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aNk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aNl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aNm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aNo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -17061,10 +17050,10 @@
 /turf/open/floor/wood,
 /area/library)
 "aNT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17199,7 +17188,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aOi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17235,7 +17224,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -17287,7 +17276,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aOt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
@@ -17300,7 +17289,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aOv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17309,20 +17298,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aOw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aOx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -17331,10 +17320,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aOy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -17553,7 +17542,7 @@
 /turf/open/floor/wood,
 /area/library)
 "aPc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -17717,7 +17706,7 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -17749,7 +17738,7 @@
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aPI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -17792,10 +17781,10 @@
 /turf/closed/wall/r_wall,
 /area/bridge)
 "aPS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -17806,7 +17795,7 @@
 /turf/open/floor/plating,
 /area/bridge)
 "aPT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -17817,10 +17806,10 @@
 /turf/open/floor/plating,
 /area/bridge)
 "aPU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/status_display/evac,
@@ -17832,13 +17821,13 @@
 /turf/open/floor/plating,
 /area/bridge)
 "aPV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -17849,10 +17838,10 @@
 /turf/open/floor/plating,
 /area/bridge)
 "aPW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/status_display/evac,
@@ -17864,7 +17853,7 @@
 /turf/open/floor/plating,
 /area/bridge)
 "aPX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -18188,7 +18177,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aQM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -18262,7 +18251,7 @@
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aRb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18287,7 +18276,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aRe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -18342,7 +18331,7 @@
 /obj/machinery/computer/monitor{
 	name = "bridge power monitoring console"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -18393,7 +18382,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/shuttle/mining,
@@ -18576,7 +18565,7 @@
 /area/hydroponics)
 "aRK" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/power/apc{
@@ -18634,7 +18623,7 @@
 /turf/open/floor/carpet,
 /area/chapel/main)
 "aRT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/rack,
@@ -18659,7 +18648,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/table,
@@ -18828,7 +18817,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -18881,7 +18870,7 @@
 /area/bridge)
 "aSB" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -19050,7 +19039,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -19204,7 +19193,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aTv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -19386,7 +19375,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -19401,7 +19390,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -19591,7 +19580,7 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -19720,13 +19709,13 @@
 /area/vacant_room/office)
 "aUS" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aUT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -19808,7 +19797,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -19853,7 +19842,7 @@
 	areastring = "/area/hallway/primary/fore";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/camera{
@@ -19873,7 +19862,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19883,10 +19872,10 @@
 /area/bridge)
 "aVk" = (
 /obj/machinery/holopad,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19895,7 +19884,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -19904,7 +19893,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19913,10 +19902,10 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19925,10 +19914,10 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -19939,7 +19928,7 @@
 /area/bridge)
 "aVp" = (
 /obj/item/beacon,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19948,7 +19937,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19977,7 +19966,7 @@
 	dir = 1;
 	name = "Logistics Station"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -20071,7 +20060,7 @@
 /area/crew_quarters/kitchen)
 "aVC" = (
 /obj/machinery/meter,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20134,7 +20123,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aVL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -20326,7 +20315,7 @@
 /area/maintenance/port)
 "aWk" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -20397,7 +20386,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20421,10 +20410,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20434,10 +20423,10 @@
 /area/maintenance/port)
 "aWx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20459,10 +20448,10 @@
 	areastring = "/area/storage/emergency/port";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20538,7 +20527,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aWI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -20551,10 +20540,10 @@
 /area/bridge)
 "aWJ" = (
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -20567,14 +20556,14 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -20593,7 +20582,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20655,7 +20644,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20753,7 +20742,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20763,10 +20752,10 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aXa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20778,7 +20767,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aXb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -20793,7 +20782,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aXc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -20809,7 +20798,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aXd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -20825,14 +20814,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aXe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -20854,7 +20843,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aXg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -21120,7 +21109,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -21195,17 +21184,17 @@
 	pixel_y = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aYb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -21250,7 +21239,7 @@
 /turf/open/floor/plating,
 /area/construction)
 "aYh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -21350,7 +21339,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aYs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -21393,7 +21382,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "aYw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -21450,7 +21439,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aYD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -21655,7 +21644,7 @@
 /area/crew_quarters/bar)
 "aZc" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -21851,7 +21840,7 @@
 "aZD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -21867,7 +21856,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -21913,7 +21902,7 @@
 	name = "Conference Room";
 	req_access_txt = "19"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -21929,7 +21918,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aZT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -21952,7 +21941,7 @@
 	name = "Captain's Office";
 	req_access_txt = "20"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22027,7 +22016,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -22109,7 +22098,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bao" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -22134,7 +22123,7 @@
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22214,7 +22203,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "baC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -22226,7 +22215,7 @@
 	areastring = "/area/hallway/secondary/exit";
 	pixel_x = -25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -22237,7 +22226,7 @@
 	},
 /area/hallway/secondary/exit)
 "baE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -22291,7 +22280,7 @@
 /area/maintenance/port)
 "baM" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/power/apc{
@@ -22301,7 +22290,7 @@
 	pixel_x = 27;
 	pixel_y = 2
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -22338,7 +22327,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "baT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22462,7 +22451,7 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "bbi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -22550,7 +22539,7 @@
 	areastring = "/area/crew_quarters/heads/captain";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/wood,
@@ -22559,10 +22548,10 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/carpet,
@@ -22635,7 +22624,7 @@
 	},
 /area/hallway/secondary/exit)
 "bbH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -22648,23 +22637,23 @@
 	areastring = "/area/vacant_room/office";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bbJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bbK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -22799,7 +22788,7 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "bcd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22817,7 +22806,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "bcf" = (
 /obj/machinery/holopad,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -22845,7 +22834,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bcj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
@@ -22873,7 +22862,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -22965,7 +22954,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bcA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -23042,7 +23031,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bcL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction/flip{
@@ -23146,7 +23135,7 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "bde" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -23166,7 +23155,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "bdg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit,
@@ -23201,10 +23190,10 @@
 /area/crew_quarters/heads/captain)
 "bdl" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -23212,7 +23201,7 @@
 /area/hallway/primary/starboard)
 "bdm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -23264,7 +23253,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23315,7 +23304,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -23334,7 +23323,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23343,14 +23332,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bdC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	sortType = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23362,7 +23351,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -23440,7 +23429,7 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -23460,7 +23449,7 @@
 /turf/closed/wall,
 /area/maintenance/disposal)
 "bdR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -23480,7 +23469,7 @@
 	areastring = "/area/maintenance/disposal";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -23519,7 +23508,7 @@
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "bdZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -23644,7 +23633,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bem" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -23726,13 +23715,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bew" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -23762,7 +23751,7 @@
 	},
 /area/hallway/primary/starboard)
 "bez" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -23780,13 +23769,13 @@
 	c_tag = "Starboard Primary Hallway 3";
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "beC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -23841,7 +23830,7 @@
 /area/hallway/secondary/exit)
 "beJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24010,7 +23999,7 @@
 	areastring = "/area/crew_quarters/locker";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -24034,7 +24023,7 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -24080,10 +24069,10 @@
 	pixel_x = 1;
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -24199,7 +24188,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bfD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
@@ -24245,7 +24234,7 @@
 /turf/closed/wall,
 /area/medical/morgue)
 "bfM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -24267,7 +24256,7 @@
 	areastring = "/area/hallway/primary/starboard";
 	pixel_y = -24
 	},
-/obj/structure/cable,
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bfQ" = (
@@ -24376,7 +24365,7 @@
 /area/hallway/secondary/exit)
 "bge" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24443,7 +24432,7 @@
 /area/hallway/primary/central)
 "bgo" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/power/apc{
@@ -24452,7 +24441,7 @@
 	areastring = "/area/science/robotics/mechbay";
 	pixel_x = 26
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24463,7 +24452,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bgq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -24508,7 +24497,7 @@
 /turf/closed/wall,
 /area/quartermaster/office)
 "bgw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -24683,7 +24672,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bgW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -24715,7 +24704,7 @@
 	areastring = "/area/medical/chemistry";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -24872,7 +24861,7 @@
 	areastring = "/area/medical/morgue";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -24917,7 +24906,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25042,7 +25031,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -25100,7 +25089,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bhO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -25298,7 +25287,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bin" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -25411,7 +25400,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "biB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -25441,7 +25430,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -25450,39 +25439,39 @@
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "biH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "biI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "biJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "biK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -25626,7 +25615,7 @@
 /area/science/lab)
 "biY" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -25689,7 +25678,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25709,7 +25698,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25718,7 +25707,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bjk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25730,10 +25719,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bjl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25798,7 +25787,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -25825,13 +25814,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bjx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -25892,7 +25881,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bjH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -25902,19 +25891,19 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bjI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bjJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bjK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -25925,7 +25914,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bjM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25952,7 +25941,7 @@
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
@@ -26112,7 +26101,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -26147,7 +26136,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bkp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -26213,7 +26202,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -26293,7 +26282,7 @@
 	name = "Cargo Bay Maintenance";
 	req_access_txt = "31"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -26317,7 +26306,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "bkK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -26362,7 +26351,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26374,7 +26363,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
@@ -26385,7 +26374,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -26409,7 +26398,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -26418,10 +26407,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26432,7 +26421,7 @@
 /area/medical/morgue)
 "bkV" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26441,7 +26430,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "bkW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -26453,17 +26442,17 @@
 	areastring = "/area/bridge/meeting_room";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bkY" = (
 /obj/effect/landmark/blobstart,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -26487,7 +26476,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26512,7 +26501,7 @@
 	name = "Captain's Office Maintenance";
 	req_access_txt = "20"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -26548,7 +26537,7 @@
 	name = "Morgue Maintenance";
 	req_access_txt = "6"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26620,7 +26609,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc{
@@ -26629,7 +26618,7 @@
 	areastring = "/area/storage/emergency/starboard";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26644,7 +26633,7 @@
 	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -26656,10 +26645,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "blq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -26698,16 +26687,16 @@
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "blv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/holopad,
@@ -26733,14 +26722,14 @@
 /obj/machinery/light_switch{
 	pixel_x = -23
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "blz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -26855,7 +26844,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -26889,7 +26878,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "blT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -26969,7 +26958,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -26979,7 +26968,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -27007,7 +26996,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bmh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -27020,7 +27009,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bmj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -27035,7 +27024,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bmm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -27074,7 +27063,7 @@
 	name = "Head of Personnel";
 	req_access_txt = "57"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -27082,7 +27071,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bmt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -27160,7 +27149,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
 "bmD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -27222,7 +27211,7 @@
 	name = "Cargo Bay";
 	req_access_txt = "31"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -27282,7 +27271,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bmN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -27304,7 +27293,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -27352,7 +27341,7 @@
 	name = "Morgue";
 	req_access_txt = "6;5"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -27382,7 +27371,7 @@
 /area/medical/genetics)
 "bna" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -27454,7 +27443,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bnl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -27535,7 +27524,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -27544,7 +27533,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -27564,7 +27553,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27580,11 +27569,11 @@
 /area/medical/chemistry)
 "bnE" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -27650,7 +27639,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bnM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -27721,7 +27710,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bnS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -27732,14 +27721,14 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "bnU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering/glass{
@@ -27749,10 +27738,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bnV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -27762,10 +27751,10 @@
 /obj/structure/sign/warning/radiation/rad_area{
 	pixel_x = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -27814,7 +27803,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "boc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -27904,7 +27893,7 @@
 	name = "Security Office";
 	req_access_txt = "63"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -28068,7 +28057,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28090,7 +28079,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28176,7 +28165,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "boV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -28284,7 +28273,7 @@
 /area/crew_quarters/heads/hop)
 "bpf" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -28363,7 +28352,7 @@
 	},
 /area/science/research)
 "bpq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -28405,7 +28394,7 @@
 /turf/closed/wall,
 /area/medical/medbay/central)
 "bpx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -28434,7 +28423,7 @@
 /area/quartermaster/office)
 "bpB" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -28451,7 +28440,7 @@
 	name = "Chemistry Lab";
 	req_access_txt = "5; 33"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -28479,7 +28468,7 @@
 	areastring = "/area/medical/genetics";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -28547,7 +28536,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -28556,7 +28545,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -28683,7 +28672,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -28761,13 +28750,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bqq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "bqr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -28796,7 +28785,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -28835,7 +28824,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -28843,7 +28832,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bqD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -28864,7 +28853,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bqG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/cable,
@@ -28892,7 +28881,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -28919,7 +28908,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -28961,7 +28950,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bqS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -28975,7 +28964,7 @@
 /area/medical/medbay/central)
 "bqT" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -28990,7 +28979,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bqU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/noticeboard{
@@ -29007,7 +28996,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bqV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29019,7 +29008,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bqW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -29028,7 +29017,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bqX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29037,14 +29026,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bqY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bqZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -29085,23 +29074,23 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "brf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "brg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "brh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -29131,7 +29120,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "brk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -29141,7 +29130,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -29222,7 +29211,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29248,7 +29237,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29260,7 +29249,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29358,10 +29347,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29370,10 +29359,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "brQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -29387,7 +29376,7 @@
 /area/maintenance/starboard)
 "brR" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -29400,7 +29389,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/cable,
@@ -29419,7 +29408,7 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "brW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/vending/cart,
@@ -29447,11 +29436,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "brZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29560,7 +29549,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -29632,7 +29621,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bsv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29646,13 +29635,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bsx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29745,7 +29734,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bsV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -29785,7 +29774,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -29843,7 +29832,7 @@
 	dir = 2;
 	sortType = 12
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30020,7 +30009,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "btE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -30044,7 +30033,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
 "btH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/chair/stool,
@@ -30058,13 +30047,13 @@
 	areastring = "/area/teleporter";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "btJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/bluespace_beacon,
@@ -30072,13 +30061,13 @@
 /area/teleporter)
 "btK" = (
 /obj/machinery/holopad,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "btL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -30089,22 +30078,22 @@
 	name = "Teleport Access";
 	req_access_txt = "17"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "btN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "btO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -30217,7 +30206,7 @@
 	pixel_x = 1;
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -30306,7 +30295,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -30329,7 +30318,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30341,7 +30330,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30358,7 +30347,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30374,20 +30363,20 @@
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 23
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "buz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30436,7 +30425,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30459,7 +30448,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30487,7 +30476,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -30571,7 +30560,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30589,7 +30578,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/heavy,
@@ -30631,7 +30620,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "bva" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/sign/warning/securearea{
@@ -30650,10 +30639,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30665,7 +30654,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
@@ -30684,10 +30673,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -30711,11 +30700,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -30843,7 +30832,7 @@
 /area/medical/genetics)
 "bvz" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30877,7 +30866,7 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/science)
 "bvD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -30920,7 +30909,7 @@
 /area/science/research)
 "bvI" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31061,10 +31050,10 @@
 /area/hallway/primary/central)
 "bwc" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31138,7 +31127,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bwl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -31196,7 +31185,7 @@
 /turf/open/floor/plating,
 /area/teleporter)
 "bwu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -31338,7 +31327,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31389,7 +31378,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bwS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31405,7 +31394,7 @@
 	name = "Quartermaster";
 	req_access_txt = "41"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31417,7 +31406,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bwU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31433,7 +31422,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bwV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31450,10 +31439,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31462,10 +31451,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bwX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -31516,7 +31505,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31528,7 +31517,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31541,7 +31530,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31605,7 +31594,7 @@
 "bxt" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -31642,7 +31631,7 @@
 /turf/closed/wall,
 /area/quartermaster/miningdock)
 "bxA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -31671,7 +31660,7 @@
 	name = "Head of Personnel";
 	req_access_txt = "57"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -31737,7 +31726,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bxP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31783,7 +31772,7 @@
 	name = "Research Director";
 	req_access_txt = "30"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31892,7 +31881,7 @@
 	name = "Server Room";
 	req_access_txt = "30"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -31905,7 +31894,7 @@
 	name = "Security Office";
 	req_access_txt = "63"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32041,7 +32030,7 @@
 	areastring = "/area/quartermaster/qm";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -32097,14 +32086,14 @@
 	areastring = "/area/quartermaster/miningdock";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "byG" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32225,7 +32214,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "byR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32469,7 +32458,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -32504,7 +32493,7 @@
 	areastring = "/area/science/server";
 	pixel_y = 25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -32664,13 +32653,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bzQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bzR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
@@ -32689,7 +32678,7 @@
 "bzT" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/quartermaster,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -32729,7 +32718,7 @@
 /area/science/research)
 "bAa" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -32743,7 +32732,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bAc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32773,7 +32762,7 @@
 	codes_txt = "patrol;next_patrol=AIW";
 	location = "QM"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -32824,7 +32813,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -32840,7 +32829,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32852,7 +32841,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc{
@@ -32862,7 +32851,7 @@
 	pixel_x = 1;
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32935,7 +32924,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33009,13 +32998,13 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bAF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bAG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -33030,7 +33019,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bAI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -33045,7 +33034,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33057,10 +33046,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33246,17 +33235,17 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "bBg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBh" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -33265,7 +33254,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -33275,14 +33264,14 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBk" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -33292,7 +33281,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -33421,7 +33410,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -33430,7 +33419,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/junction/flip{
@@ -33439,7 +33428,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -33462,10 +33451,10 @@
 	},
 /area/science/research)
 "bBE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -33773,7 +33762,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -33782,7 +33771,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33817,7 +33806,7 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -33859,7 +33848,7 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bCx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -33876,7 +33865,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -34196,7 +34185,7 @@
 	},
 /area/science/research)
 "bDm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -34257,7 +34246,7 @@
 /area/maintenance/port/aft)
 "bDu" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -34310,7 +34299,7 @@
 	areastring = "/area/storage/tech";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -34329,7 +34318,7 @@
 	areastring = "/area/medical/sleeper";
 	pixel_x = 26
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -34436,7 +34425,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bDO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -34454,7 +34443,7 @@
 /area/janitor)
 "bDQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -34495,7 +34484,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bDV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -34515,7 +34504,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bDY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/xeno_spawn,
@@ -34535,7 +34524,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bEb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -34545,7 +34534,7 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bEc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -34571,7 +34560,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -34582,7 +34571,7 @@
 	},
 /area/science/research)
 "bEg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/research{
@@ -34692,7 +34681,7 @@
 	areastring = "/area/science/research";
 	pixel_x = -25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -34700,13 +34689,13 @@
 	},
 /area/science/research)
 "bEr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -34739,7 +34728,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bEE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -34756,7 +34745,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bEG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -34768,7 +34757,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bEI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -34783,7 +34772,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -34796,7 +34785,7 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "bEN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -34827,10 +34816,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bER" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -34843,7 +34832,7 @@
 /turf/closed/wall,
 /area/maintenance/port/aft)
 "bET" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -34852,33 +34841,33 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bEU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bEV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bEW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -34891,7 +34880,7 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bEY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -34911,13 +34900,13 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bFb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "bFc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -34939,7 +34928,7 @@
 	name = "Tech Storage";
 	req_access_txt = "23"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -34957,7 +34946,7 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bFh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -34973,7 +34962,7 @@
 /area/janitor)
 "bFj" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
@@ -34988,7 +34977,7 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bFl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/power/apc{
@@ -34997,7 +34986,7 @@
 	areastring = "/area/janitor";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -35328,7 +35317,7 @@
 	areastring = "/area/science/mixing";
 	pixel_x = 26
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -35338,7 +35327,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "8;12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -35402,18 +35391,18 @@
 /area/maintenance/port/aft)
 "bGq" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bGr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bGs" = (
@@ -35421,7 +35410,7 @@
 	c_tag = "Secure Tech Storage";
 	dir = 2
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -35445,7 +35434,7 @@
 /area/storage/tech)
 "bGw" = (
 /obj/structure/rack,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/spawner/lootdrop/techstorage/rnd,
@@ -35477,7 +35466,7 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -35499,7 +35488,7 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bGC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/heavy,
@@ -35531,13 +35520,13 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bGF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -35546,10 +35535,10 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bGG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -35563,29 +35552,29 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bGH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bGI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bGJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bGK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35613,10 +35602,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bGN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35625,7 +35614,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bGO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -35641,7 +35630,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bGP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -35770,7 +35759,7 @@
 	areastring = "/area/science/storage";
 	pixel_x = -25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/camera{
@@ -35806,7 +35795,7 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bHj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -35856,7 +35845,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -35864,7 +35853,7 @@
 /area/maintenance/aft)
 "bHq" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -35983,7 +35972,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bHH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -35993,13 +35982,13 @@
 	name = "Secure Tech Storage";
 	req_access_txt = "19;23"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "bHJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/xeno_spawn,
@@ -36073,7 +36062,7 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "bHU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/grille/broken,
@@ -36086,7 +36075,7 @@
 	areastring = "/area/maintenance/aft";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -36104,7 +36093,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -36116,7 +36105,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
@@ -36162,7 +36151,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bIf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/doorButtons/access_button{
@@ -36186,10 +36175,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bIg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -36205,10 +36194,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36340,7 +36329,7 @@
 	name = "Xenobiology Maintenance";
 	req_access_txt = "55"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36352,10 +36341,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36367,7 +36356,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36448,7 +36437,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bIF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -36503,7 +36492,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bIL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -36513,7 +36502,7 @@
 /area/medical/virology)
 "bIM" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/sign/warning/securearea{
@@ -36543,7 +36532,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bIQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -36673,7 +36662,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bJg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -36729,7 +36718,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -36747,7 +36736,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bJs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -36759,7 +36748,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bJt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -36775,10 +36764,10 @@
 /turf/open/floor/plasteel,
 /area/construction)
 "bJv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -36790,13 +36779,13 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bJw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -36812,7 +36801,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bJy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -36877,20 +36866,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bJH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "bJI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -36901,7 +36890,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bJJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -36913,10 +36902,10 @@
 /area/science/xenobiology)
 "bJK" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -36932,7 +36921,7 @@
 	name = "Test Chamber";
 	req_access_txt = "55"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -36942,7 +36931,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bJM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -37017,7 +37006,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bKb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -37130,22 +37119,22 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bKr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bKs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bKt" = (
@@ -37222,10 +37211,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bKD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -37251,7 +37240,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bKG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/securearea{
@@ -37266,7 +37255,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37279,7 +37268,7 @@
 	dir = 8;
 	sortType = 11
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -37292,7 +37281,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -37302,7 +37291,7 @@
 /area/maintenance/aft)
 "bKK" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -37318,10 +37307,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37386,7 +37375,7 @@
 	areastring = "/area/crew_quarters/heads/cmo";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37412,7 +37401,7 @@
 /turf/open/floor/plating,
 /area/construction)
 "bKV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37425,7 +37414,7 @@
 /area/engine/atmos)
 "bKW" = (
 /obj/item/wrench,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -37441,7 +37430,7 @@
 	req_access_txt = "55"
 	},
 /obj/structure/table/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced{
@@ -37488,7 +37477,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bLb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -37532,7 +37521,7 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "bLf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -37545,7 +37534,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -37641,7 +37630,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bLw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -37700,7 +37689,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -37723,7 +37712,7 @@
 	pixel_x = 1;
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
@@ -37778,7 +37767,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bLO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -37807,7 +37796,7 @@
 /area/maintenance/aft)
 "bLT" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -37852,7 +37841,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bLZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -37868,7 +37857,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37884,7 +37873,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37896,10 +37885,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37908,11 +37897,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bMe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -37925,17 +37914,17 @@
 	areastring = "/area/science/xenobiology";
 	pixel_x = -25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bMh" = (
 /obj/structure/chair/stool,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -37950,7 +37939,7 @@
 /turf/closed/wall,
 /area/maintenance/port/aft)
 "bMk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -38108,10 +38097,10 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "bMG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -38161,7 +38150,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -38262,11 +38251,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -38312,10 +38301,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38327,7 +38316,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38500,7 +38489,7 @@
 /turf/open/floor/plating,
 /area/construction)
 "bNN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -38695,7 +38684,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bOq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -38891,7 +38880,7 @@
 	areastring = "/area/security/checkpoint/engineering";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/newscaster{
@@ -39017,7 +39006,7 @@
 /turf/closed/wall,
 /area/engine/atmos)
 "bOZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -39170,7 +39159,7 @@
 	areastring = "/area/science/misc_lab";
 	pixel_x = 26
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -39275,7 +39264,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -39367,7 +39356,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -39461,7 +39450,7 @@
 	pixel_y = -6;
 	req_access_txt = "10"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/radio/off,
@@ -39547,7 +39536,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39687,7 +39676,7 @@
 "bQL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -39731,7 +39720,7 @@
 /area/tcommsat/computer)
 "bQQ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -39788,7 +39777,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bRj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39797,7 +39786,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bRk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39822,7 +39811,7 @@
 	name = "Security Office";
 	req_access_txt = "63"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39946,7 +39935,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -40050,7 +40039,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bRP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -40114,7 +40103,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -40126,10 +40115,10 @@
 /area/science/xenobiology)
 "bRX" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -40137,7 +40126,7 @@
 "bRY" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/button/door{
@@ -40152,16 +40141,16 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bRZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bSa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -40217,7 +40206,7 @@
 "bSm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
@@ -40276,7 +40265,7 @@
 /turf/open/floor/plating,
 /area/construction)
 "bSw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -40399,7 +40388,7 @@
 /area/engine/atmos)
 "bSI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -40498,7 +40487,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bSV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -40507,7 +40496,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bSW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -40522,7 +40511,7 @@
 	areastring = "/area/medical/virology";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/camera{
@@ -40555,7 +40544,7 @@
 	name = "Containment Pen";
 	req_access_txt = "55"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -40566,7 +40555,7 @@
 /area/science/xenobiology)
 "bTc" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -40586,7 +40575,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bTe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/northleft{
@@ -40601,7 +40590,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bTg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -40648,7 +40637,7 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "bTr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -40727,7 +40716,7 @@
 /turf/closed/wall,
 /area/maintenance/port/aft)
 "bTD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -40795,7 +40784,7 @@
 	pixel_x = -25;
 	pixel_y = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -40950,7 +40939,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -40959,7 +40948,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bUe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/cable,
@@ -40972,10 +40961,10 @@
 /area/science/xenobiology)
 "bUf" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -41026,7 +41015,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bUm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -41059,13 +41048,13 @@
 /turf/open/space,
 /area/space/nearstation)
 "bUs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bUt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -41074,10 +41063,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41086,7 +41075,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bUv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -41096,10 +41085,10 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -41113,7 +41102,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bUz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41128,7 +41117,7 @@
 	areastring = "/area/tcommsat/computer";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41218,7 +41207,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -41284,13 +41273,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -41299,7 +41288,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41355,7 +41344,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bVe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41417,7 +41406,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bVm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41433,7 +41422,7 @@
 /turf/open/floor/plating,
 /area/engine/break_room)
 "bVp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41626,7 +41615,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bVV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -41693,7 +41682,7 @@
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "bWe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -41748,7 +41737,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -41761,7 +41750,7 @@
 "bWm" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/button/door{
@@ -41776,10 +41765,10 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bWn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -41877,7 +41866,7 @@
 	areastring = "/area/tcommsat/server";
 	pixel_y = 25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -41901,14 +41890,14 @@
 /area/tcommsat/computer)
 "bWI" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bWJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -41998,7 +41987,7 @@
 	c_tag = "Atmospherics West";
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -42121,7 +42110,7 @@
 	name = "Containment Pen";
 	req_access_txt = "55"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -42131,7 +42120,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bXg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/northleft{
@@ -42155,10 +42144,10 @@
 	codes_txt = "patrol;next_patrol=AIE";
 	location = "AftH"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -42167,7 +42156,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bXm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -42176,7 +42165,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bXn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -42189,7 +42178,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bXo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -42199,10 +42188,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bXp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -42211,7 +42200,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bXq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -42281,7 +42270,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "bXC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -42304,27 +42293,27 @@
 /area/tcommsat/computer)
 "bXF" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bXG" = (
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bXH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bXI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -42512,7 +42501,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -42525,7 +42514,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -42556,7 +42545,7 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "bYj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -42578,7 +42567,7 @@
 "bYn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -42923,35 +42912,35 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bZn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bZo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bZp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bZq" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -42962,10 +42951,10 @@
 /area/tcommsat/computer)
 "bZs" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bZt" = (
@@ -43036,7 +43025,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -43050,17 +43039,17 @@
 	name = "privacy shutter"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "bZD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -43070,7 +43059,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -43094,14 +43083,14 @@
 	areastring = "/area/engine/atmos";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bZG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -43213,7 +43202,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -43232,7 +43221,7 @@
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -43241,10 +43230,10 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bZX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -43294,7 +43283,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "cah" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -43303,7 +43292,7 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -43330,7 +43319,7 @@
 	name = "Server Room";
 	req_access_txt = "61"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -43393,7 +43382,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "caq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -43425,7 +43414,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cau" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43463,7 +43452,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cay" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -43475,7 +43464,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "caz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -43494,7 +43483,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -43570,7 +43559,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43583,10 +43572,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -43598,7 +43587,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43608,7 +43597,7 @@
 /area/maintenance/aft)
 "caO" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -43652,7 +43641,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -43664,10 +43653,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -43677,7 +43666,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -43693,7 +43682,7 @@
 	name = "Containment Pen";
 	req_access_txt = "55"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -43703,7 +43692,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "caW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/northleft{
@@ -43736,7 +43725,7 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "caZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -43777,7 +43766,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cbg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -43830,10 +43819,10 @@
 /area/tcommsat/server)
 "cbm" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cbn" = (
@@ -43845,10 +43834,10 @@
 /area/tcommsat/computer)
 "cbo" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -43864,10 +43853,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -43903,7 +43892,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -43934,7 +43923,7 @@
 	areastring = "/area/engine/break_room";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
@@ -43949,10 +43938,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cbw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -43969,7 +43958,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cby" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -44042,7 +44031,7 @@
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
 "cbJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -44055,7 +44044,7 @@
 /turf/closed/wall,
 /area/maintenance/aft)
 "cbL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -44068,7 +44057,7 @@
 /area/maintenance/aft)
 "cbN" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -44086,7 +44075,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -44110,7 +44099,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
@@ -44121,7 +44110,7 @@
 /area/science/xenobiology)
 "cbS" = (
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -44133,7 +44122,7 @@
 /area/science/xenobiology)
 "cbT" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/white,
@@ -44160,7 +44149,7 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "cca" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/solar{
@@ -44170,7 +44159,7 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
 "ccb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/solar{
@@ -44180,13 +44169,13 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
 "ccc" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
 "ccd" = (
@@ -44206,7 +44195,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -44251,10 +44240,10 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cck" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -44305,7 +44294,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -44317,7 +44306,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ccq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -44329,10 +44318,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ccr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -44347,7 +44336,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cct" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -44357,7 +44346,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ccu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -44441,7 +44430,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -44450,7 +44439,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ccJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -44462,7 +44451,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -44474,7 +44463,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -44490,7 +44479,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -44503,7 +44492,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -44534,7 +44523,7 @@
 /area/security/checkpoint/supply)
 "ccU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -44552,16 +44541,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ccX" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
 "ccY" = (
@@ -44620,7 +44609,7 @@
 	dir = 8;
 	sortType = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -44630,20 +44619,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cdj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -44703,10 +44692,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cdr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -44721,7 +44710,7 @@
 	areastring = "/area/maintenance/starboard/aft";
 	pixel_x = -25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/camera{
@@ -44749,7 +44738,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -44814,7 +44803,7 @@
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
 "cdE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -44823,10 +44812,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cdF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -44835,7 +44824,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cdG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -44850,7 +44839,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cdI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -44893,7 +44882,7 @@
 /area/maintenance/aft)
 "cdO" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -44907,11 +44896,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -44935,7 +44924,7 @@
 	pixel_x = -25;
 	pixel_y = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -44946,7 +44935,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -44989,7 +44978,7 @@
 /area/tcommsat/computer)
 "cef" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "ceg" = (
@@ -45042,7 +45031,7 @@
 "cem" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -45066,10 +45055,10 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "ceq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -45109,7 +45098,7 @@
 "cev" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -45157,14 +45146,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ceC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ceD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -45218,7 +45207,7 @@
 /area/maintenance/aft)
 "ceM" = (
 /obj/machinery/meter,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -45278,7 +45267,7 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -45316,7 +45305,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/chief)
 "cfc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -45346,14 +45335,14 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cfg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -45378,7 +45367,7 @@
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "cfk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -45466,7 +45455,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cfz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -45488,7 +45477,7 @@
 	name = "Engineering Maintenance";
 	req_access_txt = "10"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -45543,7 +45532,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
@@ -45557,7 +45546,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -45615,10 +45604,10 @@
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "cfW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -45636,7 +45625,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cfY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -45659,7 +45648,7 @@
 	capacity = 9e+006;
 	charge = 10000
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -45670,7 +45659,7 @@
 /obj/structure/sign/warning/deathsposal{
 	pixel_y = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -45749,7 +45738,7 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "cgm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45765,11 +45754,11 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cgo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45778,7 +45767,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cgp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45807,13 +45796,13 @@
 /area/maintenance/starboard/aft)
 "cgv" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -45851,7 +45840,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "cgB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/smes,
@@ -45861,11 +45850,11 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
@@ -45886,13 +45875,13 @@
 /area/maintenance/solars/port/aft)
 "cgF" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cgG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -45962,10 +45951,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cgS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -45983,7 +45972,7 @@
 	name = "SMES Room";
 	req_access_txt = "32"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46161,14 +46150,14 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "chn" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46232,7 +46221,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "chv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -46252,14 +46241,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "chA" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -46268,7 +46257,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "chB" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46279,7 +46268,7 @@
 /area/engine/engineering)
 "chC" = (
 /obj/structure/rack,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -46289,7 +46278,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "chD" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46302,17 +46291,17 @@
 /area/engine/engineering)
 "chE" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chF" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46324,7 +46313,7 @@
 /area/engine/engineering)
 "chG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -46337,24 +46326,24 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "chI" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
 "chJ" = (
 /obj/machinery/power/tracker,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
 "chK" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
 "chL" = (
@@ -46362,10 +46351,10 @@
 /turf/open/space,
 /area/solar/port/aft)
 "chM" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
 "chN" = (
@@ -46375,15 +46364,15 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "chO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
@@ -46397,10 +46386,10 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "chQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -46416,19 +46405,19 @@
 	name = "Port Quarter Solar Access";
 	req_access_txt = "10"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "chT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "chV" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46446,7 +46435,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "chX" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46481,10 +46470,10 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -46500,7 +46489,7 @@
 	areastring = "/area/engine/engineering";
 	pixel_y = 25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
@@ -46514,7 +46503,7 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/light{
@@ -46531,7 +46520,7 @@
 	pixel_x = -5;
 	pixel_y = 30
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -46540,7 +46529,7 @@
 /turf/closed/wall,
 /area/engine/engineering)
 "cii" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46559,7 +46548,7 @@
 /area/engine/engineering)
 "cij" = (
 /obj/machinery/modular_computer/console/preset/engineering,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -46598,7 +46587,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "cin" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -46632,12 +46621,12 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ciq" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "ceprivacy";
 	name = "privacy shutter"
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "cir" = (
@@ -46759,7 +46748,7 @@
 	luminosity = 2
 	},
 /obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/camera{
@@ -46770,7 +46759,7 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "ciN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -46778,7 +46767,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ciO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -46788,10 +46777,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ciP" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
 "ciQ" = (
@@ -46816,7 +46805,7 @@
 	c_tag = "Aft Port Solar Control";
 	dir = 1
 	},
-/obj/structure/cable,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "ciS" = (
@@ -46861,7 +46850,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cja" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -46879,7 +46868,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cjd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -46898,13 +46887,13 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cje" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cjf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -46960,7 +46949,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cji" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -46979,7 +46968,7 @@
 	dir = 4;
 	pixel_x = 27
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -47068,7 +47057,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cjv" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -47144,7 +47133,7 @@
 	name = "Starboard Quarter Solar Access";
 	req_access_txt = "10"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -47154,17 +47143,17 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
 "cjH" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/turf/open/space/basic,
 /area/solar/port/aft)
 "cjI" = (
 /obj/structure/closet/crate,
@@ -47275,7 +47264,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -47388,7 +47377,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "ckk" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -47433,10 +47422,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cks" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -47449,13 +47438,13 @@
 	pixel_x = -26;
 	pixel_y = 3
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cku" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes,
@@ -47468,13 +47457,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ckw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "ckx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -47483,13 +47472,13 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cky" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "ckz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -47514,7 +47503,7 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/item/storage/box/lights/mixed,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -47531,7 +47520,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ckH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -47551,7 +47540,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ckL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -47562,10 +47551,10 @@
 	name = "Chief Engineer";
 	req_access_txt = "56"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -47715,7 +47704,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "clj" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -47826,11 +47815,11 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -47850,10 +47839,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "clC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -47872,7 +47861,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "clE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/engineering,
@@ -47889,16 +47878,16 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "clF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "clG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/engineering,
@@ -48042,7 +48031,7 @@
 "cmf" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -48090,7 +48079,7 @@
 /area/maintenance/aft)
 "cml" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -48168,16 +48157,16 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cmy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cmz" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -48186,7 +48175,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -48205,7 +48194,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -48248,7 +48237,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/closet/wardrobe/engineering_yellow,
@@ -48264,7 +48253,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cmL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -48279,7 +48268,7 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -48346,7 +48335,7 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "cna" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
@@ -48399,38 +48388,38 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cnk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cnl" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/turf/open/space/basic,
 /area/solar/port/aft)
 "cnm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cnn" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -48446,10 +48435,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cnp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -48475,7 +48464,7 @@
 	c_tag = "Engineering West";
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/station_engineer,
@@ -48493,7 +48482,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -48517,7 +48506,7 @@
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/twohanded/rcl/pre_loaded,
@@ -48533,7 +48522,7 @@
 "cnC" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -48575,7 +48564,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -48592,7 +48581,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cnL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced,
@@ -48604,20 +48593,20 @@
 	name = "SMES Chamber";
 	req_access_txt = "32"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cnN" = (
 /obj/structure/window/reinforced,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal{
@@ -48630,7 +48619,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -48640,13 +48629,13 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cnQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -48661,7 +48650,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cnR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -48671,7 +48660,7 @@
 /area/engine/engine_smes)
 "cnS" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -48687,7 +48676,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cnU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/electricshock{
@@ -48700,7 +48689,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet{
@@ -48713,7 +48702,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -48725,7 +48714,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
@@ -48737,7 +48726,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "coa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -48747,13 +48736,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cob" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -48786,7 +48775,7 @@
 /obj/machinery/igniter{
 	id = "Incinerator"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/air_sensor{
@@ -48813,7 +48802,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -48825,7 +48814,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -48847,7 +48836,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -48859,7 +48848,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -48871,7 +48860,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -48890,7 +48879,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -48902,7 +48891,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -48911,7 +48900,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "coH" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48921,7 +48910,7 @@
 /area/engine/engineering)
 "coJ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48933,26 +48922,26 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "coL" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "coM" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49044,14 +49033,14 @@
 /turf/open/space,
 /area/space/nearstation)
 "cpi" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/aft)
 "cpj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -49132,7 +49121,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -49143,10 +49132,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cpv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -49155,7 +49144,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cpx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -49164,13 +49153,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cpA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/chair/office{
@@ -49187,7 +49176,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -49298,7 +49287,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -49326,7 +49315,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
@@ -49348,7 +49337,7 @@
 /area/engine/engineering)
 "cqe" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -49415,7 +49404,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -49502,7 +49491,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -49529,7 +49518,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -49614,7 +49603,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cqM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -49753,7 +49742,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cro" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -49764,21 +49753,21 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "crq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crr" = (
-/obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crs" = (
@@ -49842,63 +49831,63 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crB" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/turf/open/space/basic,
 /area/solar/starboard/aft)
 "crC" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/space/basic,
 /area/solar/starboard/aft)
 "crD" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/turf/open/space/basic,
 /area/solar/starboard/aft)
 "crE" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/starboard/aft)
-"crF" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/starboard/aft)
-"crG" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/space,
+/area/solar/starboard/aft)
+"crF" = (
 /obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/space,
+/area/solar/starboard/aft)
+"crG" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/space,
 /area/solar/starboard/aft)
 "crH" = (
@@ -50127,7 +50116,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -50137,10 +50126,10 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "csE" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/aft)
 "csH" = (
@@ -50180,10 +50169,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
@@ -50229,6 +50218,8 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "csY" = (
+/obj/structure/cable,
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -50238,16 +50229,14 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/cable,
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/aft)
 "csZ" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/turf/open/space/basic,
 /area/solar/starboard/aft)
 "cta" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -50450,7 +50439,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -50462,7 +50451,7 @@
 "ctJ" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/cyborg,
@@ -50532,17 +50521,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ctT" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -50557,7 +50546,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -50639,7 +50628,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cue" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -50685,7 +50674,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cul" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -50764,7 +50753,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cuu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -50904,7 +50893,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cuG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -50969,7 +50958,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/service)
 "cuL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -50984,7 +50973,7 @@
 	areastring = "/area/ai_monitored/turret_protected/aisat/atmos";
 	pixel_x = -27
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/portable_atmospherics/scrubber,
@@ -50994,7 +50983,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cuN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -51003,7 +50992,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cuO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/ai_slipper{
@@ -51013,7 +51002,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cuP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51022,7 +51011,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cuQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51036,7 +51025,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cuR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51046,13 +51035,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cuS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/ai_slipper{
@@ -51063,7 +51052,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cuT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51072,7 +51061,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "cuU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51086,19 +51075,19 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cuV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "cuW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -51110,7 +51099,7 @@
 	areastring = "/area/ai_monitored/turret_protected/aisat/service";
 	pixel_x = 27
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/port_gen/pacman,
@@ -51183,7 +51172,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cve" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51232,7 +51221,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "cvi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -51259,7 +51248,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51278,7 +51267,7 @@
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -51337,7 +51326,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51374,7 +51363,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -51415,7 +51404,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51467,7 +51456,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -51508,7 +51497,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -51520,19 +51509,19 @@
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -51570,7 +51559,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cwc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51580,7 +51569,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cwd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51600,7 +51589,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "cwf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51642,7 +51631,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "cwj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51677,7 +51666,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "cwo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -51706,7 +51695,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
 "cwt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51718,7 +51707,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "cwu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/ai_slipper{
@@ -51737,7 +51726,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "cww" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51746,7 +51735,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "cwx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51768,10 +51757,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "cwA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/holopad,
@@ -51816,7 +51805,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
@@ -51838,7 +51827,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "cwH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -51886,11 +51875,11 @@
 /turf/open/space,
 /area/space/nearstation)
 "cxk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -51944,15 +51933,15 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "cxN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
@@ -52115,15 +52104,15 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "cyK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
@@ -52132,7 +52121,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -52160,15 +52149,15 @@
 /turf/open/space/basic,
 /area/space)
 "cyU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -52209,7 +52198,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -52217,7 +52206,7 @@
 "czH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -52267,7 +52256,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "czR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -52288,7 +52277,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -52297,7 +52286,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52309,7 +52298,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -52318,7 +52307,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52399,16 +52388,16 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "cAh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cAi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -52417,10 +52406,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -52431,7 +52420,7 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "cAo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -52440,7 +52429,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cAp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -52462,7 +52451,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cAr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -52494,7 +52483,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cAu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/emitter/anchored{
@@ -52557,7 +52546,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cAG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc{
@@ -52566,7 +52555,7 @@
 	areastring = "/area/crew_quarters/heads/hop";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -52604,7 +52593,7 @@
 	name = "Security Maintenance";
 	req_access_txt = "1"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -52629,7 +52618,7 @@
 	name = "AI Core Door";
 	req_access_txt = "16"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/circuit,
@@ -52687,7 +52676,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "cAV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/showcase/cyborg/old{
@@ -52722,13 +52711,13 @@
 /turf/open/space,
 /area/space/nearstation)
 "cAY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/closed/wall,
 /area/ai_monitored/turret_protected/ai)
 "cAZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -52737,7 +52726,7 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/circuit,
@@ -52807,7 +52796,7 @@
 "cBj" = (
 /obj/structure/table,
 /obj/item/folder/blue,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
@@ -52870,7 +52859,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cBx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
@@ -52906,17 +52895,17 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "cBC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "cBD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -52942,17 +52931,17 @@
 /area/engine/atmos)
 "cBG" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cBH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
@@ -52994,7 +52983,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53022,7 +53011,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cBS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -53047,7 +53036,7 @@
 	name = "Security Office";
 	req_access_txt = "1"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -53122,7 +53111,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cCl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -53269,7 +53258,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -53283,10 +53272,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -53298,7 +53287,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
@@ -53311,7 +53300,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cDi" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53328,7 +53317,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cDj" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53355,16 +53344,16 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDp" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -53373,19 +53362,19 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cDs" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -53415,7 +53404,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cDx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -53486,7 +53475,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -53545,7 +53534,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "cDZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/closet/radiation,
@@ -53578,7 +53567,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -53599,7 +53588,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -53642,7 +53631,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -53660,7 +53649,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -53672,7 +53661,7 @@
 	network = list("engine");
 	pixel_x = 23
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -53682,7 +53671,7 @@
 	dir = 8
 	},
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/structure/window/plasma/reinforced{
@@ -53707,7 +53696,7 @@
 	dir = 4
 	},
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/structure/window/plasma/reinforced{
@@ -53716,7 +53705,7 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "cEz" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -53730,7 +53719,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -53739,10 +53728,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/meter,
@@ -53752,7 +53741,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -53806,7 +53795,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/item/tank/internals/plasma,
@@ -53822,7 +53811,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -53831,10 +53820,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -53859,7 +53848,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -53873,7 +53862,7 @@
 	dir = 5
 	},
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/structure/window/plasma/reinforced{
@@ -53886,7 +53875,7 @@
 	dir = 9
 	},
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/structure/window/plasma/reinforced{
@@ -53912,7 +53901,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -53921,7 +53910,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -54098,7 +54087,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -54114,7 +54103,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -54123,7 +54112,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -54175,7 +54164,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -54227,7 +54216,7 @@
 	name = "Laser Room";
 	req_access_txt = "10"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
@@ -54256,7 +54245,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cGS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -54299,46 +54288,46 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cHb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cHc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cHd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cHe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cHg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cHj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/emitter/anchored{
@@ -54348,7 +54337,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cHn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -54366,13 +54355,13 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cHr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cHD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54380,7 +54369,7 @@
 	dir = 2;
 	sortType = 14
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -54393,7 +54382,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -54415,7 +54404,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -54430,7 +54419,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -54445,10 +54434,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -54463,7 +54452,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -54478,7 +54467,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -54495,7 +54484,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -54507,7 +54496,7 @@
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -54519,7 +54508,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "cHN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit,
@@ -54722,7 +54711,7 @@
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "cMQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
@@ -54763,7 +54752,7 @@
 	areastring = "/area/maintenance/central";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -54772,7 +54761,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -54782,13 +54771,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "cNR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -54800,7 +54789,7 @@
 	areastring = "/area/maintenance/starboard";
 	pixel_x = 26
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -54809,18 +54798,18 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cNU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -54831,7 +54820,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -54843,7 +54832,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "8;12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54858,7 +54847,7 @@
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
 "cNZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54919,7 +54908,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54940,7 +54929,7 @@
 /turf/closed/wall,
 /area/security/courtroom)
 "cSE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -54956,7 +54945,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "cSH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/meter,
@@ -54979,7 +54968,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cSK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -55043,7 +55032,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -55053,7 +55042,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -55062,7 +55051,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -55075,7 +55064,7 @@
 /area/engine/engineering)
 "cSR" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -55090,7 +55079,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -55195,7 +55184,7 @@
 /area/engine/engineering)
 "cTc" = (
 /obj/effect/spawner/structure/window,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -55206,7 +55195,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cTe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -55218,7 +55207,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cTf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/requests_console{
@@ -55237,7 +55226,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cTD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/power/apc{
@@ -55246,7 +55235,7 @@
 	areastring = "/area/maintenance/central/secondary";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -55280,7 +55269,7 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -55288,17 +55277,17 @@
 /area/maintenance/department/medical/morgue)
 "cTK" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "cTL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -55310,7 +55299,7 @@
 	areastring = "/area/maintenance/department/medical/morgue";
 	pixel_x = 26
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -55319,7 +55308,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -55329,7 +55318,7 @@
 /area/maintenance/department/medical/morgue)
 "cTS" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -55339,7 +55328,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "cTX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/shieldwallgen/xenobiologyaccess,
@@ -55448,7 +55437,7 @@
 /area/security/detectives_office)
 "dCN" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -55488,12 +55477,26 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "dPH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dQC" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/space,
+/area/solar/port/fore)
 "dYq" = (
 /turf/closed/wall,
 /area/science/nanite)
@@ -55513,7 +55516,7 @@
 /area/science/nanite)
 "elq" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -55604,13 +55607,13 @@
 /area/science/mixing/chamber)
 "fgq" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -55645,7 +55648,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -55700,7 +55703,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "fXM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -55712,7 +55715,7 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "gbq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -55740,7 +55743,7 @@
 /turf/closed/wall,
 /area/quartermaster/warehouse)
 "glg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -55867,13 +55870,13 @@
 	areastring = "/area/science/lab";
 	pixel_x = 26
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "gWd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -55896,7 +55899,7 @@
 "hcE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/power/apc{
@@ -55905,7 +55908,7 @@
 	areastring = "/area/quartermaster/warehouse";
 	pixel_x = 26
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -55939,7 +55942,7 @@
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "hsQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/carpet,
@@ -55960,6 +55963,20 @@
 "hZk" = (
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"iaI" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/space,
+/area/solar/port/aft)
 "ibG" = (
 /obj/machinery/nanite_programmer,
 /obj/effect/turf_decal/bot,
@@ -55997,6 +56014,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"iBZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "iEJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod One"
@@ -56037,7 +56060,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jbf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -56075,7 +56098,7 @@
 	areastring = "/area/lawoffice";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -56099,7 +56122,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56112,7 +56135,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56153,7 +56176,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jVl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -56209,10 +56232,10 @@
 /area/security/detectives_office)
 "klL" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -56236,7 +56259,7 @@
 "kob" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -56282,7 +56305,7 @@
 /turf/closed/wall,
 /area/maintenance/starboard)
 "kyZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -56353,7 +56376,7 @@
 /area/science/mixing)
 "kPd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -56377,7 +56400,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -56432,7 +56455,7 @@
 /area/medical/chemistry)
 "ltd" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -56442,7 +56465,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ltG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -56499,6 +56522,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"lNg" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/space/basic,
+/area/solar/port/aft)
 "lNB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -56547,6 +56584,20 @@
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"mll" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/space/basic,
+/area/solar/starboard/fore)
 "mBm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -56557,7 +56608,7 @@
 /turf/open/floor/plasteel,
 /area/science/nanite)
 "mBv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -56586,14 +56637,28 @@
 	network = list("ss13","rd")
 	},
 /obj/structure/closet/l3closet/scientist,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"mKx" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/space/basic,
+/area/solar/starboard/aft)
 "mMA" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -56654,7 +56719,7 @@
 	areastring = "/area/construction";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -56673,7 +56738,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "nGt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -56684,7 +56749,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "nGv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -56755,7 +56820,7 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "nXU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -56799,10 +56864,10 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "oIK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -56862,7 +56927,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "pjk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -56907,6 +56972,13 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"ptP" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space,
+/area/solar/starboard/aft)
 "pvj" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -56963,7 +57035,7 @@
 	pixel_x = 8;
 	pixel_y = 28
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
@@ -57046,6 +57118,20 @@
 	dir = 4
 	},
 /area/science/explab)
+"qtY" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/space,
+/area/solar/starboard/aft)
 "quT" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -57078,13 +57164,13 @@
 /obj/effect/turf_decal/bot{
 	dir = 2
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "qQH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57163,7 +57249,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "rOY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57196,7 +57282,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "sjK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -57210,7 +57296,7 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -57226,7 +57312,7 @@
 	pixel_x = 27;
 	pixel_y = 2
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -57250,7 +57336,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -57315,10 +57401,10 @@
 /area/security/main)
 "sYI" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -57355,7 +57441,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57372,7 +57458,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "tfg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57395,7 +57481,7 @@
 /turf/open/floor/plasteel,
 /area/science/nanite)
 "thy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -57431,13 +57517,13 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tDw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -57447,10 +57533,10 @@
 /area/science/misc_lab)
 "tJU" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "tKG" = (
@@ -57463,6 +57549,20 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"tVp" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "tXL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -57477,7 +57577,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white,
@@ -57541,7 +57641,7 @@
 /turf/open/floor/plasteel,
 /area/science/nanite)
 "uCq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -57574,7 +57674,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
@@ -57601,7 +57701,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "uVS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -57632,7 +57732,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -57661,7 +57761,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "vqI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57681,7 +57781,7 @@
 	name = "Detective's Office APC";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -57727,7 +57827,7 @@
 	name = "Experimentation Lab";
 	req_access_txt = "47"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -57736,7 +57836,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "vHp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -57828,7 +57928,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -57863,7 +57963,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "wQy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -57889,7 +57989,7 @@
 "wZy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/white,
@@ -57924,7 +58024,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -57935,7 +58035,7 @@
 	req_one_access_txt = "25;26;35;28"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -57974,6 +58074,20 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xKR" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/space,
+/area/solar/starboard/fore)
 "xXe" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
@@ -73266,15 +73380,15 @@ aaa
 abY
 aaa
 acV
-adu
+tVp
 adZ
 aaf
 acV
-adu
+tVp
 adZ
 aaf
 acV
-adu
+tVp
 adZ
 aaa
 aaf
@@ -73361,7 +73475,7 @@ aaS
 aaa
 ccc
 ccX
-ccX
+iaI
 ccX
 ccX
 cgz
@@ -73369,7 +73483,7 @@ chL
 ciP
 cjH
 cjH
-cjH
+lNg
 cjH
 cnl
 aaa
@@ -74389,7 +74503,7 @@ aaS
 aaa
 ccc
 ccX
-ccX
+iaI
 ccX
 ccX
 cgz
@@ -74397,7 +74511,7 @@ chL
 ciP
 cjH
 cjH
-cjH
+lNg
 cjH
 cnl
 aaa
@@ -75322,15 +75436,15 @@ aaa
 aaS
 aaa
 acV
-adz
+dQC
 adZ
 aaf
 acV
-adz
+dQC
 adZ
 aaf
 acV
-adz
+dQC
 adZ
 aaa
 aaf
@@ -75417,7 +75531,7 @@ aaS
 aaa
 ccc
 ccX
-ccX
+iaI
 ccX
 ccX
 cgz
@@ -75425,7 +75539,7 @@ chL
 ciP
 cjH
 cjH
-cjH
+lNg
 cjH
 cnl
 aaa
@@ -79214,7 +79328,7 @@ aEO
 aGc
 aHF
 aJd
-aKb
+aKv
 aLN
 aMQ
 aNT
@@ -98195,15 +98309,15 @@ aaa
 aaS
 aaa
 ads
-adT
+mll
 aeG
 aaf
 ads
-adT
+mll
 aeG
 aaf
 ads
-adT
+mll
 aeG
 aaa
 aaf
@@ -100251,15 +100365,15 @@ aaa
 aaS
 aaa
 ads
-adW
+xKR
 aeG
 aaf
 ads
-adW
+xKR
 aeG
 aaf
 ads
-adW
+xKR
 aeG
 aaa
 aaf
@@ -104392,7 +104506,7 @@ auI
 awP
 avJ
 awO
-awO
+iBZ
 asB
 aCM
 aEg
@@ -105420,7 +105534,7 @@ auJ
 awS
 auI
 awO
-awO
+iBZ
 asB
 aCP
 aEj
@@ -107045,15 +107159,15 @@ aaa
 aaf
 aaa
 cMQ
-crC
+mKx
 cNa
 aaf
 cMQ
-crC
+mKx
 cNa
 aaf
 cMQ
-crC
+mKx
 cNa
 aaa
 aaS
@@ -108338,7 +108452,7 @@ crF
 aaa
 aaa
 aaa
-csZ
+ptP
 aaa
 aaa
 aaa
@@ -109101,15 +109215,15 @@ aaa
 aaf
 aaa
 cMQ
-crE
+qtY
 cNa
 aaf
 cMQ
-crE
+qtY
 cNa
 aaf
 cMQ
-crE
+qtY
 cNa
 aaa
 aaS

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -567,7 +567,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
 "act" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/light/small{
@@ -580,7 +580,7 @@
 /area/maintenance/solars/starboard/fore)
 "acu" = (
 /obj/machinery/power/smes,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -630,7 +630,7 @@
 /area/construction/mining/aux_base)
 "acH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -652,7 +652,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -666,7 +666,7 @@
 	name = "Starboard Bow Solar Access";
 	req_access_txt = "10"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -681,10 +681,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/solars/starboard/fore)
 "acK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -884,7 +884,7 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "ade" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1027,7 +1027,7 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "adP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1121,7 +1121,7 @@
 /area/hallway/secondary/entry)
 "aek" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1186,7 +1186,7 @@
 /area/construction/mining/aux_base)
 "aeD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -1304,7 +1304,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -1428,7 +1428,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -1492,7 +1492,7 @@
 /area/construction/mining/aux_base)
 "afX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -1541,7 +1541,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -1562,11 +1562,11 @@
 /area/construction/mining/aux_base)
 "agn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -1656,7 +1656,7 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "agN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
@@ -1749,7 +1749,7 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "ahb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -1795,7 +1795,7 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "ahu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -1852,7 +1852,7 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "ahE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1980,7 +1980,7 @@
 /area/hallway/secondary/entry)
 "ahY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2016,7 +2016,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aii" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2025,14 +2025,14 @@
 /area/maintenance/starboard/fore)
 "aij" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aik" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -2215,7 +2215,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aiF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -2317,7 +2317,7 @@
 /area/maintenance/starboard/fore)
 "aiX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2484,7 +2484,7 @@
 /area/maintenance/starboard/fore)
 "ajk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -2693,7 +2693,7 @@
 	},
 /area/hallway/secondary/entry)
 "ajB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -2718,7 +2718,7 @@
 	},
 /area/hallway/secondary/entry)
 "ajC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -2825,7 +2825,7 @@
 "ajM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -2970,7 +2970,7 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "akb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3128,7 +3128,7 @@
 /area/maintenance/starboard/fore)
 "akp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
@@ -3243,7 +3243,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3263,7 +3263,7 @@
 /turf/closed/wall,
 /area/security/checkpoint/customs)
 "akG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -3336,7 +3336,7 @@
 /turf/closed/wall,
 /area/security/checkpoint)
 "akQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -3609,7 +3609,7 @@
 /area/vacant_room/office)
 "alt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3631,7 +3631,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "alv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/photocopier,
@@ -3686,7 +3686,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
 "alA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/table/reinforced,
@@ -3723,7 +3723,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "alD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3738,7 +3738,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "alE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3754,7 +3754,7 @@
 /area/maintenance/starboard/fore)
 "alF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3763,7 +3763,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "alG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3772,7 +3772,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "alH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -3979,14 +3979,14 @@
 /turf/open/floor/carpet,
 /area/vacant_room/office)
 "ami" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "amj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -4007,10 +4007,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "amk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/holopad,
@@ -4131,10 +4131,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
 "amw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/holopad,
@@ -4145,7 +4145,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
 "amx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -4169,7 +4169,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "amz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -4412,7 +4412,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/electronic_marketing_den)
 "amW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -4426,7 +4426,7 @@
 	},
 /area/maintenance/port/fore)
 "amX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -4494,7 +4494,7 @@
 /area/vacant_room/office)
 "anh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -4517,7 +4517,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "anj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -4544,7 +4544,7 @@
 /area/security/checkpoint/customs)
 "anl" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -4612,7 +4612,7 @@
 /area/hallway/secondary/entry)
 "anu" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -4630,7 +4630,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
 "anw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -4682,7 +4682,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "anA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -4941,7 +4941,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/electronic_marketing_den)
 "anX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -4987,7 +4987,7 @@
 /turf/open/floor/wood,
 /area/vacant_room/office)
 "aoc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -4996,7 +4996,7 @@
 /turf/open/floor/wood,
 /area/vacant_room/office)
 "aod" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5010,7 +5010,7 @@
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5025,7 +5025,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5040,10 +5040,10 @@
 /turf/open/floor/plasteel,
 /area/vacant_room/office)
 "aog" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -5080,10 +5080,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aoi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/chair/office{
@@ -5102,7 +5102,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aoj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
@@ -5116,10 +5116,10 @@
 /area/security/checkpoint/customs)
 "aok" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor/southright{
@@ -5156,10 +5156,10 @@
 /area/hallway/secondary/entry)
 "aoq" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -5168,7 +5168,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
 "aor" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
@@ -5189,10 +5189,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
 "aos" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/chair/office{
@@ -5244,7 +5244,7 @@
 /area/maintenance/starboard/fore)
 "aov" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
@@ -5311,7 +5311,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "aoA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/chair/stool/bar,
@@ -5532,7 +5532,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5553,7 +5553,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/vacant_room/office)
 "apb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -5572,7 +5572,7 @@
 /area/vacant_room/office)
 "apd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5607,7 +5607,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "apf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -5703,7 +5703,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
 "apq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -5737,7 +5737,7 @@
 /area/security/checkpoint)
 "aps" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -5763,7 +5763,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "apx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -6040,7 +6040,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/wood,
@@ -6049,7 +6049,7 @@
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/pen,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
@@ -6058,20 +6058,20 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/crew_quarters/electronic_marketing_den)
 "apW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/electronic_marketing_den)
 "apX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/wood{
@@ -6087,7 +6087,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/electronic_marketing_den)
 "apZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6195,7 +6195,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aqk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6274,7 +6274,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
 "aqs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6306,10 +6306,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aqv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6320,7 +6320,7 @@
 /area/maintenance/starboard/fore)
 "aqw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -6341,7 +6341,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aqx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6361,7 +6361,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "aqy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6370,7 +6370,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aqz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6389,7 +6389,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "aqA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -6408,7 +6408,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "aqB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6623,7 +6623,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/electronic_marketing_den)
 "aqQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood{
@@ -6668,7 +6668,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6682,7 +6682,7 @@
 /area/maintenance/port/fore)
 "aqX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6693,7 +6693,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aqY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6711,7 +6711,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aqZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6729,7 +6729,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "ara" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -6931,7 +6931,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
@@ -6994,20 +6994,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -7019,7 +7019,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "arF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
@@ -7033,17 +7033,17 @@
 /area/maintenance/port/fore)
 "arG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -7058,20 +7058,20 @@
 	},
 /area/maintenance/port/fore)
 "arI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -7168,7 +7168,7 @@
 /area/maintenance/starboard/fore)
 "arT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -7184,7 +7184,7 @@
 /area/maintenance/starboard/fore)
 "arV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -7549,14 +7549,14 @@
 /area/maintenance/port/fore)
 "asE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -7569,16 +7569,16 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "asG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -7588,7 +7588,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "asI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7598,7 +7598,7 @@
 /area/maintenance/port/fore)
 "asJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -7607,7 +7607,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7621,7 +7621,7 @@
 /area/maintenance/port/fore)
 "asL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7632,7 +7632,7 @@
 /area/maintenance/port/fore)
 "asM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7642,7 +7642,7 @@
 /area/maintenance/port/fore)
 "asN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7660,7 +7660,7 @@
 	},
 /area/maintenance/port/fore)
 "asO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7670,10 +7670,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "asP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -7684,7 +7684,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "asQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7693,10 +7693,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -7809,7 +7809,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "atd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -7823,7 +7823,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "ate" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7840,7 +7840,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7858,7 +7858,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "atg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7874,7 +7874,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ath" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -8031,10 +8031,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "atq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -8052,7 +8052,7 @@
 /area/maintenance/starboard/fore)
 "atr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8073,10 +8073,10 @@
 /area/maintenance/starboard/fore)
 "ats" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -8096,7 +8096,7 @@
 /area/maintenance/starboard/fore)
 "att" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -8550,7 +8550,7 @@
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "auc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -8624,7 +8624,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aul" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8696,7 +8696,7 @@
 /area/maintenance/starboard/fore)
 "aut" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -8729,7 +8729,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8742,7 +8742,7 @@
 /area/maintenance/starboard/fore)
 "aux" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8762,7 +8762,7 @@
 /area/maintenance/starboard/fore)
 "auy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8775,7 +8775,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "auz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8793,7 +8793,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "auA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8806,7 +8806,7 @@
 /area/maintenance/starboard/fore)
 "auB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8818,7 +8818,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -8833,7 +8833,7 @@
 /area/maintenance/starboard/fore)
 "auD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8849,10 +8849,10 @@
 /area/maintenance/starboard/fore)
 "auE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8864,7 +8864,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8891,7 +8891,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -8910,7 +8910,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -8920,7 +8920,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -8935,7 +8935,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -8951,7 +8951,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/brown,
@@ -8968,7 +8968,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
@@ -8988,7 +8988,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -9002,7 +9002,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -9023,7 +9023,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/brown,
@@ -9267,7 +9267,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "avp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
@@ -9343,7 +9343,7 @@
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
 "avy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -9409,7 +9409,7 @@
 	areastring = "/area/janitor";
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -9541,7 +9541,7 @@
 /obj/machinery/door/airlock{
 	name = "Auxiliary Restroom"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -9625,7 +9625,7 @@
 /area/quartermaster/warehouse)
 "avR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -9801,7 +9801,7 @@
 "awn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -9910,7 +9910,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "awA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -9965,7 +9965,7 @@
 /area/janitor)
 "awD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10099,7 +10099,7 @@
 	},
 /area/crew_quarters/toilet/auxiliary)
 "awO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -10542,7 +10542,7 @@
 "axI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -10644,7 +10644,7 @@
 "axT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10690,7 +10690,7 @@
 /area/janitor)
 "axW" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -10783,7 +10783,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/auxiliary)
 "ayf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -10800,7 +10800,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -10824,7 +10824,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ayi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -10843,7 +10843,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ayj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -10859,7 +10859,7 @@
 /area/hallway/primary/fore)
 "ayk" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -10882,7 +10882,7 @@
 /area/quartermaster/warehouse)
 "ayl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -10902,7 +10902,7 @@
 "ayn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -11102,7 +11102,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "ayE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -11380,7 +11380,7 @@
 /area/janitor)
 "azb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -11397,7 +11397,7 @@
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -11489,7 +11489,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "azj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -11519,7 +11519,7 @@
 /area/hallway/primary/fore)
 "azl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11546,7 +11546,7 @@
 /area/quartermaster/warehouse)
 "azo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11716,7 +11716,7 @@
 /area/quartermaster/storage)
 "azG" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -11931,7 +11931,7 @@
 /area/maintenance/port/fore)
 "aAg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11952,7 +11952,7 @@
 	req_access_txt = "26"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -12049,7 +12049,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/auxiliary)
 "aAq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -12073,7 +12073,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aAs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12094,7 +12094,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "aAv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -12277,17 +12277,17 @@
 /area/quartermaster/storage)
 "aAI" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aAJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -12295,10 +12295,10 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aAK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -12563,7 +12563,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden/abandoned)
 "aBq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12573,7 +12573,7 @@
 /area/maintenance/port/fore)
 "aBr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12586,7 +12586,7 @@
 /area/maintenance/port/fore)
 "aBs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12598,7 +12598,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aBt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12615,7 +12615,7 @@
 /area/maintenance/port/fore)
 "aBu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12631,7 +12631,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aBv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12643,10 +12643,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aBw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12660,7 +12660,7 @@
 /area/maintenance/port/fore)
 "aBx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -12680,10 +12680,10 @@
 /area/maintenance/port/fore)
 "aBy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12797,7 +12797,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aBH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -12816,7 +12816,7 @@
 /area/hallway/primary/fore)
 "aBI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12842,7 +12842,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aBL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -13011,7 +13011,7 @@
 	dir = 8;
 	id = "cargounload"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor{
@@ -13169,7 +13169,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden/abandoned)
 "aCz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13205,10 +13205,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aCE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -13218,7 +13218,7 @@
 /area/maintenance/port/fore)
 "aCF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13232,7 +13232,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aCG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13246,7 +13246,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aCH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -13254,7 +13254,7 @@
 /area/maintenance/port/fore)
 "aCI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13272,7 +13272,7 @@
 /area/maintenance/port/fore)
 "aCJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13289,7 +13289,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13304,7 +13304,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aCL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13317,13 +13317,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aCM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -13350,7 +13350,7 @@
 /area/hallway/primary/fore)
 "aCO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13364,7 +13364,7 @@
 "aCP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -13387,7 +13387,7 @@
 /area/quartermaster/warehouse)
 "aCQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13406,10 +13406,10 @@
 /area/quartermaster/warehouse)
 "aCR" = (
 /obj/effect/decal/cleanable/oil,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -13423,10 +13423,10 @@
 /area/quartermaster/warehouse)
 "aCS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13449,7 +13449,7 @@
 /area/quartermaster/warehouse)
 "aCT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13461,14 +13461,14 @@
 /area/quartermaster/warehouse)
 "aCU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aCV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -13477,7 +13477,7 @@
 "aCW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -13486,7 +13486,7 @@
 /area/quartermaster/warehouse)
 "aCX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -13632,7 +13632,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aDh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -13793,7 +13793,7 @@
 "aDB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -13849,7 +13849,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/service)
 "aDK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -13905,7 +13905,7 @@
 /area/quartermaster/warehouse)
 "aDQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -14082,7 +14082,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aEi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
@@ -14256,7 +14256,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aEx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -14275,7 +14275,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aEy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -14290,7 +14290,7 @@
 	areastring = "/area/engine/atmospherics_engine";
 	pixel_x = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/cable,
@@ -14304,27 +14304,27 @@
 /area/space/nearstation)
 "aEB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden/abandoned)
 "aEC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden/abandoned)
 "aED" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden/abandoned)
 "aEE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -14336,7 +14336,7 @@
 /area/hydroponics/garden/abandoned)
 "aEG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -14396,7 +14396,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aEN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -14437,7 +14437,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -14608,7 +14608,7 @@
 /area/crew_quarters/bar)
 "aFb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -14624,10 +14624,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aFc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -14664,7 +14664,7 @@
 "aFg" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/mining{
@@ -14707,7 +14707,7 @@
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "aFn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -14890,7 +14890,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aFE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14912,7 +14912,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14932,7 +14932,7 @@
 /area/engine/atmospherics_engine)
 "aFG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -15012,7 +15012,7 @@
 /area/hydroponics/garden/abandoned)
 "aFP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -15036,7 +15036,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden/abandoned)
 "aFS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -15096,7 +15096,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aGa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -15149,7 +15149,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aGd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -15322,7 +15322,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aGr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -15577,7 +15577,7 @@
 	dir = 4;
 	id = "cargoload"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -15602,7 +15602,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aGI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/item/cultivator,
@@ -15617,10 +15617,10 @@
 	name = "old sink";
 	pixel_y = 28
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -15639,7 +15639,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aGK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/item/reagent_containers/glass/bucket,
@@ -15678,7 +15678,7 @@
 /area/maintenance/solars/port/fore)
 "aGN" = (
 /obj/machinery/power/smes,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/light/small{
@@ -15690,7 +15690,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aGO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/sign/directions/engineering{
@@ -15831,7 +15831,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "aGV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -15853,7 +15853,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -15880,7 +15880,7 @@
 /area/engine/atmospherics_engine)
 "aGY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -15890,7 +15890,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aGZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15904,7 +15904,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15921,7 +15921,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15931,7 +15931,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aHc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15944,10 +15944,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aHd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15966,7 +15966,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aHe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -15976,7 +15976,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aHf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -15989,7 +15989,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aHg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/electricshock{
@@ -16001,10 +16001,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aHh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16060,7 +16060,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
@@ -16080,7 +16080,7 @@
 /area/hydroponics/garden/abandoned)
 "aHp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16108,10 +16108,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aHr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -16125,7 +16125,7 @@
 /area/hallway/secondary/service)
 "aHs" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -16147,7 +16147,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aHt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16160,7 +16160,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aHu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16278,7 +16278,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aHI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16311,7 +16311,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "aHL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -16468,17 +16468,17 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aHW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aHX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white,
@@ -16486,7 +16486,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aIc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -16494,14 +16494,14 @@
 /area/security/prison)
 "aId" = (
 /obj/machinery/seed_extractor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aIe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -16518,13 +16518,13 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aIf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -16540,7 +16540,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aIg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -16558,14 +16558,14 @@
 /area/security/prison)
 "aIh" = (
 /obj/machinery/biogenerator,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aIi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -16643,10 +16643,10 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aIo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -16665,7 +16665,7 @@
 	name = "Port Bow Solar Access";
 	req_one_access_txt = "24;10"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16681,7 +16681,7 @@
 /area/maintenance/solars/port/fore)
 "aIq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -16730,7 +16730,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16762,7 +16762,7 @@
 	areastring = "/area/maintenance/disposal/incinerator";
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/oil,
@@ -16788,7 +16788,7 @@
 "aIz" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16812,7 +16812,7 @@
 /area/engine/atmospherics_engine)
 "aIB" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16835,13 +16835,13 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmospherics_engine)
 "aID" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16850,7 +16850,7 @@
 /area/engine/atmospherics_engine)
 "aIE" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
@@ -16870,7 +16870,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aIF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16900,7 +16900,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aIJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16909,7 +16909,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aIK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16920,7 +16920,7 @@
 /area/maintenance/port/fore)
 "aIL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16935,10 +16935,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aIM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -16997,7 +16997,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aIT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
@@ -17138,7 +17138,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -17181,7 +17181,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aJi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17216,11 +17216,11 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "aJl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -17230,7 +17230,7 @@
 /obj/machinery/computer/security{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -17249,10 +17249,10 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -17268,7 +17268,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aJo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -17279,7 +17279,7 @@
 /area/security/checkpoint/supply)
 "aJp" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -17364,7 +17364,7 @@
 	},
 /area/security/prison)
 "aJA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -17432,7 +17432,7 @@
 /obj/item/wrench,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -17453,13 +17453,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aJK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -17477,7 +17477,7 @@
 "aJL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -17493,11 +17493,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aJO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -17513,7 +17513,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aJP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -17532,13 +17532,13 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aJQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17558,7 +17558,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aJR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -17575,7 +17575,7 @@
 	name = "Turbine Generator Access";
 	req_one_access_txt = "24;10"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17591,7 +17591,7 @@
 /area/maintenance/disposal/incinerator)
 "aJT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17603,7 +17603,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aJU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -17648,7 +17648,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aJY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -17676,7 +17676,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aKb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -17825,7 +17825,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aKs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -18003,7 +18003,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aKH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -18052,7 +18052,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aKL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -18183,7 +18183,7 @@
 /turf/closed/wall,
 /area/security/prison)
 "aKW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -18194,13 +18194,13 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "aKX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/public/glass{
@@ -18209,7 +18209,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aKY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -18402,7 +18402,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aLs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -18441,7 +18441,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aLv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/computer/monitor{
@@ -18465,14 +18465,14 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
 "aLw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes{
 	charge = 2e+006
 	},
 /obj/machinery/light/small,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/circuit/green,
@@ -18484,7 +18484,7 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/item/radio/intercom{
@@ -18515,7 +18515,7 @@
 /turf/closed/wall,
 /area/crew_quarters/abandoned_gambling_den/secondary)
 "aLB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -18572,7 +18572,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aLI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/airalarm{
@@ -18699,7 +18699,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aLR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18724,7 +18724,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aLT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door_timer{
@@ -18749,10 +18749,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aLU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -18835,14 +18835,14 @@
 "aMe" = (
 /obj/structure/table,
 /obj/machinery/computer/libraryconsole/bookmanagement,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/security/prison)
 "aMf" = (
 /obj/structure/easel,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -18860,7 +18860,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aMg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -18870,7 +18870,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aMh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -18881,13 +18881,13 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aMi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -18899,7 +18899,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aMj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -18910,7 +18910,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aMk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -18921,7 +18921,7 @@
 /area/security/prison)
 "aMl" = (
 /obj/structure/table,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/paper_bin,
@@ -18936,7 +18936,7 @@
 "aMm" = (
 /obj/structure/table,
 /obj/item/clipboard,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/toy/figure/syndie,
@@ -18949,10 +18949,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aMn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -18962,7 +18962,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aMo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/punching_bag,
@@ -19166,7 +19166,7 @@
 /area/engine/atmos)
 "aMJ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -19245,7 +19245,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den/secondary)
 "aMU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -19281,7 +19281,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aMZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -19332,7 +19332,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "aNc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/light{
@@ -19483,20 +19483,20 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "aNq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "aNr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -19517,7 +19517,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aNs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -19662,7 +19662,7 @@
 /area/security/prison)
 "aNE" = (
 /obj/structure/table,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/paper,
@@ -20068,7 +20068,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "aOk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -20171,7 +20171,7 @@
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -20234,7 +20234,7 @@
 /area/crew_quarters/theatre)
 "aOx" = (
 /obj/machinery/vending/autodrobe,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/light{
@@ -20310,7 +20310,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aOB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -20339,7 +20339,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "aOE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -20438,7 +20438,7 @@
 /area/crew_quarters/bar/atrium)
 "aOM" = (
 /obj/structure/table,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/item/stack/wrapping_paper{
@@ -20465,7 +20465,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/cargo_technician,
@@ -20482,10 +20482,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aOO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -20504,7 +20504,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aOP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -20528,17 +20528,17 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aOR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "aOS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/closet/secure_closet/brig{
@@ -20557,10 +20557,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aOT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -20621,14 +20621,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aPb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aPc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
@@ -20641,7 +20641,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aPd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -20651,14 +20651,14 @@
 /area/quartermaster/storage)
 "aPe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aPf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -20667,7 +20667,7 @@
 "aPg" = (
 /obj/structure/cable/white,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -20735,7 +20735,7 @@
 /area/security/prison)
 "aPm" = (
 /obj/structure/table,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/toy/cards/deck,
@@ -21132,7 +21132,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "aPP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -21260,7 +21260,7 @@
 /area/crew_quarters/abandoned_gambling_den/secondary)
 "aQb" = (
 /obj/structure/chair/stool/bar,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -21278,7 +21278,7 @@
 /area/crew_quarters/abandoned_gambling_den/secondary)
 "aQd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -21320,7 +21320,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aQg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -21363,7 +21363,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aQk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
@@ -21399,7 +21399,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/atrium)
 "aQn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -21566,7 +21566,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -21628,7 +21628,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aQD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -21675,10 +21675,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aQH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -21688,7 +21688,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aQI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/chair{
@@ -21704,11 +21704,11 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aQJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -21748,7 +21748,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aQN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -21773,47 +21773,47 @@
 /turf/closed/wall,
 /area/quartermaster/qm)
 "aQR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "aQS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "aQT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "aQU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "aQV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -21939,7 +21939,7 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "aRj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -21984,7 +21984,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "aRl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -22139,7 +22139,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -22239,17 +22239,17 @@
 	},
 /area/crew_quarters/abandoned_gambling_den/secondary)
 "aRL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/crew_quarters/abandoned_gambling_den/secondary)
 "aRM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -22264,7 +22264,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aRN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22287,7 +22287,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aRO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22307,7 +22307,7 @@
 /area/crew_quarters/theatre)
 "aRP" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22320,10 +22320,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aRQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -22339,7 +22339,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aRR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22357,7 +22357,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aRS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22371,7 +22371,7 @@
 /area/crew_quarters/theatre)
 "aRT" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -22390,7 +22390,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aRU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22401,13 +22401,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aRV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -22416,7 +22416,7 @@
 /area/hallway/secondary/service)
 "aRW" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -22435,7 +22435,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "aRX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -22458,7 +22458,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "aRY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22470,7 +22470,7 @@
 /obj/structure/chair/wood/normal{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22496,7 +22496,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "aSd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22504,7 +22504,7 @@
 /area/hallway/primary/fore)
 "aSe" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/mining/glass{
@@ -22538,7 +22538,7 @@
 /turf/closed/wall,
 /area/security/checkpoint/supply)
 "aSi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -22549,13 +22549,13 @@
 /area/security/checkpoint/supply)
 "aSj" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -22575,7 +22575,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aSk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -22585,7 +22585,7 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "aSl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -22691,7 +22691,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aSr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/brown,
@@ -22737,7 +22737,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aSv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -22801,7 +22801,7 @@
 /area/quartermaster/qm)
 "aSz" = (
 /obj/structure/bed,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/bedsheet/qm,
@@ -22885,7 +22885,7 @@
 	id_tag = "permabolt2";
 	name = "Cell 2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -22954,7 +22954,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "aSJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/table/reinforced,
@@ -23001,10 +23001,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "aSK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23020,7 +23020,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "aSL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
@@ -23036,11 +23036,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "aSM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/closet/secure_closet/injection,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -23242,7 +23242,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -23261,7 +23261,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -23282,7 +23282,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -23412,7 +23412,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den/secondary)
 "aTq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -23425,7 +23425,7 @@
 /area/crew_quarters/abandoned_gambling_den/secondary)
 "aTr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -23438,7 +23438,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/barricade/wooden,
@@ -23454,10 +23454,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/abandoned_gambling_den/secondary)
 "aTt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -23530,7 +23530,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aTB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/storage/pod{
@@ -23690,7 +23690,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "aTN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -23739,7 +23739,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aTR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -23809,7 +23809,7 @@
 	areastring = "/area/quartermaster/office";
 	pixel_y = 28
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -23830,7 +23830,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aTX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -23859,7 +23859,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aTZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
@@ -23989,7 +23989,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aUg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -24071,7 +24071,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -24154,7 +24154,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aUr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -24264,7 +24264,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aUz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -24353,7 +24353,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "aUE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/chair/office{
@@ -24406,7 +24406,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "aUH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -24625,7 +24625,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -24782,7 +24782,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/theatre)
 "aVm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -24909,7 +24909,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "aVv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -24982,7 +24982,7 @@
 /area/quartermaster/office)
 "aVA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -25004,7 +25004,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aVB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -25026,7 +25026,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aVC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25048,7 +25048,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aVD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25057,7 +25057,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -25074,7 +25074,7 @@
 /area/quartermaster/office)
 "aVE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25083,7 +25083,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -25099,7 +25099,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aVF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25116,7 +25116,7 @@
 /area/quartermaster/office)
 "aVG" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mining{
@@ -25138,10 +25138,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aVH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25159,7 +25159,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aVI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -25181,7 +25181,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aVJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -25204,7 +25204,7 @@
 /area/quartermaster/storage)
 "aVK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25228,7 +25228,7 @@
 /area/quartermaster/storage)
 "aVL" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/quartermaster,
@@ -25240,7 +25240,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aVM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25262,7 +25262,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aVN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25284,7 +25284,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aVO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25303,13 +25303,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aVP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -25322,7 +25322,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aVQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -25339,7 +25339,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aVR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -25351,7 +25351,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aVS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -25367,7 +25367,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aVT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -25385,10 +25385,10 @@
 /area/quartermaster/qm)
 "aVU" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -25396,7 +25396,7 @@
 /area/quartermaster/qm)
 "aVV" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/folder/yellow,
@@ -25417,10 +25417,10 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/quartermaster,
@@ -25437,7 +25437,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aVX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/brown,
@@ -25447,7 +25447,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aVY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -25464,13 +25464,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aVZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/quartermaster,
@@ -25572,7 +25572,7 @@
 	},
 /area/security/prison)
 "aWh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -25640,7 +25640,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "aWm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -25943,7 +25943,7 @@
 /area/engine/atmos)
 "aWM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -26020,7 +26020,7 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "aWT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -26040,10 +26040,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aWU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/newscaster{
@@ -26170,7 +26170,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "aXd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -26439,7 +26439,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aXv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -26548,7 +26548,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aXC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -26608,7 +26608,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aXG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -26628,14 +26628,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aXI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "aXJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -26652,7 +26652,7 @@
 	},
 /area/security/prison)
 "aXL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -26686,7 +26686,7 @@
 	name = "Long-Term Cell 2";
 	req_access_txt = "2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -26708,7 +26708,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aXR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -26960,7 +26960,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aYm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -27054,7 +27054,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aYs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -27073,10 +27073,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aYt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -27089,7 +27089,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aYu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -27101,7 +27101,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aYv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -27115,13 +27115,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aYw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -27133,7 +27133,7 @@
 /area/maintenance/port/fore)
 "aYx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27147,7 +27147,7 @@
 /area/maintenance/port/fore)
 "aYy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27157,7 +27157,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aYz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -27176,7 +27176,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aYA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27189,10 +27189,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aYB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -27270,7 +27270,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -27508,7 +27508,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aYZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/storage/pod{
@@ -27600,7 +27600,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aZg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/brown,
@@ -27624,10 +27624,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aZi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -27636,7 +27636,7 @@
 /area/quartermaster/qm)
 "aZj" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -27644,7 +27644,7 @@
 /area/quartermaster/qm)
 "aZk" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -27667,10 +27667,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -27678,20 +27678,20 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -27701,7 +27701,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27711,7 +27711,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -27731,7 +27731,7 @@
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -27744,7 +27744,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/security/telescreen{
@@ -27759,10 +27759,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -27774,10 +27774,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27799,10 +27799,10 @@
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -27815,7 +27815,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27830,10 +27830,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -27841,7 +27841,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -27864,7 +27864,7 @@
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27876,10 +27876,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27889,10 +27889,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -27906,13 +27906,13 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/button/door{
@@ -27929,7 +27929,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27943,10 +27943,10 @@
 /area/security/prison)
 "aZF" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -27965,7 +27965,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -27974,7 +27974,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -27986,7 +27986,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -28001,7 +28001,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -28226,7 +28226,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "baf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -28327,7 +28327,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bap" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -28346,7 +28346,7 @@
 /turf/closed/wall,
 /area/hydroponics)
 "bat" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -28388,7 +28388,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bax" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -28652,7 +28652,7 @@
 /area/quartermaster/miningoffice)
 "baW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -28664,33 +28664,33 @@
 /turf/closed/wall,
 /area/quartermaster/qm)
 "baY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "baZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bba" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28707,7 +28707,7 @@
 	pixel_y = -26
 	},
 /obj/machinery/light,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28719,10 +28719,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bbc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -28732,7 +28732,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bbd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28824,7 +28824,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bbm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -28890,7 +28890,7 @@
 	},
 /area/security/prison)
 "bbs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -29083,7 +29083,7 @@
 /area/engine/atmos)
 "bbJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -29170,7 +29170,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bbT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29233,7 +29233,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bcb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29335,7 +29335,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "bcn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -29482,7 +29482,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bcA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29526,7 +29526,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bcG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
@@ -29570,7 +29570,7 @@
 	name = "Prison Wing";
 	req_access_txt = "1"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29628,7 +29628,7 @@
 /area/security/prison)
 "bcP" = (
 /obj/structure/rack,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/restraints/handcuffs,
@@ -29695,7 +29695,7 @@
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -29744,7 +29744,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bcV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/table,
@@ -29961,7 +29961,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bdp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -29995,7 +29995,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bds" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -30013,7 +30013,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bdt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30032,7 +30032,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bdu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30047,10 +30047,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bdv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30065,7 +30065,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bdw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -30080,7 +30080,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bdx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30091,7 +30091,7 @@
 /area/hydroponics)
 "bdy" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -30110,24 +30110,24 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bdz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bdA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -30136,7 +30136,7 @@
 /area/hallway/secondary/service)
 "bdB" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -30155,7 +30155,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bdC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30166,7 +30166,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bdD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30175,7 +30175,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bdE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/cook,
@@ -30185,7 +30185,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bdF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -30446,7 +30446,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bec" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30502,7 +30502,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bei" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white,
@@ -30510,20 +30510,20 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "bej" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "bek" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -30531,10 +30531,10 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "bel" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -30545,7 +30545,7 @@
 	id = "brigprison";
 	name = "Prison Blast door"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -30789,7 +30789,7 @@
 /area/maintenance/port/fore)
 "beL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -30902,7 +30902,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "beW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -31219,10 +31219,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bfz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -31338,10 +31338,10 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "bfN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/sign/warning/securearea{
@@ -31359,7 +31359,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bfO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31378,7 +31378,7 @@
 	pixel_y = 26;
 	req_access_txt = "63"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -31392,14 +31392,14 @@
 /area/security/prison)
 "bfQ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Storage Closet";
 	req_access_txt = "63"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -31415,7 +31415,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bfR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -31428,7 +31428,7 @@
 /area/security/prison)
 "bfS" = (
 /obj/structure/closet/l3closet/security,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -31680,7 +31680,7 @@
 	name = "Service Hall"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -31746,7 +31746,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bgv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
@@ -31973,7 +31973,7 @@
 /area/quartermaster/miningoffice)
 "bgN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -32066,7 +32066,7 @@
 	name = "Prison Wing";
 	req_access_txt = "1"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32082,7 +32082,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bhb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -32115,7 +32115,7 @@
 /turf/closed/wall/r_wall,
 /area/security/main)
 "bhe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -32191,7 +32191,7 @@
 	areastring = "/area/engine/atmos";
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -32282,7 +32282,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bhq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -32463,7 +32463,7 @@
 /area/hallway/secondary/service)
 "bhI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -32606,7 +32606,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -32777,7 +32777,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bii" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -32796,7 +32796,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bij" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -32809,7 +32809,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bik" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -32829,7 +32829,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bil" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -32844,7 +32844,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bim" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -32861,10 +32861,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bin" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -32952,14 +32952,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "biu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "biy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -33026,7 +33026,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "biC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -33036,7 +33036,7 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "biD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33056,7 +33056,7 @@
 /area/security/brig)
 "biE" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33097,10 +33097,10 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "biH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -33112,7 +33112,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "biI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
@@ -33127,7 +33127,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "biJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -33149,7 +33149,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "biK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/newscaster/security_unit{
@@ -33165,7 +33165,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "biL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/box,
@@ -33233,7 +33233,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
 "biQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -33244,13 +33244,13 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "biR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -33261,7 +33261,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "biS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -33415,7 +33415,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bjd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33434,7 +33434,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bje" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -33451,7 +33451,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bjf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33473,7 +33473,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bjg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33497,10 +33497,10 @@
 "bjh" = (
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33513,7 +33513,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bji" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -33532,7 +33532,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bjj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -33719,7 +33719,7 @@
 "bjy" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -33906,7 +33906,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "bjN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -34008,7 +34008,7 @@
 /area/quartermaster/miningoffice)
 "bjU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -34054,10 +34054,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bjY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -34068,7 +34068,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bjZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -34078,7 +34078,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bka" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/requests_console{
@@ -34098,7 +34098,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bkb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/brown,
@@ -34112,7 +34112,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -34124,7 +34124,7 @@
 "bkd" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/folder/yellow,
@@ -34139,20 +34139,20 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bke" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "bkf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white,
@@ -34160,11 +34160,11 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "bkj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -34172,7 +34172,7 @@
 /area/security/brig)
 "bkk" = (
 /obj/structure/table/glass,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/clothing/gloves/color/latex,
@@ -34194,13 +34194,13 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bkl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bkm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -34209,10 +34209,10 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bkn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/medical/glass{
@@ -34228,10 +34228,10 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bko" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -34246,10 +34246,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bkp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -34283,7 +34283,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bks" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -34393,7 +34393,7 @@
 /area/crew_quarters/heads/hos)
 "bkB" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/taperecorder{
@@ -34551,7 +34551,7 @@
 /area/engine/atmos)
 "bkS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -34661,7 +34661,7 @@
 "blc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -34788,7 +34788,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -35118,7 +35118,7 @@
 /area/quartermaster/miningoffice)
 "blR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/loading_area,
@@ -35126,7 +35126,7 @@
 /area/quartermaster/miningoffice)
 "blS" = (
 /obj/structure/table,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/item/storage/firstaid/regular,
@@ -35172,7 +35172,7 @@
 "blV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -35281,10 +35281,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bmi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -35300,7 +35300,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bmj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -35312,7 +35312,7 @@
 /area/security/brig)
 "bmk" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -35332,7 +35332,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -35411,7 +35411,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bms" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -35444,7 +35444,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "bmv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -35710,7 +35710,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bmV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -35834,7 +35834,7 @@
 /area/maintenance/port/fore)
 "bnf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -35943,7 +35943,7 @@
 	name = "Service Foyer"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -36000,7 +36000,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Fore Primary Hallway"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -36076,7 +36076,7 @@
 /area/quartermaster/miningoffice)
 "bnB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -36093,37 +36093,37 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "bnC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "bnD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "bnE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "bnF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -36152,7 +36152,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bnI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36194,7 +36194,7 @@
 	areastring = "/area/security/main";
 	pixel_x = -26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36213,10 +36213,10 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -36337,7 +36337,7 @@
 /area/security/main)
 "bnU" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -36369,7 +36369,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -36401,7 +36401,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "boa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -36423,7 +36423,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "bod" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -36625,7 +36625,7 @@
 /area/engine/atmos)
 "bou" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -36722,7 +36722,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -36799,7 +36799,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -36893,7 +36893,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "boV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36905,7 +36905,7 @@
 	areastring = "/area/hallway/primary/central";
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -36914,7 +36914,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "boW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -36931,7 +36931,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36947,7 +36947,7 @@
 /area/maintenance/starboard/fore)
 "boY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36964,7 +36964,7 @@
 "boZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37003,7 +37003,7 @@
 /area/security/execution/transfer)
 "bpe" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -37084,14 +37084,14 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bpj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "bpk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -37114,7 +37114,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bpm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37169,7 +37169,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bpr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -37184,7 +37184,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bps" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37203,13 +37203,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bpt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/command{
@@ -37235,10 +37235,10 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "bpu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37248,7 +37248,7 @@
 /area/crew_quarters/heads/hos)
 "bpv" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37258,7 +37258,7 @@
 /area/crew_quarters/heads/hos)
 "bpw" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/folder/red,
@@ -37266,10 +37266,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -37278,7 +37278,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/head_of_security,
@@ -37288,7 +37288,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "bpy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37297,7 +37297,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "bpz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -37313,13 +37313,13 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "bpA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/command{
@@ -37342,21 +37342,21 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "bpB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "bpC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/head_of_security,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "bpD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/crew{
@@ -37365,11 +37365,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "bpE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -37695,7 +37695,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bqd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -37796,7 +37796,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bqn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37814,7 +37814,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bqo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37831,7 +37831,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37847,7 +37847,7 @@
 /area/maintenance/port/fore)
 "bqq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37859,7 +37859,7 @@
 "bqr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37868,7 +37868,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bqs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37882,7 +37882,7 @@
 /area/maintenance/port/fore)
 "bqt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37901,7 +37901,7 @@
 	},
 /area/maintenance/port/fore)
 "bqu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37910,7 +37910,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bqv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37921,7 +37921,7 @@
 /area/maintenance/port/fore)
 "bqw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction/flip{
@@ -37931,10 +37931,10 @@
 /area/maintenance/port/fore)
 "bqx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38008,13 +38008,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38037,7 +38037,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -38057,7 +38057,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38076,7 +38076,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -38099,7 +38099,7 @@
 /area/hallway/primary/central)
 "bqJ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38114,7 +38114,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38134,7 +38134,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38149,7 +38149,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38161,7 +38161,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38173,7 +38173,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -38190,14 +38190,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38213,7 +38213,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -38222,7 +38222,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -38231,7 +38231,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -38240,7 +38240,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -38250,7 +38250,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -38266,7 +38266,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -38284,7 +38284,7 @@
 /area/hallway/primary/central)
 "bqW" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -38296,7 +38296,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -38315,7 +38315,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
@@ -38332,7 +38332,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38351,10 +38351,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bra" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -38403,7 +38403,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "brf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -38444,7 +38444,7 @@
 /area/security/execution/transfer)
 "brk" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -38467,7 +38467,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "brm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38501,7 +38501,7 @@
 /area/security/brig)
 "bro" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -38535,7 +38535,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -38622,7 +38622,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "brw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38656,7 +38656,7 @@
 /area/security/main)
 "bry" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -38670,7 +38670,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "brz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38706,7 +38706,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -39011,7 +39011,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bsg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -39043,7 +39043,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bsi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -39115,7 +39115,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -39155,7 +39155,7 @@
 /turf/closed/wall,
 /area/storage/tech)
 "bsv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -39235,7 +39235,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bsA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -39511,7 +39511,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bsU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -39543,17 +39543,17 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "bta" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "btb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -39561,17 +39561,17 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "btc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "btd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -39580,10 +39580,10 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bte" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -39654,7 +39654,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "bti" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -39668,13 +39668,13 @@
 /area/security/execution/transfer)
 "btj" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -39697,7 +39697,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "btk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -39715,13 +39715,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "btl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -39744,7 +39744,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "btm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -39759,13 +39759,13 @@
 /area/security/brig)
 "btn" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -39784,7 +39784,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bto" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -39796,10 +39796,10 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -39814,7 +39814,7 @@
 /area/security/main)
 "btq" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/folder/red,
@@ -39836,7 +39836,7 @@
 /area/security/main)
 "btr" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/paper_bin,
@@ -39857,7 +39857,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bts" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -39872,7 +39872,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "btt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -39892,7 +39892,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "btu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -39911,10 +39911,10 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "btv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -39957,13 +39957,13 @@
 	pixel_x = -24;
 	pixel_y = -32
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "btz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -40221,10 +40221,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "btX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -40244,7 +40244,7 @@
 "btY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -40261,13 +40261,13 @@
 	name = "Atmospherics Desk";
 	req_access_txt = "24"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -40284,7 +40284,7 @@
 /area/engine/atmos)
 "bua" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40294,7 +40294,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bub" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -40305,7 +40305,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "buc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -40346,11 +40346,11 @@
 /area/hallway/primary/port)
 "buh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -40372,7 +40372,7 @@
 	areastring = "/area/hallway/primary/port";
 	pixel_x = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -40383,7 +40383,7 @@
 "buj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -40424,7 +40424,7 @@
 /area/hallway/primary/central)
 "buo" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -40458,7 +40458,7 @@
 /area/hallway/primary/central)
 "bus" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -40521,10 +40521,10 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "buD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -40537,7 +40537,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "buE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -40549,10 +40549,10 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "buF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40564,10 +40564,10 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "buG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40579,7 +40579,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "buH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40592,7 +40592,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "buI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
@@ -40615,7 +40615,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "buK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -40690,7 +40690,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "buR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -40757,7 +40757,7 @@
 /area/crew_quarters/heads/hos)
 "buV" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/storage/fancy/donut_box,
@@ -40955,7 +40955,7 @@
 /area/engine/atmos)
 "bvj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -41019,7 +41019,7 @@
 /area/engine/atmos)
 "bvo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -41050,7 +41050,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bvr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -41077,7 +41077,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction,
@@ -41108,27 +41108,27 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "bvw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bvx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bvy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -41199,7 +41199,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bvG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -41243,7 +41243,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bvM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -41267,7 +41267,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bvO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -41354,7 +41354,7 @@
 /area/security/nuke_storage)
 "bvX" = (
 /obj/structure/closet/emcloset,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -41363,10 +41363,10 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bvY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -41401,7 +41401,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bwb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -41429,7 +41429,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bwd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -41499,7 +41499,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "bwk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -41528,10 +41528,10 @@
 /area/security/main)
 "bwm" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -41546,7 +41546,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "bwo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -41557,10 +41557,10 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/sign/warning/electricshock{
@@ -41575,7 +41575,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bwq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -41679,7 +41679,7 @@
 /area/engine/atmos)
 "bwA" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -41737,10 +41737,10 @@
 /area/engine/atmos)
 "bwD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -41759,7 +41759,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bwE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -41780,7 +41780,7 @@
 /area/engine/atmos)
 "bwF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -41797,14 +41797,14 @@
 "bwG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/plasticflaps/opaque,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "atmoslock";
 	name = "Atmospherics Lockdown Blast door"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -41831,7 +41831,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -41852,7 +41852,7 @@
 /area/hallway/primary/port)
 "bwJ" = (
 /obj/structure/rack,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -41863,13 +41863,13 @@
 /area/storage/tech)
 "bwK" = (
 /obj/structure/rack,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -41878,7 +41878,7 @@
 /area/storage/tech)
 "bwL" = (
 /obj/structure/rack,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -41943,10 +41943,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bwR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -41957,10 +41957,10 @@
 /turf/open/floor/plating,
 /area/bridge)
 "bwS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -41971,10 +41971,10 @@
 /turf/open/floor/plating,
 /area/bridge)
 "bwT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -41988,7 +41988,7 @@
 /turf/closed/wall/r_wall,
 /area/bridge)
 "bwV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -41999,13 +41999,13 @@
 /turf/open/floor/plating,
 /area/bridge)
 "bwW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -42016,7 +42016,7 @@
 /turf/open/floor/plating,
 /area/bridge)
 "bwX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -42036,7 +42036,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bwZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -42066,11 +42066,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bxb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -42080,7 +42080,7 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "bxc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -42133,10 +42133,10 @@
 /area/security/nuke_storage)
 "bxm" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -42157,7 +42157,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bxn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -42208,20 +42208,20 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bxr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/security/main)
 "bxs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/security{
@@ -42242,7 +42242,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bxt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -42319,7 +42319,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bxy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -42507,7 +42507,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bxO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -42553,7 +42553,7 @@
 /area/engine/atmos)
 "bxS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -42577,7 +42577,7 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bxU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -42601,7 +42601,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -42644,7 +42644,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bya" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -42664,7 +42664,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "byc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -42686,7 +42686,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bye" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -42731,7 +42731,7 @@
 /area/bridge)
 "byi" = (
 /obj/machinery/computer/med_data,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -42763,7 +42763,7 @@
 /area/bridge)
 "byl" = (
 /obj/machinery/computer/security,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -42794,7 +42794,7 @@
 /area/bridge)
 "byo" = (
 /obj/machinery/computer/station_alert,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -42823,10 +42823,10 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "byr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -42842,7 +42842,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bys" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -42855,13 +42855,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "byt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -42888,7 +42888,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "byu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42915,7 +42915,7 @@
 	name = "Vault Door";
 	req_access_txt = "53"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/electricshock{
@@ -42940,7 +42940,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
 "byw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42952,7 +42952,7 @@
 /obj/machinery/nuclearbomb/selfdestruct{
 	layer = 2
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42971,13 +42971,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
 "byy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/circuit/green,
 /area/security/nuke_storage)
 "byz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -43003,7 +43003,7 @@
 	pixel_y = 28
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -43012,10 +43012,10 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "byE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -43143,7 +43143,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "byO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -43167,7 +43167,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "byQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -43239,7 +43239,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "byU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -43248,17 +43248,17 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "byV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "byW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -43267,13 +43267,13 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "byX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/ai_slipper{
@@ -43285,10 +43285,10 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "byY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -43297,7 +43297,7 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "byZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -43307,7 +43307,7 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bza" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -43473,7 +43473,7 @@
 /area/engine/break_room)
 "bzr" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -43500,7 +43500,7 @@
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/modular_computer/console/preset/engineering{
@@ -43517,7 +43517,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -43533,19 +43533,19 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bzv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/holopad,
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bzw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -43565,7 +43565,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -43575,10 +43575,10 @@
 /area/engine/atmos)
 "bzy" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/item/folder/yellow,
@@ -43608,7 +43608,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -43641,13 +43641,13 @@
 /area/hallway/primary/port)
 "bzC" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/highsecurity{
@@ -43668,10 +43668,10 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "bzE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -43684,7 +43684,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "bzF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43698,7 +43698,7 @@
 /area/maintenance/port/fore)
 "bzG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43715,10 +43715,10 @@
 /area/maintenance/port/fore)
 "bzH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43734,7 +43734,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43749,7 +43749,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "bzJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -43762,10 +43762,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bzK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43834,7 +43834,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -43879,7 +43879,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bzR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -43942,17 +43942,17 @@
 /area/hallway/primary/central)
 "bzW" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "bzX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -44005,7 +44005,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bAg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -44086,7 +44086,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bAm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -44191,10 +44191,10 @@
 /area/security/main)
 "bAs" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -44204,7 +44204,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -44220,7 +44220,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bAu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/item/radio/intercom{
@@ -44322,7 +44322,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bAA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -44348,7 +44348,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bAC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -44383,7 +44383,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bAE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -44456,7 +44456,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bAJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -44544,7 +44544,7 @@
 "bAT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -44606,7 +44606,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bAY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -44754,7 +44754,7 @@
 /area/hallway/primary/port)
 "bBh" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -44818,7 +44818,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bBm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -44853,7 +44853,7 @@
 "bBp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -44896,7 +44896,7 @@
 "bBt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/plasticflaps/opaque,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -44928,7 +44928,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -45021,7 +45021,7 @@
 /area/bridge)
 "bBE" = (
 /obj/machinery/computer/cargo/request,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -45056,7 +45056,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bBH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -45073,7 +45073,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bBI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/beacon,
@@ -45104,7 +45104,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bBK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -45148,7 +45148,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bBN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/modular_computer/console/preset/command,
@@ -45274,10 +45274,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
 "bBY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -45366,7 +45366,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bCf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -45554,7 +45554,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bCr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -45569,7 +45569,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
 "bCu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green,
@@ -45634,7 +45634,7 @@
 /area/engine/gravity_generator)
 "bCA" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -45697,10 +45697,10 @@
 	name = "Power Tools Storage";
 	req_access_txt = "19"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -45727,10 +45727,10 @@
 	name = "Power Tools Storage";
 	req_access_txt = "19"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45745,7 +45745,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "bCJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -45806,7 +45806,7 @@
 /area/engine/storage_shared)
 "bCO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -45893,7 +45893,7 @@
 	areastring = "/area/engine/break_room";
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45908,7 +45908,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bCV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45923,10 +45923,10 @@
 	},
 /area/engine/break_room)
 "bCW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46025,7 +46025,7 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bDd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -46086,7 +46086,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bDh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -46189,7 +46189,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bDq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -46307,10 +46307,10 @@
 /turf/closed/wall,
 /area/storage/primary)
 "bDv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46332,7 +46332,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46348,10 +46348,10 @@
 /area/hallway/primary/central)
 "bDx" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -46367,7 +46367,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -46383,7 +46383,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46405,7 +46405,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -46432,13 +46432,13 @@
 /area/bridge)
 "bDA" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -46464,7 +46464,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46483,7 +46483,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -46503,10 +46503,10 @@
 /area/bridge)
 "bDD" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/light{
@@ -46534,7 +46534,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -46556,13 +46556,13 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46581,10 +46581,10 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46596,7 +46596,7 @@
 /area/bridge)
 "bDH" = (
 /obj/structure/window/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46609,7 +46609,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/southright{
@@ -46627,13 +46627,13 @@
 /area/bridge)
 "bDJ" = (
 /obj/structure/window/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46646,10 +46646,10 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -46662,10 +46662,10 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -46687,7 +46687,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46706,7 +46706,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46727,10 +46727,10 @@
 /area/bridge)
 "bDO" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -46756,7 +46756,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -46780,10 +46780,10 @@
 /area/bridge)
 "bDQ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -46796,7 +46796,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -46812,7 +46812,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -46824,10 +46824,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -46882,7 +46882,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bDX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -46965,7 +46965,7 @@
 /turf/closed/wall,
 /area/security/brig)
 "bEd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/security{
@@ -47031,7 +47031,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bEh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/ai_slipper{
@@ -47119,7 +47119,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bEl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/ai_slipper{
@@ -47195,10 +47195,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -47210,7 +47210,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -47219,26 +47219,26 @@
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bEs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bEt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -47250,7 +47250,7 @@
 	name = "Gravity Generator Room";
 	req_access_txt = "19;23"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -47265,16 +47265,16 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bEv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -47283,14 +47283,14 @@
 "bEw" = (
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bEx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -47301,7 +47301,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bEy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47311,7 +47311,7 @@
 /area/engine/storage_shared)
 "bEz" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
@@ -47334,7 +47334,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "bEA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47347,7 +47347,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "bEB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47366,7 +47366,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "bEC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -47383,13 +47383,13 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "bED" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -47403,7 +47403,7 @@
 	},
 /area/engine/storage_shared)
 "bEE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -47414,7 +47414,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "bEF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers,
@@ -47427,7 +47427,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bEG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47437,7 +47437,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bEH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -47453,7 +47453,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bEI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -47473,7 +47473,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bEJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47493,7 +47493,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bEK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47512,7 +47512,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bEL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -47531,10 +47531,10 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bEM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -47572,7 +47572,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -47660,14 +47660,14 @@
 	pixel_x = -26;
 	pixel_y = 3
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bEX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -47682,7 +47682,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bEY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -47697,7 +47697,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bEZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -47712,7 +47712,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bFa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -47774,7 +47774,7 @@
 /area/hallway/primary/central)
 "bFh" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -47842,7 +47842,7 @@
 /area/bridge)
 "bFk" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -47912,7 +47912,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bFn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -47951,7 +47951,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bFp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48016,7 +48016,7 @@
 /area/bridge)
 "bFu" = (
 /obj/machinery/computer/communications,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48070,7 +48070,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bFz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -48124,7 +48124,7 @@
 /area/bridge)
 "bFC" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -48160,7 +48160,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bFE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48189,7 +48189,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bFG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -48200,10 +48200,10 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "bFH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -48220,7 +48220,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bFI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -48228,7 +48228,7 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "bFJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -48297,7 +48297,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bFP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -48487,7 +48487,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
 "bGd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -48638,7 +48638,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bGq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48761,7 +48761,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -48778,7 +48778,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bGA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -48920,7 +48920,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bGN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -49028,7 +49028,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bGW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -49125,7 +49125,7 @@
 	color = "#596479";
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -49198,7 +49198,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bHl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -49260,7 +49260,7 @@
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
 "bHs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -49304,7 +49304,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bHw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -49351,7 +49351,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bHz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -49368,10 +49368,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bHB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49391,7 +49391,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bHC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49403,7 +49403,7 @@
 /area/security/brig)
 "bHD" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
@@ -49423,7 +49423,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bHE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49442,10 +49442,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bHF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49464,7 +49464,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bHG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -49484,7 +49484,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bHH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -49500,13 +49500,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bHI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -49525,7 +49525,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bHJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -49535,7 +49535,7 @@
 /area/security/warden)
 "bHK" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -49551,7 +49551,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bHL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -49659,7 +49659,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -49756,10 +49756,10 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bId" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -49775,7 +49775,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bIe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -49792,7 +49792,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bIf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -49808,7 +49808,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bIg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -49820,7 +49820,7 @@
 "bIh" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -49839,7 +49839,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bIi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -49847,7 +49847,7 @@
 /area/engine/break_room)
 "bIk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -49856,17 +49856,17 @@
 "bIl" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Foyer";
 	req_one_access_txt = "32;19"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -49882,7 +49882,7 @@
 /area/engine/break_room)
 "bIm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -49894,13 +49894,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bIn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -49927,7 +49927,7 @@
 /area/hallway/primary/port)
 "bIp" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/item/folder/yellow,
@@ -49952,7 +49952,7 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bIq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -49965,7 +49965,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bIr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49984,10 +49984,10 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bIs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -50058,7 +50058,7 @@
 /area/storage/tech)
 "bIw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -50171,7 +50171,7 @@
 /area/bridge/meeting_room/council)
 "bIJ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/command{
@@ -50263,7 +50263,7 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "bIQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -50336,7 +50336,7 @@
 	name = "Captain's Office";
 	req_access_txt = "20"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -50347,7 +50347,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
 "bIZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -50362,7 +50362,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -50375,7 +50375,7 @@
 /area/maintenance/starboard)
 "bJb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -50388,23 +50388,23 @@
 /area/maintenance/starboard)
 "bJc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bJd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bJe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -50412,7 +50412,7 @@
 "bJf" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -50445,10 +50445,10 @@
 /area/security/detectives_office)
 "bJh" = (
 /obj/structure/closet/secure_closet/detective,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/clothing/head/fedora/det_hat{
@@ -50474,7 +50474,7 @@
 /area/security/detectives_office)
 "bJi" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/item/book/manual/wiki/security_space_law,
@@ -50493,7 +50493,7 @@
 /area/security/detectives_office)
 "bJj" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -50518,7 +50518,7 @@
 /area/security/detectives_office)
 "bJk" = (
 /obj/structure/filingcabinet/security,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -50534,10 +50534,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "bJl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/trunk,
@@ -50645,13 +50645,13 @@
 /area/hallway/primary/starboard)
 "bJs" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -50662,7 +50662,7 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "bJt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
@@ -50675,7 +50675,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bJu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -50685,13 +50685,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bJv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/security/cell/westright{
@@ -50707,17 +50707,17 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bJw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bJx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -50759,7 +50759,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bJA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -50838,7 +50838,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bJG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -50881,7 +50881,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bJJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -50920,7 +50920,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bJL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -50964,7 +50964,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bJO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/hatch{
@@ -51125,7 +51125,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "bJW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -51227,7 +51227,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bKd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -51328,7 +51328,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bKn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -51467,7 +51467,7 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room/council)
 "bKC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
@@ -51479,7 +51479,7 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room/council)
 "bKD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -51488,7 +51488,7 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room/council)
 "bKE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/light_switch{
@@ -51518,7 +51518,7 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
 "bKJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -51559,7 +51559,7 @@
 	pixel_x = -26;
 	pixel_y = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51654,7 +51654,7 @@
 	name = "Auxiliary Tool Storage Maintenance";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -51667,7 +51667,7 @@
 /area/maintenance/starboard)
 "bKX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -51677,7 +51677,7 @@
 	name = "Detective's Office Maintenance";
 	req_access_txt = "4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -51693,7 +51693,7 @@
 	pixel_x = -26;
 	pixel_y = 32
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -51709,10 +51709,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "bLa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -51731,7 +51731,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "bLb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51740,13 +51740,13 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bLc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51755,7 +51755,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bLd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -51764,7 +51764,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bLe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/reagent_dispensers/peppertank{
@@ -51893,7 +51893,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bLo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -51924,7 +51924,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bLq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -51932,10 +51932,10 @@
 /area/security/warden)
 "bLr" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -52052,20 +52052,20 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bLy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bLz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bLA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/ai_slipper{
@@ -52074,17 +52074,17 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bLB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bLC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/circuit/green,
@@ -52174,7 +52174,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bLJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -52268,7 +52268,7 @@
 	},
 /area/crew_quarters/heads/chief)
 "bLP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -52287,10 +52287,10 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "bLQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/firedoor,
@@ -52298,7 +52298,7 @@
 	name = "Chief Engineer's Office";
 	req_access_txt = "56"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52317,7 +52317,7 @@
 	id = "ceblast";
 	name = "Chief's Lockdown Shutters"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52332,7 +52332,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bLS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52342,7 +52342,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bLT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52360,7 +52360,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bLU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52382,7 +52382,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bLV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -52404,7 +52404,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bLW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -52426,10 +52426,10 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bLX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -52451,10 +52451,10 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bLY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -52486,7 +52486,7 @@
 /turf/closed/wall,
 /area/security/checkpoint/engineering)
 "bMb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -52496,10 +52496,10 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "bMc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -52523,7 +52523,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bMd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -52631,7 +52631,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bMm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -52669,7 +52669,7 @@
 /turf/open/floor/carpet,
 /area/bridge/meeting_room/council)
 "bMr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/chair/comfy/brown,
@@ -52679,7 +52679,7 @@
 /turf/open/floor/carpet,
 /area/bridge/meeting_room/council)
 "bMs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/chair/comfy/black,
@@ -52767,7 +52767,7 @@
 	pixel_y = 28
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -52788,7 +52788,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bMB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
@@ -52874,7 +52874,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bMJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -52914,7 +52914,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bMP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
@@ -52948,7 +52948,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "bMS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -52966,7 +52966,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "bMT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -53047,7 +53047,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -53202,7 +53202,7 @@
 	pixel_x = -32;
 	pixel_y = 32
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -53217,10 +53217,10 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bNn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -53475,7 +53475,7 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bND" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53494,7 +53494,7 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bNE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/hatch{
@@ -53518,7 +53518,7 @@
 /area/aisat)
 "bNF" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53528,7 +53528,7 @@
 /area/space/nearstation)
 "bNG" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53538,7 +53538,7 @@
 /area/space/nearstation)
 "bNH" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53547,7 +53547,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "bNI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53573,7 +53573,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bNJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53592,7 +53592,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bNK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53618,7 +53618,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bNL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -53635,7 +53635,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bNM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53745,7 +53745,7 @@
 	},
 /area/crew_quarters/heads/chief)
 "bNT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -53843,7 +53843,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bOb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -53883,7 +53883,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bOf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -53935,7 +53935,7 @@
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/engineering)
 "bOk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
@@ -54012,7 +54012,7 @@
 "bOo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54079,10 +54079,10 @@
 /area/storage/primary)
 "bOv" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -54093,7 +54093,7 @@
 /turf/open/floor/plating,
 /area/bridge/meeting_room/council)
 "bOw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/photocopier,
@@ -54101,7 +54101,7 @@
 /area/bridge/meeting_room/council)
 "bOx" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -54110,14 +54110,14 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/bridge/meeting_room/council)
 "bOz" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/folder/blue,
@@ -54126,10 +54126,10 @@
 /area/bridge/meeting_room/council)
 "bOA" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/item/folder/red,
@@ -54138,10 +54138,10 @@
 /area/bridge/meeting_room/council)
 "bOB" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/item/folder/yellow,
@@ -54210,7 +54210,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bOI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -54219,7 +54219,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bOJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -54228,11 +54228,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bOK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -54294,10 +54294,10 @@
 /area/crew_quarters/heads/captain)
 "bOR" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54305,14 +54305,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bOS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bOT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -54322,7 +54322,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -54336,7 +54336,7 @@
 	pixel_x = -3
 	},
 /obj/item/clothing/mask/cigarette/cigar,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -54370,7 +54370,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "bOY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -54389,7 +54389,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "bOZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -54495,7 +54495,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -54607,7 +54607,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bPr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -54645,10 +54645,10 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bPu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -54668,7 +54668,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -54681,7 +54681,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bPw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -54836,7 +54836,7 @@
 /area/aisat)
 "bPK" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54971,7 +54971,7 @@
 /area/crew_quarters/heads/chief)
 "bPT" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/item/folder/blue{
@@ -54996,7 +54996,7 @@
 /obj/structure/chair/office/light{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -55011,10 +55011,10 @@
 	},
 /area/crew_quarters/heads/chief)
 "bPV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/light{
@@ -55048,7 +55048,7 @@
 /area/engine/break_room)
 "bPZ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -55076,7 +55076,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bQc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white,
@@ -55131,7 +55131,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -55330,7 +55330,7 @@
 /turf/open/floor/carpet,
 /area/bridge/meeting_room/council)
 "bQC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/chair/comfy/brown{
@@ -55404,7 +55404,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bQL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -55472,7 +55472,7 @@
 /area/crew_quarters/heads/captain)
 "bQS" = (
 /obj/structure/chair/comfy/brown,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -55642,33 +55642,33 @@
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "bRh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bRi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bRj" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/item/paper_bin,
@@ -55736,7 +55736,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "bRo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -55748,13 +55748,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bRp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/security/cell/westright{
@@ -55773,7 +55773,7 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -55785,13 +55785,13 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bRr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -55811,7 +55811,7 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -55910,7 +55910,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRz" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/portable_atmospherics/canister/air,
@@ -55926,7 +55926,7 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
@@ -56108,7 +56108,7 @@
 /area/space/nearstation)
 "bRT" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56118,7 +56118,7 @@
 /area/space/nearstation)
 "bRU" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56192,7 +56192,7 @@
 /area/crew_quarters/heads/chief)
 "bSa" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/clipboard,
@@ -56225,7 +56225,7 @@
 	},
 /area/crew_quarters/heads/chief)
 "bSc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -56308,7 +56308,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bSj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -56331,17 +56331,17 @@
 /turf/closed/wall,
 /area/engine/engineering)
 "bSm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "bSn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -56363,7 +56363,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bSo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -56391,7 +56391,7 @@
 /area/storage/tech)
 "bSs" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -56502,7 +56502,7 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room/council)
 "bSB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
@@ -56612,7 +56612,7 @@
 /obj/item/folder/blue,
 /obj/item/pen/fourcolor,
 /obj/item/stamp/captain,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -56712,7 +56712,7 @@
 	name = "Detective's Office";
 	req_access_txt = "4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -56731,7 +56731,7 @@
 	name = "Detective Privacy Blast door"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -56743,7 +56743,7 @@
 	name = "Detective Privacy Blast door"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -56792,7 +56792,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bTe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -56831,10 +56831,10 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bTg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -56854,7 +56854,7 @@
 /obj/machinery/computer/prisoner{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -57031,7 +57031,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bTp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -57445,7 +57445,7 @@
 /area/crew_quarters/heads/chief)
 "bTR" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/cartridge/engineering{
@@ -57485,7 +57485,7 @@
 	},
 /area/crew_quarters/heads/chief)
 "bTT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57504,13 +57504,13 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "bTU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -57530,7 +57530,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bTV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57549,7 +57549,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "bTW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57558,10 +57558,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/chief)
 "bTX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/chief_engineer,
@@ -57571,7 +57571,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/chief)
 "bTY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -57583,7 +57583,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bTZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -57602,7 +57602,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bUb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/beacon,
@@ -57630,7 +57630,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bUd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -57643,7 +57643,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "bUe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -57679,7 +57679,7 @@
 	pixel_x = 7;
 	pixel_y = 36
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -57703,7 +57703,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -57742,10 +57742,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -57764,7 +57764,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -57777,7 +57777,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -57792,7 +57792,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -57804,7 +57804,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -57817,7 +57817,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -57826,11 +57826,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bUp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -57839,7 +57839,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bUq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57851,7 +57851,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bUr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57863,7 +57863,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bUs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -57875,10 +57875,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bUt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -57888,7 +57888,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bUu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -57906,7 +57906,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bUv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57922,7 +57922,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bUw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -57932,7 +57932,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bUx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -57945,7 +57945,7 @@
 /area/hallway/primary/port)
 "bUy" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57963,10 +57963,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bUz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57995,7 +57995,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
 "bUC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -58044,7 +58044,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "bUK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -58089,7 +58089,7 @@
 	color = "#c45c57";
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/captain,
@@ -58259,7 +58259,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bVb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58412,7 +58412,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bVm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -58446,7 +58446,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bVo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -58583,7 +58583,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -58599,13 +58599,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -58621,7 +58621,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
@@ -58639,7 +58639,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -58658,7 +58658,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58680,7 +58680,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -58710,7 +58710,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58729,41 +58729,41 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -58772,7 +58772,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -58788,7 +58788,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -58812,7 +58812,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/ai_slipper{
@@ -58831,7 +58831,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -58848,7 +58848,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -58867,7 +58867,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -58891,7 +58891,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -58907,7 +58907,7 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bVO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -58926,7 +58926,7 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bVP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -58945,7 +58945,7 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bVQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/beacon,
@@ -58962,7 +58962,7 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bVR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
@@ -58979,7 +58979,7 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bVT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -59190,7 +59190,7 @@
 	},
 /area/crew_quarters/heads/chief)
 "bWi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -59250,7 +59250,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/chief)
 "bWo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -59276,7 +59276,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bWr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -59304,24 +59304,24 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bWt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "bWu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -59334,11 +59334,11 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bWv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -59355,7 +59355,7 @@
 /area/security/checkpoint/engineering)
 "bWw" = (
 /obj/structure/chair/office,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -59371,10 +59371,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bWx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -59414,7 +59414,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bWA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/navbeacon{
@@ -59578,7 +59578,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bWM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/navbeacon{
@@ -59689,7 +59689,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bWT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -59736,7 +59736,7 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "bWZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -59786,7 +59786,7 @@
 	pixel_x = 26;
 	pixel_y = -26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -59850,10 +59850,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/navbeacon{
@@ -59873,7 +59873,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -59895,7 +59895,7 @@
 /area/hallway/primary/central)
 "bXm" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/public/glass{
@@ -59910,7 +59910,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bXn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -59926,7 +59926,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bXo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
@@ -59944,7 +59944,7 @@
 /area/hallway/primary/starboard)
 "bXp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -59961,7 +59961,7 @@
 /area/hallway/primary/starboard)
 "bXq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -59977,7 +59977,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bXr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -59990,10 +59990,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bXs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -60009,10 +60009,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bXt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -60028,7 +60028,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bXu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -60045,7 +60045,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bXw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -60064,10 +60064,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bXx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -60085,7 +60085,7 @@
 /area/hallway/primary/starboard)
 "bXy" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -60098,7 +60098,7 @@
 /area/hallway/primary/starboard)
 "bXz" = (
 /obj/item/beacon,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
@@ -60122,7 +60122,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bXA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60138,7 +60138,7 @@
 /area/hallway/primary/starboard)
 "bXB" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -60163,10 +60163,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bXC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60181,10 +60181,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bXD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -60202,7 +60202,7 @@
 /area/security/brig)
 "bXE" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -60227,7 +60227,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bXF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60240,10 +60240,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bXG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60275,7 +60275,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bXI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -60301,10 +60301,10 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bXK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -60321,7 +60321,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bXL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60335,13 +60335,13 @@
 /area/security/warden)
 "bXM" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
@@ -60360,7 +60360,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bXN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60372,7 +60372,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bXO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60394,7 +60394,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60408,7 +60408,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bXQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -60489,7 +60489,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -60583,7 +60583,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bYb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -60597,7 +60597,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bYd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -60926,7 +60926,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "bYx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -60938,10 +60938,10 @@
 /area/crew_quarters/heads/chief)
 "bYy" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -60971,7 +60971,7 @@
 /area/engine/engineering)
 "bYA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -60993,7 +60993,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "bYD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
@@ -61043,7 +61043,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bYG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/secure_data{
@@ -61090,7 +61090,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -61296,7 +61296,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hop)
 "bZc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -61343,7 +61343,7 @@
 /turf/open/floor/plasteel/white/telecomms,
 /area/tcommsat/server)
 "bZi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -61399,7 +61399,7 @@
 	name = "Captain's Quarters";
 	req_access_txt = "20"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -61519,7 +61519,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bZy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -61528,7 +61528,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -61547,7 +61547,7 @@
 	areastring = "/area/hallway/primary/starboard";
 	pixel_y = -26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -61576,7 +61576,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bZD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61657,7 +61657,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bZK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -61668,7 +61668,7 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "bZL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -61678,7 +61678,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bZM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -61689,17 +61689,17 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bZN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "bZO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/event_spawn,
@@ -61716,7 +61716,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bZP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -61725,13 +61725,13 @@
 /area/security/brig)
 "bZQ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -61741,7 +61741,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bZR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61750,10 +61750,10 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bZS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/button/door{
@@ -61803,7 +61803,7 @@
 /area/security/warden)
 "bZU" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/security{
@@ -61827,7 +61827,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bZX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -61954,7 +61954,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cag" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -62176,7 +62176,7 @@
 /area/engine/engineering)
 "cax" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -62201,7 +62201,7 @@
 /turf/closed/wall,
 /area/engine/engineering)
 "caz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -62236,7 +62236,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -62329,7 +62329,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "caM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -62343,7 +62343,7 @@
 /obj/machinery/computer/card{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -62359,23 +62359,23 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "caO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "caP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hop)
 "caQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -62432,7 +62432,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "caX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -62498,7 +62498,7 @@
 	pixel_x = 26;
 	pixel_y = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -62587,7 +62587,7 @@
 	name = "Courtroom";
 	req_access_txt = "42"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -62607,7 +62607,7 @@
 /area/lawoffice)
 "cbr" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock{
@@ -62773,7 +62773,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "cbE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -62896,7 +62896,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "cbM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -62926,7 +62926,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cbO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/grille,
@@ -62934,7 +62934,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cbP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/grille,
@@ -62942,7 +62942,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cbQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/grille,
@@ -62952,7 +62952,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cbR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/grille,
@@ -62960,10 +62960,10 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cbS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/grille,
@@ -62971,7 +62971,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cbT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/grille,
@@ -63068,13 +63068,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -63087,7 +63087,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -63100,7 +63100,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cce" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -63115,13 +63115,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -63133,20 +63133,20 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cch" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/power/smes/engineering{
@@ -63155,7 +63155,7 @@
 /turf/open/floor/circuit/green,
 /area/engine/engineering)
 "cci" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/engineering{
@@ -63169,7 +63169,7 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -63307,7 +63307,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ccx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -63349,7 +63349,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "ccB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -63367,7 +63367,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "ccD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/camera{
@@ -63389,7 +63389,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "ccE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -63405,7 +63405,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "ccF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -63427,7 +63427,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "ccH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -63445,17 +63445,17 @@
 /area/tcommsat/server)
 "ccI" = (
 /obj/structure/table/glass,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/folder/yellow,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "ccJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -63476,7 +63476,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "ccL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -63502,7 +63502,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain/private)
 "ccN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -63702,7 +63702,7 @@
 	pixel_x = 26;
 	pixel_y = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -63750,7 +63750,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "cdi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -63821,7 +63821,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cdo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -63858,10 +63858,10 @@
 "cdq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/door/window/brigdoor/northright{
@@ -63962,7 +63962,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cdy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -64031,7 +64031,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cdE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/grille,
@@ -64041,7 +64041,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cdF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/grille,
@@ -64051,7 +64051,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cdG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -64066,7 +64066,7 @@
 	req_access_txt = "10; 13"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -64079,7 +64079,7 @@
 /area/engine/engineering)
 "cdI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -64097,7 +64097,7 @@
 	req_access_txt = "10; 13"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -64112,7 +64112,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -64125,7 +64125,7 @@
 /area/engine/engineering)
 "cdL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -64144,7 +64144,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -64163,7 +64163,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -64179,7 +64179,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -64195,7 +64195,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -64215,11 +64215,11 @@
 /area/engine/engineering)
 "cdQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -64271,13 +64271,13 @@
 /area/engine/engineering)
 "cdT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -64287,10 +64287,10 @@
 /area/engine/engineering)
 "cdU" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/engineering/glass{
@@ -64379,7 +64379,7 @@
 "cdZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -64538,7 +64538,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cep" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -64555,13 +64555,13 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "ceq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -64573,7 +64573,7 @@
 	areastring = "/area/crew_quarters/heads/hop";
 	pixel_x = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -64609,7 +64609,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "ceu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -64626,7 +64626,7 @@
 /area/tcommsat/server)
 "cev" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -64635,7 +64635,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "cew" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -64655,7 +64655,7 @@
 /area/tcommsat/server)
 "cex" = (
 /obj/machinery/telecomms/message_server,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
@@ -64664,7 +64664,7 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "cey" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -64685,13 +64685,13 @@
 /area/tcommsat/server)
 "cez" = (
 /obj/machinery/telecomms/hub/preset,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -64701,7 +64701,7 @@
 /area/tcommsat/server)
 "ceA" = (
 /obj/machinery/blackbox_recorder,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
@@ -64711,7 +64711,7 @@
 /area/tcommsat/server)
 "ceB" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -64720,13 +64720,13 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "ceC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -64772,7 +64772,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/start/captain,
@@ -64782,7 +64782,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain/private)
 "ceG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -64793,10 +64793,10 @@
 /area/crew_quarters/heads/captain/private)
 "ceH" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -64806,7 +64806,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "ceI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -64819,7 +64819,7 @@
 	name = "Captain's Bedroom";
 	req_access_txt = "20"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -64907,7 +64907,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ceR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -64926,7 +64926,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ceS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -64945,10 +64945,10 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ceT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -64965,7 +64965,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ceU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -64979,7 +64979,7 @@
 /area/security/courtroom)
 "ceV" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -64993,10 +64993,10 @@
 /turf/open/floor/plasteel,
 /area/lawoffice)
 "ceW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -65005,7 +65005,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "ceX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -65016,10 +65016,10 @@
 /area/lawoffice)
 "ceY" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -65029,7 +65029,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
 "ceZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/lawyer,
@@ -65050,7 +65050,7 @@
 /obj/machinery/computer/security{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -65082,7 +65082,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/button/flasher{
@@ -65152,10 +65152,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cfh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -65175,7 +65175,7 @@
 /area/security/brig)
 "cfi" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -65188,7 +65188,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cfj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -65206,7 +65206,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cfk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -65221,10 +65221,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cfl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -65239,7 +65239,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cfm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
@@ -65379,7 +65379,7 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
 "cfw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65521,7 +65521,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -65560,7 +65560,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -65570,7 +65570,7 @@
 /area/engine/engineering)
 "cfN" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -65636,7 +65636,7 @@
 /area/maintenance/port)
 "cfS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -65752,7 +65752,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hop)
 "cgf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -65811,7 +65811,7 @@
 /area/tcommsat/server)
 "cgm" = (
 /obj/machinery/ntnet_relay,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -65869,7 +65869,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "cgu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -66018,7 +66018,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "cgF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -66090,7 +66090,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/newscaster{
@@ -66127,7 +66127,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
 "cgN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -66146,7 +66146,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "cgP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/table/reinforced,
@@ -66180,7 +66180,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cgR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/filingcabinet/chestdrawer,
@@ -66203,20 +66203,20 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cgT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cgU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/security/holding/westright{
@@ -66228,7 +66228,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cgV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -66238,13 +66238,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cgW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -66260,7 +66260,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cgX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -66271,7 +66271,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cgY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -66317,10 +66317,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "chb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -66340,7 +66340,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "chc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -66358,14 +66358,14 @@
 /area/security/brig)
 "chd" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "che" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -66385,7 +66385,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "chf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -66409,7 +66409,7 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -66433,10 +66433,10 @@
 /turf/open/space,
 /area/space/nearstation)
 "chi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -66447,7 +66447,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
 "chj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
@@ -66479,7 +66479,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "chk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -66495,10 +66495,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "chl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -66507,7 +66507,7 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
 "chm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -66526,13 +66526,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "chn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -66552,7 +66552,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cho" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -66571,14 +66571,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "chp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
 "chq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
@@ -66610,10 +66610,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "chr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -66712,7 +66712,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -66734,7 +66734,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
@@ -66742,7 +66742,7 @@
 "chE" = (
 /obj/structure/cable/white,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -66756,7 +66756,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/camera{
@@ -66823,7 +66823,7 @@
 /area/maintenance/port)
 "chJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -66941,7 +66941,7 @@
 /obj/machinery/computer/security/mining{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -66958,7 +66958,7 @@
 /area/crew_quarters/heads/hop)
 "cia" = (
 /obj/structure/chair/office,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/head_of_personnel,
@@ -66974,7 +66974,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "cic" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -67062,7 +67062,7 @@
 	name = "Emergency Escape";
 	req_access_txt = "20"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -67140,7 +67140,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ciq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67241,7 +67241,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
 "cix" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -67260,7 +67260,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "ciz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/table/reinforced,
@@ -67282,7 +67282,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ciA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/nanotrasen{
@@ -67302,10 +67302,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ciB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet{
@@ -67329,10 +67329,10 @@
 	name = "Security Desk";
 	req_access_txt = "63"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -67347,7 +67347,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ciD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -67357,7 +67357,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ciE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/chair{
@@ -67384,7 +67384,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ciG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -67448,7 +67448,7 @@
 /area/security/brig)
 "ciK" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/sign/poster/official/do_not_question{
@@ -67471,7 +67471,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -67488,10 +67488,10 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/machinery/light,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -67505,7 +67505,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -67517,7 +67517,7 @@
 "ciO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -67567,7 +67567,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "ciS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -67925,7 +67925,7 @@
 /area/crew_quarters/heads/hop)
 "cjC" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -67963,7 +67963,7 @@
 /turf/open/floor/plasteel/telecomms,
 /area/tcommsat/server)
 "cjG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -68020,7 +68020,7 @@
 /turf/closed/wall,
 /area/teleporter)
 "cjM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/camera/motion{
@@ -68047,7 +68047,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "cjN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68060,7 +68060,7 @@
 /turf/open/floor/plating,
 /area/teleporter)
 "cjO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68157,7 +68157,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "cka" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -68247,7 +68247,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "ckh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -68264,7 +68264,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "ckj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -68274,13 +68274,13 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "ckk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -68300,7 +68300,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ckl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -68366,14 +68366,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "ckp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
 "ckq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/ai_slipper{
@@ -68529,11 +68529,11 @@
 /area/engine/engineering)
 "ckF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -68542,7 +68542,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ckG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -68554,7 +68554,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ckH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/station_engineer,
@@ -68572,7 +68572,7 @@
 /area/engine/engineering)
 "ckI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -68615,7 +68615,7 @@
 "ckM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -68732,7 +68732,7 @@
 /turf/closed/wall,
 /area/teleporter)
 "cld" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -68900,7 +68900,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "clo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -68960,7 +68960,7 @@
 /turf/closed/wall,
 /area/lawoffice)
 "clt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -69053,7 +69053,7 @@
 /turf/open/floor/plasteel,
 /area/security/range)
 "clC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -69157,7 +69157,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "clN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/flasher{
@@ -69178,7 +69178,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "clO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green,
@@ -69379,7 +69379,7 @@
 "cmj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -69388,7 +69388,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -69398,7 +69398,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -69409,20 +69409,20 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cmn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -69433,7 +69433,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -69448,7 +69448,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cmp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -69457,7 +69457,7 @@
 /turf/open/floor/wood,
 /area/library)
 "cmq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -69516,17 +69516,17 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "cmA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hop)
 "cmB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -69551,7 +69551,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "cmF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -69605,7 +69605,7 @@
 	areastring = "/area/teleporter";
 	pixel_y = 28
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -69626,7 +69626,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "cmL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -69765,7 +69765,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "cmV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -69816,7 +69816,7 @@
 /area/security/courtroom)
 "cmZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/blobstart,
@@ -69836,7 +69836,7 @@
 /area/maintenance/starboard)
 "cna" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -69848,7 +69848,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "cnb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -69859,10 +69859,10 @@
 /area/maintenance/starboard)
 "cnc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -69875,7 +69875,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cnd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
@@ -69892,7 +69892,7 @@
 	},
 /area/maintenance/starboard)
 "cne" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -69904,7 +69904,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cnf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -69918,7 +69918,7 @@
 /area/maintenance/starboard)
 "cng" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -69932,7 +69932,7 @@
 /area/maintenance/starboard)
 "cnh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -69955,7 +69955,7 @@
 /area/maintenance/starboard)
 "cni" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -69967,10 +69967,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cnj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -69995,13 +69995,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "cnl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -70017,16 +70017,16 @@
 /turf/open/floor/plasteel,
 /area/security/range)
 "cnm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -70047,7 +70047,7 @@
 /turf/open/floor/plasteel,
 /area/security/range)
 "cnn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -70063,7 +70063,7 @@
 /turf/open/floor/plasteel,
 /area/security/range)
 "cno" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/westright{
@@ -70073,13 +70073,13 @@
 /turf/open/floor/plating,
 /area/security/range)
 "cnp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/security/range)
 "cnq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -70087,10 +70087,10 @@
 /turf/open/floor/plating,
 /area/security/range)
 "cnr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/target/syndicate,
@@ -70099,7 +70099,7 @@
 /turf/open/floor/plasteel,
 /area/security/range)
 "cns" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -70172,7 +70172,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cnw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/table/reinforced,
@@ -70342,7 +70342,7 @@
 "cnK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -70365,7 +70365,7 @@
 /turf/open/floor/wood,
 /area/library)
 "cnN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -70458,7 +70458,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "coa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -70468,14 +70468,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hop)
 "cob" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hop)
 "coc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -70516,7 +70516,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/server)
 "coh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -70594,7 +70594,7 @@
 /area/teleporter)
 "con" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -70607,7 +70607,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "coo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -70630,10 +70630,10 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "cop" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -70655,7 +70655,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "coq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -70759,7 +70759,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "cox" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -70818,7 +70818,7 @@
 /area/security/courtroom)
 "coB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -70913,7 +70913,7 @@
 /area/maintenance/starboard)
 "coL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -70937,7 +70937,7 @@
 	areastring = "/area/security/range";
 	pixel_x = -26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -70953,10 +70953,10 @@
 /turf/open/floor/plasteel,
 /area/security/range)
 "coO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -71036,7 +71036,7 @@
 /turf/open/floor/plating,
 /area/security/range)
 "coV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -71214,7 +71214,7 @@
 /area/maintenance/port)
 "cpq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -71232,19 +71232,19 @@
 	pixel_x = -26;
 	pixel_y = 3
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/wood,
 /area/library)
 "cps" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
 /area/library)
 "cpt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -71318,7 +71318,7 @@
 /area/crew_quarters/heads/hop)
 "cpE" = (
 /obj/machinery/disposal/bin,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/trunk{
@@ -71339,7 +71339,7 @@
 	pixel_x = 26;
 	pixel_y = -26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -71374,7 +71374,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/server)
 "cpK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -71465,7 +71465,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "cpT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -71541,7 +71541,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "cpZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -71551,7 +71551,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "cqa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -71567,7 +71567,7 @@
 	areastring = "/area/security/courtroom";
 	pixel_x = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -71581,7 +71581,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -71606,7 +71606,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -71635,7 +71635,7 @@
 	name = "Security Maintenance";
 	req_access_txt = "63"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -71789,7 +71789,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -71883,7 +71883,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/port)
 "cqL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -71953,7 +71953,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "cqX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -71972,7 +71972,7 @@
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/command)
 "cqZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -71984,7 +71984,7 @@
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/command)
 "crb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -72201,7 +72201,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "crq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -72289,7 +72289,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "crx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -72302,7 +72302,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "crz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -72315,7 +72315,7 @@
 	},
 /area/maintenance/starboard)
 "crB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -72508,7 +72508,7 @@
 /area/engine/engineering)
 "crS" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
@@ -72519,7 +72519,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "crT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -72667,7 +72667,7 @@
 /area/maintenance/port)
 "csg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -72723,7 +72723,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "csm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -72783,7 +72783,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "csr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -72815,7 +72815,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "csu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -72836,7 +72836,7 @@
 	areastring = "/area/hallway/secondary/command";
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -72857,7 +72857,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "csx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -72905,7 +72905,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "csB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -73138,7 +73138,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "csS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/extinguisher_cabinet{
@@ -73239,7 +73239,7 @@
 	},
 /area/maintenance/starboard)
 "ctb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -73262,7 +73262,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cte" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -73270,13 +73270,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ctf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -73296,10 +73296,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "ctg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -73462,7 +73462,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ctw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -73622,13 +73622,13 @@
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "ctP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73650,7 +73650,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ctQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -73661,7 +73661,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ctR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -73680,7 +73680,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "ctS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73692,10 +73692,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "ctT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -73707,7 +73707,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "ctU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73723,7 +73723,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "ctV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73739,7 +73739,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "ctW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73756,10 +73756,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "ctX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -73772,7 +73772,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "ctY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -73782,7 +73782,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "ctZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73795,13 +73795,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cua" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73813,7 +73813,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cub" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73826,7 +73826,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cuc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/electricshock{
@@ -73836,7 +73836,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -73845,7 +73845,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cud" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73860,7 +73860,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cue" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/black,
@@ -73871,13 +73871,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cuf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/item/beacon,
@@ -73890,7 +73890,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cug" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/black,
@@ -73904,7 +73904,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cuh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/table/wood,
@@ -73918,7 +73918,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cui" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/electricshock{
@@ -73933,7 +73933,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cuj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73944,13 +73944,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cuk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73960,7 +73960,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cul" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73970,7 +73970,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cum" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73983,7 +73983,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cun" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -73993,10 +73993,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cuo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -74007,7 +74007,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cup" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -74021,7 +74021,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cuq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -74033,7 +74033,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cur" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -74044,7 +74044,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cus" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -74056,10 +74056,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cut" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -74091,7 +74091,7 @@
 /turf/open/floor/plating,
 /area/security/courtroom)
 "cuw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -74185,7 +74185,7 @@
 /area/maintenance/starboard)
 "cuE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -74373,7 +74373,7 @@
 /area/engine/engineering)
 "cuX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -74529,7 +74529,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "cvp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -74607,7 +74607,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cvv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -74658,7 +74658,7 @@
 /turf/closed/wall/r_wall,
 /area/gateway)
 "cvB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -74860,7 +74860,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cvR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -75023,7 +75023,7 @@
 /area/crew_quarters/locker)
 "cwb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -75142,7 +75142,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cwn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/status_display/evac{
@@ -75159,7 +75159,7 @@
 /area/engine/storage)
 "cwp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -75307,7 +75307,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cwD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -75330,7 +75330,7 @@
 	areastring = "/area/ai_monitored/storage/eva";
 	pixel_y = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -75380,20 +75380,20 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "cwJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/command)
 "cwK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -75403,7 +75403,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cwL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/table/wood,
@@ -75412,7 +75412,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cwM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/black{
@@ -75423,10 +75423,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cwN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/event_spawn,
@@ -75434,7 +75434,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cwO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/black{
@@ -75444,7 +75444,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cwP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/twohanded/required/kirbyplants{
@@ -75454,7 +75454,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cwQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -75462,10 +75462,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cwR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -75478,7 +75478,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cwT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
@@ -75493,7 +75493,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cwU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
@@ -75668,7 +75668,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/locker)
 "cxj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -75801,7 +75801,7 @@
 /area/crew_quarters/locker)
 "cxs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -75814,7 +75814,7 @@
 /area/maintenance/starboard)
 "cxt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -75834,7 +75834,7 @@
 	},
 /area/maintenance/starboard)
 "cxu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -75852,7 +75852,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -75870,7 +75870,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "cxw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -75885,7 +75885,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cxx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -75982,7 +75982,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cxH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/airalarm{
@@ -76054,14 +76054,14 @@
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cxN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cxO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -76069,7 +76069,7 @@
 "cxP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -76078,14 +76078,14 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cxQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cxR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -76095,20 +76095,20 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cxS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cxT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -76307,7 +76307,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cyk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -76318,7 +76318,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cyl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -76328,17 +76328,17 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cym" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cyn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -76348,7 +76348,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cyo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -76359,7 +76359,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cyp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -76369,7 +76369,7 @@
 /area/ai_monitored/storage/eva)
 "cyq" = (
 /obj/machinery/cell_charger,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
@@ -76387,14 +76387,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "cyr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
 "cys" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -76426,7 +76426,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cyx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -76434,7 +76434,7 @@
 /area/gateway)
 "cyy" = (
 /obj/structure/closet/secure_closet/medical1,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -76442,10 +76442,10 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cyz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -76455,10 +76455,10 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cyA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -76486,7 +76486,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cyD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -76661,7 +76661,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cyP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -76870,7 +76870,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "czh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -77034,7 +77034,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "czu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -77092,7 +77092,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "czz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -77103,7 +77103,7 @@
 /area/maintenance/port)
 "czB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -77380,7 +77380,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "czY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -77394,7 +77394,7 @@
 /turf/closed/wall/r_wall,
 /area/bridge/showroom/corporate)
 "cAa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -77432,10 +77432,10 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cAe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -77455,7 +77455,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cAf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -77466,7 +77466,7 @@
 /area/gateway)
 "cAg" = (
 /obj/structure/table,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/clipboard,
@@ -77479,7 +77479,7 @@
 /area/gateway)
 "cAh" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -77505,7 +77505,7 @@
 /area/gateway)
 "cAj" = (
 /obj/machinery/gateway/centerstation,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -77566,7 +77566,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -77643,7 +77643,7 @@
 /area/crew_quarters/locker)
 "cAt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -77660,7 +77660,7 @@
 /area/crew_quarters/locker)
 "cAu" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -77676,7 +77676,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cAv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -77718,7 +77718,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cAz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -77879,7 +77879,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cAO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -77892,7 +77892,7 @@
 /area/engine/engineering)
 "cAP" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -77971,7 +77971,7 @@
 /area/engine/storage)
 "cAV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -78147,7 +78147,7 @@
 /turf/closed/wall,
 /area/ai_monitored/storage/eva)
 "cBo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced,
@@ -78166,14 +78166,14 @@
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "cBq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "cBr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -78234,7 +78234,7 @@
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "cBw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced,
@@ -78278,7 +78278,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cBz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
@@ -78339,10 +78339,10 @@
 /area/gateway)
 "cBE" = (
 /obj/machinery/gateway,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -78467,7 +78467,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "cBN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -78535,10 +78535,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "cBS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78552,7 +78552,7 @@
 	},
 /area/crew_quarters/locker)
 "cBT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78572,7 +78572,7 @@
 /area/crew_quarters/locker)
 "cBU" = (
 /obj/structure/chair/stool,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78594,7 +78594,7 @@
 /obj/structure/table,
 /obj/item/folder,
 /obj/item/pen,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78615,7 +78615,7 @@
 "cBW" = (
 /obj/structure/table,
 /obj/item/paicard,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78635,7 +78635,7 @@
 /area/crew_quarters/locker)
 "cBX" = (
 /obj/structure/table,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/toy/gun,
@@ -78656,7 +78656,7 @@
 /area/crew_quarters/locker)
 "cBY" = (
 /obj/structure/chair/stool,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/assistant,
@@ -78664,7 +78664,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -78820,7 +78820,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cCl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -78929,10 +78929,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cCv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -78947,13 +78947,13 @@
 	name = "Engineering Storage";
 	req_access_txt = "32"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -78966,7 +78966,7 @@
 /area/engine/storage)
 "cCx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -79023,7 +79023,7 @@
 /area/engine/storage)
 "cCC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
@@ -79054,7 +79054,7 @@
 /area/maintenance/port)
 "cCG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -79201,10 +79201,10 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cCU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/power/apc{
@@ -79213,13 +79213,13 @@
 	areastring = "/area/bridge/showroom/corporate";
 	pixel_x = -26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "cCV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -79228,13 +79228,13 @@
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "cCW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -79243,10 +79243,10 @@
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "cCX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/brown{
@@ -79256,10 +79256,10 @@
 /area/bridge/showroom/corporate)
 "cCY" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
@@ -79267,10 +79267,10 @@
 /area/bridge/showroom/corporate)
 "cCZ" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/storage/fancy/donut_box,
@@ -79278,20 +79278,20 @@
 /area/bridge/showroom/corporate)
 "cDa" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/paper_bin,
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
 "cDb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/black{
@@ -79300,7 +79300,7 @@
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
 "cDc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -79309,7 +79309,7 @@
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "cDd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -79318,10 +79318,10 @@
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "cDe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/airalarm{
@@ -79411,7 +79411,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cDg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -79448,7 +79448,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cDj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -79467,7 +79467,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cDl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -79548,7 +79548,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "cDt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -79618,7 +79618,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "cDy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -79629,7 +79629,7 @@
 	},
 /area/crew_quarters/locker)
 "cDz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -79895,7 +79895,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cEc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -79909,7 +79909,7 @@
 /area/engine/engineering)
 "cEd" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -79920,7 +79920,7 @@
 /area/engine/storage)
 "cEe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -79930,7 +79930,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cEf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -79949,7 +79949,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cEg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -79968,7 +79968,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cEh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -79996,7 +79996,7 @@
 	areastring = "/area/engine/storage";
 	pixel_x = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -80073,7 +80073,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cEo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -80331,7 +80331,7 @@
 /area/ai_monitored/storage/eva)
 "cEK" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/clipboard,
@@ -80349,7 +80349,7 @@
 /area/bridge/showroom/corporate)
 "cEN" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/folder/blue,
@@ -80358,7 +80358,7 @@
 /area/bridge/showroom/corporate)
 "cEO" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/clothing/mask/cigarette/cigar/cohiba{
@@ -80372,7 +80372,7 @@
 /area/bridge/showroom/corporate)
 "cEP" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/lighter,
@@ -80386,7 +80386,7 @@
 /area/bridge/showroom/corporate)
 "cER" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/storage/secure/briefcase,
@@ -80416,7 +80416,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cEU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80426,7 +80426,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cEV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80437,7 +80437,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cEW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80449,13 +80449,13 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cEX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/command/glass{
@@ -80475,7 +80475,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "cEY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80488,7 +80488,7 @@
 /area/gateway)
 "cEZ" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80564,7 +80564,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "cFg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80580,10 +80580,10 @@
 "cFh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80597,7 +80597,7 @@
 	},
 /area/crew_quarters/toilet/restrooms)
 "cFi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80614,7 +80614,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80628,7 +80628,7 @@
 	},
 /area/crew_quarters/toilet/restrooms)
 "cFk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -80640,7 +80640,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80650,7 +80650,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "cFm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80661,7 +80661,7 @@
 /area/crew_quarters/toilet/restrooms)
 "cFn" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -80679,7 +80679,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "cFo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80727,7 +80727,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cFs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -80853,14 +80853,14 @@
 	},
 /area/holodeck/rec_center)
 "cFH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cFI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/grille,
@@ -80870,7 +80870,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cFJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/grille,
@@ -80880,7 +80880,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cFK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/grille,
@@ -80890,7 +80890,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cFL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
@@ -80903,7 +80903,7 @@
 	name = "External Containment Access";
 	req_access_txt = "10; 13"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -80915,7 +80915,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cFN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -80932,7 +80932,7 @@
 	name = "External Containment Access";
 	req_access_txt = "10; 13"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -80947,7 +80947,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cFP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -80967,7 +80967,7 @@
 /area/engine/engineering)
 "cFQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -80987,7 +80987,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cFR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -81009,13 +81009,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cFS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -81036,7 +81036,7 @@
 "cFT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -81097,7 +81097,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cFZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -81245,7 +81245,7 @@
 /area/ai_monitored/storage/eva)
 "cGo" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/folder/blue,
@@ -81278,7 +81278,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/bridge/showroom/corporate)
 "cGr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/chair/comfy/brown{
@@ -81287,14 +81287,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/bridge/showroom/corporate)
 "cGs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/grimy,
 /area/bridge/showroom/corporate)
 "cGt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/chair/comfy/black{
@@ -81324,7 +81324,7 @@
 /area/bridge/showroom/corporate)
 "cGw" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/folder/red,
@@ -81427,7 +81427,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "cGI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -81531,7 +81531,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
 "cGQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -81669,7 +81669,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cHc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/grille,
@@ -81679,7 +81679,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cHd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/grille,
@@ -81689,7 +81689,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cHe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/grille,
@@ -81699,10 +81699,10 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cHf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/grille,
@@ -81712,7 +81712,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cHg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/grille,
@@ -81774,7 +81774,7 @@
 /area/engine/engineering)
 "cHn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -81786,7 +81786,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cHo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -81895,7 +81895,7 @@
 /area/maintenance/port)
 "cHz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -81952,7 +81952,7 @@
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "cHG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -82062,7 +82062,7 @@
 	name = "Corporate Lounge";
 	req_access_txt = "19"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -82168,7 +82168,7 @@
 /area/crew_quarters/toilet/restrooms)
 "cHZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -82214,7 +82214,7 @@
 /area/crew_quarters/toilet/restrooms)
 "cId" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock{
@@ -82349,7 +82349,7 @@
 	name = "Engineering Maintenance";
 	req_access_txt = "10"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -82471,7 +82471,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cIJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82626,7 +82626,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -82682,7 +82682,7 @@
 	},
 /area/crew_quarters/dorms)
 "cJf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -82696,7 +82696,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cJg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82713,7 +82713,7 @@
 	},
 /area/crew_quarters/dorms)
 "cJh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -82725,7 +82725,7 @@
 /area/crew_quarters/dorms)
 "cJi" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -82743,7 +82743,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cJj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -82753,7 +82753,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cJk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82765,7 +82765,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cJl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82778,10 +82778,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cJm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82796,7 +82796,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cJn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82813,7 +82813,7 @@
 	},
 /area/crew_quarters/dorms)
 "cJo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82826,7 +82826,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cJp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82843,7 +82843,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cJq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -82853,7 +82853,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cJr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82866,7 +82866,7 @@
 /area/crew_quarters/dorms)
 "cJs" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -82884,7 +82884,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cJt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -82896,10 +82896,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cJu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -83209,7 +83209,7 @@
 /area/maintenance/port)
 "cJQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -83227,7 +83227,7 @@
 /area/maintenance/port)
 "cJR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -83237,7 +83237,7 @@
 /area/maintenance/port)
 "cJS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -83246,7 +83246,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cJT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -83256,7 +83256,7 @@
 /area/maintenance/port)
 "cJU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -83273,7 +83273,7 @@
 	},
 /area/maintenance/port)
 "cJV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -83291,10 +83291,10 @@
 /area/maintenance/port)
 "cJW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/delivery,
@@ -83303,10 +83303,10 @@
 /area/maintenance/port)
 "cJX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -83324,16 +83324,16 @@
 /area/maintenance/port)
 "cJY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -83343,7 +83343,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cJZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83356,7 +83356,7 @@
 /area/maintenance/port)
 "cKa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83369,7 +83369,7 @@
 /area/maintenance/port)
 "cKb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83390,10 +83390,10 @@
 /area/maintenance/port)
 "cKc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83406,7 +83406,7 @@
 /area/maintenance/port)
 "cKd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83422,10 +83422,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cKe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83438,7 +83438,7 @@
 /area/maintenance/port)
 "cKf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83453,7 +83453,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cKg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83468,7 +83468,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cKh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83482,10 +83482,10 @@
 /area/maintenance/port)
 "cKi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -83496,7 +83496,7 @@
 /area/maintenance/port)
 "cKj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83509,7 +83509,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cKk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83519,7 +83519,7 @@
 /area/maintenance/port)
 "cKl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83528,7 +83528,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cKm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -83547,7 +83547,7 @@
 "cKn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -83568,7 +83568,7 @@
 	},
 /area/maintenance/port)
 "cKo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83583,7 +83583,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cKp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -83592,16 +83592,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cKq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83613,7 +83613,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cKr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83630,7 +83630,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -83645,7 +83645,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cKt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -83660,10 +83660,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cKu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -83686,7 +83686,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cKv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -83698,10 +83698,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cKw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -83711,7 +83711,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cKx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -83720,7 +83720,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cKy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -83729,7 +83729,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cKz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -83743,7 +83743,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cKA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -83757,7 +83757,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cKB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -83766,7 +83766,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cKC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/plaque{
@@ -83775,7 +83775,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cKD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -83794,16 +83794,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cKE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
@@ -83823,7 +83823,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cKF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83844,7 +83844,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83862,7 +83862,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cKH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83875,7 +83875,7 @@
 /area/maintenance/starboard/aft)
 "cKI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83919,14 +83919,14 @@
 /area/maintenance/starboard/aft)
 "cKM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -83937,7 +83937,7 @@
 /area/maintenance/starboard/aft)
 "cKN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83950,7 +83950,7 @@
 /area/maintenance/starboard/aft)
 "cKO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83970,7 +83970,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83988,7 +83988,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cKQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -84123,7 +84123,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cLb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -84250,7 +84250,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cLk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -84403,7 +84403,7 @@
 /area/maintenance/port)
 "cLz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -84476,7 +84476,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cLE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -84518,7 +84518,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cLH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -84562,7 +84562,7 @@
 /area/maintenance/port)
 "cLN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -84771,7 +84771,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cMh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -84781,7 +84781,7 @@
 /area/maintenance/starboard/aft)
 "cMi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -84801,7 +84801,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cMj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -84811,14 +84811,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cMk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cMl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -84837,7 +84837,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -85092,7 +85092,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cMG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -85218,7 +85218,7 @@
 	name = "Engineering Auxiliary Power";
 	req_access_txt = "10"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -85252,7 +85252,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -85680,7 +85680,7 @@
 /area/medical/storage)
 "cNQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -85996,7 +85996,7 @@
 /area/maintenance/department/electrical)
 "cOx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -86121,7 +86121,7 @@
 /area/maintenance/port)
 "cOH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -86134,7 +86134,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cOI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -86154,7 +86154,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cOJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -86166,7 +86166,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cOK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -86226,7 +86226,7 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "cOT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -86327,7 +86327,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cPe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -86532,7 +86532,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cPD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -86555,10 +86555,10 @@
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "cPE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -86573,7 +86573,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "cPF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -86588,7 +86588,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "cPG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -86608,7 +86608,7 @@
 	},
 /area/medical/storage)
 "cPH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -86632,10 +86632,10 @@
 /area/maintenance/starboard/aft)
 "cPI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -86650,7 +86650,7 @@
 /area/maintenance/starboard/aft)
 "cPJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -86659,7 +86659,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cPK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86668,7 +86668,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cPL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -86681,7 +86681,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cPM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86700,7 +86700,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86718,7 +86718,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cPO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -86956,10 +86956,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "cQo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -86970,7 +86970,7 @@
 /area/maintenance/department/electrical)
 "cQp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -86981,7 +86981,7 @@
 /area/maintenance/department/electrical)
 "cQq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -86991,7 +86991,7 @@
 /area/maintenance/department/electrical)
 "cQr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -87001,7 +87001,7 @@
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/cell/high,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -87014,7 +87014,7 @@
 /area/maintenance/department/electrical)
 "cQt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -87028,7 +87028,7 @@
 /area/maintenance/port)
 "cQu" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/research{
@@ -87129,7 +87129,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cQB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -87498,7 +87498,7 @@
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "cRg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -87609,7 +87609,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cRq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -87774,7 +87774,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -87835,7 +87835,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "cRO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -87873,7 +87873,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cRR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -87883,20 +87883,20 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cRS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cRT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/camera{
@@ -87913,7 +87913,7 @@
 	pixel_x = 26;
 	pixel_y = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -87935,7 +87935,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cRW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -87946,10 +87946,10 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cRX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -87974,7 +87974,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cRY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -87986,7 +87986,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cRZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -87997,10 +87997,10 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cSa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -88025,7 +88025,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cSb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -88037,7 +88037,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cSc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -88048,10 +88048,10 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cSd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -88076,7 +88076,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cSe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -88088,7 +88088,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cSf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -88096,10 +88096,10 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cSg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/research/glass{
@@ -88115,7 +88115,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cSh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -88129,7 +88129,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cSj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -88152,7 +88152,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cSl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -88683,7 +88683,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cSZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -88896,7 +88896,7 @@
 /area/maintenance/department/electrical)
 "cTu" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -88935,7 +88935,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "cTy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -88952,7 +88952,7 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "cTB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -88972,7 +88972,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cTD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -89025,7 +89025,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cTI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -89124,7 +89124,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cTS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -89167,7 +89167,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cTX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -89186,7 +89186,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "cTY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -89200,13 +89200,13 @@
 /area/science/research)
 "cTZ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/security{
@@ -89225,7 +89225,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "cUa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -89240,10 +89240,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "cUb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/chair/office{
@@ -89262,7 +89262,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "cUc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/security{
@@ -89282,10 +89282,10 @@
 /area/security/checkpoint/science/research)
 "cUd" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -89646,7 +89646,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cUG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -89692,7 +89692,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "cUK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -90232,7 +90232,7 @@
 /area/maintenance/port)
 "cVC" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -90258,7 +90258,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cVE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -90312,7 +90312,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cVJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -90336,7 +90336,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cVL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -90379,7 +90379,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cVO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -90406,7 +90406,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cVQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -90510,7 +90510,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "cVY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -90685,11 +90685,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cWo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -90699,7 +90699,7 @@
 /obj/machinery/computer/security{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -90718,10 +90718,10 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -90737,7 +90737,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "cWr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -90748,10 +90748,10 @@
 /area/security/checkpoint/medical)
 "cWs" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/security{
@@ -90792,7 +90792,7 @@
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "cWv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -90868,7 +90868,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "cWA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -90888,7 +90888,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cWC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -90904,10 +90904,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cWD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -91054,7 +91054,7 @@
 /area/maintenance/department/electrical)
 "cWU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
@@ -91090,10 +91090,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cWW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -91118,7 +91118,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cWX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -91130,13 +91130,13 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cWY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -91145,7 +91145,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cWZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -91163,7 +91163,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cXa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -91172,7 +91172,7 @@
 /area/science/xenobiology)
 "cXb" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -91184,7 +91184,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cXc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/shower{
@@ -91198,7 +91198,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cXd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -91210,13 +91210,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cXe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -91228,7 +91228,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cXf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -91241,7 +91241,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cXg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/shower{
@@ -91257,13 +91257,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cXh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -91272,7 +91272,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cXi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -91284,10 +91284,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cXj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/scientist,
@@ -91342,7 +91342,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cXo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door_timer{
@@ -91379,10 +91379,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "cXp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -91658,7 +91658,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "cXT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -91723,7 +91723,7 @@
 	name = "Medbay Storage";
 	req_access_txt = "5"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -92158,7 +92158,7 @@
 /area/science/xenobiology)
 "cYL" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -92227,7 +92227,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cYR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92281,7 +92281,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cYV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92297,7 +92297,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cYW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92327,7 +92327,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cYY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92401,20 +92401,20 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "cZe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/science/research)
 "cZf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -92435,7 +92435,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "cZg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -92641,7 +92641,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cZC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door_timer{
@@ -92673,10 +92673,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "cZD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -92750,7 +92750,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cZI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -92840,7 +92840,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "cZQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -92852,10 +92852,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cZR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92868,7 +92868,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cZS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -92886,7 +92886,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cZT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92903,7 +92903,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cZU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -92916,7 +92916,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cZV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -92933,7 +92933,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cZW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92949,7 +92949,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cZX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -92961,7 +92961,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cZY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92974,7 +92974,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cZZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -92993,7 +92993,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -93011,7 +93011,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "dab" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -93027,7 +93027,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "dac" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -93219,7 +93219,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "das" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -93266,7 +93266,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "daw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -93351,7 +93351,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "daD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/scientist,
@@ -93379,17 +93379,17 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "daF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/science/research)
 "daG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/chair{
@@ -93407,13 +93407,13 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "daH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -93425,7 +93425,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "daI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/closet/secure_closet/brig{
@@ -93442,7 +93442,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "daJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -93672,7 +93672,7 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "dbg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -93740,20 +93740,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dbn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "dbo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -93774,7 +93774,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "dbp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -93801,7 +93801,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "dbs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -93924,7 +93924,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dbB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -94169,7 +94169,7 @@
 	areastring = "/area/maintenance/port";
 	pixel_y = 28
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -94179,7 +94179,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -94196,7 +94196,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -94215,7 +94215,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -94226,7 +94226,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -94260,7 +94260,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "dcc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -94270,7 +94270,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dcd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/airalarm{
@@ -94302,7 +94302,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "dcg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -94314,10 +94314,10 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dch" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -94342,7 +94342,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "dci" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -94353,7 +94353,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dcj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -94365,10 +94365,10 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dck" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -94393,7 +94393,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "dcl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -94404,7 +94404,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dcm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -94416,10 +94416,10 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dcn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -94444,7 +94444,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "dco" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -94473,10 +94473,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dcr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -94490,7 +94490,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dcs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -94503,7 +94503,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dct" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -94515,7 +94515,7 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
 /obj/item/pen,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
@@ -94545,7 +94545,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "dcw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -94775,7 +94775,7 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "dcS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -94879,17 +94879,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dda" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "ddb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/chair{
@@ -94907,10 +94907,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "ddc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -94936,7 +94936,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "dde" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
@@ -95271,13 +95271,13 @@
 /area/maintenance/port)
 "ddL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/delivery,
@@ -95285,7 +95285,7 @@
 /area/maintenance/port)
 "ddM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -95296,7 +95296,7 @@
 /area/maintenance/port)
 "ddN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -95309,10 +95309,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "ddO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -95398,10 +95398,10 @@
 /area/science/research)
 "ddX" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -95697,10 +95697,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "dez" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -95710,7 +95710,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "deA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -95723,11 +95723,11 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "deB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -95743,7 +95743,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "deD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -95823,7 +95823,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "deM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -95908,7 +95908,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
@@ -96004,7 +96004,7 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "dfd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -96030,17 +96030,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "dff" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -96155,7 +96155,7 @@
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -96171,7 +96171,7 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "dfr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -96188,7 +96188,7 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "dfs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -96203,7 +96203,7 @@
 /obj/machinery/holopad{
 	pixel_x = -16
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -96339,13 +96339,13 @@
 /area/security/checkpoint/medical)
 "dfE" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -96389,7 +96389,7 @@
 /area/medical/medbay/central)
 "dfI" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -96436,10 +96436,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "dfN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -96459,7 +96459,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -96479,7 +96479,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -96596,7 +96596,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dgd" = (
 /obj/structure/table/wood,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/item/clothing/gloves/color/fyellow,
@@ -96644,7 +96644,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dgi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -96671,7 +96671,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dgl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -96682,7 +96682,7 @@
 "dgm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -96695,7 +96695,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "dgn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -96709,7 +96709,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "dgo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -96722,7 +96722,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "dgp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -96733,7 +96733,7 @@
 "dgq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -97031,7 +97031,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "dgN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/table,
@@ -97178,7 +97178,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "dgZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -97310,7 +97310,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dhk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -97413,7 +97413,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dhu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -97428,7 +97428,7 @@
 	dir = 4;
 	name = "emergency shower"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -97551,10 +97551,10 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/abandoned_gambling_den)
 "dhI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -97563,7 +97563,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dhJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -97582,7 +97582,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/abandoned_gambling_den)
 "dhK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -97602,7 +97602,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/abandoned_gambling_den)
 "dhL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -97623,10 +97623,10 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/abandoned_gambling_den)
 "dhM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -97697,7 +97697,7 @@
 /area/science/research/abandoned)
 "dhT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -97940,7 +97940,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "dik" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/scientist,
@@ -98072,7 +98072,7 @@
 /turf/closed/wall,
 /area/medical/chemistry)
 "div" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -98084,7 +98084,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "diw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -98101,7 +98101,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "dix" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -98117,7 +98117,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "diy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -98133,7 +98133,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "diz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
@@ -98150,7 +98150,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "diA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -98166,7 +98166,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "diB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -98183,10 +98183,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "diC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/beacon,
@@ -98204,7 +98204,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "diD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -98221,7 +98221,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "diE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -98234,10 +98234,10 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "diF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -98253,7 +98253,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "diG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -98272,7 +98272,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "diH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -98289,10 +98289,10 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "diI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -98308,7 +98308,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "diJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -98325,10 +98325,10 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "diK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -98344,7 +98344,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "diL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -98363,7 +98363,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "diM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -98380,7 +98380,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "diN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -98390,7 +98390,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "diO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -98406,7 +98406,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "diP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -98415,10 +98415,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "diQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -98437,7 +98437,7 @@
 /obj/structure/mirror{
 	pixel_x = -28
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -98545,7 +98545,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dje" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -98587,7 +98587,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "djj" = (
 /obj/structure/table/wood/poker,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/storage/wallet/random,
@@ -98667,7 +98667,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "djx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -99058,7 +99058,7 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "dkb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -99180,7 +99180,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "dkk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -99191,7 +99191,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "dkl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -99214,7 +99214,7 @@
 	name = "Chemistry Lab";
 	req_access_txt = "5; 33"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -99229,7 +99229,7 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "dkn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -99283,7 +99283,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dks" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -99356,7 +99356,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dkz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -99446,7 +99446,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "dkH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -99613,22 +99613,22 @@
 	},
 /area/crew_quarters/abandoned_gambling_den)
 "dkW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dkX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/door/window/northright,
@@ -99646,22 +99646,22 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/abandoned_gambling_den)
 "dkY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 9
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dkZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
@@ -99670,10 +99670,10 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dla" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white,
@@ -99746,7 +99746,7 @@
 /turf/closed/wall,
 /area/maintenance/port)
 "dlm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/event_spawn,
@@ -99768,7 +99768,7 @@
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science)
 "dln" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -99840,7 +99840,7 @@
 "dlt" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -99856,7 +99856,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "dlu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -99935,7 +99935,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hor)
 "dlF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -99951,7 +99951,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hor)
 "dlH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -99962,10 +99962,10 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "dlI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -99976,10 +99976,10 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "dlJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -100020,7 +100020,7 @@
 	name = "Research and Development Lab";
 	req_one_access_txt = "7;29"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -100099,7 +100099,7 @@
 /turf/closed/wall,
 /area/medical/genetics/cloning)
 "dlY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -100113,7 +100113,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "dlZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -100172,7 +100172,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dmg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -100205,7 +100205,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dmm" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
@@ -100243,7 +100243,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dmp" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
@@ -100274,7 +100274,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -100371,7 +100371,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "dmH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -100475,7 +100475,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
 "dmT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -100508,7 +100508,7 @@
 /area/crew_quarters/heads/hor)
 "dmX" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -100542,7 +100542,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "dna" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -100551,7 +100551,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "dnb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -100560,11 +100560,11 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "dnc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -100573,7 +100573,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "dnd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -100583,7 +100583,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "dne" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
@@ -100721,7 +100721,7 @@
 /area/medical/genetics/cloning)
 "dnr" = (
 /obj/structure/table/glass,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/highcap/five_k{
@@ -100745,7 +100745,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dnt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -100825,7 +100825,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dnA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -100959,7 +100959,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "dnL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -100967,7 +100967,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dnM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -101218,10 +101218,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "dor" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -101255,7 +101255,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -101270,10 +101270,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -101296,7 +101296,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -101319,7 +101319,7 @@
 	dir = 4
 	},
 /obj/structure/chair/office/light,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -101339,7 +101339,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -101369,7 +101369,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -101391,7 +101391,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -101416,7 +101416,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -101539,7 +101539,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
 "doN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -101582,7 +101582,7 @@
 /area/crew_quarters/heads/hor)
 "doR" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -101648,7 +101648,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "doX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -101868,7 +101868,7 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics/cloning)
 "dpr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -101889,7 +101889,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -101904,7 +101904,7 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics/cloning)
 "dpt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -101917,10 +101917,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dpu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -101978,7 +101978,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "dpz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -102046,7 +102046,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "dpE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -102216,14 +102216,14 @@
 /turf/open/floor/plating,
 /area/science/research/abandoned)
 "dqa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "dqb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -102235,7 +102235,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "dqc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -102247,7 +102247,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "dqd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -102276,13 +102276,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "dqf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -102301,7 +102301,7 @@
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science)
 "dqg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -102316,10 +102316,10 @@
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science)
 "dqh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -102564,7 +102564,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "dqC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/delivery,
@@ -102574,10 +102574,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
 "dqD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -102589,10 +102589,10 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "dqE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -102610,7 +102610,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "dqF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -102626,7 +102626,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "dqG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -102640,10 +102640,10 @@
 /area/crew_quarters/heads/hor)
 "dqH" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/command{
@@ -102672,7 +102672,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -102687,7 +102687,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -102719,7 +102719,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "dqM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -102974,7 +102974,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dri" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -103100,7 +103100,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "drw" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
@@ -103186,7 +103186,7 @@
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science)
 "drH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -103358,7 +103358,7 @@
 /area/crew_quarters/heads/hor)
 "drZ" = (
 /obj/structure/chair/office/light,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -103408,7 +103408,7 @@
 /area/science/research)
 "dsd" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -103444,7 +103444,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "dsg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -103545,7 +103545,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "dsq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -103554,7 +103554,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -103562,7 +103562,7 @@
 "dss" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/south,
@@ -103647,7 +103647,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dsB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -103871,7 +103871,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dsS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -103908,7 +103908,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dsY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/eastleft,
@@ -104041,7 +104041,7 @@
 /area/crew_quarters/heads/hor)
 "dts" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/button/door{
@@ -104101,7 +104101,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -104152,7 +104152,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -104165,7 +104165,7 @@
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
 "dtD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -104177,10 +104177,10 @@
 	name = "Genetics Lab";
 	req_access_txt = "9"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -104193,7 +104193,7 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "dtF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -104201,7 +104201,7 @@
 /turf/open/floor/plating,
 /area/medical/genetics)
 "dtG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -104217,10 +104217,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dtH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -104385,10 +104385,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dtV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -104403,7 +104403,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "dtW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -104419,7 +104419,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -104495,7 +104495,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dug" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
@@ -104504,10 +104504,10 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "duh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional,
@@ -104515,7 +104515,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dui" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
@@ -104617,7 +104617,7 @@
 /area/maintenance/port)
 "duv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -104749,10 +104749,10 @@
 /obj/machinery/computer/aifixer{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -104764,7 +104764,7 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/research_director,
@@ -104776,14 +104776,14 @@
 /obj/machinery/computer/mecha{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
 "duP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -104807,7 +104807,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -104848,7 +104848,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "duV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -104933,7 +104933,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dvf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -105024,7 +105024,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dvn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -105064,7 +105064,7 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "dvq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -105075,7 +105075,7 @@
 /turf/open/floor/plating,
 /area/medical/genetics)
 "dvr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -105158,10 +105158,10 @@
 	},
 /area/crew_quarters/heads/cmo)
 "dvx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -105180,7 +105180,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "dvy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -105192,7 +105192,7 @@
 /area/medical/medbay/central)
 "dvz" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/medical{
@@ -105213,7 +105213,7 @@
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "dvA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -105228,7 +105228,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dvB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/medical_doctor,
@@ -105248,7 +105248,7 @@
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "dvC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -105266,7 +105266,7 @@
 	name = "Surgery Theatre";
 	req_access_txt = "45"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -105284,7 +105284,7 @@
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "dvE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -105299,7 +105299,7 @@
 /obj/machinery/computer/operating{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -105320,10 +105320,10 @@
 "dvG" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -105343,7 +105343,7 @@
 /area/medical/surgery)
 "dvH" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -105353,7 +105353,7 @@
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "dvI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -105367,7 +105367,7 @@
 	name = "Surgery Maintenance";
 	req_access_txt = "45"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -105382,10 +105382,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "dvK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -105545,7 +105545,7 @@
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dwc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
@@ -105624,7 +105624,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "dwq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -105662,7 +105662,7 @@
 /area/crew_quarters/heads/hor)
 "dwt" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -105690,7 +105690,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "dww" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -105700,14 +105700,14 @@
 /area/science/robotics/mechbay)
 "dwx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "dwy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -105720,14 +105720,14 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "dwz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "dwA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -105814,7 +105814,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dwJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -105823,7 +105823,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -105839,7 +105839,7 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "dwK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -105860,7 +105860,7 @@
 /area/medical/genetics)
 "dwL" = (
 /obj/structure/table/glass,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/item/clipboard,
@@ -105955,7 +105955,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dwR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -106000,7 +106000,7 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "dwU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
@@ -106021,10 +106021,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dwW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -106044,7 +106044,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "dwX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -106059,13 +106059,13 @@
 	name = "Chief Medical Officer's Office";
 	req_access_txt = "40"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -106083,7 +106083,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
 "dwZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -106096,10 +106096,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
 "dxa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -106114,7 +106114,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "dxb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -106126,7 +106126,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "dxc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -106141,7 +106141,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "dxd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -106162,13 +106162,13 @@
 	name = "Chief Medical Officer's Office";
 	req_access_txt = "40"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -106186,7 +106186,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
 "dxf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -106198,10 +106198,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dxg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -106277,7 +106277,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dxn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -106301,7 +106301,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dxq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -106527,7 +106527,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -106537,7 +106537,7 @@
 /area/crew_quarters/heads/hor)
 "dxX" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -106545,13 +106545,13 @@
 /area/crew_quarters/heads/hor)
 "dxY" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/command{
@@ -106568,7 +106568,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
 "dxZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -106577,7 +106577,7 @@
 /area/crew_quarters/heads/hor)
 "dya" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -106622,7 +106622,7 @@
 /area/science/robotics/lab)
 "dyf" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/research/glass{
@@ -106678,10 +106678,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dyj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -106701,7 +106701,7 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "dyk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -106723,7 +106723,7 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "dyl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -106744,10 +106744,10 @@
 	name = "Genetics Lab";
 	req_access_txt = "9"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -106765,7 +106765,7 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "dyn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -106787,7 +106787,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "dyo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -106805,7 +106805,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dyp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -106827,7 +106827,7 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "dyq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -106849,7 +106849,7 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "dyr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/holopad,
@@ -106899,11 +106899,11 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "dyu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -106914,7 +106914,7 @@
 /turf/open/floor/plating,
 /area/medical/genetics)
 "dyv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -106926,10 +106926,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dyw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -106966,7 +106966,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
 "dyz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -107156,11 +107156,11 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "dyL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -107173,7 +107173,7 @@
 /area/maintenance/starboard/aft)
 "dyM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -107206,7 +107206,7 @@
 	areastring = "/area/hallway/secondary/construction";
 	pixel_y = -26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/bot,
@@ -107215,7 +107215,7 @@
 "dyQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -107345,7 +107345,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/xeno_spawn,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -107364,7 +107364,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -107386,7 +107386,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -107396,7 +107396,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -107412,7 +107412,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -107423,19 +107423,19 @@
 /area/science/research/abandoned)
 "dzn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "dzo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -107451,7 +107451,7 @@
 /area/maintenance/port)
 "dzp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -107466,7 +107466,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "dzq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -107482,7 +107482,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "dzr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -107528,7 +107528,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -107550,7 +107550,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "dzC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -107634,7 +107634,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dzJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -107713,7 +107713,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dzP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -107872,7 +107872,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
 "dAc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -107897,7 +107897,7 @@
 /area/crew_quarters/heads/cmo)
 "dAe" = (
 /obj/structure/chair/office/light,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -107911,7 +107911,7 @@
 /area/crew_quarters/heads/cmo)
 "dAf" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
@@ -107948,7 +107948,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dAh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -107976,7 +107976,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -107996,7 +107996,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
 "dAl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/item/radio/intercom{
@@ -108009,7 +108009,7 @@
 /area/maintenance/solars/starboard/aft)
 "dAm" = (
 /obj/machinery/power/smes,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/light/small{
@@ -108075,7 +108075,7 @@
 /area/maintenance/port)
 "dAv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -108094,7 +108094,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "dAw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -108108,7 +108108,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dAx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -108120,7 +108120,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dAy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -108135,7 +108135,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -108174,7 +108174,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "dAG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/research_director,
@@ -108233,7 +108233,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dAK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -108243,7 +108243,7 @@
 /area/science/robotics/lab)
 "dAL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -108252,7 +108252,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dAM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -108261,7 +108261,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dAN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -108297,7 +108297,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dAQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -108309,7 +108309,7 @@
 /area/medical/genetics)
 "dAR" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/button/door{
@@ -108329,10 +108329,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dAS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -108474,7 +108474,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dBf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -108499,7 +108499,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dBh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -108517,7 +108517,7 @@
 /area/crew_quarters/heads/cmo)
 "dBi" = (
 /obj/machinery/disposal/bin,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -108530,13 +108530,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
 "dBj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -108553,7 +108553,7 @@
 /area/crew_quarters/heads/cmo)
 "dBk" = (
 /obj/structure/table/glass,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/paper_bin,
@@ -108570,10 +108570,10 @@
 /area/crew_quarters/heads/cmo)
 "dBl" = (
 /obj/structure/table/glass,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/item/folder/blue{
@@ -108596,7 +108596,7 @@
 "dBm" = (
 /obj/machinery/computer/med_data/laptop,
 /obj/structure/table/glass,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -108610,7 +108610,7 @@
 	},
 /area/crew_quarters/heads/cmo)
 "dBn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -108709,7 +108709,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dBu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -108727,7 +108727,7 @@
 	},
 /area/maintenance/starboard/aft)
 "dBv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -108745,7 +108745,7 @@
 	},
 /area/maintenance/starboard/aft)
 "dBw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -108755,17 +108755,17 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dBx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dBy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -108775,7 +108775,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dBz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -108784,7 +108784,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dBA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -108803,7 +108803,7 @@
 	},
 /area/maintenance/starboard/aft)
 "dBB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -108820,10 +108820,10 @@
 	},
 /area/maintenance/starboard/aft)
 "dBC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -108834,10 +108834,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dBD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -108855,7 +108855,7 @@
 	},
 /area/maintenance/starboard/aft)
 "dBE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -108865,7 +108865,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dBF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -108880,7 +108880,7 @@
 	name = "Starboard Quarter Solar Access";
 	req_access_txt = "10"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -108895,10 +108895,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/solars/starboard/aft)
 "dBH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -109098,7 +109098,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "dCc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -109134,7 +109134,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "dCk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/camera{
@@ -109150,7 +109150,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "dCl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -109209,7 +109209,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dCq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -109229,7 +109229,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dCw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -109253,7 +109253,7 @@
 	areastring = "/area/hallway/primary/aft";
 	pixel_x = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -109264,7 +109264,7 @@
 /area/medical/morgue)
 "dCz" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/grunge{
@@ -109296,7 +109296,7 @@
 /area/maintenance/department/medical/morgue)
 "dCE" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -109330,7 +109330,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
 "dCH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -109476,7 +109476,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dCQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -109571,7 +109571,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "dCZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -109687,7 +109687,7 @@
 /turf/open/floor/plating,
 /area/science/research/abandoned)
 "dDm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -109749,7 +109749,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dDp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -109864,7 +109864,7 @@
 /area/science/robotics/lab)
 "dDA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -109910,7 +109910,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dDG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -109959,7 +109959,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "dDK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
@@ -110076,7 +110076,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "dDU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -110114,7 +110114,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
 "dDX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/vending/wallmed{
@@ -110286,7 +110286,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -110373,7 +110373,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dEs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/scientist,
@@ -110519,7 +110519,7 @@
 /area/science/server)
 "dEF" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
@@ -110551,7 +110551,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dEI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -110595,7 +110595,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -110635,7 +110635,7 @@
 /area/medical/morgue)
 "dET" = (
 /obj/effect/decal/cleanable/blood/old,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -110738,7 +110738,7 @@
 /area/maintenance/department/medical/morgue)
 "dFc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -110756,7 +110756,7 @@
 /area/crew_quarters/heads/cmo)
 "dFf" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -110768,7 +110768,7 @@
 	name = "Chief Medical Officer's Quarters";
 	req_access_txt = "40"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -110780,7 +110780,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "dFh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -110827,7 +110827,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
 "dFm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -110918,7 +110918,7 @@
 /turf/open/floor/plating,
 /area/security/detectives_office/private_investigators_office)
 "dFu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -111037,7 +111037,7 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dFG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -111160,7 +111160,7 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "dFR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/computer/rdservercontrol{
@@ -111192,10 +111192,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -111215,7 +111215,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -111238,7 +111238,7 @@
 	name = "Research Division Server Room";
 	req_access_txt = "30"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -111258,7 +111258,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -111270,11 +111270,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -111298,7 +111298,7 @@
 /area/science/research)
 "dFY" = (
 /obj/machinery/disposal/bin,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -111314,10 +111314,10 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dFZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -111411,10 +111411,10 @@
 	},
 /area/medical/morgue)
 "dGj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -111435,7 +111435,7 @@
 /area/medical/morgue)
 "dGk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -111455,7 +111455,7 @@
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "dGl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -111475,7 +111475,7 @@
 /area/medical/morgue)
 "dGm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/medical_doctor,
@@ -111497,7 +111497,7 @@
 "dGn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -111517,7 +111517,7 @@
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "dGo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -111534,7 +111534,7 @@
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "dGp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -111563,7 +111563,7 @@
 /area/medical/morgue)
 "dGq" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/grunge{
@@ -111582,7 +111582,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/medical/morgue)
 "dGr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -111601,7 +111601,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/medical/morgue)
 "dGs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -111612,7 +111612,7 @@
 /area/maintenance/department/medical/morgue)
 "dGt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -111622,13 +111622,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "dGu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -111700,7 +111700,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "dGA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -111733,7 +111733,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "dGC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -111749,7 +111749,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre/abandoned)
 "dGF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -111813,7 +111813,7 @@
 /turf/open/floor/plating,
 /area/security/detectives_office/private_investigators_office)
 "dGM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -111975,7 +111975,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
@@ -111991,7 +111991,7 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dHf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -112035,7 +112035,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "dHj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -112090,7 +112090,7 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "dHq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -112105,10 +112105,10 @@
 	name = "Server Access";
 	req_access_txt = "30"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -112124,7 +112124,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "dHs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -112137,7 +112137,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -112175,7 +112175,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dHv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -112276,7 +112276,7 @@
 "dHE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -112430,7 +112430,7 @@
 /area/maintenance/department/medical/morgue)
 "dHP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -112568,7 +112568,7 @@
 	},
 /area/crew_quarters/theatre/abandoned)
 "dHZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
@@ -112607,7 +112607,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
 "dId" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -112620,7 +112620,7 @@
 /turf/open/floor/plating,
 /area/security/detectives_office/private_investigators_office)
 "dIe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/xeno_spawn,
@@ -112716,7 +112716,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
@@ -112740,7 +112740,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -112759,29 +112759,29 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dIr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dIs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -112804,7 +112804,7 @@
 /area/science/misc_lab)
 "dIt" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -112831,7 +112831,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dIu" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -112846,7 +112846,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dIv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -112859,13 +112859,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "dIw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -112876,7 +112876,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "dIx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -112887,7 +112887,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "dIy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -112907,7 +112907,7 @@
 	id = "rdtoxins";
 	name = "Toxins Lab Shutters"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -112925,7 +112925,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -112934,7 +112934,7 @@
 "dIB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -112943,7 +112943,7 @@
 "dIC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -112953,14 +112953,14 @@
 /area/science/storage)
 "dID" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "dIE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -113020,10 +113020,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "dIJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -113043,7 +113043,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "dIK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -113070,7 +113070,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dIM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -113148,7 +113148,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dIT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
@@ -113272,11 +113272,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "dJf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -113299,7 +113299,7 @@
 	areastring = "/area/maintenance/department/medical/morgue";
 	pixel_y = -26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -113391,7 +113391,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dJn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/green,
@@ -113415,10 +113415,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dJq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -113439,7 +113439,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -113455,7 +113455,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre/abandoned)
 "dJs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -113464,7 +113464,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre/abandoned)
 "dJt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -113475,7 +113475,7 @@
 /area/crew_quarters/theatre/abandoned)
 "dJu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -113688,7 +113688,7 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dJR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -113737,7 +113737,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dJV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -113873,7 +113873,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "dKi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -113890,7 +113890,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "dKj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -113932,7 +113932,7 @@
 /area/hallway/primary/aft)
 "dKm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -113954,7 +113954,7 @@
 /area/medical/medbay/central)
 "dKo" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/virology{
@@ -114103,7 +114103,7 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dKD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -114121,7 +114121,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dKE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -114161,7 +114161,7 @@
 	name = "Break Room";
 	req_access_txt = "47"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -114190,7 +114190,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dKK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -114278,13 +114278,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dKS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -114300,7 +114300,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dKT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -114315,7 +114315,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dKU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -114332,7 +114332,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -114350,7 +114350,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
 "dKW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -114364,7 +114364,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
 "dKX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -114376,7 +114376,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dKY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -114389,7 +114389,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dKZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -114410,7 +114410,7 @@
 	},
 /area/maintenance/aft)
 "dLa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -114430,16 +114430,16 @@
 	},
 /area/maintenance/aft)
 "dLb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -114448,7 +114448,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dLc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -114477,7 +114477,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dLe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/rack,
@@ -114499,7 +114499,7 @@
 	},
 /area/maintenance/aft)
 "dLf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -114518,10 +114518,10 @@
 	},
 /area/maintenance/aft)
 "dLg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -114535,7 +114535,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
 "dLh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -114573,7 +114573,7 @@
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
 "dLk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -114856,7 +114856,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dLQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -114906,7 +114906,7 @@
 /area/maintenance/port/aft)
 "dLV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -115010,7 +115010,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "dMf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -115050,10 +115050,10 @@
 	},
 /area/maintenance/port/aft)
 "dMi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -115062,7 +115062,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dMj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -115072,7 +115072,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dMk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -115085,24 +115085,24 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dMl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dMm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -115116,7 +115116,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dMn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -115131,7 +115131,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -115146,7 +115146,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dMp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -115157,7 +115157,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dMq" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -115171,7 +115171,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dMr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -115308,7 +115308,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
 "dME" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -115322,7 +115322,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
 "dMF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -115331,7 +115331,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dMG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -115388,7 +115388,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dMM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -115401,7 +115401,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dMN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -115415,7 +115415,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
 "dMO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -115440,7 +115440,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/medical)
 "dMP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -115453,22 +115453,22 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
 "dMQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -115477,10 +115477,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/bot,
@@ -115490,7 +115490,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/medical)
 "dMR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -115505,7 +115505,7 @@
 /area/maintenance/department/medical)
 "dMS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -115527,7 +115527,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/medical)
 "dMT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -115537,7 +115537,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "dMU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -115546,7 +115546,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dMV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -115560,7 +115560,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "dMW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -115570,7 +115570,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dMX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -115583,7 +115583,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "dMY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -115736,11 +115736,11 @@
 /area/maintenance/port/aft)
 "dNu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -115757,7 +115757,7 @@
 /area/maintenance/port/aft)
 "dNv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -115766,7 +115766,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dNw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -115786,7 +115786,7 @@
 /area/maintenance/port/aft)
 "dNx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -115806,10 +115806,10 @@
 /area/maintenance/port/aft)
 "dNy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -115817,7 +115817,7 @@
 /area/maintenance/port/aft)
 "dNz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -115831,7 +115831,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dNA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -115891,7 +115891,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -115907,7 +115907,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "dNG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -115929,7 +115929,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "dNH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -115968,7 +115968,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dNK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -115980,7 +115980,7 @@
 /area/security/checkpoint/customs/auxiliary)
 "dNM" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/command/glass{
@@ -116068,7 +116068,7 @@
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
 "dNV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -116168,7 +116168,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/delivery,
@@ -116180,7 +116180,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -116191,7 +116191,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -116205,7 +116205,7 @@
 /area/maintenance/port/aft)
 "dOi" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -116250,7 +116250,7 @@
 /area/maintenance/port/aft)
 "dOn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -116327,7 +116327,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -116402,7 +116402,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dOy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -116440,7 +116440,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
 "dOA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
@@ -116610,7 +116610,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
@@ -116672,7 +116672,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -116744,7 +116744,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dPb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
@@ -116772,7 +116772,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
 "dPd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -116810,7 +116810,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
 "dPg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -116872,7 +116872,7 @@
 /area/maintenance/department/medical)
 "dPo" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -116913,24 +116913,24 @@
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "dPr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
 "dPs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
 "dPt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -116972,7 +116972,7 @@
 /area/library/abandoned)
 "dPy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -117019,7 +117019,7 @@
 /area/library/abandoned)
 "dPF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -117034,17 +117034,17 @@
 /area/maintenance/port/aft)
 "dPG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dPH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -117082,7 +117082,7 @@
 	areastring = "/area/maintenance/port/aft";
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -117139,7 +117139,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -117193,7 +117193,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dPU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -117208,7 +117208,7 @@
 /obj/machinery/computer/card{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -117236,13 +117236,13 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
 "dPW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -117261,7 +117261,7 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -117279,7 +117279,7 @@
 /area/security/checkpoint/customs/auxiliary)
 "dPY" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/folder/blue,
@@ -117298,10 +117298,10 @@
 /area/security/checkpoint/customs/auxiliary)
 "dPZ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/door/window/brigdoor/southright{
@@ -117365,7 +117365,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dQf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -117386,7 +117386,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dQh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -117401,7 +117401,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dQj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -117450,7 +117450,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dQo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/filingcabinet/chestdrawer,
@@ -117503,7 +117503,7 @@
 "dQt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -117551,7 +117551,7 @@
 /area/maintenance/port/aft)
 "dQA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -117609,7 +117609,7 @@
 /area/maintenance/port/aft)
 "dQE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -117630,7 +117630,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dQH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -117638,7 +117638,7 @@
 	req_access_txt = "47"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -117654,7 +117654,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dQJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -117683,7 +117683,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
 "dQL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -117792,7 +117792,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dQV" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -117807,7 +117807,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dQW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -117823,7 +117823,7 @@
 /area/medical/virology)
 "dQX" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -117865,7 +117865,7 @@
 	pixel_y = 24;
 	req_access_txt = "39"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -117878,13 +117878,13 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dQZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/light/small{
@@ -117902,13 +117902,13 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dRa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -117928,7 +117928,7 @@
 	name = "Virology Access";
 	req_access_txt = "39"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -117946,7 +117946,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dRc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -117965,10 +117965,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dRd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -118035,7 +118035,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dRi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -118097,7 +118097,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "dRm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/bed,
@@ -118225,10 +118225,10 @@
 /area/maintenance/port/aft)
 "dRz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -118237,7 +118237,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dRA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -118247,7 +118247,7 @@
 /area/maintenance/port/aft)
 "dRB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -118257,10 +118257,10 @@
 /area/maintenance/port/aft)
 "dRC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -118270,22 +118270,22 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dRD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dRE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -118298,7 +118298,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dRF" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -118317,7 +118317,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dRG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -118327,10 +118327,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dRH" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -118340,14 +118340,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dRI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -118361,7 +118361,7 @@
 	},
 /area/maintenance/port/aft)
 "dRJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -118376,7 +118376,7 @@
 	},
 /area/maintenance/port/aft)
 "dRK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -118386,7 +118386,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dRL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -118404,7 +118404,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dRM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -118415,7 +118415,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dRN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -118432,10 +118432,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dRO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -118463,7 +118463,7 @@
 /area/security/checkpoint/customs/auxiliary)
 "dRQ" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/storage/box/ids,
@@ -118588,10 +118588,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dSe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -118607,7 +118607,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dSf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -118621,7 +118621,7 @@
 	name = "Virology Break Room";
 	req_access_txt = "39"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -118633,7 +118633,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dSh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -118642,7 +118642,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dSi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -118659,13 +118659,13 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dSj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -118684,7 +118684,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dSk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/green,
@@ -118695,7 +118695,7 @@
 	name = "Virology Cabin";
 	req_access_txt = "39"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -118707,7 +118707,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dSm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -118720,10 +118720,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dSn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/virologist,
@@ -118781,7 +118781,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/old,
@@ -118818,7 +118818,7 @@
 /area/maintenance/port/aft)
 "dSy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -118838,7 +118838,7 @@
 	req_access_txt = "27"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -118893,7 +118893,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dSG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -118936,7 +118936,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "dSL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -118956,14 +118956,14 @@
 /area/maintenance/port/aft)
 "dSM" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/customs/auxiliary)
 "dSN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -119042,7 +119042,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dSZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -119093,7 +119093,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dTe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -119125,7 +119125,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dTi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -119157,7 +119157,7 @@
 /area/solar/starboard/aft)
 "dTl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -119173,7 +119173,7 @@
 /area/library/abandoned)
 "dTm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood{
@@ -119181,20 +119181,20 @@
 	},
 /area/library/abandoned)
 "dTn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
 /area/library/abandoned)
 "dTo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/library/abandoned)
 "dTp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -119233,7 +119233,7 @@
 /turf/open/floor/plating,
 /area/library/abandoned)
 "dTv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -119257,7 +119257,7 @@
 /area/chapel/office)
 "dTy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -119308,7 +119308,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -119340,7 +119340,7 @@
 	dir = 2;
 	name = "departures camera"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -119380,7 +119380,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dTS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -119451,7 +119451,7 @@
 "dTW" = (
 /obj/item/clothing/neck/stethoscope,
 /obj/structure/table,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/storage/box/donkpockets,
@@ -119510,7 +119510,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "dUa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -119567,7 +119567,7 @@
 /area/maintenance/port/aft)
 "dUh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -119599,7 +119599,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "dUj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -119697,7 +119697,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "dUp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -119779,7 +119779,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -119798,7 +119798,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dUy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -119841,37 +119841,37 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dUK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
 "dUL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
 "dUM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
 "dUN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -119889,10 +119889,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dUP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -119918,7 +119918,7 @@
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -119977,7 +119977,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dUY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -119987,7 +119987,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dUZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -120043,7 +120043,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "dVd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -120087,7 +120087,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dVj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -120116,7 +120116,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dVt" = (
 /obj/structure/table/glass,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/clothing/gloves/color/latex,
@@ -120142,7 +120142,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dVv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/pandemic,
@@ -120168,7 +120168,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dVy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -120295,7 +120295,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library/abandoned)
 "dVL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -120311,7 +120311,7 @@
 /area/maintenance/port/aft)
 "dVM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -120337,7 +120337,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "dVO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/chaplain,
@@ -120381,7 +120381,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "dVS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -120420,7 +120420,7 @@
 /turf/open/floor/plasteel,
 /area/chapel/main)
 "dVX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -120430,7 +120430,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dVY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -120450,10 +120450,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dVZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -120472,7 +120472,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dWa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -120491,7 +120491,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dWb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -120586,7 +120586,7 @@
 	pixel_x = -32
 	},
 /obj/structure/table/glass,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/reagentgrinder{
@@ -120608,7 +120608,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dWo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -120632,7 +120632,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dWr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -120652,7 +120652,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dWt" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -120672,10 +120672,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dWv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -120691,7 +120691,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dWw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -120774,7 +120774,7 @@
 /area/library/abandoned)
 "dWI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -120939,13 +120939,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dXa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
@@ -120955,7 +120955,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dXb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -120967,13 +120967,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dXc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -120992,7 +120992,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dXd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
@@ -121003,7 +121003,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dXe" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -121022,13 +121022,13 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dXf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -121044,7 +121044,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dXg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -121062,13 +121062,13 @@
 	name = "Virology Lab";
 	req_access_txt = "39"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -121086,7 +121086,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dXi" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -121102,10 +121102,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dXj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -121138,7 +121138,7 @@
 /turf/closed/wall,
 /area/medical/virology)
 "dXm" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -121151,10 +121151,10 @@
 	name = "Virology Containment Cell";
 	req_access_txt = "39"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -121166,7 +121166,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dXo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -121274,7 +121274,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library/abandoned)
 "dXA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -121300,7 +121300,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "dXC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
@@ -121395,7 +121395,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dXK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -121446,7 +121446,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/book/manual/wiki/infections,
@@ -121475,7 +121475,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dXW" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -121496,7 +121496,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dXZ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -121518,7 +121518,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dYc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -121563,7 +121563,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dYg" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -121694,7 +121694,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "dYw" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -121715,7 +121715,7 @@
 	pixel_x = -26;
 	pixel_y = -26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -121772,7 +121772,7 @@
 	},
 /area/chapel/main)
 "dYD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -121837,7 +121837,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dYP" = (
 /obj/structure/table/glass,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/storage/box/beakers{
@@ -121862,7 +121862,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dYR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/disposal/bin,
@@ -121889,7 +121889,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dYU" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -121925,10 +121925,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dYX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -121945,7 +121945,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dYY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -121960,13 +121960,13 @@
 	name = "Virology Access";
 	req_access_txt = "39"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -121981,10 +121981,10 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dZa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -121999,11 +121999,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dZb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -122019,10 +122019,10 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dZc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/holopad,
@@ -122034,13 +122034,13 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dZd" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -122057,10 +122057,10 @@
 /area/medical/virology)
 "dZe" = (
 /obj/structure/table/glass,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/folder/white,
@@ -122073,7 +122073,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dZf" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -122102,7 +122102,7 @@
 	name = "Crematorium";
 	req_access_txt = "27"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -122193,14 +122193,14 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dZw" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
 "dZx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white,
@@ -122208,7 +122208,7 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "dZy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white,
@@ -122216,7 +122216,7 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "dZz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -122251,7 +122251,7 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "dZC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/sink{
@@ -122271,7 +122271,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -122299,7 +122299,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/green,
@@ -122307,7 +122307,7 @@
 /area/medical/virology)
 "dZG" = (
 /obj/structure/table/glass,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/newscaster{
@@ -122388,7 +122388,7 @@
 /area/maintenance/port/aft)
 "dZM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -122422,7 +122422,7 @@
 	pixel_x = -26;
 	pixel_y = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -122446,7 +122446,7 @@
 	pixel_x = -26;
 	pixel_y = 3
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel{
@@ -122455,7 +122455,7 @@
 	},
 /area/chapel/main)
 "dZR" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -122464,7 +122464,7 @@
 	},
 /area/chapel/main)
 "dZS" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -122473,7 +122473,7 @@
 	},
 /area/chapel/main)
 "dZT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -122521,7 +122521,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dZY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -122597,7 +122597,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "eag" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/table,
@@ -122643,7 +122643,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -122657,7 +122657,7 @@
 /area/maintenance/solars/port/aft)
 "eam" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -122670,14 +122670,14 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "ean" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "eao" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -122688,10 +122688,10 @@
 /area/maintenance/port/aft)
 "eap" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -122702,7 +122702,7 @@
 /area/maintenance/port/aft)
 "eaq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -122713,17 +122713,17 @@
 /area/maintenance/port/aft)
 "ear" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "eas" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -122734,7 +122734,7 @@
 /area/maintenance/port/aft)
 "eat" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -122768,7 +122768,7 @@
 /obj/item/radio/intercom{
 	pixel_x = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -122883,7 +122883,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -122903,7 +122903,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -122941,7 +122941,7 @@
 /area/maintenance/solars/port/aft)
 "eaS" = (
 /obj/machinery/power/smes,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/light/small{
@@ -122953,7 +122953,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "eaT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/camera{
@@ -122975,7 +122975,7 @@
 /area/maintenance/solars/port/aft)
 "eaV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -123039,7 +123039,7 @@
 	name = "Auxiliary E.V.A. Storage";
 	req_access_txt = "18"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
@@ -123092,7 +123092,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -123211,7 +123211,7 @@
 	},
 /obj/structure/chair/office/light,
 /obj/effect/decal/cleanable/greenglow,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/green,
@@ -123232,7 +123232,7 @@
 	dir = 8
 	},
 /obj/structure/chair/office/light,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -123346,10 +123346,10 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "ebI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -123366,7 +123366,7 @@
 	name = "Port Quarter Solar Access";
 	req_access_txt = "10"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -123381,7 +123381,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/aft)
 "ebK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -123417,7 +123417,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ebP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -123465,7 +123465,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ebT" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -123581,7 +123581,7 @@
 /obj/item/folder/white,
 /obj/item/pen/red,
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -123660,7 +123660,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "ecr" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -123671,7 +123671,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "ecs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -123741,7 +123741,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ecx" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -123888,7 +123888,7 @@
 /area/maintenance/port/aft)
 "ecN" = (
 /obj/structure/rack,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -123931,7 +123931,7 @@
 	name = "Relic Closet";
 	req_access_txt = "27"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -124023,7 +124023,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "ecY" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -124192,7 +124192,7 @@
 /area/maintenance/port/aft)
 "edi" = (
 /obj/structure/rack,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -124300,7 +124300,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "edn" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -124470,7 +124470,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "edz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -124541,7 +124541,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "edK" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -124551,10 +124551,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "edL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -124564,7 +124564,7 @@
 /area/maintenance/port/aft)
 "edM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -124574,17 +124574,17 @@
 /area/maintenance/port/aft)
 "edN" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "edO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -124593,10 +124593,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "edP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -124606,7 +124606,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "edQ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -124670,7 +124670,7 @@
 /area/security/checkpoint/escape)
 "eea" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -124687,7 +124687,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "eeb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -124695,10 +124695,10 @@
 /area/security/checkpoint/escape)
 "eec" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -124710,7 +124710,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "eed" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -124722,10 +124722,10 @@
 /turf/closed/wall,
 /area/security/checkpoint/escape)
 "eef" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -124734,10 +124734,10 @@
 /area/security/checkpoint/escape)
 "eeg" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -124753,10 +124753,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "eeh" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -124764,17 +124764,17 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/escape)
 "eei" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/escape)
 "eej" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -124803,7 +124803,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "eeo" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -124813,7 +124813,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "eep" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -124840,7 +124840,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ees" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -124848,7 +124848,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "eet" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -124891,7 +124891,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "eew" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -124906,7 +124906,7 @@
 	areastring = "/area/chapel/office";
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/table/wood,
@@ -125053,7 +125053,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "eeI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -125080,7 +125080,7 @@
 /area/security/checkpoint/escape)
 "eeK" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/folder/red,
@@ -125154,7 +125154,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "eeP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -125404,7 +125404,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "efu" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/light{
@@ -125429,10 +125429,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "efv" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -125452,10 +125452,10 @@
 /area/security/checkpoint/escape)
 "efw" = (
 /obj/machinery/holopad,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -125465,10 +125465,10 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -125484,7 +125484,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "efy" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -125503,7 +125503,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "efz" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -125514,7 +125514,7 @@
 /area/security/checkpoint/escape)
 "efA" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -125530,7 +125530,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "efB" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -125545,7 +125545,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "efC" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -125564,13 +125564,13 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "efD" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -125612,7 +125612,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "efG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -125838,7 +125838,7 @@
 /obj/machinery/computer/prisoner{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -125928,10 +125928,10 @@
 /area/security/checkpoint/escape)
 "egp" = (
 /obj/structure/table,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/item/restraints/handcuffs,
@@ -125947,7 +125947,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -125960,7 +125960,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -125982,11 +125982,11 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "egs" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -126025,17 +126025,17 @@
 /area/security/checkpoint/escape)
 "egF" = (
 /obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/escape)
 "egG" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -126057,7 +126057,7 @@
 /turf/open/space,
 /area/solar/port/aft)
 "ehb" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -126153,7 +126153,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "ehL" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/loading_area{
@@ -126190,7 +126190,7 @@
 	req_one_access_txt = "12;47"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -126200,7 +126200,7 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "eCM" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -126215,7 +126215,7 @@
 /area/science/mixing/chamber)
 "eMD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -126238,7 +126238,7 @@
 /area/science/mixing)
 "eMS" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -126260,7 +126260,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "faI" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -126280,7 +126280,7 @@
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science)
 "fbA" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -126292,7 +126292,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "ffO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -126345,7 +126345,7 @@
 /obj/machinery/airalarm/mixingchamber{
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -126379,7 +126379,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -126538,10 +126538,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
 "hcP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -126558,7 +126558,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "hrP" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -126593,10 +126593,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
 "huX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white,
@@ -126628,10 +126628,10 @@
 /area/science/explab)
 "hGT" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -126656,7 +126656,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -126799,7 +126799,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
@@ -126868,7 +126868,7 @@
 	name = "Toxins Chamber APC";
 	pixel_x = 26
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -126911,7 +126911,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "jIk" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -126980,7 +126980,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -127067,7 +127067,7 @@
 /area/engine/gravity_generator)
 "leh" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
@@ -127155,14 +127155,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "lEm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -127213,7 +127213,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "lXl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
@@ -127257,14 +127257,14 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "mvm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -127361,7 +127361,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -127435,7 +127435,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
@@ -127449,7 +127449,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "nSN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -127475,7 +127475,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "oxa" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -127717,7 +127717,7 @@
 	},
 /area/vacant_room/commissary)
 "pCE" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -127727,7 +127727,7 @@
 /area/engine/storage_shared)
 "pQm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -127792,7 +127792,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
@@ -127836,7 +127836,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -128009,7 +128009,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -128019,7 +128019,7 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "sfN" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -128090,13 +128090,13 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "tkj" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -128192,7 +128192,7 @@
 	pixel_x = -26;
 	pixel_y = 3
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -128257,7 +128257,7 @@
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science)
 "uCc" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -128305,7 +128305,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "uPp" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -128342,7 +128342,7 @@
 /area/hallway/primary/central)
 "vqo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -128426,7 +128426,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "vGX" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -128486,7 +128486,7 @@
 /turf/closed/wall/r_wall,
 /area/science/misc_lab/range)
 "wBO" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -128661,7 +128661,7 @@
 	name = "Abandoned Research Lab APC";
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -35156,10 +35156,10 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bpl" = (
-/obj/structure/cable{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bpm" = (
@@ -35167,10 +35167,10 @@
 	id = "transittube";
 	name = "Transit Tube Blast Door"
 	},
-/obj/structure/cable{
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bpn" = (
@@ -35180,7 +35180,7 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bpp" = (
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -35241,21 +35241,10 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /obj/structure/transit_tube/horizontal,
-/turf/open/space,
-/area/space/nearstation)
-"bpx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
 /area/space/nearstation)
 "bpy" = (
@@ -35263,7 +35252,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /obj/structure/transit_tube/horizontal,
@@ -35274,11 +35263,11 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/transit_tube/junction/flipped{
 	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -35287,7 +35276,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /turf/open/space,
@@ -35300,7 +35289,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /turf/open/space,
@@ -35312,11 +35301,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/transit_tube/station{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -35324,7 +35313,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -36437,17 +36426,17 @@
 	name = "MiniSat Access";
 	req_one_access_txt = "32;19"
 	},
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "brL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
@@ -36456,23 +36445,20 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/transit_tube/curved{
 	dir = 4
 	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
 /turf/open/space,
 /area/space/nearstation)
 "brN" = (
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/structure/table/glass,
 /obj/item/phone{
@@ -36485,6 +36471,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
@@ -80211,18 +80200,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "dgO" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"dgS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/transit_tube/horizontal,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space/nearstation)
@@ -129447,7 +129424,7 @@ dgO
 dgO
 dgw
 dgO
-dgS
+bpw
 dgO
 dgO
 dgw
@@ -129704,7 +129681,7 @@ aaa
 aaa
 aaf
 aaf
-bpx
+bpw
 aaf
 aaf
 aaf
@@ -130475,7 +130452,7 @@ aaa
 aaa
 aaf
 aaf
-bpx
+bpw
 aaf
 aaf
 aaf
@@ -132274,7 +132251,7 @@ aaa
 aaa
 aaf
 aaf
-bpx
+bpw
 aaf
 aaf
 aaa
@@ -134073,7 +134050,7 @@ aaa
 aaa
 aaf
 aaf
-bpx
+bpw
 aaf
 aaf
 aaa

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -505,13 +505,13 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "by" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "bz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -521,7 +521,7 @@
 	name = "Labor Camp Backroom";
 	req_access_txt = "2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -532,10 +532,10 @@
 	name = "Labor Camp APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
@@ -626,7 +626,7 @@
 	name = "Labor Camp Monitoring";
 	req_access_txt = "2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -636,7 +636,7 @@
 	name = "Labor Camp Maintenance";
 	req_access_txt = "2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-10"
 	},
 /turf/open/floor/plating,
@@ -657,7 +657,7 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "bQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -669,7 +669,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -682,7 +682,7 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "bS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mining/glass{
@@ -695,13 +695,13 @@
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "bT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -716,7 +716,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -771,7 +771,7 @@
 /area/mine/laborcamp/security)
 "cc" = (
 /obj/structure/chair/office,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /mob/living/simple_animal/bot/secbot/beepsky{
@@ -796,23 +796,23 @@
 	c_tag = "Labor Camp Monitoring";
 	network = list("labor")
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "ce" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "5-6"
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
 "cf" = (
 /obj/machinery/power/terminal,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -862,7 +862,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -928,10 +928,10 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-9"
 	},
 /turf/open/floor/plating,
@@ -952,7 +952,7 @@
 /area/mine/production)
 "cE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -1041,13 +1041,13 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "cT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
@@ -1061,7 +1061,7 @@
 /area/mine/living_quarters)
 "cU" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -1080,7 +1080,7 @@
 	pixel_x = -27;
 	pixel_y = 2
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/light{
@@ -1096,10 +1096,10 @@
 /area/mine/production)
 "cY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -1160,7 +1160,7 @@
 /turf/open/floor/circuit,
 /area/mine/maintenance)
 "dh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -1250,7 +1250,7 @@
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "dp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1297,7 +1297,7 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "dx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1306,7 +1306,7 @@
 /turf/open/floor/circuit,
 /area/mine/maintenance)
 "dy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1382,12 +1382,12 @@
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
 "dF" = (
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
 /obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
@@ -1401,7 +1401,7 @@
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "dH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/binary/pump/on,
@@ -1489,7 +1489,7 @@
 	name = "Mining Station Communications";
 	req_access_txt = "48"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1507,14 +1507,14 @@
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
 "dS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Station Maintenance";
 	req_access_txt = "48"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1570,7 +1570,7 @@
 /area/mine/living_quarters)
 "eb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -1618,7 +1618,7 @@
 	pixel_x = 1;
 	pixel_y = 25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
@@ -1631,7 +1631,7 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "ei" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1701,7 +1701,7 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "eq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -1713,14 +1713,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "es" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1729,26 +1729,26 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "eu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "ev" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1760,7 +1760,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1783,7 +1783,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1795,7 +1795,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -1813,7 +1813,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1829,7 +1829,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1841,7 +1841,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -1854,7 +1854,7 @@
 /area/mine/production)
 "eC" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -3717,7 +3717,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -3837,7 +3837,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -3876,7 +3876,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
 "EG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -3961,7 +3961,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4028,7 +4028,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -4041,7 +4041,7 @@
 /area/mine/maintenance)
 "Uh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4068,7 +4068,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/brown,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -97,9 +97,6 @@
 	},
 /area/ai_monitored/turret_protected/ai)
 "acj" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
 	anyai = 1;
@@ -112,13 +109,16 @@
 	dir = 1;
 	pixel_y = 26
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "ack" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/camera/motion{
@@ -129,16 +129,16 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/machinery/status_display/ai{
 	pixel_y = 32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "acl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -186,25 +186,25 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "acp" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/command/glass{
 	name = "AI Core";
 	req_access_txt = "65"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
 "acq" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/ai";
 	name = "AI Chamber turret control";
 	pixel_x = 5;
 	pixel_y = -24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
@@ -358,43 +358,22 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/AIsatextAS)
-"acG" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
+"acI" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/ai_monitored/turret_protected/ai)
-"acH" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/ai_monitored/turret_protected/ai)
-"acI" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
 	},
 /area/ai_monitored/turret_protected/ai)
 "acJ" = (
+/obj/machinery/door/firedoor/heavy,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
 "acK" = (
@@ -404,11 +383,11 @@
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
 "acL" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/machinery/ai_slipper{
 	uses = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
@@ -426,12 +405,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "acP" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/AIsatextAP)
-"acQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "acR" = (
@@ -461,7 +434,6 @@
 /area/ai_monitored/turret_protected/AIsatextAP)
 "acX" = (
 /obj/machinery/computer/monitor,
-/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "acY" = (
@@ -484,9 +456,6 @@
 /area/ai_monitored/turret_protected/ai)
 "adb" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/command/glass{
 	name = "AI Core";
 	req_access_txt = "65"
@@ -500,6 +469,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -562,9 +534,6 @@
 "adk" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "MiniSat Antechamber APC";
@@ -572,6 +541,9 @@
 	pixel_x = -24
 	},
 /obj/machinery/recharger,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adl" = (
@@ -788,10 +760,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adN" = (
@@ -949,7 +921,7 @@
 /area/security/prison)
 "aen" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -966,14 +938,14 @@
 /area/security/prison)
 "aep" = (
 /obj/item/cultivator,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aeq" = (
 /obj/machinery/hydroponics/constructable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/seeds/glowshroom,
@@ -988,10 +960,10 @@
 /area/security/prison)
 "aer" = (
 /obj/item/reagent_containers/glass/bucket,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -999,7 +971,7 @@
 "aes" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteenXnineteen,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/poster/official/random{
@@ -1008,10 +980,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aet" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -1107,7 +1079,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aeH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -1161,11 +1133,11 @@
 	req_one_access_txt = "65"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -1232,14 +1204,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "MiniSat Port Maintenance APC";
 	areastring = "/area/ai_monitored/turret_protected/AIsatextAP";
 	pixel_x = -24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -1256,9 +1228,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
@@ -1266,6 +1235,9 @@
 	c_tag = "MiniSat Maintenance Port Aft";
 	dir = 2;
 	network = list("minisat")
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -1284,7 +1256,7 @@
 	req_access_txt = "65"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -1302,38 +1274,35 @@
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aff" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afg" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Foyer";
@@ -1344,14 +1313,17 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"afh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
+"afh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -1360,11 +1332,11 @@
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -1381,9 +1353,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
@@ -1391,6 +1360,9 @@
 	c_tag = "MiniSat Maintenance Starboard Aft";
 	dir = 2;
 	network = list("minisat")
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -1402,14 +1374,14 @@
 /area/ai_monitored/turret_protected/AIsatextAS)
 "afm" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "MiniSat Starboard Maintenance APC";
 	areastring = "/area/ai_monitored/turret_protected/AIsatextAS";
 	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -1573,7 +1545,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "afH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -1844,7 +1816,7 @@
 /turf/closed/wall,
 /area/security/prison)
 "agB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -1970,7 +1942,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "agM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2033,7 +2005,7 @@
 /area/space/nearstation)
 "agT" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -2084,7 +2056,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aha" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -2197,7 +2169,7 @@
 	name = "Long-Term Cell 1";
 	req_access_txt = "2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -2231,7 +2203,7 @@
 "ahu" = (
 /obj/structure/table/glass,
 /obj/item/flashlight/lamp,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -2246,7 +2218,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "ahv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2267,10 +2239,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2365,7 +2337,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -2387,10 +2359,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -2402,7 +2374,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -2414,7 +2386,7 @@
 	pixel_x = 1;
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
@@ -2493,16 +2465,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "ahV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -2514,10 +2486,10 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2526,7 +2498,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2541,13 +2513,13 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -2556,7 +2528,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aia" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
@@ -2565,23 +2537,23 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aib" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aic" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aid" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -2729,7 +2701,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2786,7 +2758,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aiG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -2838,7 +2810,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aiN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2853,7 +2825,7 @@
 	name = "Armory APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2934,10 +2906,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aja" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -2953,7 +2925,7 @@
 	name = "Prisoner Transfer Centre";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -2986,7 +2958,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aje" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
@@ -3059,7 +3031,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aji" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -3302,7 +3274,7 @@
 	name = "Crematorium";
 	req_access_txt = "2;27"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -3323,7 +3295,7 @@
 	id = "Prison Gate";
 	name = "prison blast door"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -3423,7 +3395,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ajS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -3443,7 +3415,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ajU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -3568,7 +3540,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "akj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/light/small{
@@ -3582,7 +3554,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "akk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3594,7 +3566,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "akl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3612,7 +3584,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "akm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3624,7 +3596,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "akn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3633,7 +3605,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ako" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3646,7 +3618,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "space-bridge access"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3661,7 +3633,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "akq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/light/small{
@@ -3728,10 +3700,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/processing/cremation)
 "aky" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -3746,7 +3718,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -3829,7 +3801,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -3915,7 +3887,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "akO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -3935,7 +3907,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "akQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/newscaster{
@@ -3966,13 +3938,13 @@
 /area/security/main)
 "akT" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "akU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -4007,7 +3979,7 @@
 /area/crew_quarters/heads/hos)
 "akZ" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -4033,7 +4005,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ale" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -4101,7 +4073,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/processing/cremation)
 "aln" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -4189,7 +4161,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -4252,7 +4224,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "alB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -4304,7 +4276,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "alI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -4334,7 +4306,7 @@
 /area/crew_quarters/heads/hos)
 "alN" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
@@ -4392,13 +4364,13 @@
 /area/maintenance/department/security/brig)
 "alW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing/cremation)
 "alX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -4420,7 +4392,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ama" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -4433,7 +4405,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "amb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -4448,7 +4420,7 @@
 	icon_state = "right";
 	name = "Brig Infirmary"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -4458,20 +4430,20 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "amd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ame" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -4480,7 +4452,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
@@ -4501,7 +4473,7 @@
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "amh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -4515,7 +4487,7 @@
 	name = "Armory";
 	req_access_txt = "3"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -4532,10 +4504,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "amj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -4549,10 +4521,10 @@
 	name = "Armory";
 	req_access_txt = "3"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -4569,13 +4541,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "aml" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "amm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
@@ -4637,7 +4609,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "amr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -4654,7 +4626,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ams" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -4670,7 +4642,7 @@
 	name = "Head of Security";
 	req_access_txt = "58"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -4683,16 +4655,16 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "amu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -4701,7 +4673,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "amv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -4786,7 +4758,7 @@
 	name = "Crematorium Maintenance";
 	req_one_access_txt = "2;27"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -4828,7 +4800,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/processing/cremation)
 "amL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4837,7 +4809,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "amM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -4894,7 +4866,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4920,7 +4892,7 @@
 	name = "Brig Control APC";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/reagent_dispensers/peppertank{
@@ -4978,13 +4950,13 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ana" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "anb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -5016,7 +4988,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "anf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5027,13 +4999,13 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ang" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -5068,7 +5040,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "anp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/robot_debris{
@@ -5082,7 +5054,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "anr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -5093,7 +5065,7 @@
 "ans" = (
 /obj/item/wirecutters,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -5102,7 +5074,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "ant" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -5115,10 +5087,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -5148,7 +5120,7 @@
 	name = "Brig Infirmary Maintenance";
 	req_access_txt = "63"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5172,13 +5144,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "anz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "anA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5189,20 +5161,20 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "anB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/warden)
 "anC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -5250,7 +5222,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "anK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
@@ -5261,7 +5233,7 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "anL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -5292,7 +5264,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "anO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -5318,7 +5290,7 @@
 /area/security/main)
 "anQ" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5327,7 +5299,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "anR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -5342,7 +5314,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/keycard_auth{
@@ -5357,7 +5329,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -5369,7 +5341,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -5389,7 +5361,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -5397,7 +5369,7 @@
 	name = "Head of Security's Office APC";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -5410,7 +5382,7 @@
 /area/crew_quarters/heads/hos)
 "anW" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/cable,
@@ -5444,7 +5416,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aoe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -5453,7 +5425,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5465,7 +5437,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -5474,13 +5446,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aoi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5489,7 +5461,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aoj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5555,20 +5527,20 @@
 	name = "Brig Control";
 	req_access_txt = "3"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aot" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -5580,13 +5552,13 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aou" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aov" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5598,7 +5570,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aow" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5607,7 +5579,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aox" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -5617,10 +5589,10 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aoy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/light{
@@ -5713,10 +5685,10 @@
 	},
 /area/maintenance/department/security/brig)
 "aoL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5750,7 +5722,7 @@
 /area/security/brig)
 "aoQ" = (
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -5821,7 +5793,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aoZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
@@ -5890,7 +5862,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "apf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5916,7 +5888,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "apg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5929,7 +5901,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aph" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5943,10 +5915,10 @@
 	name = "Fore Maintenance APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5955,7 +5927,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5967,7 +5939,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -6059,7 +6031,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "apu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6068,7 +6040,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "apv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6079,7 +6051,7 @@
 	},
 /area/maintenance/department/crew_quarters/dorms)
 "apw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6119,19 +6091,19 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "apI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "apJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -6139,10 +6111,10 @@
 /area/security/warden)
 "apK" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -6164,10 +6136,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "apL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -6179,7 +6151,7 @@
 	name = "Brig Control";
 	req_access_txt = "3"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -6188,13 +6160,13 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "apN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "apO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/closed/wall/r_wall,
@@ -6210,7 +6182,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "apQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -6284,7 +6256,7 @@
 /turf/closed/wall,
 /area/crew_quarters/dorms)
 "aqa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/solar{
@@ -6304,7 +6276,7 @@
 /turf/open/space,
 /area/solar/port)
 "aqc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/solar{
@@ -6314,7 +6286,7 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port)
 "aqd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/solar{
@@ -6357,7 +6329,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -6530,7 +6502,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aqE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -6545,17 +6517,17 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aqH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/closed/wall/r_wall,
 /area/bridge)
 "aqI" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -6565,13 +6537,13 @@
 /turf/open/floor/plating,
 /area/bridge)
 "aqJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall,
 /area/bridge)
 "aqK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/closed/wall/r_wall,
@@ -6615,7 +6587,7 @@
 	name = "Vault APC";
 	pixel_y = 25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/circuit/green{
@@ -6644,7 +6616,7 @@
 	name = "Gateway APC";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6654,7 +6626,7 @@
 /area/gateway)
 "aqR" = (
 /obj/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -6667,7 +6639,7 @@
 	name = "Gateway Chamber";
 	req_access_txt = "62"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -6729,21 +6701,21 @@
 "ara" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/space,
 /area/solar/port)
 "arc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -6946,7 +6918,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "arG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
@@ -7130,7 +7102,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green{
@@ -7197,7 +7169,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "arZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7224,10 +7196,10 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "asb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -7236,7 +7208,7 @@
 	},
 /area/maintenance/department/crew_quarters/dorms)
 "asc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -7246,7 +7218,7 @@
 /area/maintenance/department/crew_quarters/dorms)
 "asd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -7259,7 +7231,7 @@
 /area/crew_quarters/dorms)
 "ase" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -7273,7 +7245,7 @@
 "asf" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -7289,7 +7261,7 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -7321,7 +7293,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "asm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -7334,7 +7306,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "asn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7344,7 +7316,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "aso" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -7353,7 +7325,7 @@
 	},
 /area/maintenance/department/security/brig)
 "asr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -7389,7 +7361,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "asx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light,
@@ -7556,7 +7528,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "asP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/closed/wall/r_wall,
@@ -7565,7 +7537,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/keycard_auth{
@@ -7600,7 +7572,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/button/door{
@@ -7617,7 +7589,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "asU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/closed/wall/r_wall,
@@ -7660,7 +7632,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green{
@@ -7685,7 +7657,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -20
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -7694,7 +7666,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "atb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -7703,7 +7675,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "atc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/event_spawn,
@@ -7810,7 +7782,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "atp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green,
@@ -7819,7 +7791,7 @@
 /turf/open/floor/circuit/green,
 /area/maintenance/department/security/brig)
 "atv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -7831,7 +7803,7 @@
 	id = "Cell 1";
 	name = "Cell 1"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -7841,10 +7813,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -7852,19 +7824,19 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "aty" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/closed/wall,
 /area/security/brig)
 "atz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -7876,7 +7848,7 @@
 	id = "Cell 2";
 	name = "Cell 2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -7886,7 +7858,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/closed/wall,
@@ -7896,7 +7868,7 @@
 	id = "Cell 3";
 	name = "Cell 3"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -7906,10 +7878,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -7923,7 +7895,7 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7937,10 +7909,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -7981,7 +7953,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "atK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -8026,7 +7998,7 @@
 /obj/machinery/computer/monitor{
 	name = "Bridge Power Monitoring Console"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -8056,7 +8028,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "atR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -8099,7 +8071,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "atW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -8166,7 +8138,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -8178,7 +8150,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -8204,7 +8176,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "auf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -8287,7 +8259,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "auo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8296,7 +8268,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "aup" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/grille/broken,
@@ -8307,7 +8279,7 @@
 /area/maintenance/department/crew_quarters/dorms)
 "auq" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8451,7 +8423,7 @@
 /turf/closed/wall,
 /area/crew_quarters/heads/captain)
 "auJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -8482,7 +8454,7 @@
 /turf/closed/wall/r_wall,
 /area/bridge)
 "auN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/airalarm{
@@ -8498,7 +8470,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "auO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -8510,10 +8482,10 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "auP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -8588,7 +8560,7 @@
 /obj/machinery/door/airlock/vault{
 	req_access_txt = "53"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8614,7 +8586,7 @@
 	name = "Gateway Access";
 	req_access_txt = "62"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -8747,7 +8719,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "avn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -9075,7 +9047,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "avT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -9171,7 +9143,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
@@ -9183,7 +9155,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -9196,7 +9168,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -9205,7 +9177,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -9215,10 +9187,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -9409,7 +9381,7 @@
 	areastring = "/area/crew_quarters/fitness/recreation";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
@@ -9418,10 +9390,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -9442,7 +9414,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "awI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -9453,10 +9425,10 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "awJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -9467,10 +9439,10 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "awK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -9490,7 +9462,7 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9503,7 +9475,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "awM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/cable,
@@ -9600,7 +9572,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
 "awT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -9653,7 +9625,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "awZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -9688,7 +9660,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "axd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -9743,7 +9715,7 @@
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
 "axm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -9828,7 +9800,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "axA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9925,7 +9897,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
 "axR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -9943,7 +9915,7 @@
 	name = "Captain's Office APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/carpet,
@@ -9994,7 +9966,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "axY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -10082,7 +10054,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ayh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10206,7 +10178,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/assistant,
@@ -10231,7 +10203,7 @@
 	name = "Port Solar Control";
 	track = 0
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -10243,7 +10215,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "ayC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -10390,7 +10362,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "ayX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -10400,10 +10372,10 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "ayY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -10435,7 +10407,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "azd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10452,10 +10424,10 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aze" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10464,7 +10436,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "azf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -10477,7 +10449,7 @@
 /obj/structure/fireaxecabinet{
 	pixel_y = -32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10489,7 +10461,7 @@
 /obj/machinery/light{
 	light_color = "#e8eaff"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10498,7 +10470,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "azi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/requests_console{
@@ -10514,10 +10486,10 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "azj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/holopad,
@@ -10536,7 +10508,7 @@
 	c_tag = "Bridge Central";
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10548,7 +10520,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/newscaster{
@@ -10557,7 +10529,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "azm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10569,16 +10541,16 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "azn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -10591,7 +10563,7 @@
 	areastring = "/area/bridge";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -10611,7 +10583,7 @@
 /area/bridge)
 "azq" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10720,7 +10692,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -10761,22 +10733,13 @@
 /turf/open/space,
 /area/solar/port)
 "azL" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port)
 "azN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port)
-"azP" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -10789,10 +10752,10 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "azR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -10802,7 +10765,7 @@
 	name = "Port Solar Access";
 	req_access_txt = "10"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -10832,7 +10795,7 @@
 	name = "Fore Primary Hallway APC";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -10844,7 +10807,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aAc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10857,7 +10820,7 @@
 /area/hallway/primary/fore)
 "aAd" = (
 /obj/machinery/light,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10869,7 +10832,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aAe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10990,7 +10953,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aAu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11023,7 +10986,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "aAz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11055,7 +11018,7 @@
 	name = "AI Upload Access";
 	req_access_txt = "16"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11075,7 +11038,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -11085,7 +11048,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/button/door{
@@ -11131,7 +11094,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aAK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11181,7 +11144,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "aAU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11221,7 +11184,7 @@
 	},
 /area/maintenance/department/security/brig)
 "aBc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11286,7 +11249,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aBl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -11322,7 +11285,7 @@
 	name = "Bridge";
 	req_access_txt = "19"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11380,7 +11343,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aBv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -11392,7 +11355,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -11410,7 +11373,7 @@
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -11424,7 +11387,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aBy" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11521,7 +11484,7 @@
 	name = "Central Hall APC";
 	pixel_x = -25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -11532,7 +11495,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aBJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -11663,7 +11626,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11675,13 +11638,13 @@
 "aCa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/space,
 /area/solar/port)
@@ -11702,7 +11665,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "aCg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11712,7 +11675,7 @@
 /area/maintenance/department/security/brig)
 "aCh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -11924,7 +11887,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aCz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -11932,7 +11895,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aCA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -11941,7 +11904,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aCB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11950,7 +11913,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aCC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/camera{
@@ -11972,7 +11935,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
 "aCE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12078,7 +12041,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "aCO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -12115,7 +12078,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aCT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12124,7 +12087,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aCU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12141,7 +12104,7 @@
 	name = "Head of Personnel";
 	req_access_txt = "57"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12153,10 +12116,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aCW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction/flip{
@@ -12168,7 +12131,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aCX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12182,10 +12145,10 @@
 /area/hallway/primary/central)
 "aCY" = (
 /obj/machinery/holopad,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12289,7 +12252,7 @@
 	},
 /area/crew_quarters/dorms)
 "aDl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -12299,7 +12262,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aDm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12358,7 +12321,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aDw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -12377,7 +12340,7 @@
 	},
 /area/storage/primary)
 "aDx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -12438,7 +12401,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aDG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12455,7 +12418,7 @@
 	name = "Captain's Office";
 	req_access_txt = "20"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12467,10 +12430,10 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aDI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12541,7 +12504,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aDP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12564,7 +12527,7 @@
 	name = "Head of Personnel";
 	req_access_txt = "57"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12573,7 +12536,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "aDR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -12586,7 +12549,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aDS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12598,10 +12561,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aDT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12613,7 +12576,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aDU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12625,7 +12588,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aDV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12634,22 +12597,22 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "aDW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "aDX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12663,7 +12626,7 @@
 	name = "Head of Personnel APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/carpet,
@@ -12672,7 +12635,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aEa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -12737,7 +12700,7 @@
 /turf/closed/wall,
 /area/maintenance/department/cargo)
 "aEk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -12795,7 +12758,7 @@
 	name = "Detective's Office APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -12834,7 +12797,7 @@
 	},
 /area/storage/primary)
 "aEu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -12889,7 +12852,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aEB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -13033,7 +12996,7 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-24"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
@@ -13058,7 +13021,7 @@
 /obj/machinery/computer/card{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -13123,7 +13086,7 @@
 	pixel_x = -24
 	},
 /obj/item/storage/toolbox,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/airalarm{
@@ -13215,7 +13178,7 @@
 "aFk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/lootdrop/minor/bowler_or_that,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -13224,7 +13187,7 @@
 	},
 /area/maintenance/department/security/brig)
 "aFm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13241,7 +13204,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/detective,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13250,7 +13213,7 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "aFp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13288,7 +13251,7 @@
 	},
 /area/storage/primary)
 "aFt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -13343,7 +13306,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -13382,7 +13345,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aFE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -13398,7 +13361,7 @@
 	name = "Starboard Emergency Storage APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -13410,7 +13373,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aFH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13419,7 +13382,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aFI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13428,7 +13391,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aFJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -13439,7 +13402,7 @@
 	name = "Unisex Showers";
 	req_access_txt = "0"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13448,7 +13411,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aFL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -13463,7 +13426,7 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13507,13 +13470,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aFU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -13530,7 +13493,7 @@
 	name = "Detective Maintenance";
 	req_access_txt = "4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13542,7 +13505,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aFW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13570,7 +13533,7 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "aGa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -13768,7 +13731,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aGv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -13801,7 +13764,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aGA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -13831,7 +13794,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aGG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13857,7 +13820,7 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13918,7 +13881,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Primary Tool Storage"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -13973,7 +13936,7 @@
 	name = "bridge blast door"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -14026,7 +13989,7 @@
 /area/bridge)
 "aHf" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -14072,17 +14035,17 @@
 "aHi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "aHj" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -14090,7 +14053,7 @@
 "aHk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -14104,7 +14067,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -14117,14 +14080,14 @@
 	req_access_txt = "0"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
 "aHo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
@@ -14180,13 +14143,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "aHC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/junction{
@@ -14227,7 +14190,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14351,7 +14314,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction,
@@ -14394,7 +14357,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14406,7 +14369,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14482,7 +14445,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -14521,7 +14484,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aIi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14550,7 +14513,7 @@
 	pixel_x = 26
 	},
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14590,14 +14553,14 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aIH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -14621,46 +14584,46 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -14669,10 +14632,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -14682,10 +14645,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -14694,35 +14657,35 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/observer_start,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -14750,10 +14713,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -14763,7 +14726,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -14776,7 +14739,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -14790,30 +14753,30 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14822,7 +14785,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJk" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14835,7 +14798,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -14845,7 +14808,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14860,7 +14823,7 @@
 	name = "Unisex Restrooms";
 	req_access_txt = "0"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14869,7 +14832,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aJo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14882,7 +14845,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aJq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -14900,7 +14863,7 @@
 	},
 /area/maintenance/department/cargo)
 "aJr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -14914,7 +14877,7 @@
 	},
 /area/maintenance/department/cargo)
 "aJs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -14926,7 +14889,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aJt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -14941,10 +14904,10 @@
 	},
 /area/maintenance/department/cargo)
 "aJv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -14993,7 +14956,7 @@
 	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -15042,7 +15005,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -15056,7 +15019,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -15121,7 +15084,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -15195,7 +15158,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -15279,13 +15242,13 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/oil,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aKn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -15343,7 +15306,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "aKD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15360,7 +15323,7 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "aKE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -15371,7 +15334,7 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "aKG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -15411,7 +15374,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Storage"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -15431,7 +15394,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Cafeteria"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -15448,7 +15411,7 @@
 	id_tag = "Potty1";
 	name = "Unisex Restrooms"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -15466,7 +15429,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -15507,7 +15470,7 @@
 /area/storage/eva)
 "aLc" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -15536,7 +15499,7 @@
 	req_access_txt = "31"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -15547,7 +15510,7 @@
 /area/maintenance/department/cargo)
 "aLj" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -15623,7 +15586,7 @@
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aLy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -15675,7 +15638,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/cafeteria)
 "aLC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -15704,7 +15667,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "aLF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -15714,7 +15677,7 @@
 /obj/structure/urinal{
 	pixel_y = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/button/door{
@@ -15801,7 +15764,7 @@
 	name = "Teleporter APC";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/airalarm{
@@ -15813,26 +15776,26 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aLX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aLY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aLZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -16017,7 +15980,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16028,7 +15991,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16039,7 +16002,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16056,7 +16019,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16074,7 +16037,7 @@
 	c_tag = "Cargo Warehouse";
 	dir = 2
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16085,7 +16048,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16102,7 +16065,7 @@
 	pixel_x = 26
 	},
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16115,7 +16078,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aMx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -16127,7 +16090,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aMy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -16152,7 +16115,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aMB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -16164,7 +16127,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aMC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -16277,7 +16240,7 @@
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aMW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -16298,7 +16261,7 @@
 "aMX" = (
 /obj/structure/table,
 /obj/item/airlock_painter,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -16403,7 +16366,7 @@
 /obj/item/crowbar,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
@@ -16411,7 +16374,7 @@
 	},
 /area/maintenance/department/crew_quarters/bar)
 "aNj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -16484,7 +16447,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aNv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -16644,7 +16607,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16667,7 +16630,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aNR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -16784,7 +16747,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aOm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16870,10 +16833,10 @@
 	},
 /area/maintenance/department/crew_quarters/bar)
 "aOx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -16883,7 +16846,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aOy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16892,7 +16855,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aOz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16901,7 +16864,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aOA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -16964,7 +16927,7 @@
 /area/teleporter)
 "aOF" = (
 /obj/structure/chair/stool,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -16977,7 +16940,7 @@
 /area/teleporter)
 "aOG" = (
 /obj/structure/chair/stool,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16987,7 +16950,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aOH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -16997,7 +16960,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aOI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17015,7 +16978,7 @@
 	id = "teleshutter";
 	name = "Teleporter Shutters"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17025,7 +16988,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aOK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17038,10 +17001,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -17051,7 +17014,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -17064,13 +17027,13 @@
 /area/hallway/primary/central)
 "aON" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "aOO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/table,
@@ -17168,7 +17131,7 @@
 "aOY" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -17327,7 +17290,7 @@
 	name = "Bar Maintenance APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -17341,7 +17304,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aPG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -17536,7 +17499,7 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -17712,7 +17675,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aQF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17721,7 +17684,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aQG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17730,10 +17693,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aQH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17747,7 +17710,7 @@
 	},
 /area/maintenance/department/crew_quarters/bar)
 "aQI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17761,7 +17724,7 @@
 "aQJ" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17773,7 +17736,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "aQK" = (
 /obj/structure/grille,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17783,7 +17746,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "aQL" = (
 /obj/structure/grille/broken,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17793,7 +17756,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "aQM" = (
 /obj/item/reagent_containers/glass/bucket,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17802,7 +17765,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aQN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17811,13 +17774,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aQO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17826,7 +17789,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aQP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17838,10 +17801,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aQQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17858,7 +17821,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17903,7 +17866,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aQX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/broken_bottle,
@@ -17924,7 +17887,7 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/crowbar,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -17935,7 +17898,7 @@
 /turf/open/floor/plasteel,
 /area/storage/eva)
 "aRa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -18040,7 +18003,7 @@
 	name = "Delivery Office APC";
 	pixel_x = 28
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
@@ -18060,7 +18023,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -18268,14 +18231,14 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aRJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aRK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -18289,7 +18252,7 @@
 	name = "Hydroponics Maintenance";
 	req_access_txt = "35"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -18300,7 +18263,7 @@
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
 "aRO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -18327,7 +18290,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aRR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/chair/wood/normal{
@@ -18339,7 +18302,7 @@
 	},
 /area/crew_quarters/bar)
 "aRS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -18348,7 +18311,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aRT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -18361,7 +18324,7 @@
 	name = "Bar Storage Maintenance";
 	req_access_txt = "25"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -18370,7 +18333,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aRV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -18379,10 +18342,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aRW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/chair,
@@ -18394,7 +18357,7 @@
 	name = "EVA Maintenance";
 	req_access_txt = "18"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -18472,7 +18435,7 @@
 "aSh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -18488,7 +18451,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -18512,7 +18475,7 @@
 	name = "Cargo Maintenance APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -18532,14 +18495,14 @@
 	name = "Disposal APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aSu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -18577,7 +18540,7 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "aSz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18592,7 +18555,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aSB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -18641,7 +18604,7 @@
 	req_access_txt = "28"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -18706,7 +18669,7 @@
 	},
 /area/crew_quarters/bar)
 "aSO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -18733,7 +18696,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aSS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -18742,10 +18705,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aST" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -18754,7 +18717,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aSV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -18857,7 +18820,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
@@ -18874,7 +18837,7 @@
 	departmentType = 2;
 	pixel_y = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -18889,7 +18852,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -18961,16 +18924,16 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aTu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aTv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -18979,10 +18942,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aTw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction/yjunction{
@@ -18994,7 +18957,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aTx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -19010,7 +18973,7 @@
 	name = "Disposal Access";
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -19022,7 +18985,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aTz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -19034,7 +18997,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aTA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -19046,7 +19009,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aTB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -19058,7 +19021,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aTC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/solar{
@@ -19078,7 +19041,7 @@
 /turf/open/space,
 /area/solar/starboard)
 "aTE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/solar{
@@ -19164,7 +19127,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aTR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -19222,7 +19185,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aTY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19268,7 +19231,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/bar)
 "aUd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -19465,7 +19428,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aUC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -19475,19 +19438,19 @@
 "aUD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/space,
 /area/solar/starboard)
 "aUG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -19505,7 +19468,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -19520,7 +19483,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -19531,7 +19494,7 @@
 	},
 /area/hallway/primary/central)
 "aUK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -19540,10 +19503,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aUL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -19553,7 +19516,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aUM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -19564,7 +19527,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aUN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19576,7 +19539,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aUO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19586,7 +19549,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aUP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -19632,7 +19595,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aUT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
@@ -19643,7 +19606,7 @@
 	name = "Hydroponics APC";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
@@ -19661,7 +19624,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aUY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -19708,7 +19671,7 @@
 	name = "Bar Storage";
 	req_access_txt = "25"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -19836,7 +19799,7 @@
 	name = "Theatre Maintenance";
 	req_access_txt = "46"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -19994,7 +19957,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aVE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -20190,14 +20153,14 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aWe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aWf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/requests_console{
@@ -20216,7 +20179,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aWg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -20228,7 +20191,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/item/radio/intercom{
@@ -20263,7 +20226,7 @@
 	name = "Theatre APC";
 	pixel_x = -25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -20279,7 +20242,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aWo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/mime,
@@ -20299,7 +20262,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aWp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20321,7 +20284,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20343,7 +20306,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aWr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -21899,7 +21862,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aZv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -21911,7 +21874,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aZw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -22037,7 +22000,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aZJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22054,7 +22017,7 @@
 	name = "Security Checkpoint";
 	req_access_txt = "1"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22073,7 +22036,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aZL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -22083,10 +22046,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22126,7 +22089,7 @@
 	name = "Custodial Closet APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -22359,7 +22322,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bav" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -22372,7 +22335,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "baw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22390,7 +22353,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "baA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22400,7 +22363,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "baB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22417,16 +22380,16 @@
 	name = "Cargo Bay APC";
 	pixel_y = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "baD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
@@ -22439,7 +22402,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "baE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -22468,7 +22431,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "baI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/solar{
@@ -22595,7 +22558,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "baV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22634,7 +22597,7 @@
 	pixel_x = -25;
 	req_access_txt = "26"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -22644,7 +22607,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -22657,7 +22620,7 @@
 	departmentType = 1;
 	pixel_x = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -22851,7 +22814,7 @@
 	name = "Cargo Office Maintenance";
 	req_access_txt = "50"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22891,7 +22854,7 @@
 	name = "Quartermaster";
 	req_access_txt = "41"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22912,7 +22875,7 @@
 /area/quartermaster/miningdock)
 "bbJ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22934,7 +22897,7 @@
 /area/quartermaster/miningdock)
 "bbL" = (
 /obj/machinery/power/smes,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -22943,24 +22906,24 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "bbO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -23028,7 +22991,7 @@
 "bbX" = (
 /obj/structure/janitorialcart,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -23247,7 +23210,7 @@
 	},
 /area/maintenance/department/cargo)
 "bcz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -23273,7 +23236,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bcB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -23322,7 +23285,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bcE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -23361,10 +23324,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bcH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -23372,13 +23335,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bcI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bcJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -23388,10 +23351,10 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "bcK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -23516,7 +23479,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -23649,7 +23612,7 @@
 	},
 /area/maintenance/department/cargo)
 "bdB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -23658,7 +23621,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bdC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -23667,7 +23630,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bdD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -23679,7 +23642,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bdE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -23688,7 +23651,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bdF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -23709,7 +23672,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bdG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -23742,7 +23705,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/shaft_miner,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -23768,7 +23731,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bdQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -23782,12 +23745,12 @@
 	},
 /area/maintenance/department/cargo)
 "bdR" = (
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Starboard Solar APC";
 	pixel_x = -24
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "bdS" = (
@@ -23854,7 +23817,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bec" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -24222,7 +24185,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "beN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -24242,7 +24205,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "beR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -24257,13 +24220,13 @@
 "beU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/space,
 /area/solar/starboard)
@@ -24305,14 +24268,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bfc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bfd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -24325,7 +24288,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -24335,7 +24298,7 @@
 /area/hallway/secondary/entry)
 "bff" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -24344,7 +24307,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bfg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -24353,10 +24316,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bfh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -24368,7 +24331,7 @@
 	name = "Custodial Closet";
 	req_access_txt = "26"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -24484,7 +24447,7 @@
 	name = "Mech Bay APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -24500,7 +24463,7 @@
 /area/science/robotics/mechbay)
 "bfy" = (
 /obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/status_display/evac{
@@ -24513,7 +24476,7 @@
 /area/science/robotics/mechbay)
 "bfA" = (
 /obj/machinery/computer/mech_bay_power_console,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -24604,7 +24567,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bfF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/shaft_miner,
@@ -24689,7 +24652,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Lounge"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -24734,7 +24697,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -24956,7 +24919,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bgF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -24971,7 +24934,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bgH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green,
@@ -24980,7 +24943,7 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "bgJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
@@ -24993,7 +24956,7 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "bgK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -25007,7 +24970,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bgL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -25041,7 +25004,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/lounge)
 "bgW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -25069,10 +25032,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/lounge)
 "bgZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -25082,7 +25045,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bha" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25094,7 +25057,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bhb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25106,7 +25069,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bhc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25193,10 +25156,10 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bhl" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25208,7 +25171,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bhm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25223,13 +25186,13 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bhn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25238,7 +25201,7 @@
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "bho" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25251,7 +25214,7 @@
 	name = "Mech Bay Maintenance";
 	req_access_txt = "29"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25260,10 +25223,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bhq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25276,7 +25239,7 @@
 	name = "Mining Maintenance";
 	req_access_txt = "48"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25288,10 +25251,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bhs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25311,7 +25274,7 @@
 /area/quartermaster/miningdock)
 "bht" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25350,7 +25313,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bhz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25365,7 +25328,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -25391,7 +25354,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/lounge)
 "bhH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -25417,7 +25380,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bhK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -25490,7 +25453,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bhS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -25527,13 +25490,13 @@
 /area/crew_quarters/lounge)
 "bic" = (
 /obj/effect/landmark/start/assistant,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/lounge)
 "bid" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
@@ -25542,7 +25505,7 @@
 /obj/structure/chair/comfy/beige{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -25692,7 +25655,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
 "bix" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/robot_debris{
@@ -25701,7 +25664,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "biy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
@@ -25710,10 +25673,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "biz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25725,7 +25688,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "biC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25749,7 +25712,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -25841,7 +25804,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/sign/departments/examroom{
@@ -25970,7 +25933,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -26049,7 +26012,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -26059,7 +26022,7 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "bjD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26071,7 +26034,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -26080,7 +26043,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -26142,7 +26105,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -26154,7 +26117,7 @@
 	name = "Morgue APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -26397,7 +26360,7 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "bkw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -26513,7 +26476,7 @@
 "bkY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -26533,7 +26496,7 @@
 	name = "Port Emergency Storage APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -26566,7 +26529,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "blf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -26890,10 +26853,10 @@
 	dir = 2;
 	sortType = 14
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -26914,7 +26877,7 @@
 	name = "Robotics Lab APC";
 	pixel_y = 25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -27019,7 +26982,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bmd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating{
@@ -27027,7 +26990,7 @@
 	},
 /area/maintenance/department/engine)
 "bme" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -27036,13 +26999,13 @@
 	},
 /area/maintenance/department/engine)
 "bmf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bmg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -27053,7 +27016,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bmh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -27065,10 +27028,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -27078,10 +27041,10 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -27135,7 +27098,7 @@
 	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/camera{
@@ -27154,7 +27117,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27311,7 +27274,7 @@
 /area/science/robotics/lab)
 "bmP" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27481,7 +27444,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bnu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
@@ -27498,7 +27461,7 @@
 	req_access_txt = "0";
 	req_one_access_txt = "5;9"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -27563,7 +27526,7 @@
 	name = "Medbay Security Post";
 	req_access_txt = "63"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -27713,7 +27676,7 @@
 /area/science/robotics/lab)
 "bnR" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -27855,7 +27818,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "boq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -27902,7 +27865,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "box" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -27986,7 +27949,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28376,7 +28339,7 @@
 /area/hallway/secondary/entry)
 "bpu" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -28428,7 +28391,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bpA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -28464,7 +28427,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "bpE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -28473,7 +28436,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "bpF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -28490,7 +28453,7 @@
 	opacity = 1;
 	req_access_txt = "6"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28499,7 +28462,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bpH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28508,14 +28471,14 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bpI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bpJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -28528,10 +28491,10 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bpK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28548,7 +28511,7 @@
 /area/engine/engineering)
 "bpM" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/grunge{
@@ -28565,10 +28528,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -28580,7 +28543,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -28771,7 +28734,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -28780,7 +28743,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -28789,7 +28752,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -28814,13 +28777,13 @@
 	name = "Server Room APC";
 	pixel_x = -25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "bqm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -29001,7 +28964,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -29019,7 +28982,7 @@
 	id = "xenobio5";
 	name = "containment blast door"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -29030,10 +28993,10 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/engine,
@@ -29044,7 +29007,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -29062,7 +29025,7 @@
 	id = "xenobio6";
 	name = "containment blast door"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -29073,10 +29036,10 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/engine,
@@ -29086,7 +29049,7 @@
 	req_access_txt = "0";
 	req_one_access_txt = "12; 55"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29100,7 +29063,7 @@
 	areastring = "/area/hallway/secondary/entry";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -29154,10 +29117,10 @@
 /area/medical/genetics)
 "bqX" = (
 /obj/machinery/holopad,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -29167,7 +29130,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bqY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -29177,7 +29140,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bqZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -29196,7 +29159,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -29209,7 +29172,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -29221,13 +29184,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "brc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -29244,7 +29207,7 @@
 	name = "Medbay APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
@@ -29488,7 +29451,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "brx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -29575,7 +29538,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "brE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -29721,7 +29684,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -29752,7 +29715,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -29786,7 +29749,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bsm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -29852,7 +29815,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bst" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29892,7 +29855,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "bsy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -30098,7 +30061,7 @@
 	name = "Research Lab APC";
 	pixel_x = 26
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -30143,7 +30106,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bsX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -30234,7 +30197,7 @@
 	name = "Server Room";
 	req_access_txt = "30"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -30353,7 +30316,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "btx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30385,7 +30348,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "btB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -30398,29 +30361,29 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "btF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/blobstart,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -30465,7 +30428,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "btN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
@@ -30475,7 +30438,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "btO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -30487,7 +30450,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "btP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -30499,10 +30462,10 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -30543,7 +30506,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30715,7 +30678,7 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "bus" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -30759,7 +30722,7 @@
 /area/hallway/primary/aft)
 "buv" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -30787,7 +30750,7 @@
 /area/science/explab)
 "bux" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -30906,7 +30869,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -30918,7 +30881,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -30930,7 +30893,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -30939,13 +30902,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -30954,7 +30917,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -30981,7 +30944,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -30995,7 +30958,7 @@
 /area/maintenance/department/engine)
 "bvb" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -31008,7 +30971,7 @@
 	name = "Genetics";
 	req_access_txt = "9"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31045,19 +31008,19 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "bvg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "bvh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction/flip{
@@ -31070,7 +31033,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
@@ -31079,7 +31042,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
@@ -31089,7 +31052,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
@@ -31188,7 +31151,7 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "bvz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -31236,7 +31199,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -31327,7 +31290,7 @@
 	name = "Research Division APC";
 	pixel_y = 25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -31353,7 +31316,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -31515,7 +31478,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bwf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -31548,7 +31511,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -31578,7 +31541,7 @@
 /area/maintenance/department/engine)
 "bwt" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
@@ -31631,7 +31594,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31693,7 +31656,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "bwC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -31872,7 +31835,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -31885,7 +31848,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bxe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -31899,7 +31862,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bxf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31914,10 +31877,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bxg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31930,7 +31893,7 @@
 /area/science/lab)
 "bxh" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31948,7 +31911,7 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "bxi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -31966,7 +31929,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bxj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
@@ -31978,7 +31941,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bxm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -31991,13 +31954,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bxn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32007,7 +31970,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32026,7 +31989,7 @@
 	name = "research shutters"
 	},
 /obj/machinery/door/firedoor/heavy,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -32043,7 +32006,7 @@
 	name = "Research Division Access";
 	req_access_txt = "47"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32052,7 +32015,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -32062,7 +32025,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -32081,7 +32044,7 @@
 	name = "Research Division Access";
 	req_access_txt = "47"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32090,10 +32053,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32103,7 +32066,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -32115,11 +32078,11 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32131,7 +32094,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32140,7 +32103,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -32150,7 +32113,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32160,7 +32123,7 @@
 /area/science/explab)
 "bxA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32274,7 +32237,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -32311,7 +32274,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -32344,7 +32307,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -32382,7 +32345,7 @@
 /area/maintenance/department/engine)
 "byc" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
@@ -32435,7 +32398,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "byi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32485,7 +32448,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "bym" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -32543,7 +32506,7 @@
 	id = "cmoshutters";
 	name = "Privacy shutters"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -32555,7 +32518,7 @@
 	name = "Chemistry APC";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32569,7 +32532,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "byx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -32621,7 +32584,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -32633,7 +32596,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -32653,11 +32616,11 @@
 /area/science/lab)
 "byG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -32729,7 +32692,7 @@
 /area/hallway/primary/aft)
 "byM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/navbeacon{
@@ -32890,7 +32853,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -32992,7 +32955,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -33010,7 +32973,7 @@
 	name = "Containment Pen #1";
 	req_access_txt = "55"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -33021,7 +32984,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/cable,
@@ -33033,7 +32996,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -33046,7 +33009,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/engine,
@@ -33057,7 +33020,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -33075,7 +33038,7 @@
 	name = "Containment Pen #3";
 	req_access_txt = "55"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -33086,7 +33049,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/cable,
@@ -33129,7 +33092,7 @@
 "bzD" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
@@ -33179,7 +33142,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bzJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33218,7 +33181,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "bzN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/green,
@@ -33336,7 +33299,7 @@
 /area/crew_quarters/heads/cmo)
 "bzZ" = (
 /obj/machinery/suit_storage_unit/cmo,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -33369,7 +33332,7 @@
 /area/crew_quarters/heads/cmo)
 "bAb" = (
 /obj/machinery/computer/med_data,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -33406,7 +33369,7 @@
 	pixel_x = 38;
 	req_access_txt = "40"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -33432,7 +33395,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bAf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -33508,7 +33471,7 @@
 	req_one_access_txt = "7;29"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -33520,13 +33483,13 @@
 	id = "rdprivacy";
 	name = "Privacy shutters"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "bAp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -33536,10 +33499,10 @@
 	req_one_access_txt = "0"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -33557,10 +33520,10 @@
 	id = "rdprivacy";
 	name = "Privacy shutters"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -33572,10 +33535,10 @@
 	id = "rdprivacy";
 	name = "Privacy shutters"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -33600,7 +33563,7 @@
 /area/hallway/primary/aft)
 "bAw" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -33643,7 +33606,7 @@
 /area/science/explab)
 "bAD" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -33697,7 +33660,7 @@
 /area/hallway/secondary/entry)
 "bAM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/extinguisher,
@@ -33758,7 +33721,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bAT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33801,7 +33764,7 @@
 	name = "Virology Exterior Airlock";
 	req_access_txt = "39"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/doorButtons/access_button{
@@ -33866,13 +33829,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -33884,7 +33847,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bBh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -33904,10 +33867,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -33922,7 +33885,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -33943,10 +33906,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/computer/security/telescreen/cmo{
@@ -33966,7 +33929,7 @@
 	name = "Chemistry Lab Maintenance";
 	req_access_txt = "5; 33"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -33993,7 +33956,7 @@
 	name = "RD Office APC";
 	pixel_x = -25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -34005,7 +33968,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -34109,7 +34072,7 @@
 /area/security/checkpoint/science)
 "bBz" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -34189,7 +34152,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bBI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -34256,7 +34219,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -34401,7 +34364,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -34410,7 +34373,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
@@ -34421,7 +34384,7 @@
 	name = "Genetics APC";
 	pixel_x = 27
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -34443,7 +34406,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bCg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -34583,7 +34546,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -34645,7 +34608,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bCv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -34655,7 +34618,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -34671,7 +34634,7 @@
 	name = "CMO Maintenance";
 	req_access_txt = "40"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -34683,7 +34646,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bCx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -34698,10 +34661,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bCy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -34712,7 +34675,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bCz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -34724,7 +34687,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bCA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
@@ -34739,7 +34702,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bCB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -34748,7 +34711,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -34762,7 +34725,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -34821,7 +34784,7 @@
 	id = "rdprivacy";
 	name = "Privacy shutters"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -34834,7 +34797,7 @@
 	network = list("ss13","rd")
 	},
 /obj/item/book/manual/wiki/security_space_law,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -34851,7 +34814,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -34913,7 +34876,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -34936,7 +34899,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bDa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -35031,7 +34994,7 @@
 "bDj" = (
 /obj/item/trash/candy,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -35086,7 +35049,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bDp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -35122,7 +35085,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -35192,7 +35155,7 @@
 /turf/closed/wall,
 /area/medical/exam_room)
 "bDz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -35254,7 +35217,7 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -35267,10 +35230,10 @@
 /area/security/checkpoint/science)
 "bDH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -35335,14 +35298,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/engine,
 /area/science/storage)
 "bDQ" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35358,7 +35321,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/storage)
 "bDR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35373,13 +35336,13 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bDS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -35388,7 +35351,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bDT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -35407,7 +35370,7 @@
 	name = "Toxins Lab";
 	req_access_txt = "8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35432,7 +35395,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bDV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -35444,7 +35407,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bDW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35453,13 +35416,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bDX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bDY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -35469,10 +35432,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/white,
@@ -35596,7 +35559,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bEo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -35605,14 +35568,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bEp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bEq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -35635,7 +35598,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bEt" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -35858,7 +35821,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bEI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/closet,
@@ -35874,7 +35837,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/exam_room)
 "bEJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
@@ -35891,7 +35854,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/exam_room)
 "bEK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/button/door{
@@ -35913,7 +35876,7 @@
 	name = "Personal Examination Room";
 	req_access_txt = "40"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35922,11 +35885,11 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/exam_room)
 "bEM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -36068,10 +36031,10 @@
 /area/security/checkpoint/science)
 "bEX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -36087,7 +36050,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/closet/secure_closet/security/science,
@@ -36136,7 +36099,7 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "bFd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
@@ -36200,7 +36163,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white,
@@ -36220,7 +36183,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -36359,7 +36322,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bFG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -36410,7 +36373,7 @@
 	name = "Virology Interior Airlock";
 	req_access_txt = "39"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/doorButtons/access_button{
@@ -36517,7 +36480,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/exam_room)
 "bFY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -36540,7 +36503,7 @@
 	name = "Research Security Post";
 	req_access_txt = "63"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36614,7 +36577,7 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "bGi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -36832,7 +36795,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -36945,7 +36908,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bGN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -37001,7 +36964,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bGT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -37013,7 +36976,7 @@
 	name = "Virology APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -37236,7 +37199,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -37287,7 +37250,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -37329,7 +37292,7 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "bHv" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/sign/poster/random{
@@ -37393,7 +37356,7 @@
 	name = "Toxins Chamber APC";
 	pixel_x = 26
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -37790,7 +37753,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/navbeacon{
@@ -37804,7 +37767,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
@@ -37817,7 +37780,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -37829,7 +37792,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -37839,24 +37802,24 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bIA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bIC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
@@ -37866,7 +37829,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bID" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -37898,17 +37861,17 @@
 	name = "Toxins Storage APC";
 	pixel_x = -25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/science/storage)
 "bIG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -37916,14 +37879,14 @@
 /area/science/storage)
 "bIH" = (
 /obj/machinery/light,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/science/storage)
 "bII" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -37935,7 +37898,7 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "bIJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/engine,
@@ -38299,7 +38262,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bJy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -38316,7 +38279,7 @@
 	name = "Surgery Maintenance";
 	req_access_txt = "45"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38325,10 +38288,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bJA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -38338,7 +38301,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bJB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -38489,7 +38452,7 @@
 	name = "Toxins Storage";
 	req_access_txt = "24"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -38574,13 +38537,13 @@
 /area/chapel/dock)
 "bKb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bKc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -38591,7 +38554,7 @@
 	name = "Monastery Docking Bay APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -38831,7 +38794,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bKH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -38847,7 +38810,7 @@
 /area/hallway/primary/aft)
 "bKJ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -38902,7 +38865,7 @@
 	name = "Atmospherics APC";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -38921,7 +38884,7 @@
 	dir = 2;
 	pixel_y = 22
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -38943,7 +38906,7 @@
 	name = "Head of Security RC";
 	pixel_y = 30
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -38961,7 +38924,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 26
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -38979,10 +38942,10 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -39080,7 +39043,7 @@
 /area/chapel/dock)
 "bLo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -39488,7 +39451,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -39572,7 +39535,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bMs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -39833,7 +39796,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bMS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39979,7 +39942,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -40071,7 +40034,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -40264,10 +40227,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bNY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -40277,7 +40240,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bNZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -40289,7 +40252,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bOa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -40302,10 +40265,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bOb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -40430,7 +40393,7 @@
 	dir = 1;
 	name = "Pure to Mix"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -40477,7 +40440,7 @@
 /turf/open/floor/plating/asteroid,
 /area/chapel/asteroid/monastery)
 "bOx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -40531,7 +40494,7 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "bOF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -40543,7 +40506,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bOG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -40552,7 +40515,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bOH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -40565,7 +40528,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bOI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -40577,7 +40540,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bOJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -40761,7 +40724,7 @@
 /area/engine/atmos)
 "bPc" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -40813,7 +40776,7 @@
 	name = "Chapel";
 	opacity = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -40862,7 +40825,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bPs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -40874,7 +40837,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -40962,7 +40925,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bPH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -41053,7 +41016,7 @@
 /area/engine/atmos)
 "bPV" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -41111,7 +41074,7 @@
 /turf/open/floor/plating/asteroid,
 /area/chapel/asteroid/monastery)
 "bQf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/sand,
@@ -41357,7 +41320,7 @@
 	pixel_x = -25;
 	pixel_y = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -41367,10 +41330,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bQC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/navbeacon{
@@ -41514,7 +41477,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bQU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -41526,7 +41489,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bQV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -41536,7 +41499,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bQW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -41551,10 +41514,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -41566,7 +41529,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -41645,7 +41608,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/chair/office{
@@ -41657,7 +41620,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -41667,7 +41630,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -41677,7 +41640,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -41689,7 +41652,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -41698,7 +41661,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -41710,7 +41673,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -41899,7 +41862,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -41909,7 +41872,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -41924,7 +41887,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -41933,7 +41896,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -42010,13 +41973,13 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bRT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -42026,7 +41989,7 @@
 	name = "Tech Storage";
 	req_access_txt = "23"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42036,7 +41999,7 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bRV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -42048,22 +42011,22 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bRW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bRX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bRY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -42072,7 +42035,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bRZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
@@ -42144,7 +42107,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/trinary/mixer{
@@ -42280,7 +42243,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -42291,7 +42254,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
@@ -42300,7 +42263,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall,
@@ -42315,7 +42278,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -42326,7 +42289,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/beacon,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -42338,7 +42301,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -42351,7 +42314,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -42364,7 +42327,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -42375,7 +42338,7 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bSK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42414,7 +42377,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bSO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42632,20 +42595,20 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "bTs" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes{
@@ -42817,7 +42780,7 @@
 	name = "Engineering";
 	req_one_access_txt = "10;24"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -43095,7 +43058,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -43106,14 +43069,14 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bUm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -43204,7 +43167,7 @@
 /area/engine/atmos)
 "bUw" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -43378,16 +43341,16 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "bUP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/closed/wall,
 /area/engine/engine_smes)
 "bUQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/engineering,
@@ -43400,10 +43363,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bUR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/engineering,
@@ -43420,7 +43383,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bUS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/engineering,
@@ -43464,7 +43427,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/start/depsec/engineering,
@@ -43474,7 +43437,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -43491,7 +43454,7 @@
 	name = "Engineering Security Post";
 	req_access_txt = "63"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -43510,7 +43473,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -43523,10 +43486,10 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bVa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -43618,7 +43581,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bVj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
@@ -43776,7 +43739,7 @@
 	name = "CE Office APC";
 	pixel_x = 28
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/item/clothing/glasses/meson/engine,
@@ -43822,7 +43785,7 @@
 	pixel_y = 7
 	},
 /obj/item/storage/box/lights/mixed,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/airalarm{
@@ -43841,7 +43804,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -43868,7 +43831,7 @@
 	areastring = "/area/security/checkpoint/engineering";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -43880,7 +43843,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bVP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43914,7 +43877,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bVT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -44076,7 +44039,7 @@
 /area/crew_quarters/heads/chief)
 "bWq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -44159,10 +44122,10 @@
 /obj/item/stack/sheet/glass/fifty{
 	layer = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
@@ -44184,10 +44147,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bWw" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -44196,13 +44159,13 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bWx" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/start/station_engineer,
@@ -44212,7 +44175,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bWy" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -44293,7 +44256,7 @@
 	name = "engineering security door"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -44404,7 +44367,7 @@
 	name = "Chapel";
 	opacity = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -44431,14 +44394,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
 "bXe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -44470,7 +44433,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bXi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -44533,13 +44496,13 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bXm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bXn" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -44557,7 +44520,7 @@
 	name = "Engine Room";
 	req_access_txt = "10"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -44682,7 +44645,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -44699,12 +44662,15 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -44719,6 +44685,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXG" = (
@@ -44731,7 +44700,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bXI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -44785,7 +44754,7 @@
 /area/maintenance/department/engine)
 "bXY" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -44797,10 +44766,10 @@
 "bXZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -44810,15 +44779,15 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "bYa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/command{
@@ -44836,7 +44805,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bYd" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/modular_computer/console/preset/engineering,
@@ -44853,7 +44822,7 @@
 /area/engine/engine_smes)
 "bYg" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -44864,7 +44833,7 @@
 	name = "Power Storage";
 	req_access_txt = "11"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -44894,7 +44863,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -44940,7 +44909,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/atmos{
@@ -44950,6 +44919,9 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bYv" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "bYw" = (
@@ -45010,7 +44982,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -45022,7 +44994,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45041,10 +45013,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -45061,10 +45033,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45082,7 +45054,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45108,7 +45080,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45126,10 +45098,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYP" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45147,7 +45119,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45165,7 +45137,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45190,7 +45162,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45211,10 +45183,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45232,16 +45204,16 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYU" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45263,7 +45235,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45273,13 +45245,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45300,7 +45272,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45325,7 +45297,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45350,7 +45322,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -45363,7 +45335,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZa" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45410,7 +45382,7 @@
 	dir = 2;
 	pixel_y = 22
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -45425,16 +45397,13 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
 	},
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45444,9 +45413,6 @@
 /area/maintenance/disposal/incinerator)
 "bZh" = (
 /obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -45454,6 +45420,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZi" = (
@@ -45483,7 +45450,7 @@
 	},
 /area/chapel/main/monastery)
 "bZn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -45535,7 +45502,7 @@
 /area/engine/engineering)
 "bZy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -45553,7 +45520,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -45576,7 +45543,7 @@
 /area/engine/engineering)
 "bZE" = (
 /obj/machinery/holopad,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -45668,7 +45635,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZP" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -45770,7 +45737,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "caj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -45820,7 +45787,7 @@
 /area/engine/engineering)
 "caq" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -45832,7 +45799,7 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -45951,7 +45918,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "caJ" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -45960,7 +45927,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "caK" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -45973,7 +45940,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "caL" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
@@ -45985,7 +45952,7 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "caM" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
@@ -45994,7 +45961,7 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "caN" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
@@ -46002,7 +45969,7 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "caO" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/igniter/incinerator_atmos,
@@ -46013,10 +45980,10 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "caP" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/compressor{
@@ -46032,7 +45999,7 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "caQ" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/turbine{
@@ -46086,13 +46053,13 @@
 	},
 /area/maintenance/department/engine)
 "cbc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -46117,7 +46084,7 @@
 	pixel_y = 3
 	},
 /obj/item/book/manual/wiki/engineering_construction,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -46164,7 +46131,7 @@
 /obj/effect/turf_decal/bot{
 	dir = 2
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -46307,7 +46274,7 @@
 "cbN" = (
 /obj/structure/table/wood,
 /obj/item/storage/book/bible,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -46372,7 +46339,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -46388,7 +46355,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/chair/office{
@@ -46414,7 +46381,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/emitter/anchored{
@@ -46427,10 +46394,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -46448,7 +46415,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/reflector/single/anchored{
@@ -46545,7 +46512,7 @@
 /turf/open/floor/plating/asteroid,
 /area/chapel/asteroid/monastery)
 "ccE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46615,7 +46582,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ccS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -46658,7 +46625,7 @@
 /area/engine/engineering)
 "cda" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -46846,15 +46813,15 @@
 /area/engine/engineering)
 "cdL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -47006,7 +46973,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cee" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
@@ -47016,7 +46983,7 @@
 /turf/open/floor/plasteel,
 /area/chapel/office)
 "cef" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/sand,
@@ -47028,7 +46995,7 @@
 	opacity = 1;
 	req_access_txt = "22"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47051,7 +47018,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -47102,9 +47069,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -47114,6 +47078,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -47136,7 +47103,7 @@
 /area/engine/engineering)
 "cex" = (
 /obj/item/screwdriver,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -47193,7 +47160,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -47202,7 +47169,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -47274,11 +47241,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -47298,7 +47265,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -47307,7 +47274,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/emitter/anchored{
@@ -47317,13 +47284,13 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cfc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cfe" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -47355,7 +47322,7 @@
 	name = "Chapel Access";
 	opacity = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -47404,7 +47371,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cfs" = (
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -47418,7 +47385,7 @@
 "cfw" = (
 /obj/item/wirecutters,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -47438,7 +47405,7 @@
 /turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cfD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -47467,7 +47434,7 @@
 	name = "Monastery APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -47583,7 +47550,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cfW" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -47673,7 +47640,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cgp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/wrench,
@@ -47690,7 +47657,7 @@
 	name = "Engineering External Access";
 	req_access_txt = "61"
 	},
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -47702,7 +47669,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cgv" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -47715,10 +47682,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cgw" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -47805,7 +47772,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
 	},
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -47827,10 +47794,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cgV" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -47868,7 +47835,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -47880,7 +47847,7 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
 "chj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/grass,
@@ -47962,7 +47929,7 @@
 	name = "Engineering External Access";
 	req_access_txt = "61"
 	},
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -48187,7 +48154,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ciD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -48267,7 +48234,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ciR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48469,11 +48436,11 @@
 /turf/open/floor/carpet,
 /area/library)
 "cjR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -48526,7 +48493,7 @@
 	charge = 5e+006
 	},
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -48659,7 +48626,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -48679,7 +48646,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -48860,7 +48827,7 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
 "clz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
@@ -48871,13 +48838,13 @@
 	name = "Telecommunications External Access";
 	req_access_txt = "61"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clB" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
@@ -48892,7 +48859,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -48924,7 +48891,7 @@
 	name = "Telecommunications External Access";
 	req_access_txt = "61"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -48962,7 +48929,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "clR" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -48977,7 +48944,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
@@ -48986,7 +48953,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/closed/wall,
@@ -48996,7 +48963,7 @@
 	dir = 9
 	},
 /obj/item/wrench,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -49013,10 +48980,10 @@
 /area/tcommsat/computer)
 "clY" = (
 /obj/item/beacon,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49026,7 +48993,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "clZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -49035,7 +49002,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cma" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49048,19 +49015,19 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49071,7 +49038,7 @@
 /area/tcommsat/computer)
 "cmd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -49124,7 +49091,7 @@
 	req_access_txt = "61"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -49134,7 +49101,7 @@
 	name = "Control Room";
 	req_access_txt = "19; 61"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49155,7 +49122,7 @@
 	areastring = "/area/tcommsat/computer";
 	pixel_y = 25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -49215,7 +49182,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmp" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply,
@@ -49304,7 +49271,7 @@
 	name = "Server Room";
 	req_access_txt = "61"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -49359,7 +49326,7 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
 "cmF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -49654,7 +49621,7 @@
 	name = "Dormitory APC";
 	pixel_y = 25
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/sign/poster/official/random{
@@ -49763,7 +49730,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cou" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -49786,7 +49753,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -49798,7 +49765,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -49811,7 +49778,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "coF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49822,7 +49789,7 @@
 	},
 /area/maintenance/department/crew_quarters/bar)
 "coG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49834,7 +49801,7 @@
 	},
 /area/maintenance/department/crew_quarters/bar)
 "coH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49845,7 +49812,7 @@
 	},
 /area/maintenance/department/crew_quarters/bar)
 "coJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49878,7 +49845,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "coW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -50383,7 +50350,7 @@
 /area/hallway/primary/aft)
 "cqv" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -50392,14 +50359,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -50489,7 +50456,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/chief_engineer,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -50708,7 +50675,7 @@
 	name = "Chapel Office APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -50748,7 +50715,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -50817,7 +50784,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -50896,7 +50863,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -50912,7 +50879,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -50928,7 +50895,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -50940,26 +50907,26 @@
 /turf/open/floor/plasteel,
 /area/chapel/office)
 "csN" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "csO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "csQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -51091,7 +51058,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ctK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -51103,13 +51070,13 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -51362,7 +51329,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51428,7 +51395,7 @@
 	name = "Garden APC";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/light/small{
@@ -51492,10 +51459,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -51504,14 +51471,14 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -51676,7 +51643,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvu" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51752,7 +51719,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvE" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -51762,7 +51729,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51781,10 +51748,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -51804,7 +51771,7 @@
 /area/chapel/main/monastery)
 "cvI" = (
 /obj/machinery/light/small,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51830,7 +51797,7 @@
 /area/chapel/main/monastery)
 "cvJ" = (
 /obj/machinery/light/small,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51853,7 +51820,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -51906,19 +51873,19 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/closed/wall/mineral/iron,
 /area/maintenance/department/chapel/monastery)
 "cvY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/closed/wall/mineral/iron,
 /area/maintenance/department/chapel/monastery)
 "cvZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/closed/wall/mineral/iron,
@@ -51927,7 +51894,7 @@
 /turf/closed/wall/mineral/iron,
 /area/maintenance/department/chapel/monastery)
 "cwc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -51944,7 +51911,7 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -51973,7 +51940,7 @@
 /area/chapel/main/monastery)
 "cwm" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -51982,7 +51949,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "cwn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/storage/toolbox/mechanical,
@@ -52000,10 +51967,10 @@
 	name = "Monastery Maintenance APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -52013,7 +51980,7 @@
 /area/maintenance/department/chapel/monastery)
 "cwp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -52025,7 +51992,7 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -52149,7 +52116,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -52213,7 +52180,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -52249,7 +52216,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -52298,7 +52265,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -52346,7 +52313,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -52382,7 +52349,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -52429,7 +52396,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -52961,7 +52928,7 @@
 	},
 /area/maintenance/department/crew_quarters/dorms)
 "cBx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52979,7 +52946,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "cBy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53122,7 +53089,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -53131,17 +53098,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "cCZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -53306,10 +53273,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "cZt" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -53345,7 +53312,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -53364,10 +53331,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "dgI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -53377,7 +53344,7 @@
 /area/maintenance/department/security/brig)
 "dhz" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53397,7 +53364,7 @@
 /area/maintenance/department/science)
 "dmT" = (
 /obj/machinery/shieldwallgen/xenobiologyaccess,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/sign/warning/electricshock{
@@ -53409,7 +53376,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
@@ -53427,7 +53394,7 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -53490,7 +53457,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
@@ -53530,10 +53497,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark,
@@ -53566,7 +53533,7 @@
 	},
 /area/maintenance/department/engine)
 "dJm" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/research/glass{
@@ -53578,7 +53545,7 @@
 "dKs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
@@ -53607,7 +53574,7 @@
 /area/maintenance/department/science)
 "dNr" = (
 /obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/sign/warning{
@@ -53651,7 +53618,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -53722,7 +53689,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -53799,7 +53766,7 @@
 	req_access_txt = "10"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53834,7 +53801,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -53856,27 +53823,27 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "eCw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "eCK" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "eDC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -53996,7 +53963,7 @@
 /area/science/xenobiology)
 "eQZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -54073,7 +54040,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -54146,7 +54113,7 @@
 /obj/item/storage/secure/safe{
 	pixel_x = -22
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54221,7 +54188,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "fpT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -54229,7 +54196,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "fsA" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -54263,7 +54230,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/wood,
@@ -54276,10 +54243,10 @@
 /area/engine/atmos)
 "fvb" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -54316,13 +54283,13 @@
 /area/science/mixing)
 "fwI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "fyF" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -54349,17 +54316,17 @@
 	dir = 1
 	},
 /obj/item/clothing/gloves/color/black,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
 "fAx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54451,7 +54418,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "fQf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -54550,7 +54517,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -54562,7 +54529,7 @@
 /turf/open/floor/plating,
 /area/chapel/office)
 "giO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54582,7 +54549,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -54656,7 +54623,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -54723,7 +54690,7 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "gpI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -54732,10 +54699,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -54886,23 +54853,23 @@
 /area/medical/chemistry)
 "gHZ" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "gIC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -54929,7 +54896,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -55143,10 +55110,10 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/engine,
@@ -55173,7 +55140,7 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "hwx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -55211,27 +55178,27 @@
 	dir = 1
 	},
 /obj/item/wrench,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "hzd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
@@ -55309,10 +55276,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "hOx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -55359,7 +55326,7 @@
 /area/maintenance/department/science)
 "hQz" = (
 /obj/structure/closet/emcloset/anchored,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -55410,7 +55377,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "hUJ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -55448,7 +55415,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hZB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -55460,7 +55427,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "hZQ" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -55495,7 +55462,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ick" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -55512,7 +55479,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -55536,7 +55503,7 @@
 /area/science/xenobiology)
 "ijF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -55618,7 +55585,7 @@
 	name = "Test Chamber";
 	req_access_txt = "55"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -55630,7 +55597,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "iyg" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -55668,7 +55635,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "iAx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -55679,6 +55646,7 @@
 /area/engine/engineering)
 "iBq" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
 "iBJ" = (
@@ -55688,7 +55656,7 @@
 	network = list("tcomms");
 	start_active = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating/airless,
@@ -55741,7 +55709,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -55810,13 +55778,13 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "iSz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -55894,7 +55862,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -55978,7 +55946,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -55995,7 +55963,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "jtf" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/green,
@@ -56008,7 +55976,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "jvi" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -56124,7 +56092,7 @@
 /area/maintenance/department/science)
 "jFO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -56201,7 +56169,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -56213,7 +56181,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -56228,7 +56196,7 @@
 /turf/closed/wall,
 /area/maintenance/department/engine)
 "jTh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -56322,7 +56290,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/emitter/anchored{
@@ -56570,7 +56538,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -56610,7 +56578,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kJo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -56631,7 +56599,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "kMO" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
@@ -56657,7 +56625,7 @@
 	name = "Containment Pen #4";
 	req_access_txt = "55"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -56683,7 +56651,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -56720,16 +56688,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "kSF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -56749,7 +56717,7 @@
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "kUj" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -56924,7 +56892,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "lBJ" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -56950,7 +56918,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lFh" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
@@ -56982,7 +56950,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lGS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -57006,11 +56974,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lIr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -57025,7 +56993,7 @@
 	req_access_txt = "0"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -57035,7 +57003,7 @@
 /area/storage/emergency/starboard)
 "lMU" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -57084,7 +57052,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -57137,7 +57105,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -57206,7 +57174,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "mgX" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
@@ -57262,7 +57230,7 @@
 /area/engine/engineering)
 "msX" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -57282,7 +57250,7 @@
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
 "mtI" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/highcap/five_k{
@@ -57320,7 +57288,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable/yellow,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "myu" = (
@@ -57410,13 +57378,13 @@
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "mKk" = (
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "mLB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57460,7 +57428,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "mTS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -57624,7 +57592,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "nqV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -57658,7 +57626,7 @@
 	areastring = "/area/construction/mining/aux_base";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
@@ -57673,7 +57641,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
@@ -57692,7 +57660,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "nwg" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -57775,7 +57743,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "nEb" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
@@ -57813,7 +57781,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -57839,7 +57807,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "nMG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -57854,7 +57822,7 @@
 	dir = 2;
 	network = list("tcomms")
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -57904,6 +57872,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"nPh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nPA" = (
 /obj/item/chair,
 /turf/open/floor/plating,
@@ -57919,7 +57894,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "nQt" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -57990,7 +57965,7 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "obj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58038,7 +58013,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "ofX" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58107,7 +58082,7 @@
 	name = "Server Room";
 	req_access_txt = "61"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -58239,15 +58214,15 @@
 /turf/open/floor/carpet,
 /area/lawoffice)
 "oCX" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -58275,7 +58250,7 @@
 	},
 /area/maintenance/department/science)
 "oEN" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -58343,7 +58318,7 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
@@ -58371,7 +58346,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "oPx" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58397,7 +58372,7 @@
 /area/maintenance/department/cargo)
 "oSc" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -58408,13 +58383,13 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "oSL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58426,7 +58401,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -58439,7 +58414,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
@@ -58461,7 +58436,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58534,7 +58509,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "pdW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -58547,10 +58522,10 @@
 /area/science/explab)
 "pfz" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -58571,7 +58546,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "pjH" = (
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
@@ -58620,7 +58595,7 @@
 /area/engine/engineering)
 "pvK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -58637,7 +58612,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "pwj" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58661,7 +58636,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "pBD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/sign/warning{
@@ -58688,7 +58663,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "pFy" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58772,7 +58747,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -58822,10 +58797,10 @@
 	name = "Test Chamber";
 	req_access_txt = "55"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -58851,7 +58826,7 @@
 /area/hydroponics)
 "pXc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/carpet,
@@ -58939,7 +58914,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -58979,7 +58954,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "qqa" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
@@ -59041,7 +59016,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "qyF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -59080,14 +59055,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "qGZ" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -59109,7 +59084,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -59137,13 +59112,13 @@
 "qMi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -59156,13 +59131,13 @@
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "qOH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59178,7 +59153,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
 "qQD" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -59236,7 +59211,7 @@
 "qXq" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -59257,13 +59232,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qYq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/item/wrench,
@@ -59277,7 +59252,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "qYS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -59319,7 +59294,7 @@
 "rgn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -59362,7 +59337,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "riW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -59400,7 +59375,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "roc" = (
-/obj/structure/cable,
+/obj/structure/cable/cyan,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ros" = (
@@ -59412,7 +59387,7 @@
 	},
 /area/maintenance/department/science)
 "rrb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -59434,7 +59409,7 @@
 /area/chapel/office)
 "rse" = (
 /obj/machinery/power/smes/engineering,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -59547,6 +59522,12 @@
 /obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rFj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port)
 "rFq" = (
 /obj/structure/chair,
 /obj/item/reagent_containers/food/snacks/donkpocket,
@@ -59584,15 +59565,15 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "rKr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
@@ -59661,7 +59642,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "rXT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -59715,7 +59696,7 @@
 	req_access_txt = "12";
 	req_one_access_txt = "32;47;48"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -59726,7 +59707,7 @@
 	name = "Engineering APC";
 	pixel_x = -28
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
@@ -59816,7 +59797,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "stQ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/sign/departments/science{
@@ -59844,7 +59825,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "swE" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -59855,7 +59836,7 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "syn" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59951,7 +59932,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "sNz" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -60037,7 +60018,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "tan" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/centcom{
@@ -60068,7 +60049,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "tbC" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -60078,7 +60059,7 @@
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "tcr" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -60087,7 +60068,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "tcY" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -60134,7 +60115,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "tfw" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating/airless,
@@ -60152,7 +60133,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "thT" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -60177,7 +60158,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -60185,6 +60166,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"tky" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "tlc" = (
 /obj/machinery/recharger,
 /obj/structure/table,
@@ -60237,7 +60224,7 @@
 /area/engine/engineering)
 "tqX" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -60254,7 +60241,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "tue" = (
-/obj/structure/cable{
+/obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
@@ -60310,7 +60297,7 @@
 	},
 /area/maintenance/department/science)
 "tyL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -60369,7 +60356,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "tMZ" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -60477,7 +60464,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "tYU" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/reflector/box/anchored,
@@ -60503,10 +60490,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "uaP" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -60537,7 +60524,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "ueV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating{
@@ -60571,7 +60558,7 @@
 /area/maintenance/department/engine)
 "ujI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -60681,7 +60668,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -60701,7 +60688,7 @@
 /area/lawoffice)
 "uvo" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
@@ -60731,7 +60718,7 @@
 /area/maintenance/department/engine)
 "uzn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -60771,7 +60758,7 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "uHG" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating/airless,
@@ -60795,7 +60782,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "uLF" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -60859,7 +60846,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -60891,7 +60878,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
@@ -60903,10 +60890,10 @@
 /area/science/xenobiology)
 "uXH" = (
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -60938,7 +60925,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -61028,7 +61015,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -61113,7 +61100,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -61131,13 +61118,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "vCC" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -61165,7 +61152,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "vIc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -61208,7 +61195,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -61223,7 +61210,7 @@
 "vRi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
@@ -61468,7 +61455,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "wun" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61495,7 +61482,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "wxb" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61558,7 +61545,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -61582,7 +61569,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "wGm" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
@@ -61599,7 +61586,7 @@
 	pixel_x = -25;
 	pixel_y = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -61621,7 +61608,7 @@
 	id = "cmoshutters";
 	name = "Privacy shutters"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -61635,14 +61622,14 @@
 	},
 /area/maintenance/department/crew_quarters/dorms)
 "wMM" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wNq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -61673,7 +61660,7 @@
 /area/science/mixing)
 "wQU" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -61693,7 +61680,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
@@ -61706,7 +61693,7 @@
 	name = "Brig Maintenance APC";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -61762,7 +61749,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -61792,7 +61779,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "xah" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -61880,7 +61867,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "xjc" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -61904,7 +61891,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "xjT" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -61992,7 +61979,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xvV" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -62028,19 +62015,19 @@
 	name = "Containment Pen #2";
 	req_access_txt = "55"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "xxS" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -62066,10 +62053,10 @@
 /area/science/xenobiology)
 "xCV" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -62092,7 +62079,7 @@
 	areastring = "/area/tcommsat/server";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -62168,7 +62155,7 @@
 /area/science/explab)
 "xQc" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -62205,7 +62192,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "xVD" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -78589,7 +78576,7 @@ aiu
 azZ
 axC
 ayA
-azP
+azN
 aAW
 axC
 aaa
@@ -79617,7 +79604,7 @@ aiu
 wxb
 axC
 xuv
-azN
+rFj
 vtT
 vtT
 aiu
@@ -90521,8 +90508,8 @@ mVM
 mVM
 mVM
 tfw
-pjH
-pjH
+tky
+tky
 uHG
 clw
 clw
@@ -90748,7 +90735,7 @@ bZy
 bZy
 cbc
 cbZ
-bZy
+nPh
 cdL
 cer
 ceV
@@ -93318,9 +93305,9 @@ kSw
 caq
 cbk
 cce
-ccY
-ccY
-ccY
+ccZ
+ccZ
+ccZ
 cfc
 cfx
 tlN
@@ -93575,9 +93562,9 @@ bZE
 car
 mgX
 ccf
-ccZ
-ccZ
-ccZ
+ccY
+ccY
+ccY
 tYU
 cfw
 cfW
@@ -93833,7 +93820,7 @@ caq
 cbk
 ceY
 cda
-ccY
+ccZ
 cex
 cfe
 cfx
@@ -93967,8 +93954,8 @@ acw
 abY
 abV
 acc
-acG
-acQ
+sWM
+acP
 acX
 adi
 adt
@@ -94224,7 +94211,7 @@ acx
 acx
 acz
 acd
-acH
+acw
 acP
 acY
 adj
@@ -112540,7 +112527,7 @@ aaa
 aaa
 aaa
 aaa
-bcQ
+bcR
 aaa
 aaa
 aaa
@@ -112797,7 +112784,7 @@ aTC
 aTC
 aTC
 aaa
-bcR
+bcS
 aaa
 aTC
 aTC
@@ -113063,7 +113050,7 @@ beU
 beU
 beU
 beU
-beU
+bkP
 abI
 aby
 aaa

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -558,8 +558,8 @@
 /obj/machinery/power/smes/engineering{
 	charge = 1e+006
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "bl" = (
@@ -779,9 +779,6 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/pirate)
 "bO" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	aidisabled = 1;
 	dir = 1;
@@ -792,6 +789,9 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "bP" = (
@@ -802,10 +802,10 @@
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "bQ" = (
-/obj/structure/cable{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "bX" = (

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -181,7 +181,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -193,7 +193,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/old,
@@ -210,7 +210,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
@@ -218,7 +218,7 @@
 "ax" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -240,7 +240,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm/all_access{
@@ -257,7 +257,7 @@
 "az" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -281,7 +281,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -304,7 +304,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -329,7 +329,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -343,10 +343,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -377,7 +377,7 @@
 /obj/item/reagent_containers/food/snacks/muffin/berry,
 /obj/item/reagent_containers/food/snacks/tofu,
 /obj/item/reagent_containers/food/snacks/burrito,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -410,7 +410,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/blood/old,
@@ -423,7 +423,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /mob/living/simple_animal/hostile/zombie{
@@ -532,10 +532,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/zombie{
 	desc = "This undead fiend looks to be badly decomposed.";
 	environment_smash = 0;
@@ -544,7 +545,6 @@
 	melee_damage_upper = 11;
 	name = "Rotting Carcass"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
 "aQ" = (
@@ -661,7 +661,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -712,7 +712,7 @@
 "bc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -814,9 +814,6 @@
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "bp" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/terminal{
 	dir = 4
 	},
@@ -826,6 +823,9 @@
 	},
 /obj/machinery/light/small/built{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
@@ -844,7 +844,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -895,7 +895,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -929,7 +929,7 @@
 "bz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -998,7 +998,7 @@
 /obj/machinery/light/small/built{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/old,
@@ -1030,7 +1030,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -1041,7 +1041,7 @@
 /obj/structure/table/reinforced,
 /obj/item/wrench,
 /obj/item/crowbar,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -1093,7 +1093,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1140,6 +1140,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/zombie{
 	desc = "This undead fiend looks to be badly decomposed.";
 	environment_smash = 0;
@@ -1148,7 +1149,6 @@
 	melee_damage_upper = 11;
 	name = "Rotting Carcass"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/medbay)
 "bT" = (
@@ -1162,7 +1162,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -1172,7 +1172,7 @@
 "bV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/medical/glass{
@@ -1182,7 +1182,7 @@
 /area/shuttle/abandoned/medbay)
 "bW" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -1194,13 +1194,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -1218,7 +1218,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1228,7 +1228,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -1268,7 +1268,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/old,
@@ -1362,7 +1362,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -1438,24 +1438,24 @@
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "cr" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "cs" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "ct" = (
@@ -1468,7 +1468,7 @@
 	pixel_y = -24;
 	req_access = null
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -1477,7 +1477,7 @@
 /obj/machinery/power/smes/engineering{
 	charge = 1e+006
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1494,7 +1494,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
@@ -1506,7 +1506,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1541,7 +1541,6 @@
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/bot,
@@ -1549,6 +1548,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "cz" = (
@@ -1560,21 +1560,21 @@
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "cB" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "cC" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -1590,10 +1590,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -1738,7 +1738,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -1750,7 +1750,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -1818,7 +1818,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/old,
@@ -1874,7 +1874,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -1884,7 +1884,7 @@
 "da" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -1896,7 +1896,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -1916,7 +1916,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1927,7 +1927,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1937,7 +1937,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -1954,7 +1954,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1965,7 +1965,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -1985,7 +1985,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1997,7 +1997,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2129,7 +2129,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -177,7 +177,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -351,7 +351,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external/glass{
@@ -392,7 +392,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -402,10 +402,10 @@
 /area/shuttle/abandoned/engine)
 "aQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -418,7 +418,7 @@
 /area/shuttle/abandoned/crew)
 "aR" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -431,7 +431,7 @@
 /area/shuttle/abandoned/crew)
 "aS" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -445,7 +445,7 @@
 "aT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm/all_access{
@@ -466,13 +466,13 @@
 /area/shuttle/abandoned/crew)
 "aU" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/power/apc{
@@ -492,7 +492,7 @@
 "aV" = (
 /obj/machinery/light/small/built,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -506,7 +506,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external/glass{
@@ -526,7 +526,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -541,7 +541,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -557,7 +557,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -567,7 +567,7 @@
 /area/shuttle/abandoned/crew)
 "ba" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -701,7 +701,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -731,7 +731,7 @@
 /obj/machinery/light/small/built{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/spider/stickyweb,
@@ -774,7 +774,7 @@
 "bq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/public/glass{
@@ -861,7 +861,7 @@
 /area/shuttle/abandoned/engine)
 "bz" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -896,7 +896,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -921,7 +921,7 @@
 /area/shuttle/abandoned/crew)
 "bG" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -1034,7 +1034,7 @@
 /area/shuttle/abandoned/engine)
 "bQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/spider/stickyweb,
@@ -1052,7 +1052,7 @@
 	req_access = null
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1089,7 +1089,7 @@
 "bU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/airalarm/all_access{
@@ -1144,7 +1144,7 @@
 /area/shuttle/abandoned/bridge)
 "bX" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1189,7 +1189,7 @@
 /area/shuttle/abandoned/crew)
 "cb" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/spider/stickyweb,
@@ -1206,7 +1206,7 @@
 	name = "Engineering"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1223,7 +1223,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -1242,10 +1242,10 @@
 /area/shuttle/abandoned/bridge)
 "cf" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/item/gun/energy/laser/retro,
@@ -1289,7 +1289,7 @@
 /area/shuttle/abandoned/bridge)
 "cj" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/spider/stickyweb,
@@ -1309,20 +1309,20 @@
 /obj/machinery/power/smes/engineering{
 	charge = 1e+006
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "cl" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -1372,7 +1372,7 @@
 	pixel_x = 2;
 	pixel_y = 2
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1413,7 +1413,7 @@
 /area/shuttle/abandoned/crew)
 "cr" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -1430,15 +1430,15 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/machinery/space_heater,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "ct" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/button/door{
@@ -1478,7 +1478,7 @@
 "cv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
@@ -1525,13 +1525,13 @@
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
 	},
-/obj/structure/cable,
 /obj/item/wrench,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "cC" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/oil,
@@ -1684,7 +1684,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/spider/stickyweb,
@@ -1705,7 +1705,7 @@
 /obj/machinery/light/small/built{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -1748,7 +1748,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1869,7 +1869,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/spider/stickyweb,
@@ -1880,7 +1880,7 @@
 /area/shuttle/abandoned/engine)
 "dd" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1893,7 +1893,7 @@
 	name = "Engineering"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1903,10 +1903,10 @@
 /area/shuttle/abandoned/engine)
 "df" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -1914,7 +1914,7 @@
 /area/shuttle/abandoned/medbay)
 "dg" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1926,7 +1926,7 @@
 /obj/machinery/door/airlock/medical{
 	name = "Medbay Storage"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1947,7 +1947,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/spider/stickyweb,
@@ -1963,7 +1963,7 @@
 /area/shuttle/abandoned/medbay)
 "dk" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -1975,13 +1975,13 @@
 /area/shuttle/abandoned/medbay)
 "dl" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -1994,7 +1994,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2010,7 +2010,7 @@
 	},
 /obj/machinery/light/small/built,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2021,7 +2021,7 @@
 "do" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2035,7 +2035,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/spider/stickyweb,
@@ -2046,7 +2046,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external/glass{
@@ -2064,7 +2064,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external/glass{
@@ -2084,7 +2084,7 @@
 /area/shuttle/abandoned/cargo)
 "dt" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2234,7 +2234,7 @@
 /area/shuttle/abandoned/medbay)
 "dG" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter{
@@ -2267,13 +2267,13 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Frigate Cargo APC";
 	pixel_x = -24;
 	req_access = null
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/cargo)
 "dK" = (
@@ -2517,7 +2517,7 @@
 /area/shuttle/abandoned/medbay)
 "oo" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -440,7 +440,7 @@
 /area/shuttle/abandoned/engine)
 "aP" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -454,7 +454,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -465,7 +465,7 @@
 /area/shuttle/abandoned/engine)
 "aR" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -488,7 +488,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -509,7 +509,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -532,7 +532,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -557,7 +557,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -581,7 +581,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -610,10 +610,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -636,7 +636,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -660,7 +660,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -684,7 +684,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -695,7 +695,7 @@
 "bb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -715,7 +715,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -729,7 +729,7 @@
 "bd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -805,7 +805,7 @@
 /area/shuttle/abandoned/engine)
 "bj" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -903,7 +903,7 @@
 "br" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -979,7 +979,7 @@
 /area/shuttle/abandoned/crew)
 "by" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -1053,7 +1053,7 @@
 	name = "Bar"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -1102,7 +1102,7 @@
 /area/shuttle/abandoned/engine)
 "bI" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1213,7 +1213,7 @@
 	pixel_y = 3
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -1231,10 +1231,10 @@
 "bO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -1277,7 +1277,7 @@
 /area/shuttle/abandoned/bridge)
 "bS" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1379,7 +1379,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -1412,7 +1412,7 @@
 /obj/item/pen{
 	pixel_x = -4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -1482,7 +1482,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -1491,7 +1491,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small/built{
@@ -1505,17 +1505,17 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "ck" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/white/line{
@@ -1612,10 +1612,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -1629,7 +1629,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1644,7 +1644,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -1664,7 +1664,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/remains/human,
@@ -1687,9 +1687,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
-/mob/living/simple_animal/hostile/syndicate/melee{
-	environment_smash = 0
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1699,6 +1696,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/mob/living/simple_animal/hostile/syndicate/melee{
+	environment_smash = 0
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/bridge)
@@ -1734,7 +1734,7 @@
 /area/shuttle/abandoned/bridge)
 "cw" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1808,7 +1808,7 @@
 "cB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -1939,7 +1939,7 @@
 	pixel_x = -24;
 	req_access = null
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2008,7 +2008,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -2050,7 +2050,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2098,7 +2098,7 @@
 	name = "Bar"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -2138,7 +2138,7 @@
 /obj/machinery/power/smes/engineering{
 	charge = 1e+006
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2148,7 +2148,7 @@
 /area/shuttle/abandoned/engine)
 "cY" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/firealarm{
@@ -2202,7 +2202,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2216,9 +2216,6 @@
 "dd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/mob/living/simple_animal/hostile/syndicate/melee{
-	environment_smash = 0
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -2228,6 +2225,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/mob/living/simple_animal/hostile/syndicate/melee{
+	environment_smash = 0
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/cargo)
@@ -2281,7 +2281,7 @@
 "dh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -2373,11 +2373,11 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/power/terminal{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
@@ -2392,10 +2392,10 @@
 /area/shuttle/abandoned/cargo)
 "dr" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2403,10 +2403,10 @@
 /area/shuttle/abandoned/engine)
 "ds" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2420,7 +2420,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2434,10 +2434,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -2456,7 +2456,7 @@
 /obj/effect/turf_decal/arrows/white,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -2481,7 +2481,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -2504,7 +2504,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -2529,7 +2529,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/stripes/white/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -2655,7 +2655,7 @@
 /area/shuttle/abandoned/engine)
 "dI" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -2818,10 +2818,10 @@
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/bot,
 /obj/item/wrench,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "dX" = (
@@ -2980,10 +2980,10 @@
 /area/shuttle/abandoned/bar)
 "el" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/oil,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR standardizes cable colors: Power source to SMES is red, SMES to main grid is yellow. Cables that can connect the main grid to AI sat/telecomms sat are cyan.

It also fixes some odd wiring at the Pubby incinerator, the zoo ruin and the BMP ship ruin.

This would probably be a good testmerge candidate, since it touches a lot of map code. Aside from the three files where I tweaked/fixed cables, the only effect should be different colors.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cable colors are all over the place, which causes a lot of confusion for players that haven't memorized every single area's cable layout. Cables are probably the smallest and most annoying objects to interact with ingame, so what they're doing should be obvious at first glance.

I chose red for power source -> SMES wires, since these are most likely to really hurt when you touch them. Yellow is IMO the best color for the main grid, since it doesn't overlap with scrubber pipes like red cables do.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
tweak: Power cable colors have been standardized across all areas. Power input cables are now red, while the main grid is yellow.
fix: Fixed SMES input/output wiring being connected to each other in the abandoned zoo and BMP ship space ruins.
tweak: Tweaked cables near Pubbystation's incinerator SMES to keep them from overlapping.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
