### PR TITLE
Fixes Meta AI sat transit tubes

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -84262,6 +84262,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"uGa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/transit_tube/crossing/horizontal,
+/turf/open/space,
+/area/space/nearstation)
 "uGW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -128664,7 +128675,7 @@ aaa
 aaa
 aaa
 aaf
-bpw
+uGa
 aaf
 aaf
 ack
@@ -129692,7 +129703,7 @@ aaa
 aaa
 aaf
 aaf
-bpw
+uGa
 aaf
 aaf
 aaf
@@ -130463,7 +130474,7 @@ aaa
 aaa
 aaf
 aaf
-bpw
+uGa
 aaf
 aaf
 aaf
@@ -132262,7 +132273,7 @@ aaa
 aaa
 aaf
 aaf
-bpw
+uGa
 aaf
 aaf
 aaa
@@ -134061,7 +134072,7 @@ aaa
 aaa
 aaf
 aaf
-bpw
+uGa
 aaf
 aaf
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds `crossing` subtypes back to AI sat transit tubes that my cable PR removed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The subtype lets players cross the transit tube, otherwise moving around it becomes extremely obnoxious. My PR removed those by mistake, now I'm putting them back.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Metastation: You can now pass parts of the AI sat transit tube again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
