### PR TITLE
Fixes rastacap icon_state (#43927)

### DIFF
--- a/code/modules/clothing/head/beanie.dm
+++ b/code/modules/clothing/head/beanie.dm
@@ -93,7 +93,7 @@
 /obj/item/clothing/head/beanie/rasta
 	name = "rastacap"
 	desc = "Perfect for tucking in those dreadlocks."
-	icon_state = "rastabeanie"
-	item_color = "rastabeanie"	
+	icon_state = "beanierasta"
+	item_color = "beanierasta"	
 
 //No dog fashion sprites yet :(  poor Ian can't be dope like the rest of us yet


### PR DESCRIPTION
## About The Pull Request

Fixes the icon state for the rastacap so it's no longer invisible. (See issue #43927 )

## Why It's Good For The Game

Nobody likes broken clothing items made by crappy coders. Now rastafarians can wear their beanies with pride.

## Changelog
:cl:
fix: Caught the wizard who was turning the rastacap shipments invisible.
/:cl: