### PR TITLE
Fixes a small issue with chem grenades

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -194,6 +194,7 @@
 				O.forceMove(drop_location())
 			beakers = list()
 		stage_change(EMPTY)
+		active = FALSE
 		return
 
 	if(nadeassembly)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can now reuse chemical grenade casings if they fail to react.

## Why It's Good For The Game

Fixes a bug. It used to drop the casing but you couldn't really do anything with it.

## Changelog
:cl:
fix: You can now reuse chemical grenade casings if they fail to react.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
