### PR TITLE
Unwraps the atom/movable Move() definition so it's not a duplicate define

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -219,48 +219,36 @@
 
 	if(loc != newloc)
 		if (!(direct & (direct - 1))) //Cardinal move
-			. = FALSE
-			if(!newloc || newloc == loc)
-				return
-
-			if(!direct)
-				direct = get_dir(src, newloc)
-				setDir(direct)
-
-			if(!loc.Exit(src, newloc))
-				return
-
-			if(!newloc.Enter(src, src.loc))
-				return
-
-			if (SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
-				return
-
 			// Past this is the point of no return
-			oldloc = loc
-			var/area/oldarea = get_area(oldloc)
-			var/area/newarea = get_area(newloc)
-			loc = newloc
-			. = TRUE
-			oldloc.Exited(src, newloc)
-			if(oldarea != newarea)
-				oldarea.Exited(src, newloc)
+			if((newloc != loc) && loc.Exit(src, newloc) && newloc.Enter(src, src.loc) && !(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE))
+				if(!direct)
+					direct = get_dir(src, newloc)
+					setDir(direct)
 
-			for(var/i in oldloc)
-				if(i == src) // Multi tile objects
-					continue
-				var/atom/movable/thing = i
-				thing.Uncrossed(src)
+				oldloc = loc
+				var/area/oldarea = get_area(oldloc)
+				var/area/newarea = get_area(newloc)
+				loc = newloc
+				. = TRUE
+				oldloc.Exited(src, newloc)
+				if(oldarea != newarea)
+					oldarea.Exited(src, newloc)
 
-			newloc.Entered(src, oldloc)
-			if(oldarea != newarea)
-				newarea.Entered(src, oldloc)
+				for(var/i in oldloc)
+					if(i == src) // Multi tile objects
+						continue
+					var/atom/movable/thing = i
+					thing.Uncrossed(src)
 
-			for(var/i in loc)
-				if(i == src) // Multi tile objects
-					continue
-				var/atom/movable/thing = i
-				thing.Crossed(src)
+				newloc.Entered(src, oldloc)
+				if(oldarea != newarea)
+					newarea.Entered(src, oldloc)
+
+				for(var/i in loc)
+					if(i == src) // Multi tile objects
+						continue
+					var/atom/movable/thing = i
+					thing.Crossed(src)
 		else //Diagonal move, split it into cardinal moves
 			moving_diagonally = FIRST_DIAG_STEP
 			var/first_step_dir


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Duplicate definitions like this are confusing syntactically and also potentially not optimized out by the compiler. In the case that they aren't, this may make move code a tiny amount faster as well but I don't know how I'd test that effectively.

@ninjanomnom mentioned something a while ago about move code being written the way it is on purpose so he might want to take a look at this.

## Why It's Good For The Game
Cleaner code, potentially better performance.
