### PR TITLE
Adds follower hoodies to crafting menu

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -645,6 +645,14 @@
 	result = /obj/item/clothing/under/mummy
 	reqs = list(/obj/item/stack/sheet/cloth = 5)
 
+/datum/crafting_recipe/chaplain_hood
+	name = "Follower Hoodie"
+	result = /obj/item/clothing/suit/hooded/chaplain_hoodie
+	time = 10
+	tools = list(/obj/item/clothing/suit/hooded/chaplain_hoodie)
+	reqs = list(/obj/item/stack/sheet/cloth = 4)
+	category = CAT_CLOTHING
+
 /datum/crafting_recipe/guillotine
 	name = "Guillotine"
 	result = /obj/structure/guillotine

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -649,7 +649,7 @@
 	name = "Follower Hoodie"
 	result = /obj/item/clothing/suit/hooded/chaplain_hoodie
 	time = 10
-	tools = list(/obj/item/clothing/suit/hooded/chaplain_hoodie)
+	tools = list(/obj/item/clothing/suit/hooded/chaplain_hoodie, /obj/item/storage/book/bible)
 	reqs = list(/obj/item/stack/sheet/cloth = 4)
 	category = CAT_CLOTHING
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Follower hoodies can be created with 4 cloth by anyone wearing a follower hoodie with a bible. The leader hoodie also enables this, but the leader hoodie cannot be made this way. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sometimes you run out of follower hoodies, and that's a shame. This gives the Chaplain's follower bundle gimmick more depth by giving the Chaplain motivation to engage material and crafting systems. Given that Chaplain can function as a leader for the bored and causeless, this opens up space for the Chappy to delegate tasks to his ~~underlings~~ acolytes. Will you convert botany to your cause or will you send your followers to the public garden? You'll need to get your cloth somehow. You'll also need to have bibles on hand to scale up production so you might need to hit up the library, too.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Follower hoodies are in the crafting menu!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Should they cost more than this? Let me know what you think re: material cost.