### PR TITLE
[s] Prevents a certain kind of antag-rolling abuse.

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -241,7 +241,7 @@ SUBSYSTEM_DEF(job)
 
 	//Get the players who are ready
 	for(var/mob/dead/new_player/player in GLOB.player_list)
-		if(player.ready == PLAYER_READY_TO_PLAY && player.mind && !player.mind.assigned_role)
+		if(player.ready == PLAYER_READY_TO_PLAY && player.has_valid_preferences() && player.mind && !player.mind.assigned_role)
 			unassigned += player
 
 	initial_players_to_assign = unassigned.len

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -364,7 +364,7 @@
 	if(M.client.prefs.be_special.len > 0)
 		has_antags = TRUE
 	if(M.client.prefs.job_preferences.len == 0)
-		to_chat(M, "<span class='danger'>You have no jobs enabled, along with return to lobby if job is unavailible. This makes you inelligible for any round start role, please update your job preferences.</span>")
+		to_chat(M, "<span class='danger'>You have no jobs enabled, along with return to lobby if job is unavailable. This makes you ineligible for any round start role, please update your job preferences.</span>")
 		if(has_antags)
 			log_admin("[M.ckey] just got booted back to lobby with no jobs, but antags enabled.")
 			message_admins("[M.ckey] just got booted back to lobby with no jobs enabled, but antag rolling enabled. Likely antag rolling abuse.")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -383,7 +383,7 @@
 				break
 			if(level > JP_LOW)
 				only_low_jobs = FALSE
-		if(!has_high_job)
+		if(!has_high_job) //Having a high job means they meet none of the potential suspicious setups
 			var/list/suspicious_conds = list()
 			if(M.client.prefs.job_preferences.len == 1) //If they only have one job enabled and it's not set to high, this is unusual
 				suspicious_conds += "one job enabled but it isn't high"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -369,29 +369,6 @@
 			log_admin("[M.ckey] just got booted back to lobby with no jobs, but antags enabled.")
 			message_admins("[M.ckey] just got booted back to lobby with no jobs enabled, but antag rolling enabled. Likely antag rolling abuse.")
 		return FALSE //This is the only case someone should actually be completely blocked from antag rolling as well
-	// If they're antag rolling, make sure they have a bit more strict of things going on.
-	// These don't necessarily mean they're trying to cheat the system, but it's an indicator they might be
-	// So just notify the admins and let them deal with it.
-	if(has_antags)
-		var/only_low_jobs = TRUE
-		var/has_high_job = FALSE
-		for(var/job in M.client.prefs.job_preferences)
-			var/level = M.client.prefs.job_preferences[job]
-			if(level == JP_HIGH)
-				has_high_job = TRUE
-				only_low_jobs = FALSE
-				break
-			if(level > JP_LOW)
-				only_low_jobs = FALSE
-		if(!has_high_job) //Having a high job means they meet none of the potential suspicious setups
-			var/list/suspicious_conds = list()
-			if(M.client.prefs.job_preferences.len == 1) //If they only have one job enabled and it's not set to high, this is unusual
-				suspicious_conds += "one job enabled but it isn't high"
-			if(only_low_jobs) //As well as if they only have jobs set to low
-				suspicious_conds += "only has jobs set to low"
-			if(suspicious_conds.len > 0)
-				log_admin("[M.ckey] has suspicious job preferences; back to lobby if job unavailible, has antags enabled, and jobs fit these conditions: [suspicious_conds.Join(", ")]")
-				message_admins("[M.ckey] has suspicious job preferences; back to lobby if job unavailible, has antags enabled, and jobs fit these conditions: [suspicious_conds.Join(", ")]")
 	return TRUE
 
 /datum/game_mode/proc/get_players_for_role(role)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -351,26 +351,6 @@
 	WARNING("Something has gone terribly wrong. /datum/game_mode/proc/antag_pick failed to select a candidate. Falling back to pick()")
 	return pick(candidates)
 
-// Used to make sure that a player has a valid job preference setup before trying to put them to any role.
-// A "valid job preference setup" in this situation means at least having one job set to low, or not having "return to lobby" enabled
-// Prevents "antag rolling" by setting antag prefs on, all jobs to never, and "return to lobby if preferences not availible"
-// Doing so would previously allow you to roll for antag, then send you back to lobby if you didn't get an antag role
-// This also does some admin notification and logging as well
-/datum/game_mode/proc/has_valid_preferences(var/mob/M)
-	if(M.client.prefs.joblessrole != RETURNTOLOBBY)
-		return TRUE
-	// If they have antags enabled, they're potentially doing this on purpose instead of by accident. Notify admins if so.
-	var/has_antags = FALSE
-	if(M.client.prefs.be_special.len > 0)
-		has_antags = TRUE
-	if(M.client.prefs.job_preferences.len == 0)
-		to_chat(M, "<span class='danger'>You have no jobs enabled, along with return to lobby if job is unavailable. This makes you ineligible for any round start role, please update your job preferences.</span>")
-		if(has_antags)
-			log_admin("[M.ckey] just got booted back to lobby with no jobs, but antags enabled.")
-			message_admins("[M.ckey] just got booted back to lobby with no jobs enabled, but antag rolling enabled. Likely antag rolling abuse.")
-		return FALSE //This is the only case someone should actually be completely blocked from antag rolling as well
-	return TRUE
-
 /datum/game_mode/proc/get_players_for_role(role)
 	var/list/players = list()
 	var/list/candidates = list()
@@ -379,7 +359,7 @@
 
 	// Ultimate randomizing code right here
 	for(var/mob/dead/new_player/player in GLOB.player_list)
-		if(player.client && player.ready == PLAYER_READY_TO_PLAY && has_valid_preferences(player))
+		if(player.client && player.ready == PLAYER_READY_TO_PLAY && player.has_valid_preferences())
 			players += player
 
 	// Shuffling, the players list is now ping-independent!!!

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -498,3 +498,25 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 	if(HAS_TRAIT(src, TRAIT_DISSECTED))
 		. += "<span class='notice'>This body has been dissected and analyzed. It is no longer worth experimenting on.</span><br>"
+
+// Used to make sure that a player has a valid job preference setup, used to knock players out of eligibility for anything if their prefs don't make sense.
+// A "valid job preference setup" in this situation means at least having one job set to low, or not having "return to lobby" enabled
+// Prevents "antag rolling" by setting antag prefs on, all jobs to never, and "return to lobby if preferences not availible"
+// Doing so would previously allow you to roll for antag, then send you back to lobby if you didn't get an antag role
+// This also does some admin notification and logging as well
+/mob/proc/has_valid_preferences()
+	if(!client)
+		return FALSE //Not sure how this would get run without the mob having a client, but let's just be safe.
+	if(client.prefs.joblessrole != RETURNTOLOBBY)
+		return TRUE
+	// If they have antags enabled, they're potentially doing this on purpose instead of by accident. Notify admins if so.
+	var/has_antags = FALSE
+	if(client.prefs.be_special.len > 0)
+		has_antags = TRUE
+	if(client.prefs.job_preferences.len == 0)
+		to_chat(src, "<span class='danger'>You have no jobs enabled, along with return to lobby if job is unavailable. This makes you ineligible for any round start role, please update your job preferences.</span>")
+		if(has_antags)
+			log_admin("[src.ckey] just got booted back to lobby with no jobs, but antags enabled.")
+			message_admins("[src.ckey] just got booted back to lobby with no jobs enabled, but antag rolling enabled. Likely antag rolling abuse.")
+		return FALSE //This is the only case someone should actually be completely blocked from antag rolling as well
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently there's a very easy way of making it so that if you don't roll antag, you aren't playing the game and can just go observe and hope for ghostroles.
Have every job set to never, have return back to lobby if preference unavailable set, and antags enabled.
if you roll antag, you get a job or the antag, if you don't, back to lobby.
If you think this is a good idea and go do this, know it's against the rules and if you get caught you'll be banned.

What this PR does is validate that you have at least one job enabled before ever even adding you to the pool of potential players, if you have "return to lobby" set. If this happens, you'll get a notification and an admin will be notified if you also had antags on.
Either of the other "my pref was unavailable options" you can have all jobs set to never just like before and you'll get your random role.

## Why It's Good For The Game
Prevents some abuse that can easily be closed on the game code end.

## Changelog
Not going to CL this one so people abusing it get a fun surprise.
