### PR TITLE
Mech plasma cutter buff, but less poorly made

### DIFF
--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -30,8 +30,8 @@
 /obj/item/projectile/plasma/adv/mech
 	damage = 25
 	range = 9
-    var/pressure_decrease_active = FALSE
-    var/pressure_decrease = 0.2
+	var/pressure_decrease_active = FALSE
+	var/pressure_decrease = 0.2
 	mine_range = 3
 
 

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -28,7 +28,7 @@
 	mine_range = 5
 
 /obj/item/projectile/plasma/adv/mech
-	damage = 10
+	damage = 25
 	range = 9
     var/pressure_decrease_active = FALSE
     var/pressure_decrease = 0.2

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -30,7 +30,18 @@
 /obj/item/projectile/plasma/adv/mech
 	damage = 10
 	range = 9
+    var/pressure_decrease_active = FALSE
+    var/pressure_decrease = 0.2
 	mine_range = 3
+
+
+/obj/item/projectile/plasma/adv/mech/Initialize()
+	. = ..()
+	if(!lavaland_equipment_pressure_check(get_turf(src)))
+		name = "weakened [name]"
+		damage = damage * pressure_decrease
+		pressure_decrease_active = TRUE
+
 
 /obj/item/projectile/plasma/turret
 	//Between normal and advanced for damage, made a beam so not the turret does not destroy glass
@@ -38,3 +49,4 @@
 	damage = 24
 	range = 7
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+


### PR DESCRIPTION
## About The Pull Request

Makes mech plasma cutters do 25 damage in low air and 5 in high, thats all.

## Why It's Good For The Game

Makes them worth a damn when it comes to killing fauna, but not overpowered before they got nerfed ages ago.

## Changelog
:cl:
balance: Mech plasma cutters now do 25 damage in low air, and 5 in high.
/:cl: