### PR TITLE
Removes ability for single tanks to explode

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -240,9 +240,7 @@
 	var/pressure = air_contents.return_pressure()
 	var/temperature = air_contents.return_temperature()
 
-	if(pressure > TANK_FRAGMENT_PRESSURE)
-		if(!istype(src.loc, /obj/item/transfer_valve))
-			log_bomber(get_mob_by_key(fingerprintslast), "was last key to touch", src, "which ruptured explosively")
+	if(pressure > TANK_FRAGMENT_PRESSURE && istype(src.loc, /obj/item/transfer_valve))
 		//Give the gas a chance to build up more pressure through reacting
 		air_contents.react(src)
 		air_contents.react(src)


### PR DESCRIPTION
:cl:
del: Single tanks can no longer explode.
/:cl:

No one liked the compromise solution, not the maintainers and not even the abuser, so here we are, it's gone.

<details>
<summary>For those wondering,</summary>

time-delayed single tank max-caps instead rupture normally, dumping their contents on their tile, which typically results in a 4-tile range fireball, overheating and overpressurizing an area.
</details>

Closes #43714