### PR TITLE
Gives the ashlizards a puddle.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -1251,11 +1251,7 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "do" = (
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/mapping_helpers/no_lava,
+/obj/structure/sink/puddle,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "dp" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -1252,6 +1252,7 @@
 /area/lavaland/surface/outdoors)
 "do" = (
 /obj/structure/sink/puddle,
+/obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "dp" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -1251,7 +1251,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "do" = (
-/obj/structure/sink/puddle,
+/obj/structure/sink/puddle{
+	pixel_x = -3;
+	pixel_y = 1
+	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the water tanks in the ashlizard base with a puddle.

Fixes #44308

## Why It's Good For The Game

Makes farming and making leather more attractive to the ashies. Both of which primal activities, so it fits pretty good. It also looks less silly than a modern water tank.

Damn, with all these small ashlizard buffs, they are soon going to dominate the station every round.

## Changelog
:cl:
tweak: Replaced the water tank in the ashlizard base with a puddle.
/:cl:
