### PR TITLE
[READY] Redecorates Syndibase after TC console removal

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -8940,7 +8940,9 @@
 /turf/closed/indestructible/rock/snow,
 /area/syndicate_mothership/control)
 "tw" = (
-/turf/open/space/basic,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/wood,
 /area/syndicate_mothership/control)
 "tx" = (
 /obj/structure/table/wood,
@@ -36240,7 +36242,7 @@ pZ
 rf
 vv
 wm
-vx
+tw
 ku
 kt
 my
@@ -37009,7 +37011,7 @@ sh
 sh
 pZ
 pZ
-vv
+vx
 wo
 tg
 ku
@@ -39059,7 +39061,7 @@ hl
 hl
 qM
 tv
-tw
+aa
 ku
 ku
 ku

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6513,11 +6513,9 @@
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "oV" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/syndicate_mothership/control)
 "oW" = (
 /obj/structure/flora/bush,
 /obj/effect/light_emitter{
@@ -8316,10 +8314,14 @@
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
 "si" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/sign/map/left{
+	pixel_y = -32
 	},
-/turf/open/floor/mineral/plastitanium/red,
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/syndicate_mothership/control)
 "sj" = (
 /obj/structure/toilet{
@@ -8826,10 +8828,14 @@
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
 "tg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/sign/map/right{
+	pixel_y = -32
 	},
-/turf/open/floor/mineral/plastitanium/red,
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/syndicate_mothership/control)
 "th" = (
 /obj/structure/closet/cardboard,
@@ -9518,12 +9524,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/syndicate_mothership/control)
-"uM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/control)
 "uO" = (
 /obj/machinery/door/airlock/centcom{
@@ -10493,36 +10493,6 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet,
 /area/wizard_station)
-"wV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/syndicate_mothership/control)
-"wW" = (
-/obj/structure/sign/map/left{
-	pixel_y = -32
-	},
-/obj/structure/rack{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "minibar_left";
-	name = "skeletal minibar"
-	},
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/open/floor/wood,
-/area/syndicate_mothership/control)
-"wX" = (
-/obj/structure/sign/map/right{
-	pixel_y = -32
-	},
-/obj/structure/rack{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "minibar_right";
-	name = "skeletal minibar"
-	},
-/obj/item/reagent_containers/food/drinks/bottle/gin,
-/turf/open/floor/wood,
-/area/syndicate_mothership/control)
 "wY" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Equipment Room";
@@ -12993,9 +12963,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
-"CT" = (
-/turf/open/floor/wood,
-/area/centcom/holding)
 "CV" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
@@ -13188,9 +13155,6 @@
 "Di" = (
 /turf/closed/indestructible/riveted,
 /area/ai_multicam_room)
-"Dj" = (
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Dq" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/turf_decal/stripes/line{
@@ -15154,10 +15118,6 @@
 	},
 /turf/open/space,
 /area/space)
-"HH" = (
-/obj/machinery/light,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "HI" = (
 /obj/structure/sink{
 	dir = 8;
@@ -17529,9 +17489,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
-"Px" = (
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Pz" = (
 /obj/structure/table/reinforced,
 /obj/item/paper/pamphlet/centcom/visitor_info,
@@ -17542,9 +17499,6 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/black,
-/area/centcom/holding)
-"PF" = (
-/turf/open/floor/wood,
 /area/centcom/holding)
 "PI" = (
 /obj/machinery/biogenerator,
@@ -17650,12 +17604,6 @@
 /obj/singularity/wizard/mapped,
 /turf/open/indestructible/binary,
 /area/fabric_of_reality)
-"Qu" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "QA" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
@@ -36265,13 +36213,13 @@ nz
 pZ
 pZ
 pZ
-rf
-rf
+sh
+sh
 pZ
 rf
 vv
 wm
-si
+vx
 ku
 kt
 my
@@ -36528,7 +36476,7 @@ pZ
 rf
 vw
 wn
-wV
+oV
 ku
 kt
 hl
@@ -36785,7 +36733,7 @@ pZ
 rf
 vv
 wn
-wW
+si
 ku
 oW
 hl
@@ -37036,13 +36984,13 @@ pF
 qa
 pZ
 rg
-rf
-rf
+sh
+sh
 pZ
 pZ
-vx
+vv
 wo
-wX
+tg
 ku
 kt
 ma
@@ -37550,10 +37498,10 @@ kt
 ku
 qL
 pZ
-sh
-sh
-sh
-sh
+pZ
+pZ
+pZ
+pZ
 pZ
 pZ
 wY
@@ -37807,10 +37755,10 @@ ma
 ku
 qM
 pZ
-si
-tg
-tg
-uM
+pZ
+pZ
+pZ
+pZ
 pZ
 wp
 ku
@@ -42985,12 +42933,12 @@ UV
 CV
 Xk
 NT
-CT
-oV
-CT
-CT
-oV
-CT
+Xk
+Yo
+Xk
+Xk
+Yo
+Xk
 Nd
 aa
 aa
@@ -43500,9 +43448,9 @@ CV
 Xk
 NT
 Xk
-PF
 Xk
-Px
+Xk
+Xk
 Xk
 Zt
 Nd
@@ -43757,11 +43705,11 @@ Xk
 Xk
 WY
 Xk
-PF
 Xk
-Px
 Xk
-PF
+Xk
+Xk
+Xk
 Nd
 aa
 aa
@@ -44014,9 +43962,9 @@ CV
 Xk
 NT
 Xk
-PF
 Xk
-Px
+Xk
+Xk
 Xk
 Zt
 Nd
@@ -44527,12 +44475,12 @@ Ym
 CV
 Xk
 NT
-Dj
-Qu
-Dj
-Dj
-Qu
-Dj
+Xk
+Xx
+Xk
+Xk
+Xx
+Xk
 Nd
 aa
 aa
@@ -44778,7 +44726,7 @@ Xk
 Xk
 Xk
 Xk
-HH
+Zt
 Nd
 Xk
 Xk
@@ -45806,7 +45754,7 @@ Xk
 Xk
 Xk
 Xk
-HH
+Zt
 Nd
 UJ
 Ud

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -7545,12 +7545,11 @@
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
 "qM" = (
-/obj/machinery/vending/cigarette/syndicate,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership/control)
 "qN" = (
 /obj/structure/urinal{
@@ -8867,6 +8866,14 @@
 /obj/structure/dresser,
 /turf/open/floor/holofloor/carpet,
 /area/holodeck/rec_center/photobooth)
+"tm" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/vending/cigarette/syndicate,
+/turf/open/floor/plasteel,
+/area/syndicate_mothership/control)
 "tn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -8929,6 +8936,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
+"tv" = (
+/turf/closed/indestructible/rock/snow,
+/area/syndicate_mothership/control)
+"tw" = (
+/turf/open/space/basic,
+/area/syndicate_mothership/control)
 "tx" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
@@ -9164,6 +9177,14 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
+"tQ" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/syndicate_mothership/control)
 "tR" = (
 /obj/machinery/status_display/ai,
 /turf/closed/indestructible/riveted,
@@ -36210,7 +36231,7 @@ hl
 hl
 kt
 nz
-pZ
+tm
 pZ
 pZ
 sh
@@ -37753,12 +37774,12 @@ hl
 mz
 ma
 ku
-qM
-pZ
-pZ
-pZ
-pZ
-pZ
+ku
+ku
+rh
+ku
+ku
+tQ
 pZ
 wp
 ku
@@ -38008,12 +38029,12 @@ hl
 mz
 hl
 kt
-pG
+kt
 ku
 ku
-rh
-ku
-ku
+qN
+ri
+Wj
 ku
 nz
 uJ
@@ -38265,12 +38286,12 @@ mA
 hl
 hl
 pG
+qM
 ku
-ku
-qN
+qO
+OA
 ri
-Wj
-ku
+sj
 ku
 nz
 ll
@@ -38522,11 +38543,11 @@ mz
 hl
 hl
 pG
-ku
-qO
-OA
-ri
-sj
+qM
+nz
+pY
+qP
+rj
 ku
 ku
 nz
@@ -38779,10 +38800,10 @@ hl
 hl
 mA
 kt
-nz
-pY
-qP
-rj
+qM
+ku
+ku
+ku
 ku
 ku
 ku
@@ -39035,10 +39056,10 @@ hl
 mA
 mz
 hl
-ma
-ku
-ku
-ku
+hl
+qM
+tv
+tw
 ku
 ku
 ku
@@ -39293,7 +39314,7 @@ hl
 hl
 hl
 pG
-ma
+hl
 hh
 aa
 ku


### PR DESCRIPTION
Removes the ugly warning tape where the TC consoles were. Puts a bar behind leaders desk, now hes actually good for something (if he knows how to make drinks). I tried once, perhaps this time will work. 
Edit: pushed bathroom in to fill empty space on right side. Looks less empty now.

![image](https://user-images.githubusercontent.com/25413060/59120316-b2986e80-891a-11e9-910b-953b32e50ac3.png)
vs
![image](https://user-images.githubusercontent.com/25413060/59112146-0a79aa00-8908-11e9-8052-e1ee49d1b595.png)

## Changelog
:cl:
tweak: Cleaned up Syndiebase after TC station removal.
/:cl: