### PR TITLE
Massive buff for Xenobiology in the form of adding additional lights on Meta and Box Station, also removal of visual clutter + igniter on meta

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -55882,6 +55882,12 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"hwp" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "hAK" = (
 /obj/structure/table,
 /obj/item/storage/box/disks_nanite,
@@ -57105,6 +57111,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"riS" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "rmX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -57204,6 +57216,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"skj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "slk" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -57230,6 +57248,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"sra" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "suO" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
@@ -57874,6 +57898,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"wOj" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "wQy" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -100348,7 +100379,7 @@ byf
 byf
 bDb
 bEm
-bEm
+skj
 bEm
 bDb
 bJH
@@ -100359,15 +100390,15 @@ bOx
 bPx
 bJN
 bRT
-bEm
-bEm
-bJN
-bRT
-bEm
+wOj
 bEm
 bJN
 bRT
+wOj
 bEm
+bJN
+bRT
+hwp
 bEm
 bDb
 cfr
@@ -101890,7 +101921,7 @@ bAC
 bBW
 bDb
 bEm
-bEm
+sra
 bEm
 bDb
 cTX
@@ -103443,15 +103474,15 @@ bOx
 bPI
 bJN
 bEm
-bEm
+riS
 bUi
 bJN
 bEm
-bEm
+riS
 bUi
 bJN
 bEm
-bEm
+riS
 bUi
 bDb
 aaf

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -77201,11 +77201,6 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/button/ignition{
-	id = "Xenobio";
-	pixel_x = -6;
-	pixel_y = -3
-	},
 /obj/machinery/button/door{
 	id = "Xenolab";
 	name = "Test Chamber Blast Doors";

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -77835,18 +77835,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"daE" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 10
-	},
-/obj/item/electropack,
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "daF" = (
-/obj/machinery/sparker{
-	id = "Xenobio";
-	pixel_x = -25
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -77861,15 +77853,8 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "daI" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -77887,26 +77872,6 @@
 /area/science/xenobiology)
 "daL" = (
 /obj/machinery/light/small,
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"daM" = (
-/obj/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -1
-	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "daN" = (
@@ -119313,9 +119278,9 @@ ddo
 dds
 cTD
 cRi
-daE
+cSn
 daI
-daM
+cSn
 cRi
 cTA
 cRi


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This adds 2 more lights to the xenobiology test chamber on MetaStation and Box, and adds a light in every slime breeding chamber on Box Station where there was none from before. It also removes the nearly useless table in the MetaStation xenobiology test chamber that doesn't have any purpose except to add more clutter to a slime storage area. I also removed the igniter on metastation which is only useful for burning slimes, which doesn't do anything except help you be a dick

Below is the map on box before:

![boxtestchamberbefore](https://user-images.githubusercontent.com/8888654/58747731-4b238000-843d-11e9-91e1-c7eeadf76dcf.PNG)

![boxxenobiobefore](https://user-images.githubusercontent.com/8888654/58747732-4fe83400-843d-11e9-9267-74ad95d74fa4.PNG)

Here is the map on box after:

![boxstationxenobiology](https://user-images.githubusercontent.com/8888654/58747744-5e365000-843d-11e9-9516-2a2a6096dc15.PNG)

![boxtestchamber](https://user-images.githubusercontent.com/8888654/58747745-61314080-843d-11e9-9748-220acd6bb260.PNG)

Here is the test chamber on Meta before:

![xenobiotestchamberwithoutlights](https://user-images.githubusercontent.com/8888654/58747756-8faf1b80-843d-11e9-9595-c8092bf22d9b.PNG)

Here it is after:

![xenobiotestchamberwithmorelights](https://user-images.githubusercontent.com/8888654/58747760-93db3900-843d-11e9-8b4e-d26a7ac98730.PNG)


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Before this PR, xenobiology was very dark and hard to see in. This is annoying if your eyesight or colour differentiation wasn't good, and made differentiating silver and metal slimes in the xenobiology test chamber incredibly difficult. On Box, this was even worse. It was dark and very difficult to see, which unfortunately was not an aspect I was able to show in my screenshots because I used an online map viewer.

This represents an increase in quality of life for xenobiology as it actually allows them to differentiate certain slime species that look similar, such as oil/black and silver/metal at a glance.

## Changelog
:cl:
add: Every slime chamber in Xenobiology on BoxStation now has its own light. 2 more lights have been added to the Xenobiology Test Chamber on BoxStation and MetaStation making it much more well lit.
del: Removed the table with an electropack, power cell stuff, and igniters in the xenobiology test chamber.
del: removed the igniter and igniter switch from the xenobiology test chamber only useful for lighting slimes on fire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
