### PR TITLE
Killing the One Mind's host destroys the One Mind

### DIFF
--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -192,7 +192,7 @@
 	for(var/datum/mind/M in hivemembers)
 		M.remove_antag_datum(/datum/antagonist/hivevessel)
 		active_one_mind.remove_member(M)
-	if(!owner?.current)
+	if(!(owner?.current))
 		return
 	var/mob/living/carbon/C = owner.current.get_real_hivehost()
 	if(!C)

--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -161,6 +161,7 @@
 	to_chat(real_C, "<span class='userdanger'>[user_warning]!</span>")
 
 /datum/antagonist/hivemind/proc/destroy_hive()
+	go_back_to_sleep()
 	hivemembers = list()
 	calc_size()
 	for(var/power in upgrade_tiers)
@@ -184,6 +185,24 @@
 	C.add_trait(TRAIT_NOLIMBDISABLE, HIVEMIND_ONE_MIND_TRAIT)
 	C.add_trait(TRAIT_NOHUNGER, HIVEMIND_ONE_MIND_TRAIT)
 	C.add_trait(TRAIT_NODISMEMBER, HIVEMIND_ONE_MIND_TRAIT)
+
+/datum/antagonist/hivemind/proc/go_back_to_sleep()
+	if(!active_one_mind)
+		return
+	for(var/datum/mind/M in hivemembers)
+		M.remove_antag_datum(/datum/antagonist/hivevessel)
+		active_one_mind.remove_member(M)
+	var/mob/living/carbon/C = owner?.current.get_real_hivehost()
+	if(!C)
+		return
+	owner.RemoveSpell(new/obj/effect/proc_holder/spell/self/hive_comms)
+	C.remove_trait(TRAIT_STUNIMMUNE, HIVEMIND_ONE_MIND_TRAIT)
+	C.remove_trait(TRAIT_SLEEPIMMUNE, HIVEMIND_ONE_MIND_TRAIT)
+	C.remove_trait(TRAIT_VIRUSIMMUNE, HIVEMIND_ONE_MIND_TRAIT)
+	C.remove_trait(TRAIT_NOLIMBDISABLE, HIVEMIND_ONE_MIND_TRAIT)
+	C.remove_trait(TRAIT_NOHUNGER, HIVEMIND_ONE_MIND_TRAIT)
+	C.remove_trait(TRAIT_NODISMEMBER, HIVEMIND_ONE_MIND_TRAIT)
+	active_one_mind.Destroy()
 
 /datum/antagonist/hivemind/on_gain()
 	owner.special_role = special_role

--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -192,7 +192,9 @@
 	for(var/datum/mind/M in hivemembers)
 		M.remove_antag_datum(/datum/antagonist/hivevessel)
 		active_one_mind.remove_member(M)
-	var/mob/living/carbon/C = owner?.current.get_real_hivehost()
+	if(!owner?.current)
+		return
+	var/mob/living/carbon/C = owner.current.get_real_hivehost()
 	if(!C)
 		return
 	owner.RemoveSpell(new/obj/effect/proc_holder/spell/self/hive_comms)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes this garbage

> i think i found a major bug
> i mean an oversight
> for hivemind
> when a hivemind host dies, he loses all his vessels
> im pretty sure thats intended and all
> but it happens even when a onemind host dies
> and now a onemind host is immune to shit, has hivemind chat, but has 0 vessels and only roundstart abilities + onemind communications

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fixes an oversight

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Kierany9
tweak: Killing the One Mind's host now destroys the One Mind
fix: Fixes bugs related to this oversight
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
