### PR TITLE
Fixes pAI radio disabling

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -92,26 +92,17 @@
 					to_chat(pai, "<span class='userdanger'>Your mental faculties leave you.</span>")
 					to_chat(pai, "<span class='rose'>oblivion... </span>")
 					qdel(pai)
-		if(href_list["toggle_transmit"])
-			if(pai.can_transmit)
-				to_chat(pai, "<span class='userdanger'>Your owner has disabled your outgoing radio transmissions!</span>")
-				pai.can_transmit = FALSE
-				to_chat(usr, "<span class='warning'>You disable your pAI's outgoing radio transmissions!</span>")
-			else
-				to_chat(pai, "<span class='boldnotice'>Your owner has enabled your outgoing radio transmissions!</span>")
-				pai.can_transmit = TRUE
-				to_chat(usr, "<span class='notice'>You enable your pAI's outgoing radio transmissions!</span>")
-			pai.radio.wires.cut(WIRE_TX)	
-		if(href_list["toggle_receive"])
-			if(pai.can_receive)
-				to_chat(pai, "<span class='userdanger'>Your owner has disabled your incoming radio transmissions!</span>")
-				pai.can_receive = FALSE
-				to_chat(usr, "<span class='warning'>You disable your pAI's incoming radio transmissions!</span>")
-			else
-				to_chat(pai, "<span class='boldnotice'>Your owner has enabled your incoming radio transmissions!</span>")
-				pai.can_receive = TRUE
-				to_chat(usr, "<span class='notice'>You enable your pAI's incoming radio transmissions!</span>")
-			pai.radio.wires.cut(WIRE_RX)
+		if(href_list["toggle_transmit"] || href_list["toggle_receive"])
+			var/transmitting = href_list["toggle_transmit"] //it can't be both so if we know it's not transmitting it must be receiving. 
+			var/transmit_holder = (transmitting ? WIRE_TX : WIRE_RX)
+			if(transmitting)
+				pai.can_transmit = !pai.can_transmit
+			else //receiving
+				pai.can_receive = !pai.can_receive
+			pai.radio.wires.cut(transmit_holder)//wires.cut toggles cut and uncut states
+			transmit_holder = (transmitting ? pai.can_transmit : pai.can_receive) //recycling can be fun!
+			to_chat(usr,"<span class='warning'>You [transmit_holder ? "enable" : "disable"] your pAI's [transmitting ? "outgoing" : "incoming"] radio transmissions!</span>")
+			to_chat(pai,"<span class='warning'>Your owner has [transmit_holder ? "enabled" : "disabled"] your [transmitting ? "outgoing" : "incoming"] radio transmissions!</span>")
 		if(href_list["setlaws"])
 			var/newlaws = copytext(sanitize(input("Enter any additional directives you would like your pAI personality to follow. Note that these directives will not override the personality's allegiance to its imprinted master. Conflicting directives will be ignored.", "pAI Directive Configuration", pai.laws.supplied[1]) as message),1,MAX_MESSAGE_LEN)
 			if(newlaws && pai)

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -43,8 +43,8 @@
 		dat += "<h3>Device Settings</h3><br>"
 		if(pai.radio)
 			dat += "<b>Radio Uplink</b><br>"
-			dat += Transmit: "<A href='byond://?src=[REF(src)];toggle_transmit=1'>\[[pai.can_transmit? "Disable" : "Enable"] Radio Transmission\]</a><br>"
-			dat += Receive: "<A href='byond://?src=[REF(src)];toggle_receive=1'>\[[pai.can_receive? "Disable" : "Enable"] Radio Reception\]</a><br>"
+			dat += "Transmit: <A href='byond://?src=[REF(src)];toggle_transmit=1'>\[[pai.can_transmit? "Disable" : "Enable"] Radio Transmission\]</a><br>"
+			dat += "Receive: <A href='byond://?src=[REF(src)];toggle_receive=1'>\[[pai.can_receive? "Disable" : "Enable"] Radio Reception\]</a><br>"
 		else
 			dat += "<b>Radio Uplink</b><br>"
 			dat += "<font color=red><i>Radio firmware not loaded. Please install a pAI personality to load firmware.</i></font><br>"

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -43,8 +43,8 @@
 		dat += "<h3>Device Settings</h3><br>"
 		if(pai.radio)
 			dat += "<b>Radio Uplink</b><br>"
-			dat += "<A href='byond://?src=[REF(src)];toggle_transmit=1'>\[[pai.can_transmit? "Disable" : "Enable"] Radio Transmission\]</a><br>"
-			dat += "<A href='byond://?src=[REF(src)];toggle_receive=1'>\[[pai.can_receive? "Disable" : "Enable"] Radio Reception\]</a><br>"
+			dat += Transmit: "<A href='byond://?src=[REF(src)];toggle_transmit=1'>\[[pai.can_transmit? "Disable" : "Enable"] Radio Transmission\]</a><br>"
+			dat += Receive: "<A href='byond://?src=[REF(src)];toggle_receive=1'>\[[pai.can_receive? "Disable" : "Enable"] Radio Reception\]</a><br>"
 		else
 			dat += "<b>Radio Uplink</b><br>"
 			dat += "<font color=red><i>Radio firmware not loaded. Please install a pAI personality to load firmware.</i></font><br>"

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -45,6 +45,7 @@
 			dat += "<b>Radio Uplink</b><br>"
 			dat += "<A href='byond://?src=[REF(src)];toggle_tx=1'>\[[pai.can_tx? "Disable" : "Enable"] Radio Transmission\]</a><br>"
 			dat += "<A href='byond://?src=[REF(src)];toggle_rx=1'>\[[pai.can_rx? "Disable" : "Enable"] Radio Reception\]</a><br>"		else
+		else	
 			dat += "<b>Radio Uplink</b><br>"
 			dat += "<font color=red><i>Radio firmware not loaded. Please install a pAI personality to load firmware.</i></font><br>"
 		if(ishuman(user))

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -43,9 +43,8 @@
 		dat += "<h3>Device Settings</h3><br>"
 		if(pai.radio)
 			dat += "<b>Radio Uplink</b><br>"
-			dat += "Transmit: <A href='byond://?src=[REF(src)];wires=[WIRE_TX]'>[(pai.radio.wires.is_cut(WIRE_TX)) ? "Disabled" : "Enabled"]</A><br>"
-			dat += "Receive: <A href='byond://?src=[REF(src)];wires=[WIRE_RX]'>[(pai.radio.wires.is_cut(WIRE_RX)) ? "Disabled" : "Enabled"]</A><br>"
-		else
+			dat += "<A href='byond://?src=[REF(src)];toggle_tx=1'>\[[pai.can_tx? "Disable" : "Enable"] Radio Transmission\]</a><br>"
+			dat += "<A href='byond://?src=[REF(src)];toggle_rx=1'>\[[pai.can_rx? "Disable" : "Enable"] Radio Reception\]</a><br>"		else
 			dat += "<b>Radio Uplink</b><br>"
 			dat += "<font color=red><i>Radio firmware not loaded. Please install a pAI personality to load firmware.</i></font><br>"
 		if(ishuman(user))
@@ -92,10 +91,26 @@
 					to_chat(pai, "<span class='userdanger'>Your mental faculties leave you.</span>")
 					to_chat(pai, "<span class='rose'>oblivion... </span>")
 					qdel(pai)
-		if(href_list["wires"])
-			var/wire = text2num(href_list["wires"])
-			if(pai.radio)
-				pai.radio.wires.cut(wire)
+		if(href_list["toggle_tx"])
+			if(pai.can_tx)
+				to_chat(pai, "<span class='userdanger'>Your owner has disabled your outgoing radio transmissions!</span>")
+				pai.can_tx = FALSE
+				to_chat(usr, "<span class='warning'>You disable your pAI's outgoing radio transmissions!</span>")
+			else
+				to_chat(pai, "<span class='boldnotice'>Your owner has enabled your outgoing radio transmissions!</span>")
+				pai.can_tx = TRUE
+				to_chat(usr, "<span class='notice'>You enable your pAI's outgoing radio transmissions!</span>")
+			pai.radio.wires.cut(WIRE_TX)	
+		if(href_list["toggle_rx"])
+			if(pai.can_rx)
+				to_chat(pai, "<span class='userdanger'>Your owner has disabled your incoming radio transmissions!</span>")
+				pai.can_rx = FALSE
+				to_chat(usr, "<span class='warning'>You disable your pAI's incoming radio transmissions!</span>")
+			else
+				to_chat(pai, "<span class='boldnotice'>Your owner has enabled your incoming radio transmissions!</span>")
+				pai.can_rx = TRUE
+				to_chat(usr, "<span class='notice'>You enable your pAI's incoming radio transmissions!</span>")
+			pai.radio.wires.cut(WIRE_RX)
 		if(href_list["setlaws"])
 			var/newlaws = copytext(sanitize(input("Enter any additional directives you would like your pAI personality to follow. Note that these directives will not override the personality's allegiance to its imprinted master. Conflicting directives will be ignored.", "pAI Directive Configuration", pai.laws.supplied[1]) as message),1,MAX_MESSAGE_LEN)
 			if(newlaws && pai)

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -44,8 +44,8 @@
 		if(pai.radio)
 			dat += "<b>Radio Uplink</b><br>"
 			dat += "<A href='byond://?src=[REF(src)];toggle_tx=1'>\[[pai.can_tx? "Disable" : "Enable"] Radio Transmission\]</a><br>"
-			dat += "<A href='byond://?src=[REF(src)];toggle_rx=1'>\[[pai.can_rx? "Disable" : "Enable"] Radio Reception\]</a><br>"		else
-		else	
+			dat += "<A href='byond://?src=[REF(src)];toggle_rx=1'>\[[pai.can_rx? "Disable" : "Enable"] Radio Reception\]</a><br>"
+		else
 			dat += "<b>Radio Uplink</b><br>"
 			dat += "<font color=red><i>Radio firmware not loaded. Please install a pAI personality to load firmware.</i></font><br>"
 		if(ishuman(user))

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -43,8 +43,8 @@
 		dat += "<h3>Device Settings</h3><br>"
 		if(pai.radio)
 			dat += "<b>Radio Uplink</b><br>"
-			dat += "<A href='byond://?src=[REF(src)];toggle_tx=1'>\[[pai.can_tx? "Disable" : "Enable"] Radio Transmission\]</a><br>"
-			dat += "<A href='byond://?src=[REF(src)];toggle_rx=1'>\[[pai.can_rx? "Disable" : "Enable"] Radio Reception\]</a><br>"
+			dat += "<A href='byond://?src=[REF(src)];toggle_transmit=1'>\[[pai.can_transmit? "Disable" : "Enable"] Radio Transmission\]</a><br>"
+			dat += "<A href='byond://?src=[REF(src)];toggle_receive=1'>\[[pai.can_receive? "Disable" : "Enable"] Radio Reception\]</a><br>"
 		else
 			dat += "<b>Radio Uplink</b><br>"
 			dat += "<font color=red><i>Radio firmware not loaded. Please install a pAI personality to load firmware.</i></font><br>"
@@ -92,24 +92,24 @@
 					to_chat(pai, "<span class='userdanger'>Your mental faculties leave you.</span>")
 					to_chat(pai, "<span class='rose'>oblivion... </span>")
 					qdel(pai)
-		if(href_list["toggle_tx"])
-			if(pai.can_tx)
+		if(href_list["toggle_transmit"])
+			if(pai.can_transmit)
 				to_chat(pai, "<span class='userdanger'>Your owner has disabled your outgoing radio transmissions!</span>")
-				pai.can_tx = FALSE
+				pai.can_transmit = FALSE
 				to_chat(usr, "<span class='warning'>You disable your pAI's outgoing radio transmissions!</span>")
 			else
 				to_chat(pai, "<span class='boldnotice'>Your owner has enabled your outgoing radio transmissions!</span>")
-				pai.can_tx = TRUE
+				pai.can_transmit = TRUE
 				to_chat(usr, "<span class='notice'>You enable your pAI's outgoing radio transmissions!</span>")
 			pai.radio.wires.cut(WIRE_TX)	
-		if(href_list["toggle_rx"])
-			if(pai.can_rx)
+		if(href_list["toggle_receive"])
+			if(pai.can_receive)
 				to_chat(pai, "<span class='userdanger'>Your owner has disabled your incoming radio transmissions!</span>")
-				pai.can_rx = FALSE
+				pai.can_receive = FALSE
 				to_chat(usr, "<span class='warning'>You disable your pAI's incoming radio transmissions!</span>")
 			else
 				to_chat(pai, "<span class='boldnotice'>Your owner has enabled your incoming radio transmissions!</span>")
-				pai.can_rx = TRUE
+				pai.can_receive = TRUE
 				to_chat(usr, "<span class='notice'>You enable your pAI's incoming radio transmissions!</span>")
 			pai.radio.wires.cut(WIRE_RX)
 		if(href_list["setlaws"])

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -57,6 +57,8 @@
 
 	var/holoform = FALSE
 	var/canholo = TRUE
+	var/can_tx = TRUE
+	var/can_rx = TRUE
 	var/obj/item/card/id/access_card = null
 	var/chassis = "repairbot"
 	var/list/possible_chassis = list("cat" = TRUE, "mouse" = TRUE, "monkey" = TRUE, "corgi" = FALSE, "fox" = FALSE, "repairbot" = TRUE, "rabbit" = TRUE)		//assoc value is whether it can be picked up.

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -57,8 +57,8 @@
 
 	var/holoform = FALSE
 	var/canholo = TRUE
-	var/can_tx = TRUE
-	var/can_rx = TRUE
+	var/can_transmit = TRUE
+	var/can_receive = TRUE
 	var/obj/item/card/id/access_card = null
 	var/chassis = "repairbot"
 	var/list/possible_chassis = list("cat" = TRUE, "mouse" = TRUE, "monkey" = TRUE, "corgi" = FALSE, "fox" = FALSE, "repairbot" = TRUE, "rabbit" = TRUE)		//assoc value is whether it can be picked up.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
Fixes quite a bit of #43620
## About The Pull Request
Whoever put together the disabling system for the pAI radio tried to make one variable work for both the TX and RX wires. I don't know if it worked at some point, but it definitely doesn't now.

I basically copied the holoform code, so please forgive me if this is shit. I am open to feedback and guidance on bringing it more into line with /tg/station's standards and quality.  
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a broken feature and now it's a less broken feature. Sometimes I guess pAI's are little gits and need to have their radio privileges removed. Or maybe you're an antag and you need to make the gameboy go SHH!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The radio configuration menu for masters of pAI will now toggle properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
I am having a bit of a hiccup, even with both wires off the pAI can still hear over common? This might be a redundancy thing. 