### PR TITLE
Resets the lastproduce variable on plant death/removal

### DIFF
--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -8,8 +8,8 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/grass
 	lifespan = 40
 	endurance = 40
-	maturation = 3
-	production = 4
+	maturation = 2
+	production = 5
 	yield = 5
 	growthstages = 2
 	icon_grow = "grass-grow"

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -8,8 +8,8 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/grass
 	lifespan = 40
 	endurance = 40
-	maturation = 2
-	production = 5
+	maturation = 3
+	production = 4
 	yield = 5
 	growthstages = 2
 	icon_grow = "grass-grow"

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -424,6 +424,7 @@
 	plant_health = 0
 	harvest = 0
 	pestlevel = 0 // Pests die
+	lastproduce = 0
 	if(!dead)
 		update_icon()
 		dead = 1
@@ -812,6 +813,7 @@
 			if(myseed) //Could be that they're just using it as a de-weeder
 				age = 0
 				plant_health = 0
+				lastproduce = 0
 				if(harvest)
 					harvest = FALSE //To make sure they can't just put in another seed and insta-harvest it
 				qdel(myseed)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Resets the tray/soil variable 'lastproduce' after the plant it refers to dies or is removed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The persistence of a value for this variable beyond the plant it referred to seems to delay the development of grass planted subsequently (and possibly other plants to a less noticeable extent).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Lets the grass grow under your feet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
