### PR TITLE
Examining intercoms/radios shows the frequency they're set to, if you're in range.

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -320,6 +320,8 @@
 
 /obj/item/radio/examine(mob/user)
 	..()
+	if (frequency && in_range(src, user))
+		to_chat(user, "<span class='notice'>It is set to broadcast over the [frequency/10] frequency.</span>")
 	if (unscrewed)
 		to_chat(user, "<span class='notice'>It can be attached and modified.</span>")
 	else


### PR DESCRIPTION
## About The Pull Request

straight from minor suggestions from like one year ago https://tgstation13.org/phpBB/viewtopic.php?f=9&t=30&start=3200

the /10 is because there are no decimal points in the constant

## Why It's Good For The Game

quality of life; at least one person requested it

## Changelog
:cl:
tweak: Examining intercoms/radios shows the frequency they're set to, if you're in range.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
