### PR TITLE
Shocks propagate to people you are pulling and pulled by.

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -451,15 +451,11 @@
 	return TRUE
 
 /obj/item/twohanded/shockpaddles/proc/shock_touching(dmg, mob/H)
-	if(!ishuman(H.pulledby))		//CLEAR!
-		return
-	var/mob/living/carbon/human/M = H.pulledby
-	if(M.has_trait(TRAIT_SHOCKIMMUNE) || (M.gloves && M.gloves.siemens_coefficient <= 0) || M.dna.species.siemens_coeff <= 0)
-		return
-	M.stop_pulling()
-	M.electrocute_act(30, src)
-	M.visible_message("<span class='danger'>[M] is electrocuted by [M.p_their()] contact with [H]!</span>")
-	M.emote("scream")
+	if(isliving(H.pulledby))		//CLEAR!
+		var/mob/living/M = H.pulledby
+		if(M.electrocute_act(30, H))
+			M.visible_message("<span class='danger'>[M] is electrocuted by [M.p_their()] contact with [H]!</span>")
+			M.emote("scream")
 
 /obj/item/twohanded/shockpaddles/proc/do_disarm(mob/living/M, mob/living/user)
 	if(req_defib && defib.safety)

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -451,11 +451,15 @@
 	return TRUE
 
 /obj/item/twohanded/shockpaddles/proc/shock_touching(dmg, mob/H)
-	if(isliving(H.pulledby))		//CLEAR!
-		var/mob/living/M = H.pulledby
-		if(M.electrocute_act(30, src))
-			M.visible_message("<span class='danger'>[M] is electrocuted by [M.p_their()] contact with [H]!</span>")
-			M.emote("scream")
+	if(!ishuman(H.pulledby))		//CLEAR!
+		return
+	var/mob/living/carbon/human/M = H.pulledby
+	if(M.has_trait(TRAIT_SHOCKIMMUNE) || (M.gloves && M.gloves.siemens_coefficient <= 0) || M.dna.species.siemens_coeff <= 0)
+		return
+	M.stop_pulling()
+	M.electrocute_act(30, src)
+	M.visible_message("<span class='danger'>[M] is electrocuted by [M.p_their()] contact with [H]!</span>")
+	M.emote("scream")
 
 /obj/item/twohanded/shockpaddles/proc/do_disarm(mob/living/M, mob/living/user)
 	if(req_defib && defib.safety)

--- a/code/modules/antagonists/clockcult/clock_mobs.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs.dm
@@ -39,7 +39,7 @@
 /mob/living/simple_animal/hostile/clockwork/ratvar_act()
 	fully_heal(TRUE)
 
-/mob/living/simple_animal/hostile/clockwork/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
+/mob/living/simple_animal/hostile/clockwork/electrocute_act(shock_damage, source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
 	return 0 //ouch, my metal-unlikely-to-be-damaged-by-electricity-body
 
 /mob/living/simple_animal/hostile/clockwork/examine(mob/user)

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -503,7 +503,7 @@
 	playsound(src,'sound/effects/sparks4.ogg',50,1)
 	do_teleport(target, F, 0, channel = TELEPORT_CHANNEL_BLUESPACE)
 
-/mob/living/simple_animal/hostile/swarmer/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)
+/mob/living/simple_animal/hostile/swarmer/electrocute_act(shock_damage, source, siemens_coeff = 1, safety = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)
 	if(!tesla_shock)
 		return FALSE
 	return ..()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -245,19 +245,11 @@
 		"<span class='italics'>You hear a heavy electrical crack.</span>" \
 		)
 	if(iscarbon(pulling) && !illusion && source != pulling)
-		if(ishuman(pulling))
-			var/mob/living/carbon/human/H = pulling
-			H.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
-		else
-			var/mob/living/carbon/C = pulling
-			C.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
+		var/mob/living/carbon/human/H = pulling
+		H.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
 	if(iscarbon(pulledby) && !illusion && source != pulledby)
-		if(ishuman(pulledby))
-			var/mob/living/carbon/human/H = pulledby
-			H.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
-		else
-			var/mob/living/carbon/C = pulledby
-			C.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
+		var/mob/living/carbon/human/H = pulledby
+		H.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
 	jitteriness += 1000 //High numbers for violent convulsions
 	do_jitter_animation(jitteriness)
 	stuttering += 2

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -244,6 +244,20 @@
 		"<span class='userdanger'>You feel a powerful shock coursing through your body!</span>", \
 		"<span class='italics'>You hear a heavy electrical crack.</span>" \
 		)
+	if(iscarbon(pulling) && !illusion && source != pulling)
+		if(ishuman(pulling))
+			var/mob/living/carbon/human/H = pulling
+			H.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
+		else
+			var/mob/living/carbon/C = pulling
+			C.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
+	if(iscarbon(pulledby) && !illusion && source != pulledby)
+		if(ishuman(pulledby))
+			var/mob/living/carbon/human/H = pulledby
+			H.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
+		else
+			var/mob/living/carbon/C = pulledby
+			C.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
 	jitteriness += 1000 //High numbers for violent convulsions
 	do_jitter_animation(jitteriness)
 	stuttering += 2
@@ -253,6 +267,7 @@
 		jitteriness = max(jitteriness - 990, 10) //Still jittery, but vastly less
 		if((!tesla_shock || (tesla_shock && siemens_coeff > 0.5)) && stun)
 			Paralyze(60)
+	
 	if(override)
 		return override
 	else

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -223,7 +223,7 @@
 		var/obj/item/organ/O = X
 		O.emp_act(severity)
 
-/mob/living/carbon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, override = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
+/mob/living/carbon/electrocute_act(shock_damage, source, siemens_coeff = 1, safety = 0, override = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
 	if(tesla_shock && (flags_1 & TESLA_IGNORE_1))
 		return FALSE
 	if(has_trait(TRAIT_SHOCKIMMUNE))
@@ -245,11 +245,11 @@
 		"<span class='italics'>You hear a heavy electrical crack.</span>" \
 		)
 	if(iscarbon(pulling) && !illusion && source != pulling)
-		var/mob/living/carbon/human/H = pulling
-		H.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
+		var/mob/living/carbon/C = pulling
+		C.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
 	if(iscarbon(pulledby) && !illusion && source != pulledby)
-		var/mob/living/carbon/human/H = pulledby
-		H.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
+		var/mob/living/carbon/C = pulledby
+		C.electrocute_act(shock_damage*0.75, src, 1, safety, override, tesla_shock, illusion, stun)
 	jitteriness += 1000 //High numbers for violent convulsions
 	do_jitter_animation(jitteriness)
 	stuttering += 2

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -267,7 +267,6 @@
 		jitteriness = max(jitteriness - 990, 10) //Still jittery, but vastly less
 		if((!tesla_shock || (tesla_shock && siemens_coeff > 0.5)) && stun)
 			Paralyze(60)
-	
 	if(override)
 		return override
 	else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -488,7 +488,7 @@
 			if(stat == CONSCIOUS)
 				to_chat(src, "<span class='notice'>You feel your heart beating again!</span>")
 	siemens_coeff *= physiology.siemens_coeff
-	
+
 	dna.species.spec_electrocute_act(src, shock_damage,source,siemens_coeff,safety,override,tesla_shock, illusion, stun)
 	. = ..(shock_damage,source,siemens_coeff,safety,override,tesla_shock, illusion, stun)
 	if(.)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -459,7 +459,7 @@
 
 
 //Added a safety check in case you want to shock a human mob directly through electrocute_act.
-/mob/living/carbon/human/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, override = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
+/mob/living/carbon/human/electrocute_act(shock_damage, source, siemens_coeff = 1, safety = 0, override = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
 	if(tesla_shock)
 		var/total_coeff = 1
 		if(gloves)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -488,6 +488,9 @@
 			if(stat == CONSCIOUS)
 				to_chat(src, "<span class='notice'>You feel your heart beating again!</span>")
 	siemens_coeff *= physiology.siemens_coeff
+	if(pulling && istype(pulling, /mob/living/carbon/human))
+		var/mob/living/carbon/human/L = pulling
+		L.electrocute_act(shock_damage*0.75, source)
 
 	dna.species.spec_electrocute_act(src, shock_damage,source,siemens_coeff,safety,override,tesla_shock, illusion, stun)
 	. = ..(shock_damage,source,siemens_coeff,safety,override,tesla_shock, illusion, stun)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -488,6 +488,7 @@
 			if(stat == CONSCIOUS)
 				to_chat(src, "<span class='notice'>You feel your heart beating again!</span>")
 	siemens_coeff *= physiology.siemens_coeff
+	
 	dna.species.spec_electrocute_act(src, shock_damage,source,siemens_coeff,safety,override,tesla_shock, illusion, stun)
 	. = ..(shock_damage,source,siemens_coeff,safety,override,tesla_shock, illusion, stun)
 	if(.)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -488,17 +488,6 @@
 			if(stat == CONSCIOUS)
 				to_chat(src, "<span class='notice'>You feel your heart beating again!</span>")
 	siemens_coeff *= physiology.siemens_coeff
-	if(ishuman(pulling))
-		var/mob/living/carbon/human/L = pulling
-		if(!has_trait(TRAIT_SHOCKIMMUNE) && !(gloves && gloves.siemens_coefficient <= 0) && !dna.species.siemens_coeff <= 0)
-			stop_pulling()
-			L.electrocute_act(shock_damage*siemens_coeff*0.75, src)
-	if(ishuman(pulledby))
-		var/mob/living/carbon/human/L = pulledby
-		if(!L.has_trait(TRAIT_SHOCKIMMUNE) && !(L.gloves && L.gloves.siemens_coefficient <= 0) && !L.dna.species.siemens_coeff <= 0)
-			L.stop_pulling()
-			L.electrocute_act(shock_damage*0.75, src)
-
 	dna.species.spec_electrocute_act(src, shock_damage,source,siemens_coeff,safety,override,tesla_shock, illusion, stun)
 	. = ..(shock_damage,source,siemens_coeff,safety,override,tesla_shock, illusion, stun)
 	if(.)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -488,9 +488,16 @@
 			if(stat == CONSCIOUS)
 				to_chat(src, "<span class='notice'>You feel your heart beating again!</span>")
 	siemens_coeff *= physiology.siemens_coeff
-	if(pulling && istype(pulling, /mob/living/carbon/human))
+	if(ishuman(pulling))
 		var/mob/living/carbon/human/L = pulling
-		L.electrocute_act(shock_damage*0.75, source)
+		if(!has_trait(TRAIT_SHOCKIMMUNE) && !(gloves && gloves.siemens_coefficient <= 0) && !dna.species.siemens_coeff <= 0)
+			stop_pulling()
+			L.electrocute_act(shock_damage*siemens_coeff*0.75, src)
+	if(ishuman(pulledby))
+		var/mob/living/carbon/human/L = pulledby
+		if(!L.has_trait(TRAIT_SHOCKIMMUNE) && !(L.gloves && L.gloves.siemens_coefficient <= 0) && !L.dna.species.siemens_coeff <= 0)
+			L.stop_pulling()
+			L.electrocute_act(shock_damage*0.75, src)
 
 	dna.species.spec_electrocute_act(src, shock_damage,source,siemens_coeff,safety,override,tesla_shock, illusion, stun)
 	. = ..(shock_damage,source,siemens_coeff,safety,override,tesla_shock, illusion, stun)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -310,7 +310,7 @@
 	take_bodypart_damage(acidpwr * min(1, acid_volume * 0.1))
 	return 1
 
-/mob/living/proc/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
+/mob/living/proc/electrocute_act(shock_damage, source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
 	SEND_SIGNAL(src, COMSIG_LIVING_ELECTROCUTE_ACT, shock_damage)
 	if(tesla_shock && (flags_1 & TESLA_IGNORE_1))
 		return FALSE

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -85,7 +85,7 @@
 		return
 	return ..()
 
-/mob/living/silicon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
+/mob/living/silicon/electrocute_act(shock_damage, source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
 	if(buckled_mobs)
 		for(var/mob/living/M in buckled_mobs)
 			unbuckle_mob(M)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -107,7 +107,7 @@
 /mob/living/simple_animal/hostile/construct/narsie_act()
 	return
 
-/mob/living/simple_animal/hostile/construct/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
+/mob/living/simple_animal/hostile/construct/electrocute_act(shock_damage, source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
 	return 0
 
 /mob/living/simple_animal/hostile/construct/adjustHealth(amount, updating_health = TRUE, forced = FALSE)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -277,5 +277,5 @@
 	// Why would bees pay attention to drones?
 	return 1
 
-/mob/living/simple_animal/drone/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
+/mob/living/simple_animal/drone/electrocute_act(shock_damage, source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
 	return 0 //So they don't die trying to fix wiring

--- a/code/modules/surgery/advanced/bioware/nerve_grounding.dm
+++ b/code/modules/surgery/advanced/bioware/nerve_grounding.dm
@@ -28,13 +28,11 @@
 	name = "Grounded Nerves"
 	desc = "Nerves form a safe path for electricity to traverse, protecting the body from electric shocks."
 	mod_type = BIOWARE_NERVES
-	var/prev_coeff
 
 /datum/bioware/grounded_nerves/on_gain()
 	..()
-	prev_coeff = owner.physiology.siemens_coeff
-	owner.physiology.siemens_coeff = 0
+	owner.add_trait(TRAIT_SHOCKIMMUNE, "grounded_nerves")
 
 /datum/bioware/grounded_nerves/on_lose()
 	..()
-	owner.physiology.siemens_coeff = prev_coeff
+	owner.remove_trait(TRAIT_SHOCKIMMUNE, "grounded_nerves")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What it says on the tin. If you for example run into a shocked door while being pulled by or pulling someone, they get shocked for 75% of the damage. Shock immune applies as normal down the chain.
Kept it to /mob/living/carbon only, simplemobs got it rough enough as is.

Also changed grounded nerves to use TRAIT_SHOCKIMMUNE instead of altering its species siemens_coeff. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds a bit of realism.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
add: Shocks now propagate to people you are pulling or pulled by.
code: Grounded nerves now uses the shock immune trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
