### PR TITLE
Fixes chem dispenser button order

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -102,3 +102,6 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 
 /proc/cmp_job_display_asc(datum/job/A, datum/job/B)
 	return A.display_order - B.display_order
+
+/proc/cmp_reagents_asc(datum/reagent/a, datum/reagent/b)
+    return sorttext(initial(b.name),initial(a.name))

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -33,48 +33,49 @@
 	var/has_panel_overlay = TRUE
 	var/macroresolution = 1
 	var/obj/item/reagent_containers/beaker = null
-	var/list/dispensable_reagents = list(
-		/datum/reagent/hydrogen,
-		/datum/reagent/lithium,
+	//These lists aren't automatically sorted, make sure you add chems in the right order.
+	var/list/dispensable_reagents = list(	
+		/datum/reagent/aluminium,
+		/datum/reagent/bromine,
 		/datum/reagent/carbon,
+		/datum/reagent/chlorine,
+		/datum/reagent/copper,
+		/datum/reagent/consumable/ethanol,
+		/datum/reagent/fluorine,
+		/datum/reagent/hydrogen,
+		/datum/reagent/iodine,
+		/datum/reagent/iron,
+		/datum/reagent/lithium,
+		/datum/reagent/mercury,
 		/datum/reagent/nitrogen,
 		/datum/reagent/oxygen,
-		/datum/reagent/fluorine,
-		/datum/reagent/sodium,
-		/datum/reagent/aluminium,
-		/datum/reagent/silicon,
 		/datum/reagent/phosphorus,
-		/datum/reagent/sulfur,
-		/datum/reagent/chlorine,
 		/datum/reagent/potassium,
-		/datum/reagent/iron,
-		/datum/reagent/copper,
-		/datum/reagent/mercury,
 		/datum/reagent/uranium/radium,
-		/datum/reagent/water,
-		/datum/reagent/consumable/ethanol,
-		/datum/reagent/consumable/sugar,
-		/datum/reagent/toxin/acid,
-		/datum/reagent/fuel,
+		/datum/reagent/silicon,
 		/datum/reagent/silver,
-		/datum/reagent/iodine,
-		/datum/reagent/bromine,
-		/datum/reagent/stable_plasma
+		/datum/reagent/sodium,
+		/datum/reagent/stable_plasma,
+		/datum/reagent/consumable/sugar,
+		/datum/reagent/sulfur,
+		/datum/reagent/toxin/acid,
+		/datum/reagent/water,
+		/datum/reagent/fuel
 	)
 	//these become available once the manipulator has been upgraded to tier 4 (femto)
 	var/list/upgrade_reagents = list(
-		"oil",
-		/datum/reagent/ash,
 		/datum/reagent/acetone,
-		/datum/reagent/saltpetre,
 		/datum/reagent/ammonia,
-		/datum/reagent/diethylamine
+		/datum/reagent/ash,
+		/datum/reagent/diethylamine,
+		/datum/reagent/oil,
+		/datum/reagent/saltpetre
 	)
 	var/list/emagged_reagents = list(
-		/datum/reagent/drug/space_drugs,
-		/datum/reagent/medicine/morphine,
 		/datum/reagent/toxin/carpotoxin,
 		/datum/reagent/medicine/mine_salve,
+		/datum/reagent/medicine/morphine,
+		/datum/reagent/drug/space_drugs,
 		/datum/reagent/toxin
 	)
 
@@ -82,7 +83,6 @@
 
 /obj/machinery/chem_dispenser/Initialize()
 	. = ..()
-	dispensable_reagents = sortList(dispensable_reagents)
 	update_icon()
 
 /obj/machinery/chem_dispenser/Destroy()

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -84,8 +84,10 @@
 /obj/machinery/chem_dispenser/Initialize()
 	. = ..()
 	dispensable_reagents = sortList(dispensable_reagents, /proc/cmp_reagents_asc)
-	emagged_reagents = sortList(emagged_reagents, /proc/cmp_reagents_asc)
-	upgrade_reagents = sortList(upgrade_reagents, /proc/cmp_reagents_asc)
+	if(emagged_reagents)
+		emagged_reagents = sortList(emagged_reagents, /proc/cmp_reagents_asc)
+	if(upgrade_reagents)
+		upgrade_reagents = sortList(upgrade_reagents, /proc/cmp_reagents_asc)
 	update_icon()
 
 /obj/machinery/chem_dispenser/Destroy()

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -33,7 +33,6 @@
 	var/has_panel_overlay = TRUE
 	var/macroresolution = 1
 	var/obj/item/reagent_containers/beaker = null
-	//These lists aren't automatically sorted, make sure you add chems in the right order.
 	var/list/dispensable_reagents = list(	
 		/datum/reagent/aluminium,
 		/datum/reagent/bromine,

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -83,6 +83,9 @@
 
 /obj/machinery/chem_dispenser/Initialize()
 	. = ..()
+	dispensable_reagents = sortList(dispensable_reagents, /proc/cmp_reagents_asc)
+	emagged_reagents = sortList(emagged_reagents, /proc/cmp_reagents_asc)
+	upgrade_reagents = sortList(upgrade_reagents, /proc/cmp_reagents_asc)
 	update_icon()
 
 /obj/machinery/chem_dispenser/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sorts the list of chems in the chem dispenser manually, removing the autosort that no longer works since chem id's are gone. Doing it manually once makes more sense than doing it automatically on every initialize anyway.
The observant among you might notice the sulphuric acid button has moved from its previous position, since it wasnt sorted properly before, I assume because "sacid".

Also speedmerge please, chemistry is suddenly very hard again. :grimacing:
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Chem dispenser buttons are now sorted alphabetically again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
