### PR TITLE
Removes /client/mousemove, changes beamrifles

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -102,17 +102,6 @@
 /obj/screen/click_catcher/IsAutoclickable()
 	. = 1
 
-//Please don't roast me too hard
-/client/MouseMove(object,location,control,params)
-	mouseParams = params
-	mouseLocation = location
-	mouseObject = object
-	mouseControlObject = control
-	if(mob && LAZYLEN(mob.mousemove_intercept_objects))
-		for(var/datum/D in mob.mousemove_intercept_objects)
-			D.onMouseMove(object, location, control, params)
-	..()
-
 /datum/proc/onMouseMove(object, location, control, params)
 	return
 

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -102,9 +102,6 @@
 /obj/screen/click_catcher/IsAutoclickable()
 	. = 1
 
-/datum/proc/onMouseMove(object, location, control, params)
-	return
-
 /client/MouseDrag(src_object,atom/over_object,src_location,over_location,src_control,over_control,params)
 	var/list/L = params2list(params)
 	if (L["middle"])

--- a/code/datums/components/lockon_aiming.dm
+++ b/code/datums/components/lockon_aiming.dm
@@ -47,14 +47,10 @@
 	if(icon_state)
 		lock_icon_state = icon_state
 	generate_lock_visuals()
-	var/mob/M = parent
-	LAZYOR(M.mousemove_intercept_objects, src)
 	START_PROCESSING(SSfastprocess, src)
 
 /datum/component/lockon_aiming/Destroy()
-	var/mob/M = parent
 	clear_visuals()
-	LAZYREMOVE(M.mousemove_intercept_objects, src)
 	STOP_PROCESSING(SSfastprocess, src)
 	return ..()
 

--- a/code/datums/components/lockon_aiming.dm
+++ b/code/datums/components/lockon_aiming.dm
@@ -116,27 +116,6 @@
 		return
 	LAZYREMOVE(immune_weakrefs, A.weak_reference)
 
-/datum/component/lockon_aiming/onMouseMove(object,location,control,params)
-	var/mob/M = parent
-	if(!istype(M) || !M.client)
-		return
-	var/datum/position/P = mouse_absolute_datum_map_position_from_client(M.client)
-	if(!P)
-		return
-	var/turf/T = P.return_turf()
-	LAZYINITLIST(last_location)
-	if(length(last_location) == 3 && last_location[1] == T.x && last_location[2] == T.y && last_location[3] == T.z)
-		return			//Same turf, don't bother.
-	if(last_location)
-		last_location.Cut()
-	else
-		last_location = list()
-	last_location.len = 3
-	last_location[1] = T.x
-	last_location[2] = T.y
-	last_location[3] = T.z
-	autolock()
-
 /datum/component/lockon_aiming/process()
 	if(update_disabled)
 		return

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -99,8 +99,6 @@
 
 	var/list/progressbars = null	//for stacking do_after bars
 
-	var/list/mousemove_intercept_objects
-
 	var/datum/click_intercept
 
 	var/registered_z

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -267,11 +267,9 @@
 	stop_aiming(current_user)
 	QDEL_NULL(mobhook)
 	if(istype(current_user))
-		LAZYREMOVE(current_user.mousemove_intercept_objects, src)
 		current_user = null
 	if(istype(user))
 		current_user = user
-		LAZYOR(current_user.mousemove_intercept_objects, src)
 		mobhook = user.AddComponent(/datum/component/redirect, list(COMSIG_MOVABLE_MOVED = CALLBACK(src, .proc/on_mob_move)))
 
 /obj/item/gun/energy/beam_rifle/onMouseDrag(src_object, over_object, src_location, over_location, params, mob)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

More or less the same thing as in #43263 except the list touched in the mousemove proc is also removed. Beam rifles still work just as before, but the aiming beam only displays with the mouse held down (when you are aiming/about to fire)

## Why It's Good For The Game

Byond reference says the following: `Don't define this unless you need it, because it generates extra communication that is otherwise avoided.`. 

## Changelog
:cl: Naksu
code: /client/mousemove has been removed.
balance: the aiming beam of a beam rifle is only shown with the mouse button held down
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
