### PR TITLE
Dragging prone mobs slows you down, fireman carrying

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -292,7 +292,7 @@
 #define GRAB_PIXEL_SHIFT_NECK 16
 
 #define PULL_PRONE_SLOWDOWN 1.5
-#define HUMAN_CARRY_SLOWDOWN 0.5
+#define HUMAN_CARRY_SLOWDOWN 0.35
 
 //Flags that control what things can spawn species (whitelist)
 //Badmin magic mirror

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -291,6 +291,9 @@
 #define GRAB_PIXEL_SHIFT_AGGRESSIVE 12
 #define GRAB_PIXEL_SHIFT_NECK 16
 
+#define PULL_PRONE_SLOWDOWN 1.5
+#define HUMAN_CARRY_SLOWDOWN 0.5
+
 //Flags that control what things can spawn species (whitelist)
 //Badmin magic mirror
 #define MIRROR_BADMIN (1<<0)

--- a/code/__DEFINES/movespeed_modification.dm
+++ b/code/__DEFINES/movespeed_modification.dm
@@ -63,4 +63,6 @@
 #define MOVESPEED_ID_SLAUGHTER                          "SLAUGHTER"
 #define MOVESPEED_ID_DIE_OF_FATE                        "DIE_OF_FATE"
 
-#define MOVESPEED_ID_SHOVE 								"SHOVE"
+#define MOVESPEED_ID_SHOVE                              "SHOVE"
+#define MOVESPEED_ID_PRONE_SLOWNDOWN                    "PRONE_DRAG"
+#define MOVESPEED_ID_CARRYING_SLOWDOWN                  "HUMAN_CARRY"

--- a/code/__DEFINES/movespeed_modification.dm
+++ b/code/__DEFINES/movespeed_modification.dm
@@ -63,6 +63,12 @@
 #define MOVESPEED_ID_SLAUGHTER                          "SLAUGHTER"
 #define MOVESPEED_ID_DIE_OF_FATE                        "DIE_OF_FATE"
 
+<<<<<<< HEAD
 #define MOVESPEED_ID_SHOVE                              "SHOVE"
 #define MOVESPEED_ID_PRONE_SLOWNDOWN                    "PRONE_DRAG"
 #define MOVESPEED_ID_CARRYING_SLOWDOWN                  "HUMAN_CARRY"
+=======
+#define MOVESPEED_ID_SHOVE "SHOVE"
+#define MOVESPEED_ID_PRONE_DRAGGING "PRONE_DRAG"
+#define MOVESPEED_ID_HUMAN_CARRYING "HUMAN_CARRY"
+>>>>>>> compiles now

--- a/code/__DEFINES/movespeed_modification.dm
+++ b/code/__DEFINES/movespeed_modification.dm
@@ -63,12 +63,6 @@
 #define MOVESPEED_ID_SLAUGHTER                          "SLAUGHTER"
 #define MOVESPEED_ID_DIE_OF_FATE                        "DIE_OF_FATE"
 
-<<<<<<< HEAD
 #define MOVESPEED_ID_SHOVE                              "SHOVE"
 #define MOVESPEED_ID_PRONE_SLOWNDOWN                    "PRONE_DRAG"
 #define MOVESPEED_ID_CARRYING_SLOWDOWN                  "HUMAN_CARRY"
-=======
-#define MOVESPEED_ID_SHOVE "SHOVE"
-#define MOVESPEED_ID_PRONE_DRAGGING "PRONE_DRAG"
-#define MOVESPEED_ID_HUMAN_CARRYING "HUMAN_CARRY"
->>>>>>> compiles now

--- a/code/__DEFINES/movespeed_modification.dm
+++ b/code/__DEFINES/movespeed_modification.dm
@@ -64,5 +64,5 @@
 #define MOVESPEED_ID_DIE_OF_FATE                        "DIE_OF_FATE"
 
 #define MOVESPEED_ID_SHOVE                              "SHOVE"
-#define MOVESPEED_ID_PRONE_SLOWNDOWN                    "PRONE_DRAG"
-#define MOVESPEED_ID_CARRYING_SLOWDOWN                  "HUMAN_CARRY"
+#define MOVESPEED_ID_PRONE_DRAGGING                     "PRONE_DRAG"
+#define MOVESPEED_ID_HUMAN_CARRYING                     "HUMAN_CARRY"

--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -19,7 +19,7 @@
 	var/v = volume
 	var/e = e_range
 	if(!T.footstep || LM.buckled || LM.lying || !CHECK_MULTIPLE_BITFIELDS(LM.mobility_flags, MOBILITY_STAND | MOBILITY_MOVE) || LM.throwing || LM.movement_type & (VENTCRAWLING | FLYING))
-		if (LM.lying && !(!T.footstep || LM.movement_type & (VENTCRAWLING | FLYING))) //play crawling sound if we're lying
+		if (LM.lying && !LM.buckled && !(!T.footstep || LM.movement_type & (VENTCRAWLING | FLYING))) //play crawling sound if we're lying
 			playsound(T, 'sound/effects/footstep/crawl1.ogg', 15 * v)
 		return
 	

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -201,20 +201,46 @@
 	. = ..()
 	RegisterSignal(parent, COMSIG_HUMAN_MELEE_UNARMED_ATTACK, .proc/on_host_unarmed_melee)
 
+/datum/component/riding/human/vehicle_mob_unbuckle(datum/source, mob/living/M, force = FALSE)
+	. = ..()
+	var/mob/living/carbon/human/H = parent
+	H.add_movespeed_modifier(MOVESPEED_ID_HUMAN_CARRYING, multiplicative_slowdown = HUMAN_CARRY_SLOWDOWN)
+
+/datum/component/riding/human/vehicle_mob_buckle(datum/source, mob/living/M, force = FALSE)
+	. = ..()
+	var/mob/living/carbon/human/H = parent
+	H.remove_movespeed_modifier(MOVESPEED_ID_HUMAN_CARRYING)
+
 /datum/component/riding/human/proc/on_host_unarmed_melee(atom/target)
-	var/mob/living/carbon/human/AM = parent
-	if(AM.a_intent == INTENT_DISARM && (target in AM.buckled_mobs))
+	var/mob/living/carbon/human/H = parent
+	if(H.a_intent == INTENT_DISARM && (target in H.buckled_mobs))
 		force_dismount(target)
 
 /datum/component/riding/human/handle_vehicle_layer()
 	var/atom/movable/AM = parent
 	if(AM.buckled_mobs && AM.buckled_mobs.len)
-		if(AM.dir == SOUTH)
-			AM.layer = ABOVE_MOB_LAYER
+		for(var/mob/M in AM.buckled_mobs) //ensure proper layering of piggyback and carry, sometimes weird offsets get applied
+			M.layer = MOB_LAYER
+		if(!AM.buckle_lying)
+			if(AM.dir == SOUTH)
+				AM.layer = ABOVE_MOB_LAYER
+			else
+				AM.layer = OBJ_LAYER
 		else
-			AM.layer = OBJ_LAYER
+			if(AM.dir == NORTH)
+				AM.layer = OBJ_LAYER
+			else
+				AM.layer = ABOVE_MOB_LAYER
 	else
 		AM.layer = MOB_LAYER
+
+/datum/component/riding/human/get_offsets(pass_index)
+	var/mob/living/carbon/human/H = parent
+	if(H.buckle_lying)
+		return list(TEXT_NORTH = list(0, 6), TEXT_SOUTH = list(0, 6), TEXT_EAST = list(0, 6), TEXT_WEST = list(0, 6))
+	else
+		return list(TEXT_NORTH = list(0, 6), TEXT_SOUTH = list(0, 6), TEXT_EAST = list(-6, 4), TEXT_WEST = list( 6, 4))
+	
 
 /datum/component/riding/human/force_dismount(mob/living/user)
 	var/atom/movable/AM = parent
@@ -280,12 +306,15 @@
 	M.throw_at(target, 14, 5, AM)
 	M.Paralyze(60)
 
-/datum/component/riding/proc/equip_buckle_inhands(mob/living/carbon/human/user, amount_required = 1)
+/datum/component/riding/proc/equip_buckle_inhands(mob/living/carbon/human/user, amount_required = 1, riding_target_override = null)
 	var/atom/movable/AM = parent
 	var/amount_equipped = 0
 	for(var/amount_needed = amount_required, amount_needed > 0, amount_needed--)
 		var/obj/item/riding_offhand/inhand = new /obj/item/riding_offhand(user)
-		inhand.rider = user
+		if(!riding_target_override)
+			inhand.rider = user
+		else
+			inhand.rider = riding_target_override
 		inhand.parent = AM
 		if(user.put_in_hands(inhand, TRUE))
 			amount_equipped++
@@ -325,7 +354,7 @@
 	. = ..()
 
 /obj/item/riding_offhand/equipped()
-	if(loc != rider)
+	if(loc != rider && loc != parent)
 		selfdeleting = TRUE
 		qdel(src)
 	. = ..()

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -204,12 +204,12 @@
 /datum/component/riding/human/vehicle_mob_unbuckle(datum/source, mob/living/M, force = FALSE)
 	. = ..()
 	var/mob/living/carbon/human/H = parent
-	H.remove_movespeed_modifier(MOVESPEED_ID_HUMAN_CARRYING, multiplicative_slowdown = HUMAN_CARRY_SLOWDOWN)
+	H.remove_movespeed_modifier(MOVESPEED_ID_HUMAN_CARRYING)
 
 /datum/component/riding/human/vehicle_mob_buckle(datum/source, mob/living/M, force = FALSE)
 	. = ..()
 	var/mob/living/carbon/human/H = parent
-	H.add_movespeed_modifier(MOVESPEED_ID_HUMAN_CARRYING)
+	H.add_movespeed_modifier(MOVESPEED_ID_HUMAN_CARRYING, multiplicative_slowdown = HUMAN_CARRY_SLOWDOWN)
 
 /datum/component/riding/human/proc/on_host_unarmed_melee(atom/target)
 	var/mob/living/carbon/human/H = parent

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -202,9 +202,9 @@
 	RegisterSignal(parent, COMSIG_HUMAN_MELEE_UNARMED_ATTACK, .proc/on_host_unarmed_melee)
 
 /datum/component/riding/human/vehicle_mob_unbuckle(datum/source, mob/living/M, force = FALSE)
-	. = ..()
 	var/mob/living/carbon/human/H = parent
 	H.remove_movespeed_modifier(MOVESPEED_ID_HUMAN_CARRYING)
+	. = ..()
 
 /datum/component/riding/human/vehicle_mob_buckle(datum/source, mob/living/M, force = FALSE)
 	. = ..()

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -204,12 +204,12 @@
 /datum/component/riding/human/vehicle_mob_unbuckle(datum/source, mob/living/M, force = FALSE)
 	. = ..()
 	var/mob/living/carbon/human/H = parent
-	H.add_movespeed_modifier(MOVESPEED_ID_HUMAN_CARRYING, multiplicative_slowdown = HUMAN_CARRY_SLOWDOWN)
+	H.remove_movespeed_modifier(MOVESPEED_ID_HUMAN_CARRYING, multiplicative_slowdown = HUMAN_CARRY_SLOWDOWN)
 
 /datum/component/riding/human/vehicle_mob_buckle(datum/source, mob/living/M, force = FALSE)
 	. = ..()
 	var/mob/living/carbon/human/H = parent
-	H.remove_movespeed_modifier(MOVESPEED_ID_HUMAN_CARRYING)
+	H.add_movespeed_modifier(MOVESPEED_ID_HUMAN_CARRYING)
 
 /datum/component/riding/human/proc/on_host_unarmed_melee(atom/target)
 	var/mob/living/carbon/human/H = parent

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -114,8 +114,8 @@
 	log_combat(user, pushed_mob, "places", null, "onto [src]")
 
 /obj/structure/table/proc/tablepush(mob/living/user, mob/living/pushed_mob)
-	if(user.has_trait(TRAIT_PACIFISM))
-		to_chat(user, "<span class='danger>Throwing [pushed_mob] onto the table might hurt them!</span>'")
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, "<span class='danger'>Throwing [pushed_mob] onto the table might hurt them!</span>")
 		return
 	var/added_passtable = FALSE
 	if(!pushed_mob.pass_flags & PASSTABLE)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -114,6 +114,9 @@
 	log_combat(user, pushed_mob, "places", null, "onto [src]")
 
 /obj/structure/table/proc/tablepush(mob/living/user, mob/living/pushed_mob)
+	if(user.has_trait(TRAIT_PACIFISM))
+		to_chat(user, "<span class='danger>Throwing [pushed_mob] onto the table might hurt them!</span>'")
+		return
 	var/added_passtable = FALSE
 	if(!pushed_mob.pass_flags & PASSTABLE)
 		added_passtable = TRUE
@@ -124,8 +127,8 @@
 	if(pushed_mob.loc != loc) //Something prevented the tabling
 		return
 	pushed_mob.Paralyze(40)
-	pushed_mob.visible_message("<span class='danger'>[user] pushes [pushed_mob] onto [src].</span>", \
-								"<span class='userdanger'>[user] pushes [pushed_mob] onto [src].</span>")
+	pushed_mob.visible_message("<span class='danger'>[user] slams [pushed_mob] onto [src]!</span>", \
+								"<span class='userdanger'>[user] slams you onto [src]!</span>")
 	log_combat(user, pushed_mob, "tabled", null, "onto [src]")
 	if(!ishuman(pushed_mob))
 		return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -893,7 +893,7 @@
 				"<span class='warning'>You can't get a grip on [target] because your hands are full!</span>")
 			return
 		else if(target_hands_needed && !equipped_hands_target)
-			M.visible_message("<span class='warning'>[target] can't get a grip on [src] because their hands are full!</span>",
+			target.visible_message("<span class='warning'>[target] can't get a grip on [src] because their hands are full!</span>",
 				"<span class='warning'>You can't get a grip on [src] because your hands are full!</span>")
 			return
 	

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -835,76 +835,71 @@
 			return
 	. = ..()
 
-//Can C try to piggyback at all.
-/mob/living/carbon/human/proc/can_piggyback(mob/living/carbon/C)
-	if(istype(C) && C.stat == CONSCIOUS)
-		return TRUE
-	return FALSE
+//src is the user that will be carrying, target is the mob to be carried
+/mob/living/carbon/human/proc/can_piggyback(mob/living/carbon/target)
+	return (istype(target) && target.stat == CONSCIOUS)
 
-/mob/living/carbon/human/proc/can_be_firemanned(mob/living/carbon/C)
-	if(ishuman(C) && !(C.mobility_flags & MOBILITY_STAND))
-		return TRUE
-	return FALSE
+/mob/living/carbon/human/proc/can_be_firemanned(mob/living/carbon/target)
+	return (ishuman(target) && !(target.mobility_flags & MOBILITY_STAND))
 
-/mob/living/carbon/human/proc/fireman_carry(mob/living/carbon/C)
-	if(can_be_firemanned(C))
-		visible_message("<span class='notice'>[src] starts lifting [C] onto their back...</span>", 
-			"<span class='notice'>You start lifting [C] onto your back...</span>")
-		if(do_after(src, 50, TRUE, C))
-			if(can_be_firemanned(C))//Second check to make sure they're still valid to be carried
+/mob/living/carbon/human/proc/fireman_carry(mob/living/carbon/target)
+	if(can_be_firemanned(target))
+		visible_message("<span class='notice'>[src] starts lifting [target] onto their back...</span>", 
+			"<span class='notice'>You start lifting [target] onto your back...</span>")
+		if(do_after(src, 50, TRUE, target))
+			if(can_be_firemanned(target))//Second check to make sure they're still valid to be carried
 				if(!incapacitated(FALSE, TRUE))
-					buckle_mob(C, TRUE, TRUE, 90, 1, 0)
+					buckle_mob(target, TRUE, TRUE, 90, 1, 0)
 					return
-		visible_message("<span class='warning'>[src] fails to fireman carry [C]!")
+		visible_message("<span class='warning'>[src] fails to fireman carry [target]!")
 	else
-		to_chat(src, "<span class='notice'>You can't fireman carry [C] while they're standing!</span>")
+		to_chat(src, "<span class='notice'>You can't fireman carry [target] while they're standing!</span>")
 
-
-/mob/living/carbon/human/proc/piggyback(mob/living/carbon/C)
-	if(can_piggyback(C))
-		visible_message("<span class='notice'>[C] starts to climb onto [src]...</span>")
-		if(do_after(C, 15, target = src))
-			if(can_piggyback(C))
-				if(C.incapacitated(FALSE, TRUE) || incapacitated(FALSE, TRUE))
-					C.visible_message("<span class='warning'>[C] can't hang onto [src]!</span>")
+/mob/living/carbon/human/proc/piggyback(mob/living/carbon/target)
+	if(can_piggyback(target))
+		visible_message("<span class='notice'>[target] starts to climb onto [src]...</span>")
+		if(do_after(target, 15, target = src))
+			if(can_piggyback(target))
+				if(target.incapacitated(FALSE, TRUE) || incapacitated(FALSE, TRUE))
+					target.visible_message("<span class='warning'>[target] can't hang onto [src]!</span>")
 					return
-				buckle_mob(C, TRUE, TRUE, FALSE, 0, 2)
+				buckle_mob(target, TRUE, TRUE, FALSE, 0, 2)
 		else
-			visible_message("<span class='warning'>[C] fails to climb onto [src]!</span>")
+			visible_message("<span class='warning'>[target] fails to climb onto [src]!</span>")
 	else
-		to_chat(C, "<span class='warning'>You can't piggyback ride [src] right now!</span>")
+		to_chat(target, "<span class='warning'>You can't piggyback ride [src] right now!</span>")
 
-/mob/living/carbon/human/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE, lying_buckle = FALSE, hands_needed = 0, target_hands_needed = 0)
+/mob/living/carbon/human/buckle_mob(mob/living/target, force = FALSE, check_loc = TRUE, lying_buckle = FALSE, hands_needed = 0, target_hands_needed = 0)
 	if(!force)//humans are only meant to be ridden through piggybacking and special cases
 		return
-	if(!is_type_in_typecache(M, can_ride_typecache))
-		M.visible_message("<span class='warning'>[M] really can't seem to mount [src]...</span>")
+	if(!is_type_in_typecache(target, can_ride_typecache))
+		target.visible_message("<span class='warning'>[target] really can't seem to mount [src]...</span>")
 		return
 	buckle_lying = lying_buckle
 	var/datum/component/riding/human/riding_datum = LoadComponent(/datum/component/riding/human)
 	riding_datum.ride_check_rider_restrained = TRUE
-	if(buckled_mobs && ((M in buckled_mobs) || (buckled_mobs.len >= max_buckled_mobs)) || buckled)
+	if(buckled_mobs && ((target in buckled_mobs) || (buckled_mobs.len >= max_buckled_mobs)) || buckled)
 		return
 	var/equipped_hands_self
 	var/equipped_hands_target
 	if(hands_needed)
-		equipped_hands_self = riding_datum.equip_buckle_inhands(src, hands_needed, M)
+		equipped_hands_self = riding_datum.equip_buckle_inhands(src, hands_needed, target)
 	if(target_hands_needed)
-		equipped_hands_target = riding_datum.equip_buckle_inhands(M, target_hands_needed)
+		equipped_hands_target = riding_datum.equip_buckle_inhands(target, target_hands_needed)
 
 	if(hands_needed || target_hands_needed)
 		if(hands_needed && !equipped_hands_self)
-			src.visible_message("<span class='warning'>[src] can't get a grip on [M] because their hands are full!</span>", 
-				"<span class='warning'>You can't get a grip on [M] because your hands are full!</span>")
+			src.visible_message("<span class='warning'>[src] can't get a grip on [target] because their hands are full!</span>", 
+				"<span class='warning'>You can't get a grip on [target] because your hands are full!</span>")
 			return
 		else if(target_hands_needed && !equipped_hands_target)
-			M.visible_message("<span class='warning'>[M] can't get a grip on [src] because their hands are full!</span>",
+			M.visible_message("<span class='warning'>[target] can't get a grip on [src] because their hands are full!</span>",
 				"<span class='warning'>You can't get a grip on [src] because your hands are full!</span>")
 			return
 	
 	stop_pulling()
 	riding_datum.handle_vehicle_layer()
-	. = ..(M, force, check_loc)
+	. = ..(target, force, check_loc)
 
 /mob/living/carbon/human/proc/is_shove_knockdown_blocked() //If you want to add more things that block shove knockdown, extend this
 	var/list/body_parts = list(head, wear_mask, wear_suit, w_uniform, back, gloves, shoes, belt, s_store, glasses, ears, wear_id) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -824,9 +824,15 @@
 	.["Add/Remove Quirks"] = "?_src_=vars;[HrefToken()];modquirks=[REF(src)]"
 
 /mob/living/carbon/human/MouseDrop_T(mob/living/target, mob/living/user)
-	//If they dragged themselves and we're currently aggressively grabbing them try to piggyback
-	if(user == target && can_piggyback(target) && pulling == target && grab_state >= GRAB_AGGRESSIVE && stat == CONSCIOUS)
-		buckle_mob(target,TRUE,TRUE)
+	if(pulling == target && grab_state >= GRAB_AGGRESSIVE && stat == CONSCIOUS)
+		//If they dragged themselves and we're currently aggressively grabbing them try to piggyback
+		if(user == target && can_piggyback(target))
+			piggyback(target)
+			return
+		//If you dragged them to you and you're aggressively grabbing try to fireman carry them
+		else if(user != target && can_be_firemanned(target))
+			fireman_carry(target)
+			return
 	. = ..()
 
 //Can C try to piggyback at all.
@@ -835,36 +841,70 @@
 		return TRUE
 	return FALSE
 
-/mob/living/carbon/human/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)
+/mob/living/carbon/human/proc/can_be_firemanned(mob/living/carbon/C)
+	if(ishuman(C) && !(C.mobility_flags & MOBILITY_STAND))
+		return TRUE
+	return FALSE
+
+/mob/living/carbon/human/proc/fireman_carry(mob/living/carbon/C)
+	if(can_be_firemanned(C))
+		visible_message("<span class='notice'>[src] starts lifting [C] onto their back...</span>", 
+			"<span class='notice'>You start lifting [C] onto your back...</span>")
+		if(do_after(src, 50, TRUE, C))
+			if(can_be_firemanned(C))//Second check to make sure they're still valid to be carried
+				if(!incapacitated(FALSE, TRUE))
+					buckle_mob(C, TRUE, TRUE, TRUE, 1, 0)
+					return
+		visible_message("<span class='warning'>[src] fails to fireman carry [C]!")
+	else
+		to_chat(src, "<span class='notice'>You can't fireman carry [C] while they're standing!</span>")
+
+
+/mob/living/carbon/human/proc/piggyback(mob/living/carbon/C)
+	if(can_piggyback(C))
+		visible_message("<span class='notice'>[C] starts to climb onto [src]...</span>")
+		if(do_after(C, 15, target = src))
+			if(can_piggyback(C))
+				if(C.incapacitated(FALSE, TRUE) || incapacitated(FALSE, TRUE))
+					C.visible_message("<span class='warning'>[C] can't hang onto [src]!</span>")
+					return
+				buckle_mob(C, TRUE, TRUE, FALSE, 0, 2)
+		else
+			visible_message("<span class='warning'>[C] fails to climb onto [src]!</span>")
+	else
+		to_chat(C, "<span class='warning'>You can't piggyback ride [src] right now!</span>")
+
+/mob/living/carbon/human/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE, lying_buckle = FALSE, hands_needed = 0, target_hands_needed = 0)
 	if(!force)//humans are only meant to be ridden through piggybacking and special cases
 		return
 	if(!is_type_in_typecache(M, can_ride_typecache))
 		M.visible_message("<span class='warning'>[M] really can't seem to mount [src]...</span>")
 		return
+	buckle_lying = lying_buckle
 	var/datum/component/riding/human/riding_datum = LoadComponent(/datum/component/riding/human)
-	riding_datum.ride_check_rider_incapacitated = TRUE
 	riding_datum.ride_check_rider_restrained = TRUE
-	riding_datum.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 6), TEXT_SOUTH = list(0, 6), TEXT_EAST = list(-6, 4), TEXT_WEST = list( 6, 4)))
-	if(buckled_mobs && ((M in buckled_mobs) || (buckled_mobs.len >= max_buckled_mobs)) || buckled || (M.stat != CONSCIOUS))
+	if(buckled_mobs && ((M in buckled_mobs) || (buckled_mobs.len >= max_buckled_mobs)) || buckled)
 		return
-	if(can_piggyback(M))
-		riding_datum.ride_check_ridden_incapacitated = TRUE
-		visible_message("<span class='notice'>[M] starts to climb onto [src]...</span>")
-		if(do_after(M, 15, target = src))
-			if(can_piggyback(M))
-				if(M.incapacitated(FALSE, TRUE) || incapacitated(FALSE, TRUE))
-					M.visible_message("<span class='warning'>[M] can't hang onto [src]!</span>")
-					return
-				if(!riding_datum.equip_buckle_inhands(M, 2))	//MAKE SURE THIS IS LAST!!
-					M.visible_message("<span class='warning'>[M] can't climb onto [src]!</span>")
-					return
-			stop_pulling()
-			. = ..(M, force, check_loc)
-		else
-			visible_message("<span class='warning'>[M] fails to climb onto [src]!</span>")
-	else
-		stop_pulling()
-		. = ..(M,force,check_loc)
+	var/equipped_hands_self
+	var/equipped_hands_target
+	if(hands_needed)
+		equipped_hands_self = riding_datum.equip_buckle_inhands(src, hands_needed, M)
+	if(target_hands_needed)
+		equipped_hands_target = riding_datum.equip_buckle_inhands(M, target_hands_needed)
+
+	if(hands_needed || target_hands_needed)
+		if(hands_needed && !equipped_hands_self)
+			src.visible_message("<span class='warning'>[src] can't get a grip on [M] because their hands are full!</span>", 
+				"<span class='warning'>You can't get a grip on [M] because your hands are full!</span>")
+			return
+		else if(target_hands_needed && !equipped_hands_target)
+			M.visible_message("<span class='warning'>[M] can't get a grip on [src] because their hands are full!</span>",
+				"<span class='warning'>You can't get a grip on [src] because your hands are full!</span>")
+			return
+	
+	stop_pulling()
+	riding_datum.handle_vehicle_layer()
+	. = ..(M, force, check_loc)
 
 /mob/living/carbon/human/proc/is_shove_knockdown_blocked() //If you want to add more things that block shove knockdown, extend this
 	var/list/body_parts = list(head, wear_mask, wear_suit, w_uniform, back, gloves, shoes, belt, s_store, glasses, ears, wear_id) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -853,7 +853,7 @@
 		if(do_after(src, 50, TRUE, C))
 			if(can_be_firemanned(C))//Second check to make sure they're still valid to be carried
 				if(!incapacitated(FALSE, TRUE))
-					buckle_mob(C, TRUE, TRUE, TRUE, 1, 0)
+					buckle_mob(C, TRUE, TRUE, 90, 1, 0)
 					return
 		visible_message("<span class='warning'>[src] fails to fireman carry [C]!")
 	else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -847,10 +847,10 @@
 		visible_message("<span class='notice'>[src] starts lifting [target] onto their back...</span>", 
 			"<span class='notice'>You start lifting [target] onto your back...</span>")
 		if(do_after(src, 50, TRUE, target))
-			if(can_be_firemanned(target))//Second check to make sure they're still valid to be carried
-				if(!incapacitated(FALSE, TRUE))
-					buckle_mob(target, TRUE, TRUE, 90, 1, 0)
-					return
+			//Second check to make sure they're still valid to be carried
+			if(can_be_firemanned(target) && !incapacitated(FALSE, TRUE))
+				buckle_mob(target, TRUE, TRUE, 90, 1, 0)
+				return
 		visible_message("<span class='warning'>[src] fails to fireman carry [target]!")
 	else
 		to_chat(src, "<span class='notice'>You can't fireman carry [target] while they're standing!</span>")
@@ -877,7 +877,8 @@
 		return
 	buckle_lying = lying_buckle
 	var/datum/component/riding/human/riding_datum = LoadComponent(/datum/component/riding/human)
-	riding_datum.ride_check_rider_restrained = TRUE
+	if(target_hands_needed)
+		riding_datum.ride_check_rider_restrained = TRUE
 	if(buckled_mobs && ((target in buckled_mobs) || (buckled_mobs.len >= max_buckled_mobs)) || buckled)
 		return
 	var/equipped_hands_self

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -299,6 +299,8 @@
 				var/mob/living/carbon/C = L
 				if(HAS_TRAIT(src, TRAIT_STRONG_GRABBER))
 					C.grippedby(src)
+			
+			update_pull_movespeed()
 
 		set_pull_offsets(M, state)
 
@@ -354,6 +356,7 @@
 	if(ismob(pulling))
 		reset_pull_offsets(pulling)
 	..()
+	update_pull_movespeed()
 	update_pull_hud_icon()
 
 /mob/living/verb/stop_pulling1()
@@ -591,6 +594,10 @@
 
 	var/old_direction = dir
 	var/turf/T = loc
+
+	if(pulling)
+		update_pull_movespeed()
+
 	. = ..()
 
 	if(pulledby && moving_diagonally != FIRST_DIAG_STEP && get_dist(src, pulledby) > 1 && (pulledby != moving_from_pull))//separated from our puller and not in the middle of a diagonal move.

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -174,7 +174,7 @@
 		switch(user.grab_state)
 			if(GRAB_AGGRESSIVE)
 				var/add_log = ""
-				if(user.has_trait(TRAIT_PACIFISM))
+				if(HAS_TRAIT(user, TRAIT_PACIFISM))
 					visible_message("<span class='danger'>[user] has firmly gripped [src]!</span>",
 						"<span class='danger'>[user] has firmly gripped you!</span>")
 					add_log = " (pacifist)"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -137,7 +137,7 @@
 		to_chat(user, "<span class='warning'>[src] can't be grabbed more aggressively!</span>")
 		return FALSE
 
-	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+	if(user.grab_state >= GRAB_AGGRESSIVE && HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='notice'>You don't want to risk hurting [src]!</span>")
 		return FALSE
 	grippedby(user)
@@ -173,11 +173,17 @@
 		user.grab_state++
 		switch(user.grab_state)
 			if(GRAB_AGGRESSIVE)
-				log_combat(user, src, "grabbed", addition="aggressive grab")
-				visible_message("<span class='danger'>[user] has grabbed [src] aggressively!</span>", \
-								"<span class='userdanger'>[user] has grabbed [src] aggressively!</span>")
-				drop_all_held_items()
+				var/add_log = ""
+				if(user.has_trait(TRAIT_PACIFISM))
+					visible_message("<span class='danger'>[user] has firmly gripped [src]!</span>",
+						"<span class='danger'>[user] has firmly gripped you!</span>")
+					add_log = " (pacifist)"
+				else
+					visible_message("<span class='danger'>[user] has grabbed [src] aggressively!</span>", \
+									"<span class='userdanger'>[user] has grabbed you aggressively!</span>")
+					drop_all_held_items()
 				stop_pulling()
+				log_combat(user, src, "grabbed", addition="aggressive grab[add_log]")
 			if(GRAB_NECK)
 				log_combat(user, src, "grabbed", addition="neck grab")
 				visible_message("<span class='danger'>[user] has grabbed [src] by the neck!</span>",\

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -116,3 +116,5 @@
 	//List of active diseases
 	var/list/diseases = list() // list of all diseases in a mob
 	var/list/disease_resistances = list()
+
+	var/drag_slowdown = TRUE //Whether the mob is slowed down when dragging another prone mob

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -41,6 +41,14 @@
 	else
 		remove_movespeed_modifier(MOVESPEED_ID_LIVING_TURF_SPEEDMOD)
 
+/mob/living/proc/update_pull_movespeed()
+	if(pulling && isliving(pulling))
+		var/mob/living/L = pulling
+		if(drag_slowdown && !(L.mobility_flags & MOBILITY_STAND) && !L.buckled && grab_state < GRAB_AGGRESSIVE)
+			add_movespeed_modifier(MOVESPEED_ID_PRONE_DRAGGING, multiplicative_slowdown = PULL_PRONE_SLOWDOWN)
+			return
+	remove_movespeed_modifier(MOVESPEED_ID_PRONE_DRAGGING)
+
 /mob/living/can_zFall(turf/T, levels)
 	return !(movement_type & FLYING)
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1163,14 +1163,12 @@
 		return
 	if(incapacitated())
 		return
-	if(M.incapacitated())
-		return
 	if(module)
 		if(!module.allow_riding)
 			M.visible_message("<span class='boldwarning'>Unfortunately, [M] just can't seem to hold onto [src]!</span>")
 			return
-	if(iscarbon(M) && (!riding_datum.equip_buckle_inhands(M, 1)))
-		if (M.get_num_arms() <= 0)
+	if(iscarbon(M) && !M.incapacitated() && !riding_datum.equip_buckle_inhands(M, 1))
+		if(M.get_num_arms() <= 0)
 			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [M.p_they()] don't have any usable arms!</span>")
 		else
 			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [M.p_their()] hands are full!</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -516,8 +516,9 @@
 
 /mob/MouseDrop_T(atom/dropping, atom/user)
 	. = ..()
-	if(dropping != src)
-		show_inv(dropping)
+	if(ismob(dropping) && dropping != user)
+		var/mob/M = dropping
+		M.show_inv(user)
 
 /mob/proc/is_muzzled()
 	return 0

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -513,7 +513,10 @@
 		return
 	if(isAI(M))
 		return
-	show_inv(usr)
+
+/mob/MouseDrop_T(atom/dropping, atom/user)
+	. = ..()
+	show_inv(user)
 
 /mob/proc/is_muzzled()
 	return 0

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -516,7 +516,8 @@
 
 /mob/MouseDrop_T(atom/dropping, atom/user)
 	. = ..()
-	show_inv(user)
+	if(dropping != src)
+		show_inv(dropping)
 
 /mob/proc/is_muzzled()
 	return 0


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5194834/58389181-ddaac600-7fdc-11e9-8d88-3a9aa887847c.png)

## About The Pull Request

Dragging prone mobs (resting, knocked down, stunned, dead, in crit, etc) that aren't buckled to anything slows you down.

You can fireman carry by aggressive grabbing then click dragging onto yourself. This causes a slight speed penalty that is lower than dragging.

## Why It's Good For The Game

Prevents the classic "stun and beat the shit out of while zipping off" which is obnoxious and I don't think anybody likes besides the people who do it.
Makes it so if you feel like being a cunt you can rest while being arrested to make you a pain to take back.
Makes it harder to steal bodies and move away before anybody can properly react, but makes dragging bodies riskier at the same time
Fireman carrying adds an element of risk reward, it takes a little while of standing still to pick them up and also slows you down slightly. More useful to move someone a long distance out of a relatively safe area than a quick pull away.

## Changelog
:cl:
add: fireman carrying. Aggressive grab then click drag onto yourself.
tweak: pulling prone mobs slows you down.
tweak: carrying another human slows you down.
tweak: pacifists can aggressive grab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
