### PR TITLE
Cleans up mood_events from deciseconds into MINUTES and SECONDS

### DIFF
--- a/code/datums/mood_events/drink_events.dm
+++ b/code/datums/mood_events/drink_events.dm
@@ -5,19 +5,19 @@
 /datum/mood_event/quality_nice
 	description = "<span class='nicegreen'>That drink wasn't bad at all.</span>\n"
 	mood_change = 1
-	timeout = 1200
+	timeout = 2 MINUTES
 
 /datum/mood_event/quality_good
 	description = "<span class='nicegreen'>That drink was pretty good.</span>\n"
 	mood_change = 2
-	timeout = 1200
+	timeout = 2 MINUTES
 
 /datum/mood_event/quality_verygood
 	description = "<span class='nicegreen'>That drink was great!</span>\n"
 	mood_change = 3
-	timeout = 1200
+	timeout = 2 MINUTES
 
 /datum/mood_event/quality_fantastic
 	description = "<span class='nicegreen'>That drink was amazing!</span>\n"
 	mood_change = 4
-	timeout = 1200
+	timeout = 2 MINUTES

--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -5,16 +5,16 @@
 /datum/mood_event/smoked
 	description = "<span class='nicegreen'>I have had a smoke recently.</span>\n"
 	mood_change = 2
-	timeout = 3600
+	timeout = 6 MINUTES
 
 /datum/mood_event/wrong_brand
 	description = "<span class='warning'>I hate that brand of cigarettes.</span>\n"
 	mood_change = -2
-	timeout = 3600
+	timeout = 6 MINUTES
 
 /datum/mood_event/overdose
 	mood_change = -8
-	timeout = 3000
+	timeout = 5 MINUTES
 
 /datum/mood_event/overdose/add_effects(drug_name)
 	description = "<span class='warning'>I think I took a bit too much of that [drug_name]</span>\n"
@@ -50,11 +50,11 @@
 /datum/mood_event/happiness_drug_good_od
 	description = "<span class='nicegreen'>YES! YES!! YES!!!</span>\n"
 	mood_change = 100
-	timeout = 300
+	timeout = 30 SECONDS
 	special_screen_obj = "mood_happiness_good"
 
 /datum/mood_event/happiness_drug_bad_od
 	description = "<span class='boldwarning'>NO! NO!! NO!!!</span>\n"
 	mood_change = -100
-	timeout = 300
+	timeout = 30 SECONDS
 	special_screen_obj = "mood_happiness_bad"

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -17,7 +17,7 @@
 /datum/mood_event/burnt_thumb
 	description = "<span class='warning'>I shouldn't play with lighters...</span>\n"
 	mood_change = -1
-	timeout = 1200
+	timeout = 2 MINUTES
 
 /datum/mood_event/cold
 	description = "<span class='warning'>It's way too cold in here.</span>\n"
@@ -30,42 +30,42 @@
 /datum/mood_event/creampie
 	description = "<span class='warning'>I've been creamed. Tastes like pie flavor.</span>\n"
 	mood_change = -2
-	timeout = 1800
+	timeout = 3 MINUTES
 
 /datum/mood_event/slipped
 	description = "<span class='warning'>I slipped. I should be more careful next time...</span>\n"
 	mood_change = -2
-	timeout = 1800
+	timeout = 3 MINUTES
 
 /datum/mood_event/eye_stab
 	description = "<span class='boldwarning'>I used to be an adventurer like you, until I took a screwdriver to the eye.</span>\n"
 	mood_change = -4
-	timeout = 1800
+	timeout = 3 MINUTES
 
 /datum/mood_event/delam //SM delamination
 	description = "<span class='boldwarning'>Those God damn engineers can't do anything right...</span>\n"
 	mood_change = -2
-	timeout = 2400
+	timeout = 4 MINUTES
 
 /datum/mood_event/depression
 	description = "<span class='warning'>I feel sad for no particular reason.</span>\n"
 	mood_change = -9
-	timeout = 1200
+	timeout = 2 MINUTES
 
 /datum/mood_event/shameful_suicide //suicide_acts that return SHAME, like sord
   description = "<span class='boldwarning'>I can't even end it all!</span>\n"
   mood_change = -10
-  timeout = 600
+  timeout = 60 SECONDS
 
 /datum/mood_event/dismembered
   description = "<span class='boldwarning'>AHH! I WAS USING THAT LIMB!</span>\n"
   mood_change = -8
-  timeout = 2400
+  timeout = 4 MINUTES
 
 /datum/mood_event/tased
 	description = "<span class='warning'>There's no \"z\" in \"taser\". It's in the zap.</span>\n"
 	mood_change = -3
-	timeout = 1200
+	timeout = 2 MINUTES
 
 /datum/mood_event/embedded
 	description = "<span class='boldwarning'>Pull it out!</span>\n"
@@ -74,7 +74,7 @@
 /datum/mood_event/table
 	description = "<span class='warning'>Someone threw me on a table!</span>\n"
 	mood_change = -2
-	timeout = 1200
+	timeout = 2 MINUTES
 
 /datum/mood_event/table/add_effects()
 	if(ishuman(owner))
@@ -99,7 +99,7 @@
 /datum/mood_event/epilepsy //Only when the mutation causes a seizure
   description = "<span class='warning'>I should have paid attention to the epilepsy warning.</span>\n"
   mood_change = -3
-  timeout = 3000
+  timeout = 5 MINUTES
 
 /datum/mood_event/nyctophobia
 	description = "<span class='warning'>It sure is dark around here...</span>\n"
@@ -112,7 +112,7 @@
 /datum/mood_event/healsbadman
 	description = "<span class='warning'>I feel like I'm held together by flimsy string, and could fall apart at any moment!</span>\n"
 	mood_change = -4
-	timeout = 1200
+	timeout = 2 MINUTES
 
 /datum/mood_event/jittery
 	description = "<span class='warning'>I'm nervous and on edge and I can't stand still!!</span>\n"
@@ -121,27 +121,27 @@
 /datum/mood_event/vomit
 	description = "<span class='warning'>I just threw up. Gross.</span>\n"
 	mood_change = -2
-	timeout = 1200
+	timeout = 2 MINUTES
 
 /datum/mood_event/vomitself
 	description = "<span class='warning'>I just threw up all over myself. This is disgusting.</span>\n"
 	mood_change = -4
-	timeout = 1800
+	timeout = 3 MINUTES
 
 /datum/mood_event/painful_medicine
 	description = "<span class='warning'>Medicine may be good for me but right now it stings like hell.</span>\n"
 	mood_change = -5
-	timeout = 600
+	timeout = 60 SECONDS
 
 /datum/mood_event/spooked
 	description = "<span class='warning'>The rattling of those bones...It still haunts me.</span>\n"
 	mood_change = -4
-	timeout = 2400
+	timeout = 4 MINUTES
 
 /datum/mood_event/loud_gong
 	description = "<span class='warning'>That loud gong noise really hurt my ears!</span>\n"
 	mood_change = -3
-	timeout = 1200
+	timeout = 2 MINUTES
 
 /datum/mood_event/notcreeping
 	description = "<span class='warning'>The voices are not happy, and they painfully contort my thoughts into getting back on task.</span>\n"
@@ -164,7 +164,7 @@
 /datum/mood_event/sapped
 	description = "<span class='boldwarning'>Some unexplainable sadness is consuming me...</span>\n"
 	mood_change = -15
-	timeout = 900
+	timeout = 90 SECONDS
 
 /datum/mood_event/back_pain
 	description = "<span class='boldwarning'>Bags never sit right on my back, this hurts like hell!</span>\n"
@@ -173,7 +173,7 @@
 /datum/mood_event/sad_empath
 	description = "<span class='warning'>Someone seems upset...</span>\n"
 	mood_change = -2
-	timeout = 600
+	timeout = 60 SECONDS
 
 /datum/mood_event/sad_empath/add_effects(mob/sadtarget)
 	description = "<span class='warning'>[sadtarget.name] seems upset...</span>\n"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -1,12 +1,12 @@
 /datum/mood_event/hug
 	description = "<span class='nicegreen'>Hugs are nice.</span>\n"
 	mood_change = 1
-	timeout = 1200
+	timeout = 2 MINUTES
 
 /datum/mood_event/betterhug
 	description = "<span class='nicegreen'>Someone was very nice to me.</span>\n"
 	mood_change = 3
-	timeout = 3000
+	timeout = 5 MINUTES
 
 /datum/mood_event/betterhug/add_effects(mob/friend)
 	description = "<span class='nicegreen'>[friend.name] was very nice to me.</span>\n"
@@ -14,7 +14,7 @@
 /datum/mood_event/besthug
 	description = "<span class='nicegreen'>Someone is great to be around, they make me feel so happy!</span>\n"
 	mood_change = 5
-	timeout = 3000
+	timeout = 5 MINUTES
 
 /datum/mood_event/besthug/add_effects(mob/friend)
 	description = "<span class='nicegreen'>[friend.name] is great to be around, [friend.p_they()] makes me feel so happy!</span>\n"
@@ -22,27 +22,27 @@
 /datum/mood_event/arcade
 	description = "<span class='nicegreen'>I beat the arcade game!</span>\n"
 	mood_change = 3
-	timeout = 3000
+	timeout = 5 MINUTES
 
 /datum/mood_event/blessing
 	description = "<span class='nicegreen'>I've been blessed.</span>\n"
 	mood_change = 3
-	timeout = 3000
+	timeout = 5 MINUTES
 
 /datum/mood_event/book_nerd
 	description = "<span class='nicegreen'>I have recently read a book.</span>\n"
 	mood_change = 3
-	timeout = 3000
+	timeout = 5 MINUTES
 
 /datum/mood_event/exercise
 	description = "<span class='nicegreen'>Working out releases those endorphins!</span>\n"
 	mood_change = 3
-	timeout = 3000
+	timeout = 5 MINUTES
 
 /datum/mood_event/pet_animal
 	description = "<span class='nicegreen'>Animals are adorable! I can't stop petting them!</span>\n"
 	mood_change = 3
-	timeout = 3000
+	timeout = 5 MINUTES
 
 /datum/mood_event/pet_animal/add_effects(mob/animal)
 	description = "<span class='nicegreen'>\The [animal.name] is adorable! I can't stop petting [animal.p_them()]!</span>\n"
@@ -50,12 +50,12 @@
 /datum/mood_event/honk
 	description = "<span class='nicegreen'>Maybe clowns aren't so bad after all. Honk!</span>\n"
 	mood_change = 2
-	timeout = 2400
+	timeout = 4 MINUTES
 
 /datum/mood_event/perform_cpr
 	description = "<span class='nicegreen'>It feels good to save a life.</span>\n"
 	mood_change = 6
-	timeout = 3000
+	timeout = 5 MINUTES
 
 /datum/mood_event/oblivious
 	description = "<span class='nicegreen'>What a lovely day.</span>\n"
@@ -64,7 +64,7 @@
 /datum/mood_event/jolly
 	description = "<span class='nicegreen'>I feel happy for no particular reason.</span>\n"
 	mood_change = 6
-	timeout = 1200
+	timeout = 2 MINUTES
 
 /datum/mood_event/focused
 	description = "<span class='nicegreen'>I have a goal, and I will reach it, whatever it takes!</span>\n" //Used for syndies, nukeops etc so they can focus on their goals
@@ -81,7 +81,7 @@
 /datum/mood_event/creeping
 	description = "<span class='greentext'>The voices have released their hooks on my mind! I feel free again!</span>\n" //creeps get it when they are around their obsession
 	mood_change = 18
-	timeout = 30
+	timeout = 3 SECONDS
 	hidden = TRUE
 
 /datum/mood_event/revolution
@@ -101,7 +101,7 @@
 /datum/mood_event/goodmusic
 	description = "<span class='nicegreen'>There is something soothing about this music.</span>\n"
 	mood_change = 3
-	timeout = 600
+	timeout = 60 MINUTES
 
 /datum/mood_event/chemical_euphoria
 	description = "<span class='nicegreen'>Heh...hehehe...hehe...</span>\n"
@@ -110,12 +110,12 @@
 /datum/mood_event/chemical_laughter
 	description = "<span class='nicegreen'>Laughter really is the best medicine! Or is it?</span>\n"
 	mood_change = 4
-	timeout = 1800
+	timeout = 3 MINUTES
 
 /datum/mood_event/chemical_superlaughter
 	description = "<span class='nicegreen'>*WHEEZE*</span>\n"
 	mood_change = 12
-	timeout = 1800
+	timeout = 3 MINUTES
 
 /datum/mood_event/religiously_comforted
 	description = "<span class='nicegreen'>You are comforted by the presence of a holy person.</span>"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -101,7 +101,7 @@
 /datum/mood_event/goodmusic
 	description = "<span class='nicegreen'>There is something soothing about this music.</span>\n"
 	mood_change = 3
-	timeout = 60 MINUTES
+	timeout = 60 SECONDS
 
 /datum/mood_event/chemical_euphoria
 	description = "<span class='nicegreen'>Heh...hehehe...hehe...</span>\n"

--- a/code/datums/mood_events/needs_events.dm
+++ b/code/datums/mood_events/needs_events.dm
@@ -70,22 +70,22 @@
 /datum/mood_event/favorite_food
 	description = "<span class='nicegreen'>I really enjoyed eating that.</span>\n"
 	mood_change = 3
-	timeout = 2400
+	timeout = 4 MINUTES
 
 /datum/mood_event/gross_food
 	description = "<span class='warning'>I really didn't like that food.</span>\n"
 	mood_change = -2
-	timeout = 2400
+	timeout = 4 MINUTES
 
 /datum/mood_event/disgusting_food
 	description = "<span class='warning'>That food was disgusting!</span>\n"
 	mood_change = -4
-	timeout = 2400
+	timeout = 4 MINUTES
 
 /datum/mood_event/nice_shower
 	description = "<span class='nicegreen'>I have recently had a nice shower.</span>\n"
 	mood_change = 2
-	timeout = 1800
+	timeout = 3 MINUTES
 
 /datum/mood_event/fresh_laundry
 	description = "<span class='nicegreen'>There's nothing like the feeling of a freshly laundered jumpsuit.</span>\n"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
We have defines for times to save us from the horrid decisecond. Inspired by the singular use of defines for the "clean laundry" moodlet I have converted all other mood_event timeouts from deciseconds to appropriate MINUTES and SECONDS.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It hurts to look at raw time outputs. Code is now a little less maddening to look at.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
refactor: mood_event timeouts are now in MINUTES and SECONDS
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
