### PR TITLE
Comms console window no longer steals focus

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -455,6 +455,8 @@
 			dat +=  dat2
 			popup.set_content(dat)
 			popup.open()
+			popup.set_content(dat)
+			popup.open()
 		return
 
 	switch(state)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -443,8 +443,7 @@
 	var/dat = ""
 	if(SSshuttle.emergency.mode == SHUTTLE_CALL)
 		var/timeleft = SSshuttle.emergency.timeLeft()
-		dat += "<B>Emergency shuttle</B>\n<BR>\nETA: [timeleft / 60 % 60]:[add_zero(num2text(timeleft % 60), 2)]"
-
+		dat += "<B>Emergency shuttle</B>\n<BR>\nETA: [timeleft / 60 % 60]:[add_zero(num2text(timeleft % 60), 2)]<BR>"
 
 	var/datum/browser/popup = new(user, "communications", "Communications Console", 400, 500)
 	popup.set_title_image(user.browse_rsc_icon(icon, icon_state))
@@ -455,8 +454,7 @@
 			dat +=  dat2
 			popup.set_content(dat)
 			popup.open()
-			popup.set_content(dat)
-			popup.open()			// set_content() and open() intentionally called twice.
+			popup.open()				// open called twice intentionally
 		return
 
 	switch(state)
@@ -582,8 +580,7 @@
 
 	popup.set_content(dat)
 	popup.open()
-	popup.set_content(dat)
-	popup.open()							// set_content() and open() intentionally called twice.
+	popup.open()						// open called twice intentionally
 
 /obj/machinery/computer/communications/proc/get_javascript_header(form_id)
 	var/dat = {"<script type="text/javascript">

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -456,7 +456,7 @@
 			popup.set_content(dat)
 			popup.open()
 			popup.set_content(dat)
-			popup.open()
+			popup.open()			// set_content() and open() intentionally called twice.
 		return
 
 	switch(state)
@@ -583,7 +583,7 @@
 	popup.set_content(dat)
 	popup.open()
 	popup.set_content(dat)
-	popup.open()
+	popup.open()							// set_content() and open() intentionally called twice.
 
 /obj/machinery/computer/communications/proc/get_javascript_header(form_id)
 	var/dat = {"<script type="text/javascript">


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #15526
Fixes #36837

Prevents the comms console window taking focus on every process() when used by AI. Only happens in default view.

Don't ask me why this works, it sets content and opens popup twice for non-ai as well. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Communications console window no longer steals focus every couple seconds when used by AI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
