### PR TITLE
Add map change voting 

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -290,6 +290,8 @@
 				currentmap.voteweight = text2num(data)
 			if ("default","defaultmap")
 				defaultmap = currentmap
+			if ("votable")
+				currentmap.votable = TRUE
 			if ("endmap")
 				LAZYINITLIST(maplist)
 				maplist[currentmap.map_name] = currentmap

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -91,6 +91,8 @@
 
 /datum/config_entry/flag/allow_vote_mode	// allow votes to change mode
 
+/datum/config_entry/flag/allow_vote_map	// allow votes to change map
+
 /datum/config_entry/number/vote_delay	// minimum time between voting sessions (deciseconds, 10 minute default)
 	config_entry_value = 6000
 	integer = FALSE
@@ -362,6 +364,12 @@
 /datum/config_entry/flag/announce_admin_login
 
 /datum/config_entry/flag/allow_map_voting
+	deprecated_by = /datum/config_entry/flag/preference_map_voting
+
+/datum/config_entry/flag/allow_map_voting/DeprecationUpdate(value)
+	return value
+
+/datum/config_entry/flag/preference_map_voting
 
 /datum/config_entry/number/client_warn_version
 	config_entry_value = null

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -9,6 +9,8 @@ SUBSYSTEM_DEF(mapping)
 	var/datum/map_config/config
 	var/datum/map_config/next_map_config
 
+	var/map_voted = FALSE
+
 	var/list/map_templates = list()
 
 	var/list/ruins_templates = list()
@@ -274,11 +276,15 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		log_world("ERROR: Station areas list failed to generate!")
 
 /datum/controller/subsystem/mapping/proc/maprotate()
+	if(map_voted)
+		map_voted = FALSE
+		return
+	
 	var/players = GLOB.clients.len
 	var/list/mapvotes = list()
 	//count votes
-	var/amv = CONFIG_GET(flag/allow_map_voting)
-	if(amv)
+	var/pmv = CONFIG_GET(flag/preference_map_voting)
+	if(pmv)
 		for (var/client/c in GLOB.clients)
 			var/vote = c.prefs.preferred_map
 			if (!vote)
@@ -311,7 +317,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 			mapvotes.Remove(map)
 			continue
 
-		if(amv)
+		if(pmv)
 			mapvotes[map] = mapvotes[map]*VM.voteweight
 
 	var/pickedmap = pickweight(mapvotes)

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -11,6 +11,7 @@
 	var/config_max_users = 0
 	var/config_min_users = 0
 	var/voteweight = 1
+	var/votable = FALSE
 
 	// Config actually from the JSON - should default to Box
 	var/map_name = "Box Station"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -519,7 +519,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							p_map = VM.map_name
 					else
 						p_map += " (No longer exists)"
-				if(CONFIG_GET(flag/allow_map_voting))
+				if(CONFIG_GET(flag/preference_map_voting))
 					dat += "<b>Preferred Map:</b> <a href='?_src_=prefs;preference=preferred_map;task=input'>[p_map]</a><br>"
 
 			dat += "</td><td width='300px' height='300px' valign='top'>"
@@ -1288,6 +1288,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						default += " ([config.defaultmap.map_name])"
 					for (var/M in config.maplist)
 						var/datum/map_config/VM = config.maplist[M]
+						if(!VM.votable)
+							continue
 						var/friendlyname = "[VM.map_name] "
 						if (VM.voteweight <= 0)
 							friendlyname += " (disabled)"

--- a/config/config.txt
+++ b/config/config.txt
@@ -164,8 +164,11 @@ ID_CONSOLE_JOBSLOT_DELAY 30
 ## allow players to initiate a restart vote
 #ALLOW_VOTE_RESTART
 
-## allow players to initate a mode-change start
+## allow players to initiate a mode-change vote
 #ALLOW_VOTE_MODE
+
+## allow players to initiate a map-change vote
+#ALLOW_VOTE_MAP
 
 ## min delay (deciseconds) between voting sessions (default 10 minutes)
 VOTE_DELAY 6000
@@ -371,9 +374,9 @@ ANNOUNCE_ADMIN_LOGOUT
 MAPROTATION
 
 ## Map voting
-## Allows players to vote for their preffered map
+## Allows players to vote with their preffered map setting
 ## When it's set to zero, the map will be randomly picked each round
-ALLOW_MAP_VOTING 1
+PREFERENCE_MAP_VOTING 1
 
 ## Map rotate chance delta
 ## This is the chance of map rotation factored to the round length.

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -10,27 +10,33 @@ Format:
 	default (The last map with this defined will get all votes of players who have not explicitly voted for a map)
 	voteweight [number] (How much to count each player vote as, defaults to 1, setting to 0.5 counts each vote as half a vote, 2 as double, etc, Setting to 0 disables the map but allows players to still pick it)
 	disabled (disables the map)
+	votable (is this map votable)
 endmap
 
 map boxstation
 	default
 	#voteweight 1.5
+	votable
 endmap
 
 map metastation
 	minplayers 25
 	#voteweight 0.5
+	votable
 endmap
 
 map pubbystation
+	votable
 endmap
 
 map deltastation
 	minplayers 50
+	votable
 endmap
 
 map donutstation
 	minplayers 50
+	votable
 endmap
 
 map runtimestation


### PR DESCRIPTION
## About The Pull Request
Adds the possibility of map voting by using the vote verb
Right now not voting takes the preferred map and votes for that, I want to hear if this is good or something I should change.

~~_also I need a better name for the PREFERENTIAL_MAP_SELECTION config_~~

## Why It's Good For The Game
Now people can change the map when the server is low pop or when people otherwise want to change map.
This should also help map makers to get feedback from maps for obvious reason.

## Changelog
:cl: TheChosenEvilOne
add: Added map voting in vote verb
config: map config can define which maps are votable
config: renamed ALLOW_MAP_VOTE to PREFERENCE_MAP_VOTING
/:cl: