### PR TITLE
Non-station AI can no longer interact off their z-level.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -23,6 +23,9 @@
 		return
 	next_click = world.time + 1
 
+	if(!can_interact_with(A))
+		return
+
 	if(multicam_on)
 		var/turf/T = get_turf(A)
 		if(T)
@@ -58,8 +61,6 @@
 	if(modifiers["middle"])
 		if(controlled_mech) //Are we piloting a mech? Placed here so the modifiers are not overridden.
 			controlled_mech.click_action(A, src, params) //Override AI normal click behavior.
-		return
-
 		return
 	if(modifiers["shift"])
 		ShiftClickOn(A)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -316,7 +316,7 @@
 	var/turf/target = get_turf(A)
 	if (.)
 		return
-	if ((ai.z != target.z) && !is_station_level(ai))
+	if ((ai.z != target.z) && !is_station_level(ai.z))
 		return FALSE
 
 	if (istype(loc, /obj/item/aicard))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what #41521 tried to do. Station AI will still be able to interact off their z-level, but offstation AI like golem/old cryo AI won't.  Ideally, station AI would be limited to only station z-level stuff as well, but keeping it like this to let AI control the mining base and gulag.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #41857

## Why It's Good For The Game
Offstation AI's interfering with station business with no recourse for the station is a problem. They can still get on station in a shell or mech.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Offstation AI can no longer interact with other z-levels. Again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
