### PR TITLE
[READY] Renames existing skin colors, adds skin colors, updates spray tan code

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -134,18 +134,22 @@
 	return pick(GLOB.skin_tones)
 
 GLOBAL_LIST_INIT(skin_tones, list(
-	"albino",
-	"caucasian1",
-	"caucasian2",
-	"caucasian3",
-	"latino",
-	"mediterranean",
-	"asian1",
-	"asian2",
-	"arab",
-	"indian",
-	"african1",
-	"african2"
+	"Albino",
+	"Porcelain",
+	"Ivory",
+	"Sand",
+	"Beige",
+	"Peach",
+	"Honey",
+	"Sienna",
+	"Olive",
+	"Mocha",
+	"Amber",
+	"Bronze",
+	"Caramel",
+	"Hazelnut",
+	"Espresso",
+	"Cacao"
 	))
 
 GLOBAL_LIST_EMPTY(species_list)
@@ -379,7 +383,7 @@ GLOBAL_LIST_EMPTY(species_list)
 	var/list/spawned_mobs = new(amount)
 
 	for(var/j in 1 to amount)
-		var/atom/movable/X 
+		var/atom/movable/X
 
 		if (istype(spawn_type, /list))
 			var/mob_type = pick(spawn_type)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -106,7 +106,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 				job_preferences[initial(J.title)] = new_value
 	if(current_version < 23)
 		var/static/list/skin_tone_lookup = list(
-			"causacian1" = 		"Porcelain",
+			"caucasian1" = 		"Porcelain",
 			"caucasian2" = 		"Sand",
 			"caucasian3" = 		"Peach",
 			"asian1" = 			"Ivory",

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -281,6 +281,34 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["facial_hair_color"]	>> facial_hair_color
 	S["eye_color"]			>> eye_color
 	S["skin_tone"]			>> skin_tone
+	if(S["skin_tone"])
+		if(S["skin_tone"] == "caucasian1")
+			"Porcelain"		>> skin_tone
+		else if(S["skin_tone"] == "asian1")
+			"Ivory"			>> skin_tone
+		else if(S["skin_tone"] == "caucasian2")
+			"Sand"			>> skin_tone
+		else if(S["skin_tone"] == "asian2")
+			"Beige"			>> skin_tone
+		else if(S["skin_tone"] == "caucasian3")
+			"Peach"			>> skin_tone
+		else if(S["skin_tone"] == "latino")
+			"Sienna"		>> skin_tone
+		else if(S["skin_tone"] == "mediterranean")
+			"Olive"			>> skin_tone
+		else if(S["skin_tone"] == "arab")
+			"Mocha"			>> skin_tone
+		else if(S["skin_tone"] == "indian")
+			"Amber"			>> skin_tone
+		else if(S["skin_tone"] == "african1")
+			"Caramel"		>> skin_tone
+		else if(S["skin_tone"] == "african2")
+			"Espresso"		>> skin_tone
+		else if(S["skin_tone"] == "albino")
+			"Albino"		>> skin_tone
+		else
+			S["skin_tone"]	>> skin_tone
+
 	S["hair_style_name"]	>> hair_style
 	S["facial_style_name"]	>> facial_hair_style
 	S["underwear"]			>> underwear

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	22
+#define SAVEFILE_VERSION_MAX	23
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -104,6 +104,22 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 						new_value = JP_LOW
 			if(new_value)
 				job_preferences[initial(J.title)] = new_value
+	if(current_version < 23)
+		var/static/list/skin_tone_lookup = list(
+			"causacian1" = 		"Porcelain",
+			"caucasian2" = 		"Sand",
+			"caucasian3" = 		"Peach",
+			"asian1" = 			"Ivory",
+			"asian2" = 			"Beige",
+			"latino" = 			"Sienna",
+			"mediterranean" = 	"Olive",
+			"arab" = 			"Mocha",
+			"indian" = 			"Amber",
+			"african1" = 		"Caramel",
+			"african2" = 		"Espresso",
+			"albino" = 			"Albino"
+		)
+		skin_tone = skin_tone_lookup[skin_tone]
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)
@@ -281,34 +297,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["facial_hair_color"]	>> facial_hair_color
 	S["eye_color"]			>> eye_color
 	S["skin_tone"]			>> skin_tone
-	if(S["skin_tone"])
-		if(S["skin_tone"] == "caucasian1")
-			"Porcelain"		>> skin_tone
-		else if(S["skin_tone"] == "asian1")
-			"Ivory"			>> skin_tone
-		else if(S["skin_tone"] == "caucasian2")
-			"Sand"			>> skin_tone
-		else if(S["skin_tone"] == "asian2")
-			"Beige"			>> skin_tone
-		else if(S["skin_tone"] == "caucasian3")
-			"Peach"			>> skin_tone
-		else if(S["skin_tone"] == "latino")
-			"Sienna"		>> skin_tone
-		else if(S["skin_tone"] == "mediterranean")
-			"Olive"			>> skin_tone
-		else if(S["skin_tone"] == "arab")
-			"Mocha"			>> skin_tone
-		else if(S["skin_tone"] == "indian")
-			"Amber"			>> skin_tone
-		else if(S["skin_tone"] == "african1")
-			"Caramel"		>> skin_tone
-		else if(S["skin_tone"] == "african2")
-			"Espresso"		>> skin_tone
-		else if(S["skin_tone"] == "albino")
-			"Albino"		>> skin_tone
-		else
-			S["skin_tone"]	>> skin_tone
-
 	S["hair_style_name"]	>> hair_style
 	S["facial_style_name"]	>> facial_hair_style
 	S["underwear"]			>> underwear

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -335,28 +335,38 @@
 			var/mob/living/carbon/human/N = M
 			if(N.dna.species.id == "human")
 				switch(N.skin_tone)
-					if("african1")
-						N.skin_tone = "african2"
-					if("indian")
-						N.skin_tone = "african1"
-					if("arab")
-						N.skin_tone = "indian"
-					if("asian2")
-						N.skin_tone = "arab"
-					if("asian1")
-						N.skin_tone = "asian2"
-					if("mediterranean")
-						N.skin_tone = "african1"
-					if("latino")
-						N.skin_tone = "mediterranean"
-					if("caucasian3")
-						N.skin_tone = "mediterranean"
-					if("caucasian2")
-						N.skin_tone = pick("caucasian3", "latino")
-					if("caucasian1")
-						N.skin_tone = "caucasian2"
-					if ("albino")
-						N.skin_tone = "caucasian1"
+					if("Amber")
+						N.skin_tone = pick("Bronze", "Caramel")
+					if("Honey")
+						N.skin_tone = "Amber"
+					if("Beige")
+						N.skin_tone = "Honey"
+					if("Ivory")
+						N.skin_tone = "Beige"
+					if("Espresso")
+						N.skin_tone = "Cacao"
+					if("Hazelnut")
+						N.skin_tone = "Espresso"
+					if("Caramel")
+						N.skin_tone = "Espresso"
+					if("Bronze")
+						N.skin_tone = pick("Caramel", "Hazelnut")
+					if("Mocha")
+						N.skin_tone = "Bronze"
+					if("Olive")
+						N.skin_tone = "Mocha"
+					if("Sienna")
+						N.skin_tone = "Olive"
+					if("Peach")
+						N.skin_tone = "Sienna"
+					if("Sand")
+						N.skin_tone = "Peach"
+					if("Porcelain")
+						N.skin_tone = "Sand"
+					if("Albino")
+						N.skin_tone = "Porcelain"
+					if("Cacao")
+						N.skin_tone = "darkorange"
 
 			if(MUTCOLORS in N.dna.species.species_traits) //take current alien color and darken it slightly
 				var/newcolor = ""

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -239,32 +239,42 @@
 /proc/skintone2hex(skin_tone)
 	. = 0
 	switch(skin_tone)
-		if("caucasian1")
+		if("Porcelain")
 			. = "ffe0d1"
-		if("caucasian2")
-			. = "fcccb3"
-		if("caucasian3")
-			. = "e8b59b"
-		if("latino")
-			. = "d9ae96"
-		if("mediterranean")
-			. = "c79b8b"
-		if("asian1")
+		if("Ivory")
 			. = "ffdeb3"
-		if("asian2")
+		if("Sand")
+			. = "fcccb3"
+		if("Beige")
 			. = "e3ba84"
-		if("arab")
+		if("Peach")
+			. = "e8b59b"
+		if("Honey")
+			. = "da9c4a"
+		if("Sienna")
+			. = "d9ae96"
+		if("Olive")
+			. = "c79b8b"
+		if("Mocha")
 			. = "c4915e"
-		if("indian")
+		if("Amber")
 			. = "b87840"
-		if("african1")
+		if("Bronze")
+			. = "885f29"
+		if("Caramel")
 			. = "754523"
-		if("african2")
+		if("Hazelnut")
+			. = "563010"
+		if("Espresso")
 			. = "471c18"
-		if("albino")
+		if("Cacao")
+			. = "2b0c0c"
+		if("Albino")
 			. = "fff4e6"
 		if("orange")
 			. = "ffc905"
+		if("darkorange")
+			. = "bb9302"
 
 /mob/living/carbon/proc/Digitigrade_Leg_Swap(swap_back)
 	var/body_plan_changed = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This renames existing skin colors while adding four new skin colors available for character preferences. The corresponding spray tan code has been updated to reflect this. This also adds the secret color "darkorange," a result of adding spray tan to the Cacao skin color. No skin colors were removed, and the albino and orange skin colors have been preserved.

Skin colors on existing saves will remain the same hex but convert to the new color name.

Colors will be listed in preferences from lightest to darkest.

Colors will appear in the following order:

Albino
Porcelain _(previously caucasian1)_
Ivory _(previously asian1)_
Sand _(previously caucasian2)_
Beige _(previously asian2)_
Peach _(previously caucasian3)_
Honey **(new)**
Sienna _(previously latino)_
Olive _(previously mediterranean)_
Mocha _(previously arab)_
Amber _(previously indian)_
Bronze **(new)**
Caramel _(previously african1)_
Hazelnut **(new)**
Espresso _(previously african2)_
Cacao **(new)**

Added colors:

Honey
![Skin-Honey](https://user-images.githubusercontent.com/50865623/58520182-7ec78700-816b-11e9-96aa-de720b3bfad2.png)

Bronze
![Bronze](https://user-images.githubusercontent.com/50865623/58520196-943cb100-816b-11e9-87e8-45e066d44a8d.png)

Hazelnut
![Skin-Hazelnut](https://user-images.githubusercontent.com/50865623/58520201-9d2d8280-816b-11e9-9d0a-d9d7e215c7b1.png)

Cacao
![Skin-Cacao](https://user-images.githubusercontent.com/50865623/58520203-9f8fdc80-816b-11e9-87b1-f4237be91e15.png)

Dark Orange (not available in character preferences)
![DarkOrange](https://user-images.githubusercontent.com/50865623/58520340-2349c900-816c-11e9-8162-5863fdbb7c3c.png)

The full spectrum of skin colors available in character preferences per this PR:

![spectrum-names](https://user-images.githubusercontent.com/50865623/58520788-58571b00-816e-11e9-9e6b-b036f856ab8f.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- The existing naming conventions were inconsistent. This creates a consistent naming standard across skin colors.
- It is now easier to quickly find your desired skin color, as the names are based on actual color.
- This looks better in-game and is more consistent with the other character preferences.
- The darkest skin color is now reactive to spray tan.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: new skin colors: Honey, Bronze, Hazelnut, Cacao
add: skin color: darkorange
tweak: skin color names
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
