### PR TITLE
[WIP NOT EVEN CLOSE TO DONE] Lavaland restat

### DIFF
--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -8,7 +8,7 @@
 
 	faction = list("mining")
 	max_mobs = 3
-	max_integrity = 250
+	max_integrity = 135
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/tendril)
 
 	move_resist=INFINITY // just killing it tears a massive hole in the ground, let's not move it
@@ -46,7 +46,7 @@ GLOBAL_LIST_INIT(tendrils, list())
 	var/last_tendril = TRUE
 	if(GLOB.tendrils.len>1)
 		last_tendril = FALSE
-	
+
 	if(last_tendril && !(flags_1 & ADMIN_SPAWNED_1))
 		if(SSmedals.hub_enabled)
 			for(var/mob/living/L in view(7,src))

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -69,6 +69,8 @@
 	icon_dead = "watcher_dead"
 	pixel_x = -10
 	throw_message = "bounces harmlessly off of"
+	maxHealth = 115
+	health = 115
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	attacktext = "impales"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -17,8 +17,8 @@
 	speak_emote = list("bellows")
 	vision_range = 4
 	speed = 3
-	maxHealth = 300
-	health = 300
+	maxHealth = 135
+	health = 135
 	harm_intent_damage = 0
 	obj_damage = 100
 	melee_damage_lower = 25
@@ -112,8 +112,8 @@
 	icon_living = "Goliath"
 	icon_aggro = "Goliath_alert"
 	icon_dead = "Goliath_dead"
-	maxHealth = 400
-	health = 400
+	maxHealth = 215
+	health = 215
 	speed = 4
 	pre_attack_icon = "Goliath_preattack"
 	throw_message = "does nothing to the rocky hide of the"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -101,6 +101,8 @@
 	mob_biotypes = list(MOB_ORGANIC, MOB_HUMANOID)
 	mouse_opacity = MOUSE_OPACITY_ICON
 	obj_damage = 60
+	maxHealth = 45
+	health = 45
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	attacktext = "lashes out at"
@@ -129,8 +131,8 @@
 	icon_living = "dwarf_legion"
 	icon_aggro = "dwarf_legion"
 	icon_dead = "dwarf_legion"
-	maxHealth = 60
-	health = 60
+	maxHealth = 30
+	health = 30
 	speed = 2 //faster!
 	crusher_drop_mod = 20
 	dwarf_mob = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -37,13 +37,13 @@
 		return
 	icon_state = icon_living
 
-//mob/living/simple_animal/hostile/asteroid/bullet_act(obj/item/projectile/P)//Reduces damage from most projectiles to curb off-screen kills
-//	if(!stat)
-//		Aggro()
-//	if(P.damage < 30 && P.damage_type != BRUTE)
-//		P.damage = (P.damage / 3)
-//		visible_message("<span class='danger'>[P] has a reduced effect on [src]!</span>")
-//	..()
+/mob/living/simple_animal/hostile/asteroid/bullet_act(obj/item/projectile/P)//Reduces damage from most projectiles to curb off-screen kills
+	if(!stat)
+		Aggro()
+	if(P.damage < 30 && P.damage_type != BRUTE)
+		P.damage = (P.damage / 3)
+		visible_message("<span class='danger'>[P] has a reduced effect on [src]!</span>")
+	..()
 
 /mob/living/simple_animal/hostile/asteroid/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum) //No floor tiling them to death, wiseguy
 	if(istype(AM, /obj/item))

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -37,13 +37,13 @@
 		return
 	icon_state = icon_living
 
-/mob/living/simple_animal/hostile/asteroid/bullet_act(obj/item/projectile/P)//Reduces damage from most projectiles to curb off-screen kills
-	if(!stat)
-		Aggro()
-	if(P.damage < 30 && P.damage_type != BRUTE)
-		P.damage = (P.damage / 3)
-		visible_message("<span class='danger'>[P] has a reduced effect on [src]!</span>")
-	..()
+//mob/living/simple_animal/hostile/asteroid/bullet_act(obj/item/projectile/P)//Reduces damage from most projectiles to curb off-screen kills
+//	if(!stat)
+//		Aggro()
+//	if(P.damage < 30 && P.damage_type != BRUTE)
+//		P.damage = (P.damage / 3)
+//		visible_message("<span class='danger'>[P] has a reduced effect on [src]!</span>")
+//	..()
 
 /mob/living/simple_animal/hostile/asteroid/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum) //No floor tiling them to death, wiseguy
 	if(istype(AM, /obj/item))

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/energy/kinetic_accelerator
 	name = "proto-kinetic accelerator"
-	desc = "A self recharging, ranged mining tool that does increased damage in low pressure."
+	desc = "A self recharging, ranged mining tool."
 	icon_state = "kineticgun"
 	item_state = "kineticgun"
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic)
@@ -167,14 +167,13 @@
 /obj/item/projectile/kinetic
 	name = "kinetic force"
 	icon_state = null
-	damage = 40
+	damage = 15
 	damage_type = BRUTE
-	flag = "bomb"
 	range = 3
 	log_override = TRUE
 
-	var/pressure_decrease_active = FALSE
-	var/pressure_decrease = 0.25
+	//var/pressure_decrease_active = FALSE
+	//var/pressure_decrease = 0.25
 	var/obj/item/gun/energy/kinetic_accelerator/kinetic_gun
 
 /obj/item/projectile/kinetic/Destroy()
@@ -188,10 +187,10 @@
 			var/list/mods = kinetic_gun.get_modkits()
 			for(var/obj/item/borg/upgrade/modkit/M in mods)
 				M.projectile_prehit(src, target, kinetic_gun)
-		if(!lavaland_equipment_pressure_check(get_turf(target)))
-			name = "weakened [name]"
-			damage = damage * pressure_decrease
-			pressure_decrease_active = TRUE
+		//if(!lavaland_equipment_pressure_check(get_turf(target)))
+			//name = "weakened [name]"
+			//damage = damage * pressure_decrease
+			//pressure_decrease_active = TRUE
 
 /obj/item/projectile/kinetic/on_range()
 	strike_thing()
@@ -317,7 +316,7 @@
 /obj/item/borg/upgrade/modkit/damage
 	name = "damage increase"
 	desc = "Increases the damage of kinetic accelerator when installed."
-	modifier = 10
+	modifier = 4
 
 /obj/item/borg/upgrade/modkit/damage/modify_projectile(obj/item/projectile/kinetic/K)
 	K.damage += modifier
@@ -493,8 +492,8 @@
 		var/mob/living/L = target
 		if(bounties_reaped[L.type])
 			var/kill_modifier = 1
-			if(K.pressure_decrease_active)
-				kill_modifier *= K.pressure_decrease
+			//if(K.pressure_decrease_active)
+				//kill_modifier *= K.pressure_decrease
 			var/armor = L.run_armor_check(K.def_zone, K.flag, "", "", K.armour_penetration)
 			L.apply_damage(bounties_reaped[L.type]*kill_modifier, K.damage_type, K.def_zone, armor)
 
@@ -508,16 +507,16 @@
 		bounties_reaped[L.type] = min(bounties_reaped[L.type] + (modifier * bonus_mod), maximum_bounty)
 
 //Indoors
-/obj/item/borg/upgrade/modkit/indoors
-	name = "decrease pressure penalty"
-	desc = "A syndicate modification kit that increases the damage a kinetic accelerator does in high pressure environments."
-	modifier = 2
-	denied_type = /obj/item/borg/upgrade/modkit/indoors
-	maximum_of_type = 2
-	cost = 35
+//obj/item/borg/upgrade/modkit/indoors
+//	name = "decrease pressure penalty"
+//	desc = "A syndicate modification kit that increases the damage a kinetic accelerator does in high pressure environments."
+//	modifier = 2
+//	denied_type = /obj/item/borg/upgrade/modkit/indoors
+//	maximum_of_type = 2
+//	cost = 35
 
-/obj/item/borg/upgrade/modkit/indoors/modify_projectile(obj/item/projectile/kinetic/K)
-	K.pressure_decrease *= modifier
+//obj/item/borg/upgrade/modkit/indoors/modify_projectile(obj/item/projectile/kinetic/K)
+//	K.pressure_decrease *= modifier
 
 
 //Trigger Guard

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1680,7 +1680,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 //datum/uplink_item/role_restricted/pressure_mod
 //	name = "Kinetic Accelerator Pressure Mod"
 //	desc = "A modification kit which allows Kinetic Accelerators to do greatly increased damage while indoors. \
-			Occupies 35% mod capacity."
+//			Occupies 35% mod capacity."
 //	item = /obj/item/borg/upgrade/modkit/indoors
 //	cost = 5 //you need two for full damage, so total of 10 for maximum damage
 //	limited_stock = 2 //you can't use more than two!

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1677,14 +1677,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	restricted_roles = list("Mime")
 	surplus = 0
 
-/datum/uplink_item/role_restricted/pressure_mod
-	name = "Kinetic Accelerator Pressure Mod"
-	desc = "A modification kit which allows Kinetic Accelerators to do greatly increased damage while indoors. \
+//datum/uplink_item/role_restricted/pressure_mod
+//	name = "Kinetic Accelerator Pressure Mod"
+//	desc = "A modification kit which allows Kinetic Accelerators to do greatly increased damage while indoors. \
 			Occupies 35% mod capacity."
-	item = /obj/item/borg/upgrade/modkit/indoors
-	cost = 5 //you need two for full damage, so total of 10 for maximum damage
-	limited_stock = 2 //you can't use more than two!
-	restricted_roles = list("Shaft Miner")
+//	item = /obj/item/borg/upgrade/modkit/indoors
+//	cost = 5 //you need two for full damage, so total of 10 for maximum damage
+//	limited_stock = 2 //you can't use more than two!
+//	restricted_roles = list("Shaft Miner")
 
 /datum/uplink_item/role_restricted/magillitis_serum
 	name = "Magillitis Serum Autoinjector"


### PR DESCRIPTION
## About The Pull Request

This PR tries to unsnowflake lavaland's balance, ie lasers not doing full damage to fauna, KAs doing more damage in low air, things like that.

## Why It's Good For The Game

Should make lavaland less of a pain to balance

## Changelog
:cl:
balance: Watchers, goliaths, and legions have lower health
balance: KAs now do 15 damage everywhere
balance: KA damage mods now only make KAs do 4 more damage
:cl: 

still needs a lot more things changed but i'm opening it now for feedback, numbers are still in the air so if you have good ideas tell me them, also contains a lot of commented out code for if maintainers want it back.