### PR TITLE
Makes nicotine kill pests.

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -602,6 +602,11 @@
 		adjustToxic(round(S.get_reagent_amount(/datum/reagent/toxin/pestkiller) * 0.5))
 		adjustPests(-rand(1,2))
 
+	//Nicotine is used as a pesticide IRL.
+	if(S.has_reagent(/datum/reagent/drug/nicotine, 1))
+		adjustToxic(round(S.get_reagent_amount(/datum/reagent/drug/nicotine)))
+		adjustPests(-rand(1,2))
+
 	// Healing
 	if(S.has_reagent(/datum/reagent/medicine/cryoxadone, 1))
 		adjustHealth(round(S.get_reagent_amount(/datum/reagent/medicine/cryoxadone) * 3))


### PR DESCRIPTION
## About The Pull Request

Makes nicotine kill pests. It's just as effective as bug spray, but more toxic.

## Why It's Good For The Game

Nicotine is used as a pest killer IRL and this adds a ghetto way of removing pests from plants.

Especially ashwalkers *surprise surprise* are effected by this since they can now use mushroom to remove the pests.

Maybe I make PRs a bit too atomic.

## Changelog
:cl:
add: Nicotine now kills pest and add toxicity when added to a plant tray.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
