### PR TITLE
Adds a bloodtest for changelings.

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -576,3 +576,9 @@
 
 /datum/antagonist/changeling/xenobio/antag_listing_name()
 	return ..() + "(Xenobio)"
+
+/datum/proc/changelingTest(datum/reagents/holder ,datum/reagent/blood/B, temperature)
+	if(holder && istype(B) && B.data && temperature > 350 && B.data["changeling"])
+		playsound(holder.my_atom, 'sound/magic/demon_consume.ogg', 50, 1)
+		holder.my_atom.visible_message("<span class='warning'>Grotesce tenticles sprout from the blood, trying to flee their impending doom.</span>")
+		holder.remove_reagent(B.id, B.volume, TRUE)

--- a/code/modules/antagonists/changeling/powers/hide.dm
+++ b/code/modules/antagonists/changeling/powers/hide.dm
@@ -1,0 +1,26 @@
+/datum/action/changeling/hide //Be stupid with this and you will be dead dead.
+	name = "Hide Identity"
+	desc = "Halts chemical production but makes us invisible to the blood test."
+	button_icon_state = "mimic_voice" //Much unique, very wow.
+	helptext = "We will be unable to regenerate chemicals while this is active. Turning this ability off will take us time."
+	chemical_cost = 0//constant chemical drain hardcoded
+	dna_cost = 1
+	req_human = 0
+	active = FALSE
+
+/datum/action/changeling/hide/sting_action(mob/user)
+	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
+	if(!active)
+		changeling.chem_recharge_slowdown += 1
+		to_chat(user, "<span class='notice'>We slow down our chemical production.</span>")
+		active = !active
+	else
+		to_chat(user, "<span class='notice'>We attempt to restart our chemical production.</span>")
+		if(do_after(user, 300, target = get_turf(user)))
+			changeling.chem_recharge_slowdown -= 1
+			to_chat(user, "<span class='notice'>We restart our chemical production.</span>")
+			active = !active
+		else
+			return FALSE
+	..()
+	return TRUE

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -178,10 +178,17 @@
 		for(var/datum/reagent/R in reagents.reagent_list)
 			temp_chem[R.id] = R.volume
 		blood_data["trace_chem"] = list2params(temp_chem)
+		var/datum/antagonist/changeling/ling
 		if(mind)
 			blood_data["mind"] = mind
+			ling = mind.has_antag_datum(/datum/antagonist/changeling)
+			if(istype(ling) && !ling.was_absorbed && ling.chem_recharge_slowdown < 1)
+				blood_data["changeling"] = ling
 		else if(last_mind)
 			blood_data["mind"] = last_mind
+			ling = mind.has_antag_datum(/datum/antagonist/changeling)
+			if(istype(ling) && !ling.was_absorbed && ling.chem_recharge_slowdown < 1)
+				blood_data["changeling"] = ling
 		if(ckey)
 			blood_data["ckey"] = ckey
 		else if(last_mind)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -186,7 +186,7 @@
 				blood_data["changeling"] = ling
 		else if(last_mind)
 			blood_data["mind"] = last_mind
-			ling = mind.has_antag_datum(/datum/antagonist/changeling)
+			ling = last_mind.has_antag_datum(/datum/antagonist/changeling)
 			if(istype(ling) && !ling.was_absorbed && ling.chem_recharge_slowdown < 1)
 				blood_data["changeling"] = ling
 		if(ckey)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -347,6 +347,8 @@
 	if(flags & NO_REACT)
 		return //Yup, no reactions here. No siree.
 
+	changelingTest(src, has_reagent("blood"), chem_temp) //This is really ugly but it can't be a normal reaction so it's gotta be snowflake.
+
 	var/list/cached_reagents = reagent_list
 	var/list/cached_reactions = GLOB.chemical_reactions_list
 	var/datum/cached_my_atom = my_atom

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1,5 +1,5 @@
 /datum/reagent/blood
-	data = list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"=null,"resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null,"quirks"=null)
+	data = list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"=null,"resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null,"quirks"=null,"changeling"=null)
 	name = "Blood"
 	id = "blood"
 	color = "#C80000" // rgb: 200, 0, 0
@@ -31,6 +31,11 @@
 				C.reagents.add_reagent("toxin", reac_volume * 0.5)
 			else
 				C.blood_volume = min(C.blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM)
+		if((method == INJECT || method == INGEST || method == PATCH || method == VAPOR) && data && data["changeling"] && C.mind)
+			if(C.mind.has_antag_datum(/datum/antagonist/changeling) == data["changeling"])
+				to_chat(C, "<span class='notice'>This substance is part of us.</span>")
+			else
+				to_chat(C, "<span class='warning'>This substance comes from another changeling!</span>")
 
 
 /datum/reagent/blood/on_new(list/data)
@@ -61,6 +66,11 @@
 					if(!istype(D, /datum/disease/advance))
 						preserve += D
 				data["viruses"] = preserve
+		if(mix_data["changeling"])
+			if(data["changeling"] && data["changeling"] != mix_data["changeling"])
+				data["changeling"] = TRUE
+			else
+				data["changeling"] = mix_data["changeling"]
 	return 1
 
 /datum/reagent/blood/proc/get_diseases()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1233,6 +1233,7 @@
 #include "code\modules\antagonists\changeling\powers\fakedeath.dm"
 #include "code\modules\antagonists\changeling\powers\fleshmend.dm"
 #include "code\modules\antagonists\changeling\powers\headcrab.dm"
+#include "code\modules\antagonists\changeling\powers\hide.dm"
 #include "code\modules\antagonists\changeling\powers\hivemind.dm"
 #include "code\modules\antagonists\changeling\powers\humanform.dm"
 #include "code\modules\antagonists\changeling\powers\lesserform.dm"


### PR DESCRIPTION
## About The Pull Request

This adds a blood test to changelings. Just like this entire antag, it is a reference to "The Thing". Basically, heating up the blood of a changeling will result in it displaying abnormal properties and will allow you to identify a changeling easily. Changelings gain the ability to identify other changelings by ingesting their blood.

This also adds an ability to changelings that supresses the production of chemicals, but makes their blood immune to the blood test. Deactivating this ability takes a long time, although respecing your abilities cancels it instantly. This ability allows changeling that try to take a more stealthy approach the possiblity to hide their true nature, even if shitcurity instates mandatory blood inspection.

## Why It's Good For The Game

I'm not completly convinced this is good for the game. That's why this is a draft for now. But I do feel like the lack of a hard tell for lings encourages bad gameplay. Lings are also horrendously strong so bringing them down a notch won't be all that bad.

## Changelog
:cl:
add: Adds a blood test for lings. Heating their blood will reveal their true identity.
add: A new ability for lings: Hide identity. You won't regenerate chemicals while this is active but your blood will resist the blood test. Turning this ability off takes a long time.
/:cl:
