### PR TITLE
Twisted construction fix

### DIFF
--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -212,6 +212,8 @@
 
 
 /proc/makeNewConstruct(mob/living/simple_animal/hostile/construct/ctype, mob/target, mob/stoner = null, cultoverride = 0, loc_override = null)
+	if(QDELETED(target))
+		return
 	var/mob/living/simple_animal/hostile/construct/newstruct = new ctype((loc_override) ? (loc_override) : (get_turf(target)))
 	if(stoner)
 		newstruct.faction |= "[REF(stoner)]"


### PR DESCRIPTION
## About The Pull Request

The bug was that for each time you click on a borg with twisted construction it will make a separate construct, all but one of the constructs would be brainless so you could only use them as sacrifices. Those sacrifices would make soulstones so by following that process you could make as many soulstones as you could click during the conversion channel which is bad for obvious reasons. This PR fixes that by making makeNewConstruct check to make sure the target isn't being queued for deletion.

## Changelog
:cl: Garen
fix: You can only make one construct when using twisted construction on a borg.
/:cl: