### PR TITLE
Time of death fix to show round time

### DIFF
--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -25,7 +25,7 @@
 		to_chat(user, "<span class='notice'>We begin our stasis, preparing energy to arise once more.</span>")
 		if(user.stat != DEAD)
 			user.emote("deathgasp")
-			user.tod = station_time_timestamp()
+			user.tod = gameTimestamp()
 		user.fakedeath("changeling") //play dead
 		user.update_stat()
 		user.update_mobility()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -50,7 +50,7 @@
 	stat = DEAD
 	unset_machine()
 	timeofdeath = world.time
-	tod = station_time_timestamp()
+	tod = gameTimestamp()
 	var/turf/T = get_turf(src)
 	for(var/obj/item/I in contents)
 		I.on_mob_death(src, gibbed)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -448,7 +448,7 @@
 		emote("deathgasp")
 	ADD_TRAIT(src, TRAIT_FAKEDEATH, source)
 	ADD_TRAIT(src, TRAIT_DEATHCOMA, source)
-	tod = station_time_timestamp()
+	tod = gameTimestamp()
 	update_stat()
 
 /mob/living/proc/unignore_slowdown(source)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #44033
I found these different tod-situations with the following regex search: tod[^a-z]

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the health analyzer show a more intuitive time of death for the body.
![Capture](https://user-images.githubusercontent.com/5420151/58726301-11755980-83ea-11e9-8f9e-5945a2f99a35.PNG)
![Capture2](https://user-images.githubusercontent.com/5420151/58726303-133f1d00-83ea-11e9-855d-b03f159e66fc.PNG)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Only thing is, I'm not completely sure is the status_procs.dm change appropriate? Does it affect some admin log stuff?