### PR TITLE
Fixes timestop interaction with antimagic

### DIFF
--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -73,6 +73,11 @@
 /datum/proximity_monitor/advanced/timestop/proc/freeze_atom(atom/movable/A)
 	if(immune[A] || global_frozen_atoms[A] || !istype(A))
 		return FALSE
+	if(ismob(A))
+		var/mob/M = A
+		if(M.anti_magic_check(check_anti_magic, check_holy))
+			immune[A] = TRUE
+			return
 	var/frozen = TRUE
 	if(isliving(A))
 		freeze_mob(A)
@@ -154,9 +159,6 @@
 
 /datum/proximity_monitor/advanced/timestop/proc/freeze_mob(mob/living/L)
 	frozen_mobs += L
-	if(L.anti_magic_check(check_anti_magic, check_holy))
-		immune += L
-		return
 	L.Stun(20, 1, 1)
 	walk(L, 0) //stops them mid pathing even if they're stunimmune
 	if(isanimal(L))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
only one of these is my fault
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: timestop is properly defeated by antimagic.
fix: timestop only checks antimagic once
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
