### PR TITLE
Krav Maga Rework

### DIFF
--- a/code/__DEFINES/movespeed_modification.dm
+++ b/code/__DEFINES/movespeed_modification.dm
@@ -61,4 +61,5 @@
 #define MOVESPEED_ID_SLAUGHTER                          "SLAUGHTER"
 #define MOVESPEED_ID_DIE_OF_FATE                        "DIE_OF_FATE"
 
-#define MOVESPEED_ID_SHOVE "SHOVE"
+#define MOVESPEED_ID_KRAV_MAGA                          "KRAV_MAGA"
+#define MOVESPEED_ID_SHOVE                              "SHOVE"

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -20,9 +20,9 @@
 			streak = ""
 			leg_sweep(A,D)
 			return 1
-		if("quick_choke")//is actually lung punch
+		if("lung_punch")
 			streak = ""
-			quick_choke(A,D)
+			lung_punch(A,D)
 			return 1
 		if("eye_strike")
 			streak = ""
@@ -49,14 +49,14 @@
 	log_combat(A, D, "leg sweeped")
 	return 1
 
-/datum/martial_art/krav_maga/proc/quick_choke(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)//is actually lung punch
+/datum/martial_art/krav_maga/proc/lung_punch(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	D.visible_message("<span class='warning'>[A] pounds [D] on the chest!</span>", \
 				  	"<span class='userdanger'>[A] slams your chest! You can't breathe!</span>")
 	playsound(get_turf(A), 'sound/effects/hit_punch.ogg', 50, 1, -1)
 	if(D.losebreath <= 10)
 		D.losebreath = CLAMP(D.losebreath + 5, 0, 10)
 	D.adjustOxyLoss(10)
-	log_combat(A, D, "quickchoked")
+	log_combat(A, D, "lung punched")
 	return 1
 
 /datum/martial_art/krav_maga/proc/neck_chop(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
@@ -94,8 +94,13 @@
 	D.visible_message("<span class='warning'>[A] headbutts [D]!</span>", \
 				  	"<span class='userdanger'>[A] headbutts you!</span>")
 	playsound(get_turf(A), 'sound/effects/meteorimpact.ogg', 50, 1, -1)
-	A.apply_damage(10 BRUTE)
-	D.
+	A.apply_damage(10, BRUTE)
+	D.adjustBrainLoss(10)
+	if(D.stat == CONSCIOUS)
+		D.confused = max(D.confused, 20)
+		D.adjust_blurriness(10)
+	if(prob(10))
+		D.gain_trauma(/datum/brain_trauma/mild/concussion)
 	log_combat(A, D, "headbutted")
 	return 1
 
@@ -138,22 +143,18 @@
 	return 1
 
 /datum/martial_art/krav_maga/disarm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	if(check_streak(A,D))
-		return 1
-	var/obj/item/I = null
-	if(prob(60))
-		I = D.get_active_held_item()
-		if(I)
-			if(D.temporarilyRemoveItemFromInventory(I))
-				A.put_in_hands(I)
-		D.visible_message("<span class='danger'>[A] has disarmed [D]!</span>", \
-							"<span class='userdanger'>[A] has disarmed [D]!</span>")
-		playsound(D, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-	else
-		D.visible_message("<span class='danger'>[A] attempted to disarm [D]!</span>", \
-							"<span class='userdanger'>[A] attempted to disarm [D]!</span>")
-		playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-	log_combat(A, D, "disarmed (Krav Maga)", "[I ? " removing \the [I]" : ""]")
+	if(user.zone_selected == BODY_ZONE_PRECISE_MOUTH)
+		H.mind.martial_art.streak = "neck_chop"
+	if(user.zone_selected == BODY_ZONE_L_LEG || user.zone_selected == BODY_ZONE_R_LEG)
+		H.mind.martial_art.streak = "leg_sweep"
+	if(user.zone_selected == BODY_ZONE_CHEST)
+		H.mind.martial_art.streak = "lung_punch"
+	if(user.zone_selected == BODY_ZONE_PRECISE_EYES)
+		H.mind.martial_art.streak = "eye_strike"
+	if(user.zone_selected == BODY_ZONE_L_ARM || user.zone_selected == BODY_ZONE_R_ARM)
+		H.mind.martial_art.streak = "unarm"
+	if(user.zone_selected == BODY_ZONE_HEAD)
+		H.mind.martial_art.streak = "headbutt"
 	return 1
 	
 //Krav Maga Gloves
@@ -209,7 +210,7 @@
 
 	to_chat(usr, "<span class='notice'>Neck Chop</span>: Mouth. Injures the neck, stopping the victim from speaking for a while.")
 	to_chat(usr, "<span class='notice'>Eye Strike</span>: Eye. Causes eye damage to the victim, may make him blind after considerable usage.")
-	to_chat(usr, "<span class='notice'>Headbutt</span>: Head. Smashes your skull into the victim's, giving you small damage while making his life worse.")
+	to_chat(usr, "<span class='notice'>Headbutt</span>: Head. Smashes your skull into the victim's, giving you small damage while giving the victim concussions.")
 	to_chat(usr, "<span class='notice'>Lung Punch</span>: Chest. Delivers a strong punch just above the victim's abdomen, constraining the lungs. The victim will be unable to breathe for a short time.")
 	to_chat(usr, "<span class='notice'>Unarm</span>: Arm. Knocks the victim's items out of their hands.")
 	to_chat(usr, "<span class='notice'>Leg Sweep</span>: Leg. Trips the victim, knocking them down for a brief moment.")

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -1,74 +1,14 @@
 /datum/martial_art/krav_maga
 	name = "Krav Maga"
 	id = MARTIALART_KRAVMAGA
-	var/datum/action/neck_chop/neckchop = new/datum/action/neck_chop()
-	var/datum/action/leg_sweep/legsweep = new/datum/action/leg_sweep()
-	var/datum/action/lung_punch/lungpunch = new/datum/action/lung_punch()
-
-/datum/action/neck_chop
-	name = "Neck Chop - Injures the neck, stopping the victim from speaking for a while."
-	icon_icon = 'icons/mob/actions/actions_items.dmi'
-	button_icon_state = "neckchop"
-
-/datum/action/neck_chop/Trigger()
-	if(owner.incapacitated())
-		to_chat(owner, "<span class='warning'>You can't use [name] while you're incapacitated.</span>")
-		return
-	var/mob/living/carbon/human/H = owner
-	if (H.mind.martial_art.streak == "neck_chop")
-		owner.visible_message("<span class='danger'>[owner] assumes a neutral stance.</span>", "<b><i>Your next attack is cleared.</i></b>")
-		H.mind.martial_art.streak = ""
-	else
-		owner.visible_message("<span class='danger'>[owner] assumes the Neck Chop stance!</span>", "<b><i>Your next attack will be a Neck Chop.</i></b>")
-		H.mind.martial_art.streak = "neck_chop"
-
-/datum/action/leg_sweep
-	name = "Leg Sweep - Trips the victim, knocking them down for a brief moment."
-	icon_icon = 'icons/mob/actions/actions_items.dmi'
-	button_icon_state = "legsweep"
-
-/datum/action/leg_sweep/Trigger()
-	if(owner.incapacitated())
-		to_chat(owner, "<span class='warning'>You can't use [name] while you're incapacitated.</span>")
-		return
-	var/mob/living/carbon/human/H = owner
-	if (H.mind.martial_art.streak == "leg_sweep")
-		owner.visible_message("<span class='danger'>[owner] assumes a neutral stance.</span>", "<b><i>Your next attack is cleared.</i></b>")
-		H.mind.martial_art.streak = ""
-	else
-		owner.visible_message("<span class='danger'>[owner] assumes the Leg Sweep stance!</span>", "<b><i>Your next attack will be a Leg Sweep.</i></b>")
-		H.mind.martial_art.streak = "leg_sweep"
-
-/datum/action/lung_punch//referred to internally as 'quick choke'
-	name = "Lung Punch - Delivers a strong punch just above the victim's abdomen, constraining the lungs. The victim will be unable to breathe for a short time."
-	icon_icon = 'icons/mob/actions/actions_items.dmi'
-	button_icon_state = "lungpunch"
-
-/datum/action/lung_punch/Trigger()
-	if(owner.incapacitated())
-		to_chat(owner, "<span class='warning'>You can't use [name] while you're incapacitated.</span>")
-		return
-	var/mob/living/carbon/human/H = owner
-	if (H.mind.martial_art.streak == "quick_choke")
-		owner.visible_message("<span class='danger'>[owner] assumes a neutral stance.</span>", "<b><i>Your next attack is cleared.</i></b>")
-		H.mind.martial_art.streak = ""
-	else
-		owner.visible_message("<span class='danger'>[owner] assumes the Lung Punch stance!</span>", "<b><i>Your next attack will be a Lung Punch.</i></b>")
-		H.mind.martial_art.streak = "quick_choke"//internal name for lung punch
+	help_verb = /mob/living/carbon/human/proc/krav_maga_help
 
 /datum/martial_art/krav_maga/teach(mob/living/carbon/human/H,make_temporary=0)
 	if(..())
 		to_chat(H, "<span class = 'userdanger'>You know the arts of [name]!</span>")
-		to_chat(H, "<span class = 'danger'>Place your cursor over a move at the top of the screen to see what it does.</span>")
-		neckchop.Grant(H)
-		legsweep.Grant(H)
-		lungpunch.Grant(H)
 
 /datum/martial_art/krav_maga/on_remove(mob/living/carbon/human/H)
 	to_chat(H, "<span class = 'userdanger'>You suddenly forget the arts of [name]...</span>")
-	neckchop.Remove(H)
-	legsweep.Remove(H)
-	lungpunch.Remove(H)
 
 /datum/martial_art/krav_maga/proc/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	switch(streak)
@@ -207,3 +147,17 @@
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	resistance_flags = NONE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 50)
+	
+	/mob/living/carbon/human/proc/krav_maga_help()
+	set name = "Remember The Basics"
+	set desc = "You try to remember some of the basics of Krav Maga."
+	set category = "Krav Maga"
+	to_chat(usr, "<b><i>You try to remember some of the basics of Krav Maga.</i></b>")
+
+	to_chat(usr, "<span class='notice'>Neck Chop</span>: Mouth. Injures the neck, stopping the victim from speaking for a while.")
+	to_chat(usr, "<span class='notice'>Eye Strike</span>: Eye. Causes eye damage to the victim, may make him blind after considerable usage.")
+	to_chat(usr, "<span class='notice'>Headbutt</span>: Head. Locks opponents into a restraining position, disarm to knock them out with a chokehold.")
+	to_chat(usr, "<span class='notice'>Lung Punch</span>: Chest. Delivers a strong punch just above the victim's abdomen, constraining the lungs. The victim will be unable to breathe for a short time.")
+	to_chat(usr, "<span class='notice'>Unarm</span>: Arm. Knocks the victim's items out of their hands.")
+	to_chat(usr, "<span class='notice'>Leg Sweep</span>: Leg. Trips the victim, knocking them down for a brief moment.")
+	to_chat(usr, "<span class='notice'>Groin Kick</span>: Groin. Slows down the victim and deals decent damage, may include screaming.")

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -15,23 +15,14 @@
 	switch(streak)
 		if("neck_chop")
 			streak = ""
-			if(cooldown < world.time)
-				return
 			neck_chop(A,D)
-			cooldown = world.time + 50
 			return 1
 		if("leg_sweep")
-			if(cooldown < world.time)
-				return
 			leg_sweep(A,D)
-			cooldown = world.time + 20
 			return 1
 		if("lung_punch")
 			streak = ""
-			if(cooldown < world.time)
-				return
 			lung_punch(A,D)
-			cooldown = world.time + 30
 			return 1
 		if("eye_strike")
 			streak = ""
@@ -43,17 +34,11 @@
 			return 1
 		if("headbutt")
 			streak = ""
-			if(cooldown < world.time)
-				return
 			headbutt(A,D)
-			cooldown = world.time + 30
 			return 1
 		if("groin_kick")
 			streak = ""
-			if(cooldown < world.time)
-				return
 			groin_kick(A,D)
-			cooldown = world.time + 30
 			return 1
 	return 0
 

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -52,12 +52,12 @@
 	return 0
 
 /datum/martial_art/krav_maga/proc/leg_sweep(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	if(D.stat || D.IsParalyzed())
-		return 0
 	D.visible_message("<span class='warning'>[A] leg sweeps [D]!</span>", \
 					  	"<span class='userdanger'>[A] leg sweeps you!</span>")
 	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
 	D.apply_damage(5, BRUTE, A.zone_selected)
+	if(D.stat || D.IsParalyzed())
+		return 0
 	D.Paralyze(40)
 	log_combat(A, D, "leg sweeped")
 	return 1
@@ -83,20 +83,21 @@
 	return 1
 
 /datum/martial_art/krav_maga/proc/eye_strike(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	var/obj/item/organ/eyes/eyes = D.getorganslot(ORGAN_SLOT_EYES)
 	D.visible_message("<span class='warning'>[A] eye struck [D]!</span>", \
 				  	"<span class='userdanger'>[A] strikes your eye!</span>")
 	playsound(get_turf(A), 'sound/effects/hit_punch.ogg', 50, 1, -1)
 	D.apply_damage(3, BRUTE, A.zone_selected)
-	D.adjust_blurriness(3)
-	D.adjust_eye_damage(rand(1,3))
-	var/obj/item/organ/eyes/eyes = D.getorganslot(ORGAN_SLOT_EYES)
-	if (!eyes)
+	if (!eyes || D.is_eyes_covered())
 		return
+	D.adjust_blurriness(2)
+	D.adjust_eye_damage(rand(1,3))
 	if(eyes.eye_damage >= 10)
 		D.adjust_blurriness(15)
 		if(D.stat != DEAD)
 			to_chat(D, "<span class='danger'>Your eyes start to bleed profusely!</span>")
-		to_chat(D, "<span class='danger'>You become nearsighted!</span>")
+		if(!(HAS_TRAIT(D, TRAIT_BLIND) || HAS_TRAIT(D, TRAIT_NEARSIGHT)))
+			to_chat(D, "<span class='danger'>You become nearsighted!</span>")
 		D.become_nearsighted(EYE_DAMAGE)
 		if(prob(50))
 			if(D.stat != DEAD)
@@ -129,13 +130,14 @@
 	playsound(get_turf(A), 'sound/effects/meteorimpact.ogg', 50, 1, -1)
 	A.apply_damage(10, BRUTE, A.zone_selected)
 	D.apply_damage(15, A.dna.species.attack_type, A.zone_selected)
-	if (prob(50))
-		D.adjustBrainLoss(10)
-		if(D.stat == CONSCIOUS)
-			D.confused = max(D.confused, 20)
-			D.adjust_blurriness(10)
-		if(prob(10))
-			D.gain_trauma(/datum/brain_trauma/mild/concussion)
+	if(!istype(D.head, /obj/item/clothing/head/helmet))
+		if (prob(75))
+			D.adjustBrainLoss(10)
+			if(D.stat == CONSCIOUS)
+				D.confused = max(D.confused, 20)
+				D.adjust_blurriness(10)
+			if(prob(10))
+				D.gain_trauma(/datum/brain_trauma/mild/concussion)
 	log_combat(A, D, "headbutted")
 	return 1
 

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -113,8 +113,7 @@
 	return 1
 
 /datum/martial_art/krav_maga/proc/unarm(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	var/obj/item/I = null
-	I = D.get_active_held_item()
+	var/obj/item/I = D.get_active_held_item()
 	if(I)
 		if(D.temporarilyRemoveItemFromInventory(I))
 			A.put_in_hands(I)

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -87,7 +87,7 @@
 		D.visible_message("<span class='danger'>[A] has unarmed [D]!</span>", \
 							"<span class='userdanger'>[A] has unarmed you!</span>")
 		playsound(D, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-	log_combat(A, D, "disarmed (Krav Maga)", "[I ? " removing \the [I]" : ""]")
+	log_combat(A, D, "unarmed", "[I ? " removing \the [I]" : ""]")
 	return 1
 
 /datum/martial_art/krav_maga/proc/headbutt(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -24,6 +24,18 @@
 			streak = ""
 			quick_choke(A,D)
 			return 1
+		if("eye_strike")
+			streak = ""
+			eye_strike(A,D)
+			return 1
+		if("unarm")
+			streak = ""
+			unarm(A,D)
+			return 1
+		if("headbutt")
+			streak = ""
+			headbutt(A,D)
+			return 1
 	return 0
 
 /datum/martial_art/krav_maga/proc/leg_sweep(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
@@ -55,6 +67,47 @@
 	if(D.silent <= 10)
 		D.silent = CLAMP(D.silent + 10, 0, 10)
 	log_combat(A, D, "neck chopped")
+	return 1
+
+/datum/martial_art/krav_maga/proc/eye_strike(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	D.visible_message("<span class='warning'>[A] eye strikes [D]!</span>", \
+				  	"<span class='userdanger'>[A] strikes your eye!</span>")
+	playsound(get_turf(A), 'sound/effects/hit_punch.ogg', 50, 1, -1)
+	D.apply_damage(5, BRUTE)
+	D.eyestab
+	log_combat(A, D, "eye striked")
+	return 1
+
+/datum/martial_art/krav_maga/proc/unarm(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	var/obj/item/I = null
+		I = D.get_active_held_item()
+		if(I)
+			if(D.temporarilyRemoveItemFromInventory(I))
+				A.put_in_hands(I)
+		D.visible_message("<span class='danger'>[A] has unarmed [D]!</span>", \
+							"<span class='userdanger'>[A] has unarmed you!</span>")
+		playsound(D, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+	log_combat(A, D, "disarmed (Krav Maga)", "[I ? " removing \the [I]" : ""]")
+	return 1
+
+/datum/martial_art/krav_maga/proc/headbutt(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	D.visible_message("<span class='warning'>[A] headbutts [D]!</span>", \
+				  	"<span class='userdanger'>[A] headbutts you!</span>")
+	playsound(get_turf(A), 'sound/effects/meteorimpact.ogg', 50, 1, -1)
+	A.apply_damage(10 BRUTE)
+	D.
+	log_combat(A, D, "headbutted")
+	return 1
+
+/datum/martial_art/krav_maga/proc/groin_kick(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	D.visible_message("<span class='warning'>[A] groin kicks [D]!</span>", \
+				  	"<span class='userdanger'>[A] kicks your groin! You scream out!</span>")
+	playsound(get_turf(A), 'sound/effects/meteorimpact.ogg', 50, 1, -1)
+	D.apply_damage(10, A.dna.species.attack_type)
+	D.add_movespeed_modifier(MOVESPEED_ID_KRAV_MAGA, update=TRUE, priority=100, multiplicative_slowdown=1)
+	addtimer(CALLBACK(src, .proc/remove_movespeed_modifier, MOVESPEED_ID_KRAV_MAGA, TRUE), 3 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+	D.emote("scream")
+	log_combat(A, D, "groin kicked")
 	return 1
 
 /datum/martial_art/krav_maga/grab_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
@@ -102,7 +155,7 @@
 		playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 	log_combat(A, D, "disarmed (Krav Maga)", "[I ? " removing \the [I]" : ""]")
 	return 1
-
+	
 //Krav Maga Gloves
 
 /obj/item/clothing/gloves/krav_maga
@@ -156,7 +209,7 @@
 
 	to_chat(usr, "<span class='notice'>Neck Chop</span>: Mouth. Injures the neck, stopping the victim from speaking for a while.")
 	to_chat(usr, "<span class='notice'>Eye Strike</span>: Eye. Causes eye damage to the victim, may make him blind after considerable usage.")
-	to_chat(usr, "<span class='notice'>Headbutt</span>: Head. Locks opponents into a restraining position, disarm to knock them out with a chokehold.")
+	to_chat(usr, "<span class='notice'>Headbutt</span>: Head. Smashes your skull into the victim's, giving you small damage while making his life worse.")
 	to_chat(usr, "<span class='notice'>Lung Punch</span>: Chest. Delivers a strong punch just above the victim's abdomen, constraining the lungs. The victim will be unable to breathe for a short time.")
 	to_chat(usr, "<span class='notice'>Unarm</span>: Arm. Knocks the victim's items out of their hands.")
 	to_chat(usr, "<span class='notice'>Leg Sweep</span>: Leg. Trips the victim, knocking them down for a brief moment.")

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -130,7 +130,7 @@
 	playsound(get_turf(A), 'sound/effects/meteorimpact.ogg', 50, 1, -1)
 	A.apply_damage(10, BRUTE, A.zone_selected)
 	D.apply_damage(15, A.dna.species.attack_type, A.zone_selected)
-	if(!istype(D.head, /obj/item/clothing/head/helmet))
+	if(!istype(D.head, (/obj/item/clothing/head/helmet || /obj/item/clothing/head/hardhat)))
 		if (prob(75))
 			D.adjustBrainLoss(10)
 			if(D.stat == CONSCIOUS)

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -14,15 +14,20 @@
 /datum/martial_art/krav_maga/proc/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	switch(streak)
 		if("neck_chop")
-			streak = ""
-			neck_chop(A,D)
+			if(cooldown < world.time)
+				streak = ""
+				neck_chop(A,D)
+				cooldown = world.time + 30
 			return 1
 		if("leg_sweep")
+			streak = ""
 			leg_sweep(A,D)
 			return 1
 		if("lung_punch")
-			streak = ""
-			lung_punch(A,D)
+			if(cooldown < world.time)
+				streak = ""
+				lung_punch(A,D)
+				cooldown = world.time + 20
 			return 1
 		if("eye_strike")
 			streak = ""
@@ -33,12 +38,16 @@
 			unarm(A,D)
 			return 1
 		if("headbutt")
-			streak = ""
-			headbutt(A,D)
+			if(cooldown < world.time)
+				streak = ""
+				headbutt(A,D)
+				cooldown = world.time + 30
 			return 1
 		if("groin_kick")
-			streak = ""
-			groin_kick(A,D)
+			if(cooldown < world.time)
+				streak = ""
+				groin_kick(A,D)
+				cooldown = world.time + 25
 			return 1
 	return 0
 
@@ -64,8 +73,8 @@
 	return 1
 
 /datum/martial_art/krav_maga/proc/neck_chop(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	D.visible_message("<span class='warning'>[A] karate chops [D]'s neck!</span>", \
-				  	"<span class='userdanger'>[A] karate chops your neck, rendering you unable to speak!</span>")
+	D.visible_message("<span class='warning'>[A] neck chops [D]'s neck!</span>", \
+				  	"<span class='userdanger'>[A] neck chops your neck, rendering you unable to speak!</span>")
 	playsound(get_turf(A), 'sound/effects/hit_punch.ogg', 50, 1, -1)
 	D.apply_damage(5, A.dna.species.attack_type, A.zone_selected)
 	if(D.silent <= 10)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -141,7 +141,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			smack = 0
 		else if(iscarbon(M))
 			var/mob/living/carbon/C = M
-			if(!istype(D.head, (/obj/item/clothing/head/helmet || /obj/item/clothing/head/hardhat)))
+			if(!istype(C.head, (/obj/item/clothing/head/helmet || /obj/item/clothing/head/hardhat)))
 				C.adjustBrainLoss(5, 60)
 				to_chat(C, "<span class='danger'>You feel dumber.</span>")
 

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -141,7 +141,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			smack = 0
 		else if(iscarbon(M))
 			var/mob/living/carbon/C = M
-			if(!istype(C.head, /obj/item/clothing/head/helmet))
+			if(!istype(D.head, /obj/item/clothing/head/helmet || D.head, /obj/item/clothing/head/hardhat))
 				C.adjustBrainLoss(5, 60)
 				to_chat(C, "<span class='danger'>You feel dumber.</span>")
 

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -141,7 +141,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			smack = 0
 		else if(iscarbon(M))
 			var/mob/living/carbon/C = M
-			if(!istype(D.head, /obj/item/clothing/head/helmet || D.head, /obj/item/clothing/head/hardhat))
+			if(!istype(D.head, (/obj/item/clothing/head/helmet || /obj/item/clothing/head/hardhat)))
 				C.adjustBrainLoss(5, 60)
 				to_chat(C, "<span class='danger'>You feel dumber.</span>")
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -498,7 +498,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A pair of gloves that are fireproof and shock resistant, however unlike the regular Combat Gloves this one uses nanotechnology \
 			to learn the abilities of krav maga to the wearer."
 	item = /obj/item/clothing/gloves/krav_maga/combatglovesplus
-	cost = 5
+	cost = 10
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	surplus = 0
 


### PR DESCRIPTION
## About The Pull Request

Makes Krav Maga work by disarm intent with different body intents intead of action buttons, gives it cooldown, also expands the moveset by 4 new moves, Eye Strike, Headbutt, Groin Kick and Unarm
Eye Strike - causes eye damage and blurriness to the target, can cause blindness with enough damage
Headbutt - gives the target concussions, makes them confused (does not deconvert)
Unarm - steals the target's item
Groin Kick - slows down the target, causes screaming
**please suggest balancing if you see issues because im not very good at it**

## Why It's Good For The Game

Krav Maga always felt weird, was a martial art, but with action buttons, and only 3 moves, this is still different by not having combos and instead a combination of body intent with disarm, but I made the arsenal bigger

## Changelog
:cl: Fikou
add: Krav Maga now operates on body intents with the disarm intent.
balance: Krav Maga moves now have cooldown.
del: Removes Krav Maga action buttons.
add: 4 New Moves, check the new help button to learn all about them!
/:cl: