### PR TITLE
Chuncky jackhammer and shovel webbing

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -259,6 +259,7 @@
 		/obj/item/resonator,
 		/obj/item/mining_scanner,
 		/obj/item/pickaxe,
+		/obj/item/shovel,
 		/obj/item/stack/sheet/animalhide,
 		/obj/item/stack/sheet/sinew,
 		/obj/item/stack/sheet/bone,

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -85,6 +85,7 @@
 	icon_state = "jackhammer"
 	item_state = "jackhammer"
 	toolspeed = 0.1 //the epitome of powertools. extremely fast mining, laughs at puny walls
+	w_class = WEIGHT_CLASS_HUGE //the epitome of power(gamer)tools is CHUNCKY
 	usesound = 'sound/weapons/sonic_jackhammer.ogg'
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	desc = "Cracks rocks with sonic blasts, and doubles as a demolition power tool for smashing walls."


### PR DESCRIPTION
## About The Pull Request

Makes jackhammers huge, making them unable to be stored in the explorers webbing.
Shovels can now be stored in the explorers webbing.

## Why It's Good For The Game

Theshovel is one of the most basic mining tools, it would only make sense to be in the list of items that can be equipped in the webbing.

The jackhammer on the other hand isn't really that needed for mining unless you want large amounts of sand and is mostly used for station grief. It's only fair that you would have to pay a bigger price for an item with this powerlevel.

## Changelog
:cl:
tweak: Shovels can now be stored in explorers webbing.
balance: The sonic jackhammer can no longer be stored in the explorers webbing.
/:cl:
