### PR TITLE
[READY] Smooth(er) Movement V2 (60 FPS fix)

### DIFF
--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -1,0 +1,9 @@
+//The minimum for glide_size to be clamped to.
+//If you want more classic style "delay" movement while still retaining the smoothness improvements at higher framerates, set this to 8
+#define MIN_GLIDE_SIZE 0
+//The maximum for glide_size to be clamped to.
+//This shouldn't be higher than the icon size, and generally you shouldn't be changing this, but it's here just in case.
+#define MAX_GLIDE_SIZE 32
+
+#define DELAY_TO_GLIDE_SIZE(delay) (CLAMP((world.icon_size / max(CEILING(delay / world.tick_lag, 0.1), 1)), MIN_GLIDE_SIZE, MAX_GLIDE_SIZE))
+ 

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -32,10 +32,14 @@
 	var/atom/movable/AM = parent
 	restore_position(M)
 	unequip_buckle_inhands(M)
+	M.updating_glide_size = TRUE
 	if(del_on_unbuckle_all && !AM.has_buckled_mobs())
 		qdel(src)
 
 /datum/component/riding/proc/vehicle_mob_buckle(datum/source, mob/living/M, force = FALSE)
+	var/atom/movable/AM = parent
+	M.set_glide_size(AM.glide_size)
+	M.updating_glide_size = FALSE
 	handle_vehicle_offsets()
 
 /datum/component/riding/proc/handle_vehicle_layer()
@@ -53,8 +57,10 @@
 
 /datum/component/riding/proc/vehicle_moved(datum/source)
 	var/atom/movable/AM = parent
-	for(var/i in AM.buckled_mobs)
-		ride_check(i)
+	AM.set_glide_size(DELAY_TO_GLIDE_SIZE(vehicle_move_delay))
+	for(var/mob/M in AM.buckled_mobs)
+		ride_check(M)
+		M.set_glide_size(AM.glide_size)
 	handle_vehicle_offsets()
 	handle_vehicle_layer()
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -162,20 +162,20 @@
 
 /atom/movable/proc/Move_Pulled(atom/A)
 	if(!pulling)
-		return
+		return FALSE
 	if(pulling.anchored || pulling.move_resist > move_force || !pulling.Adjacent(src))
 		stop_pulling()
-		return
+		return FALSE
 	if(isliving(pulling))
 		var/mob/living/L = pulling
 		if(L.buckled && L.buckled.buckle_prevents_pull) //if they're buckled to something that disallows pulling, prevent it
 			stop_pulling()
-			return
+			return FALSE
 	if(A == loc && pulling.density)
-		return
+		return FALSE
 	var/move_dir = get_dir(pulling.loc, A)
 	if(!Process_Spacemove(move_dir))
-		return
+		return FALSE
 	pulling.Move(get_step(pulling.loc, move_dir), move_dir, glide_size)
 	return TRUE
 
@@ -352,7 +352,7 @@
 			//puller and pullee more than one tile away or in diagonal position
 			if(get_dist(src, pulling) > 1 || (moving_diagonally != SECOND_DIAG_STEP && ((pull_dir - 1) & pull_dir)))
 				pulling.moving_from_pull = src
-				pulling.Move(T, get_dir(pulling, T)) //the pullee tries to reach our previous position
+				pulling.Move(T, get_dir(pulling, T), glide_size) //the pullee tries to reach our previous position
 				pulling.moving_from_pull = null
 			check_pulling()
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -70,6 +70,7 @@
 	buckled_mobs |= M
 	M.update_mobility()
 	M.throw_alert("buckled", /obj/screen/alert/restrained/buckled)
+	M.set_glide_size(glide_size)
 	post_buckle_mob(M)
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_BUCKLE, M, force)
@@ -89,6 +90,7 @@
 		buckled_mob.anchored = initial(buckled_mob.anchored)
 		buckled_mob.update_mobility()
 		buckled_mob.clear_alert("buckled")
+		buckled_mob.set_glide_size(DELAY_TO_GLIDE_SIZE(buckled_mob.total_multiplicative_slowdown()))
 		buckled_mobs -= buckled_mob
 		SEND_SIGNAL(src, COMSIG_MOVABLE_UNBUCKLE, buckled_mob, force)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -228,8 +228,8 @@
 	var/current_dir
 	if(isliving(AM))
 		current_dir = AM.dir
-	if(step(AM, t))
-		step(src, t)
+	if(AM.Move(get_step(AM.loc, t), t, glide_size))
+		Move(get_step(loc, t), t)
 	if(current_dir)
 		AM.setDir(current_dir)
 	now_pushing = FALSE

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -104,3 +104,5 @@
 	var/datum/click_intercept
 
 	var/registered_z
+
+	var/updating_glide_size = TRUE

--- a/code/modules/mob/mob_movespeed.dm
+++ b/code/modules/mob/mob_movespeed.dm
@@ -77,6 +77,7 @@
 				continue
 		. += amt
 	cached_multiplicative_slowdown = .
+	set_glide_size(DELAY_TO_GLIDE_SIZE(cached_multiplicative_slowdown))
 
 /mob/proc/get_movespeed_modifiers()
 	return movespeed_modification

--- a/code/modules/mob/mob_movespeed.dm
+++ b/code/modules/mob/mob_movespeed.dm
@@ -77,7 +77,8 @@
 				continue
 		. += amt
 	cached_multiplicative_slowdown = .
-	set_glide_size(DELAY_TO_GLIDE_SIZE(cached_multiplicative_slowdown))
+	if(updating_glide_size)
+		set_glide_size(DELAY_TO_GLIDE_SIZE(cached_multiplicative_slowdown))
 
 /mob/proc/get_movespeed_modifiers()
 	return movespeed_modification

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -995,7 +995,6 @@
 	throwforce = 10
 	throw_speed = 0.1
 	throw_range = 28
-	glide_size = 2
 	flags_1 = CONDUCT_1
 	max_amount = 60
 	turf_type = /turf/open/floor/sepia

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -67,6 +67,7 @@
 #include "code\__DEFINES\mobs.dm"
 #include "code\__DEFINES\monkeys.dm"
 #include "code\__DEFINES\move_force.dm"
+#include "code\__DEFINES\movement.dm"
 #include "code\__DEFINES\movespeed_modification.dm"
 #include "code\__DEFINES\nanites.dm"
 #include "code\__DEFINES\networks.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
If you're clicking on this wondering why the game isn't at 60 fps when this is testmerged or whatever, client defaults weren't changed. You'll still need to set your framerate to 60 in game prefs.
## About The Pull Request

`glide_size` is now set automatically based on movespeed using an algorithm ported from CEV Eris. This results in smoother looking movement between tiles. At lower speeds, mobs will appear to move slower between tiles. At higher speeds, mobs will actually animate at a correct speed between tiles and not appear to teleport between tiles as much.
This (mostly) fixes the extremely fucked camera movement on 60 fps.
Video demonstration: https://youtu.be/LdlTy96Oit4
extra video showing very fast speeds at 60 fps that I forgot to record originally: https://youtu.be/vBW-77444cU
I just realized I accidentally recorded both of those with move_delay set to 1, it actually looks a little better with move_delay 1.5 imo.

Known weirdness:
- Mobs on patrol routes like beepsky and medibots sometimes appear to teleport a tile. I think they did this before but I'm not really sure. I don't know what's causing this but it's probably fixable. (further testing has confirmed that yes, they did do this before, but it looks worse with a lower glide_size set)
- Due to how movement works, moving on and off of movement affecting turfs such as sepia tiles is a little janky. This may not be possible to fix because there's no practical way to know when the movement animation has ended.
- Byond claims that it scales glide_size based on client fps, but I think there's something wrong with it. The higher of a framerate you have set, the more you will notice this. 60 fps has some oddness mostly noticable only at very low speeds, but 120 is very broken. The default of 20 fps also seems a _little_ off for very high speeds but I'm not entirely sure.

## Why It's Good For The Game

Looks good
60 fps is usable without massive camera weirdness while moving fast
You can see at a glance if someone has slowdown from one movement

## Changelog
:cl:
tweak: Changed movement animation handling so it looks smoother.
fix:  60 fps movement no longer makes your camera freak out when moving fast
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
  