### PR TITLE
Removes commented-out what-if atmos code

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -428,23 +428,9 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 					continue
 				if(!cached_gases[id] || cached_gases[id][MOLES] < min_reqs[id])
 					continue reaction_loop
-			//at this point, all minimum requirements for the reaction are satisfied.
 
-			/*	currently no reactions have maximum requirements, so we can leave the checks commented out for a slight performance boost
-				PLEASE DO NOT REMOVE THIS CODE. the commenting is here only for a performance increase.
-				enabling these checks should be as easy as possible and the fact that they are disabled should be as clear as possible
-
-			var/list/max_reqs = reaction.max_requirements
-			if((max_reqs["TEMP"] && temp > max_reqs["TEMP"]) \
-			|| (max_reqs["ENER"] && ener > max_reqs["ENER"]))
-				continue
-			for(var/id in max_reqs)
-				if(id == "TEMP" || id == "ENER")
-					continue
-				if(cached_gases[id] && cached_gases[id][MOLES] > max_reqs[id])
-					continue reaction_loop
 			//at this point, all requirements for the reaction are satisfied. we can now react()
-			*/
+			
 			. |= reaction.react(src, holder)
 			if (. & STOP_REACTIONS)
 				break

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -36,7 +36,6 @@
 	//regarding the requirements lists: the minimum or maximum requirements must be non-zero.
 	//when in doubt, use MINIMUM_MOLE_COUNT.
 	var/list/min_requirements
-	var/list/max_requirements
 	var/exclude = FALSE //do it this way to allow for addition/removal of reactions midmatch in the future
 	var/priority = 100 //lower numbers are checked/react later than higher numbers. if two reactions have the same priority they may happen in either order
 	var/name = "reaction"


### PR DESCRIPTION
If or when this is needed, the author can just write it again, copypaste min req code or dig it from version history. No need to keep it around.