### PR TITLE
Fixes movement hunger costs.

### DIFF
--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -34,7 +34,7 @@
 
 /mob/living/carbon/Move(NewLoc, direct)
 	. = ..()
-	if(. && (movement_type & FLOATING)) //floating is easy
+	if(. && !(movement_type & FLOATING)) //floating is easy
 		if(has_trait(TRAIT_NOHUNGER))
 			set_nutrition(NUTRITION_LEVEL_FED - 1)	//just less than feeling vigorous
 		else if(nutrition && stat != DEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It seems it was intended to make movement cost a bit of hunger per tile, but was actually only happening while you were floating (despite the comment saying it should be easy).

This reverses that so it's now working as intended.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Testing shows this increases nutrition by about 5.6 per minute of non-stop (non-floating) running movement. Walking cuts this cost by more than half as not only do you cover fewer tiles in a minute, but walking also costs half as much in tile-tile movement.

If you're on meth, expect to get quite hungry from zooming around the station like a madman at 300 mph, which I think makes quite a bit of sense.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: WJohnston
fix: Fixes movement hunger cost happening only while floating. This has now been reversed, grounded movement is what actually makes you hungrier rather than while floating.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
