### PR TITLE
Turns Perf into The Standard Oxychem, Heavily Tweaks Perf To Fit My Fantasy

### DIFF
--- a/code/datums/diseases/tuberculosis.dm
+++ b/code/datums/diseases/tuberculosis.dm
@@ -3,8 +3,8 @@
 	name = "Fungal tuberculosis"
 	max_stages = 5
 	spread_text = "Airborne"
-	cure_text = "Spaceacillin & salbutamol"
-	cures = list("spaceacillin", "salbutamol")
+	cure_text = "Spaceacillin & Perfluorodecalin"
+	cures = list("spaceacillin", "perfluorodecalin")
 	agent = "Fungal Tubercle bacillus Cosmosis"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	cure_chance = 5//like hell are you getting out of hell

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -487,7 +487,7 @@
 		else
 			owner.visible_message("[owner]'s soul is absorbed into the rod, relieving the previous snake of its duty.")
 			var/mob/living/simple_animal/hostile/retaliate/poison/snake/healSnake = new(owner.loc)
-			var/list/chems = list("bicaridine", "salbutamol", "kelotane", "antitoxin")
+			var/list/chems = list("bicaridine", "perfluorodecalin", "kelotane", "antitoxin")
 			healSnake.poison_type = pick(chems)
 			healSnake.name = "Asclepius's Snake"
 			healSnake.real_name = "Asclepius's Snake"

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -17,9 +17,9 @@
 	var/list/available_chems
 	var/controls_inside = FALSE
 	var/list/possible_chems = list(
-		list("epinephrine", "morphine", "salbutamol", "bicaridine", "kelotane"),
+		list("epinephrine", "morphine", "perfluorodecalin", "bicaridine", "kelotane"),
 		list("oculine","inacusiate"),
-		list("antitoxin", "mutadone", "mannitol", "pen_acid"),
+		list("antitoxin", "mutadone", "mannitol", "pen_acid", "salbutamol"),
 		list("omnizine")
 	)
 	var/list/chem_buttons	//Used when emagged to scramble which chem is used, eg: antitoxin -> morphine

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -111,8 +111,8 @@
 	if(empty)
 		return
 	var/static/items_inside = list(
-		/obj/item/reagent_containers/pill/salbutamol = 4,
-		/obj/item/reagent_containers/hypospray/medipen = 2,
+		/obj/item/reagent_containers/syringe/perfluorodecalin = 5,
+		/obj/item/reagent_containers/hypospray/medipen = 1,
 		/obj/item/healthanalyzer = 1)
 	generate_items_inside(items_inside,src)
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -543,6 +543,8 @@
 	if(oxycalc)
 		M.adjustOxyLoss(-oxycalc, 0)
 		M.adjustToxLoss(oxycalc/2.5, 0) //1*REM*current_cycle
+	if(prob(current_cycle) && M.losebreath)
+		M.losebreath--
 	..()
 	return TRUE
 
@@ -551,7 +553,7 @@
 	var/oxycalc = 2.5*REM*current_cycle
 	M.adjustOxyLoss(-oxycalc, 0)
 	M.adjustToxLoss(oxycalc/2.5, 0)
-	//we then cancel out any healing done by on_mob_life since we want to simulate the same mechanism and NOT doubledip.
+	//we then cancel out any healing done by on_mob_life since we want to simulate the same mechanism and NOT doubledip. losebreath is done regardless so *shrug*
 	oxycalc = min(oxycalc,0)
 	if(oxycalc)
 		M.adjustOxyLoss(oxycalc, 0)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1,3 +1,4 @@
+#define PERF_BASE_DAMAGE		0.5
 
 //////////////////////////////////////////////////////////////////////////////////////////
 					// MEDICINE REAGENTS
@@ -531,7 +532,7 @@
 /datum/reagent/medicine/perfluorodecalin
 	name = "Perfluorodecalin"
 	id = "perfluorodecalin"
-	description = "An emergency medication used to rapidly treat oxygen deprivation. The mechanism becomes more potent as exposure is increased. Overdose causes the mechanism to run regardless if the user has oxygen deprivation."
+	description = "Restores oxygen deprivation while producing a lesser amount of toxic byproducts. Both scale with exposure to the drug and current amount of oxygen deprivation. Overdose causes toxic byproducts regardless of oxygen deprivation."
 	reagent_state = LIQUID
 	color = "#FF6464"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
@@ -539,7 +540,7 @@
 
 /datum/reagent/medicine/perfluorodecalin/on_mob_life(mob/living/carbon/human/M)
 	var/oxycalc = 2.5*REM*current_cycle
-	oxycalc = min(oxycalc, M.oxyloss)
+	oxycalc = min(oxycalc, M.oxyloss + PERF_BASE_DAMAGE) // this is so you always take at least PERF_BASE_DAMAGE tox even if you don't have oxygen loss to deter stacking (it is an emergency chem after all!)
 	if(oxycalc)
 		M.adjustOxyLoss(-oxycalc, 0)
 		M.adjustToxLoss(oxycalc/2.5, 0) //1*REM*current_cycle
@@ -554,7 +555,7 @@
 	M.adjustOxyLoss(-oxycalc, 0)
 	M.adjustToxLoss(oxycalc/2.5, 0)
 	//we then cancel out any healing done by on_mob_life since we want to simulate the same mechanism and NOT doubledip. losebreath is done regardless so *shrug*
-	oxycalc = min(oxycalc,0)
+	oxycalc = min(oxycalc,M.oxyloss + PERF_BASE_DAMAGE)
 	if(oxycalc)
 		M.adjustOxyLoss(oxycalc, 0)
 		M.adjustToxLoss(-oxycalc/2.5, 0)
@@ -1376,3 +1377,6 @@
 	M.adjustToxLoss(1, 0)
 	..()
 	. = 1
+
+
+#undef PERF_BASE_DAMAGE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -560,6 +560,7 @@
 		M.adjustOxyLoss(oxycalc, 0)
 		M.adjustToxLoss(-oxycalc/2.5, 0)
 
+	metabolization_rate += 1
 	..()
 
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -531,16 +531,34 @@
 /datum/reagent/medicine/perfluorodecalin
 	name = "Perfluorodecalin"
 	id = "perfluorodecalin"
-	description = "Extremely rapidly restores oxygen deprivation, but inhibits speech. May also heal small amounts of bruising and burns."
+	description = "An emergency medication used to rapidly treat oxygen deprivation. The mechanism becomes more potent as exposure is increased. Overdose causes the mechanism to run regardless if the user has oxygen deprivation."
 	reagent_state = LIQUID
 	color = "#FF6464"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
+	overdose_threshold = 35 // at least 2 full syringes +some, this stuff is nasty if left in for long
 
 /datum/reagent/medicine/perfluorodecalin/on_mob_life(mob/living/carbon/human/M)
-	M.adjustOxyLoss(-12*REM, 0)
-	M.adjustToxLoss(0.3*REM, 0)
+	var/oxycalc = 2.5*REM*current_cycle
+	oxycalc = min(oxycalc, M.oxyloss)
+	if(oxycalc)
+		M.adjustOxyLoss(-oxycalc, 0)
+		M.adjustToxLoss(oxycalc/2.5, 0) //1*REM*current_cycle
 	..()
 	return TRUE
+
+/datum/reagent/medicine/perfluorodecalin/overdose_process(mob/living/M)
+	. = TRUE
+	var/oxycalc = 2.5*REM*current_cycle
+	M.adjustOxyLoss(-oxycalc, 0)
+	M.adjustToxLoss(oxycalc/2.5, 0)
+	//we then cancel out any healing done by on_mob_life since we want to simulate the same mechanism and NOT doubledip.
+	oxycalc = min(oxycalc,0)
+	if(oxycalc)
+		M.adjustOxyLoss(oxycalc, 0)
+		M.adjustToxLoss(-oxycalc/2.5, 0)
+
+	..()
+
 
 /datum/reagent/medicine/ephedrine
 	name = "Ephedrine"

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -165,7 +165,7 @@
 	results = list("mannitol" = 3)
 	required_reagents = list("sugar" = 1, "hydrogen" = 1, "water" = 1)
 	mix_message = "The solution slightly bubbles, becoming thicker."
-	
+
 /datum/chemical_reaction/neurine
 	name = "Neurine"
 	id = "neurine"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -186,6 +186,11 @@
 	desc = "Contains charcoal."
 	list_reagents = list("charcoal" = 15)
 
+/obj/item/reagent_containers/syringe/perfluorodecalin
+	name = "syringe (perfluorodecalin)"
+	desc = "Contains perfluorodecalin."
+	list_reagents = list("perfluorodecalin" = 15)
+
 /obj/item/reagent_containers/syringe/antiviral
 	name = "syringe (spaceacillin)"
 	desc = "Contains antiviral agents."

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -11,7 +11,7 @@
 					/obj/item/healthanalyzer = 4,
 					/obj/item/reagent_containers/pill/patch/styptic = 5,
 					/obj/item/reagent_containers/pill/patch/silver_sulf = 5,
-					/obj/item/reagent_containers/pill/salbutamol = 2,
+					/obj/item/reagent_containers/syringe/perfluorodecalin = 2,
 					/obj/item/reagent_containers/pill/insulin = 5,
 					/obj/item/reagent_containers/glass/bottle/charcoal = 4,
 					/obj/item/reagent_containers/glass/bottle/epinephrine = 4,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Salbu is No Longer The Standard
- Salbu has been removed from every roundstart machinery. It was way too good as a roundstart chem. It can still be crafted.
- Salbu has been added to sleepers as a T3 upgrade chemical (hehe)

### Perf's Debut
- Perf has replaced every entry where Salbu was. Perf converts O2 healing into lesser amounts of Toxin damage more evenly than previous (40 : 1 [lol] to 5 : 2)
- Perf now ramps up effects the longer you have it in your system (`current_cycle`)
- You will always get at least 0.5 tox damage a cycle even without O2 healing to avoid doping.
- Perf now has a 35u OD. The OD mechanic is the same as it functions normally but does NOT account for actual O2 healed. The threshold rational was to ensure one needed at least 3 syringes from a syringe gun to OD.

### Tweaks
- Salbu's 50u pills were replaced with Perf 15u syringes. This is because Perf ramps so you won't need as much.
- The O2 Deprivation kit dropped a pen since It's not a "critkit" but an O2 kit and because epi compliments perf. Make your own Epi if you need another pen.
- TB will now use Perf to cure

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

All in all my goal here is to make oxygen damage something that is a little less forgiving without more preparation. I did this by replacing the standard BTFO2 chem with a lesser chem. However, the "lesser chem" was initially arms racing with the standard (that shouldn't have been the standard) so I just tweaked it while keeping it conceptually similar (high o2 healing with toxin conversion).

#### Salbu Removal
This is because Salbu was both more than capable of healing you out of any situation O2 wise and permitted doping, while also being the most abundant O2 chem.

#### Perf's Rework
This is because Perf was borderline OP pre-PR compared to the MUCH HARDER to craft Salbu. I wanted to rework it to be more of an emergency chem, with emergency meaning it comes at a cost that wasn't laughably negligible and you wanted to be conscious about how much you're putting into someone.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cO2by
del: Salbu has been replaced in all roundstart items with the PERFect chem
add: Salbu is now a T3 sleeper upgrade
balance: Perf now converts O2 deprivation to lesser amounts of Toxin more evenly than before
add: Perf effects scale based on O2 deprivation and how long perf is in your system
balance: Perf now has a 35u OD which ignores O2dep adjustment (You will take scaled toxin damage regardless of healed oxygen damage)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
