### PR TITLE
removes VR from ss13 camera network

### DIFF
--- a/_maps/RandomZLevels/VR/vrhub.dmm
+++ b/_maps/RandomZLevels/VR/vrhub.dmm
@@ -1995,7 +1995,7 @@
 /obj/machinery/camera{
 	c_tag = "Virtual Reality";
 	dir = 1;
-	network = list("ss13","virtual");
+	network = list("virtual");
 	pixel_x = 16;
 	pixel_y = 0;
 	resistance_flags = 64
@@ -2323,7 +2323,7 @@
 /obj/machinery/camera{
 	c_tag = "Virtual Reality";
 	dir = 8;
-	network = list("ss13","virtual");
+	network = list("virtual");
 	pixel_x = 0;
 	pixel_y = -16;
 	resistance_flags = 64


### PR DESCRIPTION
Fixes #43719
:cl: ShizCalev
fix: switching to the SS13 camera network will no longer send you to the VR area.
/:cl:\

have another WIP solution that i'll be posting at another time, but this should do for now.