### PR TITLE
Adds Iron and Charcoal production to Steel Caps

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -25,6 +25,7 @@
 	plantname = "Steel Caps"
 	product = /obj/item/grown/log/steel
 	mutatelist = list()
+	reagents_add = list("iron" = 0.2, "charcoal" = 0.1)
 	rarity = 20
 
 


### PR DESCRIPTION
:cl: Dimmadunk
add: Adds 20% Iron production and 10% Charcoal production to Steel Caps.

/:cl:

Now that Separated Chemicals trait is gone, people won't complain for EMP creation on botany. Instead, have some tasty iron (and charcoal, since there's no coal chemical) to make coherence on "Steel" Caps, those two being the materials needed to make steel.