### PR TITLE
Adds apc outages and slips to the blackbox

### DIFF
--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -16,4 +16,5 @@
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	var/mob/victim = AM
 	if(istype(victim) && !victim.is_flying() && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
+		SSblackbox.record_feedback("amount", "slips", 1)
 		callback.Invoke(victim)

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -16,5 +16,5 @@
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	var/mob/victim = AM
 	if(istype(victim) && !victim.is_flying() && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
-		SSblackbox.record_feedback("amount", "slips", 1)
+		SSblackbox.record_feedback("tally", "slips", 1, source.type)
 		callback.Invoke(victim)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -156,6 +156,9 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	if (state != poweralm)
 		poweralm = state
 		if(istype(source))	//Only report power alarms on the z-level where the source is located.
+
+			SSblackbox.record_feedback("associative", "power_alert", 1, list( "area" = src, "time" = time_stamp("YYYY-MM-DD hh:mm:ss", 1)))
+
 			for (var/item in GLOB.silicon_mobs)
 				var/mob/living/silicon/aiPlayer = item
 				if (state == 1)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -233,6 +233,7 @@
 		if(!(lube&SLIDE_ICE))
 			to_chat(C, "<span class='notice'>You slipped[ O ? " on the [O.name]" : ""]!</span>")
 			playsound(C.loc, 'sound/misc/slip.ogg', 50, 1, -3)
+			SSblackbox.record_feedback("amount", "slips", 1)
 
 		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "slipped", /datum/mood_event/slipped)
 		if(force_drop)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -233,7 +233,6 @@
 		if(!(lube&SLIDE_ICE))
 			to_chat(C, "<span class='notice'>You slipped[ O ? " on the [O.name]" : ""]!</span>")
 			playsound(C.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-			SSblackbox.record_feedback("amount", "slips", 1)
 
 		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "slipped", /datum/mood_event/slipped)
 		if(force_drop)


### PR DESCRIPTION
Like the title says, apc power alerts and slips are now tracked in the blackbox.

For power outages, the area and timestamp is recorded:
`{"data":{"1":{"area":"The area power controller","time":"2019-05-01 19:52:52:9"}}}`
For slips, the object that slipped and a count of how often it did is recorded:
`{"data":{"/obj/item/grown/bananapeel":1,"/turf/open/floor/plasteel":1,"/obj/item/pda/clown":1}}`