### PR TITLE
Printed Forensic Scanner Documents now have an ID.

### DIFF
--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -18,6 +18,7 @@
 	var/list/log = list()
 	var/range = 8
 	var/view_check = TRUE
+	var/forensicPrintCount = 0
 	actions_types = list(/datum/action/item_action/displayDetectiveScanResults)
 
 /datum/action/item_action/displayDetectiveScanResults
@@ -42,8 +43,12 @@
 /obj/item/detective_scanner/proc/PrintReport()
 	// Create our paper
 	var/obj/item/paper/P = new(get_turf(src))
-	P.name = "paper- 'Scanner Report'"
-	P.info = "<center><font size='6'><B>Scanner Report</B></font></center><HR><BR>"
+
+	//This could be a global count like sec and med record printouts. See GLOB.data_core.medicalPrintCount AKA datacore.dm
+	var frNum = ++forensicPrintCount
+
+	P.name = text("FR-[] 'Forensic Record'", frNum)
+	P.info = text("<center><B>Forensic Record - (FR-[])</B></center><HR><BR>", frNum)
 	P.info += jointext(log, "<BR>")
 	P.info += "<HR><B>Notes:</B><BR>"
 	P.info_links = P.info


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added a counter to the Forensic Scanner Obj (counter is unique per Scanner object. I'd prefer it be global, up to the reviewer)
Modified the way the name of the document.
paper- 'Scanner Report'"
TO
FR-1 'Forensic Record'
FR-2 'Forensic Record'
etc.

The title when opening the document has been changed from
Scanner Report
to
Forensic Record - (FR-1)
Forensic Record - (FR-2)
etc


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This makes it easier to organize and reference documents when doing court cases in the courtroom.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Forensic Scanner documents are numbered now.
tweak: Forensic Scanner document titles modified
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
