### PR TITLE
Widescreen toggle support (doesn't actually enable it)

### DIFF
--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -6,6 +6,6 @@
 #define HUD_VERSIONS 3	//Used in show_hud(); Please ensure this is the same as the maximum index.
 
 //1:1 HUD layout stuff
-#define ui_boxcraft "EAST-4:22,SOUTH+1:6"
-#define ui_boxarea "EAST-4:6,SOUTH+1:6"
-#define ui_boxlang "EAST-5:22,SOUTH+1:6"
+#define UI_BOXCRAFT "EAST-4:22,SOUTH+1:6"
+#define UI_BOXAREA "EAST-4:6,SOUTH+1:6"
+#define UI_BOXLANG "EAST-5:22,SOUTH+1:6"

--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -4,3 +4,8 @@
 #define HUD_STYLE_NOHUD 3 //No hud (for screenshots)
 
 #define HUD_VERSIONS 3	//Used in show_hud(); Please ensure this is the same as the maximum index.
+
+//1:1 HUD layout stuff
+#define ui_boxcraft "EAST-4:22,SOUTH+1:6"
+#define ui_boxarea "EAST-4:6,SOUTH+1:6"
+#define ui_boxlang "EAST-5:22,SOUTH+1:6"

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -94,19 +94,19 @@
 	using = new /obj/screen/craft
 	using.icon = ui_style
 	if(!widescreen_layout)
-		using.screen_loc = ui_boxcraft
+		using.screen_loc = UI_BOXCRAFT
 	static_inventory += using
 
 	using = new/obj/screen/language_menu
 	using.icon = ui_style
 	if(!widescreen_layout)
-		using.screen_loc = ui_boxlang
+		using.screen_loc = UI_BOXLANG
 	static_inventory += using
 
 	using = new /obj/screen/area_creator
 	using.icon = ui_style
 	if(!widescreen_layout)
-		using.screen_loc = ui_boxarea
+		using.screen_loc = UI_BOXAREA
 	static_inventory += using
 
 	action_intent = new /obj/screen/act_intent/segmented

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -84,19 +84,29 @@
 	..()
 	owner.overlay_fullscreen("see_through_darkness", /obj/screen/fullscreen/see_through_darkness)
 
+	var/widescreen_layout = FALSE
+	if(owner.client && owner.client.prefs && owner.client.prefs.widescreenpref)
+		widescreen_layout = TRUE
+
 	var/obj/screen/using
 	var/obj/screen/inventory/inv_box
 
 	using = new /obj/screen/craft
 	using.icon = ui_style
+	if(!widescreen_layout)
+		using.screen_loc = ui_boxcraft
 	static_inventory += using
 
 	using = new/obj/screen/language_menu
 	using.icon = ui_style
+	if(!widescreen_layout)
+		using.screen_loc = ui_boxlang
 	static_inventory += using
 
 	using = new /obj/screen/area_creator
 	using.icon = ui_style
+	if(!widescreen_layout)
+		using.screen_loc = ui_boxarea
 	static_inventory += using
 
 	action_intent = new /obj/screen/act_intent/segmented

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -85,7 +85,7 @@
 	owner.overlay_fullscreen("see_through_darkness", /obj/screen/fullscreen/see_through_darkness)
 
 	var/widescreen_layout = FALSE
-	if(owner.client && owner.client.prefs && owner.client.prefs.widescreenpref)
+	if(owner.client?.prefs?.widescreenpref)
 		widescreen_layout = TRUE
 
 	var/obj/screen/using

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -462,6 +462,9 @@
 /datum/config_entry/string/default_view
 	config_entry_value = "15x15"
 
+/datum/config_entry/string/default_view_square
+	config_entry_value = "15x15"
+
 /datum/config_entry/flag/log_pictures
 
 /datum/config_entry/flag/picture_logging_camera

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -826,6 +826,10 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	if (isnull(new_size))
 		CRASH("change_view called without argument.")
 
+	if(prefs && CONFIG_GET(string/default_view))
+		if(!prefs.widescreenpref && new_size == CONFIG_GET(string/default_view))
+			new_size = "15x15"
+
 	view = new_size
 	apply_clickcatcher()
 	mob.reload_fullscreen()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -826,9 +826,8 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	if (isnull(new_size))
 		CRASH("change_view called without argument.")
 
-	if(prefs && CONFIG_GET(string/default_view))
-		if(!prefs.widescreenpref && new_size == CONFIG_GET(string/default_view))
-			new_size = "15x15"
+	if(prefs && !prefs.widescreenpref && new_size == CONFIG_GET(string/default_view))
+		new_size = CONFIG_GET(string/default_view_square)
 
 	view = new_size
 	apply_clickcatcher()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -514,7 +514,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 			dat += "<b>Ambient Occlusion:</b> <a href='?_src_=prefs;preference=ambientocclusion'>[ambientocclusion ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>Fit Viewport:</b> <a href='?_src_=prefs;preference=auto_fit_viewport'>[auto_fit_viewport ? "Auto" : "Manual"]</a><br>"
-			dat += "<b>Widescreen:</b> <a href='?_src_=prefs;preference=widescreenpref'>[widescreenpref ? "Enabled ([CONFIG_GET(string/default_view)])" : "Disabled (15x15)"]</a><br>"
+			if (CONFIG_GET(string/default_view) != CONFIG_GET(string/default_view_square))
+				dat += "<b>Widescreen:</b> <a href='?_src_=prefs;preference=widescreenpref'>[widescreenpref ? "Enabled ([CONFIG_GET(string/default_view)])" : "Disabled ([CONFIG_GET(string/default_view_square)])"]</a><br>"
 
 			if (CONFIG_GET(flag/maprotation))
 				var/p_map = preferred_map

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -105,6 +105,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/ambientocclusion = TRUE
 	var/auto_fit_viewport = FALSE
+	var/widescreenpref = TRUE
 
 	var/uplink_spawn_loc = UPLINK_PDA
 
@@ -513,6 +514,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 			dat += "<b>Ambient Occlusion:</b> <a href='?_src_=prefs;preference=ambientocclusion'>[ambientocclusion ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>Fit Viewport:</b> <a href='?_src_=prefs;preference=auto_fit_viewport'>[auto_fit_viewport ? "Auto" : "Manual"]</a><br>"
+			dat += "<b>Widescreen:</b> <a href='?_src_=prefs;preference=widescreenpref'>[widescreenpref ? "Enabled ([CONFIG_GET(string/default_view)])" : "Disabled (15x15)"]</a><br>"
 
 			if (CONFIG_GET(flag/maprotation))
 				var/p_map = preferred_map
@@ -1533,6 +1535,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					auto_fit_viewport = !auto_fit_viewport
 					if(auto_fit_viewport && parent)
 						parent.fit_viewport()
+				
+				if("widescreenpref")
+					widescreenpref = !widescreenpref
+					user.client.change_view(CONFIG_GET(string/default_view))
 
 				if("save")
 					save_preferences()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -60,18 +60,18 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 /datum/preferences/proc/load_preferences()
 	if(!path)
-		return 0
+		return FALSE
 	if(!fexists(path))
-		return 0
+		return FALSE
 
 	var/savefile/S = new /savefile(path)
 	if(!S)
-		return 0
+		return FALSE
 	S.cd = "/"
 
 	var/needs_update = savefile_needs_update(S)
 	if(needs_update == -2)		//fatal, can't load any data
-		return 0
+		return FALSE
 
 	//general preferences
 	S["asaycolor"]			>> asaycolor
@@ -102,6 +102,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["parallax"]			>> parallax
 	S["ambientocclusion"]	>> ambientocclusion
 	S["auto_fit_viewport"]	>> auto_fit_viewport
+	S["widescreenpref"]	    >> widescreenpref
 	S["menuoptions"]		>> menuoptions
 	S["enable_tips"]		>> enable_tips
 	S["tip_delay"]			>> tip_delay
@@ -121,13 +122,14 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	tgui_fancy		= sanitize_integer(tgui_fancy, 0, 1, initial(tgui_fancy))
 	tgui_lock		= sanitize_integer(tgui_lock, 0, 1, initial(tgui_lock))
 	buttons_locked	= sanitize_integer(buttons_locked, 0, 1, initial(buttons_locked))
-	windowflashing		= sanitize_integer(windowflashing, 0, 1, initial(windowflashing))
+	windowflashing	= sanitize_integer(windowflashing, 0, 1, initial(windowflashing))
 	default_slot	= sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
 	toggles			= sanitize_integer(toggles, 0, 65535, initial(toggles))
 	clientfps		= sanitize_integer(clientfps, 0, 1000, 0)
 	parallax		= sanitize_integer(parallax, PARALLAX_INSANE, PARALLAX_DISABLE, null)
 	ambientocclusion	= sanitize_integer(ambientocclusion, 0, 1, initial(ambientocclusion))
 	auto_fit_viewport	= sanitize_integer(auto_fit_viewport, 0, 1, initial(auto_fit_viewport))
+	widescreenpref  = sanitize_integer(widescreenpref, 0, 1, initial(widescreenpref))
 	ghost_form		= sanitize_inlist(ghost_form, GLOB.ghost_forms, initial(ghost_form))
 	ghost_orbit 	= sanitize_inlist(ghost_orbit, GLOB.ghost_orbits, initial(ghost_orbit))
 	ghost_accs		= sanitize_inlist(ghost_accs, GLOB.ghost_accs_options, GHOST_ACCS_DEFAULT_OPTION)
@@ -137,14 +139,14 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	pda_style		= sanitize_inlist(pda_style, GLOB.pda_styles, initial(pda_style))
 	pda_color		= sanitize_hexcolor(pda_color, 6, 1, initial(pda_color))
 
-	return 1
+	return TRUE
 
 /datum/preferences/proc/save_preferences()
 	if(!path)
-		return 0
+		return FALSE
 	var/savefile/S = new /savefile(path)
 	if(!S)
-		return 0
+		return FALSE
 	S.cd = "/"
 
 	WRITE_FILE(S["version"] , SAVEFILE_VERSION_MAX)		//updates (or failing that the sanity checks) will ensure data is not invalid at load. Assume up-to-date
@@ -176,22 +178,23 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["parallax"], parallax)
 	WRITE_FILE(S["ambientocclusion"], ambientocclusion)
 	WRITE_FILE(S["auto_fit_viewport"], auto_fit_viewport)
+	WRITE_FILE(S["widescreenpref"], widescreenpref)
 	WRITE_FILE(S["menuoptions"], menuoptions)
 	WRITE_FILE(S["enable_tips"], enable_tips)
 	WRITE_FILE(S["tip_delay"], tip_delay)
 	WRITE_FILE(S["pda_style"], pda_style)
 	WRITE_FILE(S["pda_color"], pda_color)
 
-	return 1
+	return TRUE
 
 /datum/preferences/proc/load_character(slot)
 	if(!path)
-		return 0
+		return FALSE
 	if(!fexists(path))
-		return 0
+		return FALSE
 	var/savefile/S = new /savefile(path)
 	if(!S)
-		return 0
+		return FALSE
 	S.cd = "/"
 	if(!slot)
 		slot = default_slot
@@ -203,7 +206,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S.cd = "/character[slot]"
 	var/needs_update = savefile_needs_update(S)
 	if(needs_update == -2)		//fatal, can't load any data
-		return 0
+		return FALSE
 
 	//Species
 	var/species_id
@@ -352,14 +355,14 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	negative_quirks = SANITIZE_LIST(negative_quirks)
 	neutral_quirks = SANITIZE_LIST(neutral_quirks)
 
-	return 1
+	return TRUE
 
 /datum/preferences/proc/save_character()
 	if(!path)
-		return 0
+		return FALSE
 	var/savefile/S = new /savefile(path)
 	if(!S)
-		return 0
+		return FALSE
 	S.cd = "/character[default_slot]"
 
 	WRITE_FILE(S["version"]			, SAVEFILE_VERSION_MAX)	//load_character will sanitize any bad data, so assume up-to-date.)
@@ -421,7 +424,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["negative_quirks"]		, negative_quirks)
 	WRITE_FILE(S["neutral_quirks"]		, neutral_quirks)
 
-	return 1
+	return TRUE
 
 
 #undef SAVEFILE_VERSION_MAX

--- a/config/config.txt
+++ b/config/config.txt
@@ -490,7 +490,7 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 ##  15x15 would be the standard square view. 21x15 is what goonstation uses for widescreen.
 ##  Setting this to something different from DEFAULT_VIEW_SQUARE will enable widescreen toggles
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
-DEFAULT_VIEW 21x15
+DEFAULT_VIEW 15x15
 
 ##Default view size, in tiles. Should *always* be square.
 ## The alternative square viewport size if you're using a widescreen view size

--- a/config/config.txt
+++ b/config/config.txt
@@ -485,8 +485,14 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 #ROUNDS_UNTIL_HARD_RESTART 10
 
 
-##Default screen resolution, in tiles.
-##	By default, this is 21x15, which matches goonstation's default
-##  15x15 would be the standard square view.
+##Default view size, in tiles.
+##	By default, this is 15x15, which gets simplified to 7 by byond
+##  15x15 would be the standard square view. 21x15 is what goonstation uses for widescreen.
+##  Setting this to something different from DEFAULT_VIEW_SQUARE will enable widescreen toggles
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
-DEFAULT_VIEW 15x15
+DEFAULT_VIEW 21x15
+
+##Default view size, in tiles. Should *always* be square.
+## The alternative square viewport size if you're using a widescreen view size
+## You probably shouldn't ever be changing this, but it's here if you want to.
+DEFAULT_VIEW_SQUARE 15x15

--- a/config/config.txt
+++ b/config/config.txt
@@ -489,4 +489,4 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 ##	By default, this is 21x15, which matches goonstation's default
 ##  15x15 would be the standard square view.
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
-DEFAULT_VIEW 21x15
+DEFAULT_VIEW 15x15

--- a/config/config.txt
+++ b/config/config.txt
@@ -486,7 +486,7 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 
 
 ##Default screen resolution, in tiles.
-##	By default, this is 15x15, which gets simplified to 7 by BYOND, as it is a 1:1 screen ratio.
-##	For reference, Goonstation uses a resolution of 21x15 for it's widescreen mode.
+##	By default, this is 21x15, which matches goonstation's default
+##  15x15 would be the standard square view.
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
 DEFAULT_VIEW 21x15

--- a/config/config.txt
+++ b/config/config.txt
@@ -489,4 +489,4 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 ##	By default, this is 15x15, which gets simplified to 7 by BYOND, as it is a 1:1 screen ratio.
 ##	For reference, Goonstation uses a resolution of 21x15 for it's widescreen mode.
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
-DEFAULT_VIEW 15x15
+DEFAULT_VIEW 21x15


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds support for a widescreen toggle ported from citadel. It only shows up if widescreen is configured in configs.
**THIS WOULD NOT ACTUALLY HAVE WIDESCREEN ON THE LIVE SERVER. IT WOULD REQUIRE A CONFIG CHANGE.**
On that note, petition for `DEFAULT_VIEW` in config.txt to be set to 21x15 instead of 15x15:
![image](https://user-images.githubusercontent.com/5194834/56891631-fce02300-6a31-11e9-9e0c-be8ecf3387fd.png)

## Why It's Good For The Game

Staging for a good future change.

## Changelog
:cl:
add: Added support for a widescreen toggle, actual widescreen will require a config change.
tweak: Auto-fit view is now the default. This will only apply to new players.
/:cl:

FAQ about widescreen:
**Will having a super wide monitor put you at a huge advantage?**
No. If widescreen view is enabled in the configs, it is a fixed widescreen size for all users no matter what their screen size/aspect ratio is. 21x15 works very well for 16:9
**Does this mean someone else can see me when I can't see them?**
No, unless you're using square mode while the other person is using widescreen.
**What if I have a 4:3 monitor?**
You're in a very small minority. If you really don't want to be at a disadvantage, you can adjust the size of the sidebar to get something like this:
![image](https://user-images.githubusercontent.com/5194834/56896978-23a65580-6a42-11e9-9fcf-f4f44435903a.png)
**Does this make tiles smaller?**
No. It just adds 3 extra columns on either side of the view. Tiles are still the same size.
