### PR TITLE
Auto shuttle caller no longer tries to run if no players are on

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -127,7 +127,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/threshold = CONFIG_GET(number/emergency_shuttle_autocall_threshold)
 	if(!threshold)
 		return
-
+	
 	var/alive = 0
 	for(var/I in GLOB.player_list)
 		var/mob/M = I
@@ -135,6 +135,8 @@ SUBSYSTEM_DEF(shuttle)
 			++alive
 
 	var/total = GLOB.joined_player_list.len
+	if(total <= 0)
+		return //no players no autoevac
 
 	if(alive / total <= threshold)
 		var/msg = "Automatically dispatching shuttle due to crew death."


### PR DESCRIPTION
This prevents a runtime due to division by zero

Fixes #43239 
