### PR TITLE
Traitor Panel now shows the names of blood brothers' brothers.

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -32,8 +32,7 @@
 	return ..()
 
 /datum/antagonist/brother/antag_panel_data()
-	var/brother_text = get_brother_names()
-	return "Conspirators: [brother_text]"
+	return "Conspirators : [get_brother_names()]]"
 
 /datum/antagonist/brother/proc/get_brother_names()
 	var/list/brothers = team.members - owner

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -31,15 +31,13 @@
 	owner.special_role = null
 	return ..()
 
-/datum/antagonist/brother/proc/give_meeting_area()
-	if(!owner.current || !team || !team.meeting_area)
-		return
-	to_chat(owner.current, "<B>Your designated meeting area:</B> [team.meeting_area]")
-	antag_memory += "<b>Meeting Area</b>: [team.meeting_area]<br>"
+/datum/antagonist/brother/antag_panel_data()
+	var/brother_text = get_brother_names()
+	return "Conspirators: [brother_text]"
 
-/datum/antagonist/brother/greet()
-	var/brother_text = ""
+/datum/antagonist/brother/proc/get_brother_names()
 	var/list/brothers = team.members - owner
+	var/brother_text = ""
 	for(var/i = 1 to brothers.len)
 		var/datum/mind/M = brothers[i]
 		brother_text += M.name
@@ -47,6 +45,16 @@
 			brother_text += " and "
 		else if(i != brothers.len)
 			brother_text += ", "
+	return brother_text
+
+/datum/antagonist/brother/proc/give_meeting_area()
+	if(!owner.current || !team || !team.meeting_area)
+		return
+	to_chat(owner.current, "<B>Your designated meeting area:</B> [team.meeting_area]")
+	antag_memory += "<b>Meeting Area</b>: [team.meeting_area]<br>"
+
+/datum/antagonist/brother/greet()
+	var/brother_text = get_brother_names()
 	to_chat(owner.current, "<B><font size=3 color=red>You are the [owner.special_role] of [brother_text].</font></B>")
 	to_chat(owner.current, "The Syndicate only accepts those that have proven themselves. Prove yourself and prove your [team.member_name]s by completing your objectives together!")
 	owner.announce_objectives()


### PR DESCRIPTION
## About The Pull Request

Exactly what it says in the title, TP now lists blood brothers' names. 
## Why It's Good For The Game

Because it helps admins doing investigations and looking in TP. Feel free to suggest other antag shit that should be in TP and isn't.

## Changelog
:cl:
admin: TP now shows the names of blood brothers' brothers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
