### PR TITLE
Fixes AI integrity restorer dropping AI core on decon

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -149,6 +149,6 @@
 		else if (!occupier)
 			to_chat(user, "<span class='boldannounce'>ERROR</span>: Unable to locate artificial intelligence.")
 
-obj/machinery/computer/aifixer/on_deconstruction()
+/obj/machinery/computer/aifixer/on_deconstruction()
 	if(occupier)
 		occupier.Destroy()

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -9,8 +9,8 @@
 	icon_screen = "ai-fixer"
 	light_color = LIGHT_COLOR_PINK
 
-/obj/machinery/computer/aifixer/attackby(obj/item/I, mob/user, params)
-	if(occupier && I.tool_behaviour == TOOL_SCREWDRIVER)
+/obj/machinery/computer/aifixer/screwdriver_act(mob/living/user, obj/item/I)
+	if(occupier)
 		if(stat & (NOPOWER|BROKEN))
 			to_chat(user, "<span class='warning'>The screws on [name]'s screen won't budge.</span>")
 		else
@@ -148,3 +148,7 @@
 			to_chat(user, "<span class='boldannounce'>ERROR</span>: Reconstruction in progress.")
 		else if (!occupier)
 			to_chat(user, "<span class='boldannounce'>ERROR</span>: Unable to locate artificial intelligence.")
+
+obj/machinery/computer/aifixer/on_deconstruction()
+	if(occupier)
+		occupier.Destroy()

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -151,4 +151,4 @@
 
 /obj/machinery/computer/aifixer/on_deconstruction()
 	if(occupier)
-		occupier.Destroy()
+		QDEL_NULL(occupier)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

AI mob would get dropped when deconning or destroying the integrity restorer.  The previous check to prevent screwdriver deconstruction with an ai inside was using the wrong proc, and destroying it by force wasn't accounted for.  Now the screwdriver check works, and it can't be deconned with an ai inside.  If the console is destroyed into a computer frame, AI is removed permanently.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Previously you could stick an intellicard into the console, then decon or destroy it, and get a free AI core.  I was also promised nedbux.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Tetr4
fix: AI integrity restorer no longer drops a free AI core on deconstruction/destruction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
