### PR TITLE
makes RD's and CMO's cape acidproof

### DIFF
--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -27,6 +27,7 @@
 	name = "chief medical officer's cloak"
 	desc = "Worn by Meditopia, the valiant men and women keeping pestilence at bay."
 	icon_state = "cmocloak"
+	resistance_flags = ACID_PROOF
 
 /obj/item/clothing/neck/cloak/ce
 	name = "chief engineer's cloak"
@@ -38,6 +39,7 @@
 	name = "research director's cloak"
 	desc = "Worn by Sciencia, thaumaturges and researchers of the universe."
 	icon_state = "rdcloak"
+	resistance_flags = ACID_PROOF
 
 /obj/item/clothing/neck/cloak/cap
 	name = "captain's cloak"


### PR DESCRIPTION
## About The Pull Request

As the title says, this PR makes Research Director's and Chief Medical Officer's cape acidproof.

## Why It's Good For The Game

They should be more unique, as CE's cape is.

## Changelog
:cl: Rowell
add: RD's and CMO's cape are now acidproof. Feel free to test it.
/:cl: