### PR TITLE
Fixes windoors bump/hand interactions

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -160,7 +160,7 @@
 			open()
 		else
 			close()
-		return
+		return TRUE
 	if(density)
 		do_animate("deny")
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -55,12 +55,15 @@
 		icon_state = "[base_state]open"
 
 /obj/machinery/door/window/proc/open_and_close()
-	open()
+	if(!open())
+		return
+	autoclose = TRUE
 	if(check_access(null))
 		sleep(50)
 	else //secure doors close faster
 		sleep(20)
-	close()
+	if(!density && autoclose) //did someone change state while we slept?
+		close()
 
 /obj/machinery/door/window/Bumped(atom/movable/AM)
 	if( operating || !density )
@@ -282,6 +285,10 @@
 
 /obj/machinery/door/window/interact(mob/user)		//for sillycones
 	try_to_activate_door(user)
+
+/obj/machinery/door/window/try_to_activate_door(mob/user)
+	if (..())
+		autoclose = FALSE
 
 /obj/machinery/door/window/try_to_crowbar(obj/item/I, mob/user)
 	if(!hasPower())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If you bump into a windoor, you currently have to wait until it closes before you can manually open it to keep it open, or it autocloses anyway. This makes windoors only auto close from bumping if noone has closed it manually already.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: windoors can now be closed manually after bumping open without having them close again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
