### PR TITLE
Grenades no longer toggle throwmode

### DIFF
--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -68,9 +68,6 @@
 	log_grenade(user, T) //Inbuilt admin procs already handle null users
 	if(user)
 		add_fingerprint(user)
-		if(iscarbon(user))
-			var/mob/living/carbon/C = user
-			C.throw_mode_on()
 		if(msg)
 			to_chat(user, "<span class='warning'>You prime [src]! [DisplayTimeText(det_time)]!</span>")
 	playsound(src, 'sound/weapons/armbomb.ogg', volume, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Grenades no longer toggle on throw mode

## Why It's Good For The Game

It always felt like this behaviour was out of place. Priming a grenade doesn't mean that you intend to throw it. Those things are two different actions and therefore they should require two seperate inputs.

And yes, this is a Ided PR because I dropped a primed flashbang and then threw away my baton.

## Changelog
:cl:
tweak: Activating a grenade no longer toggles throw mode.
/:cl:
