### PR TITLE
Fixes abductors not knowing how to use the abductor console

### DIFF
--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -28,7 +28,7 @@
 	. = ..()
 	if(.)
 		return
-	if(!HAS_TRAIT(user, TRAIT_ABDUCTOR_TRAINING))
+	if(!HAS_TRAIT(user, TRAIT_ABDUCTOR_TRAINING) && !HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_TRAINING))
 		to_chat(user, "<span class='warning'>You start mashing alien buttons at random!</span>")
 		if(do_after(user,100, target = src))
 			TeleporterSend()

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -99,7 +99,7 @@
 
 /obj/item/organ/tongue/abductor/examine(mob/M)
 	. = ..()
-	if(HAS_TRAIT(M, TRAIT_ABDUCTOR_TRAINING) || isobserver(M))
+	if(HAS_TRAIT(M, TRAIT_ABDUCTOR_TRAINING) || HAS_TRAIT(M.mind, TRAIT_ABDUCTOR_TRAINING) || isobserver(M))
 		if(!mothership)
 			to_chat(M, "<span class='notice'>It is not attuned to a specific mothership.</span>")
 		else


### PR DESCRIPTION
Fixes #43879 

## About The Pull Request

I missed these implicit mind checks in the trait PR. Also fixes a missing examine message on the abductor tongue.

## Changelog
:cl: Naksu
fix: Abductors can use their own console again.
/:cl:
