### PR TITLE
Fixes transforming weapons resetting their throw speed.

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -25,7 +25,6 @@
 #define NOBLUDGEON				(1<<7)		// when an item has this it produces no "X has been hit by Y with Z" message in the default attackby()
 #define ABSTRACT				(1<<9) 	// for all things that are technically items but used for various different stuff
 #define IMMUTABLE_SLOW			(1<<10) // When players should not be able to change the slowdown of the item (Speed potions, etc)
-#define SHRAPNEL				(1<<11) // Explosion propelled, always try to embed.
 
 // Flags for the clothing_flags var on /obj/item/clothing
 

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -25,6 +25,7 @@
 #define NOBLUDGEON				(1<<7)		// when an item has this it produces no "X has been hit by Y with Z" message in the default attackby()
 #define ABSTRACT				(1<<9) 	// for all things that are technically items but used for various different stuff
 #define IMMUTABLE_SLOW			(1<<10) // When players should not be able to change the slowdown of the item (Speed potions, etc)
+#define SHRAPNEL				(1<<11) // Explosion propelled, always try to embed.
 
 // Flags for the clothing_flags var on /obj/item/clothing
 

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -221,7 +221,6 @@ GLOBAL_LIST_EMPTY(explosions)
 			if(!I.anchored)
 				var/throw_range = rand(throw_dist, max_range)
 				var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
-				I.item_flags |= SHRAPNEL //Try to embed even with lower inherent throw_speed
 				I.throw_at(throw_at, throw_range, EXPLOSION_THROW_SPEED)
 
 		//wait for the lists to repop

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -221,7 +221,7 @@ GLOBAL_LIST_EMPTY(explosions)
 			if(!I.anchored)
 				var/throw_range = rand(throw_dist, max_range)
 				var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
-				I.throw_speed = EXPLOSION_THROW_SPEED //Temporarily change their throw_speed for embedding purposes (Reset when it finishes throwing, regardless of hitting anything)
+				I.item_flags |= SHRAPNEL //Try to embed even with lower inherent throw_speed
 				I.throw_at(throw_at, throw_range, EXPLOSION_THROW_SPEED)
 
 		//wait for the lists to repop

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -534,7 +534,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/after_throw(datum/callback/callback)
 	if (callback) //call the original callback
 		. = callback.Invoke()
-	//throw_speed = initial(throw_speed) //explosions change this.
 	item_flags &= ~(IN_INVENTORY | SHRAPNEL)
 
 /obj/item/proc/remove_item_from_storage(atom/newLoc) //please use this if you're going to snowflake an item out of a obj/item/storage

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -534,7 +534,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/after_throw(datum/callback/callback)
 	if (callback) //call the original callback
 		. = callback.Invoke()
-	item_flags &= ~(IN_INVENTORY | SHRAPNEL)
+	item_flags &= ~IN_INVENTORY
 
 /obj/item/proc/remove_item_from_storage(atom/newLoc) //please use this if you're going to snowflake an item out of a obj/item/storage
 	if(!newLoc)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -534,8 +534,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/after_throw(datum/callback/callback)
 	if (callback) //call the original callback
 		. = callback.Invoke()
-	throw_speed = initial(throw_speed) //explosions change this.
-	item_flags &= ~IN_INVENTORY
+	//throw_speed = initial(throw_speed) //explosions change this.
+	item_flags &= ~(IN_INVENTORY | SHRAPNEL)
 
 /obj/item/proc/remove_item_from_storage(atom/newLoc) //please use this if you're going to snowflake an item out of a obj/item/storage
 	if(!newLoc)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -153,7 +153,7 @@
 		skipcatch = TRUE
 		blocked = TRUE
 	else if(I)
-		if((I.throw_speed >= EMBED_THROWSPEED_THRESHOLD) || I.embedding.embedded_ignore_throwspeed_threshold)
+		if((I.throw_speed >= EMBED_THROWSPEED_THRESHOLD) || I.embedding.embedded_ignore_throwspeed_threshold || I.item_flags & SHRAPNEL)
 			if(can_embed(I))
 				if(prob(I.embedding.embed_chance) && !has_trait(TRAIT_PIERCEIMMUNE))
 					throw_alert("embeddedobject", /obj/screen/alert/embeddedobject)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -153,7 +153,7 @@
 		skipcatch = TRUE
 		blocked = TRUE
 	else if(I)
-		if((I.throw_speed >= EMBED_THROWSPEED_THRESHOLD) || I.embedding.embedded_ignore_throwspeed_threshold || I.item_flags & SHRAPNEL)
+		if(((throwingdatum ? throwingdatum.speed : I.throw_speed) >= EMBED_THROWSPEED_THRESHOLD) || I.embedding.embedded_ignore_throwspeed_threshold)
 			if(can_embed(I))
 				if(prob(I.embedding.embed_chance) && !has_trait(TRAIT_PIERCEIMMUNE))
 					throw_alert("embeddedobject", /obj/screen/alert/embeddedobject)


### PR DESCRIPTION
Fixes #43621

I feel kinda bad for adding such useless item flag, but the alternatives would be costly messing with embedding list or changing the embed check which might be some balance meme.