### PR TITLE
AIs no longer get stuck on death

### DIFF
--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -15,6 +15,8 @@
 	cameraFollow = null
 
 	anchored = FALSE //unbolt floorbolts
+	move_resist = MOVE_FORCE_NORMAL
+
 	if(eyeobj)
 		eyeobj.setLoc(get_turf(src))
 		set_eyeobj_visible(FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adjusts AI cores' move_resist to MOVE_FORCE_NORMAL when they die. This was previously an oversight where their death set `anchored = FALSE`, but didn't adjust their move_resist to let them be dragged away.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now players can once again move dead AIs like before the move_resist PR.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Dead AIs no longer get stuck in place and become movable again.
/:cl:

Closes: #43717
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
