### PR TITLE
Printing mops.

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -10,6 +10,15 @@
 	build_path = /obj/item/reagent_containers/glass/bucket
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+	
+/datum/design/mop
+	name = "Mop"
+	id = "mop"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(MAT_METAL = 1000)
+	build_path = /obj/item/mop
+	category = list("initial","Tools","Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
 /datum/design/crowbar
 	name = "Pocket Crowbar"

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -261,6 +261,16 @@
 /////////////////////////////////////////
 
 /datum/design/advmop
+	name = "Mop"
+	desc = "It mops."
+	id = "mop"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 1000)
+	build_path = /obj/item/mop
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+
+/datum/design/advmop
 	name = "Advanced Mop"
 	desc = "An upgraded mop with a large internal capacity for holding water or other cleaning chemicals."
 	id = "advmop"

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -260,7 +260,7 @@
 ////////////Janitor Designs//////////////
 /////////////////////////////////////////
 
-/datum/design/advmop
+/datum/design/mop
 	name = "Mop"
 	desc = "It mops."
 	id = "mop"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -48,7 +48,7 @@
 	starting_node = TRUE
 	display_name = "Basic Tools"
 	description = "Basic mechanical, electronic, surgical and botanical tools."
-	design_ids = list("screwdriver", "wrench", "wirecutters", "crowbar", "multitool", "welding_tool", "tscanner", "analyzer", "cable_coil", "pipe_painter", "airlock_painter", "scalpel", "circular_saw", "surgicaldrill", "retractor", "cautery", "hemostat", "cultivator", "plant_analyzer", "shovel", "spade", "hatchet")
+	design_ids = list("screwdriver", "wrench", "wirecutters", "crowbar", "multitool", "welding_tool", "tscanner", "analyzer", "cable_coil", "pipe_painter", "airlock_painter", "scalpel", "circular_saw", "surgicaldrill", "retractor", "cautery", "hemostat", "cultivator", "plant_analyzer", "shovel", "spade", "hatchet", "mop")
 
 /////////////////////////Biotech/////////////////////////
 /datum/techweb_node/biotech


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes mops printable.

## Why It's Bad For The Game

Excuse me, you can't just print out more mops. A mere autolathe could not even begin to understand the advanced science underpinning the mopping marvel you see before you. These super mops utilize GPS positioning to accurately and intelligently wipe away stains with surgical precision. They also incorporate the latest in synergistic machine learning to identify messes from stains to save you time and money. The smart hydration technology found in these sublime mopping units conserves water, minimizing time wasted on wringing, yet at the same time holds huge volumes of water. The ergonomically designed handle doubles as a self-defense tool, because it's a dangerous station out there and Nanotrasen has your back. Even the top of the mop was painstakingly crafted to be compatible with janicarts. Do you have any idea how difficult that was? People have lost there lives in pursuit of better mopping and yet you seem blissfully unaware of the sacrifices required. Frankly you should be thankful to even get these miracles of modern science at all, and now you want a lowly autolathe to print out more of them by claiming they are "just mops"? How dare you. I demand you apologize. Not to me, not to Nanotrasen, not even to the engineers and scientists who spent countless thankless hours developing the latest in mopping technology. No, you must apologize to the mop itself. Once you admit that this mop is a crowning achievement of humanity, truly the pinnacle of all that we are and ever will be, then you will be forgiven and allowed to gaze upon this mop, much less hold or even use one ever again. Repent, sinner.

## Changelog
:cl:
add: Mops can now be printed at the autolathe and protolathe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
