### PR TITLE
Buffs blob rerolls by allowing them to choose from 4 different strains

### DIFF
--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -93,8 +93,8 @@
 
 /obj/screen/blob/ReadaptStrain
 	icon_state = "ui_chemswap"
-	name = "Readapt Chemical (40)"
-	desc = "Randomly rerolls your chemical for 40 resources."
+	name = "Readapt Strain (40)"
+	desc = "Allows you to choose a new strain from 4 random choices for 40 resources."
 
 /obj/screen/blob/ReadaptStrain/MouseEntered(location,control,params)
 	if(hud && hud.mymob && isovermind(hud.mymob))

--- a/code/modules/antagonists/blob/blobstrains/_blobstrain.dm
+++ b/code/modules/antagonists/blob/blobstrains/_blobstrain.dm
@@ -22,6 +22,19 @@ GLOBAL_LIST_INIT(valid_blobstrains, subtypesof(/datum/blobstrain) - list(/datum/
 		stack_trace("blobstrain created without overmind")
 	overmind = new_overmind
 
+/datum/blobstrain/proc/on_gain()
+	overmind.color = complementary_color
+	for(var/BL in GLOB.blobs)
+		var/obj/structure/blob/B = BL
+		B.update_icon()
+	for(var/BLO in overmind.blob_mobs)
+		var/mob/living/simple_animal/hostile/blob/BM = BLO
+		BM.update_icons() //If it's getting a new strain, tell it what it does!
+		to_chat(BM, "Your overmind's blob strain is now: <b><font color=\"[color]\">[name]</b></font>!")
+		to_chat(BM, "The <b><font color=\"[color]\">[name]</b></font> strain [shortdesc ? "[shortdesc]" : "[description]"]")
+
+/datum/blobstrain/proc/on_lose()
+
 /datum/blobstrain/proc/on_sporedeath(mob/living/spore)
 
 /datum/blobstrain/proc/send_message(mob/living/M)

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	real_name = new_name
 	last_attack = world.time
 	var/datum/blobstrain/BS = pick(GLOB.valid_blobstrains)
-	blobstrain = new BS(src)
+	set_strain(BS)
 	color = blobstrain.complementary_color
 	if(blob_core)
 		blob_core.update_icon()
@@ -69,6 +69,22 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	if(!T)
 		CRASH("No blobspawnpoints and blob spawned in nullspace.")
 	forceMove(T)
+
+/mob/camera/blob/proc/set_strain(datum/blobstrain/new_strain)
+	if (ispath(new_strain))
+		var/hadstrain = FALSE
+		if (istype(blobstrain))
+			blobstrain.on_lose()
+			qdel(blobstrain)
+			hadstrain = TRUE
+		blobstrain = new new_strain(src)
+		blobstrain.on_gain()
+		if (hadstrain)
+			to_chat(src, "Your strain is now: <b><font color=\"[blobstrain.color]\">[blobstrain.name]</b></font>!")
+			to_chat(src, "The <b><font color=\"[blobstrain.color]\">[blobstrain.name]</b></font> strain [blobstrain.description]")
+			if(blobstrain.effectdesc)
+				to_chat(src, "The <b><font color=\"[blobstrain.color]\">[blobstrain.name]</b></font> strain [blobstrain.effectdesc]")
+
 
 /mob/camera/blob/proc/is_valid_turf(turf/T)
 	var/area/A = get_area(T)

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -38,6 +38,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	var/max_count = 0 //The biggest it got before death
 	var/blobwincount = 400
 	var/victory_in_progress = FALSE
+	var/rerolling = FALSE
 
 /mob/camera/blob/Initialize(mapload, starting_points = 60)
 	validate_location()

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -340,8 +340,10 @@
 	set category = "Blob"
 	set name = "Reactive Strain Adaptation (40)"
 	set desc = "Replaces your strain with a random, different one."
-	if(free_strain_rerolls || can_buy(40))
+	if(!rerolling && (free_strain_rerolls || can_buy(40)))
+		rerolling = TRUE
 		reroll_strain()
+		rerolling = FALSE
 		if(free_strain_rerolls)
 			free_strain_rerolls--
 		last_reroll_time = world.time

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -341,27 +341,22 @@
 	set name = "Reactive Strain Adaptation (40)"
 	set desc = "Replaces your strain with a random, different one."
 	if(free_strain_rerolls || can_buy(40))
-		set_strain()
+		reroll_strain()
 		if(free_strain_rerolls)
 			free_strain_rerolls--
 		last_reroll_time = world.time
 
-/mob/camera/blob/proc/set_strain()
-	var/datum/blobstrain/bs = pick((GLOB.valid_blobstrains - blobstrain.type))
-	blobstrain = new bs(src)
-	color = blobstrain.complementary_color
-	for(var/BL in GLOB.blobs)
-		var/obj/structure/blob/B = BL
-		B.update_icon()
-	for(var/BLO in blob_mobs)
-		var/mob/living/simple_animal/hostile/blob/BM = BLO
-		BM.update_icons() //If it's getting a new strain, tell it what it does!
-		to_chat(BM, "Your overmind's blob strain is now: <b><font color=\"[blobstrain.color]\">[blobstrain.name]</b></font>!")
-		to_chat(BM, "The <b><font color=\"[blobstrain.color]\">[blobstrain.name]</b></font> strain [blobstrain.shortdesc ? "[blobstrain.shortdesc]" : "[blobstrain.description]"]")
-	to_chat(src, "Your strain is now: <b><font color=\"[blobstrain.color]\">[blobstrain.name]</b></font>!")
-	to_chat(src, "The <b><font color=\"[blobstrain.color]\">[blobstrain.name]</b></font> strain [blobstrain.description]")
-	if(blobstrain.effectdesc)
-		to_chat(src, "The <b><font color=\"[blobstrain.color]\">[blobstrain.name]</b></font> strain [blobstrain.effectdesc]")
+/mob/camera/blob/proc/reroll_strain()
+	var/list/choices = list()
+	while (length(choices) < 4)
+		var/datum/blobstrain/bs = pick((GLOB.valid_blobstrains))
+		choices[initial(bs.name)] = bs
+
+	var/choice = input(usr, "Please choose a new strain","Strain") as anything in choices
+	if (choice && choices[choice] && !QDELETED(src))
+		var/datum/blobstrain/bs = choices[choice]
+		set_strain(bs)
+
 
 /mob/camera/blob/verb/blob_help()
 	set category = "Blob"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pretty much what it says on the tin. Also provides a more convenient interface for admins to set a blob strain (call set_strain with a /datum/blobstrain typepath on the overmind camera mob)

## Why It's Good For The Game

The balance of rerolling is currently too much against the blob, leading people to sit tightly on a couple of "known-good" blobstrains and not using the reroll option even if there were many better strains for their current situation, as some of the other strains are total whammies which might get the blob killed near-instantly. Making the reroll option more but still not totally reliable allows blob players to play with the strains more.

## Changelog
:cl: Naksu
balance: Blob rerolls now give the blob 4 different options to choose from, rather than forcing a single random one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
