### PR TITLE
Restricts robotics control console to current z-level

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -25,15 +25,14 @@
 
 /obj/machinery/computer/robotics/ui_interact(mob/user)
 	. = ..()
-	if(z > 6)
-		to_chat(user, "<span class='boldannounce'>Unable to establish a connection: You're too far away from the station!</span>")
-		return
 	user.set_machine(src)
 	var/dat
 	var/list/robo_list = list()
 	var/robot_count
 	for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
 		if(!can_control(user, R))
+			continue
+		if(z != (get_turf(R)).z)
 			continue
 		robot_count++
 		var/unit_sync = "Independent"
@@ -83,6 +82,8 @@
 	var/drones = 0
 	for(var/mob/living/simple_animal/drone/D in GLOB.drones_list)
 		if(D.hacked)
+			continue
+		if(z != (get_turf(D)).z)
 			continue
 		if(drones)
 			dat += "<br><br>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes robotics control consoles only list cyborgs and drones on current z-level. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents crew from metagaming non-station cyborgs/drones, as well as preventing them from blowing them up. Notably, innocent golem and old cryo cyborgs will no longer get blown by traitors/paranoid RD's.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
balance: Robotics control console can now only blow/lockdown borgs and drones on current z-level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
