### PR TITLE
Makes /datum/pipeline/proc/reconcile_air() 34% faster 

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -851,10 +851,6 @@
 		. = t_air.return_temperature()
 	return
 
-/obj/mecha/portableConnectorReturnAir()
-	return internal_tank.return_air()
-
-
 /obj/mecha/MouseDrop_T(mob/M, mob/user)
 	if((user != M) || user.incapacitated() || !Adjacent(user))
 		return

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -43,7 +43,6 @@
 	. = ..()
 	temperature = initial_temperature
 
-
 //used by space tiles
 /datum/gas_mixture/immutable/space
 	initial_temperature = TCMB

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -42,13 +42,6 @@
 		to_chat(user, "<span class='warning'>You cannot unwrench [src], detach [connected_device] first!</span>")
 		return FALSE
 
-/obj/machinery/atmospherics/components/unary/portables_connector/portableConnectorReturnAir()
-	return connected_device.portableConnectorReturnAir()
-
-/obj/proc/portableConnectorReturnAir()
-	return
-
-
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1
 	piping_layer = 1
 	icon_state = "connector_map-1"

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -218,7 +218,8 @@
 		var/datum/pipeline/P = PL[i]
 		if(!P)
 			continue
-		GL += P.return_air()
+		GL += P.other_airs
+		GL += P.air
 		for(var/atmosmch in P.other_atmosmch)
 			if (istype(atmosmch, /obj/machinery/atmospherics/components/binary/valve))
 				var/obj/machinery/atmospherics/components/binary/valve/V = atmosmch
@@ -228,20 +229,29 @@
 			else if (istype(atmosmch, /obj/machinery/atmospherics/components/unary/portables_connector))
 				var/obj/machinery/atmospherics/components/unary/portables_connector/C = atmosmch
 				if(C.connected_device)
-					GL += C.portableConnectorReturnAir()
+					GL += C.connected_device.air_contents
 
 	var/total_thermal_energy = 0
 	var/total_heat_capacity = 0
 	var/datum/gas_mixture/total_gas_mixture = new(0)
 
+	var/list/total_gases = total_gas_mixture.gases
+
 	for(var/i in GL)
 		var/datum/gas_mixture/G = i
 		total_gas_mixture.volume += G.volume
 
-		total_gas_mixture.merge(G)
+		// This is sort of a combined merge + heat_capacity calculation
+
+		var/list/giver_gases = G.gases
+		//gas transfer
+		for(var/giver_id in giver_gases)
+			var/giver_gas_data = giver_gases[giver_id]
+			ASSERT_GAS(giver_id, total_gas_mixture)
+			total_gases[giver_id][MOLES] += giver_gas_data[MOLES]
+			total_heat_capacity += giver_gas_data[MOLES] * giver_gas_data[GAS_META][META_GAS_SPECIFIC_HEAT]
 
 		total_thermal_energy += THERMAL_ENERGY(G)
-		total_heat_capacity += G.heat_capacity()
 
 	total_gas_mixture.temperature = total_heat_capacity ? total_thermal_energy/total_heat_capacity : 0
 

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -92,9 +92,6 @@
 	update_icon()
 	return TRUE
 
-/obj/machinery/portable_atmospherics/portableConnectorReturnAir()
-	return air_contents
-
 /obj/machinery/portable_atmospherics/AltClick(mob/living/user)
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, !ismonkey(user)))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

gas_mixture/merge(var/giver) calls heat_capacity() on src and giver in order to do temperature calculation, we don't need it here. However since we're doing a loop through the giver gases anyways, we can add these gases' heat capacity to the pipeline total heat capacity, saving us MANY heat_capacity() calls later.

portableConnectorReturnAir() has been removed as it's completely useless.


## Changelog
:cl: Naksu
code: pipeline gas reconciliation is now faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
