### PR TITLE
Makes Airlock Charges Purchaseable for 6TC

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -181,7 +181,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndicate/bundle_A
 	cost = 20
 	exclude_modes = list(/datum/game_mode/nuclear)
-	
+
 /datum/uplink_item/bundles_TC/bundle_B
 	name = "Syndi-kit Special"
 	desc = "Syndicate Bundles, also known as Syndi-Kits, are specialized groups of items that arrive in a plain box. \
@@ -860,6 +860,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/backpack/duffelbag/syndie/x4
 	cost = 4 //
 	cant_discount = TRUE
+
+/datum/uplink_item/explosives/doorcharge
+	name = "Airlock Charge"
+	desc = "An easily-concealable charge of explosives designed to fit snugly in the maintenance panels of airlocks, becoming set to explode when the airlock is opened, resulting in the activator to be ignited and stunned. \
+			To install, remove an airlock's maintenance panel with a screwdriver and place the device within to prime it. Screwdriver not included. \
+			WARNING: Device lacks proper identification equipment, activation of airlock by agent may result in premature and accidental detonation."
+	item = /obj/item/doorCharge
+	cost = 6 //These things fucking hurt.
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/explosives/clown_bomb_clownops
 	name = "Clown Bomb"
@@ -1547,7 +1556,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 20
 	restricted_roles = list("Assistant")
 	surplus = 0
-	
+
 /datum/uplink_item/role_restricted/oldtoolboxclean
 	name = "Ancient Toolbox"
 	desc = "An iconic toolbox design notorious with Assistants everywhere, this design was especially made to become more robust the more telecrystals it has inside it! Tools and insulated gloves included."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes Airlock Charges purchaseable in the syndicate uplink for 6TC, but not nukie ones because walking the captain into a door and instantly winning seems a bit cheap.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Airlock Charges have been in the sabotage bundle for a while now but not the actual _uplink_, I think it'd be pretty neat to see them used in game. They're relatively expensive meaning you can't buy 20 (you can only get 3 at most) of them and spam them everywhere and death isn't _guaranteed_ from a detonation, my only worry is there's no tell if an airlock is trapped or not, but i'm far too feeble-brained to code a tell though i'd be more than happy to with instruction.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: zeroisthebiggay
add: Makes Airlock Charges purchasable in the syndicate uplink for 6TC. Warranty of item is void if agent blows themselves up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
