### PR TITLE
Changes cryoxadone recipe to be less free

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -188,7 +188,7 @@
 	name = "Cryoxadone"
 	id = "cryoxadone"
 	results = list("cryoxadone" = 3)
-	required_reagents = list("stable_plasma" = 1, "acetone" = 1, "mutagen" = 1)
+	required_reagents = list("plasma" = 1, "acetone" = 1, "mutagen" = 1)
 
 /datum/chemical_reaction/pyroxadone
 	name = "Pyroxadone"


### PR DESCRIPTION

## About The Pull Request

This changes the recipie for cryoxadone to use regular plasma in its recipie as opposed to the free stable plasma from the chem machine.

## Why It's Good For The Game

Cryo has always been the epitome of set it and forget it braindead medbay and with a simple chem macro you too can make enough of the stuff to last a whole round in no time flat. Now that medbay has the medfab the small gate of getting bigger beakers from cargo or taking time out to make plastic bottles is also gone meaning a chemist can easily stack medbay with the most braindead of healing chems with no effort and no resource expenditure.  Here they will have to choose to give up their roundstart plasma or get some from mining before they can churn out enough healing to restore a thousand peoples worth of hitpoints.

Clonedexone remains as it was because it only heals clone damage and therefore isn't a braindead cure all.

## Changelog
:cl: Guyonbroadway
balance: cryoxadone now needs normal plasma in it's recipie as opposed to stable plasma
/:cl:


