### PR TITLE
Tweaks nurse spiders

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -91,6 +91,8 @@
 		to_chat(user, "<span class='notice'>Someone else already took this spider.</span>")
 		return 1
 	key = user.key
+	if(directive)
+		log_game("[key_name(src)] took control of [name] with the objective: '[directive]'.")
 	return 1
 
 //nursemaids - these create webs and eggs
@@ -480,12 +482,24 @@
 	desc = "Set a directive for your children to follow."
 	check_flags = AB_CHECK_CONSCIOUS
 	button_icon_state = "directive"
+	
+/datum/action/innate/spider/set_directive/IsAvailable()
+	if(..())
+		if(!istype(owner, /mob/living/simple_animal/hostile/poison/giant_spider))
+			return FALSE
+		var/mob/living/simple_animal/hostile/poison/giant_spider/S = owner
+		if(S.playable_spider)
+			return FALSE
+		return TRUE
 
 /datum/action/innate/spider/set_directive/Activate()
 	if(!istype(owner, /mob/living/simple_animal/hostile/poison/giant_spider/nurse))
 		return
 	var/mob/living/simple_animal/hostile/poison/giant_spider/nurse/S = owner
-	S.directive = stripped_input(S, "Enter the new directive", "Create directive", "[S.directive]")
+	if(!S.playable_spider)
+		S.directive = stripped_input(S, "Enter the new directive", "Create directive", "[S.directive]")
+		message_admins("[ADMIN_LOOKUPFLW(owner)] set its directive to: '[S.directive]'.")
+		log_game("[key_name(owner)] set its directive to: '[S.directive]'.")
 
 /mob/living/simple_animal/hostile/poison/giant_spider/Login()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so that only the first generation of player controlled nurse spiders can change their directive. Following generations will still pass it on but can't change it. Also adds logging for spider directives.

## Why It's Good For The Game

Gives admins insight into who was a naughty boy and somewhat babyproofs xenobio spiders.

## Changelog
:cl:
tweak: Only the first generation of spiders can change directives for their offsprings.
admin: Spider directives are now logged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
