### PR TITLE
Fixes mixing beer with other drinks breaking the sprite

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -24,6 +24,7 @@
 			icon_state = R.glass_icon_state
 		else
 			var/mutable_appearance/reagent_overlay = mutable_appearance(icon, "glassoverlay")
+			icon_state = "glass_empty"
 			reagent_overlay.color = mix_color_from_reagents(reagents.reagent_list)
 			add_overlay(reagent_overlay)
 	else


### PR DESCRIPTION
## About The Pull Request
fixes: #43070
All credit for this should go to @ExcessiveUseOfCobblestone as he made a comment on the issue that fixed it perfectly. All I did was implement it since it wasn't in the code yet and the bug was still there.
## Why It's Good For The Game
Bug fixes are always good.
## Changelog
:cl: Fire Chance
fix: Fixed the drink sprites overlapping when you are mixing beer with other drinks.
/:cl: