### PR TITLE
Fixes mining shuttle on boxstation.

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -2691,7 +2691,7 @@
 	area_type = /area/lavaland/surface/outdoors;
 	dir = 8;
 	dwidth = 2;
-	height = 10;
+	height = 5;
 	id = "laborcamp_away";
 	name = "labor camp";
 	width = 9
@@ -4102,7 +4102,7 @@
 	area_type = /area/lavaland/surface/outdoors;
 	dir = 8;
 	dwidth = 3;
-	height = 5;
+	height = 10;
 	id = "mining_away";
 	name = "lavaland mine";
 	width = 7


### PR DESCRIPTION
## About The Pull Request

When making the new mining shuttle I accidentally forgot to set the stationary port on lavaland's height variable to 10. No big deal, set it to 10 in notepad and done! I set the labor mining camp's to 10 instead of the mining shuttle (they had the same height of 5 so I confused them at a glance.)

## Why It's Good For The Game

Speedmerge or boxstation miners literally cannot go to lavaland :)

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
