### PR TITLE
Makes pneumatic cannons bulky!

### DIFF
--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -219,11 +219,10 @@
 		tank = null
 		update_icon()
 
-/obj/item/pneumatic_cannon/ghetto //Obtainable by improvised methods; more gas per use, less capacity, but smaller
+/obj/item/pneumatic_cannon/ghetto //Obtainable by improvised methods; more gas per use, less capacity
 	name = "improvised pneumatic cannon"
 	desc = "A gas-powered, object-firing cannon made out of common parts."
 	force = 5
-	w_class = WEIGHT_CLASS_NORMAL
 	maxWeightClass = 7
 	gasPerThrow = 5
 


### PR DESCRIPTION
## About The Pull Request

Makes pneumatic cannons bulky. I'm open to making them equippable on the back, but not without a sprite and I can't sprite for the life of me.

## Why It's Good For The Game

The pneumatic cannon was always somewhat of a meme item. But the way it's designed is horrendous. You can instantly crit people with cooking oil, make a ghetto grenades launchers or imbed all your ninja stars into some poor sod. It's a bit stupid that we can put multiple of these things into our backpacks when it's almost as strong as old elances.

There's probably not a person that has abused this item more than me. And let me tell you, this nerf is well deserved.

## Changelog
:cl:
balance: Pneumatic cannons are now bulky.
/:cl:
