### PR TITLE
You can now recolo(u)r lightbulbs

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -344,10 +344,9 @@
 	if(on)
 		var/BR = brightness
 		var/PO = bulb_power
+		var/CO = bulb_colour
 		if(color)
 			CO = color
-		else
-			CO = bulb_colour
 		var/area/A = get_area(src)
 		if (A && A.fire)
 			CO = bulb_emergency_colour

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -344,7 +344,10 @@
 	if(on)
 		var/BR = brightness
 		var/PO = bulb_power
-		var/CO = bulb_colour
+		if(color)
+			CO = color
+		else
+			CO = bulb_colour
 		var/area/A = get_area(src)
 		if (A && A.fire)
 			CO = bulb_emergency_colour
@@ -383,6 +386,10 @@
 			removeStaticPower(static_power_used, STATIC_LIGHT)
 
 	broken_sparks(start_only=TRUE)
+	
+/obj/machinery/light/update_atom_colour()
+	..()
+	update()
 
 /obj/machinery/light/proc/broken_sparks(start_only=FALSE)
 	if(status == LIGHT_BROKEN && has_power())


### PR DESCRIPTION
## About The Pull Request

Makes lights shine in a different color if you recolour them.

## Why It's Good For The Game

Whoever created the rapid lighting device intended for this to be a feature but it just didn't work. I'm not seeing a reason why this shouldn't be a thing. Feels very natural.

## Changelog
:cl:
add: Colored lights now shine in different colours.
/:cl:
