### PR TITLE
Makes box's chapel wider

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -17113,19 +17113,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"aNZ" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "aOa" = (
 /obj/machinery/light{
 	dir = 1
@@ -17620,23 +17607,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"aPp" = (
-/obj/machinery/camera{
-	c_tag = "Escape Arm Holding Area";
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "aPq" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -18100,15 +18070,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"aQB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "aQC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -21015,12 +20976,6 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
-"aXC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "aXD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -21692,12 +21647,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
 /area/chapel/main)
-"aZi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "aZj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -22210,12 +22159,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"baC" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "baD" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -56476,6 +56419,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"lqJ" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lantern,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "ltd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -56881,6 +56829,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"ozs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "oDF" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
@@ -104803,7 +104759,7 @@ aFw
 aMM
 aFz
 aFz
-aQw
+lqJ
 aRS
 aRS
 aRS
@@ -105050,7 +105006,7 @@ auI
 azu
 aAz
 asB
-aCO
+ozs
 aEh
 aFz
 aHk
@@ -105061,7 +105017,7 @@ aML
 aFz
 aFz
 aQw
-cdl
+aRS
 aRS
 aRS
 aRS
@@ -105307,24 +105263,24 @@ auI
 azw
 aAA
 asB
-aCQ
-aEk
-aFB
-aHn
-aFB
-csT
-aFB
-aLr
-aFB
-aPn
-aQy
-aPn
-aTi
-aUK
-aVU
-aWg
+aCO
+aEh
+aFz
+aCO
+aFz
+aFz
+aFz
+aEh
+aFz
+aFz
+lqJ
+cdl
+aRS
+aRS
+aRS
+aRS
 aZf
-baA
+aRS
 bbF
 aYV
 aXq
@@ -105564,24 +105520,24 @@ auI
 awO
 iBZ
 asB
-aCP
-aEj
-aFA
-aHm
-aEj
-aEj
-aEj
-aEj
-aEj
-aPm
-aQx
-aPm
-aTh
-aUJ
-aTh
-aXz
-aZg
-aFz
+aCQ
+aEk
+aFB
+aHn
+aFB
+csT
+aFB
+aLr
+aFB
+aPn
+aQy
+aPn
+aTi
+aUK
+aVU
+aWg
+aZf
+baA
 bbF
 aYV
 bdv
@@ -105821,25 +105777,25 @@ ayj
 azx
 aAB
 asB
-aCR
-aEm
-aCR
-aPl
-aQv
-aPl
-aQv
-aCR
-aNY
-aCR
-aQA
-aCR
-aTj
+aCP
+aEj
+aFA
+aHm
+aEj
+aEj
+aEj
+aEj
+aEj
+aPm
+aQx
+aPm
+aTh
+aUJ
+aTh
+aXz
+aZg
 aFz
-aVV
-aXB
-aZh
-baB
-aCR
+bbF
 bcq
 bdx
 bcq
@@ -106079,23 +106035,23 @@ asB
 asB
 asB
 aCR
-bfb
+aEm
 aCR
-aHo
-aIE
-aKe
-aIE
+aPl
+aQv
+aPl
+aQv
 aCR
-aNX
-aPo
-aQz
+aNY
 aCR
+aQA
 aCR
-aCR
-aCR
-aXy
-aZe
-aCR
+aTj
+aFz
+aVV
+aXB
+aZh
+baB
 aCR
 bcy
 bdw
@@ -106336,24 +106292,24 @@ aaf
 aaf
 atS
 aCR
-aEn
+bfb
 aCR
-aHq
-aHq
-aHq
-aHq
+aHo
+aIE
+aKe
+aIE
+aCR
+aNX
+aPo
+aQz
 aCR
 aCR
 aCR
 aCR
+aXy
+aZe
 aCR
-aTl
-aUL
-aVW
-aXD
-aZj
-baD
-bbG
+aCR
 aTk
 bdy
 beI
@@ -106592,25 +106548,25 @@ aoV
 aoV
 aaf
 atS
-aaf
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aMZ
-aNZ
-aPp
-aQB
-aNa
-aTk
-aPq
-aPq
-aXC
-aZi
-baC
-aPq
+aCR
+aEn
+aCR
+aHq
+aHq
+aHq
+aHq
+aCR
+aCR
+aCR
+aCR
+aCR
+aTl
+aUL
+aVW
+aXD
+aZj
+baD
+bbG
 aPq
 bdy
 beH

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -17134,6 +17134,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aOc" = (
@@ -17612,6 +17615,19 @@
 /area/hallway/secondary/exit)
 "aPr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Escape Arm Holding Area";
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_x = -25
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aPs" = (
@@ -51526,21 +51542,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"cwd" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "Station Intercom (AI Private)";
-	pixel_x = -28;
-	pixel_y = -29
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
 "cwe" = (
 /obj/structure/sign/warning/securearea,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -56569,6 +56570,12 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
+"mvb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/exit)
 "mBm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -57970,6 +57977,16 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"wXs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "wZy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -96634,7 +96651,7 @@ cvT
 cBS
 cwc
 cvz
-cwd
+cvz
 cwf
 cwj
 cwo
@@ -106815,9 +106832,9 @@ aaf
 aMZ
 aOb
 aPr
-aQC
+wXs
 aRU
-aQC
+mvb
 aQC
 aQC
 czO

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -17127,7 +17127,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aOb" = (
-/obj/structure/chair,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -17137,6 +17136,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aOc" = (
@@ -17627,6 +17628,9 @@
 	},
 /obj/item/radio/intercom{
 	pixel_x = -25
+	},
+/obj/structure/chair{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -57984,6 +57988,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The chapel is now an uneven number of tiles wide so you can comfortably stand in the middle and give a cool sermon.
Also the tables now have lanterns like other chapels and in the funeral room there's a new table with a candle pack on it because that place is barren.
Before
![cwVmcpt](https://user-images.githubusercontent.com/49726786/57550652-47816980-7367-11e9-8082-b4a6cd313597.png)
After
![eiT24cz](https://user-images.githubusercontent.com/49726786/57550667-4cdeb400-7367-11e9-8b80-e4a371fad6f2.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes a very minor annoyance that triggered every chaplain with OCD.
Edit: Note: Literally every other chapel has an uneven amount of tiles in the 'sermon room' so this just brings the map in line with every other.(I don't remember if Pubby does but it's chapel is a pretty big exception either way).
Edit 2: Actually Donut also doesn't have an uneven wide chapel. But I think we all know how Donut is a bad example.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: An extra tile to the Box chapel's width
del: One barely noticeable tile of width from escape(one escape brig chair dead [*] )
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
