### PR TITLE
Fixes tactical component removal/unmodification

### DIFF
--- a/code/datums/components/tactical.dm
+++ b/code/datums/components/tactical.dm
@@ -12,6 +12,7 @@
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/unmodify)
 
 /datum/component/tactical/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
 	unmodify()
 
 /datum/component/fantasy/Destroy()
@@ -31,4 +32,10 @@
 	I.layer = ABOVE_MOB_LAYER
 
 /datum/component/tactical/proc/unmodify(obj/item/source, mob/user)
+	var/obj/item/master = source || parent
+	if(!user)
+		if(!ismob(master.loc))
+			return
+		user = master.loc
+	
 	user.remove_alt_appearance("sneaking_mission")


### PR DESCRIPTION
I'm not sure what happened here but I must have forgotten to update something after a change during the initial coding of tactical. This clearly doesn't handle removal properly.

fixes #44103

## Changelog
:cl:
fix: Tactical should no longer leave the disguise on you in some cases
/:cl: