### PR TITLE
Stops corpses from receiving new information about their damaged brain

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -241,12 +241,13 @@
 			else
 				gain_trauma_type(BRAIN_TRAUMA_SEVERE)
 
-	if(prev_brainloss < BRAIN_DAMAGE_MILD && brainloss >= BRAIN_DAMAGE_MILD)
-		to_chat(src, "<span class='warning'>You feel lightheaded.</span>")
-	else if(prev_brainloss < BRAIN_DAMAGE_SEVERE && brainloss >= BRAIN_DAMAGE_SEVERE)
-		to_chat(src, "<span class='warning'>You feel less in control of your thoughts.</span>")
-	else if(prev_brainloss < (BRAIN_DAMAGE_DEATH - 20) && brainloss >= (BRAIN_DAMAGE_DEATH - 20))
-		to_chat(src, "<span class='warning'>You can feel your mind flickering on and off...</span>")
+	if (stat < UNCONSCIOUS) // conscious or soft-crit
+		if(prev_brainloss < BRAIN_DAMAGE_MILD && brainloss >= BRAIN_DAMAGE_MILD)
+			to_chat(src, "<span class='warning'>You feel lightheaded.</span>")
+		else if(prev_brainloss < BRAIN_DAMAGE_SEVERE && brainloss >= BRAIN_DAMAGE_SEVERE)
+			to_chat(src, "<span class='warning'>You feel less in control of your thoughts.</span>")
+		else if(prev_brainloss < (BRAIN_DAMAGE_DEATH - 20) && brainloss >= (BRAIN_DAMAGE_DEATH - 20))
+			to_chat(src, "<span class='warning'>You can feel your mind flickering on and off...</span>")
 
 /mob/living/carbon/setBrainLoss(amount)
 	var/obj/item/organ/brain/B = getorganslot(ORGAN_SLOT_BRAIN)


### PR DESCRIPTION
What it says on the tin

Fixes #43833

## Changelog
:cl: Naksu
fix: corpses no longer feel, light-headed or otherwise
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
