### PR TITLE
Adds a source var to a signal receiver that should have it

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -52,7 +52,7 @@
 	else
 		steps++
 
-/datum/component/squeak/proc/play_squeak_crossed(atom/movable/AM)
+/datum/component/squeak/proc/play_squeak_crossed(datum/source, atom/movable/AM)
 	if(isitem(AM))
 		var/obj/item/I = AM
 		if(I.item_flags & ABSTRACT)


### PR DESCRIPTION
We should be doing the checks against the thing crossing, not ourselves. Probably fixes some bugs by the look of things.