### PR TITLE
Makes PubbyStation's Incinerator less bad

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -55967,6 +55967,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "jzi" = (
@@ -58473,6 +58476,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"paI" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "pbm" = (
 /obj/machinery/door/airlock/external{
 	name = "Pod Docking Bay"
@@ -60381,6 +60390,12 @@
 	},
 /turf/closed/wall,
 /area/engine/engineering)
+"tQj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "tQJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Cold Loop Bypass"
@@ -101554,7 +101569,7 @@ caL
 bZT
 bYw
 cdk
-bYw
+tQj
 bYw
 aht
 fon
@@ -101811,7 +101826,7 @@ caM
 fDm
 ltu
 cdl
-ltu
+paI
 ceA
 aaa
 mau

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -45883,6 +45883,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "caK" = (
@@ -46151,9 +46154,6 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "cbz" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -46161,6 +46161,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cbA" = (
@@ -46170,12 +46171,15 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/tank/toxins,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cbC" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
 	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cbF" = (
@@ -46419,6 +46423,11 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "ccr" = (
@@ -53923,6 +53932,10 @@
 /obj/item/stack/cable_coil/cut/random,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fbC" = (
+/obj/machinery/atmospherics/components/trinary/filter,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "fdQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55105,12 +55118,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"hCM" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxillary Base Construction";
@@ -55179,7 +55186,7 @@
 "hMa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/maintenance/disposal/incinerator)
 "hOx" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -55636,9 +55643,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/storage/emergency/port)
-"iHA" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "iJi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -55770,7 +55774,7 @@
 	req_access_txt = "24"
 	},
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/disposal/incinerator)
 "jcT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -57161,9 +57165,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"mnb" = (
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "mnG" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/wood,
@@ -58113,11 +58114,11 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "ots" = (
-/obj/machinery/atmospherics/components/trinary/filter,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "ous" = (
@@ -59055,7 +59056,7 @@
 "qFJ" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
-/area/space)
+/area/maintenance/disposal/incinerator)
 "qGu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -59224,7 +59225,7 @@
 "qXu" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/maintenance/disposal/incinerator)
 "qXH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -60133,10 +60134,6 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"tfY" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "tfZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -60202,9 +60199,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "tlU" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -61198,10 +61192,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"vIK" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/maintenance/disposal/incinerator)
 "vIM" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/blood/old,
@@ -61427,7 +61417,7 @@
 "wit" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
-/area/space)
+/area/maintenance/disposal/incinerator)
 "wiB" = (
 /obj/item/shard{
 	icon_state = "small"
@@ -61652,6 +61642,12 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
+"wLq" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "wMF" = (
 /obj/effect/spawner/lootdrop/three_course_meal,
 /obj/effect/spawner/lootdrop/three_course_meal,
@@ -100285,7 +100281,7 @@ cBT
 bYw
 bYw
 bYw
-mnb
+bYw
 aht
 aby
 aaa
@@ -100796,10 +100792,10 @@ bZg
 oMk
 oMk
 oMk
-oMk
+wLq
 oMk
 tlU
-iHA
+bYw
 aaa
 aaa
 aaa
@@ -101053,11 +101049,11 @@ bZh
 bZP
 caK
 cbC
-ccr
+fbC
 ccr
 ots
 cec
-hCM
+ceA
 aaa
 aaa
 aaa
@@ -102083,8 +102079,8 @@ caN
 bZT
 bYw
 jcB
-mnb
-vIK
+bYw
+abI
 aht
 fon
 aaa
@@ -102591,11 +102587,11 @@ bWg
 bVo
 bJP
 oex
-iHA
+bYw
 bYw
 caP
 bYw
-iHA
+bYw
 aaa
 aaa
 aaa
@@ -103104,8 +103100,8 @@ aaa
 aaa
 aaa
 abI
-tfY
-tfY
+abI
+abI
 qFJ
 wit
 qFJ

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -44669,9 +44669,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXF" = (
@@ -44685,17 +44682,11 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -45400,6 +45391,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZh" = (
@@ -45411,6 +45405,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -56070,12 +56067,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"jLW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "jMt" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -58688,6 +58679,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"pIh" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "inc_in";
+	on = 0
+	},
+/turf/open/floor/plating/airless,
+/area/maintenance/disposal/incinerator)
 "pKd" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/closet/crate,
@@ -60846,12 +60846,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "uQR" = (
@@ -101301,7 +101302,7 @@ bVl
 bWc
 bWR
 bXG
-jLW
+bYw
 uPu
 hUX
 cYq
@@ -101823,7 +101824,7 @@ fDm
 ltu
 cdl
 paI
-ceA
+pIh
 aaa
 mau
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -44686,7 +44686,7 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -44694,8 +44694,8 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 6
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -44919,9 +44919,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bYv" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "bYw" = (
@@ -45400,6 +45397,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
+"bZh" = (
 /obj/machinery/power/terminal{
 	dir = 4
 	},
@@ -45409,18 +45412,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
-"bZh" = (
-/obj/machinery/power/smes,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/cable/yellow,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZi" = (
@@ -45640,25 +45631,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
-"bZQ" = (
-/obj/machinery/computer/turbine_computer{
-	dir = 8;
-	id = "incineratorturbine"
-	},
-/obj/machinery/button/door/incinerator_vent_atmos_main{
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/obj/machinery/button/door/incinerator_vent_atmos_aux{
-	pixel_x = 24;
-	pixel_y = -6
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
 "bZR" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
@@ -45689,10 +45661,6 @@
 	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
-"bZV" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "bZY" = (
 /turf/closed/wall,
@@ -45917,25 +45885,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
-"caJ" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
 "caK" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -46006,10 +45958,6 @@
 	dir = 4;
 	luminosity = 2
 	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
-"caR" = (
-/obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "caS" = (
@@ -46203,13 +46151,19 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "cbz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cbA" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -46218,34 +46172,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
-"cbB" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
 "cbC" = (
-/obj/machinery/button/ignition/incinerator/atmos{
-	pixel_x = 26;
-	pixel_y = -6
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
-"cbE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "cbF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -46490,17 +46421,8 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
-"ccq" = (
-/obj/structure/chair/office,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
 "ccr" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "ccs" = (
@@ -46638,42 +46560,16 @@
 /area/engine/engineering)
 "cdg" = (
 /obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/storage/toolbox/emergency,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
-"cdh" = (
-/obj/structure/table/glass,
-/obj/item/storage/toolbox/emergency,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
-"cdi" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/machinery/meter,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
-"cdj" = (
+"cdk" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -46681,31 +46577,16 @@
 	name = "Atmospherics External Access";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
-"cdk" = (
+"cdl" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal/incinerator)
-"cdl" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Access";
-	req_access_txt = "24"
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cdm" = (
@@ -46967,10 +46848,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
-"ced" = (
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cee" = (
 /obj/structure/cable/yellow{
@@ -53272,6 +53149,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"cYq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "cZt" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -54370,6 +54257,14 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space/basic,
 /area/space)
+"fDm" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "fEl" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -55210,6 +55105,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"hCM" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxillary Base Construction";
@@ -55275,6 +55176,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"hMa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/space)
 "hOx" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -55385,6 +55290,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"hUX" = (
+/obj/machinery/computer/turbine_computer{
+	dir = 8;
+	id = "incineratorturbine"
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_main{
+	pixel_x = 24;
+	pixel_y = 6
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_aux{
+	pixel_x = 24;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "hVx" = (
 /obj/structure/chair{
 	dir = 4
@@ -55467,6 +55391,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
+"igl" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "igE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -55705,6 +55636,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/storage/emergency/port)
+"iHA" = (
+/turf/closed/wall/r_wall,
+/area/space)
 "iJi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -55827,6 +55761,16 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"jcB" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "jcT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -56015,6 +55959,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"jza" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "jzi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -56110,7 +56064,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "jLW" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "jMt" = (
@@ -56859,6 +56815,10 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"ltu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
@@ -57198,6 +57158,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"mnb" = (
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "mnG" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/wood,
@@ -57409,6 +57372,20 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"mOH" = (
+/obj/machinery/button/ignition/incinerator/atmos{
+	pixel_x = 26;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "mPh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -58132,6 +58109,14 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"ots" = (
+/obj/machinery/atmospherics/components/trinary/filter,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "ous" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/loading_area{
@@ -58331,6 +58316,9 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
+"oMk" = (
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "oMN" = (
 /turf/open/floor/plasteel/stairs/left,
 /area/maintenance/department/crew_quarters/dorms)
@@ -59006,6 +58994,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qux" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "qxq" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Air Out"
@@ -59051,6 +59043,10 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"qFJ" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/space)
 "qGu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -59216,6 +59212,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"qXu" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "qXH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -60124,14 +60124,14 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"tfY" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "tfZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
-"thA" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "thT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60192,6 +60192,16 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"tlU" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "tnY" = (
 /obj/machinery/button/door{
 	id = "aux_base_shutters";
@@ -60822,6 +60832,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uPu" = (
+/obj/machinery/power/smes,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "uQR" = (
 /obj/item/ammo_casing/shotgun/beanbag,
 /turf/open/floor/plating,
@@ -61160,6 +61183,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"vIK" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/maintenance/disposal/incinerator)
 "vIM" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/blood/old,
@@ -61382,6 +61409,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"wit" = (
+/obj/machinery/door/poddoor/incinerator_atmos_main,
+/turf/open/floor/engine/vacuum,
+/area/space)
 "wiB" = (
 /obj/item/shard{
 	icon_state = "small"
@@ -61591,13 +61622,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"wJP" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "wKa" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -100246,7 +100270,7 @@ cBT
 bYw
 bYw
 bYw
-aht
+mnb
 aht
 aby
 aaa
@@ -100503,7 +100527,7 @@ cbA
 ccp
 cdg
 cbz
-aaa
+hMa
 aaa
 aby
 aaa
@@ -100754,13 +100778,13 @@ bWQ
 bXE
 bYu
 bZg
-bZP
-caJ
-cbB
-ccq
-cdh
-bYw
-aaa
+oMk
+oMk
+oMk
+oMk
+oMk
+tlU
+iHA
 aaa
 aaa
 aaa
@@ -101011,14 +101035,14 @@ bNl
 bXF
 bYv
 bZh
-bZQ
+bZP
 caK
 cbC
 ccr
-cdi
+ccr
+ots
 cec
-ceA
-aaa
+hCM
 aaa
 aaa
 aaa
@@ -101267,13 +101291,13 @@ bWc
 bWR
 bXG
 jLW
-bZi
-bZR
-caL
-bZT
-bYw
-cdj
-bYw
+uPu
+hUX
+cYq
+mOH
+igl
+igl
+jza
 bYw
 aaa
 gYo
@@ -101522,15 +101546,15 @@ bUA
 bVm
 bWd
 bWS
-wJP
-aht
-bZj
-bZS
-caM
-cbE
-thA
+bWd
+qXu
+bZi
+bZR
+caL
+bZT
+bYw
 cdk
-ced
+bYw
 bYw
 aht
 fon
@@ -101780,15 +101804,15 @@ bLb
 bMi
 bLb
 bJP
-aaa
-bYw
-bZT
-caN
-bZT
-bYw
+oex
+bZj
+bZS
+caM
+fDm
+ltu
 cdl
-bYw
-bYw
+ltu
+ceA
 aaa
 mau
 aaa
@@ -102037,15 +102061,15 @@ bVn
 bWe
 bWT
 bJP
-aht
+mZE
 bYw
-bZU
-caO
-cbF
-ccs
-cdm
-cdm
+bZT
+caN
+bZT
 bYw
+jcB
+mnb
+vIK
 aht
 fon
 aaa
@@ -102296,12 +102320,12 @@ bVo
 bJP
 aht
 bYw
-bYw
-caP
-bYw
-bYw
-aaa
-aaa
+bZU
+caO
+cbF
+ccs
+qux
+qux
 aaa
 aaa
 aaa
@@ -102551,12 +102575,12 @@ bVo
 bWg
 bVo
 bJP
-aaa
-aaa
+oex
+iHA
 bYw
-caQ
+caP
 bYw
-aaa
+iHA
 aaa
 aaa
 aaa
@@ -102808,11 +102832,11 @@ bJP
 bJP
 bJP
 bJP
-abI
-abI
-bZV
-caR
-bZV
+mZE
+mZE
+bYw
+caQ
+bYw
 aaa
 aaa
 aaa
@@ -103065,11 +103089,11 @@ aaa
 aaa
 aaa
 abI
-aaa
-aaa
-aaa
-aaa
-aaa
+tfY
+tfY
+qFJ
+wit
+qFJ
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changed the layout of PubbyStation's Incinerator, making it slightly larger and cleaning up the mess of pipes that it was.

Previous layout:
![image](https://user-images.githubusercontent.com/222630/56400788-90338000-620a-11e9-8d09-1b696c5b2912.png)

Current layout:
![image](https://user-images.githubusercontent.com/222630/56400791-945f9d80-620a-11e9-928e-1ae8dd9390f9.png)

Expanded the area, cleaned up the mess of pipes, moved the tables to be less in the way, removed the office chair. Made the airlock scrubber separate from the chamber scrubber, with its very own air injector into space(shared with the room's scrubber). Might connect the room scrubber to main distro if I ever do a full rework of pubby atmos.
Gas Filter now lets you filter a single gas into the connector as the default setup. Makes much more sense.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes any Atmos Tech's life on Pubby easier, by making the Incinerator easier to modify and work with. While the new piping isn't that much better the much larger amount of free space allows an Atmospheric Technician more room for experimentation.
Also non-Meta maps need some love so there's more reason for playing them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked the pubby incinerator
/:cl:
I really hope I didn't screw up the mapmerger.
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->