### PR TITLE
Small storage refactor and examine change

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -36,7 +36,7 @@
 #define COMSIG_COMPONENT_REMOVING "component_removing"			//before a component is removed from a datum because of RemoveComponent: (/datum/component)
 #define COMSIG_PARENT_PREQDELETED "parent_preqdeleted"			//before a datum's Destroy() is called: (force), returning a nonzero value will cancel the qdel operation
 #define COMSIG_PARENT_QDELETED "parent_qdeleted"				//after a datum's Destroy() is called: (force, qdel_hint), at this point none of the other components chose to interrupt qdel and Destroy has been called
-#define COMSIG_TOPIC "handle_topic"                             //generic topic handler (/datum/source, href_list)
+#define COMSIG_TOPIC "handle_topic"                             //generic topic handler (usr, href_list)
 
 // /atom signals
 #define COMSIG_PARENT_ATTACKBY "atom_attackby"			        //from base of atom/attackby(): (/obj/item, /mob/living, params)

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -32,6 +32,7 @@
 //////////////////////////////////////////////////////////////////
 
 // /datum signals
+#define COMSIG_TOPIC "handle_topic"                             //generic topic handler (/datum/source, href_list)
 #define COMSIG_COMPONENT_ADDED "component_added"				//when a component is added to a datum: (/datum/component)
 #define COMSIG_COMPONENT_REMOVING "component_removing"			//before a component is removed from a datum because of RemoveComponent: (/datum/component)
 #define COMSIG_PARENT_PREQDELETED "parent_preqdeleted"			//before a datum's Destroy() is called: (force), returning a nonzero value will cancel the qdel operation
@@ -270,7 +271,6 @@
 #define COMSIG_TRY_STORAGE_QUICK_EMPTY "storage_quick_empty"			//(loc) - returns bool - if loc is null it will dump at parent location.
 #define COMSIG_TRY_STORAGE_RETURN_INVENTORY "storage_return_inventory"	//(list/list_to_inject_results_into, recursively_search_inside_storages = TRUE)
 #define COMSIG_TRY_STORAGE_CAN_INSERT "storage_can_equip"				//(obj/item/insertion_candidate, mob/user, silent) - returns bool
-#define COMSIG_SHOW_ALLOWED "storage_show_allowed_items"            	//(/obj/item/clothing/, usr) - returns bool
 
 // /datum/action signals
 #define COMSIG_ACTION_TRIGGER "action_trigger"						//from base of datum/action/proc/Trigger(): (datum/action)

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -32,11 +32,11 @@
 //////////////////////////////////////////////////////////////////
 
 // /datum signals
-#define COMSIG_TOPIC "handle_topic"                             //generic topic handler (/datum/source, href_list)
 #define COMSIG_COMPONENT_ADDED "component_added"				//when a component is added to a datum: (/datum/component)
 #define COMSIG_COMPONENT_REMOVING "component_removing"			//before a component is removed from a datum because of RemoveComponent: (/datum/component)
 #define COMSIG_PARENT_PREQDELETED "parent_preqdeleted"			//before a datum's Destroy() is called: (force), returning a nonzero value will cancel the qdel operation
 #define COMSIG_PARENT_QDELETED "parent_qdeleted"				//after a datum's Destroy() is called: (force, qdel_hint), at this point none of the other components chose to interrupt qdel and Destroy has been called
+#define COMSIG_TOPIC "handle_topic"                             //generic topic handler (/datum/source, href_list)
 
 // /atom signals
 #define COMSIG_PARENT_ATTACKBY "atom_attackby"			        //from base of atom/attackby(): (/obj/item, /mob/living, params)

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -257,19 +257,20 @@
 #define COMSIG_NANITE_SYNC "nanite_sync"						//(datum/component/nanites, full_overwrite, copy_activation) Called to sync the target's nanites to a given nanite component
 
 // /datum/component/storage signals
-#define COMSIG_CONTAINS_STORAGE "is_storage"						//() - returns bool.
-#define COMSIG_TRY_STORAGE_INSERT "storage_try_insert"				//(obj/item/inserting, mob/user, silent, force) - returns bool
-#define COMSIG_TRY_STORAGE_SHOW "storage_show_to"					//(mob/show_to, force) - returns bool.
-#define COMSIG_TRY_STORAGE_HIDE_FROM "storage_hide_from"			//(mob/hide_from) - returns bool
-#define COMSIG_TRY_STORAGE_HIDE_ALL "storage_hide_all"				//returns bool
-#define COMSIG_TRY_STORAGE_SET_LOCKSTATE "storage_lock_set_state"	//(newstate)
-#define COMSIG_IS_STORAGE_LOCKED "storage_get_lockstate"			//() - returns bool. MUST CHECK IF STORAGE IS THERE FIRST!
-#define COMSIG_TRY_STORAGE_TAKE_TYPE "storage_take_type"			//(type, atom/destination, amount = INFINITY, check_adjacent, force, mob/user, list/inserted) - returns bool - type can be a list of types.
-#define COMSIG_TRY_STORAGE_FILL_TYPE "storage_fill_type"			//(type, amount = INFINITY, force = FALSE)			//don't fuck this up. Force will ignore max_items, and amount is normally clamped to max_items.
-#define COMSIG_TRY_STORAGE_TAKE "storage_take_obj"					//(obj, new_loc, force = FALSE) - returns bool
-#define COMSIG_TRY_STORAGE_QUICK_EMPTY "storage_quick_empty"		//(loc) - returns bool - if loc is null it will dump at parent location.
+#define COMSIG_CONTAINS_STORAGE "is_storage"							//() - returns bool.
+#define COMSIG_TRY_STORAGE_INSERT "storage_try_insert"					//(obj/item/inserting, mob/user, silent, force) - returns bool
+#define COMSIG_TRY_STORAGE_SHOW "storage_show_to"						//(mob/show_to, force) - returns bool.
+#define COMSIG_TRY_STORAGE_HIDE_FROM "storage_hide_from"				//(mob/hide_from) - returns bool
+#define COMSIG_TRY_STORAGE_HIDE_ALL "storage_hide_all"					//returns bool
+#define COMSIG_TRY_STORAGE_SET_LOCKSTATE "storage_lock_set_state"		//(newstate)
+#define COMSIG_IS_STORAGE_LOCKED "storage_get_lockstate"				//() - returns bool. MUST CHECK IF STORAGE IS THERE FIRST!
+#define COMSIG_TRY_STORAGE_TAKE_TYPE "storage_take_type"				//(type, atom/destination, amount = INFINITY, check_adjacent, force, mob/user, list/inserted) - returns bool - type can be a list of types.
+#define COMSIG_TRY_STORAGE_FILL_TYPE "storage_fill_type"				//(type, amount = INFINITY, force = FALSE)			//don't fuck this up. Force will ignore max_items, and amount is normally clamped to max_items.
+#define COMSIG_TRY_STORAGE_TAKE "storage_take_obj"						//(obj, new_loc, force = FALSE) - returns bool
+#define COMSIG_TRY_STORAGE_QUICK_EMPTY "storage_quick_empty"			//(loc) - returns bool - if loc is null it will dump at parent location.
 #define COMSIG_TRY_STORAGE_RETURN_INVENTORY "storage_return_inventory"	//(list/list_to_inject_results_into, recursively_search_inside_storages = TRUE)
-#define COMSIG_TRY_STORAGE_CAN_INSERT "storage_can_equip"			//(obj/item/insertion_candidate, mob/user, silent) - returns bool
+#define COMSIG_TRY_STORAGE_CAN_INSERT "storage_can_equip"				//(obj/item/insertion_candidate, mob/user, silent) - returns bool
+#define COMSIG_SHOW_ALLOWED "storage_show_allowed_items"            	//(/obj/item/clothing/, usr) - returns bool
 
 // /datum/action signals
 #define COMSIG_ACTION_TRIGGER "action_trigger"						//from base of datum/action/proc/Trigger(): (datum/action)

--- a/code/datums/components/storage/concrete/implant.dm
+++ b/code/datums/components/storage/concrete/implant.dm
@@ -9,7 +9,7 @@
 
 /datum/component/storage/concrete/implant/Initialize()
 	. = ..()
-	cant_hold = typecacheof(list(/obj/item/disk/nuclear))
+	cant_hold = list(/obj/item/disk/nuclear)
 
 /datum/component/storage/concrete/implant/InheritComponent(datum/component/storage/concrete/implant/I, original)
 	if(!istype(I))

--- a/code/datums/components/storage/concrete/implant.dm
+++ b/code/datums/components/storage/concrete/implant.dm
@@ -9,7 +9,7 @@
 
 /datum/component/storage/concrete/implant/Initialize()
 	. = ..()
-	cant_hold = list(/obj/item/disk/nuclear)
+	set_holdable(null, list(/obj/item/disk/nuclear))
 
 /datum/component/storage/concrete/implant/InheritComponent(datum/component/storage/concrete/implant/I, original)
 	if(!istype(I))

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -43,24 +43,26 @@
 
 /datum/component/storage/concrete/pockets/shoes/Initialize()
 	. = ..()
-	cant_hold = list(/obj/item/screwdriver/power) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
-	can_hold = list(
+	set_holdable(list(
 		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
 		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
 		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
 		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
 		/obj/item/firing_pin
+		),
+		list(/obj/item/screwdriver/power)
 		)
 
 /datum/component/storage/concrete/pockets/shoes/clown/Initialize()
 	. = ..()
-	cant_hold = list(/obj/item/screwdriver/power) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
-	can_hold = list(
+	set_holdable(list(
 		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
 		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
 		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
 		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/firing_pin, /obj/item/bikehorn)
+		/obj/item/firing_pin, /obj/item/bikehorn),
+		list(/obj/item/screwdriver/power)
+		)
 
 /datum/component/storage/concrete/pockets/pocketprotector
 	max_items = 3
@@ -70,12 +72,13 @@
 /datum/component/storage/concrete/pockets/pocketprotector/Initialize()
 	original_parent = parent
 	. = ..()
-	can_hold = list( //Same items as a PDA
+	set_holdable(list( //Same items as a PDA
 		/obj/item/pen,
 		/obj/item/toy/crayon,
 		/obj/item/lipstick,
 		/obj/item/flashlight/pen,
 		/obj/item/clothing/mask/cigarette)
+		)
 
 /datum/component/storage/concrete/pockets/pocketprotector/real_location()
 	// if the component is reparented to a jumpsuit, the items still go in the protector
@@ -87,5 +90,5 @@
 
 /datum/component/storage/concrete/pockets/small/helmet/Initialize()
 	. = ..()
-	can_hold = list(/obj/item/reagent_containers/glass/bottle,
-								/obj/item/ammo_box/a762)
+	set_holdable(list(/obj/item/reagent_containers/glass/bottle,
+								/obj/item/ammo_box/a762))

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -43,7 +43,7 @@
 
 /datum/component/storage/concrete/pockets/shoes/Initialize()
 	. = ..()
-	cant_hold = typecacheof(list(/obj/item/screwdriver/power)) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
+	cant_hold = list(/obj/item/screwdriver/power) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
 	can_hold = list(
 		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
 		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
@@ -54,7 +54,7 @@
 
 /datum/component/storage/concrete/pockets/shoes/clown/Initialize()
 	. = ..()
-	cant_hold = typecacheof(list(/obj/item/screwdriver/power)) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
+	cant_hold = list(/obj/item/screwdriver/power) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
 	can_hold = list(
 		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
 		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -44,23 +44,23 @@
 /datum/component/storage/concrete/pockets/shoes/Initialize()
 	. = ..()
 	cant_hold = typecacheof(list(/obj/item/screwdriver/power)) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
-	can_hold = typecacheof(list(
+	can_hold = list(
 		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
 		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
 		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
 		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
 		/obj/item/firing_pin
-		))
+		)
 
 /datum/component/storage/concrete/pockets/shoes/clown/Initialize()
 	. = ..()
 	cant_hold = typecacheof(list(/obj/item/screwdriver/power)) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
-	can_hold = typecacheof(list(
+	can_hold = list(
 		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
 		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
 		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
 		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/firing_pin, /obj/item/bikehorn))
+		/obj/item/firing_pin, /obj/item/bikehorn)
 
 /datum/component/storage/concrete/pockets/pocketprotector
 	max_items = 3
@@ -70,12 +70,12 @@
 /datum/component/storage/concrete/pockets/pocketprotector/Initialize()
 	original_parent = parent
 	. = ..()
-	can_hold = typecacheof(list( //Same items as a PDA
+	can_hold = list( //Same items as a PDA
 		/obj/item/pen,
 		/obj/item/toy/crayon,
 		/obj/item/lipstick,
 		/obj/item/flashlight/pen,
-		/obj/item/clothing/mask/cigarette))
+		/obj/item/clothing/mask/cigarette)
 
 /datum/component/storage/concrete/pockets/pocketprotector/real_location()
 	// if the component is reparented to a jumpsuit, the items still go in the protector
@@ -87,5 +87,5 @@
 
 /datum/component/storage/concrete/pockets/small/helmet/Initialize()
 	. = ..()
-	can_hold = typecacheof(list(/obj/item/reagent_containers/glass/bottle,
-								/obj/item/ammo_box/a762))
+	can_hold = list(/obj/item/reagent_containers/glass/bottle,
+								/obj/item/ammo_box/a762)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -569,6 +569,7 @@
 			to_chat(M, "<span class='warning'>[host] is full, make some space!</span>")
 		return FALSE //Storage item is full
 	if(length(can_hold))
+		can_hold = typecacheof(can_hold)
 		if(!is_type_in_typecache(I, can_hold))
 			if(!stop_messages)
 				to_chat(M, "<span class='warning'>[host] cannot hold [I]!</span>")

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -551,6 +551,8 @@
 //This proc return 1 if the item can be picked up and 0 if it can't.
 //Set the stop_messages to stop it from printing messages
 /datum/component/storage/proc/can_be_inserted(obj/item/I, stop_messages = FALSE, mob/M)
+	can_hold = typecacheof(can_hold)
+	cant_hold = typecacheof(cant_hold)
 	if(!istype(I) || (I.item_flags & ABSTRACT))
 		return FALSE //Not an item
 	if(I == parent)
@@ -569,7 +571,6 @@
 			to_chat(M, "<span class='warning'>[host] is full, make some space!</span>")
 		return FALSE //Storage item is full
 	if(length(can_hold))
-		can_hold = typecacheof(can_hold)
 		if(!is_type_in_typecache(I, can_hold))
 			if(!stop_messages)
 				to_chat(M, "<span class='warning'>[host] cannot hold [I]!</span>")

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -18,9 +18,6 @@
 	var/list/cant_hold								//if this is set, items, and their children, won't fit
 	var/list/exception_hold                         //if set, these items will be the exception to the max size of object that can fit.
 
-	var/static/list/can_hold_full							//will be populated by the typecache of all items added to can_hold
-	var/static/list/cant_hold_full							//will be populated by the typecache of all items added to cant_hold
-
 	var/list/mob/is_using							//lazy list of mobs looking at the contents of this storage.
 
 	var/locked = FALSE								//when locked nothing can see inside or use it.
@@ -507,7 +504,7 @@
 	interface |= return_inv(recursive)
 	return TRUE
 
-/datum/component/storage/proc/topic_handle(datum/source, href_list, user)
+/datum/component/storage/proc/topic_handle(datum/source, user, href_list)
 	if(href_list["show_valid_pocket_items"])
 		handle_show_valid_items(source, user)
 
@@ -567,8 +564,8 @@
 //This proc return 1 if the item can be picked up and 0 if it can't.
 //Set the stop_messages to stop it from printing messages
 /datum/component/storage/proc/can_be_inserted(obj/item/I, stop_messages = FALSE, mob/M)
-	can_hold_full = typecacheof(can_hold)
-	cant_hold_full = typecacheof(cant_hold)
+	can_hold = typecacheof(can_hold)
+	cant_hold = typecacheof(cant_hold)
 
 	if(!istype(I) || (I.item_flags & ABSTRACT))
 		return FALSE //Not an item
@@ -588,11 +585,11 @@
 			to_chat(M, "<span class='warning'>[host] is full, make some space!</span>")
 		return FALSE //Storage item is full
 	if(length(can_hold))
-		if(!is_type_in_typecache(I, can_hold_full))
+		if(!is_type_in_typecache(I, can_hold))
 			if(!stop_messages)
 				to_chat(M, "<span class='warning'>[host] cannot hold [I]!</span>")
 			return FALSE
-	if(is_type_in_typecache(I, cant_hold_full)) //Check for specific items which this container can't hold.
+	if(is_type_in_typecache(I, cant_hold)) //Check for specific items which this container can't hold.
 		if(!stop_messages)
 			to_chat(M, "<span class='warning'>[host] cannot hold [I]!</span>")
 		return FALSE

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -18,8 +18,8 @@
 	var/list/cant_hold								//if this is set, items, and their children, won't fit
 	var/list/exception_hold                         //if set, these items will be the exception to the max size of object that can fit.
 
-	var/list/can_hold_full							//will be populated by the typecache of all items added to can_hold
-	var/list/cant_hold_full							//will be populated by the typecache of all items added to cant_hold
+	var/static/list/can_hold_full							//will be populated by the typecache of all items added to can_hold
+	var/static/list/cant_hold_full							//will be populated by the typecache of all items added to cant_hold
 
 	var/list/mob/is_using							//lazy list of mobs looking at the contents of this storage.
 
@@ -507,16 +507,16 @@
 	interface |= return_inv(recursive)
 	return TRUE
 
-/datum/component/storage/proc/topic_handle(datum/source, href_list)
+/datum/component/storage/proc/topic_handle(datum/source, href_list, user)
 	if(href_list["show_valid_pocket_items"])
-		handle_show_valid_items(source)
+		handle_show_valid_items(source, user)
 
-/datum/component/storage/proc/handle_show_valid_items(datum/source)
-	to_chat(usr, "<span class='notice'>[source] can hold: </span>")
+/datum/component/storage/proc/handle_show_valid_items(datum/source, user)
+	to_chat(user, "<span class='notice'>[source] can hold: </span>")
 
 	for(var/valid_obj in can_hold)
 		var/obj/item/valid_item = new valid_obj()
-		to_chat(usr, "\t <span class='notice'>\a [valid_item.name]</span>")
+		to_chat(user, "\t <span class='notice'>\a [valid_item.name]</span>")
 
 /datum/component/storage/proc/mousedrop_onto(datum/source, atom/over_object, mob/M)
 	set waitfor = FALSE
@@ -569,6 +569,7 @@
 /datum/component/storage/proc/can_be_inserted(obj/item/I, stop_messages = FALSE, mob/M)
 	can_hold_full = typecacheof(can_hold)
 	cant_hold_full = typecacheof(cant_hold)
+
 	if(!istype(I) || (I.item_flags & ABSTRACT))
 		return FALSE //Not an item
 	if(I == parent)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -117,6 +117,21 @@
 /datum/component/storage/PreTransfer()
 	update_actions()
 
+/datum/component/storage/set_holdable(can_hold, cant_hold)
+	can_hold_description = generate_hold_desc()
+
+	can_hold = typecacheof(can_hold)
+	cant_hold = typecacheof(cant_hold)
+
+/datum/component/storage/proc/generate_hold_desc()
+	var/desc = ""
+
+	for(var/valid_obj in can_hold)
+		var/obj/item/valid_item = new valid_obj()
+		desc += "\n\t <span class='notice'>\a [valid_item.name]</span>"
+
+	return desc
+
 /datum/component/storage/proc/update_actions()
 	QDEL_NULL(modeswitch_action)
 	if(!isitem(parent) || !allow_quick_gather)
@@ -510,10 +525,7 @@
 
 /datum/component/storage/proc/handle_show_valid_items(datum/source, user)
 	to_chat(user, "<span class='notice'>[source] can hold: </span>")
-
-	for(var/valid_obj in can_hold)
-		var/obj/item/valid_item = new valid_obj()
-		to_chat(user, "\t <span class='notice'>\a [valid_item.name]</span>")
+	to_chat(user, can_hold_description)
 
 /datum/component/storage/proc/mousedrop_onto(datum/source, atom/over_object, mob/M)
 	set waitfor = FALSE
@@ -564,9 +576,6 @@
 //This proc return 1 if the item can be picked up and 0 if it can't.
 //Set the stop_messages to stop it from printing messages
 /datum/component/storage/proc/can_be_inserted(obj/item/I, stop_messages = FALSE, mob/M)
-	can_hold = typecacheof(can_hold)
-	cant_hold = typecacheof(cant_hold)
-
 	if(!istype(I) || (I.item_flags & ABSTRACT))
 		return FALSE //Not an item
 	if(I == parent)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -122,8 +122,11 @@
 /datum/component/storage/proc/set_holdable(can_hold_list, cant_hold_list)
 	can_hold_description = generate_hold_desc(can_hold_list)
 
-	can_hold = typecacheof(can_hold_list)
-	cant_hold = typecacheof(cant_hold_list)
+	if (can_hold_list != null)
+		can_hold = typecacheof(can_hold_list)
+
+	if (cant_hold_list != null)	
+		cant_hold = typecacheof(cant_hold_list)
 
 /datum/component/storage/proc/generate_hold_desc(can_hold_list)
 	var/list/desc = list()

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -85,7 +85,7 @@
 	RegisterSignal(parent, COMSIG_TRY_STORAGE_HIDE_ALL, .proc/close_all)
 	RegisterSignal(parent, COMSIG_TRY_STORAGE_RETURN_INVENTORY, .proc/signal_return_inv)
 
-	RegisterSignal(parent, COMSIG_SHOW_ALLOWED, .proc/signal_show_allowed)
+	RegisterSignal(parent, COMSIG_TOPIC, .proc/topic_handle)
 
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/attackby)
 
@@ -507,10 +507,14 @@
 	interface |= return_inv(recursive)
 	return TRUE
 
-/datum/component/storage/proc/signal_show_allowed(datum/source, usr)
+/datum/component/storage/proc/topic_handle(datum/source, href_list)
+	if(href_list["show_valid_pocket_items"])
+		handle_show_valid_items(source)
+
+/datum/component/storage/proc/handle_show_valid_items(datum/source)
 	to_chat(usr, "<span class='notice'>[source] can hold: </span>")
 
-	for(var/valid_obj in src.can_hold)
+	for(var/valid_obj in can_hold)
 		var/obj/item/valid_item = new valid_obj()
 		to_chat(usr, "\t <span class='notice'>\a [valid_item.name]</span>")
 

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -16,7 +16,9 @@
 
 	var/list/can_hold								//if this is set, only items, and their children, will fit
 	var/list/cant_hold								//if this is set, items, and their children, won't fit
-	var/list/exception_hold                         //if set, these items will be the exception to the max size of object that can fit.
+	var/list/exception_hold           //if set, these items will be the exception to the max size of object that can fit.
+
+	var/can_hold_description
 
 	var/list/mob/is_using							//lazy list of mobs looking at the contents of this storage.
 
@@ -117,16 +119,16 @@
 /datum/component/storage/PreTransfer()
 	update_actions()
 
-/datum/component/storage/set_holdable(can_hold, cant_hold)
-	can_hold_description = generate_hold_desc()
+/datum/component/storage/proc/set_holdable(can_hold_list, cant_hold_list)
+	can_hold_description = generate_hold_desc(can_hold_list)
 
-	can_hold = typecacheof(can_hold)
-	cant_hold = typecacheof(cant_hold)
+	can_hold = typecacheof(can_hold_list)
+	cant_hold = typecacheof(cant_hold_list)
 
-/datum/component/storage/proc/generate_hold_desc()
+/datum/component/storage/proc/generate_hold_desc(can_hold_list)
 	var/desc = ""
 
-	for(var/valid_obj in can_hold)
+	for(var/valid_obj in can_hold_list)
 		var/obj/item/valid_item = new valid_obj()
 		desc += "\n\t <span class='notice'>\a [valid_item.name]</span>"
 
@@ -524,8 +526,7 @@
 		handle_show_valid_items(source, user)
 
 /datum/component/storage/proc/handle_show_valid_items(datum/source, user)
-	to_chat(user, "<span class='notice'>[source] can hold: </span>")
-	to_chat(user, can_hold_description)
+	to_chat(user, "<span class='notice'>[source] can hold: [can_hold_description]</span>")
 
 /datum/component/storage/proc/mousedrop_onto(datum/source, atom/over_object, mob/M)
 	set waitfor = FALSE

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -126,13 +126,13 @@
 	cant_hold = typecacheof(cant_hold_list)
 
 /datum/component/storage/proc/generate_hold_desc(can_hold_list)
-	var/desc = ""
+	var/list/desc = list()
 
-	for(var/valid_obj in can_hold_list)
-		var/obj/item/valid_item = new valid_obj()
-		desc += "\n\t <span class='notice'>\a [valid_item.name]</span>"
+	for(var/valid_type in can_hold_list)
+		var/obj/item/valid_item = valid_type
+		desc += "\a [initial(valid_item.name)]"
 
-	return desc
+	return "\n\t<span class='notice'>[desc.Join("\n\t")]</span>"
 
 /datum/component/storage/proc/update_actions()
 	QDEL_NULL(modeswitch_action)

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -21,7 +21,7 @@
 
 /datum/Topic(href, href_list[])
 	..()
-	SEND_SIGNAL(src, COMSIG_TOPIC, href_list, usr)
+	SEND_SIGNAL(src, COMSIG_TOPIC, usr, href_list)
 
 // Default implementation of clean-up code.
 // This should be overridden to remove all references pointing to the object being destroyed.

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -21,7 +21,7 @@
 
 /datum/Topic(href, href_list[])
 	..()
-	SEND_SIGNAL(src, COMSIG_TOPIC, href_list)
+	SEND_SIGNAL(src, COMSIG_TOPIC, href_list, usr)
 
 // Default implementation of clean-up code.
 // This should be overridden to remove all references pointing to the object being destroyed.

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -19,6 +19,10 @@
 	var/list/cached_vars
 #endif
 
+/datum/Topic(href, href_list[])
+	..()
+	SEND_SIGNAL(src, COMSIG_TOPIC, href_list)
+
 // Default implementation of clean-up code.
 // This should be overridden to remove all references pointing to the object being destroyed.
 // Return the appropriate QDEL_HINT; in most cases this is QDEL_HINT_QUEUE.

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -507,7 +507,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 7
-	STR.can_hold = list(/obj/item/toy/crayon)
+	STR.set_holdable(list(/obj/item/toy/crayon))
 
 /obj/item/storage/crayons/PopulateContents()
 	new /obj/item/toy/crayon/red(src)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -507,7 +507,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 7
-	STR.can_hold = typecacheof(list(/obj/item/toy/crayon))
+	STR.can_hold = list(/obj/item/toy/crayon)
 
 /obj/item/storage/crayons/PopulateContents()
 	new /obj/item/toy/crayon/red(src)

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -326,9 +326,9 @@
 	STR.max_items = 20
 	STR.max_combined_w_class = 40
 	STR.display_numerical_stacking = TRUE
-	STR.can_hold = typecacheof(list(
+	STR.can_hold = list(
 		/obj/item/throwing_star/magspear
-		))
+		)
 
 /obj/item/storage/backpack/magspear_quiver/PopulateContents()
 	for(var/i in 1 to 20)

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -326,9 +326,9 @@
 	STR.max_items = 20
 	STR.max_combined_w_class = 40
 	STR.display_numerical_stacking = TRUE
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/throwing_star/magspear
-		)
+		))
 
 /obj/item/storage/backpack/magspear_quiver/PopulateContents()
 	for(var/i in 1 to 20)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -305,7 +305,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_combined_w_class = 15
-	STR.cant_hold = list(/obj/item/storage/backpack/satchel/flat) //muh recursive backpacks
+	STR.set_holdable(null, list(/obj/item/storage/backpack/satchel/flat)) //muh recursive backpacks)
 
 /obj/item/storage/backpack/satchel/flat/hide(intact)
 	if(intact)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -305,7 +305,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_combined_w_class = 15
-	STR.cant_hold = typecacheof(list(/obj/item/storage/backpack/satchel/flat)) //muh recursive backpacks
+	STR.cant_hold = list(/obj/item/storage/backpack/satchel/flat) //muh recursive backpacks
 
 /obj/item/storage/backpack/satchel/flat/hide(intact)
 	if(intact)

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -48,7 +48,7 @@
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 	STR.max_combined_w_class = 30
 	STR.max_items = 30
-	STR.cant_hold = typecacheof(list(/obj/item/disk/nuclear))
+	STR.cant_hold = list(/obj/item/disk/nuclear)
 
 /obj/item/storage/bag/trash/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] puts [src] over [user.p_their()] head and starts chomping at the insides! Disgusting!</span>")
@@ -230,7 +230,7 @@
 	GET_COMPONENT(STR, /datum/component/storage/concrete/stack)
 	STR.allow_quick_empty = TRUE
 	STR.can_hold = list(/obj/item/stack/sheet)
-	STR.cant_hold = typecacheof(list(/obj/item/stack/sheet/mineral/sandstone, /obj/item/stack/sheet/mineral/wood))
+	STR.cant_hold = list(/obj/item/stack/sheet/mineral/sandstone, /obj/item/stack/sheet/mineral/wood)
 	STR.max_combined_stack_amount = 300
 
 // -----------------------------

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -110,7 +110,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage/concrete/stack)
 	STR.allow_quick_empty = TRUE
-	STR.can_hold = typecacheof(list(/obj/item/stack/ore))
+	STR.can_hold = list(/obj/item/stack/ore)
 	STR.max_w_class = WEIGHT_CLASS_HUGE
 	STR.max_combined_stack_amount = 50
 
@@ -191,7 +191,7 @@
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = 100
 	STR.max_items = 100
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/grown, /obj/item/seeds, /obj/item/grown, /obj/item/reagent_containers/honeycomb))
+	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/grown, /obj/item/seeds, /obj/item/grown, /obj/item/reagent_containers/honeycomb)
 
 ////////
 
@@ -229,7 +229,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage/concrete/stack)
 	STR.allow_quick_empty = TRUE
-	STR.can_hold = typecacheof(list(/obj/item/stack/sheet))
+	STR.can_hold = list(/obj/item/stack/sheet)
 	STR.cant_hold = typecacheof(list(/obj/item/stack/sheet/mineral/sandstone, /obj/item/stack/sheet/mineral/wood))
 	STR.max_combined_stack_amount = 300
 
@@ -266,7 +266,7 @@
 	STR.max_combined_w_class = 21
 	STR.max_items = 7
 	STR.display_numerical_stacking = FALSE
-	STR.can_hold = typecacheof(list(/obj/item/book, /obj/item/storage/book, /obj/item/spellbook))
+	STR.can_hold = list(/obj/item/book, /obj/item/storage/book, /obj/item/spellbook)
 
 /*
  * Trays - Agouri
@@ -344,7 +344,7 @@
 	STR.max_combined_w_class = 200
 	STR.max_items = 50
 	STR.insert_preposition = "in"
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/pill, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/medspray, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/dropper))
+	STR.can_hold = list(/obj/item/reagent_containers/pill, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/medspray, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/dropper)
 
 /*
  *  Biowaste bag (mostly for xenobiologists)
@@ -364,4 +364,4 @@
 	STR.max_combined_w_class = 200
 	STR.max_items = 25
 	STR.insert_preposition = "in"
-	STR.can_hold = typecacheof(list(/obj/item/slime_extract, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/blood, /obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/food/snacks/deadmouse, /obj/item/reagent_containers/food/snacks/monkeycube))
+	STR.can_hold = list(/obj/item/slime_extract, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/blood, /obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/food/snacks/deadmouse, /obj/item/reagent_containers/food/snacks/monkeycube)

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -48,7 +48,7 @@
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 	STR.max_combined_w_class = 30
 	STR.max_items = 30
-	STR.cant_hold = list(/obj/item/disk/nuclear)
+	STR.set_holdable(null, list(/obj/item/disk/nuclear))
 
 /obj/item/storage/bag/trash/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] puts [src] over [user.p_their()] head and starts chomping at the insides! Disgusting!</span>")
@@ -110,7 +110,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage/concrete/stack)
 	STR.allow_quick_empty = TRUE
-	STR.can_hold = list(/obj/item/stack/ore)
+	STR.set_holdable(list(/obj/item/stack/ore))
 	STR.max_w_class = WEIGHT_CLASS_HUGE
 	STR.max_combined_stack_amount = 50
 
@@ -191,8 +191,7 @@
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = 100
 	STR.max_items = 100
-	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/grown, /obj/item/seeds, /obj/item/grown, /obj/item/reagent_containers/honeycomb)
-
+	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/grown, /obj/item/seeds, /obj/item/grown, /obj/item/reagent_containers/honeycomb))
 ////////
 
 /obj/item/storage/bag/plants/portaseeder
@@ -229,8 +228,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage/concrete/stack)
 	STR.allow_quick_empty = TRUE
-	STR.can_hold = list(/obj/item/stack/sheet)
-	STR.cant_hold = list(/obj/item/stack/sheet/mineral/sandstone, /obj/item/stack/sheet/mineral/wood)
+	STR.set_holdable(list(/obj/item/stack/sheet), list(/obj/item/stack/sheet/mineral/sandstone, /obj/item/stack/sheet/mineral/wood))
 	STR.max_combined_stack_amount = 300
 
 // -----------------------------
@@ -266,7 +264,7 @@
 	STR.max_combined_w_class = 21
 	STR.max_items = 7
 	STR.display_numerical_stacking = FALSE
-	STR.can_hold = list(/obj/item/book, /obj/item/storage/book, /obj/item/spellbook)
+	STR.set_holdable(list(/obj/item/book, /obj/item/storage/book, /obj/item/spellbook))
 
 /*
  * Trays - Agouri
@@ -344,7 +342,7 @@
 	STR.max_combined_w_class = 200
 	STR.max_items = 50
 	STR.insert_preposition = "in"
-	STR.can_hold = list(/obj/item/reagent_containers/pill, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/medspray, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/dropper)
+	STR.set_holdable(list(/obj/item/reagent_containers/pill, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/medspray, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/dropper))
 
 /*
  *  Biowaste bag (mostly for xenobiologists)
@@ -364,4 +362,4 @@
 	STR.max_combined_w_class = 200
 	STR.max_items = 25
 	STR.insert_preposition = "in"
-	STR.can_hold = list(/obj/item/slime_extract, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/blood, /obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/food/snacks/deadmouse, /obj/item/reagent_containers/food/snacks/monkeycube)
+	STR.set_holdable(list(/obj/item/slime_extract, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/blood, /obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/food/snacks/deadmouse, /obj/item/reagent_containers/food/snacks/monkeycube))

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -43,7 +43,7 @@
 /obj/item/storage/belt/utility/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	var/static/list/can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/crowbar,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
@@ -63,8 +63,7 @@
 		/obj/item/forcefield_projector,
 		/obj/item/assembly/signaler,
 		/obj/item/lightreplacer
-		)
-	STR.can_hold = can_hold
+		))
 
 /obj/item/storage/belt/utility/chief
 	name = "\improper Chief Engineer's toolbelt" //"the Chief Engineer's toolbelt", because "Chief Engineer's toolbelt" is not a proper noun
@@ -129,7 +128,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_BULKY
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/healthanalyzer,
 		/obj/item/dnainjector,
 		/obj/item/reagent_containers/dropper,
@@ -176,7 +175,7 @@
 		/obj/item/implanter,
 		/obj/item/pinpointer/crew,
 		/obj/item/holosign_creator/medical
-		)
+		))
 
 /obj/item/storage/belt/security
 	name = "security belt"
@@ -190,7 +189,7 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 5
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/melee/baton,
 		/obj/item/melee/classic_baton,
 		/obj/item/grenade,
@@ -208,7 +207,7 @@
 		/obj/item/clothing/gloves,
 		/obj/item/restraints/legcuffs/bola,
 		/obj/item/holosign_creator/security
-		)
+		))
 
 /obj/item/storage/belt/security/full/PopulateContents()
 	new /obj/item/reagent_containers/spray/pepper(src)
@@ -244,7 +243,7 @@
 	STR.max_items = 6
 	STR.max_w_class = WEIGHT_CLASS_BULKY
 	STR.max_combined_w_class = 20
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/crowbar,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
@@ -281,7 +280,7 @@
 		/obj/item/wormhole_jaunter,
 		/obj/item/storage/bag/plants,
 		/obj/item/stack/marker_beacon
-		)
+		))
 
 
 /obj/item/storage/belt/mining/vendor
@@ -312,9 +311,9 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 6
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/soulstone
-		)
+		))
 
 /obj/item/storage/belt/soulstone/full/PopulateContents()
 	for(var/i in 1 to 6)
@@ -335,9 +334,9 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 1
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/clothing/mask/luchador
-		)
+		))
 
 /obj/item/storage/belt/military
 	name = "chest rig"
@@ -364,10 +363,10 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 6
 	STR.max_w_class = WEIGHT_CLASS_SMALL
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/reagent_containers/food/snacks,
 		/obj/item/reagent_containers/food/drinks
-		)
+		))
 
 	var/amount = 5
 	var/rig_snacks
@@ -444,14 +443,14 @@
 	STR.display_numerical_stacking = TRUE
 	STR.max_combined_w_class = 60
 	STR.max_w_class = WEIGHT_CLASS_BULKY
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/grenade,
 		/obj/item/screwdriver,
 		/obj/item/lighter,
 		/obj/item/multitool,
 		/obj/item/reagent_containers/food/drinks/bottle/molotov,
 		/obj/item/grenade/plastic/c4,
-		)
+		))
 
 /obj/item/storage/belt/grenade/full/PopulateContents()
 	var/static/items_inside = list(
@@ -479,9 +478,9 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 6
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/gun/magic/wand
-		)
+		))
 
 /obj/item/storage/belt/wands/full/PopulateContents()
 	new /obj/item/gun/magic/wand/death(src)
@@ -506,7 +505,7 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 6
 	STR.max_w_class = WEIGHT_CLASS_BULKY // Set to this so the  light replacer can fit.
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/grenade/chem_grenade,
 		/obj/item/lightreplacer,
 		/obj/item/flashlight,
@@ -518,7 +517,7 @@
 		/obj/item/clothing/gloves,
 		/obj/item/melee/flyswatter,
 		/obj/item/assembly/mousetrap
-		)
+		))
 
 /obj/item/storage/belt/janitor/full/PopulateContents()
 	new /obj/item/lightreplacer(src)
@@ -538,9 +537,9 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 18
 	STR.display_numerical_stacking = TRUE
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/ammo_casing/shotgun
-		)
+		))
 
 /obj/item/storage/belt/holster
 	name = "shoulder holster"
@@ -554,12 +553,12 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 3
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/gun/ballistic/automatic/pistol,
 		/obj/item/gun/ballistic/revolver,
 		/obj/item/ammo_box,
 		/obj/item/gun/energy/e_gun/mini
-		)
+		))
 
 /obj/item/storage/belt/holster/full/PopulateContents()
 	var/static/items_inside = list(
@@ -654,9 +653,9 @@
 	STR.max_items = 1
 	STR.rustle_sound = FALSE
 	STR.max_w_class = WEIGHT_CLASS_BULKY
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/melee/sabre
-		)
+		))
 
 /obj/item/storage/belt/sabre/examine(mob/user)
 	..()

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -43,7 +43,7 @@
 /obj/item/storage/belt/utility/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	var/static/list/can_hold = typecacheof(list(
+	var/static/list/can_hold = list(
 		/obj/item/crowbar,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
@@ -63,7 +63,7 @@
 		/obj/item/forcefield_projector,
 		/obj/item/assembly/signaler,
 		/obj/item/lightreplacer
-		))
+		)
 	STR.can_hold = can_hold
 
 /obj/item/storage/belt/utility/chief
@@ -129,7 +129,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_BULKY
-	STR.can_hold = typecacheof(list(
+	STR.can_hold = list(
 		/obj/item/healthanalyzer,
 		/obj/item/dnainjector,
 		/obj/item/reagent_containers/dropper,
@@ -176,7 +176,7 @@
 		/obj/item/implanter,
 		/obj/item/pinpointer/crew,
 		/obj/item/holosign_creator/medical
-		))
+		)
 
 /obj/item/storage/belt/security
 	name = "security belt"
@@ -190,7 +190,7 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 5
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.can_hold = typecacheof(list(
+	STR.can_hold = list(
 		/obj/item/melee/baton,
 		/obj/item/melee/classic_baton,
 		/obj/item/grenade,
@@ -208,7 +208,7 @@
 		/obj/item/clothing/gloves,
 		/obj/item/restraints/legcuffs/bola,
 		/obj/item/holosign_creator/security
-		))
+		)
 
 /obj/item/storage/belt/security/full/PopulateContents()
 	new /obj/item/reagent_containers/spray/pepper(src)
@@ -244,7 +244,7 @@
 	STR.max_items = 6
 	STR.max_w_class = WEIGHT_CLASS_BULKY
 	STR.max_combined_w_class = 20
-	STR.can_hold = typecacheof(list(
+	STR.can_hold = list(
 		/obj/item/crowbar,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
@@ -281,7 +281,7 @@
 		/obj/item/wormhole_jaunter,
 		/obj/item/storage/bag/plants,
 		/obj/item/stack/marker_beacon
-		))
+		)
 
 
 /obj/item/storage/belt/mining/vendor
@@ -312,9 +312,9 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 6
-	STR.can_hold = typecacheof(list(
+	STR.can_hold = list(
 		/obj/item/soulstone
-		))
+		)
 
 /obj/item/storage/belt/soulstone/full/PopulateContents()
 	for(var/i in 1 to 6)
@@ -364,10 +364,10 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 6
 	STR.max_w_class = WEIGHT_CLASS_SMALL
-	STR.can_hold = typecacheof(list(
+	STR.can_hold = list(
 		/obj/item/reagent_containers/food/snacks,
 		/obj/item/reagent_containers/food/drinks
-		))
+		)
 
 	var/amount = 5
 	var/rig_snacks
@@ -444,14 +444,14 @@
 	STR.display_numerical_stacking = TRUE
 	STR.max_combined_w_class = 60
 	STR.max_w_class = WEIGHT_CLASS_BULKY
-	STR.can_hold = typecacheof(list(
+	STR.can_hold = list(
 		/obj/item/grenade,
 		/obj/item/screwdriver,
 		/obj/item/lighter,
 		/obj/item/multitool,
 		/obj/item/reagent_containers/food/drinks/bottle/molotov,
 		/obj/item/grenade/plastic/c4,
-		))
+		)
 
 /obj/item/storage/belt/grenade/full/PopulateContents()
 	var/static/items_inside = list(
@@ -479,9 +479,9 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 6
-	STR.can_hold = typecacheof(list(
+	STR.can_hold = list(
 		/obj/item/gun/magic/wand
-		))
+		)
 
 /obj/item/storage/belt/wands/full/PopulateContents()
 	new /obj/item/gun/magic/wand/death(src)
@@ -506,7 +506,7 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 6
 	STR.max_w_class = WEIGHT_CLASS_BULKY // Set to this so the  light replacer can fit.
-	STR.can_hold = typecacheof(list(
+	STR.can_hold = list(
 		/obj/item/grenade/chem_grenade,
 		/obj/item/lightreplacer,
 		/obj/item/flashlight,
@@ -518,7 +518,7 @@
 		/obj/item/clothing/gloves,
 		/obj/item/melee/flyswatter,
 		/obj/item/assembly/mousetrap
-		))
+		)
 
 /obj/item/storage/belt/janitor/full/PopulateContents()
 	new /obj/item/lightreplacer(src)
@@ -538,9 +538,9 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 18
 	STR.display_numerical_stacking = TRUE
-	STR.can_hold = typecacheof(list(
+	STR.can_hold = list(
 		/obj/item/ammo_casing/shotgun
-		))
+		)
 
 /obj/item/storage/belt/holster
 	name = "shoulder holster"
@@ -554,12 +554,12 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 3
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.can_hold = typecacheof(list(
+	STR.can_hold = list(
 		/obj/item/gun/ballistic/automatic/pistol,
 		/obj/item/gun/ballistic/revolver,
 		/obj/item/ammo_box,
 		/obj/item/gun/energy/e_gun/mini
-		))
+		)
 
 /obj/item/storage/belt/holster/full/PopulateContents()
 	var/static/items_inside = list(
@@ -654,9 +654,9 @@
 	STR.max_items = 1
 	STR.rustle_sound = FALSE
 	STR.max_w_class = WEIGHT_CLASS_BULKY
-	STR.can_hold = typecacheof(list(
+	STR.can_hold = list(
 		/obj/item/melee/sabre
-		))
+		)
 
 /obj/item/storage/belt/sabre/examine(mob/user)
 	..()

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -402,7 +402,7 @@
 /obj/item/storage/box/donkpockets/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/donkpocket))
+	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/donkpocket)
 
 /obj/item/storage/box/donkpockets/PopulateContents()
 	for(var/i in 1 to 6)
@@ -419,7 +419,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 7
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/monkeycube))
+	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/monkeycube)
 
 /obj/item/storage/box/monkeycubes/PopulateContents()
 	for(var/i in 1 to 5)
@@ -439,7 +439,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 3
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/monkeycube))
+	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/monkeycube)
 
 /obj/item/storage/box/gorillacubes/PopulateContents()
 	for(var/i in 1 to 3)
@@ -591,7 +591,7 @@
 /obj/item/storage/box/snappops/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.can_hold = typecacheof(list(/obj/item/toy/snappop))
+	STR.can_hold = list(/obj/item/toy/snappop)
 	STR.max_items = 8
 
 /obj/item/storage/box/snappops/PopulateContents()
@@ -610,7 +610,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 10
-	STR.can_hold = typecacheof(list(/obj/item/match))
+	STR.can_hold = list(/obj/item/match)
 
 /obj/item/storage/box/matches/PopulateContents()
 	SEND_SIGNAL(src, COMSIG_TRY_STORAGE_FILL_TYPE, /obj/item/match)
@@ -633,7 +633,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 21
-	STR.can_hold = typecacheof(list(/obj/item/light/tube, /obj/item/light/bulb))
+	STR.can_hold = list(/obj/item/light/tube, /obj/item/light/bulb)
 	STR.max_combined_w_class = 21
 	STR.click_gather = FALSE //temp workaround to re-enable filling the light replacer with the box
 

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -402,7 +402,7 @@
 /obj/item/storage/box/donkpockets/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/donkpocket)
+	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/donkpocket))
 
 /obj/item/storage/box/donkpockets/PopulateContents()
 	for(var/i in 1 to 6)
@@ -419,7 +419,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 7
-	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/monkeycube)
+	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/monkeycube))
 
 /obj/item/storage/box/monkeycubes/PopulateContents()
 	for(var/i in 1 to 5)
@@ -439,7 +439,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 3
-	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/monkeycube)
+	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/monkeycube))
 
 /obj/item/storage/box/gorillacubes/PopulateContents()
 	for(var/i in 1 to 3)
@@ -591,7 +591,7 @@
 /obj/item/storage/box/snappops/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.can_hold = list(/obj/item/toy/snappop)
+	STR.set_holdable(list(/obj/item/toy/snappop))
 	STR.max_items = 8
 
 /obj/item/storage/box/snappops/PopulateContents()
@@ -610,7 +610,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 10
-	STR.can_hold = list(/obj/item/match)
+	STR.set_holdable(list(/obj/item/match))
 
 /obj/item/storage/box/matches/PopulateContents()
 	SEND_SIGNAL(src, COMSIG_TRY_STORAGE_FILL_TYPE, /obj/item/match)
@@ -633,7 +633,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 21
-	STR.can_hold = list(/obj/item/light/tube, /obj/item/light/bulb)
+	STR.set_holdable(list(/obj/item/light/tube, /obj/item/light/bulb))
 	STR.max_combined_w_class = 21
 	STR.click_gather = FALSE //temp workaround to re-enable filling the light replacer with the box
 

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -74,7 +74,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 6
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/donut))
+	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/donut)
 
 /*
  * Egg Box
@@ -95,7 +95,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 12
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/egg))
+	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/egg)
 
 /*
  * Candle Box
@@ -140,7 +140,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 6
-	STR.can_hold = typecacheof(list(/obj/item/clothing/mask/cigarette, /obj/item/lighter))
+	STR.can_hold = list(/obj/item/clothing/mask/cigarette, /obj/item/lighter)
 
 /obj/item/storage/fancy/cigarettes/examine(mob/user)
 	..()
@@ -278,7 +278,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 10
-	STR.can_hold = typecacheof(list(/obj/item/rollingpaper))
+	STR.can_hold = list(/obj/item/rollingpaper)
 
 /obj/item/storage/fancy/rollingpapers/update_icon()
 	cut_overlays()
@@ -302,7 +302,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 5
-	STR.can_hold = typecacheof(list(/obj/item/clothing/mask/cigarette/cigar))
+	STR.can_hold = list(/obj/item/clothing/mask/cigarette/cigar)
 
 /obj/item/storage/fancy/cigarettes/cigars/update_icon()
 	cut_overlays()
@@ -349,4 +349,4 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 8
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/tinychocolate))
+	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/tinychocolate)

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -74,7 +74,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 6
-	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/donut)
+	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/donut))
 
 /*
  * Egg Box
@@ -95,7 +95,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 12
-	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/egg)
+	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/egg))
 
 /*
  * Candle Box
@@ -140,7 +140,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 6
-	STR.can_hold = list(/obj/item/clothing/mask/cigarette, /obj/item/lighter)
+	STR.set_holdable(list(/obj/item/clothing/mask/cigarette, /obj/item/lighter))
 
 /obj/item/storage/fancy/cigarettes/examine(mob/user)
 	..()
@@ -278,7 +278,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 10
-	STR.can_hold = list(/obj/item/rollingpaper)
+	STR.set_holdable(list(/obj/item/rollingpaper))
 
 /obj/item/storage/fancy/rollingpapers/update_icon()
 	cut_overlays()
@@ -302,7 +302,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 5
-	STR.can_hold = list(/obj/item/clothing/mask/cigarette/cigar)
+	STR.set_holdable(list(/obj/item/clothing/mask/cigarette/cigar))
 
 /obj/item/storage/fancy/cigarettes/cigars/update_icon()
 	cut_overlays()
@@ -349,4 +349,4 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 8
-	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/tinychocolate)
+	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/tinychocolate))

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -219,7 +219,7 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.allow_quick_gather = TRUE
 	STR.click_gather = TRUE
-	STR.can_hold = list(/obj/item/reagent_containers/pill, /obj/item/dice)
+	STR.set_holdable(list(/obj/item/reagent_containers/pill, /obj/item/dice))
 
 /obj/item/storage/pill_bottle/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is trying to get the cap off [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -219,7 +219,7 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.allow_quick_gather = TRUE
 	STR.click_gather = TRUE
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/pill, /obj/item/dice))
+	STR.can_hold = list(/obj/item/reagent_containers/pill, /obj/item/dice)
 
 /obj/item/storage/pill_bottle/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is trying to get the cap off [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -103,7 +103,7 @@
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 	STR.max_items = 10
 	STR.max_combined_w_class = 20
-	STR.can_hold = typecacheof(list(/obj/item/clothing/accessory/medal))
+	STR.can_hold = list(/obj/item/clothing/accessory/medal)
 
 /obj/item/storage/lockbox/medal/examine(mob/user)
 	..()

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -103,7 +103,7 @@
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 	STR.max_items = 10
 	STR.max_combined_w_class = 20
-	STR.can_hold = list(/obj/item/clothing/accessory/medal)
+	STR.set_holdable(list(/obj/item/clothing/accessory/medal))
 
 /obj/item/storage/lockbox/medal/examine(mob/user)
 	..()

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -171,7 +171,7 @@
 /obj/item/storage/secure/safe/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.cant_hold = typecacheof(list(/obj/item/storage/secure/briefcase))
+	STR.cant_hold = list(/obj/item/storage/secure/briefcase)
 	STR.max_w_class = 8						//??
 
 /obj/item/storage/secure/safe/PopulateContents()

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -171,7 +171,7 @@
 /obj/item/storage/secure/safe/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.cant_hold = list(/obj/item/storage/secure/briefcase)
+	STR.set_holdable(null, list(/obj/item/storage/secure/briefcase))
 	STR.max_w_class = 8						//??
 
 /obj/item/storage/secure/safe/PopulateContents()

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -257,7 +257,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.can_hold = typecacheof(list(/obj/item/clothing/suit/space/syndicate, /obj/item/clothing/head/helmet/space/syndicate))
+	STR.can_hold = list(/obj/item/clothing/suit/space/syndicate, /obj/item/clothing/head/helmet/space/syndicate)
 
 /obj/item/storage/box/syndie_kit/space/PopulateContents()
 	if(prob(50))

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -10,8 +10,8 @@
 			new /obj/item/encryptionkey/syndicate(src) // 2 tc
 			new /obj/item/storage/box/syndie_kit/space(src) //4 tc
 			new /obj/item/grenade/syndieminibomb/concussion/frag(src) // ~2 tc each?
-			new /obj/item/grenade/syndieminibomb/concussion/frag(src) 
-			
+			new /obj/item/grenade/syndieminibomb/concussion/frag(src)
+
 		if("bloodyspai") // 27 tc now this is more right
 			new /obj/item/clothing/under/chameleon(src) // 2 tc since it's not the full set
 			new /obj/item/clothing/mask/chameleon(src) // Goes with above
@@ -33,7 +33,7 @@
 			new /obj/item/chameleon(src)
 			new /obj/item/soap/syndie(src)
 			new /obj/item/clothing/glasses/thermal/syndi(src)
-			
+
 		if("guns") // 28 tc now
 			new /obj/item/gun/ballistic/revolver(src)
 			new /obj/item/ammo_box/a357(src)
@@ -109,7 +109,7 @@
 			new /obj/item/grenade/plastic/c4 (src) // 1 tc
 			new /obj/item/grenade/plastic/c4 (src) // 1 tc
 			new /obj/item/card/emag(src) // 6 tc
-			
+
 /obj/item/storage/box/syndicate/bundle_B/PopulateContents()
 	switch (pickweight(list( "bond" = 2, "ninja" = 1, "darklord" = 1, "white_whale_holy_grail" = 2, "mad_scientist" = 2, "bee" = 2, "mr_freeze" = 2)))
 		if("bond") // 29 tc
@@ -120,7 +120,7 @@
 			new /obj/item/clothing/under/chameleon(src)
 			new /obj/item/card/id/syndicate(src)
 			new /obj/item/reagent_containers/syringe/stimulants(src)
-			
+
 		if("ninja") // 33 tc worth
 			new /obj/item/katana(src) // Unique , hard to tell how much tc this is worth. 8 tc?
 			new /obj/item/implanter/adrenalin(src) // 8 tc
@@ -128,8 +128,8 @@
 				new /obj/item/throwing_star(src) // ~5 tc for all 6
 			new /obj/item/storage/belt/chameleon(src) // Unique but worth at least 2 tc
 			new /obj/item/card/id/syndicate(src) // 2 tc
-			new /obj/item/chameleon(src) // 7 tc	
-			
+			new /obj/item/chameleon(src) // 7 tc
+
 		if("darklord") //20 tc + tk + summon item close enough for now
 			new /obj/item/twohanded/dualsaber(src)
 			new /obj/item/dnainjector/telemut/darkbundle(src)
@@ -137,14 +137,14 @@
 			new /obj/item/card/id/syndicate(src)
 			new /obj/item/clothing/shoes/chameleon/noslip(src) //because slipping while being a dark lord sucks
 			new /obj/item/book/granter/spell/summonitem(src)
-			
+
 		if("white_whale_holy_grail") //Unique items that don't appear anywhere else
 			new /obj/item/pneumatic_cannon/speargun(src)
 			new /obj/item/storage/backpack/magspear_quiver(src)
 			new /obj/item/clothing/suit/space/hardsuit/carp(src)
 			new /obj/item/clothing/mask/gas/carp(src)
 			new /obj/item/grenade/spawnergrenade/spesscarp(src)
-			
+
 		if("mad_scientist") // ~26 tc
 			new /obj/item/clothing/suit/toggle/labcoat/mad(src) // 0 tc
 			new /obj/item/clothing/shoes/jackboots(src) // 0 tc
@@ -157,7 +157,7 @@
 			new /obj/item/assembly/signaler(src) // 0 tc
 			new /obj/item/assembly/signaler(src) // 0 tc
 			new /obj/item/storage/toolbox/syndicate(src) // 1 tc
-			
+
 		if("bee") // ~25 tc
 			new /obj/item/paper/fluff/bee_objectives(src) // 0 tc (motivation)
 			new /obj/item/clothing/suit/hooded/bee_costume(src) // 0 tc
@@ -165,7 +165,7 @@
 			new /obj/item/storage/belt/fannypack/yellow(src) // 0 tc
 			new /obj/item/storage/box/syndie_kit/bee_grenades(src) // 15 tc
 			new /obj/item/reagent_containers/glass/bottle/beesease(src) // 10 tc?
-			
+
 		if("mr_freeze")
 			new /obj/item/clothing/glasses/cold(src)
 			new /obj/item/clothing/gloves/color/black(src)
@@ -179,7 +179,7 @@
 			new /obj/item/dnainjector/geladikinesis(src)
 			new /obj/item/dnainjector/cryokinesis(src)
 			new /obj/item/gun/energy/temperature/security(src)
-			
+
 /obj/item/storage/box/syndie_kit
 	name = "box"
 	desc = "A sleek, sturdy box."
@@ -257,17 +257,17 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.can_hold = list(/obj/item/clothing/suit/space/syndicate, /obj/item/clothing/head/helmet/space/syndicate)
+	STR.set_holdable(list(/obj/item/clothing/suit/space/syndicate, /obj/item/clothing/head/helmet/space/syndicate))
 
 /obj/item/storage/box/syndie_kit/space/PopulateContents()
 	if(prob(50))
 		new /obj/item/clothing/suit/space/syndicate/black/red(src) // Black and red is so in right now
 		new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
-		
+
 	else
 		new /obj/item/clothing/head/helmet/space/syndicate(src)
 		new /obj/item/clothing/suit/space/syndicate(src)
-		
+
 /obj/item/storage/box/syndie_kit/emp
 	name = "EMP kit"
 

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -13,8 +13,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 4
-	STR.cant_hold = list(/obj/item/screwdriver/power) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
-	STR.can_hold = list(
+	STR.set_holdable(list(
 		/obj/item/stack/spacecash,
 		/obj/item/holochip,
 		/obj/item/card,
@@ -36,7 +35,8 @@
 		/obj/item/reagent_containers/dropper,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/screwdriver,
-		/obj/item/stamp)
+		/obj/item/stamp),
+		list(/obj/item/screwdriver/power))
 
 /obj/item/storage/wallet/Exited(atom/movable/AM)
 	. = ..()

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -13,7 +13,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 4
-	STR.cant_hold = typecacheof(list(/obj/item/screwdriver/power)) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
+	STR.cant_hold = list(/obj/item/screwdriver/power) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
 	STR.can_hold = typecacheof(list(
 		/obj/item/stack/spacecash,
 		/obj/item/holochip,

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -14,7 +14,7 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 4
 	STR.cant_hold = list(/obj/item/screwdriver/power) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
-	STR.can_hold = typecacheof(list(
+	STR.can_hold = list(
 		/obj/item/stack/spacecash,
 		/obj/item/holochip,
 		/obj/item/card,
@@ -36,7 +36,7 @@
 		/obj/item/reagent_containers/dropper,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/screwdriver,
-		/obj/item/stamp))
+		/obj/item/stamp)
 
 /obj/item/storage/wallet/Exited(atom/movable/AM)
 	. = ..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -115,13 +115,7 @@
 /obj/item/clothing/Topic(href, href_list)
 	..()
 	if(href_list["show_valid_pocket_items"])
-		to_chat(usr, "<span class='notice'>[src] can hold: </span>")
-
-		GET_COMPONENT(pockets, /datum/component/storage)
-
-		for(var/valid_obj in pockets.can_hold)
-			var/obj/item/valid_item = new valid_obj()
-			to_chat(usr, "\t <span class='notice'>\a [valid_item.name]</span>")
+		SEND_SIGNAL(src, COMSIG_SHOW_ALLOWED, usr)
 
 /obj/item/clothing/examine(mob/user)
 	..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -135,13 +135,10 @@
 			how_cool_are_your_threads += "[src]'s storage opens when clicked.\n"
 		else
 			how_cool_are_your_threads += "[src]'s storage opens when dragged to yourself.\n"
-		how_cool_are_your_threads += "[src] can store [pockets.max_items] item\s.\n"
 		if (!pockets.can_hold.len) // If pocket type can hold anything, vs only specific items
-			how_cool_are_your_threads += "[src] can store items that are [weightclass2text(pockets.max_w_class)] or smaller.\n"
+			how_cool_are_your_threads += "[src] can store [pockets.max_items] item\s that are [weightclass2text(pockets.max_w_class)] or smaller.\n"
 		else
-			to_chat(usr, pockets.can_hold)
-			to_chat(usr, pockets.can_hold.len)
-			how_cool_are_your_threads += "[src] can store <a href='?src=[REF(src)];show_valid_pocket_items=1'>specific</a> items.\n"
+			how_cool_are_your_threads += "[src] can store [pockets.max_items] <a href='?src=[REF(src)];show_valid_pocket_items=1'>item\s</a>.\n"
 		if(pockets.quickdraw)
 			how_cool_are_your_threads += "You can quickly remove an item from [src] using Alt-Click.\n"
 		if(pockets.silent)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -112,11 +112,6 @@
 					LAZYSET(user_vars_remembered, variable, user.vars[variable])
 					user.vv_edit_var(variable, user_vars_to_edit[variable])
 
-/obj/item/clothing/Topic(href, href_list)
-	..()
-	if(href_list["show_valid_pocket_items"])
-		SEND_SIGNAL(src, COMSIG_SHOW_ALLOWED, usr)
-
 /obj/item/clothing/examine(mob/user)
 	..()
 	clothing_resistance_flag_examine_message(user)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -112,6 +112,17 @@
 					LAZYSET(user_vars_remembered, variable, user.vars[variable])
 					user.vv_edit_var(variable, user_vars_to_edit[variable])
 
+/obj/item/clothing/Topic(href, href_list)
+	..()
+	if(href_list["show_valid_pocket_items"])
+		to_chat(usr, "<span class='notice'>[src] can hold: </span>")
+
+		GET_COMPONENT(pockets, /datum/component/storage)
+
+		for(var/valid_obj in pockets.can_hold)
+			var/obj/item/valid_item = new valid_obj()
+			to_chat(usr, "\t <span class='notice'>\a [valid_item.name]</span>")
+
 /obj/item/clothing/examine(mob/user)
 	..()
 	clothing_resistance_flag_examine_message(user)
@@ -125,7 +136,12 @@
 		else
 			how_cool_are_your_threads += "[src]'s storage opens when dragged to yourself.\n"
 		how_cool_are_your_threads += "[src] can store [pockets.max_items] item\s.\n"
-		how_cool_are_your_threads += "[src] can store items that are [weightclass2text(pockets.max_w_class)] or smaller.\n"
+		if (!pockets.can_hold.len) // If pocket type can hold anything, vs only specific items
+			how_cool_are_your_threads += "[src] can store items that are [weightclass2text(pockets.max_w_class)] or smaller.\n"
+		else
+			to_chat(usr, pockets.can_hold)
+			to_chat(usr, pockets.can_hold.len)
+			how_cool_are_your_threads += "[src] can store only <a href='?src=[REF(src)];show_valid_pocket_items=1'>specific</a> items.\n"
 		if(pockets.quickdraw)
 			how_cool_are_your_threads += "You can quickly remove an item from [src] using Alt-Click.\n"
 		if(pockets.silent)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -141,7 +141,7 @@
 		else
 			to_chat(usr, pockets.can_hold)
 			to_chat(usr, pockets.can_hold.len)
-			how_cool_are_your_threads += "[src] can store only <a href='?src=[REF(src)];show_valid_pocket_items=1'>specific</a> items.\n"
+			how_cool_are_your_threads += "[src] can store <a href='?src=[REF(src)];show_valid_pocket_items=1'>specific</a> items.\n"
 		if(pockets.quickdraw)
 			how_cool_are_your_threads += "You can quickly remove an item from [src] using Alt-Click.\n"
 		if(pockets.silent)

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -69,7 +69,7 @@
 /obj/item/storage/bag/easterbasket/Initialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/egg, /obj/item/reagent_containers/food/snacks/chocolateegg, /obj/item/reagent_containers/food/snacks/boiledegg)
+	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/egg, /obj/item/reagent_containers/food/snacks/chocolateegg, /obj/item/reagent_containers/food/snacks/boiledegg))
 
 /obj/item/storage/bag/easterbasket/proc/countEggs()
 	cut_overlays()

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -69,7 +69,7 @@
 /obj/item/storage/bag/easterbasket/Initialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/egg, /obj/item/reagent_containers/food/snacks/chocolateegg, /obj/item/reagent_containers/food/snacks/boiledegg))
+	STR.can_hold = list(/obj/item/reagent_containers/food/snacks/egg, /obj/item/reagent_containers/food/snacks/chocolateegg, /obj/item/reagent_containers/food/snacks/boiledegg)
 
 /obj/item/storage/bag/easterbasket/proc/countEggs()
 	cut_overlays()

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -15,7 +15,7 @@
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_items = 40
 	STR.max_combined_w_class = 40
-	STR.can_hold = typecacheof(list(/obj/item/coin, /obj/item/stack/spacecash, /obj/item/holochip))
+	STR.can_hold = list(/obj/item/coin, /obj/item/stack/spacecash, /obj/item/holochip)
 
 /obj/item/storage/bag/money/vault/PopulateContents()
 	new /obj/item/coin/silver(src)

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -15,7 +15,7 @@
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_items = 40
 	STR.max_combined_w_class = 40
-	STR.can_hold = list(/obj/item/coin, /obj/item/stack/spacecash, /obj/item/holochip)
+	STR.set_holdable(list(/obj/item/coin, /obj/item/stack/spacecash, /obj/item/holochip))
 
 /obj/item/storage/bag/money/vault/PopulateContents()
 	new /obj/item/coin/silver(src)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -674,8 +674,6 @@
 				to_chat(src, "<span class='notice'>You succesfuly remove the durathread strand.</span>")
 				remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
 			return
-		visible_message("[src] examines [p_them()]self.", \
-			"<span class='notice'>You check yourself for injuries.</span>")
 		check_self_for_injuries()
 
 

--- a/code/modules/photography/photos/album.dm
+++ b/code/modules/photography/photos/album.dm
@@ -14,7 +14,7 @@
 /obj/item/storage/photo_album/Initialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.can_hold = list(/obj/item/photo)
+	STR.set_holdable(list(/obj/item/photo))
 	STR.max_combined_w_class = 42
 	STR.max_items = 21
 	LAZYADD(SSpersistence.photo_albums, src)

--- a/code/modules/photography/photos/album.dm
+++ b/code/modules/photography/photos/album.dm
@@ -14,7 +14,7 @@
 /obj/item/storage/photo_album/Initialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.can_hold = typecacheof(list(/obj/item/photo))
+	STR.can_hold = list(/obj/item/photo)
 	STR.max_combined_w_class = 42
 	STR.max_items = 21
 	LAZYADD(SSpersistence.photo_albums, src)

--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -321,7 +321,7 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 	STR.max_items = 2
-	STR.can_hold = typecacheof(list(/obj/item/gun/energy/dueling))
+	STR.can_hold = list(/obj/item/gun/energy/dueling)
 
 /obj/item/storage/lockbox/dueling/update_icon()
 	cut_overlays()

--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -1,6 +1,6 @@
 #define DUEL_IDLE 1
 #define DUEL_PREPARATION 2
-#define DUEL_READY 3 
+#define DUEL_READY 3
 #define DUEL_COUNTDOWN 4
 #define DUEL_FIRING 5
 
@@ -219,7 +219,7 @@
 	else
 		duel.fired[src] = TRUE
 		. = ..()
-	
+
 /obj/item/gun/energy/dueling/before_firing(target,user)
 	var/obj/item/ammo_casing/energy/duel/D = chambered
 	D.setting = setting
@@ -297,7 +297,7 @@
 	var/mob/living/L = target
 	if(!istype(target))
 		return BULLET_ACT_BLOCK
-	
+
 	var/obj/item/bodypart/B = L.get_bodypart(BODY_ZONE_HEAD)
 	B.dismember()
 	qdel(B)
@@ -321,7 +321,7 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 	STR.max_items = 2
-	STR.can_hold = list(/obj/item/gun/energy/dueling)
+	STR.set_holdable(list(/obj/item/gun/energy/dueling))
 
 /obj/item/storage/lockbox/dueling/update_icon()
 	cut_overlays()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the jackboots/winter boots examine text to better show what can be stored inside them. Before this change it says they can store any item normal-sized or lower, when they can actually only store a very specific set of items. 

The refactor fixes some item issues, e.g. the champion belt was intended to be able to store a Luchador mask, but was bugged. This also fixes the repeated "You check yourself for injuries." line when you examine yourself.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes incorrect examine text, and adds a way of actually checking what can be stored in the fairly obscure "shoe storage". Cleans up some unneeded code too, and fixes intended features.

## Changelog
:cl:
fix: Fixes the examine text on jackboots/winter boots to properly show what items can be stored inside.
fix: Can now, as originally intended, store a Luchador mask inside the champion belt.
refactor: Work on storage code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
