### PR TITLE
Removes Grandpa as a random first name

### DIFF
--- a/strings/names/first_male.txt
+++ b/strings/names/first_male.txt
@@ -261,7 +261,6 @@ Gordon
 Grady
 Graeme
 Graham
-Grandpa
 Grant
 Gratian
 Grayson


### PR DESCRIPTION


## About The Pull Request

Removes Grandpa from the first name list. 

## Why It's Good For The Game

Grandpa is no longer an acceptable name under naming policy since it falls under a honorific/nickname, so there is no reason for it to be generated as part of a random name.

## Changelog
:cl:
del: Removed grandpa from the first name list. 
/:cl:
