### PR TITLE
Tank fragmentation now reacts air contents additionally once instead of thrice

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -245,8 +245,6 @@
 			log_bomber(get_mob_by_key(fingerprintslast), "was last key to touch", src, "which ruptured explosively")
 		//Give the gas a chance to build up more pressure through reacting
 		air_contents.react(src)
-		air_contents.react(src)
-		air_contents.react(src)
 		pressure = air_contents.return_pressure()
 		var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
 		var/turf/epicenter = get_turf(loc)


### PR DESCRIPTION
:cl:
tweak: Air contents inside a tank react additionally once instead of thrice when exploding
/:cl:

>no im saying make it actually hard to reach the maxcap limit we have

If this is the goal then this PR is a first step. It's either this or increasing the fragmentation scale, if not both. Giving mixes too much time to react contradicts the physics of explosives anyways.

Pure oxygen and plasma mixes can still maxcap. No idea how it affects the tritium meta since I haven't played with it. At worst this does nothing except remove two lines of unneeded code.