### PR TITLE
Refactors electrocute_act

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -150,7 +150,7 @@
 #define COMSIG_LIVING_RESIST "living_resist"					//from base of mob/living/resist() (/mob/living)
 #define COMSIG_LIVING_IGNITED "living_ignite"					//from base of mob/living/IgniteMob() (/mob/living)
 #define COMSIG_LIVING_EXTINGUISHED "living_extinguished"		//from base of mob/living/ExtinguishMob() (/mob/living)
-#define COMSIG_LIVING_ELECTROCUTE_ACT "living_electrocute_act"		//from base of mob/living/electrocute_act(): (shock_damage)
+#define COMSIG_LIVING_ELECTROCUTE_ACT "living_electrocute_act"	//from base of mob/living/electrocute_act(): (shock_damage, siemens_coeff, illusion)
 #define COMSIG_LIVING_MINOR_SHOCK "living_minor_shock"			//sent by stuff like stunbatons and tasers: ()
 
 //ALL OF THESE DO NOT TAKE INTO ACCOUNT WHETHER AMOUNT IS 0 OR LOWER AND ARE SENT REGARDLESS!

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -179,7 +179,9 @@
 		var/datum/nanite_program/NP = X
 		NP.on_emp(severity)
 
-/datum/component/nanites/proc/on_shock(datum/source, shock_damage)
+/datum/component/nanites/proc/on_shock(datum/source, shock_damage, siemens_coeff, illusion)
+	if(illusion)
+		return
 	nanite_volume *= (rand(0.45, 0.80))		//Lose 20-55% of nanites
 	adjust_nanites(null, -(rand(5, 50)))			//Lose 5-50 flat nanite volume
 	for(var/X in programs)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -226,7 +226,7 @@
 /mob/living/carbon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)
 	if(reagents.has_reagent(/datum/reagent/teslium))
 		siemens_coeff *= 1.5 //TODO, make this a reagent thing.
-	.=..(shock_damage, source, siemens_coeff, safety, tesla_shock, illusion, stun) //We say fuck it and just send it to living.
+	. = ..() //We say fuck it and just send it to living.
 	if(.) //We do stuff if it did stuff.
 	
 		if(undergoing_cardiac_arrest() && !illusion) //We reignite some hearts.

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -224,6 +224,7 @@
 		O.emp_act(severity)
 
 /mob/living/carbon/electrocute_act(shock_damage, source, siemens_coeff = 1, safety = 0, override = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
+	SEND_SIGNAL(src, COMSIG_LIVING_ELECTROCUTE_ACT, shock_damage, siemens_coeff, illusion)
 	if(tesla_shock && (flags_1 & TESLA_IGNORE_1))
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -251,7 +251,6 @@
 		addtimer(CALLBACK(src, .proc/endShockJitter), 20)
 	if(override) //We return shitcode to it's place of origin.
 		return override //Seriously, I still have no idea why this exists.
-	return .
 	
 /mob/living/carbon/proc/endShockJitter() //Think of a better name
 	jitteriness = max(jitteriness - 990, 10)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -479,7 +479,7 @@
 	dna.species.spec_electrocute_act(src, shock_damage,source,siemens_coeff,safety,override,tesla_shock, illusion, stun)
 	siemens_coeff *= dna.species.siemens_coeff
 	
-	. = ..(shock_damage,source,siemens_coeff,safety,override,tesla_shock, illusion, stun) //We send this to carbon
+	. = ..() //We send this to carbon
 	if(.) //We make it look fancy
 		electrocution_animation(40)
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -317,7 +317,7 @@
 	SEND_SIGNAL(src, COMSIG_LIVING_ELECTROCUTE_ACT, shock_damage ,siemens_coeff, illusion) //We finally fix that stupid nanite bug.
 	if(tesla_shock && (flags_1 & TESLA_IGNORE_1))
 		return 0 //Yes, this is a number. It's not a T/F
-	if(HAS_TRAIT(TRAIT_SHOCKIMMUNE, src))
+	if(HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
 		return 0
 		
 	shock_damage *= siemens_coeff

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -314,7 +314,7 @@
 	return 1
 
 /mob/living/proc/electrocute_act(shock_damage, source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
-	SEND_SIGNAL(src, COMSIG_LIVING_ELECTROCUTE_ACT, shock_damage)
+	SEND_SIGNAL(src, COMSIG_LIVING_ELECTROCUTE_ACT, shock_damage, siemens_coeff, illusion)
 	if(tesla_shock && (flags_1 & TESLA_IGNORE_1))
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -313,21 +313,26 @@
 	take_bodypart_damage(acidpwr * min(1, acid_volume * 0.1))
 	return 1
 
-/mob/living/proc/electrocute_act(shock_damage, source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
-	SEND_SIGNAL(src, COMSIG_LIVING_ELECTROCUTE_ACT, shock_damage, siemens_coeff, illusion)
+/mob/living/proc/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
+	SEND_SIGNAL(src, COMSIG_LIVING_ELECTROCUTE_ACT, shock_damage ,siemens_coeff, illusion) //We finally fix that stupid nanite bug.
 	if(tesla_shock && (flags_1 & TESLA_IGNORE_1))
-		return FALSE
-	if(HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
-		return FALSE
-	if(shock_damage > 0)
-		if(!illusion)
-			adjustFireLoss(shock_damage)
-		visible_message(
-			"<span class='danger'>[src] was shocked by \the [source]!</span>", \
-			"<span class='userdanger'>You feel a powerful shock coursing through your body!</span>", \
-			"<span class='italics'>You hear a heavy electrical crack.</span>" \
+		return 0 //Yes, this is a number. It's not a T/F
+	if(has_trait(TRAIT_SHOCKIMMUNE))
+		return 0
+		
+	shock_damage *= siemens_coeff
+	if(shock_damage < 1) //How are shocks even real?.
+		return 0
+	if(illusion)
+		adjustStaminaLoss(shock_damage)
+	else
+		adjustFireLoss(shock_damage)
+	visible_message(
+		"<span class='danger'>[src] was shocked by \the [source]!</span>", \
+		"<span class='userdanger'>You feel a powerful shock coursing through your body!</span>", \
+		"<span class='italics'>You hear a heavy electrical crack.</span>" \
 		)
-		return shock_damage
+	return shock_damage
 
 /mob/living/emp_act(severity)
 	. = ..()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -317,7 +317,7 @@
 	SEND_SIGNAL(src, COMSIG_LIVING_ELECTROCUTE_ACT, shock_damage ,siemens_coeff, illusion) //We finally fix that stupid nanite bug.
 	if(tesla_shock && (flags_1 & TESLA_IGNORE_1))
 		return 0 //Yes, this is a number. It's not a T/F
-	if(has_trait(TRAIT_SHOCKIMMUNE))
+	if(HAS_TRAIT(TRAIT_SHOCKIMMUNE, src))
 		return 0
 		
 	shock_damage *= siemens_coeff


### PR DESCRIPTION
## About The Pull Request

COMSIG_LIVING_ELECTROCUTE_ACT now fires from carbons. This results in nanites being shockable. Also adds more parameters to it, so it can account for illusions.

Also moves the code for stopping heart attacks with shocks to carbons, because why not?

/mob/ is cursed.

## Why It's Good For The Game

Fixes a bug. Makes the code more readable.
I'm passing the siemens coeff down because I'm planning on using it later in my ethereal stomach remake. Not using it here because of balance concerns.

## Changelog
:cl:
fix: Nanites actually get removed by shocks now.
/:cl:
