### PR TITLE
Rubber shot actually does its job now.

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -65,7 +65,7 @@
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
 	damage = 3
-	stamina = 11
+	stamina = 17
 
 /obj/item/projectile/bullet/pellet/Range()
 	..()


### PR DESCRIPTION
Changes rubber shot pellet stamina damage from 11 to 17, allowing it to one shot stun at 1 tile range. The stamina damage dropoff change from #43572 was left in, causing the damage to quickly drop off. It's bullshit that getting shot point blank with a rubber shot doesn't knock you down.

:cl:
balance: Rubber shot pellet stamina damage was changed to 17.
/:cl:
