### PR TITLE
Fixes a runtime in mutations

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -183,7 +183,7 @@
 		qdel(src)
 
 /datum/mutation/human/proc/grant_spell()
-	if(!power || !owner)
+	if(!ispath(power) || !owner)
 		return FALSE
 
 	power = new power()

--- a/code/datums/mutations/radioactive.dm
+++ b/code/datums/mutations/radioactive.dm
@@ -6,6 +6,7 @@
 	time_coeff = 5
 	instability = 5
 	difficulty = 8
+	power_coeff = 1
 
 
 /datum/mutation/human/radioactive/on_life()

--- a/code/datums/mutations/radioactive.dm
+++ b/code/datums/mutations/radioactive.dm
@@ -6,7 +6,6 @@
 	time_coeff = 5
 	instability = 5
 	difficulty = 8
-	power = 1
 
 
 /datum/mutation/human/radioactive/on_life()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

`power` is a typepath and not a number. Trying to instantiate a number via `new` runtimes.

## Changelog
:cl: Naksu
fix: fixed a mutation runtime
/:cl:

