### PR TITLE
Adds an explosion log to the tachyon-doppler array

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -90,7 +90,6 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 		for(var/message in messages)
 			say(message)
 	LAZYADD(message_log, messages)
-	log_game("[src] logged explosion: [messages]")
 	return TRUE
 
 /obj/machinery/doppler_array/power_change()

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -11,6 +11,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	var/integrated = FALSE
 	var/max_dist = 150
 	verb_say = "states coldly"
+	var/list/message_log = list()
 
 /obj/machinery/doppler_array/Initialize()
 	. = ..()
@@ -26,6 +27,9 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 /obj/machinery/doppler_array/examine(mob/user)
 	..()
 	to_chat(user, "<span class='notice'>Its dish is facing to the [dir2text(dir)].</span>")
+	for(var/i in 1 to message_log.len)
+		to_chat(user, "<span class='notice'>Log recording #[i]: [message_log[i]].</span>")
+
 
 /obj/machinery/doppler_array/process()
 	return PROCESS_KILL
@@ -85,6 +89,8 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	else
 		for(var/message in messages)
 			say(message)
+	LAZYADD(message_log, messages)
+	log_game("[src] logged explosion: [messages]")
 	return TRUE
 
 /obj/machinery/doppler_array/power_change()

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -112,9 +112,6 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	LAZYADD(message_log, messages.Join(" "))
 	return TRUE
 
-/obj/machinery/doppler_array/proc/get_log_info()
-	return
-
 /obj/machinery/doppler_array/power_change()
 	if(stat & BROKEN)
 		icon_state = "[initial(icon_state)]-broken"

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -29,6 +29,9 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 
 /obj/machinery/doppler_array/ui_interact(mob/user)
 	. = ..()
+	if(stat)
+		return FALSE
+
 	var/dat = {"<html><head><title>[src.name]</title><style>h3 {margin: 0px; padding: 0px;}</style></head><body><br>
 				<h3>Explosion logs</h3>"}
 	for(var/i in 1 to message_log.len)
@@ -38,8 +41,10 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	dat += "<A href='?src=[REF(src)];refresh=1'>(Refresh)</A><br>"
 	dat += "</body></html>"
 
-	user << browse(dat, "window=computer;size=400x500")
-	onclose(user, "computer")
+	var/datum/browser/popup = new(user, "computer", name, 400, 500)
+	popup.set_content(dat)
+	popup.open()
+	return
 
 /obj/machinery/doppler_array/Topic(href, href_list)
 	if(..())

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -12,7 +12,6 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	var/max_dist = 150
 	verb_say = "states coldly"
 	var/list/message_log = list()
-	var/output_log
 
 /obj/machinery/doppler_array/Initialize()
 	. = ..()
@@ -32,17 +31,15 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	if(stat)
 		return FALSE
 
-	var/dat = {"<html><head><title>[src.name]</title><style>h3 {margin: 0px; padding: 0px;}</style></head><body><br>
-				<h3>Explosion logs</h3>"}
+	var/list/dat = list()
 	for(var/i in 1 to message_log.len)
 		dat += "Log recording #[i]: [message_log[i]]<br/><br>"
 	dat += "<A href='?src=[REF(src)];delete_log=1'>Delete logs</A><br>"
 	dat += "<hr>"
 	dat += "<A href='?src=[REF(src)];refresh=1'>(Refresh)</A><br>"
 	dat += "</body></html>"
-
 	var/datum/browser/popup = new(user, "computer", name, 400, 500)
-	popup.set_content(dat)
+	popup.set_content(dat.Join(" "))
 	popup.open()
 	return
 
@@ -112,10 +109,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	else
 		for(var/message in messages)
 			say(message)
-	output_log = messages.Join(" ")
-	LAZYADD(message_log, output_log)
-	if(output_log)
-		qdel(output_log)
+	LAZYADD(message_log, messages.Join(" "))
 	return TRUE
 
 /obj/machinery/doppler_array/proc/get_log_info()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tachyon-doppler arrays now log explosion events. They also have a ui to view and clear them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I came across this when testing bombs one day and I was very annoyed that I couldn't see a simple log history. This I hope will address that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: YoYoBatty
add: Tachyon-doppler arrays now have explosion logging.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Things to do:
- [x] Add ability to delete messages
- [x] Add a ui