### PR TITLE
Gives security night vision goggles flash protection

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -131,6 +131,7 @@
 	darkness_view = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	glass_colour_type = /datum/client_colour/glass_colour/green
+	flash_protect = 1
 
 /obj/item/clothing/glasses/hud/security/sunglasses/gars
 	name = "\improper HUD gar glasses"


### PR DESCRIPTION
## About The Pull Request
Gives Sechud NV goggles flash protection

## Why It's Good For The Game
Every other sec item has flash protection. These goggles not having them makes them borderline useless. Anyone can just flash you, flashbangs are a self stun and the portable flashers every damn warden sets up at the brig entrance are going to be annoying.


:cl:
tweak: Added flash protection to Sechud Night Vision Goggles
/:cl:
