### PR TITLE
Add Crematorium access to the Crematorium button

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -272,7 +272,7 @@
 	icon_state = "launcher"
 	skin = "launcher"
 	device_type = /obj/item/assembly/control/crematorium
-	req_access = list()
+	req_access = list(ACCESS_CREMATORIUM)
 	id = 1
 
 /obj/machinery/button/crematorium/indestructible


### PR DESCRIPTION
Add Crematorium access to the Crematorium button.w

## About The Pull Request

Simply adds Crematorium access to the (currently empty) access requirements of the Crematorium igniter.    It looks like it had been there before as the line for access requirements was left in, but left empty.


## Why It's Good For The Game

Crematorium is way, way too robust to be hidden behind a single maintenance door.  Now people will have to either have an emag or Chapel access to remove evidence of traitoring/murder.  Also makes the chaplain more valuable in Changeling rounds.

## Changelog
:cl: NovaRemnant
balance: Made Crematorium button require Crematorium access.
/:cl:

