### PR TITLE
Make GetComponent throw an error on dupe enabled components

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -185,7 +185,10 @@
 		var/datum/callback/CB = C.signal_procs[src][sigtype]
 		. |= CB.InvokeAsync(arglist(arguments))
 
-/datum/proc/GetComponent(c_type)
+// The type arg is casted so initial works, you shouldn't be passing a real instance into this
+/datum/proc/GetComponent(datum/component/c_type)
+	if(initial(c_type.dupe_mode) == COMPONENT_DUPE_ALLOWED)
+		stack_trace("GetComponent was called to get a component of which multiple copies could be on an object. This can easily break and should be changed. Type: \[[c_type]\]")
 	var/list/dc = datum_components
 	if(!dc)
 		return null


### PR DESCRIPTION
GetComponent gets a singular component, if you're trying to get a component which allows duplicates on the object then you're doing something that can very easily break. Stop it.

I'll straight up disable the capability once everything that does this has been cleaned up but each and every one is its own project.