### PR TITLE
Removes a dead code block from antag selection

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -404,24 +404,6 @@
 		else												// Not enough scrubs, ABORT ABORT ABORT
 			break
 
-	if(restricted_jobs)
-		for(var/datum/mind/player in drafted)				// Remove people who can't be an antagonist
-			for(var/job in restricted_jobs)
-				if(player.assigned_role == job)
-					drafted -= player
-
-	drafted = shuffle(drafted) // Will hopefully increase randomness, Donkie
-
-	while(candidates.len < recommended_enemies)				// Pick randomlly just the number of people we need and add them to our list of candidates
-		if(drafted.len > 0)
-			applicant = pick(drafted)
-			if(applicant)
-				candidates += applicant
-				drafted.Remove(applicant)
-
-		else												// Not enough scrubs, ABORT ABORT ABORT
-			break
-
 	return candidates		// Returns: The number of people who had the antagonist role set to yes, regardless of recomended_enemies, if that number is greater than recommended_enemies
 							//			recommended_enemies if the number of people with that role set to yes is less than recomended_enemies,
 							//			Less if there are not enough valid players in the game entirely to make recommended_enemies.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I just noticed this inexplicable code duplication. Basically the part that pulls "drafted" (players without the antag type enabled but still qualify otherwise) into the candidates list was copypasted twice, but never actually had the drafted pool modified. So if there was enough drafted players to make there be enough candidates, it wouldn't run, and if there wasn't enough, the drafted pool would be empty and it would break out instantly. What the fuck.

Since this requires a decent amount of players to properly test, can't test this myself. However, pretty sure anyone else looking at the code can confirm that this block of code does absolutely nothing.

## Why It's Good For The Game

shitcode removal