### PR TITLE
Fixes an exploit with plux giving cargo way too many credits.

### DIFF
--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -148,5 +148,5 @@
 	worth += gases[/datum/gas/hypernoblium][MOLES]*1000
 	worth += gases[/datum/gas/miasma][MOLES]*40
 	worth += gases[/datum/gas/tritium][MOLES]*5
-	worth += gases[/datum/gas/pluoxium][MOLES]*50
+	worth += gases[/datum/gas/pluoxium][MOLES]*1
 	return worth

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -148,5 +148,5 @@
 	worth += gases[/datum/gas/hypernoblium][MOLES]*1000
 	worth += gases[/datum/gas/miasma][MOLES]*40
 	worth += gases[/datum/gas/tritium][MOLES]*5
-	worth += gases[/datum/gas/pluoxium][MOLES]*1
+	worth += gases[/datum/gas/pluoxium][MOLES]*5
 	return worth


### PR DESCRIPTION


:cl: shellspeed1

fix: removes an exploit using plux to generate massive amounts of credits.

/:cl:

By changing the sell price of plux from 50 credits per mol to 1 credit per mol we keep cargo from getting millions of credits for what is essentially minimal effort.

