### PR TITLE
Removes trekchem mixing

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -209,30 +209,6 @@
 	results = list(/datum/reagent/medicine/haloperidol = 5)
 	required_reagents = list(/datum/reagent/chlorine = 1, /datum/reagent/fluorine = 1, /datum/reagent/aluminium = 1, /datum/reagent/medicine/potass_iodide = 1, /datum/reagent/oil = 1)
 
-/datum/chemical_reaction/bicaridine
-	name = "Bicaridine"
-	id = /datum/reagent/medicine/bicaridine
-	results = list(/datum/reagent/medicine/bicaridine = 3)
-	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/oxygen = 1, /datum/reagent/consumable/sugar = 1)
-
-/datum/chemical_reaction/kelotane
-	name = "Kelotane"
-	id = /datum/reagent/medicine/kelotane
-	results = list(/datum/reagent/medicine/kelotane = 2)
-	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/silicon = 1)
-
-/datum/chemical_reaction/antitoxin
-	name = "Antitoxin"
-	id = /datum/reagent/medicine/antitoxin
-	results = list(/datum/reagent/medicine/antitoxin = 3)
-	required_reagents = list(/datum/reagent/nitrogen = 1, /datum/reagent/silicon = 1, /datum/reagent/potassium = 1)
-
-/datum/chemical_reaction/tricordrazine
-	name = "Tricordrazine"
-	id = /datum/reagent/medicine/tricordrazine
-	results = list(/datum/reagent/medicine/tricordrazine = 3)
-	required_reagents = list(/datum/reagent/medicine/bicaridine = 1, /datum/reagent/medicine/kelotane = 1, /datum/reagent/medicine/antitoxin = 1)
-
 /datum/chemical_reaction/regen_jelly
 	name = "Regenerative Jelly"
 	id = /datum/reagent/medicine/regen_jelly


### PR DESCRIPTION
_note from ninjanomnom: I'm just acting as a relay for goof here and don't really care about this very much. If you want a response from him contact him somewhere he isn't banned._

 ## About The Pull Request 

Removes the reactions for mixing trekchems(Bicard, Anti-tox, Kelotane, Tricord) from the game.

## Why It's Good For The Game  

When Goonchem was added, it was intended to fully replace the trekchem chemistry elements. This was done by porting replacement chems, and removing the existing chems.  

The Sleeper however was missing chemicals as a result, as the Goon sleeper functioned more like the stasis pods we know now. So, I compromised and re-added the trekchem meds as **nonmixable sleeper only chemicals**.  

People then threw a hissy fit and re-added recipes for the trekchems. I protested this, saying it would lead to people nerfing the goonchems for making trekchems "underpowered by comparison". This was ignored as fearmongering.  

Currently, two PRs are up to do exactly what I said would happen. As such, to avoid issues of people crippling medical by nerfing the baseline meds you're supposed to be using, I'm removing the trekchem recipes as they are obsoleted by the goonchems, should not have been given recipes in the first place, and run against the design goals of the current chemistry system.  

Nerfing the base-line medical chems because they make chems that aren't supposed to be mixable underpowered by comparison is, quite frankly, absurd. This PR is essential to avoid further confusion down the line.

## Changelog 
:cl:  Iamgoofball
del: Removed the recipes for Bicard, Kelotane, Tricord, and Anti-tox as they're not supposed to have recipes due to the existence of Styptic Powder, Silver Sulfadiazine, Omnizine, and Charcoal. 
/:cl: