### PR TITLE
Reworks ethereal charge. Adds framework for chargable organs.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -136,6 +136,7 @@
 #define TRAIT_BOOZE_SLIDER      "booze-slider"
 #define TRAIT_UNINTELLIGIBLE_SPEECH "unintelligible-speech"
 #define TRAIT_UNSTABLE			"unstable"
+#define TRAIT_CHARGER			"charger"
 
 //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -339,7 +339,7 @@
 
 /datum/component/mood/proc/HandleCharge(mob/living/carbon/human/H)
 	var/datum/species/ethereal/E = H.dna?.species
-	switch(E.ethereal_charge)
+	switch(E.get_charge(H))
 		if(ETHEREAL_CHARGE_NONE to ETHEREAL_CHARGE_LOWPOWER)
 			add_event(null, "charge", /datum/mood_event/decharged)
 		if(ETHEREAL_CHARGE_LOWPOWER to ETHEREAL_CHARGE_NORMAL)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -80,13 +80,12 @@
 
 /obj/machinery/recharge_station/open_machine()
 	. = ..()
-	if(iscyborg(occupant) || isethereal(occupant))
-		use_power = IDLE_POWER_USE
+	use_power = IDLE_POWER_USE
 
 /obj/machinery/recharge_station/close_machine()
 	. = ..()
 	if(occupant)
-		if(iscyborg(occupant) || isethereal(occupant))
+		if(iscyborg(occupant) || HAS_TRAIT(occupant, TRAIT_CHARGER))
 			use_power = ACTIVE_POWER_USE
 		add_fingerprint(occupant)
 
@@ -113,11 +112,11 @@
 			R.heal_bodypart_damage(repairs, repairs - 1)
 		if(R.cell)
 			R.cell.charge = min(R.cell.charge + recharge_speed, R.cell.maxcharge)
-	if(isethereal(occupant))
-		var/mob/living/carbon/human/H = occupant
-		var/datum/species/ethereal/E = H.dna?.species
-		if(E)
-			E.adjust_charge(recharge_speed / 70) //Around 3 per process if unupgraded
+	if(iscarbon(occupant) && HAS_TRAIT(occupant, TRAIT_CHARGER))
+		var/mob/living/carbon/C = occupant
+		for(var/V in C.internal_organs)
+			var/obj/item/organ/O = V
+			O.charge(recharge_speed)		
 
 /obj/machinery/recharge_station/proc/restock_modules()
 	if(occupant)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -239,6 +239,9 @@
 		adjustStaminaLoss(shock_damage)
 	else
 		take_overall_damage(0,shock_damage)
+		for(var/V in internal_organs)
+			var/obj/item/organ/O = V
+			O.on_electrocute(shock_damage, siemens_coeff)
 	visible_message(
 		"<span class='danger'>[src] was shocked by \the [source]!</span>", \
 		"<span class='userdanger'>You feel a powerful shock coursing through your body!</span>", \

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1115,8 +1115,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					. += hungry / 50
 			else if(isethereal(H))
 				var/datum/species/ethereal/E = H.dna.species
-				if(E.ethereal_charge <= ETHEREAL_CHARGE_NORMAL)
-					. += 1.5 * (1 - E.ethereal_charge / 100)
+				var/charge = E.get_charge()
+				if(charge <= ETHEREAL_CHARGE_NORMAL)
+					. += 1.5 * (1 - charge / 100)
 
 		//Moving in high gravity is very slow (Flying too)
 		if(gravity > STANDARD_GRAVITY)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -7,18 +7,18 @@
 	attack_sound = 'sound/weapons/etherealhit.ogg'
 	miss_sound = 'sound/weapons/etherealmiss.ogg'
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ethereal
+	mutantstomach = /obj/item/organ/stomach/ethereal
 	exotic_blood = "liquidelectricity" //Liquid Electricity. fuck you think of something better gamer
 	siemens_coeff = 0.5 //They thrive on energy
 	brutemod = 1.25 //They're weak to punches
 	attack_type = BURN //burn bish
 	damage_overlay_type = "" //We are too cool for regular damage overlays
-	species_traits = list(DYNCOLORS, NOSTOMACH, AGENDER, NO_UNDERWEAR)
+	species_traits = list(DYNCOLORS, AGENDER, NO_UNDERWEAR)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	inherent_traits = list(TRAIT_NOHUNGER)
 	sexes = FALSE //no fetish content allowed
 	toxic_food = NONE
 	var/current_color
-	var/ethereal_charge = ETHEREAL_CHARGE_FULL
 	var/EMPeffect = FALSE
 	var/emageffect = FALSE
 	var/r1
@@ -90,15 +90,6 @@
 	.=..()
 	handle_charge(H)
 
-/datum/species/ethereal/spec_fully_heal(mob/living/carbon/human/H)
-	.=..()
-	set_charge(ETHEREAL_CHARGE_FULL)
-
-/datum/species/ethereal/spec_electrocute_act(mob/living/carbon/human/H, shock_damage, obj/source, siemens_coeff = 1, safety = 0, override = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
-	.=..()
-	adjust_charge(shock_damage * siemens_coeff * 2)
-	to_chat(H, "<span class='notice'>You absorb some of the shock into your body!</span>")
-
 
 /datum/species/ethereal/proc/stop_emp(mob/living/carbon/human/H)
 	EMPeffect = FALSE
@@ -119,10 +110,8 @@
 	H.visible_message("<span class='danger'>[H] stops flickering and goes back to their normal state!</span>")
 
 /datum/species/ethereal/proc/handle_charge(mob/living/carbon/human/H)
-	var/charge_rate = ETHEREAL_CHARGE_FACTOR
 	brutemod = 1.25
-	adjust_charge(-charge_rate)
-	switch(ethereal_charge)
+	switch(get_charge(H))
 		if(ETHEREAL_CHARGE_NONE)
 			H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 3)
 		if(ETHEREAL_CHARGE_NONE to ETHEREAL_CHARGE_LOWPOWER)
@@ -136,8 +125,8 @@
 		else
 			H.clear_alert("ethereal_charge")
 
-/datum/species/ethereal/proc/adjust_charge(var/change)
-	ethereal_charge = CLAMP(ethereal_charge + change, ETHEREAL_CHARGE_NONE, ETHEREAL_CHARGE_FULL)
-
-/datum/species/ethereal/proc/set_charge(var/change)
-	ethereal_charge = CLAMP(change, ETHEREAL_CHARGE_NONE, ETHEREAL_CHARGE_FULL)
+/datum/species/ethereal/proc/get_charge(mob/living/carbon/human/H) //this feels like it should be somewhere else. Eh?
+	var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+	if(istype(stomach))
+		return stomach.crystal_charge
+	return ETHEREAL_CHARGE_NONE

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -630,8 +630,12 @@
 			if(istype(eth_species))
 				to_chat(H, "<span class='notice'>You start channeling some power through the [fitting] into your body.</span>")
 				if(do_after(user, 50, target = src))
-					to_chat(H, "<span class='notice'>You receive some charge from the [fitting].</span>")
-					eth_species.adjust_charge(5)
+					var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+					if(istype(stomach))
+						to_chat(H, "<span class='notice'>You receive some charge from the [fitting].</span>")
+						stomach.adjust_charge(5)
+					else
+						to_chat(H, "<span class='notice'>You can't receive charge from the [fitting].</span>")
 					return
 				return
 

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -724,12 +724,16 @@
 	color = "#97ee63"
 	taste_description = "pure electrictiy"
 
+/datum/reagent/consumable/liquidelectricity/reaction_mob(mob/living/M, method=TOUCH, reac_volume) //can't be on life because of the way blood works.
+	if(method == INGEST || method == INJECT || method == PATCH)
+		if(iscarbon(M))
+			var/mob/living/carbon/C = M
+			var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
+			if(istype(stomach))
+				stomach.adjust_charge(reac_volume * 2 * REM)
+
 /datum/reagent/consumable/liquidelectricity/on_mob_life(mob/living/carbon/M)
-	if(isethereal(M))
-		var/mob/living/carbon/human/H = M
-		var/datum/species/ethereal/E = H.dna?.species
-		E.adjust_charge(5*REM)
-	else if(prob(25)) //scp13 optimization
+	if(prob(25) && !isethereal(M))
 		M.electrocute_act(rand(10,15), "Liquid Electricity in their body", 1) //lmao at the newbs who eat energy bars
 		playsound(M, "sparks", 50, 1)
 	return ..()

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -60,6 +60,11 @@
 	if(status == ORGAN_ROBOTIC && broken_cyber_organ)
 		to_chat(user, "<span class='warning'>[src] seems to be broken!</span>")
 
+/obj/item/organ/proc/charge(amount)
+	return
+	
+/obj/item/organ/proc/on_electrocute(shock_damage, siemens_coeff = 1)
+	return
 
 /obj/item/organ/proc/prepare_eat()
 	var/obj/item/reagent_containers/food/snacks/organ/S = new

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -79,10 +79,10 @@
 	
 /obj/item/organ/stomach/ethereal/Insert(mob/living/carbon/M, special = 0)
 	..()
-	owner.add_trait(TRAIT_CHARGER, ORGAN_TRAIT)
+	ADD_TRAIT(owner, TRAIT_CHARGER, ORGAN_TRAIT)
 
 /obj/item/organ/stomach/ethereal/Remove(mob/living/carbon/M, special = 0)
-	owner.remove_trait(TRAIT_CHARGER, ORGAN_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_CHARGER, ORGAN_TRAIT)
 	..()
 	
 /obj/item/organ/stomach/ethereal/charge(amount)

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -64,5 +64,33 @@
 
 /obj/item/organ/stomach/plasmaman
 	name = "digestive crystal"
-	icon_state = "stomach-p"
+	icon_state = "stomach-p" 
 	desc = "A strange crystal that is responsible for metabolizing the unseen energy force that feeds plasmamen."
+	
+/obj/item/organ/stomach/ethereal
+	name = "biological battery"
+	icon_state = "stomach-p" //Welp. At least it's more unique in functionaliy.
+	desc = "A crystal-like organ that stores the electric charge of ethereals."
+	var/crystal_charge = ETHEREAL_CHARGE_FULL
+	
+/obj/item/organ/stomach/ethereal/on_life()
+	..()
+	adjust_charge(-ETHEREAL_CHARGE_FACTOR)
+	
+/obj/item/organ/stomach/ethereal/Insert(mob/living/carbon/M, special = 0)
+	..()
+	owner.add_trait(TRAIT_CHARGER, ORGAN_TRAIT)
+
+/obj/item/organ/stomach/ethereal/Remove(mob/living/carbon/M, special = 0)
+	owner.remove_trait(TRAIT_CHARGER, ORGAN_TRAIT)
+	..()
+	
+/obj/item/organ/stomach/ethereal/charge(amount)
+	adjust_charge(amount / 70)
+	
+/obj/item/organ/stomach/ethereal/on_electrocute(shock_damage, siemens_coeff = 1)
+	adjust_charge(shock_damage * siemens_coeff * 2)
+	to_chat(owner, "<span class='notice'>You absorb some of the shock into your body!</span>")
+	
+/obj/item/organ/stomach/ethereal/proc/adjust_charge(amount)
+	crystal_charge = CLAMP(crystal_charge + amount, ETHEREAL_CHARGE_NONE, ETHEREAL_CHARGE_FULL)


### PR DESCRIPTION
## About The Pull Request

Changes the way ethereals handle their charge. Instead of it being saved in their species, they get a organ that replaces their (currently non-existant) stomach. This also makes ethereals vunerable to digust. They have been immune to that until now.

Also adds procs for charging and shocking organs. They don't have much other use as of yet. There are some implants that could benefit from these proc but it would be out of the scope of this to change them.

Also changes the way liquid electricity restores charge to ethereals. Due to the way exotic blood worked, almost all the reagents were quickly turned into blood instead of actually charging the ethereal. Now they gain the charge instantly on consumption, instead of over time.

## Why It's Good For The Game

Adds a bit more uniqueness to an, in my opinion, quite bland race. It also makes them not immune to disgust which I think was an oversight and not an intended feature. Lays a better framework for future implants and organs.

## Changelog
:cl:
add: Ethereals now have an organ which stores their charge. Removing it will drop their charge to zero.
fix: Ethereals are no longer immune to disgust.
balance: Liquid electricity is now more effective at restoring charge to ethereals.
/:cl: