### PR TITLE
Removes the mutation on_move hook in favor of having chameleon mutation register for a signal

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -97,9 +97,6 @@
 /datum/mutation/human/proc/on_ranged_attack(atom/target)
 	return
 
-/datum/mutation/human/proc/on_move(new_loc)
-	return
-
 /datum/mutation/human/proc/on_life()
 	return
 

--- a/code/datums/mutations/chameleon.dm
+++ b/code/datums/mutations/chameleon.dm
@@ -13,11 +13,12 @@
 	if(..())
 		return
 	owner.alpha = CHAMELEON_MUTATION_DEFAULT_TRANSPARENCY
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, .proc/on_move)
 
 /datum/mutation/human/chameleon/on_life()
 	owner.alpha = max(0, owner.alpha - 25)
 
-/datum/mutation/human/chameleon/on_move()
+/datum/mutation/human/chameleon/proc/on_move()
 	owner.alpha = CHAMELEON_MUTATION_DEFAULT_TRANSPARENCY
 
 /datum/mutation/human/chameleon/on_attack_hand(atom/target, proximity)
@@ -29,3 +30,4 @@
 	if(..())
 		return
 	owner.alpha = 255
+	UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -43,8 +43,6 @@
 
 /mob/living/carbon/human/Move(NewLoc, direct)
 	. = ..()
-	for(var/datum/mutation/human/HM in dna.mutations)
-		HM.on_move(NewLoc)
 
 	if(shoes)
 		if(mobility_flags & MOBILITY_STAND)


### PR DESCRIPTION
## Why It's Good For The Game

This 
```
for(var/datum/mutation/human/HM in dna.mutations)
	HM.on_move(NewLoc)
``` 
pattern is just awful, especially when only one mutation out of all of them implements it.

## Changelog
:cl: Naksu
code: removed /datum/mutation/human/proc/on_move in favor of having the chameleon mutation register for a signal
/:cl:
