### PR TITLE
Mindswap + Stand Interaction/Fix

### DIFF
--- a/code/modules/spells/spell_types/mind_transfer.dm
+++ b/code/modules/spells/spell_types/mind_transfer.dm
@@ -66,6 +66,16 @@ Also, you never added distance checking after target is selected. I've went ahea
 			to_chat(user, "<span class='warning'>[target.p_their(TRUE)] mind is resisting your spell!</span>")
 		return
 
+	if(istype(target, /mob/living/simple_animal/hostile/guardian))
+		var/mob/living/simple_animal/hostile/guardian/stand = target
+		if(stand.summoner)
+			if(stand.summoner == user)
+				if(!silent)
+					to_chat(user, "<span class='warning'>Swapping minds with your own guardian would just put you back into your own head!</span>")
+				return
+			else
+				target = stand.summoner
+
 	var/mob/living/victim = target//The target of the spell whos body will be transferred to.
 	var/mob/living/caster = user//The wizard/whomever doing the body transferring.
 


### PR DESCRIPTION
:cl:
fix: Mindswapping with a stand instead mindswaps you with that stand's owner, giving you ownership of their stand.
/:cl:

Fixes https://github.com/tgstation/tgstation/issues/43782

Also prevents you from mindswapping your own stand.
Haven't actually tested this.