### PR TITLE
Fixes colored items like scarves and beanies being shown as white in vending machines

### DIFF
--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -682,8 +682,11 @@ GLOBAL_LIST_EMPTY(asset_datums)
 		icon_file = initial(item.icon)
 		icon_state = initial(item.icon_state)
 
-		if(icon_state in icon_states(icon_file))
+		else if(icon_state in icon_states(icon_file))
 			I = icon(icon_file, icon_state, SOUTH)
+			var/c = initial(item.color)
+			if (!isnull(c) && c != "#FFFFFF")
+				I.Blend(initial(c), ICON_MULTIPLY)
 		else
 			item = new item()
 			I = icon(item.icon, item.icon_state, SOUTH)

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -682,7 +682,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 		icon_file = initial(item.icon)
 		icon_state = initial(item.icon_state)
 
-		else if(icon_state in icon_states(icon_file))
+		if(icon_state in icon_states(icon_file))
 			I = icon(icon_file, icon_state, SOUTH)
 			var/c = initial(item.color)
 			if (!isnull(c) && c != "#FFFFFF")


### PR DESCRIPTION
## Changelog
:cl: Naksu
fix: Items using atom colors for coloring now show up properly colored in vending machines, rather than snow-white
/:cl: