### PR TITLE
Fixes gutlunches lunch behaviour

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -31,7 +31,7 @@
 	stop_automated_movement_when_pulled = TRUE
 	stat_exclusive = TRUE
 	robust_searching = TRUE
-	search_objects = TRUE
+	search_objects = 3 //Ancient simplemob AI shitcode. This makes them ignore all other mobs.
 	del_on_death = TRUE
 	loot = list(/obj/effect/decal/cleanable/blood/gibs)
 	deathmessage = "is pulped into bugmash."


### PR DESCRIPTION
## About The Pull Request

Fixes #44307

Gutlunches now ignore other mobs, food is always the highest priority for them.

Holy hell did I have a hard time recreating this bug. Apparently simple_mob AI shitcode uses some weird system to determine if search behaviour should be interrupted by other mobs. They really should be turned into defines or something.

## Why It's Good For The Game

Fixes an oversight.

## Changelog
:cl:
fix: Gutlunches will no longer be too shy to feast near other mobs. This results in them being more much inclined to eat.
/:cl:
