### PR TITLE
Adding rotting to dismembered limbs and organs

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -304,4 +304,4 @@ GLOBAL_LIST_INIT(pipe_paint_colors, list(
 #define MIASMA_CORPSE_MOLES 0.02
 #define MIASMA_GIBS_MOLES 0.005
 #define MIASMA_HYGIENE_MOLES 0.002
-GLOBAL_DATUM(MIASMA_PROCESSOR, /datum/controller/miasma_processor)
+GLOBAL_DATUM_INIT(MIASMA_PROCESSOR, /datum/controller/miasma_processor, new())

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -304,3 +304,4 @@ GLOBAL_LIST_INIT(pipe_paint_colors, list(
 #define MIASMA_CORPSE_MOLES 0.02
 #define MIASMA_GIBS_MOLES 0.005
 #define MIASMA_HYGIENE_MOLES 0.002
+GLOBAL_DATUM(MIASMA_PROCESSOR, /datum/controller/miasma_processor)

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -379,6 +379,6 @@
 	if(istype(H.loc, /obj/structure/closet/crate/coffin)|| istype(H.loc, /obj/structure/closet/body_bag) || istype(H.loc, /obj/structure/bodycontainer))
 		return
 
-	miasma_manager.tilestodiffuse[get_turf(H)] += MIASMA_HYGIENE_MOLES
+	GLOB.MIASMA_PROCESSOR.tilestodiffuse[get_turf(H)] += MIASMA_HYGIENE_MOLES
 #undef MINOR_INSANITY_PEN
 #undef MAJOR_INSANITY_PEN

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -379,12 +379,6 @@
 	if(istype(H.loc, /obj/structure/closet/crate/coffin)|| istype(H.loc, /obj/structure/closet/body_bag) || istype(H.loc, /obj/structure/bodycontainer))
 		return
 
-	var/turf/T = get_turf(H)
-	var/datum/gas_mixture/stank = new
-	ADD_GAS(/datum/gas/miasma, stank.gases)
-	stank.gases[/datum/gas/miasma][MOLES] = MIASMA_HYGIENE_MOLES
-	T.assume_air(stank)
-	T.air_update_turf()
-
+	miasma_manager.tilestodiffuse[get_turf(H)] += MIASMA_HYGIENE_MOLES
 #undef MINOR_INSANITY_PEN
 #undef MAJOR_INSANITY_PEN

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -1,4 +1,9 @@
 //This is supposed to help make miasma at certain turfs by reducing the number of atmos changes to do
+//Needed, since it would attach the processor to null, which would make the process() proc not trigger
+datum/controller/miasma_processor/New()
+	..()
+	Initialize()
+
 /datum/controller/miasma_processor
 	var/list/tilestodiffuse = list()
 

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -39,7 +39,7 @@ var/datum/controller/miasma_processor/miasma_manager
 	var/turf/open/T = get_turf(A)
 
 	if(istype(T) && !istype(T,/turf/open/space))
-		miasma_manager.tilestodiffuse[T] += amount
+		GLOB.MIASMA_PROCESSOR.tilestodiffuse[T] += amount
 
 /datum/component/rot/corpse
 	amount = MIASMA_CORPSE_MOLES

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -33,7 +33,8 @@
 
 /datum/component/rot/corpse/process()
 	var/mob/living/carbon/C = parent
-	if(C.stat != DEAD)
+	//There is no way to de-husk and inorganic mobs/ skeletons don't rot: remove the component
+	if(C.stat != DEAD || C.has_trait(TRAIT_HUSK) || (!(MOB_ORGANIC in C.mob_biotypes) && !(MOB_UNDEAD in C.mob_biotypes)))
 		qdel(src)
 		return
 
@@ -46,14 +47,34 @@
 		return
 
 	// No decay if formaldehyde in corpse or when the corpse is charred
-	if(C.reagents.has_reagent("formaldehyde", 15) || C.has_trait(TRAIT_HUSK))
+	if(C.reagents.has_reagent("formaldehyde", 15))
 		return
 
 	// Also no decay if corpse chilled or not organic/undead
-	if(C.bodytemperature <= T0C-10 || (!(MOB_ORGANIC in C.mob_biotypes) && !(MOB_UNDEAD in C.mob_biotypes)))
+	if(C.bodytemperature <= T0C-10)
 		return
 
 	..()
 
 /datum/component/rot/gibs
 	amount = MIASMA_GIBS_MOLES
+
+/datum/component/rot/bodypart
+	amount = MIASMA_GIBS_MOLES
+
+/datum/component/rot/bodypart/process()
+	var/obj/item/bodypart/BP = parent
+	if(BP.owner || BP.burn_dam > 100)
+		qdel(src)
+		return
+	..()
+
+/datum/component/rot/organ
+	amount = MIASMA_GIBS_MOLES
+
+/datum/component/rot/organ/process()
+	var/obj/item/organ/O = parent
+	if(O.owner)
+		qdel(src)
+		return
+	..()

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -14,7 +14,11 @@ datum/controller/miasma_processor/New()
 	for(var/turf/T in tilestodiffuse)
 		if(!istype(T))
 			continue
-	
+		//No miasma on cold turf
+		var/datum/gas_mixture/turfgas = T.return_air()
+		if(turfgas.temperature <= T0C-20)
+			continue
+
 		var/datum/gas_mixture/stank = new
 		ADD_GAS(/datum/gas/miasma, stank.gases)
 		stank.gases[/datum/gas/miasma][MOLES] = tilestodiffuse[T]

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -1,6 +1,4 @@
 //This is supposed to help make miasma at certain turfs by reducing the number of atmos changes to do
-var/datum/controller/miasma_processor/miasma_manager
-
 /datum/controller/miasma_processor
 	var/list/tilestodiffuse = list()
 

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -1,3 +1,26 @@
+//This is supposed to help make miasma at certain turfs by reducing the number of atmos changes to do
+var/datum/controller/miasma_processor/miasma_manager
+
+/datum/controller/miasma_processor
+	var/list/tilestodiffuse = list()
+
+/datum/controller/miasma_processor/Initialize()
+	START_PROCESSING(SSprocessing, src)
+
+/datum/controller/miasma_processor/process()
+	for(var/turf/T in tilestodiffuse)
+		if(!istype(T))
+			continue
+	
+		var/datum/gas_mixture/stank = new
+		ADD_GAS(/datum/gas/miasma, stank.gases)
+		stank.gases[/datum/gas/miasma][MOLES] = tilestodiffuse[T]
+		T.assume_air(stank)
+		T.air_update_turf()
+	
+	tilestodiffuse.Cut()	
+
+
 /datum/component/rot
 	var/amount = 1
 
@@ -14,14 +37,9 @@
 	var/atom/A = parent
 
 	var/turf/open/T = get_turf(A)
-	if(!istype(T))
-		return
 
-	var/datum/gas_mixture/stank = new
-	ADD_GAS(/datum/gas/miasma, stank.gases)
-	stank.gases[/datum/gas/miasma][MOLES] = amount
-	T.assume_air(stank)
-	T.air_update_turf()
+	if(istype(T) && !istype(T,/turf/open/space))
+		miasma_manager.tilestodiffuse[T] += amount
 
 /datum/component/rot/corpse
 	amount = MIASMA_CORPSE_MOLES

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -53,8 +53,6 @@ GLOBAL_VAR(restart_counter)
 	if(TEST_RUN_PARAMETER in params)
 		HandleTestRun()
 
-	miasma_manager = new
-
 /world/proc/HandleTestRun()
 	//trigger things to run the whole process
 	Master.sleep_offline_after_initializations = FALSE

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -53,6 +53,8 @@ GLOBAL_VAR(restart_counter)
 	if(TEST_RUN_PARAMETER in params)
 		HandleTestRun()
 
+	miasma_manager = new
+
 /world/proc/HandleTestRun()
 	//trigger things to run the whole process
 	Master.sleep_offline_after_initializations = FALSE

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -34,8 +34,7 @@
 				if(no_brain || !istype(X, /obj/item/organ/brain))
 					qdel(X)
 		else //we're going to drop all bodyparts except chest, so the only organs that needs spilling are those inside it.
-			for(var/X in internal_organs)
-				var/obj/item/organ/O = X
+			for(var/obj/item/organ/O in internal_organs)
 				if(no_brain && istype(O, /obj/item/organ/brain))
 					qdel(O) //so the brain isn't transfered to the head when the head drops.
 					continue
@@ -44,9 +43,9 @@
 					O.Remove(src)
 					O.forceMove(Tsec)
 					O.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
+					O.start_rotting()
 	else
-		for(var/X in internal_organs)
-			var/obj/item/organ/I = X
+		for(var/obj/item/organ/I in internal_organs)
 			if(no_brain && istype(I, /obj/item/organ/brain))
 				qdel(I)
 				continue
@@ -56,10 +55,10 @@
 			I.Remove(src)
 			I.forceMove(Tsec)
 			I.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
+			I.start_rotting()
 
 
 /mob/living/carbon/spread_bodyparts()
-	for(var/X in bodyparts)
-		var/obj/item/bodypart/BP = X
+	for(var/obj/item/bodypart/BP in bodyparts)
 		BP.drop_limb()
 		BP.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -530,6 +530,11 @@
 		if(L)
 			L.update_icon()
 
+//Called by dismember(), meaning the organ wasn't carefully (surgically) removed, rather violently
+/obj/item/bodypart/proc/start_rotting()
+	desc += " It smells terrible."
+	AddComponent(/datum/component/rot/bodypart)
+
 /obj/item/bodypart/l_arm/monkey
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "default_monkey_l_arm"

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -532,6 +532,10 @@
 
 //Called by dismember(), meaning the organ wasn't carefully (surgically) removed, rather violently
 /obj/item/bodypart/proc/start_rotting()
+	if(status == BODYPART_ORGANIC)
+		addtimer(CALLBACK(src, .proc/rot_now), 2 MINUTES)
+
+/obj/item/organ/proc/rot_now()
 	desc += " It smells terrible."
 	AddComponent(/datum/component/rot/bodypart)
 

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -535,7 +535,7 @@
 	if(status == BODYPART_ORGANIC)
 		addtimer(CALLBACK(src, .proc/rot_now), 2 MINUTES)
 
-/obj/item/organ/proc/rot_now()
+/obj/item/bodypart/proc/rot_now()
 	desc += " It smells terrible."
 	AddComponent(/datum/component/rot/bodypart)
 

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -59,13 +59,13 @@
 	var/turf/T = get_turf(C)
 	C.add_splatter_floor(T)
 	playsound(get_turf(C), 'sound/misc/splort.ogg', 80, 1)
-	for(var/X in C.internal_organs)
-		var/obj/item/organ/O = X
+	for(var/obj/item/organ/O in C.internal_organs)
 		var/org_zone = check_zone(O.zone)
 		if(org_zone != BODY_ZONE_CHEST)
 			continue
 		O.Remove(C)
 		O.forceMove(T)
+		O.start_rotting()
 		organ_spilled = 1
 		. += X
 	if(cavity_item)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -22,6 +22,9 @@
 	SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "dismembered", /datum/mood_event/dismembered)
 	drop_limb()
 
+	if(status == BODYPART_ORGANIC)
+		addtimer(CALLBACK(src, .proc/start_rotting), 2 MINUTES)
+
 	if(dam_type == BURN)
 		burn()
 		return 1

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -67,7 +67,7 @@
 		O.forceMove(T)
 		O.start_rotting()
 		organ_spilled = 1
-		. += X
+		. += O
 	if(cavity_item)
 		cavity_item.forceMove(T)
 		. += cavity_item

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -100,6 +100,9 @@
 
 /obj/item/organ/proc/start_rotting()
 	if(!synthetic)
+		addtimer(CALLBACK(src, .proc/rot_now), 2 MINUTES)
+
+/obj/item/organ/proc/rot_now()
 		desc += " It smells terrible."
 		AddComponent(/datum/component/rot/organ)
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -98,6 +98,10 @@
 	else
 		..()
 
+/obj/item/organ/proc/start_rotting()
+	desc += " It smells terrible."
+	AddComponent(/datum/component/rot/organ)
+
 /obj/item/organ/item_action_slot_check(slot,mob/user)
 	return //so we don't grant the organ's action to mobs who pick up the organ.
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -99,8 +99,9 @@
 		..()
 
 /obj/item/organ/proc/start_rotting()
-	desc += " It smells terrible."
-	AddComponent(/datum/component/rot/organ)
+	if(!synthetic)
+		desc += " It smells terrible."
+		AddComponent(/datum/component/rot/organ)
 
 /obj/item/organ/item_action_slot_check(slot,mob/user)
 	return //so we don't grant the organ's action to mobs who pick up the organ.


### PR DESCRIPTION
## About The Pull Request

This PR mainly adds the rot that we know from corpses and gibs to **dismembered** limbs. Since surgical removal should be a procedure done carefully, it doesn't trigger that. The component qdeletes itself automatically once the limb has been reimplanted. Organs spilling out are also subject to rotting.
There's also been a small tweak for the corpse decomposition: In case the body isn't organic or has been husked, the component is also qdeleted, which would stop making it run even if it would just return before triggering for the rest of the game. Also, the game now has a miasma manager, which is basically a list of turfs and how much miasma to add on each. It makes it so that the tick intensive add_gas() proc isn't called each time, especially in cases where bodies, organs, limbs and gibs are piled up in one turf.

## Why It's Good For The Game

It expands on the yet insignificant miasma subsystem and seems logical: since corpses and gibs rot, why not dismembered limbs/organs? Also gives more insentive to clean up after a fight and do surgery right instead of just hammering with a chainsaw. Currently, the quantity of miasma is so insignificant that even with a round ending in full chaos, it barely has any impact.

## Changelog
:cl: Shdorsh
tweak: Made limbs and organs rot and make miasma when dismembered after 2 minutes, like corpses or gibs.
tweak: made the rot component for corpses a bit more efficient by removing it when it would just return without triggering anyway
tweak: Added a miasma processor. Made all the miasma add_gas() run off of it.
/:cl:
