### PR TITLE
Grenades and throwmode

### DIFF
--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -112,7 +112,9 @@
 		prime()
 		return TRUE //It hit the grenade, not them
 		
-/obj/item/grenade/afterattack(atom/target as mob|obj|turf|area, mob/user)
+/obj/item/grenade/afterattack(atom/target, mob/user)
 	. = ..()
 	if(active && user.dropItemToGround(src))
+		visible_message("<span class='danger'>[user] has thrown [name].</span>")
+		log_message("has thrown [name]", LOG_ATTACK)
 		throw_at(target, throw_range, throw_speed)

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -68,9 +68,6 @@
 	log_grenade(user, T) //Inbuilt admin procs already handle null users
 	if(user)
 		add_fingerprint(user)
-		if(iscarbon(user))
-			var/mob/living/carbon/C = user
-			C.throw_mode_on()
 		if(msg)
 			to_chat(user, "<span class='warning'>You prime [src]! [DisplayTimeText(det_time)]!</span>")
 	playsound(src, 'sound/weapons/armbomb.ogg', volume, 1)
@@ -114,3 +111,8 @@
 		owner.visible_message("<span class='danger'>[attack_text] hits [owner]'s [src], setting it off! What a shot!</span>")
 		prime()
 		return TRUE //It hit the grenade, not them
+		
+/obj/item/grenade/afterattack(atom/target as mob|obj|turf|area, mob/user)
+	. = ..()
+	if(active && user.dropItemToGround(src))
+		throw_at(target, throw_range, throw_speed)

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -114,7 +114,5 @@
 		
 /obj/item/grenade/afterattack(atom/target, mob/user)
 	. = ..()
-	if(active && user.dropItemToGround(src))
-		visible_message("<span class='danger'>[user] has thrown [name].</span>")
-		log_message("has thrown [name]", LOG_ATTACK)
-		throw_at(target, throw_range, throw_speed)
+	if(active)
+		user.throw_item(target)


### PR DESCRIPTION
## About The Pull Request

Better version of #43781 

The idea behind it is the same, only that you will throw active grenades regardless of throwmode.

## Changelog
:cl:
tweak: Activating a grenade no longer puts you in throwmode.
tweak: You always throw active grenades now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
