### PR TITLE
Syndicate codewords are highlighted to traitors

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -117,9 +117,9 @@ SUBSYSTEM_DEF(ticker)
 
 
 	if(!GLOB.syndicate_code_phrase)
-		GLOB.syndicate_code_phrase	= generate_code_phrase()
+		GLOB.syndicate_code_phrase	= generate_code_phrase(return_list=TRUE)
 	if(!GLOB.syndicate_code_response)
-		GLOB.syndicate_code_response = generate_code_phrase()
+		GLOB.syndicate_code_response = generate_code_phrase(return_list=TRUE)
 
 	start_at = world.time + (CONFIG_GET(number/lobby_countdown) * 10)
 	if(CONFIG_GET(flag/randomize_shift_time))
@@ -412,7 +412,7 @@ SUBSYSTEM_DEF(ticker)
 		queued_players.len = 0
 		queue_delay = 0
 		return
-		
+
 	queue_delay++
 	var/mob/dead/new_player/next_in_line = queued_players[1]
 

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -70,18 +70,6 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 	return "[spanpart1][spanpart2][freqpart][languageicon][compose_track_href(speaker, namepart)][namepart][compose_job(speaker, message_language, raw_message, radio_freq)][endspanpart][messagepart]"
 
-/atom/movable/proc/augment_heard(message, mob/mob_hearing)
-	if (mob_hearing.mind.special_role == ROLE_TRAITOR)
-		for (var/codeword in GLOB.syndicate_code_phrase)
-			var/regex/codeword_match = new("(" + codeword + ")", "ig")
-			message = codeword_match.Replace(message, "<font color=blue>$1</font>")
-
-		for (var/codeword in GLOB.syndicate_code_response)
-			var/regex/codeword_match = new("(" + codeword + ")", "ig")
-			message = codeword_match.Replace(message, "<font color=red>$1</font>")
-
-	return message
-
 /atom/movable/proc/compose_track_href(atom/movable/speaker, message_langs, raw_message, radio_freq)
 	return ""
 
@@ -214,8 +202,6 @@ INITIALIZE_IMMEDIATE(/atom/movable/virtualspeaker)
 		job = "Machine"
 	else  // Unidentifiable mob
 		job = "Unknown"
-
-
 
 /atom/movable/virtualspeaker/GetJob()
 	return job

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -70,6 +70,18 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 	return "[spanpart1][spanpart2][freqpart][languageicon][compose_track_href(speaker, namepart)][namepart][compose_job(speaker, message_language, raw_message, radio_freq)][endspanpart][messagepart]"
 
+/atom/movable/proc/augment_heard(message, mob/mob_hearing)
+	if (mob_hearing.mind.special_role == ROLE_TRAITOR)
+		for (var/codeword in GLOB.syndicate_code_phrase)
+			var/regex/codeword_match = new("(" + codeword + ")", "ig")
+			message = codeword_match.Replace(message, "<font color=blue>$1</font>")
+
+		for (var/codeword in GLOB.syndicate_code_response)
+			var/regex/codeword_match = new("(" + codeword + ")", "ig")
+			message = codeword_match.Replace(message, "<font color=red>$1</font>")
+
+	return message
+
 /atom/movable/proc/compose_track_href(atom/movable/speaker, message_langs, raw_message, radio_freq)
 	return ""
 
@@ -202,6 +214,8 @@ INITIALIZE_IMMEDIATE(/atom/movable/virtualspeaker)
 		job = "Machine"
 	else  // Unidentifiable mob
 		job = "Unknown"
+
+
 
 /atom/movable/virtualspeaker/GetJob()
 	return job

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -246,14 +246,14 @@
 	var/responses = jointext(GLOB.syndicate_code_response, ", ")
 
 	to_chat(traitor_mob, "<U><B>The Syndicate have provided you with the following codewords to identify fellow agents:</B></U>")
-	to_chat(traitor_mob, "<B>Code Phrase</B>: <font color=blue>[phrases]</font>")
-	to_chat(traitor_mob, "<B>Code Response</B>: <font color=red>[responses]</font>")
+	to_chat(traitor_mob, "<B>Code Phrase</B>: <span class='blue'>[phrases]</span>")
+	to_chat(traitor_mob, "<B>Code Response</B>: <span class='red'>[responses]</span>")
 
-	antag_memory += "<b>Code Phrase</b>: <font color=blue>[phrases]</font><br>"
-	antag_memory += "<b>Code Response</b>: <font color=red>[responses]</font><br>"
+	antag_memory += "<b>Code Phrase</b>: <span class='blue'>[phrases]</span><br>"
+	antag_memory += "<b>Code Response</b>: <span class='red'>[responses]</span><br>"
 
 	to_chat(traitor_mob, "Use the codewords during regular conversation to identify other agents. Proceed with caution, however, as everyone is a potential foe.")
-	to_chat(traitor_mob, "<font size=3 color=red>You memorize the codewords, allowing you to recognise them when heard.</font>")
+	to_chat(traitor_mob, "<span class='alertwarning'>You memorize the codewords, allowing you to recognise them when heard.</span>")
 
 /datum/antagonist/traitor/proc/add_law_zero()
 	var/mob/living/silicon/ai/killer = owner.current

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -242,14 +242,18 @@
 		return
 	var/mob/traitor_mob=owner.current
 
-	to_chat(traitor_mob, "<U><B>The Syndicate provided you with the following information on how to identify their agents:</B></U>")
-	to_chat(traitor_mob, "<B>Code Phrase</B>: <span class='danger'>[GLOB.syndicate_code_phrase]</span>")
-	to_chat(traitor_mob, "<B>Code Response</B>: <span class='danger'>[GLOB.syndicate_code_response]</span>")
+	var/phrases = jointext(GLOB.syndicate_code_phrase, ", ")
+	var/responses = jointext(GLOB.syndicate_code_response, ", ")
 
-	antag_memory += "<b>Code Phrase</b>: [GLOB.syndicate_code_phrase]<br>"
-	antag_memory += "<b>Code Response</b>: [GLOB.syndicate_code_response]<br>"
+	to_chat(traitor_mob, "<U><B>The Syndicate have provided you with the following codewords to identify fellow agents:</B></U>")
+	to_chat(traitor_mob, "<B>Code Phrase</B>: <font color=blue>[phrases]</font>")
+	to_chat(traitor_mob, "<B>Code Response</B>: <font color=red>[responses]</font>")
 
-	to_chat(traitor_mob, "Use the code words in the order provided, during regular conversation, to identify other agents. Proceed with caution, however, as everyone is a potential foe.")
+	antag_memory += "<b>Code Phrase</b>: <font color=blue>[phrases]</font><br>"
+	antag_memory += "<b>Code Response</b>: <font color=red>[responses]</font><br>"
+
+	to_chat(traitor_mob, "Use the codewords during regular conversation to identify other agents. Proceed with caution, however, as everyone is a potential foe.")
+	to_chat(traitor_mob, "<font size=3 color=red>You memorize the codewords, allowing you to recognise them when heard.</font>")
 
 /datum/antagonist/traitor/proc/add_law_zero()
 	var/mob/living/silicon/ai/killer = owner.current

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -17,7 +17,7 @@ body {
     line-height: 1.2;
 	overflow-x: hidden;
 	overflow-y: scroll;
-	word-wrap: break-word;		
+	word-wrap: break-word;
 	scrollbar-face-color:#1A1A1A;
 	scrollbar-track-color:#171717;
 	scrollbar-highlight-color:#171717;
@@ -305,6 +305,7 @@ em						{font-style: normal;	font-weight: bold;}
 .userdanger				{color: #c51e1e;	font-weight: bold; font-size: 24px;}
 .danger					{color: #c51e1e;}
 .warning				{color: #c51e1e;	font-style: italic;}
+.alertwarning           {color: #FF0000;    font-weight: bold}
 .boldwarning			{color: #c51e1e;	font-style: italic;	font-weight: bold}
 .announce 				{color: #c51e1e;	font-weight: bold;}
 .boldannounce			{color: #c51e1e;	font-weight: bold;}
@@ -318,6 +319,8 @@ em						{font-style: normal;	font-weight: bold;}
 .unconscious			{color: #a4bad6;	font-weight: bold;}
 .suicide				{color: #ff5050;	font-style: italic;}
 .green					{color: #059223;}
+.red                    {color: #FF0000}
+.blue                   {color: #215cff}
 .nicegreen				{color: #059223;}
 .shadowling				{color: #8e8a99;}
 .cult					{color: #aa1c1c;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -303,6 +303,7 @@ h1.alert, h2.alert		{color: #000000;}
 .userdanger				{color: #ff0000;	font-weight: bold; font-size: 24px;}
 .danger					{color: #ff0000;}
 .warning				{color: #ff0000;	font-style: italic;}
+.alertwarning           {color: #FF0000;    font-weight: bold}
 .boldwarning			{color: #ff0000;	font-style: italic;	font-weight: bold}
 .announce 				{color: #228b22;	font-weight: bold;}
 .boldannounce			{color: #ff0000;	font-weight: bold;}
@@ -316,7 +317,9 @@ h1.alert, h2.alert		{color: #000000;}
 .unconscious			{color: #0000ff;	font-weight: bold;}
 .suicide				{color: #ff5050;	font-style: italic;}
 .green					{color: #03ff39;}
-.nicegreen					{color: #14a833;}
+.red                    {color: #FF0000}
+.blue                   {color: #0000FF}
+.nicegreen				{color: #14a833;}
 .shadowling				{color: #3b2769;}
 .cult					{color: #960000;}
 

--- a/code/modules/mob/living/carbon/say.dm
+++ b/code/modules/mob/living/carbon/say.dm
@@ -49,11 +49,11 @@
 
 	if (src.mind.has_antag_datum(/datum/antagonist/traitor))
 		for (var/codeword in GLOB.syndicate_code_phrase)
-			var/regex/codeword_match = new("(" + codeword + ")", "ig")
-			message = codeword_match.Replace(message, "<font color=blue>$1</font>")
+			var/regex/codeword_match = new("([codeword])", "ig")
+			message = codeword_match.Replace(message, "<span class='blue'>$1</span>")
 
 		for (var/codeword in GLOB.syndicate_code_response)
-			var/regex/codeword_match = new("(" + codeword + ")", "ig")
-			message = codeword_match.Replace(message, "<font color=red>$1</font>")
-			
+			var/regex/codeword_match = new("([codeword])", "ig")
+			message = codeword_match.Replace(message, "<span class='red'>$1</span>")
+
 	return message

--- a/code/modules/mob/living/carbon/say.dm
+++ b/code/modules/mob/living/carbon/say.dm
@@ -46,4 +46,14 @@
 	for(var/T in get_traumas())
 		var/datum/brain_trauma/trauma = T
 		message = trauma.on_hear(message, speaker, message_language, raw_message, radio_freq)
+
+	if (src.mind.has_antag_datum(/datum/antagonist/traitor))
+		for (var/codeword in GLOB.syndicate_code_phrase)
+			var/regex/codeword_match = new("(" + codeword + ")", "ig")
+			message = codeword_match.Replace(message, "<font color=blue>$1</font>")
+
+		for (var/codeword in GLOB.syndicate_code_response)
+			var/regex/codeword_match = new("(" + codeword + ")", "ig")
+			message = codeword_match.Replace(message, "<font color=red>$1</font>")
+			
 	return message

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -229,7 +229,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	// Recompose message for AI hrefs, language incomprehension.
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode)
 	message = hear_intercept(message, speaker, message_language, raw_message, radio_freq, spans, message_mode)
-	message = augment_heard(message, src)
 
 	show_message(message, 2, deaf_message, deaf_type)
 	return message

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -229,6 +229,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	// Recompose message for AI hrefs, language incomprehension.
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode)
 	message = hear_intercept(message, speaker, message_language, raw_message, radio_freq, spans, message_mode)
+	message = augment_heard(message, src)
+
 	show_message(message, 2, deaf_message, deaf_type)
 	return message
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Codeword phrases are now highlighted in blue for traitors in spoken text, with responses in red. The traitor greet text has had some minor text changes, with a new line being added to just mention that they "memorized" the words, so they pick up on them in spoken conversation.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Codewords are an interesting, but very underused element of being a traitor. People that may of wanted to use them were limited by the fact that other traitors probably didn't look at them. This encourages more interaction with them, by making it very easy to see in conversation if they're being used, and can then be responded to accordingly.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Traitors now recognize codewords automatically in spoken conversation. Phrases in blue, responses in red.
tweak: Changed traitor greet text slightly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
