### PR TITLE
Buffs mech plasma cutters

### DIFF
--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -28,7 +28,7 @@
 	mine_range = 5
 
 /obj/item/projectile/plasma/adv/mech
-	damage = 10
+	damage = 25
 	range = 9
 	mine_range = 3
 

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -6,10 +6,20 @@
 	range = 4
 	dismemberment = 20
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
+    var/pressure_decrease_active = FALSE
+    var/pressure_decrease = 0.2
 	var/mine_range = 3 //mines this many additional tiles of rock
 	tracer_type = /obj/effect/projectile/tracer/plasma_cutter
 	muzzle_type = /obj/effect/projectile/muzzle/plasma_cutter
 	impact_type = /obj/effect/projectile/impact/plasma_cutter
+
+/obj/item/projectile/plasma/Initialize()
+	. = ..()
+	if(!lavaland_equipment_pressure_check(get_turf(src)))
+		name = "weakened [name]"
+		damage = damage * pressure_decrease
+		pressure_decrease_active = TRUE
+
 
 /obj/item/projectile/plasma/on_hit(atom/target)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Ups the damage of mech plasma cutters to 25, up from 10, thats all, also makes them do 20% damage in air, this goes for all plasma cutters because i'm a feral ape who doesn't know how to make it only work for mech plasma cutters, please forgive.

## Why It's Good For The Game

They are no longer painfuly useless for dealing with fauna, i'd PR mech KAs if i knew how to code them but i sadly don't.

## Changelog
:cl:
balance: Mech plasma cutters now do 25 damage in low air environments, up from 10, normal handheld plasma cutters do 2 damage in environments with air.
/:cl: