### PR TITLE
[Ready] Fixes the monk's frock glitch when hood is pulled up (#43928)

### DIFF
--- a/code/modules/clothing/suits/chaplainsuits.dm
+++ b/code/modules/clothing/suits/chaplainsuits.dm
@@ -57,6 +57,7 @@
 	name = "monk's hood"
 	desc = "For when a man wants to cover up his tonsure."
 	icon_state = "monkhood"
+	item_state = "monkhood"
 	body_parts_covered = HEAD
 	flags_inv = HIDEHAIR|HIDEEARS
 

--- a/code/modules/clothing/suits/chaplainsuits.dm
+++ b/code/modules/clothing/suits/chaplainsuits.dm
@@ -51,7 +51,6 @@
 	icon_state = "monkfrock"
 	item_state = "monkfrock"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	flags_inv = HIDEJUMPSUIT
 	hoodtype = /obj/item/clothing/head/hooded/monkfrock
 	
 /obj/item/clothing/head/hooded/monkfrock


### PR DESCRIPTION
## About The Pull Request
Should *hopefully* fix #43928 
**Any advice from experienced coders is appreciated.**

At the moment, pulling up the hood on the monk's frock results in two problems:
1. The suit portion of the monk's frock goes invisible, leaving the player nude below the neck.
2. The monk's frock icon (in the inventory suit slot) glitches out. The hood icon (in the head slot) does not appear.

My efforts to fix these problems are as follows:
1. Remove the HIDEJUMPSUIT tag from the monk's frock. I added this tag because it's included in other robe items, like holiday priest, but it might be causing the suit portion to disappear after the hood is toggled.
2. Added an item_state to the monk's hood. It should definitely fix the hood icon, though I'm not entirely certain as to whether it will fix the glitchy suit slot icon.

Once this glitch is figured out, I'll open a PR to add the monk's frock to the chaplain vendor and we're golden.

## Changelog
:cl:
fix: The monk's frock has been sanctified and will no longer reveal your naked body when the hood is pulled up.
/:cl: