### PR TITLE
No one can just deflect the emerald splash

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -55,7 +55,7 @@
 						if(prob(30))
 							say(pick("OH NO!!!", "OH MY GOD!!", "HORY SHET!!"), forced = P.type)
 						var/mob/living/guardian = P.firer
-						if(prob(20))
+						if(prob(20) && guardian)
 							guardian.say("No one can just deflect the [P]!", forced = P.type)
 					else
 						if(!isturf(loc)) //if we're inside something and still got hit

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -50,21 +50,30 @@
 		if(mind.martial_art && !incapacitated(FALSE, TRUE) && mind.martial_art.can_use(src) && mind.martial_art.deflection_chance) //Some martial arts users can deflect projectiles!
 			if(prob(mind.martial_art.deflection_chance))
 				if((mobility_flags & MOBILITY_USE) && dna && !dna.check_mutation(HULK)) //But only if they're otherwise able to use items, and hulks can't do it
-					if(!isturf(loc)) //if we're inside something and still got hit
-						P.force_hit = TRUE //The thing we're in passed the bullet to us. Pass it back, and tell it to take the damage.
-						loc.bullet_act(P)
-						return BULLET_ACT_HIT
-					if(mind.martial_art.deflection_chance >= 100) //if they can NEVER be hit, lets clue sec in ;)
-						visible_message("<span class='danger'>[src] deflects the projectile; [p_they()] can't be hit with ranged weapons!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
+					if(istype(P, /obj/item/projectile/guardian)) //meme code incoming
+						visible_message("<span class='danger'>[src] tries to deflect the [P] but can't.</span>", "<span class='userdanger'>You can not deflect the [P]!</span>")
+						if(prob(30))
+							say(pick("OH NO!!!", "OH MY GOD!!", "HORY SHET!!"), forced = P.type)
+						var/mob/living/guardian = P.firer
+						if(prob(20))
+							guardian.say("No one can just deflect the [P]!", forced = P.type)
 					else
-						visible_message("<span class='danger'>[src] deflects the projectile!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
-					playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, 1)
-					if(!mind.martial_art.reroute_deflection)
-						return BULLET_ACT_BLOCK
-					else
-						P.firer = src
-						P.setAngle(rand(0, 360))//SHING
-						return BULLET_ACT_FORCE_PIERCE
+						if(!isturf(loc)) //if we're inside something and still got hit
+							P.force_hit = TRUE //The thing we're in passed the bullet to us. Pass it back, and tell it to take the damage.
+							loc.bullet_act(P)
+							return BULLET_ACT_HIT
+								
+						if(mind.martial_art.deflection_chance >= 100) //if they can NEVER be hit, lets clue sec in ;)
+							visible_message("<span class='danger'>[src] deflects the projectile; [p_they()] can't be hit with ranged weapons!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
+						else
+							visible_message("<span class='danger'>[src] deflects the projectile!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
+						playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, 1)
+						if(!mind.martial_art.reroute_deflection)
+							return BULLET_ACT_BLOCK
+						else
+							P.firer = src
+							P.setAngle(rand(0, 360))//SHING
+							return BULLET_ACT_FORCE_PIERCE
 
 	if(!(P.original == src && P.firer == src)) //can't block or reflect when shooting yourself
 		if(P.reflectable & REFLECT_NORMAL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the emerald splash undeflectable.

## Why It's Good For The Game

![jojoreference](https://user-images.githubusercontent.com/47324920/58714010-19ba9e00-83c4-11e9-8c02-b21a5a2e8c4f.PNG)

## Changelog
:cl:
balance: The emerald splash can no longer be deflected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
