### PR TITLE
Baby grublunch for ma and pap gutlunch.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -37,7 +37,7 @@
 	deathmessage = "is pulped into bugmash."
 
 	animal_species = /mob/living/simple_animal/hostile/asteroid/gutlunch
-	childtype = list(/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck = 45, /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen = 55)
+	childtype = list(/mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch = 100)
 
 	wanted_objects = list(/obj/effect/decal/cleanable/xenoblood/xgibs, /obj/effect/decal/cleanable/blood/gibs/, /obj/item/organ)
 	var/obj/item/udder/gutlunch/udder = null
@@ -119,6 +119,38 @@
 	if(.)
 		udder.reagents.clear_reagents()
 		regenerate_icons()
+
+/mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch
+	name = "grublunch"
+	wanted_objects = list() //They don't eat.
+	gold_core_spawnable = NO_SPAWN
+	var/growth = 0
+
+//Baby gutlunch
+/mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch/Initialize()
+	. = ..()
+	add_atom_colour("#9E9E9E", FIXED_COLOUR_PRIORITY) //Somewhat hidden
+	resize = 0.45
+	update_transform()
+
+/mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch/Life()
+	..()
+	growth++
+	if(growth > 50) //originally used a timer for this but was more problem that it's worth.
+		growUp()
+
+/mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch/proc/growUp()
+	var/mob/living/L
+	if(prob(45))
+		L = new /mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck(loc)
+	else
+		L = new /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen(loc)
+	L.key = key //I don't think this needs logging
+	L.faction = faction
+	L.setDir(dir)
+	L.Stun(20, ignore_canstun = TRUE)
+	visible_message("<span class='notice'>[src] grows up into [L].</span>")
+	Destroy()
 
 //Gutlunch udder
 /obj/item/udder/gutlunch

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -145,9 +145,8 @@
 		L = new /mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck(loc)
 	else
 		L = new /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen(loc)
-	L.key = key //I don't think this needs logging
-	L.mind = mind
-	L.faction = faction
+	if(mind)
+		mind.transfer_to(L)
 	L.setDir(dir)
 	L.Stun(20, ignore_canstun = TRUE)
 	visible_message("<span class='notice'>[src] grows up into [L].</span>")

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -145,8 +145,7 @@
 		L = new /mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck(loc)
 	else
 		L = new /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen(loc)
-	if(mind)
-		mind.transfer_to(L)
+	mind?.transfer_to(L)
 	L.faction = faction
 	L.setDir(dir)
 	L.Stun(20, ignore_canstun = TRUE)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -146,6 +146,7 @@
 	else
 		L = new /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen(loc)
 	L.key = key //I don't think this needs logging
+	L.mind = mind
 	L.faction = faction
 	L.setDir(dir)
 	L.Stun(20, ignore_canstun = TRUE)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -147,6 +147,7 @@
 		L = new /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen(loc)
 	if(mind)
 		mind.transfer_to(L)
+	L.faction = faction
 	L.setDir(dir)
 	L.Stun(20, ignore_canstun = TRUE)
 	visible_message("<span class='notice'>[src] grows up into [L].</span>")


### PR DESCRIPTION
## About The Pull Request

Adds baby gutlunches to the game. They do not eat organs and are generally very cute things. Fixes a bug where gutlunches wouldn't reproduce.

## Why It's Good For The Game

When two gutlunches love each other, they produce many small grubs, but not actually because they used to just make grownups as children and therefore all gutlunches are minors and wouldn't get it on.

## Changelog
:cl:
add: Added gutlunch babies.
fix: Gutlunches now actually reproduce.
/:cl:
