### PR TITLE
Syndicate Bomb Bugfixes and Quality of Death Changes

### DIFF
--- a/code/datums/wires/syndicatebomb.dm
+++ b/code/datums/wires/syndicatebomb.dm
@@ -22,16 +22,19 @@
 				holder.visible_message("<span class='danger'>[icon2html(B, viewers(holder))] An alarm sounds! It's go-</span>")
 				B.explode_now = TRUE
 				tell_admins(B)
+			else
+				holder.visible_message("<span class='notice'>[icon2html(B, viewers(holder))] Nothing happens.</span>")
 		if(WIRE_UNBOLT)
 			holder.visible_message("<span class='notice'>[icon2html(B, viewers(holder))] The bolts spin in place for a moment.</span>")
 		if(WIRE_DELAY)
 			if(B.delayedbig)
-				holder.visible_message("<span class='notice'>[icon2html(B, viewers(holder))] The bomb has already been delayed.</span>")
+				holder.visible_message("<span class='notice'>[icon2html(B, viewers(holder))] Nothing happens.</span>")
 			else
 				holder.visible_message("<span class='notice'>[icon2html(B, viewers(holder))] The bomb chirps.</span>")
 				playsound(B, 'sound/machines/chime.ogg', 30, 1)
 				B.detonation_timer += 300
-				B.delayedbig = TRUE
+				if(B.active)
+					B.delayedbig = TRUE
 		if(WIRE_PROCEED)
 			holder.visible_message("<span class='danger'>[icon2html(B, viewers(holder))] The bomb buzzes ominously!</span>")
 			playsound(B, 'sound/machines/buzz-sigh.ogg', 30, 1)
@@ -43,7 +46,7 @@
 			else if(seconds >= 11) // Both to prevent negative timers and to have a little mercy.
 				B.detonation_timer = world.time + 100
 		if(WIRE_ACTIVATE)
-			if(!B.active && !B.defused)
+			if(!B.active)
 				holder.visible_message("<span class='danger'>[icon2html(B, viewers(holder))] You hear the bomb start ticking!</span>")
 				B.activate()
 				B.update_icon()
@@ -58,15 +61,10 @@
 	var/obj/machinery/syndicatebomb/B = holder
 	switch(wire)
 		if(WIRE_BOOM)
-			if(mend)
-				B.defused = FALSE // Cutting and mending all the wires of an inactive bomb will thus cure any sabotage.
-			else
-				if(B.active)
-					holder.visible_message("<span class='danger'>[icon2html(B, viewers(holder))] An alarm sounds! It's go-</span>")
-					B.explode_now = TRUE
-					tell_admins(B)
-				else
-					B.defused = TRUE
+			if(!mend && B.active)
+				holder.visible_message("<span class='danger'>[icon2html(B, viewers(holder))] An alarm sounds! It's go-</span>")
+				B.explode_now = TRUE
+				tell_admins(B)
 		if(WIRE_UNBOLT)
 			if(!mend && B.anchored)
 				holder.visible_message("<span class='notice'>[icon2html(B, viewers(holder))] The bolts lift out of the ground!</span>")
@@ -81,7 +79,8 @@
 			if(!mend && B.active)
 				holder.visible_message("<span class='notice'>[icon2html(B, viewers(holder))] The timer stops! The bomb has been defused!</span>")
 				B.active = FALSE
-				B.defused = TRUE
+				B.delayedlittle = FALSE
+				B.delayedbig = FALSE
 				B.update_icon()
 
 /datum/wires/syndicatebomb/proc/tell_admins(obj/machinery/syndicatebomb/B)


### PR DESCRIPTION
Fixes #28937
Fixes #43955 (through balance changes)
Fixes an unreported issue where a training bomb would not reset its wires if successfully defused.
Fixes an unreported issue where a clown bomb would not play a sad trombone if successfully defused.
Changes:

**The defused state has been removed from bomb cores, which means that a bomb that had been stopped is now still fully capable of detonation so long as its wires are restored.**

I found that the whole "you have to cut and rewire all the wires after a defusal for the core to work" had become secret knowledge. It was only frustrating people who even bought into futzing with the wires, and I had essentially just added it originally for complexity's sake anyways. It also was just confusing in code because it meant defusal meant two disparate things, either that the bomb had stopped ticking, or the core had been rendered inert.

**Training bombs no longer mysteriously regenerate their covers when wires reset**

Just didn't make sense and inhibited training on the training bomb for no reason.

**The bomb can now be delayed endlessly when not active, and its delayability when active can be reset if the bomb is first rendered inactive**

Before this it was a theoretical power move to trigger the delay pulses and then set your time, as it would have deprived any would be hero of those potential bonuses. You can already set these bombs to have arbitrarily high timers manually, so being able to pulse to do the same thing is not a balance concern.

**Pulsing already used delay wires is now consistent in messaging**

For some reason you can currently tell when you pulse the big delay wire but it's already been used, but NOT the little delay wire. Now neither give that feedback.

## Changelog
:cl:
add: After a very long period of being broken, the training bomb in security finally works properly again.
tweak: Syndicate bomb cores have become a little more robust in their operation. Defused but still cored bombs are no longer inert and can be set again. Would be heroes are advised to cut out and dispose of bomb cores, and dismantle unneeded bomb shells to be absolutely sure.
/:cl: