### PR TITLE
Fixes a bunch of harddels and weirdness.

### DIFF
--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -9,7 +9,9 @@
 	var/can_contaminate
 
 /datum/radiation_wave/New(atom/_source, dir, _intensity=0, _range_modifier=RAD_DISTANCE_COEFFICIENT, _can_contaminate=TRUE)
-	source = _source
+
+	source = "[_source] \[[REF(_source)]\]"
+
 	master_turf = get_turf(_source)
 
 	move_dir = dir

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -150,7 +150,8 @@ Class Procs:
 	if(length(component_parts))
 		if (loc)
 			for(var/atom/movable/AM in component_parts)
-				AM.forceMove(loc)
+				if (!QDELETED(AM))
+					AM.forceMove(loc)
 		else
 			for(var/atom/A in component_parts)
 				qdel(A)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -148,13 +148,8 @@ Class Procs:
 		STOP_PROCESSING(SSfastprocess, src)
 	dropContents()
 	if(length(component_parts))
-		if (loc)
-			for(var/atom/movable/AM in component_parts)
-				if (!QDELETED(AM))
-					AM.forceMove(loc)
-		else
-			for(var/atom/A in component_parts)
-				qdel(A)
+		for(var/atom/A in component_parts)
+			qdel(A)
 		component_parts.Cut()
 	return ..()
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -147,6 +147,14 @@ Class Procs:
 	else
 		STOP_PROCESSING(SSfastprocess, src)
 	dropContents()
+	if(length(component_parts))
+		if (loc)
+			for(var/atom/movable/AM in component_parts)
+				AM.forceMove(loc)
+		else
+			for(var/atom/A in component_parts)
+				qdel(A)
+		component_parts.Cut()
 	return ..()
 
 /obj/machinery/proc/locate_machinery()

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -20,6 +20,9 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	GLOB.cameranet.updateVisibility(src)
 	return ..()
 
+/obj/effect/particle_effect/newtonian_move() // Prevents effects from getting registered for SSspacedrift
+	return TRUE
+
 /datum/effect_system
 	var/number = 3
 	var/cardinals = FALSE

--- a/code/game/objects/effects/effect_system/effects_explosion.dm
+++ b/code/game/objects/effects/effect_system/effects_explosion.dm
@@ -5,19 +5,23 @@
 	anchored = TRUE
 
 /obj/effect/particle_effect/expl_particles/Initialize()
-	. = ..()
-	QDEL_IN(src, 15)
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/effect/particle_effect/expl_particles/LateInitialize()
+	var/direct = pick(GLOB.alldirs)
+	var/steps_amt = pick(1;25,2;50,3,4;200)
+	for(var/j in 1 to steps_amt)
+		step(src, direct)
+		sleep(1)
+	qdel(src)
 
 /datum/effect_system/expl_particles
 	number = 10
 
 /datum/effect_system/expl_particles/start()
 	for(var/i in 1 to number)
-		var/obj/effect/particle_effect/expl_particles/expl = new /obj/effect/particle_effect/expl_particles(location)
-		var/direct = pick(GLOB.alldirs)
-		var/steps_amt = pick(1;25,2;50,3,4;200)
-		for(var/j in 1 to steps_amt)
-			addtimer(CALLBACK(GLOBAL_PROC, .proc/_step, expl, direct), j)
+		new /obj/effect/particle_effect/expl_particles(location)
 
 /obj/effect/explosion
 	name = "fire"

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -25,13 +25,17 @@
 	light_color = LIGHT_COLOR_FIRE
 
 /obj/effect/particle_effect/sparks/Initialize()
-	. = ..()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/effect/particle_effect/sparks/LateInitialize()
 	flick("sparks", src) // replay the animation
 	playsound(src, "sparks", 100, TRUE)
 	var/turf/T = loc
 	if(isturf(T))
 		T.hotspot_expose(1000,100)
-	QDEL_IN(src, 20)
+	sleep(20)
+	qdel(src)
 
 /obj/effect/particle_effect/sparks/Destroy()
 	var/turf/T = loc

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -125,6 +125,13 @@
 	if(mapload && access_txt)
 		access = text2access(access_txt)
 
+/obj/item/card/id/Destroy()
+	if (registered_account)
+		registered_account.bank_cards -= src
+	if (my_store && my_store.my_card == src)
+		my_store.my_card = null
+	return ..()
+
 /obj/item/card/id/attack_self(mob/user)
 	if(Adjacent(user))
 		user.visible_message("<span class='notice'>[user] shows you: [icon2html(src, viewers(user))] [src.name].</span>", "<span class='notice'>You show \the [src.name].</span>")
@@ -175,7 +182,7 @@
 		return
 	if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		return
-	
+
 	return TRUE
 
 /obj/item/card/id/AltClick(mob/living/user)
@@ -199,7 +206,7 @@
 		return
 
 	if (world.time < registered_account.withdrawDelay)
-		registered_account.bank_card_talk("<span class='warning'>ERROR: UNABLE TO LOGIN DUE TO SCHEDULED MAINTENANCE. MAINTENANCE IS SCHEDULED TO COMPLETE IN [(registered_account.withdrawDelay - world.time)/10] SECONDS.</span>", TRUE) 
+		registered_account.bank_card_talk("<span class='warning'>ERROR: UNABLE TO LOGIN DUE TO SCHEDULED MAINTENANCE. MAINTENANCE IS SCHEDULED TO COMPLETE IN [(registered_account.withdrawDelay - world.time)/10] SECONDS.</span>", TRUE)
 		return
 
 	var/amount_to_remove =  FLOOR(input(user, "How much do you want to withdraw? Current Balance: [registered_account.account_balance]", "Withdraw Funds", 5) as num, 1)
@@ -216,7 +223,7 @@
 		return
 	else
 		var/difference = amount_to_remove - registered_account.account_balance
-		registered_account.bank_card_talk("<span class='warning'>ERROR: The linked account requires [difference] more credit\s to perform that withdrawal.</span>", TRUE) 
+		registered_account.bank_card_talk("<span class='warning'>ERROR: The linked account requires [difference] more credit\s to perform that withdrawal.</span>", TRUE)
 
 /obj/item/card/id/examine(mob/user)
 	..()

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -41,6 +41,11 @@
 	var/comp_id = 0
 	var/efficiency
 
+/obj/machinery/power/compressor/Destroy()
+	if (turbine && turbine.compressor == src)
+		turbine.compressor = null
+	turbine = null
+	return ..()
 
 /obj/machinery/power/turbine
 	name = "gas turbine generator"
@@ -56,6 +61,12 @@
 	var/turf/outturf
 	var/lastgen
 	var/productivity = 1
+
+/obj/machinery/power/turbine/Destroy()
+	if (compressor && compressor.turbine == src)
+		compressor.turbine = null
+	compressor = null
+	return ..()
 
 /obj/machinery/computer/turbine_computer
 	name = "gas turbine control computer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. the turbine and the compressor were preventing eachother from deleting
2. bank accounts and paystands were preventing ID cards from deleting
3. radiation waves prevented their source from deleting
4. component parts of a machine would harddel if the machine was not deleted before the parts get processed
5. explosion effects would harddel because the movement callbacks kept references to it
6. effects near space would harddel because they would get registered for SSspacedrift

This includes a minor rewrite to how sparks/explosion effects do the moving, I've moved the handling into LateInitialize which was made waitfor = 0 in a previous PR. This is in favor of using (# of steps)+1 of timers and callbacks for each spark.

The branch name is a reference to atmos passive gates, but unlike all of these others things i was unable to find what keeps it harddeling.


## Changelog
:cl: Naksu
code: Several fixes for stuff harddeling
/:cl: