### PR TITLE
fixes styptic and silver sulf the right way

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -285,7 +285,7 @@
 	reagent_state = LIQUID
 	color = "#FF9696"
 	metabolization_rate = 5 * REAGENTS_METABOLISM
-	overdose_threshold = 60
+	overdose_threshold = 100
 
 /datum/reagent/medicine/styptic_powder/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -230,6 +230,7 @@
 	description = "If used in touch-based applications, immediately restores burn wounds as well as restoring more over time. If ingested through other means, deals minor toxin damage."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
+	metabolization_rate = 5 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/silver_sulfadiazine/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
@@ -279,6 +280,7 @@
 	description = "If used in touch-based applications, immediately restores bruising as well as restoring more over time. If ingested through other means, deals minor toxin damage."
 	reagent_state = LIQUID
 	color = "#FF9696"
+	metabolization_rate = 5 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/styptic_powder/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
@@ -383,9 +385,10 @@
 /datum/reagent/medicine/synthflesh
 	name = "Synthflesh"
 	id = "synthflesh"
-	description = "Has a 100% chance of instantly healing brute and burn damage. One unit of the chemical will heal one point of damage. Touch application only."
+	description = "Has a 100% chance of instantly healing brute and burn damage. It is 125% more efficient at healing than styptic powder and silver sulfadiazine. Touch application only."
 	reagent_state = LIQUID
 	color = "#FFEBEB"
+	metabolization_rate = 5 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/synthflesh/reaction_mob(mob/living/M, method=TOUCH, reac_volume,show_message = 1)
 	if(iscarbon(M))

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -231,6 +231,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 5 * REAGENTS_METABOLISM
+	overdose_threshold = 100
 
 /datum/reagent/medicine/silver_sulfadiazine/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
@@ -250,6 +251,9 @@
 	M.adjustFireLoss(-2*REM, 0)
 	..()
 	. = 1
+
+/datum/reagent/medicine/silver_sulfadiazine/overdose_start(mob/living/M)
+	metabolization_rate = 15 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/oxandrolone
 	name = "Oxandrolone"
@@ -281,6 +285,7 @@
 	reagent_state = LIQUID
 	color = "#FF9696"
 	metabolization_rate = 5 * REAGENTS_METABOLISM
+	overdose_threshold = 60
 
 /datum/reagent/medicine/styptic_powder/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
@@ -301,6 +306,9 @@
 	M.adjustBruteLoss(-2*REM, 0)
 	..()
 	. = 1
+
+/datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
+	metabolization_rate = 15 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/salglu_solution
 	name = "Saline-Glucose Solution"


### PR DESCRIPTION
:cl:
balance: silver sulf, styptic powder and synthflesh metabolize at 2u/tick
/:cl:

- the problem with those meds was that you were easily able to eat all the sprays/patches in medical to have 200u of the meds in body with the same effects of od less bicaridine

- by upping it to 2u/tick it makes the default patches heal 20 instantly and 20 overtime and makes anyone trying to abuse it waste time as their 1230923u in bloodstream will disappear before they need it
bicardine/kelo is still more metabolism efficient as pill for healing overtime

- also i upped the synthflesh metabolism as it does nothing in bloodstream

- the barhhahr pr would just leave the powergamers unaffected as they use a different technique to use those chemicals and just make medical default patches shit (ahahah a whole brute medkit now heals 60 while a brute pack heals 40 * 6 * 2 of brute and burn)
