### PR TITLE
Removes holoparasite zombie and memento mori memes.

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -132,7 +132,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	med_hud_set_health()
 	med_hud_set_status()
 	if(!QDELETED(summoner))
-		if(summoner.stat == DEAD)
+		if(summoner.stat == DEAD || HAS_TRAIT(summoner, TRAIT_NODEATH) && summoner.health <= HEALTH_THRESHOLD_DEAD)
 			forceMove(summoner.loc)
 			to_chat(src, "<span class='danger'>Your summoner has died!</span>")
 			visible_message("<span class='danger'><B>\The [src] dies along with its user!</B></span>")

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -132,7 +132,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	med_hud_set_health()
 	med_hud_set_status()
 	if(!QDELETED(summoner))
-		if(summoner.stat == DEAD || HAS_TRAIT(summoner, TRAIT_NODEATH) && summoner.health <= HEALTH_THRESHOLD_DEAD)
+		if(summoner.stat == DEAD || summoner.health <= HEALTH_THRESHOLD_DEAD)
 			forceMove(summoner.loc)
 			to_chat(src, "<span class='danger'>Your summoner has died!</span>")
 			visible_message("<span class='danger'><B>\The [src] dies along with its user!</B></span>")


### PR DESCRIPTION
## About The Pull Request

Same spirit as #41505 
Only this time it extends to memento mori and actually fixes the issue at it's core. You could still choose high functioning zombie from the magic mirror.
Basically makes you die of damage as long as you have a guardian even if you have NODEATH. 

## Why It's Good For The Game

Having a guy who can only be killed by gibbing/beheading while being dragged around by an immortal holoparasite that probably murders while you attempt to do it isn't really that fun.

## Changelog
:cl:
tweak: The NODEATH trait no longer prevents you from dyin from to damage if you have a guardian spirit.
/:cl: