### PR TITLE
removes an unnessecary goonchat code block

### DIFF
--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -187,16 +187,6 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 	if(!target)
 		return
 
-	//Ok so I did my best but I accept that some calls to this will be for shit like sound and images
-	//It stands that we PROBABLY don't want to output those to the browser output so just handle them here
-	if (istype(target, /savefile))
-		CRASH("Invalid message! [message]")
-
-	if(!istext(message))
-		if (istype(message, /image) || istype(message, /sound))
-			CRASH("Invalid message! [message]")
-		return
-
 	if(target == world)
 		target = GLOB.clients
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Kills a pointless check in to_chat that was apparently put in to make sure that nothing slipped through the initial regex conversion of direct output to to_chat. This should be enforced by not being a shitty coder going forward since the to_chat conversion happened long ago, instead of an is_type check run every time to_chat is called.

## Why It's Good For The Game

Improved readability, likely dead code removed, slight speedup on a _very_ commonly called proc