### PR TITLE
Removes loudspeak option from command and AI radio

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -160,7 +160,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	keyslot = new /obj/item/encryptionkey/headset_com
 
 /obj/item/radio/headset/heads
-	command = TRUE
 
 /obj/item/radio/headset/heads/captain
 	name = "\proper the captain's headset"
@@ -269,7 +268,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 /obj/item/radio/headset/silicon/ai
 	name = "\proper Integrated Subspace Transceiver "
 	keyslot2 = new /obj/item/encryptionkey/ai
-	command = TRUE
 
 /obj/item/radio/headset/silicon/can_receive(freq, level)
 	return ..(freq, level, TRUE)


### PR DESCRIPTION
## About The Pull Request
Removes loudspeak option from command and AI radio

## Why It's Good For The Game
Makes announcements stand out way more and all chatter becomes more readable instead of constant font changes
edit: not only announcements stand out more, but every message that is important for the player will, like injections, forcefeed, stripping, etc.