### PR TITLE
Anatomic Panacea now imparts neurine in addition to other chemicals.

### DIFF
--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -30,6 +30,7 @@
 	user.reagents.add_reagent("pen_acid", 20)
 	user.reagents.add_reagent("antihol", 10)
 	user.reagents.add_reagent("mannitol", 25)
+	user.reagents.add_reagent("neurine", 6)
 
 	if(isliving(user))
 		var/mob/living/L = user

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/panacea
 	name = "Anatomic Panacea"
-	desc = "Expels impurifications from our form; curing diseases, removing parasites, sobering us, purging toxins and radiation, and resetting our genetic code completely. Costs 20 chemicals."
+	desc = "Expels impurifications from our form; curing diseases and minor traumas, removing parasites, sobering us, purging toxins and radiation, and resetting our genetic code completely. Costs 20 chemicals."
 	helptext = "Can be used while unconscious."
 	button_icon_state = "panacea"
 	chemical_cost = 20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Anatomic Panacea now adds neurine in addition to other chemicals, allowing Changelings to cure minor brain traumas with their own abilities. Recovering from traumas with neurine is still RNG-based; the amount chosen is because six units of neurine is the smallest whole number value that affords a >90% chance of curing a minor trauma.

## Why It's Good For The Game

While Anatomic Panacea is able to heal brain damage from the user, balance changes to changeling abilities are dated and not cognizant of the divide between brain damage and brain traumas. Changelings are meant to be masters of biology, and their brain is vestigial anyway, so it makes no sense that some drugs, a random event, or a really good bonk on the head can permanently inhibit their bodily function.

This change is meant to be more of a quality-of-life and sanity (the ability says it fixes all of my problems, why doesn't it fix my brain?) patch than one that will significantly change interaction balance. As such, major brain traumas are not cured and changelings are still able to be brainwashed via surgery.

## Changelog
:cl:
balance: Changelings can now cure minor brain traumas with Anatomic Panacea.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
