### PR TITLE
Fedoras hold small and gimmick items

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -17,6 +17,7 @@
 
 /datum/component/storage/concrete/pockets/small
 	max_items = 1
+	max_w_class = WEIGHT_CLASS_SMALL
 	attack_hand_interact = FALSE
 
 /datum/component/storage/concrete/pockets/tiny

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -27,10 +27,11 @@
 
 /datum/component/storage/concrete/pockets/small/fedora/Initialize()
 	. = ..()
-	exception_hold = typecacheof(list(
+	var/static/list/exception_cache = typecacheof(list(
 		/obj/item/katana, /obj/item/toy/katana, /obj/item/nullrod/claymore/katana,
-		/obj/item/gun/ballistic/automatic/tommygun
+		/obj/item/energy_katana, /obj/item/gun/ballistic/automatic/tommygun
 		))
+	exception_hold = exception_cache
 
 /datum/component/storage/concrete/pockets/small/fedora/detective
 	attack_hand_interact = TRUE // so the detectives would discover pockets in their hats

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -25,8 +25,21 @@
 	max_w_class = WEIGHT_CLASS_TINY
 	attack_hand_interact = FALSE
 
-/datum/component/storage/concrete/pockets/small/detective
+/datum/component/storage/concrete/pockets/small/detective/Initialize()
+	. = ..()
 	attack_hand_interact = TRUE // so the detectives would discover pockets in their hats
+
+	exception_hold = typecacheof(list(
+		/obj/item/katana, /obj/item/toy/katana, /obj/item/nullrod/claymore/katana,
+		/obj/item/gun/ballistic/automatic/tommygun
+		))
+
+/datum/component/storage/concrete/pockets/small/fedora/Initialize()
+	. = ..()
+	exception_hold = typecacheof(list(
+		/obj/item/katana, /obj/item/toy/katana, /obj/item/nullrod/claymore/katana,
+		/obj/item/gun/ballistic/automatic/tommygun
+		))
 
 /datum/component/storage/concrete/pockets/shoes
 	attack_hand_interact = FALSE

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -25,21 +25,15 @@
 	max_w_class = WEIGHT_CLASS_TINY
 	attack_hand_interact = FALSE
 
-/datum/component/storage/concrete/pockets/small/detective/Initialize()
-	. = ..()
-	attack_hand_interact = TRUE // so the detectives would discover pockets in their hats
-
-	exception_hold = typecacheof(list(
-		/obj/item/katana, /obj/item/toy/katana, /obj/item/nullrod/claymore/katana,
-		/obj/item/gun/ballistic/automatic/tommygun
-		))
-
 /datum/component/storage/concrete/pockets/small/fedora/Initialize()
 	. = ..()
 	exception_hold = typecacheof(list(
 		/obj/item/katana, /obj/item/toy/katana, /obj/item/nullrod/claymore/katana,
 		/obj/item/gun/ballistic/automatic/tommygun
 		))
+
+/datum/component/storage/concrete/pockets/small/fedora/detective
+	attack_hand_interact = TRUE // so the detectives would discover pockets in their hats
 
 /datum/component/storage/concrete/pockets/shoes
 	attack_hand_interact = FALSE

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -14,8 +14,9 @@
 	dupe_mode = COMPONENT_DUPE_UNIQUE
 	var/datum/component/storage/concrete/master		//If not null, all actions act on master and this is just an access point.
 
-	var/list/can_hold								//if this is set, only things in this typecache will fit.
+	var/list/can_hold								//if this is set, only things in this typecache will fit, if within the size limit.
 	var/list/cant_hold								//if this is set, anything in this typecache will not be able to fit.
+	var/list/exception_hold                         //if set, these items will be the exception to the max size of object that can fit.
 
 	var/list/mob/is_using							//lazy list of mobs looking at the contents of this storage.
 
@@ -576,7 +577,7 @@
 		if(!stop_messages)
 			to_chat(M, "<span class='warning'>[host] cannot hold [I]!</span>")
 		return FALSE
-	if(I.w_class > max_w_class)
+	if(I.w_class > max_w_class && !is_type_in_typecache(I, exception_hold))
 		if(!stop_messages)
 			to_chat(M, "<span class='warning'>[I] is too big for [host]!</span>")
 		return FALSE

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -59,7 +59,7 @@
 	icon_state = "nun_hood"
 	flags_inv = HIDEHAIR
 	flags_cover = HEADCOVERSEYES
-	
+
 /obj/item/clothing/head/bishopmitre
 	name = "bishop mitre"
 	desc = "An opulent hat that functions as a radio to God. Or as a lightning rod, depending on who you ask."
@@ -72,7 +72,7 @@
 	armor = list("melee" = 25, "bullet" = 5, "laser" = 25, "energy" = 10, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 50)
 	icon_state = "detective"
 	var/candy_cooldown = 0
-	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small/detective
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small/fedora/detective
 	dog_fashion = /datum/dog_fashion/head/detective
 
 /obj/item/clothing/head/fedora/det_hat/Initialize()

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -204,7 +204,7 @@
 	icon_state = "fedora"
 	item_state = "fedora"
 	desc = "A really cool hat if you're a mobster. A really lame hat if you're not."
-	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small/fedora
 
 /obj/item/clothing/head/fedora/suicide_act(mob/user)
 	if(user.gender == FEMALE)

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -367,28 +367,28 @@
 		if(prob(3))
 			M += pick(" Honh honh honh!"," Honh!"," Zut Alors!")
 	return trim(M)
-	
+
 /obj/item/clothing/head/clownmitre
 	name = "Hat of the Honkmother"
 	desc = "It's hard for parishoners to see a banana peel on the floor when they're looking up at your glorious chapeau."
 	icon_state = "clownmitre"
-	
+
 /obj/item/clothing/head/kippah
 	name = "kippah"
-	desc = "Signals that you follow the Jewish Halakha. Keeps the head covered and the soul extra-Orthodox." 
+	desc = "Signals that you follow the Jewish Halakha. Keeps the head covered and the soul extra-Orthodox."
 	icon_state = "kippah"
-	
+
 /obj/item/clothing/head/medievaljewhat
 	name = "medieval Jew hat"
 	desc = "A silly looking hat, intended to be placed on the heads of the station's oppressed religious minorities."
 	icon_state = "medievaljewhat"
-	
+
 /obj/item/clothing/head/taqiyahwhite
 	name = "white taqiyah"
 	desc = "An extra-mustahabb way of showing your devotion to Allah."
 	icon_state = "taqiyahwhite"
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small
-	
+
 /obj/item/clothing/head/taqiyahred
 	name = "red taqiyah"
 	desc = "An extra-mustahabb way of showing your devotion to Allah."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes fedoras and the ChapDrobe's taqiyahs to only be able to store small items, the same as pockets. 

Fedoras can store a katana and tommy gun as well, ignoring the size limit.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Because all women are queens, and you also might actually be a badass gangster.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Fedoras/taqiyahs fit pocket sized items. Fedoras can also store the tommy gun and katana. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
