### PR TITLE
Any restraints can be used to craft a spear now

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -338,7 +338,7 @@
 /datum/crafting_recipe/spear
 	name = "Spear"
 	result = /obj/item/twohanded/spear
-	reqs = list(/obj/item/restraints/handcuffs/cable = 1,
+	reqs = list(/obj/item/restraints/handcuffs = 1,
 				/obj/item/shard = 1,
 				/obj/item/stack/rods = 1)
 	parts = list(/obj/item/shard = 1)


### PR DESCRIPTION

## About The Pull Request

Fixes #44309 

## Why It's Good For The Game

Consistency

## Changelog
:cl:
tweak: Any kind of handcuffs, sinew included, can be used to craft spears now.
/:cl:


