### PR TITLE
Fixes venus human traps not respecting density, and grasping vines

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -110,6 +110,7 @@
 
 // /atom/movable signals
 #define COMSIG_MOVABLE_PRE_MOVE "movable_pre_move"					//from base of atom/movable/Moved(): (/atom)
+	#define COMPONENT_MOVABLE_BLOCK_PRE_MOVE 1
 #define COMSIG_MOVABLE_MOVED "movable_moved"					//from base of atom/movable/Moved(): (/atom, dir)
 #define COMSIG_MOVABLE_CROSS "movable_cross"					//from base of atom/movable/Cross(): (/atom/movable)
 #define COMSIG_MOVABLE_CROSSED "movable_crossed"                //from base of atom/movable/Crossed(): (/atom/movable)

--- a/code/datums/components/tether.dm
+++ b/code/datums/components/tether.dm
@@ -1,0 +1,37 @@
+/datum/component/tether
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	var/atom/tether_target
+	var/max_dist
+	var/tether_name
+
+/datum/component/tether/Initialize(atom/tether_target, max_dist = 4, tether_name)
+	if(!isliving(parent) || !istype(tether_target) || !tether_target.loc)
+		return COMPONENT_INCOMPATIBLE
+	src.tether_target = tether_target
+	src.max_dist = max_dist
+	if (ispath(tether_name, /atom))
+		var/atom/tmp = tether_name
+		src.tether_name = initial(tmp.name)
+	else
+		src.tether_name = tether_name
+	RegisterSignal(parent, list(COMSIG_MOVABLE_PRE_MOVE), .proc/checkTether)
+
+/datum/component/tether/proc/checkTether(mob/mover, newloc)
+	if (get_dist(mover,newloc) > max_dist)
+		to_chat(mover, "<span class='userdanger'>The [tether_name] runs out of slack and prevents you from moving!</span>")
+		return COMPONENT_MOVABLE_BLOCK_PRE_MOVE
+
+	var/atom/blocker
+	:out
+		for(var/turf/T in getline(tether_target,newloc))
+			if (T.density)
+				blocker = T
+				break out
+			for(var/a in T)
+				var/atom/A = a
+				if(A.density && A != mover && A != tether_target)
+					blocker = A
+					break out
+	if (blocker)
+		to_chat(mover, "<span class='userdanger'>The [tether_name] catches on [blocker] and prevents you from moving!</span>")
+		return COMPONENT_MOVABLE_BLOCK_PRE_MOVE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -223,8 +223,10 @@
 	if(!newloc.Enter(src, src.loc))
 		return
 
+	if (SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
+		return
+
 	// Past this is the point of no return
-	SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc)
 	var/atom/oldloc = loc
 	var/area/oldarea = get_area(oldloc)
 	var/area/newarea = get_area(newloc)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -378,6 +378,7 @@
 #include "code\datums\components\squeak.dm"
 #include "code\datums\components\stationloving.dm"
 #include "code\datums\components\swarming.dm"
+#include "code\datums\components\tether.dm"
 #include "code\datums\components\thermite.dm"
 #include "code\datums\components\uplink.dm"
 #include "code\datums\components\waddling.dm"


### PR DESCRIPTION
Fixes #13757
## About The Pull Request

This PR adds a new component for rigid tethers that prevent movement where the tether would go through a wall or a dense object, or too far away from the source.

It also fixes a bug where grasping vines did not work at all because the previous 
```
for(var/t in getline(src,L))
	for(var/a in t)
		var/atom/A = a
			if(A.density && A != L)
```
check did not include a test for A != src, and human traps themselves are dense. 

Also fixes a bug where human traps would shoot a non-grasping vine beams through walls.

## Why It's Good For The Game

Honestly I'm pretty sure this will be absolute cancer, but it IS a bug that should be fixed.

## Changelog
:cl: Naksu
fix: Fixed several issues with venus human traps and their vines going through walls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
