### PR TITLE
Changes grenade detonation timers.

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -60,6 +60,8 @@
 			if (newtime != null && user.canUseTopic(src, BE_CLOSE))
 				change_det_time(newtime)
 				to_chat(user, "<span class='notice'>You modify the time delay. It's set for [DisplayTimeText(det_time)].</span>")
+				if (round(newtime * 10) != det_time)
+					to_chat(user, "<span class='warning'>The new value is out of bounds. The lowest possible time is 3 seconds and highest is 5 seconds. Instant detonations are also possible.</span>")
 		return
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
 		if(stage == WIRED)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -54,6 +54,13 @@
 			..()
 
 /obj/item/grenade/chem_grenade/attackby(obj/item/I, mob/user, params)
+	if(I.tool_behaviour == TOOL_MULTITOOL)
+		if(stage == READY && !nadeassembly && !active)
+			var/newtime = text2num(stripped_input(user, "Please enter a new detonation time", name))
+			if (newtime != null && user.canUseTopic(src, BE_CLOSE))
+				change_det_time(newtime)
+				to_chat(user, "<span class='notice'>You modify the time delay. It's set for [DisplayTimeText(det_time)].</span>")
+		return
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
 		if(stage == WIRED)
 			if(beakers.len)
@@ -62,12 +69,12 @@
 				I.play_tool_sound(src, 25)
 			else
 				to_chat(user, "<span class='warning'>You need to add at least one beaker before locking the [initial(name)] assembly!</span>")
-		else if(stage == READY && !nadeassembly)
-			det_time = det_time == 50 ? 30 : 50	//toggle between 30 and 50
+		else if(stage == READY && !nadeassembly && !active)
+			change_det_time()
 			to_chat(user, "<span class='notice'>You modify the time delay. It's set for [DisplayTimeText(det_time)].</span>")
 		else if(stage == EMPTY)
 			to_chat(user, "<span class='warning'>You need to add an activation mechanism!</span>")
-
+		return
 	else if(stage == WIRED && is_type_in_list(I, allowed_containers))
 		. = TRUE //no afterattack
 		if(is_type_in_list(I, banned_containers))
@@ -278,16 +285,14 @@
 	var/unit_spread = 10 // Amount of units per repeat. Can be altered with a multitool.
 
 /obj/item/grenade/chem_grenade/adv_release/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_MULTITOOL)
-		switch(unit_spread)
-			if(0 to 24)
-				unit_spread += 5
-			if(25 to 99)
-				unit_spread += 25
-			else
-				unit_spread = 5
-		to_chat(user, "<span class='notice'> You set the time release to [unit_spread] units per detonation.</span>")
-		return
+	if(I.tool_behaviour == TOOL_MULTITOOL && !active)
+		var/newspread = text2num(stripped_input(user, "Please enter a new spread amount", name))
+		if (newspread != null && user.canUseTopic(src, BE_CLOSE))
+			newspread = round(newspread)
+			unit_spread = CLAMP(newspread, 5, 100)
+			to_chat(user, "<span class='notice'>You set the time release to [unit_spread] units per detonation.</span>")
+		if (newspread != unit_spread)
+			to_chat(user, "<span class='notice'>The new value is out of bounds. Minimum spread is 5 units, maximum is 100 units.</span>")
 	..()
 
 /obj/item/grenade/chem_grenade/adv_release/prime()

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -90,7 +90,7 @@
 				change_det_time(newtime)
 				to_chat(user, "<span class='notice'>You modify the time delay. It's set for [DisplayTimeText(det_time)].</span>")
 				if (round(newtime * 10) != det_time)
-					to_chat(user, "<span class='warning'>The new value is out of bounds. The lowest possible time is 0 seconds and highest is 30 seconds.</span>")
+					to_chat(user, "<span class='warning'>The new value is out of bounds. The lowest possible time is 3 seconds and highest is 5 seconds. Instant detonations are also possible.</span>")
 			return
 		else if(W.tool_behaviour == TOOL_SCREWDRIVER)
 			change_det_time()
@@ -100,13 +100,13 @@
 		
 /obj/item/grenade/proc/change_det_time(time) //Time uses real time.
 	if(time != null)
-		det_time = round(CLAMP(time * 10, 0, 300))
+		if(time < 3)
+			time = 3
+		det_time = round(CLAMP(time * 10, 0, 50))
 	else
 		var/previous_time = det_time
 		switch(det_time)
 			if (0)
-				det_time = 10
-			if (10)
 				det_time = 30
 			if (30)
 				det_time = 50

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -49,7 +49,7 @@
 /obj/item/grenade/examine(mob/user)
 	..()
 	if(display_timer)
-		if(det_time > 1)
+		if(det_time > 0)
 			to_chat(user, "The timer is set to [DisplayTimeText(det_time)].")
 		else
 			to_chat(user, "\The [src] is set for instant detonation.")
@@ -69,7 +69,7 @@
 	if(user)
 		add_fingerprint(user)
 		if(msg)
-			to_chat(user, "<span class='warning'>You prime [src]! [DisplayTimeText(det_time)]!</span>")
+			to_chat(user, "<span class='warning'>You prime [src]! [capitalize(DisplayTimeText(det_time))]!</span>")
 	playsound(src, 'sound/weapons/armbomb.ogg', volume, 1)
 	active = TRUE
 	icon_state = initial(icon_state) + "_active"
@@ -82,25 +82,38 @@
 		var/mob/M = loc
 		M.dropItemToGround(src)
 
-
 /obj/item/grenade/attackby(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		switch(det_time)
-			if (1)
-				det_time = 10
-				to_chat(user, "<span class='notice'>You set the [name] for 1 second detonation time.</span>")
-			if (10)
-				det_time = 30
-				to_chat(user, "<span class='notice'>You set the [name] for 3 second detonation time.</span>")
-			if (30)
-				det_time = 50
-				to_chat(user, "<span class='notice'>You set the [name] for 5 second detonation time.</span>")
-			if (50)
-				det_time = 1
-				to_chat(user, "<span class='notice'>You set the [name] for instant detonation.</span>")
-		add_fingerprint(user)
+	if(!active)
+		if(W.tool_behaviour == TOOL_MULTITOOL)
+			var/newtime = text2num(stripped_input(user, "Please enter a new detonation time", name))
+			if (newtime != null && user.canUseTopic(src, BE_CLOSE))
+				change_det_time(newtime)
+				to_chat(user, "<span class='notice'>You modify the time delay. It's set for [DisplayTimeText(det_time)].</span>")
+				if (round(newtime * 10) != det_time)
+					to_chat(user, "<span class='warning'>The new value is out of bounds. The lowest possible time is 0 seconds and highest is 30 seconds.</span>")
+			return
+		else if(W.tool_behaviour == TOOL_SCREWDRIVER)
+			change_det_time()
+			to_chat(user, "<span class='notice'>You modify the time delay. It's set for [DisplayTimeText(det_time)].</span>")
 	else
 		return ..()
+		
+/obj/item/grenade/proc/change_det_time(time) //Time uses real time.
+	if(time != null)
+		det_time = round(CLAMP(time * 10, 0, 300))
+	else
+		var/previous_time = det_time
+		switch(det_time)
+			if (0)
+				det_time = 10
+			if (10)
+				det_time = 30
+			if (30)
+				det_time = 50
+			if (50)
+				det_time = 0
+		if(det_time == previous_time)
+			det_time = 50
 
 /obj/item/grenade/attack_paw(mob/user)
 	return attack_hand(user)

--- a/code/game/objects/items/grenades/smokebomb.dm
+++ b/code/game/objects/items/grenades/smokebomb.dm
@@ -3,7 +3,6 @@
 	desc = "The word 'Dank' is scribbled on it in crayon."
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "smokewhite"
-	det_time = 20
 	item_state = "flashbang"
 	slot_flags = ITEM_SLOT_BELT
 	var/datum/effect_system/smoke_spread/bad/smoke


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it possible to adjust the timer of all grenades with a screwdriver.

Also makes it possible to adjust the timer with a multitool. You put ot anywhere between 3 and 5 seconds. Instant detonations are also possible.

Changes how you input the spread amount on advanced release grenades. Instead of repeatedly clicking with a multitool, it now opens a window.

## Why It's Good For The Game

Makes grenades more consistent with each other. It made little sense that you could adjust the timer on flashbangs but not on smoke grenades, for example. It also gives the player more control about how they want to use grenades by letting them set the timer more accurately.

Also adds more bloat to the multitool. Exactly what this game needed.

## Changelog
:cl:
balance: The timer of all grenades can now be adjusted with a screwdriver. Possible values are instant, 3 seconds and 5 seconds.
add: You can now adjust the timer of grenades with a multitool. You can put it anywhere between 3 and 5 seconds. Instant detonations are also possible.
tweak: Advanced release grenades now open a window if you want to change the amount of units released.
tweak: The default timer on smoke grenades is now 3 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
