### PR TITLE
Revert "Fixes carbons with no eyes having a flash overlay applied when they're flashed."

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -287,13 +287,13 @@
 
 
 /mob/living/carbon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0)
+	var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES) //technically parent will fail regardless if eyes are lacking, but noping out here prevents two get_eye_protection() calls
+	if (!eyes)
+		return
 	. = ..()
 
 	var/damage = intensity - get_eye_protection()
 	if(.) // we've been flashed
-		var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
-		if (!eyes)
-			return
 		if(visual)
 			return
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -287,16 +287,13 @@
 
 
 /mob/living/carbon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0)
-	if(NOEYES in dna?.species?.species_traits)
-		return
-	var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
-	if(!eyes) //can't flash what can't see!
-		return
-
 	. = ..()
 
 	var/damage = intensity - get_eye_protection()
 	if(.) // we've been flashed
+		var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
+		if (!eyes)
+			return
 		if(visual)
 			return
 


### PR DESCRIPTION
Reverts tgstation/tgstation#43175

NOEYES is actually "no eye sprites, they still have actual eyes lol". The PR being reverted makes moths flashproof, which is opposite of what is intended; until it can be fixed properly (by giving moths eye sprites + renaming current NOEYES into NOEYESPRITES or something) this should be reverted.