### PR TITLE
Clean up VR sleeper from techweb

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -56,7 +56,7 @@
 	display_name = "Biological Technology"
 	description = "What makes us tick."	//the MC, silly!
 	prereq_ids = list("base")
-	design_ids = list("chem_heater", "chem_master", "chem_dispenser", "vr_sleeper", "pandemic", "defibrillator", "defibmount", "operating", "soda_dispenser", "beer_dispenser", "healthanalyzer", "medspray","genescanner")
+	design_ids = list("chem_heater", "chem_master", "chem_dispenser", "pandemic", "defibrillator", "defibmount", "operating", "soda_dispenser", "beer_dispenser", "healthanalyzer", "medspray","genescanner")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
There's a warning on server start about this still being here when the design datum was removed in #43832

[![Screenshot_20190513_134000](https://user-images.githubusercontent.com/5211576/57642147-a07a1900-7584-11e9-9fe7-999555c8a8dd.png)](https://github.com/tgstation/tgstation/pull/43832/files#diff-3fb512cd3475f49bdf38115143a0609aL136)

Maybe we should consider failing travis when there are warnings during unit tests.
https://travis-ci.org/tgstation/tgstation/jobs/529493150#L1263