### PR TITLE
Storage implants drop their items when removed.

### DIFF
--- a/code/game/objects/items/implants/implant_storage.dm
+++ b/code/game/objects/items/implants/implant_storage.dm
@@ -19,7 +19,7 @@
 		implantee.visible_message("<span class='warning'>A bluespace pocket opens around [src] as it exits [implantee], spewing out its contents and rupturing the surrounding tissue!</span>")
 		implantee.apply_damage(20, BRUTE, BODY_ZONE_CHEST)
 		qdel(lostimplant)
-	. = ..()
+	return ..()
 
 /obj/item/implant/storage/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
 	for(var/X in target.implants)

--- a/code/game/objects/items/implants/implant_storage.dm
+++ b/code/game/objects/items/implants/implant_storage.dm
@@ -10,10 +10,16 @@
 	SEND_SIGNAL(src, COMSIG_TRY_STORAGE_SHOW, imp_in, TRUE)
 
 /obj/item/implant/storage/removed(source, silent = FALSE, special = 0)
+	if(!special)
+		var/datum/component/storage/lostimplant = GetComponent(/datum/component/storage/concrete/implant)
+		var/mob/living/implantee = source
+		for (var/obj/item/I in lostimplant.contents())
+			I.add_mob_blood(implantee)
+		lostimplant.do_quick_empty()
+		implantee.visible_message("<span class='warning'>A bluespace pocket opens around [src] as it exits [implantee], spewing out its contents and rupturing the surrounding tissue!</span>")
+		implantee.apply_damage(20, BRUTE, BODY_ZONE_CHEST)
+		qdel(lostimplant)
 	. = ..()
-	if(.)
-		if(!special)
-			qdel(GetComponent(/datum/component/storage/concrete/implant))
 
 /obj/item/implant/storage/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
 	for(var/X in target.implants)

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -23,8 +23,8 @@
 
 /datum/surgery_step/extract_implant/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(I)
-		user.visible_message("[user] successfully removes [I] from [target]'s [target_zone]!", "<span class='notice'>You successfully remove [I] from [target]'s [target_zone].</span>")
 		I.removed(target)
+		user.visible_message("[user] successfully removes [I] from [target]'s [target_zone]!", "<span class='notice'>You successfully remove [I] from [target]'s [target_zone].</span>")
 
 		var/obj/item/implantcase/case
 		for(var/obj/item/implantcase/ic in user.held_items)

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -23,8 +23,8 @@
 
 /datum/surgery_step/extract_implant/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(I)
-		I.removed(target)
 		user.visible_message("[user] successfully removes [I] from [target]'s [target_zone]!", "<span class='notice'>You successfully remove [I] from [target]'s [target_zone].</span>")
+		I.removed(target)
 
 		var/obj/item/implantcase/case
 		for(var/obj/item/implantcase/ic in user.held_items)


### PR DESCRIPTION
When storage implants are removed from a mob, they properly drop the items in storage. Fixes https://github.com/tgstation/tgstation/issues/42136

This also:

- Applies damage to the mob the implant is removed from (although if you're having a storage implant removed from you, your ass is likely already grass.)
- Makes those items bloody, although due to https://github.com/tgstation/tgstation/issues/38820 they don't actually appear bloody

:cl:
tweak: Nanotrasen has cracked the code of the Syndicate storage implant. Removing the implant will also drop any items contained within, doing minor damage to the person implanted.
/:cl: