### PR TITLE
Easy suit sensor reminder alert prompt

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -28,6 +28,7 @@
 #define COMSIG_GLOB_MOB_CREATED "!mob_created"					//mob was created somewhere : (mob)
 #define COMSIG_GLOB_MOB_DEATH "!mob_death"						//mob died somewhere : (mob , gibbed)
 #define COMSIG_GLOB_LIVING_SAY_SPECIAL "!say_special"			//global living say plug - use sparingly: (mob/speaker , message)
+#define COMSIG_GLOB_AI_VOX "!ai_vox"							//ai used vox announcements : (mob/living/silicon/ai, list/words)
 
 //////////////////////////////////////////////////////////////////
 

--- a/code/datums/components/suit_sensors_reminder.dm
+++ b/code/datums/components/suit_sensors_reminder.dm
@@ -1,0 +1,53 @@
+#define SUIT_SENSORS_ALERT_LIFETIME 15 SECONDS
+
+/datum/component/suit_sensors_reminder
+	var/last_used = 0
+
+/datum/component/suit_sensors_reminder/Initialize()
+	RegisterSignal(SSdcs, COMSIG_GLOB_AI_VOX, .proc/ai_vox)
+	RegisterSignal(parent, COMSIG_MOVABLE_HEAR, .proc/on_hear)
+
+/datum/component/suit_sensors_reminder/proc/ai_vox(datum/source, mob/living/silicon/ai/ai, list/words)
+	var/turf/T = get_turf(parent)
+	if(ai.z == T?.z && ("sensors" in words))
+		try_notify(ai)
+
+/datum/component/suit_sensors_reminder/proc/on_hear(datum/source, message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
+	if((SPAN_COMMAND in spans) && findtext(lowertext(message), "sensors"))
+		try_notify(source)
+
+/datum/component/suit_sensors_reminder/proc/try_notify(datum/source)
+	if(world.time - last_used < SUIT_SENSORS_ALERT_LIFETIME)
+		return
+	var/mob/living/carbon/human/H = parent
+	var/obj/item/clothing/under/U = H?.w_uniform
+	if(!istype(U))
+		return
+	last_used = world.time
+	var/obj/screen/alert/toggle_suit_sensors/notification = H.throw_alert("toggle_suit_sensors", /obj/screen/alert/toggle_suit_sensors)
+	if(!notification)
+		return
+	var/ui_style = H.client?.prefs?.UI_style
+	if(ui_style)
+		notification.icon = ui_style2icon(ui_style)
+	notification.desc = "[source] wants to remind you to toggle your suit sensors so that the medical staff can find you in the case of an emergency."
+	var/mutable_appearance/overlay = new()
+	overlay.icon = U.icon
+	overlay.icon_state = U.icon_state
+	overlay.layer = FLOAT_LAYER
+	overlay.plane = FLOAT_PLANE
+	notification.add_overlay(overlay)
+
+/obj/screen/alert/toggle_suit_sensors
+	name = "Toggle Suit Sensors"
+	icon_state = "template"
+	timeout = SUIT_SENSORS_ALERT_LIFETIME
+
+/obj/screen/alert/toggle_suit_sensors/Click()
+	if(!usr || !usr.client)
+		return
+	var/mob/living/carbon/human/H = usr
+	var/obj/item/clothing/under/U = H?.w_uniform
+	U?.toggle()
+
+#undef SUIT_SENSORS_ALERT_LIFETIME

--- a/code/datums/components/suit_sensors_reminder.dm
+++ b/code/datums/components/suit_sensors_reminder.dm
@@ -37,6 +37,7 @@
 	overlay.layer = FLOAT_LAYER
 	overlay.plane = FLOAT_PLANE
 	notification.add_overlay(overlay)
+	RemoveComponent()
 
 /obj/screen/alert/toggle_suit_sensors
 	name = "Toggle Suit Sensors"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -216,6 +216,9 @@ BLIND     // can't see anything
 		if(H.w_uniform == src)
 			H.update_suit_sensors()
 
+	usr.GetComponent(/datum/component/suit_sensors_reminder)?.RemoveComponent()
+	usr.clear_alert("toggle_suit_sensors")
+
 /obj/item/clothing/under/AltClick(mob/user)
 	if(..())
 		return 1

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -216,7 +216,6 @@ BLIND     // can't see anything
 		if(H.w_uniform == src)
 			H.update_suit_sensors()
 
-	usr.GetComponent(/datum/component/suit_sensors_reminder)?.RemoveComponent()
 	usr.clear_alert("toggle_suit_sensors")
 
 /obj/item/clothing/under/AltClick(mob/user)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -37,6 +37,7 @@
 
 /mob/living/carbon/human/ComponentInitialize()
 	. = ..()
+	AddComponent(/datum/component/suit_sensors_reminder)
 	if(!CONFIG_GET(flag/disable_human_mood))
 		AddComponent(/datum/component/mood)
 

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -131,6 +131,7 @@
 	announcing_vox = world.time + VOX_DELAY
 
 	log_game("[key_name(src)] made a vocal announcement with the following message: [message].")
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_AI_VOX, src, words)
 
 	for(var/word in words)
 		play_vox_word(word, src.z, null)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -377,6 +377,7 @@
 #include "code\datums\components\spooky.dm"
 #include "code\datums\components\squeak.dm"
 #include "code\datums\components\stationloving.dm"
+#include "code\datums\components\suit_sensors_reminder.dm"
 #include "code\datums\components\swarming.dm"
 #include "code\datums\components\thermite.dm"
 #include "code\datums\components\uplink.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Players will now have an easy alert they can click on to adjust their suit sensors when either the AI over vox or someone with a megaphone mentions them, anecdotally the two inevitabilities. ~~The first time a user adjusts their sensors (doesn't matter how), they will no longer get the prompt.~~ Alert only shows the very first time.

![](https://giant.gfycat.com/PitifulPeriodicFairybluebird.gif)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adjusting suit sensors is a weird process; opening inventory, right clicking on your jumpsuit, and clicking Adjust Suit Sensors, or typing in the verb in the command bar. This is exemplified for new players, as having to right click on something in the first place isn't that common, and these messages about suit sensors are as meaningful as the ambience telling players to go to the disembarkation lounge. This just adds basic quality of life that helps both new and old players while also ideally having little overhead and annoyance.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added an alert prompt to easily adjust suit sensors when reminded.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
