### PR TITLE
[DNM] Add R&D console to bridge on station maps

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -19389,6 +19389,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/computer/rdconsole/bridge{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTZ" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -45055,6 +45055,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/computer/rdconsole/bridge{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bBH" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -54748,6 +54748,12 @@
 	},
 /turf/open/floor/circuit/green,
 /area/engine/supermatter)
+"qao" = (
+/obj/machinery/computer/rdconsole/bridge{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/bridge)
 "qkE" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -104372,7 +104378,7 @@ ajK
 bJk
 bLS
 aJO
-ajK
+qao
 bJO
 bKM
 aEH

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -31877,10 +31877,6 @@
 /turf/open/floor/plating,
 /area/bridge)
 "biZ" = (
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -31897,6 +31893,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bja" = (
@@ -32786,17 +32783,13 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bkE" = (
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/computer/rdconsole/bridge,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bkF" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6960,21 +6960,17 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/item/folder/yellow{
-	pixel_y = 4
-	},
-/obj/structure/table/glass,
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#e8eaff"
 	},
-/obj/item/pen,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/computer/rdconsole/bridge,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arL" = (

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -28,7 +28,7 @@ Nothing else in the console has ID requirements.
 	var/obj/machinery/rnd/production/protolathe/linked_lathe				//Linked Protolathe
 	var/obj/machinery/rnd/production/circuit_imprinter/linked_imprinter	//Linked Circuit Imprinter
 
-	req_access = list(ACCESS_TOX)	//lA AND SETTING MANIPULATION REQUIRES SCIENTIST ACCESS.
+	req_one_access = list(ACCESS_HEADS, ACCESS_TOX)
 
 	//UI VARS
 	var/screen = RDSCREEN_MENU
@@ -1121,8 +1121,7 @@ Nothing else in the console has ID requirements.
 
 /obj/machinery/computer/rdconsole/robotics
 	name = "Robotics R&D Console"
-	req_access = null
-	req_access_txt = "29"
+	req_access = list(ACCESS_ROBOTICS)
 
 /obj/machinery/computer/rdconsole/robotics/Initialize()
 	. = ..()
@@ -1135,3 +1134,6 @@ Nothing else in the console has ID requirements.
 
 /obj/machinery/computer/rdconsole/experiment
 	name = "E.X.P.E.R.I-MENTOR R&D Console"
+
+/obj/machinery/computer/rdconsole/bridge
+	name = "Bridge R&D Console"


### PR DESCRIPTION
## About The Pull Request

This adds an R&D console to the bridge on all station maps. It also adds ACCESS_HEADS to the default console. I made this PR because others wanted it, and a few people interested in doing the work were too lazy. I don't have any strong feelings myself on it.

### Box
![image](https://user-images.githubusercontent.com/5211576/57050644-ba922e00-6c4b-11e9-8cfd-6e233aa3ff17.png)

### Delta
![image](https://user-images.githubusercontent.com/5211576/57050816-705d7c80-6c4c-11e9-9768-7922bb1d7f2e.png)

### Meta
![image](https://user-images.githubusercontent.com/5211576/57050952-fda0d100-6c4c-11e9-8ef0-3ffaa6c2aec1.png)

### Pubby
![image](https://user-images.githubusercontent.com/5211576/57051036-6f791a80-6c4d-11e9-9478-f4bfa1d5a47d.png)

### Donut
![image](https://user-images.githubusercontent.com/5211576/57051147-1eb5f180-6c4e-11e9-8876-1d2a3f02e807.png)



## Why It's Good For The Game

Heads of Staff have control over the techweb tree alongside scientists. <!-- the fruit wanted this -->

## Changelog
:cl:
add: R&D console added to bridge.
/:cl: