### PR TITLE
Colossus and drake have checks to stop attacking after death [READY]

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -1,3 +1,4 @@
+#define COLOSSUS_SLEEP(X) sleep(X); if(QDELETED(src)) return;
 /*
 
 COLOSSUS
@@ -73,7 +74,7 @@ Difficulty: Very Hard
 		telegraph()
 
 		if(health < maxHealth/3)
-			double_spiral()
+			INVOKE_ASYNC(src, .proc/double_spiral)
 		else
 			visible_message("<span class='colossus'>\"<b>Judgement.</b>\"</span>")
 			INVOKE_ASYNC(src, .proc/spiral_shoot, pick(TRUE, FALSE))
@@ -123,17 +124,17 @@ Difficulty: Very Hard
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/alternating_dir_shots()
 	dir_shots(GLOB.diagonals)
-	sleep(10)
+	COLOSSUS_SLEEP(10)
 	dir_shots(GLOB.cardinals)
-	sleep(10)
+	COLOSSUS_SLEEP(10)
 	dir_shots(GLOB.diagonals)
-	sleep(10)
+	COLOSSUS_SLEEP(10)
 	dir_shots(GLOB.cardinals)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/double_spiral()
 	visible_message("<span class='colossus'>\"<b>Die.</b>\"</span>")
 
-	sleep(10)
+	COLOSSUS_SLEEP(10)
 	INVOKE_ASYNC(src, .proc/spiral_shoot)
 	INVOKE_ASYNC(src, .proc/spiral_shoot, TRUE)
 
@@ -151,7 +152,7 @@ Difficulty: Very Hard
 			counter = 16
 		shoot_projectile(start_turf, counter * 22.5)
 		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, 1)
-		sleep(1)
+		COLOSSUS_SLEEP(1)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/shoot_projectile(turf/marker, set_angle)
 	if(!isnum(set_angle) && (!marker || marker == loc))

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -3,6 +3,7 @@
 
 #define SWOOP_DAMAGEABLE 1
 #define SWOOP_INVULNERABLE 2
+#define DRAKE_SLEEP(X) sleep(X); if(QDELETED(src) || stat == DEAD) return;
 
 /*
 
@@ -137,20 +138,24 @@ Difficulty: Medium
 		var/turf/T = pick(RANGE_TURFS(1, target))
 		new /obj/effect/temp_visual/lava_warning(T, 60) // longer reset time for the lava
 		amount--
-		sleep(delay)
+		DRAKE_SLEEP(delay)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/lava_swoop(var/amount = 30)
 	INVOKE_ASYNC(src, .proc/lava_pools, amount)
 	swoop_attack(FALSE, target, 1000) // longer cooldown until it gets reset below
+	if(QDELETED(src) || stat == DEAD)
+		return
 	fire_cone()
 	if(health < maxHealth*0.5)
-		sleep(10)
+		DRAKE_SLEEP(10)
 		fire_cone()
-		sleep(10)
+		DRAKE_SLEEP(10)
 		fire_cone()
 	SetRecoveryTime(40)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/mass_fire(var/spiral_count = 12, var/range = 15, var/times = 3)
+	if(QDELETED(src) || stat == DEAD)
+		return
 	for(var/i = 1 to times)
 		SetRecoveryTime(50)
 		playsound(get_turf(src),'sound/magic/fireball.ogg', 200, 1)
@@ -158,7 +163,7 @@ Difficulty: Medium
 		for(var/j = 1 to spiral_count)
 			var/list/turfs = line_target(j * increment + i * increment / 2, range, src)
 			INVOKE_ASYNC(src, .proc/fire_line, turfs)
-		sleep(25)
+		DRAKE_SLEEP(25)
 	SetRecoveryTime(30)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/lava_arena()
@@ -179,7 +184,7 @@ Difficulty: Medium
 			T.ChangeTurf(/turf/open/floor/plating/asteroid/basalt/lava_land_surface)
 		else
 			indestructible_turfs += T
-	sleep(10) // give them a bit of time to realize what attack is actually happening
+	DRAKE_SLEEP(10) // give them a bit of time to realize what attack is actually happening
 
 	var/list/turfs = RANGE_TURFS(2, center)
 	while(amount > 0)
@@ -203,10 +208,12 @@ Difficulty: Medium
 			else if(!istype(T, /turf/closed/indestructible))
 				new /obj/effect/temp_visual/lava_safe(T)
 		amount--
-		sleep(24)
+		DRAKE_SLEEP(24)
 	return 1 // attack finished completely
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/arena_escape_enrage() // you ran somehow / teleported away from my arena attack now i'm mad fucker
+	if(QDELETED(src) || stat == DEAD)
+		return //angry but helpless
 	SetRecoveryTime(80)
 	visible_message("<span class='boldwarning'>[src] starts to glow vibrantly as its wounds close up!</span>")
 	adjustBruteLoss(-250) // yeah you're gonna pay for that, don't run nerd
@@ -214,10 +221,12 @@ Difficulty: Medium
 	move_to_delay = move_to_delay / 2
 	light_range = 10
 	sleep(10) // run.
-	mass_fire(20, 15, 3)
-	remove_atom_colour(TEMPORARY_COLOUR_PRIORITY)
-	move_to_delay = initial(move_to_delay)
-	light_range = initial(light_range)
+	if(!QDELETED(src))
+		if(stat != DEAD)
+			mass_fire(20, 15, 3)
+			move_to_delay = initial(move_to_delay)
+		remove_atom_colour(TEMPORARY_COLOUR_PRIORITY)
+		light_range = initial(light_range)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/fire_cone(var/atom/at = target)
 	playsound(get_turf(src),'sound/magic/fireball.ogg', 200, 1)
@@ -245,6 +254,10 @@ Difficulty: Medium
 	return (getline(src, T) - get_turf(src))
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/fire_line(var/list/turfs)
+	dragon_fire_line(src, turfs)
+
+//fire line keeps going even if dragon is deleted
+/proc/dragon_fire_line(var/source, var/list/turfs)
 	var/list/hit_list = list()
 	for(var/turf/T in turfs)
 		if(istype(T, /turf/closed))
@@ -252,11 +265,11 @@ Difficulty: Medium
 		new /obj/effect/hotspot(T)
 		T.hotspot_expose(700,50,1)
 		for(var/mob/living/L in T.contents)
-			if(L in hit_list || L == src)
+			if(L in hit_list || L == source)
 				continue
 			hit_list += L
 			L.adjustFireLoss(20)
-			to_chat(L, "<span class='userdanger'>You're hit by [src]'s fire breath!</span>")
+			to_chat(L, "<span class='userdanger'>You're hit by [source]'s fire breath!</span>")
 
 		// deals damage to mechs
 		for(var/obj/mecha/M in T.contents)
@@ -306,6 +319,7 @@ Difficulty: Medium
 	swooping |= SWOOP_INVULNERABLE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	sleep(7)
+	//badmins please don't kill it while it's invulnerable
 
 	while(target && loc != get_turf(target))
 		forceMove(get_step(src, get_dir(src, target)))
@@ -354,6 +368,8 @@ Difficulty: Medium
 
 	density = TRUE
 	sleep(1)
+	if(QDELETED(src))
+		return
 	swooping &= ~SWOOP_DAMAGEABLE
 	SetRecoveryTime(swoop_cooldown)
 	if(!lava_success)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stops a bunch of runtimes from colossus + drakes corpse trying to burn you
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: colossus and drake can no longer attack from the afterlife
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
