### PR TITLE
Tweaks the CE's cloak to make it fireproof

### DIFF
--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -32,6 +32,7 @@
 	name = "chief engineer's cloak"
 	desc = "Worn by Engitopia, wielders of an unlimited power."
 	icon_state = "cecloak"
+	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/neck/cloak/rd
 	name = "research director's cloak"


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
It's a bit odd that it's not fireproof already, the CE usually deals with fires and it's quite sad to see the cloak dissipate once you step into a fire.

## Changelog
:cl: Vile Beggar
tweak: The CE's cloak is now fireproof.
/:cl: