### PR TITLE
Adds affix validation and a slight cleanup of fantasy component

### DIFF
--- a/code/datums/components/fantasy/_fantasy.dm
+++ b/code/datums/components/fantasy/_fantasy.dm
@@ -63,22 +63,25 @@
 			var/datum/fantasy_affix/affix = new T
 			affixListing[affix] = affix.weight
 
-	var/usedSlots = NONE
-	for(var/i in affixes)
-		var/datum/fantasy_affix/affix = i
-		usedSlots |= affix.placement
-	
+	if(length(affixes))
+		if(!force)
+			return
+		affixes = list()
+
 	var/alignment
 	if(quality >= 0)
 		alignment |= AFFIX_GOOD
 	if(quality <= 0)
 		alignment |= AFFIX_EVIL
 	
+	var/usedSlots = NONE
 	for(var/i in 1 to max(1, abs(quality))) // We want at least 1 affix applied
 		var/datum/fantasy_affix/affix = pickweight(affixListing)
 		if(affix.placement & usedSlots)
 			continue
 		if(!(affix.alignment & alignment))
+			continue
+		if(!affix.validate(src))
 			continue
 		affixes += affix
 		usedSlots |= affix.placement

--- a/code/datums/components/fantasy/affix.dm
+++ b/code/datums/components/fantasy/affix.dm
@@ -3,6 +3,10 @@
 	var/alignment
 	var/weight = 10
 
+// For those occasional affixes which only make sense in certain circumstances
+/datum/fantasy_affix/proc/validate(datum/component/fantasy/comp)
+	return TRUE
+
 /datum/fantasy_affix/proc/apply(datum/component/fantasy/comp, newName)
 	return newName
 


### PR DESCRIPTION
It seemed obvious after a bit of discussion about affixes that they need a way to prevent themselves being added to something which makes no sense. For example a component for ranged weapons being applied to a pen.

Also makes the force argument in randomAffixes() actually do something and handles existing affixes a bit better. We shouldn't be adding extra affixes if someone specified exactly what affixes they want ahead of time.
