### PR TITLE
Stasis Beds are no longer Borg-Proof

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -138,4 +138,10 @@
 
 /obj/machinery/stasis/nap_violation(mob/violator)
 	unbuckle_mob(violator, TRUE)
+
+/obj/machinery/stasis/attack_robot(mob/user)
+	if(Adjacent(user) && occupant)
+		unbuckle_mob(occupant)
+	else
+		..()
 #undef STASIS_TOGGLE_COOLDOWN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
## Why It's Good For The Game
Medborgs can't do their job without human assistance

## Changelog
:cl:
balance: borgs can now unbuckle people from stasis beds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
