### PR TITLE
Bruise packs/ointments now less effective, especially against heavily damaged body parts

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -93,11 +93,11 @@
 				if(!H.bleedsuppress) //so you can't stack bleed suppression
 					H.suppress_bloodloss(stop_bleeding)
 		if(affecting.status == BODYPART_ORGANIC) //Limb must be organic to be healed - RR
-			var/actual_heal_brute = max(heal_brute - brute_damage_penalty * affecting.brute_dam,0)
-			var/actual_heal_burn = max(heal_burn - burn_damage_penalty * affecting.burn_dam,0)
+			var/actual_heal_brute = max(heal_brute - brute_heal_penalty * affecting.brute_dam,0)
+			var/actual_heal_burn = max(heal_burn - burn_heal_penalty * affecting.burn_dam,0)
 			if(actual_heal_brute + actual_heal_burn <= 0)
 				to_chat(user, "<span class='notice'>These injuries are too severe for the [src] to treat!</span>")
-				return
+
 			if(affecting.heal_damage(actual_heal_brute, actual_heal_burn))
 				C.update_damage_overlays()
 		else

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -13,6 +13,8 @@
 	novariants = FALSE
 	var/heal_brute = 0
 	var/heal_burn = 0
+	var/burn_heal_penalty = 0
+	var/brute_heal_penalty = 0
 	var/stop_bleeding = 0
 	var/self_delay = 50
 
@@ -91,7 +93,12 @@
 				if(!H.bleedsuppress) //so you can't stack bleed suppression
 					H.suppress_bloodloss(stop_bleeding)
 		if(affecting.status == BODYPART_ORGANIC) //Limb must be organic to be healed - RR
-			if(affecting.heal_damage(heal_brute, heal_burn))
+			var/actual_heal_brute = max(heal_brute - brute_damage_penalty * affecting.brute_dam,0)
+			var/actual_heal_burn = max(heal_burn - burn_damage_penalty * affecting.burn_dam,0)
+			if(actual_heal_brute + actual_heal_burn <= 0)
+				to_chat(user, "<span class='notice'>These injuries are too severe for the [src] to treat!</span>")
+				return
+			if(affecting.heal_damage(actual_heal_brute, actual_heal_burn))
 				C.update_damage_overlays()
 		else
 			to_chat(user, "<span class='notice'>Medicine won't work on a robotic limb!</span>")
@@ -105,12 +112,13 @@
 /obj/item/stack/medical/bruise_pack
 	name = "bruise pack"
 	singular_name = "bruise pack"
-	desc = "A therapeutic gel pack and bandages designed to treat blunt-force trauma."
+	desc = "A therapeutic gel pack and bandages designed to treat minor blunt-force trauma."
 	icon_state = "brutepack"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	heal_brute = 40
-	self_delay = 20
+	heal_brute = 30
+	brute_heal_penalty = 0.4
+	self_delay = 15
 	grind_results = list("styptic_powder" = 10)
 
 /obj/item/stack/medical/bruise_pack/suicide_act(mob/user)
@@ -158,14 +166,15 @@
 
 /obj/item/stack/medical/ointment
 	name = "ointment"
-	desc = "Used to treat those nasty burn wounds."
+	desc = "Used to treat those nasty burn wounds. Just not too nasty. For those, you'll need something else."
 	gender = PLURAL
 	singular_name = "ointment"
 	icon_state = "ointment"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	heal_burn = 40
-	self_delay = 20
+	heal_burn = 30
+	burn_heal_penalty = 0.4
+	self_delay = 15
 	grind_results = list("silver_sulfadiazine" = 10)
 
 /obj/item/stack/medical/ointment/suicide_act(mob/living/user)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -2,8 +2,8 @@
 	name = "medical pack"
 	singular_name = "medical pack"
 	icon = 'icons/obj/stack_objects.dmi'
-	amount = 6
-	max_amount = 6
+	amount = 8
+	max_amount = 8
 	w_class = WEIGHT_CLASS_TINY
 	full_w_class = WEIGHT_CLASS_TINY
 	throw_speed = 3

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -97,7 +97,6 @@
 			var/actual_heal_burn = max(heal_burn - burn_heal_penalty * affecting.burn_dam,0)
 			if(actual_heal_brute + actual_heal_burn <= 0)
 				to_chat(user, "<span class='notice'>These injuries are too severe for the [src] to treat!</span>")
-
 			if(affecting.heal_damage(actual_heal_brute, actual_heal_burn))
 				C.update_damage_overlays()
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the base healing of bruise packs and ointments from 40 to 30. Additionally, adds a factor that reduces the healing of bruise packs/ointments for each point of brute/burn respectively on the target limb (currently -0.4 healing per point of damage). To compensate, bruise packs and ointments now have 8 uses per stack, up from 6, and the delay on self use is now 15, down from 20.
Tweaks description text of bruise packs and ointment, and adds a message for when a bruise pack or ointment fails to do any healing due to the penalty.

Quick numbers: 
-optimal amount of damage on a body part to heal is now about 21.4. any less and heal will be wasted, any more and the penalty cuts into healing.
-theoretical maximum healing of a single stack of bruise packs/ointments went from 240 to 171.2
-Bruise packs and ointments are completely ineffective when the target limb has 75 damage of the appropriate type. Normal limbs have a maximum damage of 50, so this can only come up on head or chest injuries.

-healing a limb with less than 21.4  of the relevant damage type is unchanged
-healing a limb with 25 of the relevant damage type now takes 2 charges, up from 1
-healing a limb with 50 of the relevant damage type now takes 4 charges, up from 2.
-healing a torso/head with 65 of the relevant damage type now takes 6 charges, up from 2
-healing a torso/head with 74 of the relevant damage type now takes 13 charges, up from 2

## Why It's Good For The Game

First aid kits should ostensibly be first aid kits as opposed to medbay in a box. Before this change, first aid kits carry 960 hitpoints, which is enough to bring four people from the brink of death to full health. This seems a bit much, especially given how common basic first-aid kits are and how their contents carry no risk of overdose. After this change, first-aid kits are still useful for patching yourself up after a quick spacewalk or misadventure with a shocked door (better, in fact, since you get 33% more charges) but severe injuries will now be better served either in the medbay or using the medbay's specialty first aid kits.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: increased charges of bruise packs and ointment from 6 to 8
balance: decreased self-application time of bruise packs and ointments from 20 to 15
balance: reduced base healing of bruise packs and ointment from 40 to 30
balance: bruise packs and ointment are now less effective against severe wounds and severe burns.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
