### PR TITLE
plasma cutter fix

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -159,6 +159,10 @@
 	else
 		..()
 
+//unaffected by emp
+/obj/item/gun/energy/plasmacutter/emp_act(severity)
+	return
+
 // Tool procs, in case plasma cutter is used as welder
 // Can we start welding?
 /obj/item/gun/energy/plasmacutter/tool_start_check(mob/living/user, amount)


### PR DESCRIPTION
## About The Pull Request

Fixes #43685 

## Changelog
:cl: Garen
fix: Plasma cutters no longer loose their ammo when emp'ed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
