### PR TITLE
Crab Protocol Now has Limited Stock

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1424,6 +1424,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/suspiciousphone
 	restricted = TRUE
 	cost = 7
+	limited_stock = 2 
 
 // Implants
 /datum/uplink_item/implants

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1424,7 +1424,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/suspiciousphone
 	restricted = TRUE
 	cost = 7
-	limited_stock = 2 
+	limited_stock = 1
 
 // Implants
 /datum/uplink_item/implants


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can now only buy one crab protocol. 
## Why It's Good For The Game

Spam sucks. Its honestly funny as shit, but each announcement blocks out the screen, and has the most fucking annoying sound. 

## Changelog
:cl: weeweesoda
balance: The CRAB protocol traitor item now has a maximum stock of 1 each round
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
