### PR TITLE
Rounds ALL Time Feedback To The Second (No Longer Prints Deciseconds)

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -64,7 +64,7 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 //Takes a value of time in deciseconds.
 //Returns a text value of that number in hours, minutes, or seconds.
 /proc/DisplayTimeText(time_value, round_seconds_to = 0.1)
-	var/second = FLOOR(time_value * 0.1, round_seconds_to)
+	var/second = FLOOR(time_value * 0.1, round_seconds_to = 1)
 	if(!second)
 		return "right now"
 	if(second < 60)


### PR DESCRIPTION
## About The Pull Request
Rounds all seconds to seconds instead of deciseconds.

Before:
![Capture2](https://user-images.githubusercontent.com/5420151/59060109-0b2f2380-88a9-11e9-9a4b-87ca71145e25.PNG)
![kuva](https://user-images.githubusercontent.com/5420151/59060823-a4ab0500-88aa-11e9-9400-cb2b4bf0bbd9.png)

After:
![Capture](https://user-images.githubusercontent.com/5420151/59060108-09656000-88a9-11e9-8e34-f260ab63daf3.PNG)
![kuva](https://user-images.githubusercontent.com/5420151/59061338-f30cd380-88ab-11e9-897a-11d5e79b0930.png)

## Why It's Good For The Game
This kind of format is more common and also there's less change to misread it.