### PR TITLE
donut tweaks

### DIFF
--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -569,15 +569,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"abt" = (
-/obj/machinery/light/small,
-/obj/machinery/camera/motion{
-	c_tag = "Secure - AI Upload Front Access";
-	dir = 1;
-	network = list("ss13","Secure")
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "abu" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4154,8 +4145,8 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "brigexternalblast";
-	name = "External Security Blast Door"
+	id = "brigexternalblastentry";
+	name = "External Security Entry Blast Door"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5599,8 +5590,8 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "brigexternalblast";
-	name = "External Security Blast Door"
+	id = "brigexternalblastentry";
+	name = "External Security Entry Blast Door"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6735,7 +6726,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aqT" = (
-/obj/machinery/food_cart,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -7326,7 +7316,7 @@
 	},
 /obj/machinery/button/door{
 	id = "brigexternalblast";
-	name = "External Blast Door Toggle";
+	name = "Brig Cell Blast Door Toggle";
 	pixel_x = -6;
 	pixel_y = 30
 	},
@@ -7337,6 +7327,12 @@
 	pixel_y = 30
 	},
 /obj/effect/landmark/start/warden,
+/obj/machinery/button/door{
+	id = "brigexternalblastentry";
+	name = "External Blast Door Toggle";
+	pixel_x = 0;
+	pixel_y = 38
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "asg" = (
@@ -9057,7 +9053,18 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/engine/atmos)
 "avY" = (
 /obj/effect/turf_decal/tile/red{
@@ -9899,6 +9906,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "axU" = (
@@ -16748,24 +16756,6 @@
 "aNw" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
-"aNx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aishutters";
-	name = "AI privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai)
 "aNy" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16869,7 +16859,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/ai)
+/area/space/nearstation)
 "aNL" = (
 /obj/structure/closet/secure_closet/security,
 /obj/effect/turf_decal/tile/red{
@@ -18149,7 +18139,8 @@
 "aQA" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Hydroponics";
-	req_access_txt = "35"
+	req_access_txt = "0";
+	req_one_access_txt = "35;28"
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -23047,9 +23038,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "baq" = (
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_y = -32
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Front Desk";
 	dir = 1;
@@ -23057,6 +23045,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -25
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -24109,13 +24100,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "bcP" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "bcQ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -24155,15 +24153,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"bcU" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "bcV" = (
 /obj/structure/chair,
 /obj/machinery/light/small{
@@ -24397,9 +24386,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -25213,6 +25203,7 @@
 	name = "Bar Access";
 	req_access_txt = "25"
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "bfi" = (
@@ -25569,6 +25560,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"bfR" = (
+/obj/machinery/food_cart,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "bfS" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -25730,6 +25727,10 @@
 	dir = 4;
 	network = list("ss13","Bar Area")
 	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "bgj" = (
@@ -25840,8 +25841,9 @@
 "bgy" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bgz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -26629,16 +26631,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"bic" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/item/toy/figure/assistant,
-/obj/item/toy/figure/assistant{
-	pixel_x = 3;
-	pixel_y = -4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bie" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -27310,13 +27302,6 @@
 /obj/item/seeds/random,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"bju" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/item/toy/figure/wizard,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bjv" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -27594,20 +27579,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"bjV" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "bjW" = (
 /obj/structure/table,
 /obj/machinery/airalarm{
@@ -28396,6 +28367,7 @@
 	pixel_x = -4;
 	pixel_y = -24
 	},
+/obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "blp" = (
@@ -29818,6 +29790,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -37097,23 +37073,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
-"bCf" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/item/toy/figure/assistant{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/toy/figure/assistant{
-	pixel_x = 3;
-	pixel_y = -4
-	},
-/obj/item/toy/figure/assistant{
-	pixel_x = 8;
-	pixel_y = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bCg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -39859,8 +39818,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bHe" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -40946,13 +40906,23 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/northright{
+	name = "AI Access";
+	req_access_txt = "16"
+	},
+/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bJx" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bJy" = (
 /obj/machinery/ai_slipper{
@@ -41013,17 +40983,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/button/door{
-	id = "aishutters";
-	name = "Privacy Shutter Control";
-	pixel_x = -24;
-	pixel_y = 24
-	},
-/obj/machinery/button/door{
-	id = "aishuttersexternal";
-	name = "External Privacy Shutter Control";
-	pixel_x = 24;
-	pixel_y = 24
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -42181,7 +42143,14 @@
 	dir = 4;
 	network = list("AISat")
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/southright{
+	name = "AI Access";
+	req_access_txt = "16"
+	},
+/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bMe" = (
 /obj/structure/table,
@@ -42355,7 +42324,14 @@
 	dir = 8;
 	network = list("AISat")
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/southleft{
+	name = "AI Access";
+	req_access_txt = "16"
+	},
+/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bMB" = (
 /obj/structure/cable{
@@ -42517,13 +42493,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aishutters";
-	name = "AI privacy shutters"
-	},
 /obj/machinery/door/window/westright{
 	name = "AI Access";
 	req_access_txt = "16"
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -42582,6 +42558,12 @@
 	departmentType = 5;
 	pixel_x = 28;
 	pixel_y = -28
+	},
+/obj/machinery/button/door{
+	id = "aishuttersexternal";
+	name = "External Privacy Shutter Control";
+	pixel_x = 0;
+	pixel_y = -40
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -42753,7 +42735,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/space,
-/area/ai_monitored/turret_protected/ai)
+/area/space/nearstation)
 "bNi" = (
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI External East";
@@ -42765,7 +42747,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/space,
-/area/ai_monitored/turret_protected/ai)
+/area/space/nearstation)
 "bNj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -42846,7 +42828,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/ai)
+/area/space/nearstation)
 "bNs" = (
 /obj/item/stack/cable_coil/cut/red,
 /turf/open/space/basic,
@@ -45120,10 +45102,6 @@
 /obj/item/book/random/triple,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"bRV" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/engine/atmos)
 "bRX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -47682,7 +47660,7 @@
 	pixel_x = -32
 	},
 /turf/open/space/basic,
-/area/engine/atmos)
+/area/space/nearstation)
 "bYa" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -50005,6 +49983,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cdu" = (
@@ -51083,6 +51062,10 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"dxJ" = (
+/obj/structure/closet/wardrobe/science_white,
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "dzi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -51241,6 +51224,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "elZ" = (
@@ -51308,6 +51292,16 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"esb" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northleft{
+	name = "AI Access";
+	req_access_txt = "16"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "esp" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 4
@@ -51433,6 +51427,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"eKx" = (
+/obj/machinery/smartfridge/drinks,
+/turf/closed/wall,
+/area/crew_quarters/bar)
 "eLr" = (
 /obj/machinery/button/door{
 	id = "podescape";
@@ -51487,6 +51485,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"eQp" = (
+/obj/machinery/smartfridge/food,
+/turf/closed/wall,
+/area/crew_quarters/kitchen)
 "eQq" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -52556,6 +52558,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"ili" = (
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	dir = 2;
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
+/area/science/research)
 "ipB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -52658,6 +52670,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1,
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "iMs" = (
@@ -52825,6 +52838,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "jxP" = (
@@ -54425,13 +54439,13 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aishutters";
-	name = "AI privacy shutters"
-	},
 /obj/machinery/door/window/eastleft{
 	name = "AI Access";
 	req_access_txt = "16"
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -55003,8 +55017,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"qWm" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "qXl" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/engine)
@@ -56093,22 +56112,26 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "uTy" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "uUp" = (
@@ -56514,6 +56537,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"vSP" = (
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vUd" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 2;
@@ -56927,6 +56956,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"xhv" = (
+/obj/machinery/airalarm{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "xhI" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen/coldroom)
@@ -56987,6 +57024,12 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"xyU" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "xBI" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/effect/turf_decal/stripes/corner{
@@ -57040,11 +57083,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "xLk" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -25
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -79957,7 +80003,7 @@ bkt
 bkh
 afN
 aoB
-aFj
+ili
 aeA
 aeA
 aBe
@@ -82516,7 +82562,7 @@ acw
 amW
 bjX
 bnX
-adW
+dxJ
 blo
 acp
 afN
@@ -87701,7 +87747,7 @@ akW
 bRM
 akW
 akl
-ahT
+eKx
 akW
 akW
 api
@@ -87958,7 +88004,7 @@ akl
 akl
 akl
 akl
-bjV
+akl
 akl
 akl
 akl
@@ -89757,7 +89803,7 @@ bZY
 alF
 alF
 alF
-amU
+xhv
 amU
 amU
 amU
@@ -90011,7 +90057,7 @@ aAd
 rDY
 bAL
 aDj
-alV
+eQp
 aqT
 bdz
 bbM
@@ -90020,7 +90066,7 @@ bbO
 bbM
 bcD
 bcI
-amU
+bfR
 xhI
 bgJ
 bhi
@@ -90837,7 +90883,7 @@ aal
 aug
 aNi
 cdt
-aNq
+qWm
 aeJ
 asA
 bLJ
@@ -91302,7 +91348,7 @@ aPp
 aPy
 aQR
 aRI
-asr
+vSP
 baY
 bcY
 baY
@@ -91359,11 +91405,11 @@ aNw
 aNw
 bZM
 bNn
-aNB
+aNC
 aNC
 bJy
 aNC
-aNB
+aNC
 aNB
 bZM
 aNw
@@ -91874,7 +91920,7 @@ aNC
 aNC
 bNo
 bOo
-aNw
+aNB
 bMP
 aNw
 aNw
@@ -92130,8 +92176,8 @@ bOd
 bOh
 bOj
 bOk
+aNB
 aNA
-aNx
 bJE
 bMS
 aNw
@@ -92388,7 +92434,7 @@ aNC
 aNC
 bNq
 bOp
-aNw
+aNB
 oVG
 aNw
 aNw
@@ -92591,9 +92637,9 @@ xLk
 bcP
 bgy
 bgy
-bic
-bju
-bCf
+bgy
+bgy
+bgy
 bgy
 bHd
 awG
@@ -92845,7 +92891,7 @@ aQO
 aRh
 aYA
 uTy
-bcU
+acj
 acj
 acj
 acj
@@ -92901,11 +92947,11 @@ aNw
 aNw
 bZM
 bNn
-aNB
+aNC
 aNC
 bMl
 aNC
-aNB
+aNC
 aNB
 bZM
 aNw
@@ -93159,8 +93205,8 @@ aNw
 aNw
 ceN
 bME
-aNB
-aNB
+esb
+xyU
 bMA
 bME
 aNA
@@ -97478,9 +97524,9 @@ aRd
 axi
 bil
 acj
-bRV
+aal
 bXZ
-bRV
+aal
 acj
 bWG
 bYL
@@ -103326,7 +103372,7 @@ asj
 bQO
 aRV
 bta
-abt
+aRW
 aiV
 bfD
 alP

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -24150,6 +24150,10 @@
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
+/obj/machinery/camera{
+	c_tag = "Civilian - Disposals Waste Management";
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bcV" = (
@@ -55752,6 +55756,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"tzv" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "tzD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -97538,7 +97554,7 @@ bca
 bcA
 bcS
 bdf
-bdf
+tzv
 bwF
 bwJ
 bxf

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -7330,7 +7330,6 @@
 /obj/machinery/button/door{
 	id = "brigexternalblastentry";
 	name = "External Blast Door Toggle";
-	pixel_x = 0;
 	pixel_y = 38
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -42562,7 +42561,6 @@
 /obj/machinery/button/door{
 	id = "aishuttersexternal";
 	name = "External Privacy Shutter Control";
-	pixel_x = 0;
 	pixel_y = -40
 	},
 /turf/open/floor/circuit,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Chefs now have access to Hydroponics, as Botanist had Kitchen access before
- There is now a smart fridge north of the kitchen for depositing foodstuff
- Bar has a drink showcase because why not
- Extra air alarm on the external part of the theatre room.
- Experimentor room now has a sci-robe vendor
- Warden now has separate buttons for either closing the brig's front doors or the cell windows.
- Slight change to the AI core to remove a cheese spot for wraiths to avoid the turrets, gave the tri-AI spawns similar little cubbies so you can't bum-rush with an inteli-card on them.
- Extra engineer spawns in the SM room
- Window into space between outer foyer/main Atmospherics for pipes where used to exist a weird maintenance cubby hole that never saw the light of day
- Added two extra rapid pipe dispenser tools to the atmos lockers to replace the bulky machines I removed earlier
- Removed motion camera in maintenance outside the upload due to complaints from AIs about needless warnings.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
👏 map 👏 maintenance 👏 

## Changelog
:cl: MMMiracles
tweak: Various minor tweaks to Donutstation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
