### PR TITLE
Updates cryo tube appearance when a mob exits via teleportation

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -48,6 +48,12 @@
 	radio.canhear_range = 0
 	radio.recalculateChannels()
 
+/obj/machinery/atmospherics/components/unary/cryo_cell/Exited(atom/movable/AM, atom/newloc)
+	var/oldoccupant = occupant
+	. = ..() // Parent proc takes care of removing occupant if necessary
+	if (AM == oldoccupant)
+		update_icon()
+
 /obj/machinery/atmospherics/components/unary/cryo_cell/on_construction()
 	..(dir, dir)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This actually happened in-game and was reported. Easy fix I guess?

fixes #43992

## Changelog
:cl: Naksu
fix: Cryotubes no longer display a double of a person that was once in but teleported out by having ingested bluespace or other such nonsense
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
