### PR TITLE
Move lighting queues inside the lighting subsystem

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -1,15 +1,14 @@
-GLOBAL_LIST_EMPTY(lighting_update_lights) // List of lighting sources  queued for update.
-GLOBAL_LIST_EMPTY(lighting_update_corners) // List of lighting corners  queued for update.
-GLOBAL_LIST_EMPTY(lighting_update_objects) // List of lighting objects queued for update.
-
 SUBSYSTEM_DEF(lighting)
 	name = "Lighting"
 	wait = 2
 	init_order = INIT_ORDER_LIGHTING
 	flags = SS_TICKER
+	var/static/list/sources_queue = list() // List of lighting sources queued for update.
+	var/static/list/corners_queue = list() // List of lighting corners queued for update.
+	var/static/list/objects_queue = list() // List of lighting objects queued for update.
 
 /datum/controller/subsystem/lighting/stat_entry()
-	..("L:[GLOB.lighting_update_lights.len]|C:[GLOB.lighting_update_corners.len]|O:[GLOB.lighting_update_objects.len]")
+	..("L:[length(sources_queue)]|C:[length(corners_queue)]|O:[length(objects_queue)]")
 
 
 /datum/controller/subsystem/lighting/Initialize(timeofday)
@@ -31,9 +30,10 @@ SUBSYSTEM_DEF(lighting)
 	MC_SPLIT_TICK_INIT(3)
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
+	var/list/queue = sources_queue
 	var/i = 0
-	for (i in 1 to GLOB.lighting_update_lights.len)
-		var/datum/light_source/L = GLOB.lighting_update_lights[i]
+	for (i in 1 to length(queue))
+		var/datum/light_source/L = queue[i]
 
 		L.update_corners()
 
@@ -44,14 +44,15 @@ SUBSYSTEM_DEF(lighting)
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
-		GLOB.lighting_update_lights.Cut(1, i+1)
+		queue.Cut(1, i+1)
 		i = 0
 
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
-	for (i in 1 to GLOB.lighting_update_corners.len)
-		var/datum/lighting_corner/C = GLOB.lighting_update_corners[i]
+	queue = corners_queue
+	for (i in 1 to length(queue))
+		var/datum/lighting_corner/C = queue[i]
 
 		C.update_objects()
 		C.needs_update = FALSE
@@ -60,15 +61,16 @@ SUBSYSTEM_DEF(lighting)
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
-		GLOB.lighting_update_corners.Cut(1, i+1)
+		queue.Cut(1, i+1)
 		i = 0
 
 
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
-	for (i in 1 to GLOB.lighting_update_objects.len)
-		var/atom/movable/lighting_object/O = GLOB.lighting_update_objects[i]
+	queue = objects_queue
+	for (i in 1 to length(queue))
+		var/atom/movable/lighting_object/O = queue[i]
 
 		if (QDELETED(O))
 			continue
@@ -80,7 +82,7 @@ SUBSYSTEM_DEF(lighting)
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
-		GLOB.lighting_update_objects.Cut(1, i+1)
+		queue.Cut(1, i+1)
 
 
 /datum/controller/subsystem/lighting/Recover()

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -96,7 +96,7 @@ GLOBAL_LIST_INIT(LIGHTING_CORNER_DIAGONAL, list(NORTHEAST, SOUTHEAST, SOUTHWEST,
 
 	if (!needs_update)
 		needs_update = TRUE
-		GLOB.lighting_update_corners += src
+		SSlighting.corners_queue += src
 
 /datum/lighting_corner/proc/update_objects()
 	// Cache these values a head of time so 4 individual lighting objects don't all calculate them individually.
@@ -127,7 +127,7 @@ GLOBAL_LIST_INIT(LIGHTING_CORNER_DIAGONAL, list(NORTHEAST, SOUTHEAST, SOUTHWEST,
 		if (T.lighting_object)
 			if (!T.lighting_object.needs_update)
 				T.lighting_object.needs_update = TRUE
-				GLOB.lighting_update_objects += T.lighting_object
+				SSlighting.objects_queue += T.lighting_object
 
 
 /datum/lighting_corner/dummy/New()

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -28,11 +28,11 @@
 		S.update_starlight()
 
 	needs_update = TRUE
-	GLOB.lighting_update_objects += src
+	SSlighting.objects_queue += src
 
 /atom/movable/lighting_object/Destroy(var/force)
 	if (force)
-		GLOB.lighting_update_objects     -= src
+		SSlighting.objects_queue -= src
 		if (loc != myturf)
 			var/turf/oldturf = get_turf(myturf)
 			var/turf/newturf = get_turf(loc)

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -58,7 +58,7 @@
 		LAZYREMOVE(top_atom.light_sources, src)
 
 	if (needs_update)
-		GLOB.lighting_update_lights -= src
+		SSlighting.sources_queue -= src
 
 	. = ..()
 
@@ -67,7 +67,7 @@
 // Actually that'd be great if you could!
 #define EFFECT_UPDATE(level)                \
 	if (needs_update == LIGHTING_NO_UPDATE) \
-		GLOB.lighting_update_lights += src; \
+		SSlighting.sources_queue += src; \
 	if (needs_update < level)               \
 		needs_update            = level;    \
 


### PR DESCRIPTION
## About The Pull Request
I did this small cleanup as a part of testing a potential optimization, but the optimization turned out to require a larger overhaul of the lighting system so I didn't go for it. 

The optimization to the fire() loops is super-minor but it's one of those "might as well" kind of things. Basically it reuses a proc-scoped variable as a reference to the queues instead of accessing the queues directly, which should be VERY SLIGHTLY faster.

## Why It's Good For The Game

Having subsystems' queues inside the subsystem makes plain sense.
