### PR TITLE
Fixes ninja dashing

### DIFF
--- a/code/datums/dash_weapon.dm
+++ b/code/datums/dash_weapon.dm
@@ -32,7 +32,7 @@
 	if(!IsAvailable())
 		return
 	var/turf/T = get_turf(target)
-	if(target in view(user.client.view, get_turf(user)))
+	if(target in view(user.client.view, user))
 		var/obj/spot1 = new phaseout(get_turf(user), user.dir)
 		user.forceMove(T)
 		playsound(T, dash_sound, 25, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes ninja dash check target against user view, instead of turf view. The latter causes issues with dash not working in darkness despite wearing nvg's. This makes you able to dash to anything you can see, as intended.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes ninja dash (and other sword dash abilities) work consistently when wearing vision altering items.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Ninja dash now works in dark areas if you can see in the dark. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
