### PR TITLE
Art produces moodlets, good or bad depending on quality. THE REMAKE

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -178,6 +178,11 @@
 /datum/mood_event/sad_empath/add_effects(mob/sadtarget)
 	description = "<span class='warning'>[sadtarget.name] seems upset...</span>\n"
 
+/datum/mood_event/artbad
+	description = "<span class='warning'>I've produced better art than that from my ass.</span>\n"
+	mood_change = -2
+	timeout = 1200
+
 //These are unused so far but I want to remember them to use them later
 /datum/mood_event/cloned_corpse
 	description = "<span class='boldwarning'>I recently saw my own corpse...</span>\n"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -125,3 +125,18 @@
 /datum/mood_event/clownshoes
 	description = "<span class='nicegreen'>The shoes are a clown's legacy, I never want to take them off!</span>\n"
 	mood_change = 5
+
+/datum/mood_event/artok
+	description = "<span class='nicegreen'>It's nice to see people are making art around here.</span>\n"
+	mood_change = 2
+	timeout = 2 MINUTES
+
+/datum/mood_event/artgood
+	description = "<span class='nicegreen'>What a thought-provoking piece of art. I'll remember that for a while.</span>\n"
+	mood_change = 3
+	timeout = 3 MINUTES
+
+/datum/mood_event/artgreat
+	description = "<span class='nicegreen'>That work of art was so great it made me believe in the goodness of humanity. Says a lot in a place like this.</span>\n"
+	mood_change = 4
+	timeout = 4 MINUTES

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -477,8 +477,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. = ..()
 	if(.)
 		return
-	if(!do_after(user, 20, target = src))
-		return
 	add_fingerprint(user)
 	user.visible_message("[user] stops to admire off [src].", \
 						 "<span class='notice'>You take in [src], admiring its fine craftsmanship.</span>")

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -470,6 +470,15 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "A bust of the famous Greek physician Hippocrates of Kos, often referred to as the father of western medicine."
 	icon_state = "hippocratic"
 
+/obj/item/statuebust/attack_self(mob/living/user)
+	. = ..()
+	if(.)
+		return
+	add_fingerprint(user)
+	user.visible_message("[user] rubs some dust off [src].", \
+						 "<span class='notice'>You take in [src], rubbing some dust off its surface.</span>")
+	SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artgood", /datum/mood_event/artgood)
+
 /obj/item/tailclub
 	name = "tail club"
 	desc = "For the beating to death of lizards with their own tails."

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -471,12 +471,17 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	icon_state = "hippocratic"
 
 /obj/item/statuebust/attack_self(mob/living/user)
+	user.examinate(src)
+
+/obj/item/statuebust/examine(mob/living/user)
 	. = ..()
 	if(.)
 		return
+	if(!do_after(user, 20, target = src))
+		return
 	add_fingerprint(user)
-	user.visible_message("[user] rubs some dust off [src].", \
-						 "<span class='notice'>You take in [src], rubbing some dust off its surface.</span>")
+	user.visible_message("[user] stops to admire off [src].", \
+						 "<span class='notice'>You take in [src], admiring its fine craftsmanship.</span>")
 	SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artgood", /datum/mood_event/artgood)
 
 /obj/item/tailclub

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -471,14 +471,16 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	icon_state = "hippocratic"
 
 /obj/item/statuebust/attack_self(mob/living/user)
+	add_fingerprint(user)
 	user.examinate(src)
 
 /obj/item/statuebust/examine(mob/living/user)
 	. = ..()
 	if(.)
 		return
-	add_fingerprint(user)
-	user.visible_message("[user] stops to admire off [src].", \
+	if (!isliving(user))
+		return
+	user.visible_message("[user] stops to admire [src].", \
 						 "<span class='notice'>You take in [src], admiring its fine craftsmanship.</span>")
 	SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artgood", /datum/mood_event/artgood)
 

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -1,3 +1,8 @@
+
+#define BAD_ART 12.5
+#define GOOD_ART 25
+#define GREAT_ART 50
+
 /obj/structure/statue
 	name = "statue"
 	desc = "Placeholder. Yell at Firecage if you SOMEHOW see this."
@@ -8,12 +13,14 @@
 	max_integrity = 100
 	var/oreAmount = 5
 	var/material_drop_type = /obj/item/stack/sheet/metal
+	var/impressiveness = 15
 	CanAtmosPass = ATMOS_PASS_DENSITY
 
 
 /obj/structure/statue/attackby(obj/item/W, mob/living/user, params)
 	add_fingerprint(user)
-	user.changeNext_move(CLICK_CD_MELEE)
+	if(!do_after(user, 20, target = src))
+		return
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(default_unfasten_wrench(user, W))
 			return
@@ -34,10 +41,21 @@
 	. = ..()
 	if(.)
 		return
-	user.changeNext_move(CLICK_CD_MELEE)
 	add_fingerprint(user)
-	user.visible_message("[user] rubs some dust off from the [name]'s surface.", \
-						 "<span class='notice'>You rub some dust off from the [name]'s surface.</span>")
+	user.visible_message("[user] rubs some dust off [src].", \
+						 "<span class='notice'>You take in [src], rubbing some dust off its surface.</span>")
+	if(!ishuman(user)) // only humans have the capacity to appreciate art
+		return
+	var/totalimpressiveness = (impressiveness *(obj_integrity/max_integrity))
+	switch(totalimpressiveness)
+		if(GREAT_ART to 100)
+			SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artgreat", /datum/mood_event/artgreat)
+		if (GOOD_ART to GREAT_ART)
+			SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artgood", /datum/mood_event/artgood)
+		if (BAD_ART to GOOD_ART)
+			SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artok", /datum/mood_event/artok)
+		if (0 to BAD_ART)
+			SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artbad", /datum/mood_event/artbad)
 
 /obj/structure/statue/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
@@ -58,6 +76,8 @@
 	material_drop_type = /obj/item/stack/sheet/mineral/uranium
 	var/last_event = 0
 	var/active = null
+	impressiveness = 25 // radiation makes an impression
+
 
 /obj/structure/statue/uranium/nuke
 	name = "statue of a nuclear fission explosive"
@@ -100,6 +120,7 @@
 /obj/structure/statue/plasma
 	max_integrity = 200
 	material_drop_type = /obj/item/stack/sheet/mineral/plasma
+	impressiveness = 20
 	desc = "This statue is suitably made from plasma."
 
 /obj/structure/statue/plasma/scientist
@@ -150,6 +171,7 @@
 /obj/structure/statue/gold
 	max_integrity = 300
 	material_drop_type = /obj/item/stack/sheet/mineral/gold
+	impressiveness = 25
 	desc = "This is a highly valuable statue made from gold."
 
 /obj/structure/statue/gold/hos
@@ -177,6 +199,7 @@
 /obj/structure/statue/silver
 	max_integrity = 300
 	material_drop_type = /obj/item/stack/sheet/mineral/silver
+	impressiveness = 25
 	desc = "This is a valuable statue made from silver."
 
 /obj/structure/statue/silver/md
@@ -204,6 +227,7 @@
 /obj/structure/statue/diamond
 	max_integrity = 1000
 	material_drop_type = /obj/item/stack/sheet/mineral/diamond
+	impressiveness = 50
 	desc = "This is a very expensive diamond statue."
 
 /obj/structure/statue/diamond/captain
@@ -223,6 +247,7 @@
 /obj/structure/statue/bananium
 	max_integrity = 300
 	material_drop_type = /obj/item/stack/sheet/mineral/bananium
+	impressiveness = 50
 	desc = "A bananium statue with a small engraving:'HOOOOOOONK'."
 	var/spam_flag = 0
 
@@ -258,6 +283,7 @@
 /obj/structure/statue/sandstone
 	max_integrity = 50
 	material_drop_type = /obj/item/stack/sheet/mineral/sandstone
+	impressiveness = 15
 
 /obj/structure/statue/sandstone/assistant
 	name = "statue of an assistant"

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -19,8 +19,6 @@
 
 /obj/structure/statue/attackby(obj/item/W, mob/living/user, params)
 	add_fingerprint(user)
-	if(!do_after(user, 20, target = src))
-		return
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(default_unfasten_wrench(user, W))
 			return
@@ -42,6 +40,8 @@
 	if(.)
 		return
 	add_fingerprint(user)
+	if(!do_after(user, 20, target = src))
+		return
 	user.visible_message("[user] rubs some dust off [src].", \
 						 "<span class='notice'>You take in [src], rubbing some dust off its surface.</span>")
 	if(!ishuman(user)) // only humans have the capacity to appreciate art

--- a/code/modules/photography/photos/frame.dm
+++ b/code/modules/photography/photos/frame.dm
@@ -109,6 +109,7 @@
 /obj/structure/sign/picture_frame/examine(mob/user)
 	if(in_range(src, user) && framed)
 		framed.show(user)
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "artok", /datum/mood_event/artok)
 	else
 		..()
 


### PR DESCRIPTION
:cl: bandit
add: Art now affects mood depending on its quality.
/:cl:

(Remake of https://github.com/tgstation/tgstation/pull/42446 and addresses concerns in it.)

When you interact with a piece of art, you get a moodlet. The higher-quality the art, the more positive the moodlet.

There are four tiers of art quality.
- OK art. The default. Most statues and all framed photos qualify for this. Small positive moodlet.
- Good art. Gold, silver, and uranium statues qualify for this, as do statue busts (I have no idea if these are even used but they should count). Even higher moodlet. Higher moodlet.
- Great art. Diamond and bananium statues qualify for this. Highest moodlet.
- Bad art. Currently, no pieces of art start out bad. However, if statues take enough damage, they will count as bad. Higher-quality statues require more damage to be "bad" -- currently good statues need 50% damage, great statues 25%. This gives you a small negative moodlet.

Why this is added: Because we need more positive moodlets, and it also encourages people to decorate the station.

The art quality system is currently very much a rudimentary thing. Other objects things may be able to use the moodlets above in the future.