### PR TITLE
End on_mob_add effects on liver removal

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -608,7 +608,8 @@
 
 	if(isliving(my_atom))
 		if (iscarbon(my_atom))
-			if (getorganslot(ORGAN_SLOT_LIVER)) // For carbons, conditional on the presence of a liver
+			var/mob/living/carbon/C = my_atom
+			if (C.getorganslot(ORGAN_SLOT_LIVER)) // For carbons, conditional on the presence of a liver
 				R.on_mob_add(my_atom)
 		else
 			R.on_mob_add(my_atom) //Must occur befor it could posibly run on_mob_delete

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -607,7 +607,11 @@
 		R.on_new(data)
 
 	if(isliving(my_atom))
-		R.on_mob_add(my_atom) //Must occur befor it could posibly run on_mob_delete
+		if (iscarbon(my_atom))
+			if (getorganslot(ORGAN_SLOT_LIVER)) // For carbons, conditional on the presence of a liver
+				R.on_mob_add(my_atom)
+		else
+			R.on_mob_add(my_atom) //Must occur befor it could posibly run on_mob_delete
 	update_total()
 	if(my_atom)
 		my_atom.on_reagent_change(ADD_REAGENT)

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -57,6 +57,25 @@
 #undef HAS_NO_TOXIN
 #undef HAS_PAINFUL_TOXIN
 
+/obj/item/organ/liver/Remove(mob/living/carbon/M, special = FALSE)
+	var/mob/living/carbon/C = owner
+	if (istype(C) && C.reagents)
+		for(var/I in C.reagents.reagent_list)
+			var/datum/reagent/R = I
+			if(QDELETED(R.holder))
+				continue
+			R.on_mob_delete(C)
+	return ..()
+
+/obj/item/organ/liver/Insert(mob/living/carbon/C, special = 0, drop_if_replaced = TRUE)
+	. = ..()
+	if (istype(C) && C.reagents)
+		for(var/I in C.reagents.reagent_list)
+			var/datum/reagent/R = I
+			if(QDELETED(R.holder))
+				continue
+			R.on_mob_add(C)
+
 /obj/item/organ/liver/prepare_eat()
 	var/obj/S = ..()
 	S.reagents.add_reagent("iron", 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

on_mob_delete is called for reagents in the mob when the liver is removed, and on_mob_add is called again when a liver is restored.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Naksu
tweak: Reagents that provide permanent effects cease working when the liver is removed. This is in line with reagents not processing without a liver.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
