### PR TITLE
Adds bomb cap modifier and halves single tank explosive cap

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -4,8 +4,8 @@ GLOBAL_LIST_EMPTY(explosions)
 //Against my better judgement, I will return the explosion datum
 //If I see any GC errors for it I will find you
 //and I will gib you
-/proc/explosion(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = TRUE, ignorecap = FALSE, flame_range = 0, silent = FALSE, smoke = FALSE)
-	return new /datum/explosion(epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog, ignorecap, flame_range, silent, smoke)
+/proc/explosion(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = TRUE, ignorecap = FALSE, flame_range = 0, silent = FALSE, smoke = FALSE, cap_modifier)
+	return new /datum/explosion(epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog, ignorecap, flame_range, silent, smoke, cap_modifier)
 
 //This datum creates 3 async tasks
 //1 GatherSpiralTurfsProc runs spiral_range_turfs(tick_checked = TRUE) to populate the affected_turfs list
@@ -33,7 +33,7 @@ GLOBAL_LIST_EMPTY(explosions)
 		EX_PREPROCESS_EXIT_CHECK\
 	}
 
-/datum/explosion/New(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog, ignorecap, flame_range, silent, smoke)
+/datum/explosion/New(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog, ignorecap, flame_range, silent, smoke, cap_modifier)
 	set waitfor = FALSE
 
 	var/id = ++id_counter
@@ -62,12 +62,16 @@ GLOBAL_LIST_EMPTY(explosions)
 	if (isnull(cap_multiplier))
 		cap_multiplier = 1
 
+	//Argument bomb cap modifier
+	if (isnull(cap_modifier))
+		cap_modifier = 1
+
 	if(!ignorecap)
-		devastation_range = min(GLOB.MAX_EX_DEVESTATION_RANGE * cap_multiplier, devastation_range)
-		heavy_impact_range = min(GLOB.MAX_EX_HEAVY_RANGE * cap_multiplier, heavy_impact_range)
-		light_impact_range = min(GLOB.MAX_EX_LIGHT_RANGE * cap_multiplier, light_impact_range)
-		flash_range = min(GLOB.MAX_EX_FLASH_RANGE * cap_multiplier, flash_range)
-		flame_range = min(GLOB.MAX_EX_FLAME_RANGE * cap_multiplier, flame_range)
+		devastation_range = min(round(GLOB.MAX_EX_DEVESTATION_RANGE * cap_multiplier * cap_modifier), devastation_range)
+		heavy_impact_range = min(round(GLOB.MAX_EX_HEAVY_RANGE * cap_multiplier * cap_modifier), heavy_impact_range)
+		light_impact_range = min(round(GLOB.MAX_EX_LIGHT_RANGE * cap_multiplier * cap_modifier), light_impact_range)
+		flash_range = min(round(GLOB.MAX_EX_FLASH_RANGE * cap_multiplier * cap_modifier), flash_range)
+		flame_range = min(round(GLOB.MAX_EX_FLAME_RANGE * cap_multiplier * cap_modifier), flame_range)
 
 	//DO NOT REMOVE THIS STOPLAG, IT BREAKS THINGS
 	//not sleeping causes us to ex_act() the thing that triggered the explosion

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -241,7 +241,9 @@
 	var/temperature = air_contents.return_temperature()
 
 	if(pressure > TANK_FRAGMENT_PRESSURE)
+		var/cap_mod = 1
 		if(!istype(src.loc, /obj/item/transfer_valve))
+			cap_mod = 0.5
 			log_bomber(get_mob_by_key(fingerprintslast), "was last key to touch", src, "which ruptured explosively")
 		//Give the gas a chance to build up more pressure through reacting
 		air_contents.react(src)
@@ -252,7 +254,7 @@
 		var/turf/epicenter = get_turf(loc)
 
 
-		explosion(epicenter, round(range*0.25), round(range*0.5), round(range), round(range*1.5))
+		explosion(epicenter, round(range*0.25), round(range*0.5), round(range), round(range*1.5), cap_modifier = cap_mod)
 		if(istype(src.loc, /obj/item/transfer_valve))
 			qdel(src.loc)
 		else


### PR DESCRIPTION
Adds a maxcap modifier argument for the explosion proc/datum and sets it to 0.5 for tank explosions without a TTV (single tank bombs).

:cl:
balance: halfcaps single tank explosions
/:cl:

you put in half the volume you get half the boom

Closes #43823
