### PR TITLE
No more cross map punches

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -77,5 +77,5 @@
 	var/input = stripped_input(user,"What do you want your battlecry to be? Max length of 6 characters.", ,"", 7)
 	if(input == "*me") //If they try to do a *me emote it will stop the attack to prompt them for an emote then they can walk away and enter the emote for a punch from far away
 		to_chat(user, "Invalid battlecry, please use another.")
-	if(input)
+	else if(input)
 		warcry = input

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -75,5 +75,7 @@
 
 /obj/item/clothing/gloves/rapid/attack_self(mob/user)
 	var/input = stripped_input(user,"What do you want your battlecry to be? Max length of 6 characters.", ,"", 7)
+	if(input == "*me") //If they try to do a *me emote it will stop the attack to prompt them for an emote then they can walk away and enter the emote for a punch from far away
+		to_chat(user, "Invalid battlecry, please use another.")
 	if(input)
 		warcry = input


### PR DESCRIPTION
## About The Pull Request

Fixes #44159 

## Changelog
:cl: Garen
fix: You can no longer do custom emotes with fists of the north star.
/:cl:

I'm not sure if *me was the only way to do an emote, can someone verify that it is the only way to do an emote with 6 characters? Also before anyone asks this still allows normal emotes like *laugh to be used, it just prevents custom emotes.