### PR TITLE
Fixes charged oil explosion. Reworks burning oil

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -245,8 +245,10 @@ Burning extracts:
 	addtimer(CALLBACK(src, .proc/boom), 50)
 
 /obj/item/slimecross/burning/oil/proc/boom()
-	playsound(get_turf(src), 'sound/effects/explosion2.ogg', 200, 1)
-	for(var/mob/living/M in range(3,get_turf(src)))
+	var/turf/T = get_turf(src)
+	playsound(T, 'sound/effects/explosion2.ogg', 200, 1)
+	for(var/mob/living/M in range(3, T))
+		new /obj/effect/temp_visual/explosion(get_turf(M))
 		M.ex_act(EXPLODE_HEAVY)
 	qdel(src)
 

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -247,7 +247,7 @@ Burning extracts:
 /obj/item/slimecross/burning/oil/proc/boom()
 	var/turf/T = get_turf(src)
 	playsound(T, 'sound/effects/explosion2.ogg', 200, 1)
-	for(var/mob/living/M in range(3, T))
+	for(var/mob/living/M in range(2, T))
 		new /obj/effect/temp_visual/explosion(get_turf(M))
 		M.ex_act(EXPLODE_HEAVY)
 	qdel(src)

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -247,7 +247,7 @@ Burning extracts:
 /obj/item/slimecross/burning/oil/proc/boom()
 	playsound(get_turf(src), 'sound/effects/explosion2.ogg', 200, 1)
 	for(var/mob/living/M in range(3,get_turf(src)))
-			M.ex_act(EXPLODE_LIGHT)
+		M.ex_act(EXPLODE_HEAVY)
 	qdel(src)
 
 /obj/item/slimecross/burning/black

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -241,11 +241,16 @@ Burning extracts:
 	colour = "oil"
 
 /obj/item/slimecross/burning/oil/do_effect(mob/user)
-	user.visible_message("<span class='danger'>[src] begins to shake with rapidly increasing force!</span>")
+	user.visible_message("<span class='warning'>[user] activates [src]. It's going to explode!</span>", "<span class='danger'>You activate [src]. It crackles in anticipation</span>")
 	addtimer(CALLBACK(src, .proc/boom), 50)
 
 /obj/item/slimecross/burning/oil/proc/boom()
-	explosion(get_turf(src), 2, 4, 4) //Same area as normal oils, but increased high-impact values by one each, then decreased light by 2.
+	user.visible_message("<span class='danger'>[src] creates a powerful shockwave!</span>")
+	playsound(get_turf(src), 'sound/effects/explosion2.ogg', 200, 1)
+	for(var/mob/living/M in range(4,get_turf(user)))
+		if(M != user)
+			M.ex_act(EXPLODE_LIGHT)
+	..()
 	qdel(src)
 
 /obj/item/slimecross/burning/black

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -245,12 +245,9 @@ Burning extracts:
 	addtimer(CALLBACK(src, .proc/boom), 50)
 
 /obj/item/slimecross/burning/oil/proc/boom()
-	user.visible_message("<span class='danger'>[src] creates a powerful shockwave!</span>")
 	playsound(get_turf(src), 'sound/effects/explosion2.ogg', 200, 1)
-	for(var/mob/living/M in range(4,get_turf(user)))
-		if(M != user)
+	for(var/mob/living/M in range(3,get_turf(src)))
 			M.ex_act(EXPLODE_LIGHT)
-	..()
 	qdel(src)
 
 /obj/item/slimecross/burning/black

--- a/code/modules/research/xenobiology/crossbreeding/charged.dm
+++ b/code/modules/research/xenobiology/crossbreeding/charged.dm
@@ -205,7 +205,7 @@ Charged extracts:
 	addtimer(CALLBACK(src, .proc/boom), 50)
 
 /obj/item/slimecross/charged/oil/proc/boom()
-	explosion(get_turf(src), 3, 2, 1) //Much smaller effect than normal oils, but devastatingly strong where it does hit.
+	explosion(get_turf(src), 2, 3, 4) //Much smaller effect than normal oils, but devastatingly strong where it does hit.
 	qdel(src)
 
 /obj/item/slimecross/charged/black


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the charged oil explosion look less stupid. Also slightly nerfs it.

Also reworks how burning oil works. It now call ex_act on nearby mobs when it explodes, damaging mobs but leaving the enviroment unharmed.

## Why It's Good For The Game

I think THIS is ~~unintended~~ **stupid** behaviour
![chargedoil](https://user-images.githubusercontent.com/47324920/58192918-22272080-7cc2-11e9-87f3-d7d619293259.PNG)

Burning oil now steps less on the toes of charged oil.

## Changelog
:cl:
balance: Charged oil explosions now look less stupid and are slightly weaker.
balance: Reworked burning oil. It no longer destroys nearby turfs but still damages mobs.
/:cl: