### PR TITLE
Upgrades policy config + policy verb.

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -84,3 +84,7 @@
 
 #define STICKYBAN_DB_CACHE_TIME 10 SECONDS
 #define STICKYBAN_ROGUE_CHECK_TIME 5
+
+
+#define POLICY_POLYMORPH "polymorph" //Shown to vicitm of staff of change and related effects.
+#define POLICY_VERB_HEADER "policy_verb_header" //Shown on top of policy verb window

--- a/code/__HELPERS/config.dm
+++ b/code/__HELPERS/config.dm
@@ -1,0 +1,2 @@
+/proc/get_policy(keyword)
+	return global.config.policy[keyword]

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -19,6 +19,7 @@
 	var/list/mode_false_report_weight
 
 	var/motd
+	var/policy
 
 /datum/controller/configuration/proc/admin_reload()
 	if(IsAdminAdvancedProcCall())
@@ -47,6 +48,7 @@
 				break
 	loadmaplist(CONFIG_MAPS_FILE)
 	LoadMOTD()
+	LoadPolicy()
 
 /datum/controller/configuration/proc/full_wipe()
 	if(IsAdminAdvancedProcCall())
@@ -243,6 +245,16 @@
 	var/tm_info = GLOB.revdata.GetTestMergeInfo()
 	if(motd || tm_info)
 		motd = motd ? "[motd]<br>[tm_info]" : tm_info
+
+/datum/controller/configuration/proc/LoadPolicy()
+	policy = list()
+	var/rawpolicy = file2text("[directory]/policy.json")
+	if(rawpolicy)
+		var/parsed = json_decode(rawpolicy)
+		if(!parsed)
+			log_config("JSON parsing failure for policy.json")
+		else
+			policy = parsed
 
 /datum/controller/configuration/proc/loadmaplist(filename)
 	log_config("Loading config file [filename]...")

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -254,6 +254,7 @@ Job titles / Assigned roles (ghost spawners for example) : Assistant , Captain ,
 Mob types : /mob/living/simple_animal/hostile/carp
 Antagonist types : /datum/antagonist/highlander
 Species types : /datum/species/lizard
+special keywords defined in _DEFINES/admin.dm
 
 Example config:
 {

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -245,7 +245,24 @@
 	var/tm_info = GLOB.revdata.GetTestMergeInfo()
 	if(motd || tm_info)
 		motd = motd ? "[motd]<br>[tm_info]" : tm_info
+/*
+Policy file should be a json file with a single object.
+Value is raw html.
 
+Possible keywords : 
+Job titles / Assigned roles (ghost spawners for example) : Assistant , Captain , Ash Walker
+Mob types : /mob/living/simple_animal/hostile/carp
+Antagonist types : /datum/antagonist/highlander
+Species types : /datum/species/lizard
+
+Example config:
+{
+    "Assistant" : "Don't kill everyone",
+    "/datum/antagonist/highlander" : "<b>Kill everyone</b>",
+    "Ash Walker" : "Kill all spacemans"
+}
+
+*/
 /datum/controller/configuration/proc/LoadPolicy()
 	policy = list()
 	var/rawpolicy = file2text("[directory]/policy.json")

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -35,10 +35,6 @@
 /datum/config_entry/keyed_list/midround_antag/ValidateListEntry(key_name, key_value)
 	return key_name in config.modes
 
-/datum/config_entry/keyed_list/policy
-	key_mode = KEY_MODE_TEXT
-	value_mode = VALUE_MODE_TEXT
-
 /datum/config_entry/number/damage_multiplier
 	config_entry_value = 1
 	integer = FALSE

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -372,7 +372,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	for(var/datum/antagonist/A in M.antag_datums)
 		keywords += "[A.type]"
 
-	var/list/policytext = list("")
+	var/list/policytext = list("<hr>")
 	var/anything = FALSE
 	for(var/keyword in keywords)
 		var/p = get_policy(keyword)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -353,3 +353,30 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 		pct += delta
 		winset(src, "mainwindow.split", "splitter=[pct]")
+
+
+/client/verb/policy()
+	set name = "Show Policy"
+	set desc = "Show special server rules related to your current character."
+	set category = "OOC"
+	
+	//Collect keywords
+	var/list/keywords = list()
+	keywords += "[mob.type]"
+	var/mob/living/carbon/human/H = mob
+	if(istype(H))
+		keywords += H.dna.species.id
+	var/datum/mind/M = mob.mind
+	keywords += M.assigned_role
+	keywords += M.special_role //In case there's something special leftover
+	for(var/datum/antagonist/A in M.antag_datums)
+		keywords += A.name
+
+	var/list/policytext = list("")
+	for(var/keyword in keywords)
+		var/p = get_policy(keyword)
+		if(p)
+			policytext += p
+			policytext += "<hr>"
+
+	usr << browse(policytext.Join(""),"window=policy")

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -360,19 +360,10 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	set desc = "Show special server rules related to your current character."
 	set category = "OOC"
 	
-	//Collect keywords - should be turned into proper helper later.
-	var/list/keywords = list()
-	keywords += "[mob.type]"
-	var/mob/living/carbon/human/H = mob
-	if(istype(H))
-		keywords += "[H.dna.species.type]"
-	var/datum/mind/M = mob.mind
-	keywords += M.assigned_role
-	keywords += M.special_role //In case there's something special leftover, try to avoid
-	for(var/datum/antagonist/A in M.antag_datums)
-		keywords += "[A.type]"
-
-	var/list/policytext = list("<hr>")
+	//Collect keywords
+	var/list/keywords = mob.get_policy_keywords()
+	var/header = get_policy(POLICY_VERB_HEADER)
+	var/list/policytext = list(header,"<hr>")
 	var/anything = FALSE
 	for(var/keyword in keywords)
 		var/p = get_policy(keyword)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -360,23 +360,27 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	set desc = "Show special server rules related to your current character."
 	set category = "OOC"
 	
-	//Collect keywords
+	//Collect keywords - should be turned into proper helper later.
 	var/list/keywords = list()
 	keywords += "[mob.type]"
 	var/mob/living/carbon/human/H = mob
 	if(istype(H))
-		keywords += H.dna.species.id
+		keywords += "[H.dna.species.type]"
 	var/datum/mind/M = mob.mind
 	keywords += M.assigned_role
-	keywords += M.special_role //In case there's something special leftover
+	keywords += M.special_role //In case there's something special leftover, try to avoid
 	for(var/datum/antagonist/A in M.antag_datums)
-		keywords += A.name
+		keywords += "[A.type]"
 
 	var/list/policytext = list("")
+	var/anything = FALSE
 	for(var/keyword in keywords)
 		var/p = get_policy(keyword)
 		if(p)
 			policytext += p
 			policytext += "<hr>"
+			anything = TRUE
+	if(!anything)
+		policytext += "No related rules found."
 
 	usr << browse(policytext.Join(""),"window=policy")

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -160,3 +160,7 @@
 		return account
 
 	return FALSE
+
+/mob/living/carbon/human/get_policy_keywords()
+	. = ..()
+	. += "[dna.species.type]"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -498,3 +498,12 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 	if(HAS_TRAIT(src, TRAIT_DISSECTED))
 		. += "<span class='notice'>This body has been dissected and analyzed. It is no longer worth experimenting on.</span><br>"
+
+/mob/proc/get_policy_keywords()
+	. = list()
+	. += "[type]"
+	if(mind)
+		. += mind.assigned_role
+		. += mind.special_role //In case there's something special leftover, try to avoid
+		for(var/datum/antagonist/A in mind.antag_datums)
+			. += "[A.type]"

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -278,7 +278,7 @@
 
 	to_chat(new_mob, "<span class='warning'>Your form morphs into that of a [randomize].</span>")
 
-	var/poly_msg = get_policy("polymorph")
+	var/poly_msg = get_policy(POLICY_POLYMORPH)
 	if(poly_msg)
 		to_chat(new_mob, poly_msg)
 

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -278,7 +278,7 @@
 
 	to_chat(new_mob, "<span class='warning'>Your form morphs into that of a [randomize].</span>")
 
-	var/poly_msg = CONFIG_GET(keyed_list/policy)["polymorph"]
+	var/poly_msg = get_policy("polymorph")
 	if(poly_msg)
 		to_chat(new_mob, poly_msg)
 

--- a/config/policies.txt
+++ b/config/policies.txt
@@ -1,5 +1,0 @@
-## SERVER POLICIES ##
-# Each line is pure html that gets sent to the user under certain conditions
-
-# When a mob is polymorphed
-POLYMORPH <span class='danger'>Note that you are allowed to act as an antagonist while transformed into a hostile mob, unless you volunteered for or sought out transformation.</span>

--- a/config/policy.json
+++ b/config/policy.json
@@ -1,5 +1,1 @@
-{
-    "Assistant" : "Don't kill everyone",
-    "/datum/antagonist/highlander" : "Kill everyone",
-    "Ash Walker" : "Kill all spacemans"
-}
+{}

--- a/config/policy.json
+++ b/config/policy.json
@@ -1,0 +1,5 @@
+{
+    "Assistant" : "Don't kill everyone",
+    "/datum/antagonist/highlander" : "Kill everyone",
+    "Ash Walker" : "Kill all spacemans"
+}

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -113,6 +113,7 @@
 #include "code\__HELPERS\areas.dm"
 #include "code\__HELPERS\AStar.dm"
 #include "code\__HELPERS\cmp.dm"
+#include "code\__HELPERS\config.dm"
 #include "code\__HELPERS\dates.dm"
 #include "code\__HELPERS\dna.dm"
 #include "code\__HELPERS\files.dm"


### PR DESCRIPTION
* Removes old `policy.txt` from the repo and related config entry, the default one was broken anyway.
* Policy texts are now loaded from `policy.json`
* Adds `Show Policy` verb to OOC tab that shows policies related to your current character.

I need to move the example config somewhere else so this is WIP for now.

:cl:
add: You can now view special server rules for your current character with "Show Policy" verb in OOC tab
/:cl: