### PR TITLE
Slimes now 'metabolize' reagents over time

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -16,6 +16,7 @@
 			handle_feeding()
 		if(!stat) // Slimes in stasis don't lose nutrition, don't change mood and don't respond to speech
 			handle_nutrition()
+			reagents.remove_all(0.2) //Slimes are such snowflakes
 			handle_targets()
 			if (!ckey)
 				handle_mood()

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -16,7 +16,7 @@
 			handle_feeding()
 		if(!stat) // Slimes in stasis don't lose nutrition, don't change mood and don't respond to speech
 			handle_nutrition()
-			reagents.remove_all(0.2) //Slimes are such snowflakes
+			reagents.remove_all(0.5 * REAGENTS_METABOLISM) //Slimes are such snowflakes
 			handle_targets()
 			if (!ckey)
 				handle_mood()

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -16,7 +16,7 @@
 			handle_feeding()
 		if(!stat) // Slimes in stasis don't lose nutrition, don't change mood and don't respond to speech
 			handle_nutrition()
-			reagents.remove_all(0.5 * REAGENTS_METABOLISM) //Slimes are such snowflakes
+			reagents.remove_all(0.5 * REAGENTS_METABOLISM * reagents.reagent_list.len) //Slimes are such snowflakes
 			handle_targets()
 			if (!ckey)
 				handle_mood()


### PR DESCRIPTION
## About The Pull Request

Slimes now lose 0.2 units of reagents every tick.

## Why It's Good For The Game

Slimes didn't use to lose reagents over time at all. The only way to lose them was through stuff like the smoke reaction. 

This resulted in certain *fun interactions*, for example frost oil + morphine would slow the slime permanently to a crawl. But a more productive use of this was injecting slimes with adrenaline nanites and giving them a (hilariously large) permanent speed boost upon triggering them.

I haven't actually seen this used ingame, but better ~~fix~~ **nerf** it before someone does.

## Changelog
:cl:
tweak: Slimes now lose interal reagents over time.
/:cl:
