### PR TITLE
Fixes soda can's open_soda(mob/user) not passing the mob to it

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -456,7 +456,7 @@
 
 /obj/item/reagent_containers/food/drinks/soda_cans/attack_self(mob/user)
 	if(!is_drainable())
-		open_soda()
+		open_soda(user)
 	return ..()
 
 /obj/item/reagent_containers/food/drinks/soda_cans/cola


### PR DESCRIPTION
Just a lil bugfix for those who make custom sodas that do things when you open them.