### PR TITLE
Adds input() to remote signaller

### DIFF
--- a/code/__HELPERS/radio.dm
+++ b/code/__HELPERS/radio.dm
@@ -12,3 +12,8 @@
 /proc/format_frequency(frequency)
 	frequency = text2num(frequency)
 	return "[round(frequency / 10)].[frequency % 10]"
+
+//Opposite of format, returns as a number
+/proc/unformat_frequency(frequency)
+	frequency = text2num(frequency)
+	return frequency * 10

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -60,22 +60,12 @@
 <A href='byond://?src=[REF(src)];send=1'>Send Signal</A><BR>
 <B>Frequency/Code</B> for signaler:<BR>
 Frequency:
-<A href='byond://?src=[REF(src)];freq=-50'>-</A>
-<A href='byond://?src=[REF(src)];freq=-10'>-</A>
-<A href='byond://?src=[REF(src)];freq=-2'>-</A>
 [format_frequency(src.frequency)]
-<A href='byond://?src=[REF(src)];freq=2'>+</A>
-<A href='byond://?src=[REF(src)];freq=10'>+</A>
-<A href='byond://?src=[REF(src)];freq=50'>+</A><BR>
+<A href='byond://?src=[REF(src)];set=freq'>+</A><BR>
 
 Code:
-<A href='byond://?src=[REF(src)];code=-10'>-</A>
-<A href='byond://?src=[REF(src)];code=-5'>-</A>
-<A href='byond://?src=[REF(src)];code=-1'>-</A>
 [src.code]
-<A href='byond://?src=[REF(src)];code=1'>+</A>
-<A href='byond://?src=[REF(src)];code=5'>+</A>
-<A href='byond://?src=[REF(src)];code=10'>+</A><BR>
+<A href='byond://?src=[REF(src)];set=code'>+</A><BR>
 [t1]
 </TT>"}
 		user << browse(dat, "window=radio")
@@ -91,17 +81,19 @@ Code:
 		onclose(usr, "radio")
 		return
 
-	if (href_list["freq"])
-		var/new_frequency = (frequency + text2num(href_list["freq"]))
-		if(new_frequency < MIN_FREE_FREQ || new_frequency > MAX_FREE_FREQ)
-			new_frequency = sanitize_frequency(new_frequency, TRUE)
-		set_frequency(new_frequency)
+	if (href_list["set"])
 
-	if(href_list["code"])
-		src.code += text2num(href_list["code"])
-		src.code = round(src.code)
-		src.code = min(100, src.code)
-		src.code = max(1, src.code)
+		if(href_list["set"] == "freq")
+			var/new_freq = input(usr, "Input a new signalling frequency", "Remote Signaller Frequency", frequency) as num|null
+			new_freq = unformat_frequency(new_freq)
+			new_freq = sanitize_frequency(new_freq, TRUE)
+			set_frequency(new_freq)
+
+		if(href_list["set"] == "code")
+			var/new_code = input(usr, "Input a new signalling code", "Remote Signaller Code", code) as num|null
+			new_code = round(new_code)
+			new_code = CLAMP(new_code, 1, 100)
+			src.code = new_code
 
 	if(href_list["send"])
 		spawn( 0 )

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -97,7 +97,7 @@ Code:
 				return
 			new_code = round(new_code)
 			new_code = CLAMP(new_code, 1, 100)
-			src.code = new_code
+			code = new_code
 
 	if(href_list["send"])
 		spawn( 0 )

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -85,12 +85,16 @@ Code:
 
 		if(href_list["set"] == "freq")
 			var/new_freq = input(usr, "Input a new signalling frequency", "Remote Signaller Frequency", format_frequency(frequency)) as num|null
+			if(!usr.canUseTopic(src, BE_CLOSE))
+				return
 			new_freq = unformat_frequency(new_freq)
 			new_freq = sanitize_frequency(new_freq, TRUE)
 			set_frequency(new_freq)
 
 		if(href_list["set"] == "code")
 			var/new_code = input(usr, "Input a new signalling code", "Remote Signaller Code", code) as num|null
+			if(!usr.canUseTopic(src, BE_CLOSE))
+				return
 			new_code = round(new_code)
 			new_code = CLAMP(new_code, 1, 100)
 			src.code = new_code

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -60,18 +60,22 @@
 <A href='byond://?src=[REF(src)];send=1'>Send Signal</A><BR>
 <B>Frequency/Code</B> for signaler:<BR>
 Frequency:
+<A href='byond://?src=[REF(src)];freq=-50'>-</A>
 <A href='byond://?src=[REF(src)];freq=-10'>-</A>
 <A href='byond://?src=[REF(src)];freq=-2'>-</A>
 [format_frequency(src.frequency)]
 <A href='byond://?src=[REF(src)];freq=2'>+</A>
-<A href='byond://?src=[REF(src)];freq=10'>+</A><BR>
+<A href='byond://?src=[REF(src)];freq=10'>+</A>
+<A href='byond://?src=[REF(src)];freq=50'>+</A><BR>
 
 Code:
+<A href='byond://?src=[REF(src)];code=-10'>-</A>
 <A href='byond://?src=[REF(src)];code=-5'>-</A>
 <A href='byond://?src=[REF(src)];code=-1'>-</A>
 [src.code]
 <A href='byond://?src=[REF(src)];code=1'>+</A>
-<A href='byond://?src=[REF(src)];code=5'>+</A><BR>
+<A href='byond://?src=[REF(src)];code=5'>+</A>
+<A href='byond://?src=[REF(src)];code=10'>+</A><BR>
 [t1]
 </TT>"}
 		user << browse(dat, "window=radio")
@@ -90,7 +94,7 @@ Code:
 	if (href_list["freq"])
 		var/new_frequency = (frequency + text2num(href_list["freq"]))
 		if(new_frequency < MIN_FREE_FREQ || new_frequency > MAX_FREE_FREQ)
-			new_frequency = sanitize_frequency(new_frequency)
+			new_frequency = sanitize_frequency(new_frequency, TRUE)
 		set_frequency(new_frequency)
 
 	if(href_list["code"])

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -61,11 +61,11 @@
 <B>Frequency/Code</B> for signaler:<BR>
 Frequency:
 [format_frequency(src.frequency)]
-<A href='byond://?src=[REF(src)];set=freq'>+</A><BR>
+<A href='byond://?src=[REF(src)];set=freq'>Set</A><BR>
 
 Code:
 [src.code]
-<A href='byond://?src=[REF(src)];set=code'>+</A><BR>
+<A href='byond://?src=[REF(src)];set=code'>Set</A><BR>
 [t1]
 </TT>"}
 		user << browse(dat, "window=radio")
@@ -84,7 +84,7 @@ Code:
 	if (href_list["set"])
 
 		if(href_list["set"] == "freq")
-			var/new_freq = input(usr, "Input a new signalling frequency", "Remote Signaller Frequency", frequency) as num|null
+			var/new_freq = input(usr, "Input a new signalling frequency", "Remote Signaller Frequency", format_frequency(frequency)) as num|null
 			new_freq = unformat_frequency(new_freq)
 			new_freq = sanitize_frequency(new_freq, TRUE)
 			set_frequency(new_freq)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes to use an input box in remote signallers for freq and code entry, previously it was cumbersome increase/decrease buttons.  Fixes going outside of freq range clamping to comms channel frequency range instead of free freq range.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a god damn effort clicking through the frequencies for anomalies, taking 20-30 clicks fairly frequently.  With the range clamping, if you went over 159.9 or below 120.1 it would clamp to whatever the comms freq range is (140s?).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Tetr4
tweak: Remote signallers now use input boxes instead of inc/dec buttons.
fix: Remote signaller freq range no longer clamps to the wrong range.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
