### PR TITLE
pAI's have headsets and can use encryption keys

### DIFF
--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -29,7 +29,7 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 /obj/machinery/announcement_system/Initialize()
 	. = ..()
 	GLOB.announcement_systems += src
-	radio = new /obj/item/radio/headset/ai(src)
+	radio = new /obj/item/radio/headset/silicon/ai(src)
 	update_icon()
 
 /obj/machinery/announcement_system/update_icon()

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -41,13 +41,13 @@
 		dat += "<a href='byond://?src=[REF(src)];setlaws=1'>Configure Directives</a><br>"
 		dat += "<br>"
 		dat += "<h3>Device Settings</h3><br>"
-		if(pai.radio)
-			dat += "<b>Radio Uplink</b><br>"
-			dat += "Transmit: <A href='byond://?src=[REF(src)];wires=[WIRE_TX]'>[(pai.radio.wires.is_cut(WIRE_TX)) ? "Disabled" : "Enabled"]</A><br>"
-			dat += "Receive: <A href='byond://?src=[REF(src)];wires=[WIRE_RX]'>[(pai.radio.wires.is_cut(WIRE_RX)) ? "Disabled" : "Enabled"]</A><br>"
-		else
-			dat += "<b>Radio Uplink</b><br>"
-			dat += "<font color=red><i>Radio firmware not loaded. Please install a pAI personality to load firmware.</i></font><br>"
+//		if(pai.radio)
+//			dat += "<b>Radio Uplink</b><br>"
+//			dat += "Transmit: <A href='byond://?src=[REF(src)];wires=[WIRE_TX]'>[(pai.radio.wires.is_cut(WIRE_TX)) ? "Disabled" : "Enabled"]</A><br>"
+//			dat += "Receive: <A href='byond://?src=[REF(src)];wires=[WIRE_RX]'>[(pai.radio.wires.is_cut(WIRE_RX)) ? "Disabled" : "Enabled"]</A><br>"
+//		else
+//			dat += "<b>Radio Uplink</b><br>"
+//			dat += "<font color=red><i>Radio firmware not loaded. Please install a pAI personality to load firmware.</i></font><br>"
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if(H.real_name == pai.master || H.dna.unique_enzymes == pai.master_dna)
@@ -157,3 +157,4 @@
 		return
 	if(pai && !pai.holoform)
 		pai.emp_act(severity)
+

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -41,13 +41,13 @@
 		dat += "<a href='byond://?src=[REF(src)];setlaws=1'>Configure Directives</a><br>"
 		dat += "<br>"
 		dat += "<h3>Device Settings</h3><br>"
-//		if(pai.radio)
-//			dat += "<b>Radio Uplink</b><br>"
-//			dat += "Transmit: <A href='byond://?src=[REF(src)];wires=[WIRE_TX]'>[(pai.radio.wires.is_cut(WIRE_TX)) ? "Disabled" : "Enabled"]</A><br>"
-//			dat += "Receive: <A href='byond://?src=[REF(src)];wires=[WIRE_RX]'>[(pai.radio.wires.is_cut(WIRE_RX)) ? "Disabled" : "Enabled"]</A><br>"
-//		else
-//			dat += "<b>Radio Uplink</b><br>"
-//			dat += "<font color=red><i>Radio firmware not loaded. Please install a pAI personality to load firmware.</i></font><br>"
+		if(pai.radio)
+			dat += "<b>Radio Uplink</b><br>"
+			dat += "Transmit: <A href='byond://?src=[REF(src)];wires=[WIRE_TX]'>[(pai.radio.wires.is_cut(WIRE_TX)) ? "Disabled" : "Enabled"]</A><br>"
+			dat += "Receive: <A href='byond://?src=[REF(src)];wires=[WIRE_RX]'>[(pai.radio.wires.is_cut(WIRE_RX)) ? "Disabled" : "Enabled"]</A><br>"
+		else
+			dat += "<b>Radio Uplink</b><br>"
+			dat += "<font color=red><i>Radio firmware not loaded. Please install a pAI personality to load firmware.</i></font><br>"
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if(H.real_name == pai.master || H.dna.unique_enzymes == pai.master_dna)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -255,12 +255,17 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	. = ..()
 	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
-/obj/item/radio/headset/ai
+/obj/item/radio/headset/silicon/pai
+	name = "\proper personal Integrated Subspace Transceiver "
+	keyslot = null
+	keyslot2 = null
+
+/obj/item/radio/headset/silicon/ai
 	name = "\proper Integrated Subspace Transceiver "
 	keyslot2 = new /obj/item/encryptionkey/ai
 	command = TRUE
 
-/obj/item/radio/headset/ai/can_receive(freq, level)
+/obj/item/radio/headset/silicon/can_receive(freq, level)
 	return ..(freq, level, TRUE)
 
 /obj/item/radio/headset/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -257,8 +257,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/headset/silicon/pai
 	name = "\proper personal Integrated Subspace Transceiver "
-	keyslot = null
-	keyslot2 = null
 
 /obj/item/radio/headset/silicon/ai
 	name = "\proper Integrated Subspace Transceiver "

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -256,7 +256,12 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 /obj/item/radio/headset/silicon/pai
+<<<<<<< HEAD
 	name = "\proper personal Integrated Subspace Transceiver "
+=======
+	name = "\proper Integrated Subspace Transceiver "
+	subspace_transmission = FALSE
+>>>>>>> 1a8bc1a2ac... Final version
 
 /obj/item/radio/headset/silicon/ai
 	name = "\proper Integrated Subspace Transceiver "

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -256,12 +256,9 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 /obj/item/radio/headset/silicon/pai
-<<<<<<< HEAD
-	name = "\proper personal Integrated Subspace Transceiver "
-=======
-	name = "\proper Integrated Subspace Transceiver "
+	name = "\proper mini Integrated Subspace Transceiver "
 	subspace_transmission = FALSE
->>>>>>> 1a8bc1a2ac... Final version
+
 
 /obj/item/radio/headset/silicon/ai
 	name = "\proper Integrated Subspace Transceiver "

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -148,7 +148,7 @@
 	aiPDA.name = real_name + " (" + aiPDA.ownjob + ")"
 
 	aiMulti = new(src)
-	radio = new /obj/item/radio/headset/ai(src)
+	radio = new /obj/item/radio/headset/silicon/ai(src)
 	aicamera = new/obj/item/camera/siliconcam/ai_camera(src)
 
 	deploy_action.Grant(src)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -108,13 +108,7 @@
 	card = P
 	signaler = new(src)
 	if(!radio)
-<<<<<<< HEAD
-		radio = new /obj/item/radio/(src)
-	if(!headset)
-		headset = new /obj/item/radio/headset/silicon/pai(src)
-=======
 		radio = new /obj/item/radio/headset/silicon/pai(src)
->>>>>>> 1a8bc1a2ac... Final version
 
 	//PDA
 	pda = new(src)
@@ -299,14 +293,6 @@
 	emitterhealth = CLAMP((emitterhealth + emitterregen), -50, emittermaxhealth)
 
 /obj/item/paicard/attackby(obj/item/W, mob/user, params)
-<<<<<<< HEAD
-    user.set_machine(src)
-
-    if(W.tool_behaviour == TOOL_SCREWDRIVER)
-        pai.headset.attackby(W, user, params)
-    else if(istype(W, /obj/item/encryptionkey))
-        pai.headset.attackby(W, user, params)
-=======
 	user.set_machine(src)
 	if(pai.encryptmod == TRUE)
 		if(W.tool_behaviour == TOOL_SCREWDRIVER)
@@ -315,4 +301,3 @@
 			pai.radio.attackby(W, user, params)
 	else
 		to_chat(user, "Encryption Key ports not configured.")
->>>>>>> 1a8bc1a2ac... Final version

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -56,6 +56,7 @@
 
 	var/obj/item/instrument/piano_synth/internal_instrument
 
+	var/encryptmod = FALSE
 	var/holoform = FALSE
 	var/canholo = TRUE
 	var/obj/item/card/id/access_card = null
@@ -107,9 +108,13 @@
 	card = P
 	signaler = new(src)
 	if(!radio)
+<<<<<<< HEAD
 		radio = new /obj/item/radio/(src)
 	if(!headset)
 		headset = new /obj/item/radio/headset/silicon/pai(src)
+=======
+		radio = new /obj/item/radio/headset/silicon/pai(src)
+>>>>>>> 1a8bc1a2ac... Final version
 
 	//PDA
 	pda = new(src)
@@ -294,9 +299,20 @@
 	emitterhealth = CLAMP((emitterhealth + emitterregen), -50, emittermaxhealth)
 
 /obj/item/paicard/attackby(obj/item/W, mob/user, params)
+<<<<<<< HEAD
     user.set_machine(src)
 
     if(W.tool_behaviour == TOOL_SCREWDRIVER)
         pai.headset.attackby(W, user, params)
     else if(istype(W, /obj/item/encryptionkey))
         pai.headset.attackby(W, user, params)
+=======
+	user.set_machine(src)
+	if(pai.encryptmod == TRUE)
+		if(W.tool_behaviour == TOOL_SCREWDRIVER)
+			pai.radio.attackby(W, user, params)
+		else if(istype(W, /obj/item/encryptionkey))
+			pai.radio.attackby(W, user, params)
+	else
+		to_chat(user, "Encryption Key ports not configured.")
+>>>>>>> 1a8bc1a2ac... Final version

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -293,6 +293,7 @@
 	emitterhealth = CLAMP((emitterhealth + emitterregen), -50, emittermaxhealth)
 
 /obj/item/paicard/attackby(obj/item/W, mob/user, params)
+	..()
 	user.set_machine(src)
 	if(pai.encryptmod == TRUE)
 		if(W.tool_behaviour == TOOL_SCREWDRIVER)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -106,7 +106,7 @@
 	card = P
 	signaler = new(src)
 	if(!radio)
-		radio = new /obj/item/radio(src)
+		radio = new /obj/item/radio/headset/silicon/pai(src)
 
 	//PDA
 	pda = new(src)
@@ -289,3 +289,11 @@
 
 /mob/living/silicon/pai/process()
 	emitterhealth = CLAMP((emitterhealth + emitterregen), -50, emittermaxhealth)
+
+/obj/item/paicard/attackby(obj/item/W, mob/user, params)
+    user.set_machine(src)
+
+    if(W.tool_behaviour == TOOL_SCREWDRIVER)
+        pai.radio.attackby(W, user, params)
+    else if(istype(W, /obj/item/encryptionkey))
+        pai.radio.attackby(W, user, params)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -26,6 +26,7 @@
 	var/speakDoubleExclamation = "alarms"
 	var/speakQuery = "queries"
 
+	var/obj/item/radio/headset			// The pAI's headset
 	var/obj/item/pai_cable/cable		// The cable we produce and use when door or camera jacking
 
 	var/master				// Name of the one who commands us
@@ -106,7 +107,9 @@
 	card = P
 	signaler = new(src)
 	if(!radio)
-		radio = new /obj/item/radio/headset/silicon/pai(src)
+		radio = new /obj/item/radio/(src)
+	if(!headset)
+		headset = new /obj/item/radio/headset/silicon/pai(src)
 
 	//PDA
 	pda = new(src)
@@ -294,6 +297,6 @@
     user.set_machine(src)
 
     if(W.tool_behaviour == TOOL_SCREWDRIVER)
-        pai.radio.attackby(W, user, params)
+        pai.headset.attackby(W, user, params)
     else if(istype(W, /obj/item/encryptionkey))
-        pai.radio.attackby(W, user, params)
+        pai.headset.attackby(W, user, params)

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -1,5 +1,4 @@
 // TODO:
-//	- Additional radio modules
 //	- Potentially roll HUDs and Records into one
 //	- Shock collar/lock system for prisoner pAIs?
 //  - Put cable in user's hand instead of on the ground
@@ -20,7 +19,8 @@
 															"universal translator" = 35,
 															//"projection array" = 15
 															"remote signaller" = 5,
-															"loudness booster" = 25
+															"loudness booster" = 25,
+															"encryption keys" = 20
 															)
 
 /mob/living/silicon/pai/proc/paiInterface()
@@ -51,6 +51,8 @@
 				left_part = softwareMedicalRecord()
 			if("securityrecord")
 				left_part = softwareSecurityRecord()
+			if("encryptionkeys")
+				left_part = softwareEncryptionKeys()
 			if("translator")
 				left_part = softwareTranslator()
 			if("atmosensor")
@@ -252,6 +254,9 @@
 				else
 					var/datum/atom_hud/med = GLOB.huds[med_hud]
 					med.remove_hud_from(src)
+		if("encryptionkeys")
+			if(href_list["toggle"])
+				encryptmod = TRUE
 		if("translator")
 			if(href_list["toggle"])
 				grant_all_languages(TRUE)
@@ -320,6 +325,8 @@
 			dat += "<a href='byond://?src=[REF(src)];software=securityhud;sub=0'>Facial Recognition Suite</a>[(secHUD) ? "<font color=#55FF55> On</font>" : "<font color=#FF5555> Off</font>"] <br>"
 		if(s == "medical HUD")
 			dat += "<a href='byond://?src=[REF(src)];software=medicalhud;sub=0'>Medical Analysis Suite</a>[(medHUD) ? "<font color=#55FF55> On</font>" : "<font color=#FF5555> Off</font>"] <br>"
+		if(s == "encryption keys")
+			dat += "<a href='byond://?src=[REF(src)];software=encryptionkeys;sub=0'>Channel Encryption Firmware</a>[(encryptmod) ? "<font color=#55FF55> On</font>" : "<font color=#FF5555> Off</font>"] <br>"
 		if(s == "universal translator")
 			var/datum/language_holder/H = get_language_holder()
 			dat += "<a href='byond://?src=[REF(src)];software=translator;sub=0'>Universal Translator</a>[H.omnitongue ? "<font color=#55FF55> On</font>" : "<font color=#FF5555> Off</font>"] <br>"
@@ -470,6 +477,14 @@
 				. += "<pre>Requested security record not found,</pre><BR>"
 			. += "<BR>\n<A href='?src=[REF(src)];software=securityrecord;sub=0'>Back</A><BR>"
 	return .
+
+// Encryption kets
+/mob/living/silicon/pai/proc/softwareEncryptionKeys()
+	var/dat = {"<h3>Encryption Key Firmware</h3><br>
+				When enabled, this device will be able to use up to two (2) encryption keys for departmental channel access.<br><br>
+				The device is currently [encryptmod ? "<font color=#55FF55>en" : "<font color=#FF5555>dis" ]abled.</font><br>[encryptmod ? "" : "<a href='byond://?src=[REF(src)];software=encryptionkeys;sub=0;toggle=1'>Activate Encryption Key Ports</a><br>"]"}
+	return dat
+
 
 // Universal Translator
 /mob/living/silicon/pai/proc/softwareTranslator()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
From the holy page `/code/modules/mob/living/silicon/pai/software.dm`
`// TODO:
//	- Additional radio modules
//	- Potentially roll HUDs and Records into one
//	- Shock collar/lock system for prisoner pAIs?
//  - Put cable in user's hand instead of on the ground
//  - Camera jack`

This PR accomplishes one of the Precursor TODO's: Additional Radio Modules

## About The Pull Request

This gives pAI's access to speaking on departmental channels. Any encryption key you can add to a headset will do. They will need to download the program before it will work.

- pAI's spawn with an empty version of the AI headset 
  - It cannot use high-volume  
  - It acts like a station bounced radio when comms are down.
- You can add encryption up to 2 keys 
  - Add them to the pAI by using the key on the pAI card. 
  - Remove them by using the screwdriver on the pAI card. 
  - While in a bot the keys are unavailable to you, but access returns on eject
  - It will hold binary keys, but will not grant binary access
- It will cost 20 RAM to allow encryptionkeys to be added to the pAI (I welcome feedback on pricing)
 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently these little guys are limited to common and eavesdropping headsets by occupying the same tile. If AI's get to have headsets, then surely pAI's can have that same tech. This PR adds more use to encryption keys and also creates a more interesting pAI experience, as they can be slotted with 2 keys for their own use.

- This enables pAI's to have better communication with other people in their master's department.
- You can match pAI's with med or sec huds and the corresponding keys. More synergies with existing abilities.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: pAI's now have the same headset tech as AI. Add and remove keys just like you would with headsets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

ToDo
- [x] pAI's spawn with headset that can be used like a Station Bounced Radio (unique)
- [x] the paicard can be interacted with like a headset re: encryption keys
- [x] No high volume allowed
- [x] Slap a RAM price tag on it 
- [x] Integrate it into the software stack
