### PR TITLE
Examine tooltips now work on items put into storage

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -25,6 +25,7 @@
 #define NOBLUDGEON				(1<<7)		// when an item has this it produces no "X has been hit by Y with Z" message in the default attackby()
 #define ABSTRACT				(1<<9) 	// for all things that are technically items but used for various different stuff
 #define IMMUTABLE_SLOW			(1<<10) // When players should not be able to change the slowdown of the item (Speed potions, etc)
+#define IN_STORAGE				(1<<11) //is this item in the storage item, such as backpack? used for tooltips
 
 // Flags for the clothing_flags var on /obj/item/clothing
 

--- a/code/_globalvars/bitfields.dm
+++ b/code/_globalvars/bitfields.dm
@@ -48,6 +48,7 @@ GLOBAL_LIST_INIT(bitfields, list(
 		"DROPDEL" = DROPDEL,
 		"NOBLUDGEON" = NOBLUDGEON,
 		"ABSTRACT" = ABSTRACT,
+		"IN_STORAGE" = IN_STORAGE,
 		),
 	"admin_flags" = list(
 		"BUILDMODE" = R_BUILD,

--- a/code/datums/components/storage/concrete/_concrete.dm
+++ b/code/datums/components/storage/concrete/_concrete.dm
@@ -187,6 +187,7 @@
 			parent.add_fingerprint(M)
 			if(!prevent_warning)
 				mob_item_insertion_feedback(usr, M, I)
+	I.item_flags |= IN_INVENTORY
 	update_icon()
 	return TRUE
 

--- a/code/datums/components/storage/concrete/_concrete.dm
+++ b/code/datums/components/storage/concrete/_concrete.dm
@@ -126,6 +126,7 @@
 		var/obj/item/I = AM
 		var/mob/M = parent.loc
 		I.dropped(M)
+		I.item_flags &= ~IN_STORAGE
 	if(new_location)
 		//Reset the items values
 		_removal_reset(AM)
@@ -173,6 +174,7 @@
 				I.forceMove(parent.drop_location())
 		return FALSE
 	I.on_enter_storage(master)
+	I.item_flags |= IN_STORAGE
 	refresh_mob_views()
 	I.mouse_opacity = MOUSE_OPACITY_OPAQUE //So you can click on the area around the item to equip it, instead of having to pixel hunt
 	if(M)
@@ -187,7 +189,6 @@
 			parent.add_fingerprint(M)
 			if(!prevent_warning)
 				mob_item_insertion_feedback(usr, M, I)
-	I.item_flags |= IN_INVENTORY
 	update_icon()
 	return TRUE
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -687,7 +687,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		openToolTip(user,src,params,title = name,content = "[desc]<br><b>Force:</b> [force_string]",theme = "")
 
 /obj/item/MouseEntered(location, control, params)
-	if(((item_flags & IN_INVENTORY || (item_flags & IN_STORAGE)) && usr.client.prefs.enable_tips && !QDELETED(src)))
+	if((item_flags & IN_INVENTORY || item_flags & IN_STORAGE) && usr.client.prefs.enable_tips && !QDELETED(src))
 		var/timedelay = usr.client.prefs.tip_delay/100
 		var/user = usr
 		tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), timedelay, TIMER_STOPPABLE)//timer takes delay in deciseconds, but the pref is in milliseconds. dividing by 100 converts it.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -687,7 +687,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		openToolTip(user,src,params,title = name,content = "[desc]<br><b>Force:</b> [force_string]",theme = "")
 
 /obj/item/MouseEntered(location, control, params)
-	if((item_flags & IN_INVENTORY) && usr.client.prefs.enable_tips && !QDELETED(src))
+	if(((item_flags & IN_INVENTORY || (item_flags & IN_STORAGE)) && usr.client.prefs.enable_tips && !QDELETED(src)))
 		var/timedelay = usr.client.prefs.tip_delay/100
 		var/user = usr
 		tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), timedelay, TIMER_STOPPABLE)//timer takes delay in deciseconds, but the pref is in milliseconds. dividing by 100 converts it.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes it so that you can hover any item put into storage, such as backpack, and have examine tooltip be displayed to you, providing you have them enabled in preferences, of course.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You can comfortably view examine tooltips on all items in your storage without needing to put them into your hand/pockets.

![EtipsStorage](https://user-images.githubusercontent.com/43862960/58880168-91940b80-86d7-11e9-8292-51691a60fc9c.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
tweak: Examine tooltips now work on items put into storage, such as backpacks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
