### PR TITLE
No waiting for lateloaders, move sql books over to lateinit

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -93,7 +93,7 @@
 
 //called if Initialize returns INITIALIZE_HINT_LATELOAD
 /atom/proc/LateInitialize()
-	return
+	set waitfor = FALSE
 
 // Put your AddComponent() calls here
 /atom/proc/ComponentInitialize()

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -15,8 +15,11 @@
 
 /obj/item/book/random/Initialize()
 	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/item/book/random/LateInitialize()
 	create_random_books(amount, src.loc, TRUE, category)
-	return INITIALIZE_HINT_QDEL
+	qdel(src)
 
 /obj/item/book/random/triple
 	amount = 3
@@ -30,12 +33,13 @@
 
 /obj/structure/bookcase/random/Initialize(mapload)
 	. = ..()
-	if(!book_count || !isnum(book_count))
-		update_icon()
-		return
-	book_count += pick(-1,-1,0,1,1)
-	create_random_books(book_count, src, FALSE, category)
+	if(book_count && isnum(book_count))
+		book_count += pick(-1,-1,0,1,1)
+		. = INITIALIZE_HINT_LATELOAD
 	update_icon()
+
+/obj/structure/bookcase/random/LateInitialize()
+	create_random_books(book_count, src, FALSE, category)
 
 /proc/create_random_books(amount = 2, location, fail_loud = FALSE, category = null)
 	. = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This sets waitfor = 0 on LateInitialize(), potentially making late inits faster if the late init sleeps. It also ports the SQL parts of random books/bookcases into lateinit, thus speeding up regular atom initialization and removing the initialization error.

I don't think we rely on LateInitialize happening in a specific order?

## Changelog
:cl: Naksu
tweak: LateInitialize no longer waits for sleepers, moved some book/bookcase initialization sql over there.
/:cl:
