### PR TITLE
Fixes an age old issue with the explosive guardian

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -81,7 +81,7 @@
 		else
 			to_chat(user, "<span class='holoparasite'>[src] glows with a strange <font color=\"[spawner.namedatum.colour]\">light</font>, and you don't touch it.</span>")
 
-/obj/guardian_bomb/Bump(atom/A)
+/obj/guardian_bomb/Bumped(atom/A)
 	detonate(A)
 	..()
 


### PR DESCRIPTION
## About The Pull Request

Fixes an issue where only pushing a guardian bomb into a mob made it explode. It's supposed to be the other way around. Now they explode if you bump into them.

## Why It's Good For The Game

 This makes rigging airlocks actually work as intended and removes locker memes.

## Changelog
:cl:
fix: Explosive holoparasite bombs now explode if you bump into them, instead of the other way around.
/:cl:
