### PR TITLE
Queries attempt reconnection on mysql 2006 error

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -4,6 +4,7 @@ SUBSYSTEM_DEF(dbcore)
 	wait = 1 MINUTES
 	init_order = INIT_ORDER_DBCORE
 	var/const/FAILED_DB_CONNECTION_CUTOFF = 5
+	var/failed_connection_timeout = 0
 
 	var/schema_mismatch = 0
 	var/db_minor = 0
@@ -64,7 +65,11 @@ SUBSYSTEM_DEF(dbcore)
 	if(IsConnected())
 		return TRUE
 
-	if(failed_connections > FAILED_DB_CONNECTION_CUTOFF)	//If it failed to establish a connection more than 5 times in a row, don't bother attempting to connect anymore.
+	if(failed_connection_timeout <= world.time) //it's been more than 5 seconds since we failed to connect, reset the counter
+		failed_connections = 0
+
+	if(failed_connections > FAILED_DB_CONNECTION_CUTOFF)	//If it failed to establish a connection more than 5 times in a row, don't bother attempting to connect for 5 seconds.
+		failed_connection_timeout = world.time + 50
 		return FALSE
 
 	if(!CONFIG_GET(flag/sql_enabled))


### PR DESCRIPTION
Modification of code from https://github.com/tgstation/TerraGov-Marine-Corps/pull/1606

When queries error out with code 2006 `MySQL server has gone away`, due to the database connection being dropped while the server thinks it's still alive, they will attempt to force a re connection and if successful rerun the query before returning.

Seems to work but I'm not wholly confident in my failure testing since I can't locally replicate the same conditions which our servers lose their connection in so I'd like to give it a bit more testing and if possible confirmation from @Cyberboss this won't mess with BSQL's handling of connections (I'm fairly sure it's fine).

@DominikPanic 