### PR TITLE
 Lowers nukie war limit, makes tc reward scale to crew size.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -103,7 +103,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 	if(declaring_war)
 		to_chat(user, "You are already in the process of declaring war! Make your mind up.")
 		return FALSE
-	if(GLOB.player_list.len < CHALLENGE_MIN_PLAYERS+1)
+	if(GLOB.player_list.len <= CHALLENGE_MIN_PLAYERS)
 		to_chat(user, "The enemy crew is too small to be worth declaring war on.")
 		return FALSE
 	if(!user.onSyndieBase())

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -74,7 +74,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 			continue
 		uplinks += uplink
 
-	var/tc_to_distribute = CHALLENGE_TELECRYSTALS * ((CHALLENGE_MAX_PAYOUT - min(CHALLENGE_MAX_PAYOUT, GLOB.player_list.len)) / (CHALLENGE_MAX_PAYOUT - CHALLENGE_MIN_PLAYERS))
+	var/tc_to_distribute = CHALLENGE_TELECRYSTALS * (1 - ((CHALLENGE_MAX_PAYOUT - min(CHALLENGE_MAX_PAYOUT, GLOB.player_list.len)) / (CHALLENGE_MAX_PAYOUT - CHALLENGE_MIN_PLAYERS)))
 	var/tc_per_nukie = round(tc_to_distribute / (length(orphans)+length(uplinks)))
 
 	for (var/datum/component/uplink/uplink in uplinks)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,6 +1,7 @@
 #define CHALLENGE_TELECRYSTALS 280
 #define CHALLENGE_TIME_LIMIT 3000
-#define CHALLENGE_MIN_PLAYERS 50
+#define CHALLENGE_MIN_PLAYERS 30
+#define CHALLENGE_MAX_PAYOUT 50
 #define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
 GLOBAL_LIST_EMPTY(jam_on_wardec)
@@ -23,7 +24,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		return
 
 	declaring_war = TRUE
-	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew? You have [DisplayTimeText(world.time-SSticker.round_start_time - CHALLENGE_TIME_LIMIT)] to decide", "Declare war?", "Yes", "No")
+	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew? You will get [round(CHALLENGE_TELECRYSTALS * ((CHALLENGE_MAX_PAYOUT - min(CHALLENGE_MAX_PAYOUT, GLOB.player_list.len)) / (CHALLENGE_MAX_PAYOUT - CHALLENGE_MIN_PLAYERS)),1)] extra telecystals. You have [DisplayTimeText(world.time-SSticker.round_start_time - CHALLENGE_TIME_LIMIT)] to decide", "Declare war?", "Yes", "No")
 	declaring_war = FALSE
 
 	if(!check_allowed(user))
@@ -73,8 +74,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 			continue
 		uplinks += uplink
 
-
-	var/tc_to_distribute = CHALLENGE_TELECRYSTALS
+	var/tc_to_distribute = CHALLENGE_TELECRYSTALS * ((CHALLENGE_MAX_PAYOUT - min(CHALLENGE_MAX_PAYOUT, GLOB.player_list.len)) / (CHALLENGE_MAX_PAYOUT - CHALLENGE_MIN_PLAYERS))
 	var/tc_per_nukie = round(tc_to_distribute / (length(orphans)+length(uplinks)))
 
 	for (var/datum/component/uplink/uplink in uplinks)
@@ -103,7 +103,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 	if(declaring_war)
 		to_chat(user, "You are already in the process of declaring war! Make your mind up.")
 		return FALSE
-	if(GLOB.player_list.len < CHALLENGE_MIN_PLAYERS)
+	if(GLOB.player_list.len < CHALLENGE_MIN_PLAYERS+1)
 		to_chat(user, "The enemy crew is too small to be worth declaring war on.")
 		return FALSE
 	if(!user.onSyndieBase())
@@ -125,4 +125,5 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 #undef CHALLENGE_TELECRYSTALS
 #undef CHALLENGE_TIME_LIMIT
 #undef CHALLENGE_MIN_PLAYERS
+#undef CHALLENGE_MAX_PAYOUT
 #undef CHALLENGE_SHUTTLE_DELAY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sets the nukie war limit to 30 players (same as the mode req), and scales the TC reward when below the old war requirement. Currently using linear scaling, though I am not dead set on that. 

Please give the math a twice over, I've not been able to test this properly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's my impression that most people prefer war ops to stealth/blitz ops. This allows the nuke team to decide if they still want to war on lower pops for a lower reward, instead of being forced into a less enjoyable strategy.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Nuke ops war limit reduced to 30 players (from 50), TC reward now scales to crew size when below the old limit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
