### PR TITLE
Makes vending machines use spritesheets over artisanal handwritten getflaticon memes

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -13,7 +13,6 @@ GLOBAL_LIST_EMPTY(deliverybeacontags)			    //list of all tags associated with d
 GLOBAL_LIST_EMPTY(nuke_list)
 GLOBAL_LIST_EMPTY(alarmdisplay)				        //list of all machines or programs that can display station alerts
 GLOBAL_LIST_EMPTY(singularities)				    //list of all singularities on the station (actually technically all engines)
-GLOBAL_LIST_EMPTY(vending_cache)
 
 GLOBAL_LIST(chemical_reactions_list)				//list of all /datum/chemical_reaction datums. Used during chemical reactions
 GLOBAL_LIST(chemical_reagents_list)				//list of all /datum/reagent datums indexed by reagent id. Used by chemistry stuff

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -39,8 +39,12 @@
 	//title_image = ntitle_image
 
 /datum/browser/proc/add_stylesheet(name, file)
-	stylesheets["[ckey(name)].css"] = file
-	register_asset("[ckey(name)].css", file)
+	if (istype(name, /datum/asset/spritesheet))
+		var/datum/asset/spritesheet/sheet = name
+		stylesheets["spritesheet_[sheet.name].css"] = "data/spritesheets/[sheet.name]"
+	else
+		stylesheets["[ckey(name)].css"] = file
+		register_asset("[ckey(name)].css", file)
 
 /datum/browser/proc/add_script(name, file)
 	scripts["[ckey(name)].js"] = file

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -663,6 +663,37 @@ GLOBAL_LIST_EMPTY(asset_datums)
 		Insert(initial(D.id), I)
 	return ..()
 
+/datum/asset/spritesheet/vending
+	name = "vending"
+
+/datum/asset/spritesheet/vending/register()
+	for (var/k in GLOB.vending_products)
+		var/atom/item = k
+
+
+		var/icon_file
+		var/icon_state
+		var/icon/I
+
+
+		if (!ispath(item, /atom))
+			continue
+
+		icon_file = initial(item.icon)
+		icon_state = initial(item.icon_state)
+
+		if(icon_state in icon_states(icon_file))
+			I = icon(icon_file, icon_state, SOUTH)
+		else
+			item = new item()
+			I = icon(item.icon, item.icon_state, SOUTH)
+			qdel(item)
+
+		var/imgid = replacetext(replacetext("[item]", "/obj/item/", ""), "/", "-")
+
+		Insert(imgid, I)
+	return ..()
+
 /datum/asset/simple/genetics
 	assets = list(
 		"dna_discovered.png"	= 'html/dna_discovered.png',

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -324,8 +324,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 		H = user
 		C = H.get_idcard(TRUE)
 
-	var/datum/asset/spritesheet/sheet = get_asset_datum(/datum/asset/spritesheet/vending)
-	dat += "[sheet.css_tag()]"
 	if(!C)
 		dat += "<font color = 'red'><h3>No ID Card detected!</h3></font>"
 	else if (!C.registered_account)
@@ -374,6 +372,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		dat += "</div>"
 
 	var/datum/browser/popup = new(user, "vending", (name))
+	popup.add_stylesheet(get_asset_datum(/datum/asset/spritesheet/vending))
 	popup.set_content(dat.Join(""))
 	popup.set_title_image(user.browse_rsc_icon(icon, icon_state))
 	popup.open()

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -167,14 +167,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 				if (dump_amount >= 16)
 					return
 
-/obj/machinery/vending/proc/GetIconForProduct(datum/data/vending_product/P)
-	if(GLOB.vending_cache[P.product_path])
-		return GLOB.vending_cache[P.product_path]
-
-	var/product = new P.product_path()
-	GLOB.vending_cache[P.product_path] = icon2base64(getFlatIcon(product, no_anim = TRUE))
-	qdel(product)
-	return GLOB.vending_cache[P.product_path]
+GLOBAL_LIST_EMPTY(vending_products)
 
 /obj/machinery/vending/proc/build_inventory(list/productlist, list/recordlist, start_empty = FALSE)
 	for(var/typepath in productlist)
@@ -184,6 +177,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 
 		var/atom/temp = typepath
 		var/datum/data/vending_product/R = new /datum/data/vending_product()
+		GLOB.vending_products[typepath] = 1
 		R.name = initial(temp.name)
 		R.product_path = typepath
 		if(!start_empty)
@@ -322,7 +316,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	return ..()
 
 /obj/machinery/vending/ui_interact(mob/user)
-	var/dat = ""
+	var/list/dat = list()
 	var/datum/bank_account/account
 	var/mob/living/carbon/human/H
 	var/obj/item/card/id/C
@@ -330,14 +324,16 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 		H = user
 		C = H.get_idcard(TRUE)
 
+	var/datum/asset/spritesheet/sheet = get_asset_datum(/datum/asset/spritesheet/vending)
+	dat += "[sheet.css_tag()]"
 	if(!C)
 		dat += "<font color = 'red'><h3>No ID Card detected!</h3></font>"
 	else if (!C.registered_account)
 		dat += "<font color = 'red'><h3>No account on registered ID card!</h3></font>"
 	if(onstation && C && C.registered_account)
 		account = C.registered_account
-	dat += "<h3>Select an item</h3>"
-	dat += "<div class='statusDisplay'>"
+	dat += {"<h3>Select an item</h3>
+					<div class='statusDisplay'>"}
 	if(!product_records.len)
 		dat += "<font color = 'red'>No product loaded!</font>"
 	else
@@ -356,8 +352,8 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 				price_listed = "FREE"
 			if(coin_records.Find(R) || is_hidden)
 				price_listed = "$[R.custom_premium_price ? R.custom_premium_price : extra_price]"
-			dat += "<tr><td><img src='data:image/jpeg;base64,[GetIconForProduct(R)]'/></td>"
-			dat += "<td style=\"width: 100%\"><b>[sanitize(R.name)]  ([price_listed])</b></td>"
+			dat += {"<tr><td><span class="vending32x32 [replacetext(replacetext("[R.product_path]", "/obj/item/", ""), "/", "-")]"></td>
+							<td style=\"width: 100%\"><b>[sanitize(R.name)]  ([price_listed])</b></td>"}
 			if(R.amount > 0 && ((C && C.registered_account && onstation) || (!onstation && isliving(user))))
 				dat += "<td align='right'><b>[R.amount]&nbsp;</b><a href='byond://?src=[REF(src)];vend=[REF(R)]'>Vend</a></td>"
 			else
@@ -378,7 +374,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 		dat += "</div>"
 
 	var/datum/browser/popup = new(user, "vending", (name))
-	popup.set_content(dat)
+	popup.set_content(dat.Join(""))
 	popup.set_title_image(user.browse_rsc_icon(icon, icon_state))
 	popup.open()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pretty much what it says on the tin. 

Oh yeah I also removed the string concatenation nonsense in favor of multiline strings and a list.

## Why It's Good For The Game

Removes many getFlatIcon calls during the round, also some runtimes from ephemeral items being created and immediately deleted when the vending machines are used.

## Changelog
:cl: Naksu
tweak: vending machines now use spritesheets
/:cl: