### PR TITLE
Added a toggle-able alert for using OOC during a round

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -104,6 +104,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/action_buttons_screen_locs = list()
 
+	var/icooc_warn = TRUE
+
 /datum/preferences/New(client/C)
 	parent = C
 
@@ -562,7 +564,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Play Lobby Music:</b> <a href='?_src_=prefs;preference=lobby_music'>[(toggles & SOUND_LOBBY) ? "Enabled":"Disabled"]</a><br>"
 			dat += "<b>See Pull Requests:</b> <a href='?_src_=prefs;preference=pull_requests'>[(chat_toggles & CHAT_PULLR) ? "Enabled":"Disabled"]</a><br>"
 			dat += "<br>"
-
+			dat +="<b>IC-OOC Warning:</b> <a href='?_src_=prefs;preference=icooc_warn'>[(toggles & icooc_warn) ? "Enabled":"Disabled"]</a><br>"
 
 			if(user.client)
 				if(unlock_content)
@@ -774,7 +776,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(job_preferences[j] == JP_HIGH)
 				job_preferences[j] = JP_MEDIUM
 				//technically break here
-	
+
 	job_preferences[job.title] = level
 	return TRUE
 
@@ -792,7 +794,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		to_chat(user, "<span class='danger'>UpdateJobPreference - desired level was not a number. Please notify coders!</span>")
 		ShowChoices(user)
 		return
-	
+
 	var/jpval = null
 	switch(desiredLvl)
 		if(3)
@@ -807,7 +809,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			jpval = null
 		else
 			jpval = JP_LOW
-	
+
 	SetJobPreferenceLevel(job, jpval)
 	SetChoices(user)
 
@@ -1422,6 +1424,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("pull_requests")
 					chat_toggles ^= CHAT_PULLR
 
+				if("icooc_warn")
+					chat_toggles ^= icooc_warn
+
 				if("allow_midround_antag")
 					toggles ^= MIDROUND_ANTAG
 
@@ -1445,7 +1450,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					auto_fit_viewport = !auto_fit_viewport
 					if(auto_fit_viewport && parent)
 						parent.fit_viewport()
-				
+
 				if("widescreenpref")
 					widescreenpref = !widescreenpref
 					user.client.change_view(CONFIG_GET(string/default_view))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -56,7 +56,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		var/job_civilian_high = 0
 		var/job_civilian_med = 0
 		var/job_civilian_low = 0
-		
+
 		var/job_medsci_high = 0
 		var/job_medsci_med = 0
 		var/job_medsci_low = 0
@@ -160,6 +160,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["tip_delay"]			>> tip_delay
 	S["pda_style"]			>> pda_style
 	S["pda_color"]			>> pda_color
+	S["icooc_warn"]			>> icooc_warn
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
@@ -190,6 +191,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	be_special		= SANITIZE_LIST(be_special)
 	pda_style		= sanitize_inlist(pda_style, GLOB.pda_styles, initial(pda_style))
 	pda_color		= sanitize_hexcolor(pda_color, 6, 1, initial(pda_color))
+	icooc_warn	= sanitize_integer(icooc_warn, 0, 1, initial(icooc_warn))
 
 	return TRUE
 
@@ -236,6 +238,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["tip_delay"], tip_delay)
 	WRITE_FILE(S["pda_style"], pda_style)
 	WRITE_FILE(S["pda_color"], pda_color)
+	WRITE_FILE(S["icooc_warn"], icooc_warn)
 
 	return TRUE
 

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -360,6 +360,19 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 		to_chat(src, "<span class='notice'>You will no longer examine things you click on.</span>")
 	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Ghost Inquisitiveness", "[prefs.inquisitive_ghost ? "Enabled" : "Disabled"]"))
 
+/client/verb/toggle_icooc_warn() //Toggling the OOC warning if the round is in progress
+	set name = "Toggle Midround OOC Warning"
+	set desc = "Sets whether you receive a warning when sending OOC messages during a round"
+	set category = "Preferences"
+
+	prefs.icooc_warn = !prefs.icooc_warn
+	prefs.save_preferences()
+	if(prefs.icooc_warn)
+		to_chat(src, "<span class='notice'>You will be alerted if you are about to send a message to OOC during the round.</span>")
+	else
+		to_chat(src, "<span class='notice'>You will no longer be alerted if you are about to send a message to OOC during the round.</span>")
+	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Midround OOC Warning", "[prefs.icooc_warn? "Enabled" : "Disabled"]"))
+
 //Admin Preferences
 /client/proc/toggleadminhelpsound()
 	set name = "Hear/Silence Adminhelps"

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -36,6 +36,10 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 	msg = emoji_parse(msg)
 
+	if(SSticker.IsRoundInProgress() && SSticker.HasRoundStarted() && !isnewplayer(usr) && prefs.icooc_warn)
+		if(alert("The Round is still ongoing. Are you sure you want to say this in OOC? Your Message was \" [raw_msg]\"", "Speak in OOC?", "No", "Yes") != "Yes")
+			return
+
 	if((copytext(msg, 1, 2) in list(".",";",":","#")) || (findtext(lowertext(copytext(msg, 1, 5)), "say")))
 		if(alert("Your message \"[raw_msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
 			return

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -36,12 +36,11 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 	msg = emoji_parse(msg)
 
-	if(SSticker.IsRoundInProgress() && SSticker.HasRoundStarted() && !isnewplayer(usr) && prefs.icooc_warn)
-		if(alert("The Round is still ongoing. Are you sure you want to say this in OOC? Your Message was \" [raw_msg]\"", "Speak in OOC?", "No", "Yes") != "Yes")
-			return
-
 	if((copytext(msg, 1, 2) in list(".",";",":","#")) || (findtext(lowertext(copytext(msg, 1, 5)), "say")))
-		if(alert("Your message \"[raw_msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
+		if(alert("Your message \"[raw_msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")  //Radio/Say check
+			return
+	else if(SSticker.IsRoundInProgress() && SSticker.HasRoundStarted() && !isnewplayer(usr) && prefs.icooc_warn) //ICOOC Prefcheck
+		if(alert("The Round is still ongoing. Are you sure you want to say this in OOC? Your Message was \" [raw_msg]\"", "Speak in OOC?", "No", "Yes") != "Yes")
 			return
 
 	if(!holder)


### PR DESCRIPTION
## About The Pull Request

This PR adds a new alert that will pop up if the player attempts to send a message to OOC whilst a round is ongoing.

The preference can be toggled in the players Preferences Tab, and does not affect sending OOC before a round, whilst the player is in a lobby during the round, or after the round.

## Why It's Good For The Game

Should significantly reduce the number of accidental IC-in-OOC events, particularly from ghost chat which currently doesn't have a safeguard akin to the radio-prefix/say check, and is often home to the more round-critical information. 

The toggle allows people that just want to chat about a topic unrelated to the round to be unimpeded by constant alerts.

The current OOC muting system is also tied to being able to see OOC, so this adjustment allows people to still read OOC whilst limiting their ability to send to it.

## Changelog
:cl: GreyGanon
add: Added an alert if you're about to send a message to OOC whilst the round is ongoing. No more excuses for accidental IC-OOC!
config: Makes the IC-OOC Alert toggleable in preferences. So maybe there's one excuse left...
/:cl:

## Outstanding issues:

* Even though there is a box in the Preferences window for the IC-OOC Warning, it currently does not work correctly. It will reflect the state of the setting based on the Preferences Tab toggle, but does not serve as a toggle itself and requires the window to be refreshed by other means to reflect the change.
This will need to be resolved before merging.

* When typing ooc directly into the chat bar, it no longer autocompletes to [OOC "], leaving out the inverted commas. Whilst technically unnessary for the OOC verb to function, this unintended change bothers me and I cannot figure out what has caused it.


