### PR TITLE
Surgical incisions cause actual bleeding; clamping bleeders and/or cauterizing stops that bleeding.

### DIFF
--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -95,6 +95,9 @@
 		if(is_robotic)
 			close_tool_type = /obj/item/screwdriver
 		if(istype(close_tool, close_tool_type) || iscyborg(user))
+			if (ishuman(M))
+				var/mob/living/carbon/human/H = M
+				H.bleed_rate = max( (H.bleed_rate - 3), 0)
 			M.surgeries -= S
 			user.visible_message("[user] closes [M]'s [parse_zone(selected_zone)] with [close_tool] and removes [I].", \
 				"<span class='notice'>You close [M]'s [parse_zone(selected_zone)] with [close_tool] and remove [I].</span>")

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -20,7 +20,7 @@
 	if ishuman(target)
 		var/mob/living/carbon/human/H = target
 		if (!(NOBLOOD in H.dna.species.species_traits))
-			user.visible_message("Blood pools around the incision in [H]'s [parse_zone(target_zone)].", "<span class='notice'>Blood pools around your incision in [H]'s [parse_zone(target_zone)].</span>")
+			H.visible_message("Blood pools around the incision in [H]'s [parse_zone(target_zone)].", "<span class='notice'>Blood pools around the incision in your [parse_zone(target_zone)].</span>")
 			H.bleed_rate += 3
 	return TRUE
 

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -21,7 +21,7 @@
 		var/mob/living/carbon/human/H = target
 		if (!(NOBLOOD in H.dna.species.species_traits))
 			user.visible_message("Blood pools around the incision in [H]'s [parse_zone(target_zone)].", "<span class='notice'>Blood pools around your incision in [H]'s [parse_zone(target_zone)].</span>")
-			H.bleed_rate += 5
+			H.bleed_rate += 3
 	return TRUE
 
 //clamp bleeders
@@ -39,7 +39,7 @@
 		target.heal_bodypart_damage(20,0)
 	if ishuman(target)
 		var/mob/living/carbon/human/H = target
-		H.bleed_rate = max( (H.bleed_rate - 5), 0)
+		H.bleed_rate = max( (H.bleed_rate - 3), 0)
 	return ..()
 
 //retract skin
@@ -74,6 +74,9 @@
 /datum/surgery_step/close/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(locate(/datum/surgery_step/saw) in surgery.steps)
 		target.heal_bodypart_damage(45,0)
+	if (ishuman(target))
+		var/mob/living/carbon/human/H = target
+		H.bleed_rate = max( (H.bleed_rate - 3), 0)
 	return ..()
 
 

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -37,7 +37,7 @@
 /datum/surgery_step/clamp_bleeders/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(locate(/datum/surgery_step/saw) in surgery.steps)
 		target.heal_bodypart_damage(20,0)
-	if ishuman(target)
+	if (ishuman(target))
 		var/mob/living/carbon/human/H = target
 		H.bleed_rate = max( (H.bleed_rate - 3), 0)
 	return ..()

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -16,6 +16,14 @@
 
 	return TRUE
 
+/datum/surgery_step/incise/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if ishuman(target)
+		var/mob/living/carbon/human/H = target
+		if (!(NOBLOOD in H.dna.species.species_traits))
+			user.visible_message("Blood pools around the incision in [H]'s [parse_zone(target_zone)].", "<span class='notice'>Blood pools around your incision in [H]'s [parse_zone(target_zone)].</span>")
+			H.bleed_rate += 5
+	return TRUE
+
 //clamp bleeders
 /datum/surgery_step/clamp_bleeders
 	name = "clamp bleeders"
@@ -29,8 +37,10 @@
 /datum/surgery_step/clamp_bleeders/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(locate(/datum/surgery_step/saw) in surgery.steps)
 		target.heal_bodypart_damage(20,0)
+	if ishuman(target)
+		var/mob/living/carbon/human/H = target
+		H.bleed_rate = max( (H.bleed_rate - 5), 0)
 	return ..()
-
 
 //retract skin
 /datum/surgery_step/retract_skin


### PR DESCRIPTION
## About The Pull Request

What it says in the title. For humans who are being operated on, surgical incisions will cause them to bleed. Clamping bleeders will reverse this, as will closing the incision with a cautery (either as a step or to cancel the server.)

The amount of bleeding is slightly less than other bleeding-causing things in the code, and if someone is doing surgery at a reasonable speed it shouldn't cause too much trouble, even if it isn't the immediate next step.

## Why It's Good For The Game

Because this is literally what clamping bleeders means -- that's why they're called bleeders -- and now that we have a bleeding system it seems silly not to reflect that. 

## Changelog
:cl: bandit
tweak: Surgical incisions cause actual bleeding now. Clamping bleeders and/or cauterizing the incision stops that bleeding.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
