### PR TITLE
Improves itching and makes itching powder slightly less deadly.

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -177,6 +177,11 @@
 
 /datum/mood_event/sad_empath/add_effects(mob/sadtarget)
 	description = "<span class='warning'>[sadtarget.name] seems upset...</span>\n"
+	
+/datum/mood_event/itching
+	description = "<span class='boldwarning'>I really want to scratch that itch but can't!</span>\n"
+	mood_change = -4
+	timeout = 30 SECONDS
 
 //These are unused so far but I want to remember them to use them later
 /datum/mood_event/cloned_corpse

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -140,7 +140,7 @@
 		/datum/reagent/napalm,\
 		/datum/reagent/firefighting_foam,\
 		/datum/reagent/consumable/mayonnaise,\
-		/datum/reagent/toxin/itching_powder,\
+		/datum/reagent/itching_powder,\
 		/datum/reagent/toxin/cyanide,\
 		/datum/reagent/toxin/heparin,\
 		/datum/reagent/medicine/pen_acid,\

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1868,10 +1868,11 @@
 /datum/reagent/itching_powder/on_mob_life(mob/living/carbon/M)
 	if(prob(30) && M.mobility_flags & MOBILITY_USE)
 		to_chat(M, "You scratch yourself.")
-		M.take_bodypart_damage(0.2 * REM)
+		M.take_bodypart_damage(0.2 * REM, required_status = BODYPART_ORGANIC)
 		. = TRUE
 	else
-		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "itch", /datum/mood_event/itching)	
+		if(!M.IsSleeping())
+			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "itch", /datum/mood_event/itching)	
 	if(prob(3))
 		M.reagents.add_reagent("histamine",rand(1,3))
 		M.reagents.remove_reagent("itching_powder",1.2)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1869,7 +1869,7 @@
 	if(prob(30) && M.mobility_flags & MOBILITY_USE)
 		to_chat(M, "You scratch yourself.")
 		M.take_bodypart_damage(0.2 * REM)
-		. = 1
+		. = TRUE
 	else
 		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "itch", /datum/mood_event/itching)	
 	if(prob(3))

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1852,3 +1852,26 @@
 /datum/reagent/tranquility/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
 	if(method==PATCH || method==INGEST || method==INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		L.ForceContractDisease(new /datum/disease/transformation/gondola(), FALSE, TRUE)
+
+/datum/reagent/itching_powder
+	name = "Itching Powder"
+	id = "itching_powder"
+	description = "A powder that induces itching upon contact with the skin. Causes the victim to scratch at their itches and has a very low chance to decay into Histamine."
+	reagent_state = LIQUID
+	color = "#C8C8C8"
+	metabolization_rate = 0.4 * REAGENTS_METABOLISM
+
+/datum/reagent/itching_powder/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
+	if(method == TOUCH || method == VAPOR)
+		M.reagents.add_reagent("itching_powder", reac_volume)
+
+/datum/reagent/itching_powder/on_mob_life(mob/living/carbon/M)
+	if(prob(30) && M.mobility_flags & MOBILITY_USE)
+		to_chat(M, "You scratch yourself.")
+		M.take_bodypart_damage(0.2 * REM)
+	if(prob(3))
+		M.reagents.add_reagent("histamine",rand(1,3))
+		M.reagents.remove_reagent("itching_powder",1.2)
+		return
+	..()
+	

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1869,6 +1869,9 @@
 	if(prob(30) && M.mobility_flags & MOBILITY_USE)
 		to_chat(M, "You scratch yourself.")
 		M.take_bodypart_damage(0.2 * REM)
+		. = 1
+	else
+		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "itch", /datum/mood_event/itching)	
 	if(prob(3))
 		M.reagents.add_reagent("histamine",rand(1,3))
 		M.reagents.remove_reagent("itching_powder",1.2)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -400,9 +400,9 @@
 			if(3)
 				M.emote("sneeze")
 			if(4)
-				if(prob(75))
-					to_chat(M, "You scratch at an itch.")
-					M.adjustBruteLoss(2*REM, 0)
+				if(prob(75) && M.mobility_flags & MOBILITY_USE)
+					to_chat(M, "You scratch yourself violently.")
+					M.take_bodypart_damage(2 * REM)
 					. = 1
 	..()
 
@@ -494,39 +494,6 @@
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	toxpwr = 0.5
 	taste_description = "bad cooking"
-
-/datum/reagent/toxin/itching_powder
-	name = "Itching Powder"
-	id = "itching_powder"
-	description = "A powder that induces itching upon contact with the skin. Causes the victim to scratch at their itches and has a very low chance to decay into Histamine."
-	silent_toxin = TRUE
-	reagent_state = LIQUID
-	color = "#C8C8C8"
-	metabolization_rate = 0.4 * REAGENTS_METABOLISM
-	toxpwr = 0
-
-/datum/reagent/toxin/itching_powder/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
-	if(method == TOUCH || method == VAPOR)
-		M.reagents.add_reagent("itching_powder", reac_volume)
-
-/datum/reagent/toxin/itching_powder/on_mob_life(mob/living/carbon/M)
-	if(prob(15))
-		to_chat(M, "You scratch at your head.")
-		M.adjustBruteLoss(0.2*REM, 0)
-		. = 1
-	if(prob(15))
-		to_chat(M, "You scratch at your leg.")
-		M.adjustBruteLoss(0.2*REM, 0)
-		. = 1
-	if(prob(15))
-		to_chat(M, "You scratch at your arm.")
-		M.adjustBruteLoss(0.2*REM, 0)
-		. = 1
-	if(prob(3))
-		M.reagents.add_reagent("histamine",rand(1,3))
-		M.reagents.remove_reagent("itching_powder",1.2)
-		return
-	..()
 
 /datum/reagent/toxin/initropidril
 	name = "Initropidril"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -403,10 +403,11 @@
 				if(prob(75))
 					if(M.mobility_flags & MOBILITY_USE)
 						to_chat(M, "You scratch yourself violently.")
-						M.take_bodypart_damage(2 * REM)
+						M.take_bodypart_damage(2 * REM, required_status = BODYPART_ORGANIC)
 						. = TRUE
 					else
-						SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "itch", /datum/mood_event/itching)
+						if(!M.IsSleeping())
+							SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "itch", /datum/mood_event/itching)
 	..()
 
 /datum/reagent/toxin/histamine/overdose_process(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -404,7 +404,7 @@
 					if(M.mobility_flags & MOBILITY_USE)
 						to_chat(M, "You scratch yourself violently.")
 						M.take_bodypart_damage(2 * REM)
-						. = 1
+						. = TRUE
 					else
 						SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "itch", /datum/mood_event/itching)
 	..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -400,10 +400,13 @@
 			if(3)
 				M.emote("sneeze")
 			if(4)
-				if(prob(75) && M.mobility_flags & MOBILITY_USE)
-					to_chat(M, "You scratch yourself violently.")
-					M.take_bodypart_damage(2 * REM)
-					. = 1
+				if(prob(75))
+					if(M.mobility_flags & MOBILITY_USE)
+						to_chat(M, "You scratch yourself violently.")
+						M.take_bodypart_damage(2 * REM)
+						. = 1
+					else
+						SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "itch", /datum/mood_event/itching)
 	..()
 
 /datum/reagent/toxin/histamine/overdose_process(mob/living/M)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -601,3 +601,9 @@
 	id = "pax"
 	results = list("pax" = 3)
 	required_reagents  = list("mindbreaker" = 1, "synaptizine" = 1, "water" = 1)
+
+/datum/chemical_reaction/itching_powder
+	name = "Itching Powder"
+	id = "itching_powder"
+	results = list("itching_powder" = 3)
+	required_reagents = list("welding_fuel" = 1, "ammonia" = 1, "charcoal" = 1)

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -20,12 +20,6 @@
 	required_reagents = list("oil" = 1, "ammonia" = 1, "oxygen" = 1)
 	required_temp = 380
 
-/datum/chemical_reaction/itching_powder
-	name = "Itching Powder"
-	id = "itching_powder"
-	results = list("itching_powder" = 3)
-	required_reagents = list("welding_fuel" = 1, "ammonia" = 1, "charcoal" = 1)
-
 /datum/chemical_reaction/facid
 	name = "Fluorosulfuric acid"
 	id = "facid"


### PR DESCRIPTION
## About The Pull Request

Makes itching only damage on bodypart at a time and makes you require the use of your arms to actually itch yourself.

Also makes itching powder not a toxin so it doesn't cause liver failure.

## Why It's Good For The Game

Due to the ease of application, itching powder was one of the easiest ways to cause liver failure in a person. This turns it more into a prank chemical instead of an easy way to murder a guy.

I consider itching only damaging one body part at a time to be a nice flavour change. Handcuffing will also prevent harm from itches. Balance implications of this are minimal, except for that big bad EVIL moodlet you get from failing to scratch yourself.

## Changelog
:cl:
balance: Itching powder is no longer a toxin and will not cause liver failure anymore.
tweak: The itching from itching powder and histamine will now only damages one bodypart at the time. Handcuffs and having no arms will prevent the damage but gives you a new bad moodlet.
/:cl:
