### PR TITLE
Vending Machine Input Framework & Clothing Vendor Inputs

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -80,6 +80,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 
 	var/list/vending_machine_input = list()
 	var/input_display_header = "Custom Compartment"
+	var/inputs_give_cash_now = TRUE //if we find out it's crazy lucrative we can just change it on individuals
 
 	var/obj/item/vending_refill/refill_canister = null		//The type of refill canisters used by this machine.
 
@@ -305,14 +306,18 @@ GLOBAL_LIST_EMPTY(vending_products)
 		..()
 
 /obj/machinery/vending/proc/loadingAttempt(obj/item/I,mob/user)
-  . = TRUE
-  if(!user.transferItemToLoc(I, src))
-    return FALSE
-  if(vending_machine_input[I.name])
-    vending_machine_input[I.name]++
-  else
-    vending_machine_input[I.name] = 1
-  to_chat(user, "<span class='notice'>You insert [I] into [src]'s input compartment.</span>")
+	. = TRUE
+	if(!user.transferItemToLoc(I, src))
+		return FALSE
+	if(vending_machine_input[I.name])
+		vending_machine_input[I.name]++
+	else
+		vending_machine_input[I.name] = 1
+		to_chat(user, "<span class='notice'>You insert [I] into [src]'s input compartment.</span>")
+	if(ishuman(user) && inputs_give_cash_now)
+		var/mob/living/carbon/human/the_vending_janitor = user
+		the_vending_janitor.get_idcard(TRUE)?.registered_account?.adjust_money(round(default_price*0.4,1)) //not the most lucrative but hey to each their own.
+
 
 
 /obj/machinery/vending/exchange_parts(mob/user, obj/item/storage/part_replacer/W)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -16,6 +16,8 @@
 IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY CANISTER CHARGES in vending_items.dm
 */
 
+#define MAX_VENDING_INPUT_AMOUNT 30
+
 /datum/data/vending_product
 	name = "generic"
 	var/product_path = null
@@ -74,8 +76,10 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/default_price = 25
 	var/extra_price = 50
 	var/onstation = TRUE //if it doesn't originate from off-station during mapload, everything is free
+	var/list/canload_access_list
 
-	var/dish_quants = list()  //used by the snack machine's custom compartment to count dishes.
+	var/list/vending_machine_input = list()
+	var/input_display_header = "Custom Compartment"
 
 	var/obj/item/vending_refill/refill_canister = null		//The type of refill canisters used by this machine.
 
@@ -274,8 +278,42 @@ GLOBAL_LIST_EMPTY(vending_products)
 				else
 					to_chat(user, "<span class='notice'>There's nothing to restock!</span>")
 			return
+	if(compartmentLoadAccessCheck(user))
+		if(canLoadItem(I))
+			loadingAttempt(I,user)
+			updateUsrDialog() //can't put this on the proc above because we spam it below
+
+		if(istype(I, /obj/item/storage/bag)) //trays USUALLY
+			var/obj/item/storage/T = I
+			var/loaded = 0
+			var/denied_items = 0
+			for(var/obj/item/the_item in T.contents)
+				if(contents.len >= MAX_VENDING_INPUT_AMOUNT) // no more than 30 item can fit inside, legacy from snack vending although not sure why it exists
+					to_chat(user, "<span class='warning'>[src]'s chef compartment is full.</span>")
+					break
+				if(loadingAttempt(the_item,user))
+					SEND_SIGNAL(T, COMSIG_TRY_STORAGE_TAKE, the_item, src, TRUE)
+					loaded++
+				else
+					denied_items++
+			if(denied_items)
+				to_chat(user, "<span class='notice'>[src] refuses some items.</span>")
+			if(loaded)
+				to_chat(user, "<span class='notice'>You insert [loaded] dishes into [src]'s chef compartment.</span>")
+				updateUsrDialog()
 	else
-		return ..()
+		..()
+
+/obj/machinery/vending/proc/loadingAttempt(obj/item/I,mob/user)
+  . = TRUE
+  if(!user.transferItemToLoc(I, src))
+    return FALSE
+  if(vending_machine_input[I.name])
+    vending_machine_input[I.name]++
+  else
+    vending_machine_input[I.name] = 1
+  to_chat(user, "<span class='notice'>You insert [I] into [src]'s input compartment.</span>")
+
 
 /obj/machinery/vending/exchange_parts(mob/user, obj/item/storage/part_replacer/W)
 	if(!istype(W))
@@ -361,12 +399,12 @@ GLOBAL_LIST_EMPTY(vending_products)
 	dat += "</div>"
 	if(onstation && C && C.registered_account)
 		dat += "<b>Balance: $[account.account_balance]</b>"
-	if(istype(src, /obj/machinery/vending/snack))
-		dat += "<h3>Chef's Food Selection</h3>"
+	if(vending_machine_input.len)
+		dat += "<h3>[input_display_header]</h3>"
 		dat += "<div class='statusDisplay'>"
-		for (var/O in dish_quants)
-			if(dish_quants[O] > 0)
-				var/N = dish_quants[O]
+		for (var/O in vending_machine_input)
+			if(vending_machine_input[O] > 0)
+				var/N = vending_machine_input[O]
 				dat += "<a href='byond://?src=[REF(src)];dispense=[sanitize(O)]'>Dispense</A> "
 				dat += "<B>[capitalize(O)] ($[default_price]): [N]</B><br>"
 		dat += "</div>"
@@ -385,7 +423,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 
 	if((href_list["dispense"]) && (vend_ready))
 		var/N = href_list["dispense"]
-		if(dish_quants[N] <= 0) // Sanity check, there are probably ways to press the button when it shouldn't be possible.
+		if(vending_machine_input[N] <= 0) // Sanity check, there are probably ways to press the button when it shouldn't be possible.
 			return
 		vend_ready = 0
 		if(ishuman(usr) && onstation)
@@ -410,7 +448,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 			D.adjust_money(chef_price)
 		use_power(5)
 
-		dish_quants[N] = max(dish_quants[N] - 1, 0)
+		vending_machine_input[N] = max(vending_machine_input[N] - 1, 0)
 		for(var/obj/O in contents)
 			if(O.name == N)
 				say("Thank you for supporting your local kitchen and purchasing [O]!")
@@ -574,6 +612,28 @@ GLOBAL_LIST_EMPTY(vending_products)
 		return TRUE
 	else
 		return FALSE
+
+/obj/machinery/vending/proc/canLoadItem(obj/item/I,mob/user)
+	return FALSE
+
+/obj/machinery/vending/proc/compartmentLoadAccessCheck(mob/user)
+	if(!canload_access_list)
+		return TRUE
+	else
+		var/do_you_have_access = FALSE
+		for(var/i in canload_access_list)
+			req_access_txt = i
+			if(!allowed(user) && !(obj_flags & EMAGGED) && scan_id)
+				continue
+			else
+				do_you_have_access = TRUE
+				break //you passed don't bother looping anymore
+		req_access_txt = "0" //revert to normal
+		if(do_you_have_access)
+			return TRUE
+		else
+			to_chat(user, "<span class='warning'>[src]'s input compartment blinks red: Access denied.</span>")
+			return FALSE
 
 /obj/machinery/vending/onTransitZ()
 	return

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -621,6 +621,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		return TRUE
 	else
 		var/do_you_have_access = FALSE
+		var/req_access_txt_holder = req_access_txt
 		for(var/i in canload_access_list)
 			req_access_txt = i
 			if(!allowed(user) && !(obj_flags & EMAGGED) && scan_id)
@@ -628,7 +629,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 			else
 				do_you_have_access = TRUE
 				break //you passed don't bother looping anymore
-		req_access_txt = "0" //revert to normal
+		req_access_txt = req_access_txt_holder // revert to normal (before the proc ran)
 		if(do_you_have_access)
 			return TRUE
 		else

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -80,7 +80,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 
 	var/list/vending_machine_input = list()
 	var/input_display_header = "Custom Compartment"
-	var/inputs_give_cash_now = TRUE //if we find out it's crazy lucrative we can just change it on individuals
 
 	var/obj/item/vending_refill/refill_canister = null		//The type of refill canisters used by this machine.
 
@@ -306,18 +305,14 @@ GLOBAL_LIST_EMPTY(vending_products)
 		..()
 
 /obj/machinery/vending/proc/loadingAttempt(obj/item/I,mob/user)
-	. = TRUE
-	if(!user.transferItemToLoc(I, src))
-		return FALSE
-	if(vending_machine_input[I.name])
-		vending_machine_input[I.name]++
-	else
-		vending_machine_input[I.name] = 1
-		to_chat(user, "<span class='notice'>You insert [I] into [src]'s input compartment.</span>")
-	if(ishuman(user) && inputs_give_cash_now)
-		var/mob/living/carbon/human/the_vending_janitor = user
-		the_vending_janitor.get_idcard(TRUE)?.registered_account?.adjust_money(round(default_price*0.4,1)) //not the most lucrative but hey to each their own.
-
+  . = TRUE
+  if(!user.transferItemToLoc(I, src))
+    return FALSE
+  if(vending_machine_input[I.name])
+    vending_machine_input[I.name]++
+  else
+    vending_machine_input[I.name] = 1
+  to_chat(user, "<span class='notice'>You insert [I] into [src]'s input compartment.</span>")
 
 
 /obj/machinery/vending/exchange_parts(mob/user, obj/item/storage/part_replacer/W)

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -132,6 +132,9 @@
 				   /obj/item/clothing/head/clownmitre = 1,
 		           /obj/item/skub = 1,)
 
+/obj/machinery/vending/autodrobe/canLoadItem(obj/item/I,mob/user)
+	return (I.type in products)
+
 	refill_canister = /obj/item/vending_refill/autodrobe
 	default_price = 50
 	extra_price = 75

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -123,6 +123,9 @@
 	extra_price = 75
 	payment_department = NO_FREEBIES
 
+/obj/machinery/vending/clothing/canLoadItem(obj/item/I,mob/user)
+	return (I.type in products)
+
 /obj/item/vending_refill/clothing
 	machine_name = "ClothesMate"
 	icon_state = "refill_clothes"

--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -14,79 +14,34 @@
 					/obj/item/reagent_containers/food/snacks/energybar = 6)
 	contraband = list(/obj/item/reagent_containers/food/snacks/syndicake = 6)
 	refill_canister = /obj/item/vending_refill/snack
-	var/chef_compartment_access = "28" //ACCESS_KITCHEN
+	canload_access_list = list(ACCESS_KITCHEN)
 	default_price = 20
 	extra_price = 30
 	payment_department = ACCOUNT_SRV
+	input_display_header = "Chef's Food Selection"
 
 /obj/item/vending_refill/snack
 	machine_name = "Getmore Chocolate Corp"
 
-/obj/machinery/vending/snack/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/reagent_containers/food/snacks))
-		if(!compartment_access_check(user))
-			return
-		var/obj/item/reagent_containers/food/snacks/S = W
-		if(!S.junkiness)
-			if(!iscompartmentfull(user))
-				if(!user.transferItemToLoc(W, src))
-					return
-				food_load(W)
-				to_chat(user, "<span class='notice'>You insert [W] into [src]'s chef compartment.</span>")
-		else
-			to_chat(user, "<span class='notice'>[src]'s chef compartment does not accept junk food.</span>")
-
-	else if(istype(W, /obj/item/storage/bag/tray))
-		if(!compartment_access_check(user))
-			return
-		var/obj/item/storage/T = W
-		var/loaded = 0
-		var/denied_items = 0
-		for(var/obj/item/reagent_containers/food/snacks/S in T.contents)
-			if(iscompartmentfull(user))
-				break
-			if(!S.junkiness)
-				SEND_SIGNAL(T, COMSIG_TRY_STORAGE_TAKE, S, src, TRUE)
-				food_load(S)
-				loaded++
-			else
-				denied_items++
-		if(denied_items)
-			to_chat(user, "<span class='notice'>[src] refuses some items.</span>")
-		if(loaded)
-			to_chat(user, "<span class='notice'>You insert [loaded] dishes into [src]'s chef compartment.</span>")
-		updateUsrDialog()
-		return
-
-	else
-		return ..()
+/obj/machinery/vending/snack/canLoadItem(obj/item/I,mob/user)
+	. = FALSE
+	if(istype(I,/obj/item/reagent_containers/food/snacks))
+		var/obj/item/reagent_containers/food/snacks/snacki = I
+		if(snacki.junkiness)
+			return FALSE
+		return TRUE
 
 /obj/machinery/vending/snack/Destroy()
 	for(var/obj/item/reagent_containers/food/snacks/S in contents)
 		S.forceMove(get_turf(src))
 	return ..()
 
-/obj/machinery/vending/snack/proc/compartment_access_check(user)
-	req_access_txt = chef_compartment_access
-	if(!allowed(user) && !(obj_flags & EMAGGED) && scan_id)
-		to_chat(user, "<span class='warning'>[src]'s chef compartment blinks red: Access denied.</span>")
-		req_access_txt = "0"
-		return 0
-	req_access_txt = "0"
-	return 1
-
-/obj/machinery/vending/snack/proc/iscompartmentfull(mob/user)
-	if(contents.len >= 30) // no more than 30 dishes can fit inside
-		to_chat(user, "<span class='warning'>[src]'s chef compartment is full.</span>")
-		return 1
-	return 0
-
 /obj/machinery/vending/snack/proc/food_load(obj/item/reagent_containers/food/snacks/S)
-	if(dish_quants[S.name])
-		dish_quants[S.name]++
+	if(vending_machine_input[S.name])
+		vending_machine_input[S.name]++
 	else
-		dish_quants[S.name] = 1
-	sortList(dish_quants)
+		vending_machine_input[S.name] = 1
+	sortList(vending_machine_input)
 
 /obj/machinery/vending/snack/random
 	name = "\improper Random Snackies"

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -6,6 +6,9 @@
 	extra_price = 75
 	payment_department = NO_FREEBIES
 
+/obj/machinery/vending/wardrobe/canLoadItem(obj/item/I,mob/user)
+	return (I.type in products)
+
 /obj/machinery/vending/wardrobe/sec_wardrobe
 	name = "\improper SecDrobe"
 	desc = "A vending machine for security and security-related clothing!"
@@ -320,7 +323,7 @@
 					/obj/item/toy/plush/narplush = 1,
 					/obj/item/clothing/head/medievaljewhat = 3,
 					/obj/item/clothing/suit/chaplainsuit/clownpriest = 1,
-					/obj/item/clothing/head/clownmitre = 1)		
+					/obj/item/clothing/head/clownmitre = 1)
 	premium = list(/obj/item/clothing/suit/chaplainsuit/bishoprobe = 1,
 					/obj/item/clothing/head/bishopmitre = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/chap_wardrobe

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -5,6 +5,7 @@
 	default_price = 50
 	extra_price = 75
 	payment_department = NO_FREEBIES
+	input_display_header = "Returned Clothing"
 
 /obj/machinery/vending/wardrobe/canLoadItem(obj/item/I,mob/user)
 	return (I.type in products)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I didn't like how the wardrobe replaced lockers but you couldn't clean up after yourself say once you switched to the nurse's outfit as a doctor. Now, anyone can put clothes in a wardrobe so long as that clothing is a vendable product of said wardrobe (No engineering jumpsuits in science vendor, etc.).

Building off the previous snack machine vendor, this lays the framework for ALL vendors to allow all sorts of items to be inputted into vendors, all you have to do is change `canLoadItem(obj/item/I,mob/user)` to TRUE for the items you want the vendor to accept! It also has an option to restrict loading by changing `canload_access_list`. NOTE: having any of the access permits input instead of all access is needed to input (important distinction!)

ECONOMY: This will make it so any clothes you put in becomes a sellable product. It does NOT make it free unless you can already access the vendor's contents for free.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Code improvement + minor QoL with minute balance implications. If you want to discuss how making it easier to clean up your unused clothes makes it more difficult for antags to sneak then I'm in trouble lol.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: ExcessiveUseOfVending
tweak: Wardrobe Vendors will now accept clothing types they sell. Now you can clean up after getting that cool alternate uniform!
code: see PR #43964 on how to easily setup a vending machine to accept items!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
