### PR TITLE
Fixes Pubbystation incinerator waste to space injector

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -58679,8 +58679,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1;
 	frequency = 1441;
-	id = "inc_in";
-	on = 0
+	id = "inc_in"
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR defaults the Pubby waste to space injector to on.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If this injector starts off, it messes with the atmos cycle airlock and can trap players inside it, since there is a very likely chance that the connected waste pipe will clog and leave the air pump unable to completely siphon the airlock chamber.
That in turn leaves the player inside the airlock bolted in with no real way to escape short of hacking the airlock or deconstructing an rwall.

![qfdfewqdewde](https://user-images.githubusercontent.com/32391752/56763691-4b2bc280-67a3-11e9-9cbb-2bf8a86ec7aa.PNG)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Pubbystation: Fixed the incinerator's waste to space injector starting powered off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
