### PR TITLE
lightning holoparasite no longer fires lightning bolts after death

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -308,3 +308,5 @@
 #define SLIME_EXTRACT (1<<5)
 //Wabbacjack staff projectiles
 #define WABBAJACK     (1<<6)
+
+#define SLEEP_CHECK_DEATH(X) sleep(X); if(QDELETED(src) || stat == DEAD) return;

--- a/code/modules/mob/living/simple_animal/guardian/types/lightning.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/lightning.dm
@@ -47,7 +47,7 @@
 				successfulshocks = 0
 			if(shockallchains())
 				successfulshocks++
-			sleep(3)
+			SLEEP_CHECK_DEATH(3)
 
 /mob/living/simple_animal/hostile/guardian/beam/Recall()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -1,4 +1,3 @@
-#define COLOSSUS_SLEEP(X) sleep(X); if(QDELETED(src)) return;
 /*
 
 COLOSSUS
@@ -124,17 +123,17 @@ Difficulty: Very Hard
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/alternating_dir_shots()
 	dir_shots(GLOB.diagonals)
-	COLOSSUS_SLEEP(10)
+	SLEEP_CHECK_DEATH(10)
 	dir_shots(GLOB.cardinals)
-	COLOSSUS_SLEEP(10)
+	SLEEP_CHECK_DEATH(10)
 	dir_shots(GLOB.diagonals)
-	COLOSSUS_SLEEP(10)
+	SLEEP_CHECK_DEATH(10)
 	dir_shots(GLOB.cardinals)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/double_spiral()
 	visible_message("<span class='colossus'>\"<b>Die.</b>\"</span>")
 
-	COLOSSUS_SLEEP(10)
+	SLEEP_CHECK_DEATH(10)
 	INVOKE_ASYNC(src, .proc/spiral_shoot)
 	INVOKE_ASYNC(src, .proc/spiral_shoot, TRUE)
 
@@ -152,7 +151,7 @@ Difficulty: Very Hard
 			counter = 16
 		shoot_projectile(start_turf, counter * 22.5)
 		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, 1)
-		COLOSSUS_SLEEP(1)
+		SLEEP_CHECK_DEATH(1)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/shoot_projectile(turf/marker, set_angle)
 	if(!isnum(set_angle) && (!marker || marker == loc))

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -3,7 +3,6 @@
 
 #define SWOOP_DAMAGEABLE 1
 #define SWOOP_INVULNERABLE 2
-#define DRAKE_SLEEP(X) sleep(X); if(QDELETED(src) || stat == DEAD) return;
 
 /*
 
@@ -138,7 +137,7 @@ Difficulty: Medium
 		var/turf/T = pick(RANGE_TURFS(1, target))
 		new /obj/effect/temp_visual/lava_warning(T, 60) // longer reset time for the lava
 		amount--
-		DRAKE_SLEEP(delay)
+		SLEEP_CHECK_DEATH(delay)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/lava_swoop(var/amount = 30)
 	INVOKE_ASYNC(src, .proc/lava_pools, amount)
@@ -147,9 +146,9 @@ Difficulty: Medium
 		return
 	fire_cone()
 	if(health < maxHealth*0.5)
-		DRAKE_SLEEP(10)
+		SLEEP_CHECK_DEATH(10)
 		fire_cone()
-		DRAKE_SLEEP(10)
+		SLEEP_CHECK_DEATH(10)
 		fire_cone()
 	SetRecoveryTime(40)
 
@@ -163,7 +162,7 @@ Difficulty: Medium
 		for(var/j = 1 to spiral_count)
 			var/list/turfs = line_target(j * increment + i * increment / 2, range, src)
 			INVOKE_ASYNC(src, .proc/fire_line, turfs)
-		DRAKE_SLEEP(25)
+		SLEEP_CHECK_DEATH(25)
 	SetRecoveryTime(30)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/lava_arena()
@@ -184,7 +183,7 @@ Difficulty: Medium
 			T.ChangeTurf(/turf/open/floor/plating/asteroid/basalt/lava_land_surface)
 		else
 			indestructible_turfs += T
-	DRAKE_SLEEP(10) // give them a bit of time to realize what attack is actually happening
+	SLEEP_CHECK_DEATH(10) // give them a bit of time to realize what attack is actually happening
 
 	var/list/turfs = RANGE_TURFS(2, center)
 	while(amount > 0)
@@ -208,7 +207,7 @@ Difficulty: Medium
 			else if(!istype(T, /turf/closed/indestructible))
 				new /obj/effect/temp_visual/lava_safe(T)
 		amount--
-		DRAKE_SLEEP(24)
+		SLEEP_CHECK_DEATH(24)
 	return 1 // attack finished completely
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/arena_escape_enrage() // you ran somehow / teleported away from my arena attack now i'm mad fucker


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes #44277
also unifies macros for drake and colossus
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: lightning holoparasite will no longer zap across the entire zlevel after death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
