### PR TITLE
Replaces hear_intercept with signals, refactors MOVABLE_HEAR, touches up nanites and to_chat

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -151,6 +151,16 @@
 	#define SPEECH_LANGUAGE 5
 	#define SPEECH_IGNORE_SPAM 6
 	#define SPEECH_FORCED 7 */
+#define COMSIG_MOB_HEAR "mob_hear" // from /mob/living/Hear(): (proc args list)
+// (message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
+	#define HEARING_MESSAGE 1
+/*	#define HEARING_SPEAKER 2
+	#define HEARING_LANGUAGE 3
+	#define HEARING_RAW_MESSAGE 4
+	#define HEARING_RADIO_FREQ 5
+	#define HEARING_SPANS 6
+	#define HEARING_MESSAGE_MODE 7 */
+
 
 // /mob/living signals
 #define COMSIG_LIVING_RESIST "living_resist"					//from base of mob/living/resist() (/mob/living)

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -124,7 +124,14 @@
 #define COMSIG_MOVABLE_POST_THROW "movable_post_throw"			//from base of atom/movable/throw_at(): (datum/thrownthing, spin)
 #define COMSIG_MOVABLE_Z_CHANGED "movable_ztransit" 			//from base of atom/movable/onTransitZ(): (old_z, new_z)
 #define COMSIG_MOVABLE_SECLUDED_LOCATION "movable_secluded" 	//called when the movable is placed in an unaccessible area, used for stationloving: ()
-#define COMSIG_MOVABLE_HEAR "movable_hear"						//from base of atom/movable/Hear(): (message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
+#define COMSIG_MOVABLE_HEAR "movable_hear"						//from base of atom/movable/Hear(): (proc args list(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode))
+	#define HEARING_MESSAGE 1
+	/*	#define HEARING_SPEAKER 2
+	#define HEARING_LANGUAGE 3
+	#define HEARING_RAW_MESSAGE 4
+	#define HEARING_RADIO_FREQ 5
+	#define HEARING_SPANS 6
+	#define HEARING_MESSAGE_MODE 7 */
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"			//called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
 
 // /mob signals
@@ -141,7 +148,7 @@
 #define COMSIG_MOB_ATTACK_RANGED "mob_attack_ranged"			//from base of mob/RangedAttack(): (atom/A, params)
 #define COMSIG_MOB_THROW "mob_throw"							//from base of /mob/throw_item(): (atom/target)
 #define COMSIG_MOB_UPDATE_SIGHT "mob_update_sight"				//from base of /mob/update_sight(): ()
-#define COMSIG_MOB_SAY "mob_say" // from /mob/living/say(): (proc args list)
+#define COMSIG_MOB_SAY "mob_say" // from /mob/living/say(): ()
 	#define COMPONENT_UPPERCASE_SPEECH 1
 	// used to access COMSIG_MOB_SAY argslist
 	#define SPEECH_MESSAGE 1
@@ -151,16 +158,6 @@
 	#define SPEECH_LANGUAGE 5
 	#define SPEECH_IGNORE_SPAM 6
 	#define SPEECH_FORCED 7 */
-#define COMSIG_MOB_HEAR "mob_hear" // from /mob/living/Hear(): (proc args list)
-// (message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
-	#define HEARING_MESSAGE 1
-/*	#define HEARING_SPEAKER 2
-	#define HEARING_LANGUAGE 3
-	#define HEARING_RAW_MESSAGE 4
-	#define HEARING_RADIO_FREQ 5
-	#define HEARING_SPANS 6
-	#define HEARING_MESSAGE_MODE 7 */
-
 
 // /mob/living signals
 #define COMSIG_LIVING_RESIST "living_resist"					//from base of mob/living/resist() (/mob/living)

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -126,10 +126,10 @@
 #define COMSIG_MOVABLE_SECLUDED_LOCATION "movable_secluded" 	//called when the movable is placed in an unaccessible area, used for stationloving: ()
 #define COMSIG_MOVABLE_HEAR "movable_hear"						//from base of atom/movable/Hear(): (proc args list(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode))
 	#define HEARING_MESSAGE 1
-	/*	#define HEARING_SPEAKER 2
-	#define HEARING_LANGUAGE 3
+	#define HEARING_SPEAKER 2
+//	#define HEARING_LANGUAGE 3
 	#define HEARING_RAW_MESSAGE 4
-	#define HEARING_RADIO_FREQ 5
+	/* #define HEARING_RADIO_FREQ 5
 	#define HEARING_SPANS 6
 	#define HEARING_MESSAGE_MODE 7 */
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"			//called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -41,20 +41,23 @@
 /datum/brain_trauma/proc/on_gain()
 	to_chat(owner, gain_text)
 	RegisterSignal(owner, COMSIG_MOB_SAY, .proc/handle_speech)
+	RegisterSignal(owner, COMSIG_MOVABLE_HEAR, .proc/handle_hearing)
 
 //Called when removed from a mob
 /datum/brain_trauma/proc/on_lose(silent)
 	if(!silent)
 		to_chat(owner, lose_text)
 	UnregisterSignal(owner, COMSIG_MOB_SAY)
+	UnregisterSignal(owner, COMSIG_MOVABLE_HEAR)
 
 //Called when hearing a spoken message
-/datum/brain_trauma/proc/on_hear(message, speaker, message_language, raw_message, radio_freq)
-	return message
+/datum/brain_trauma/proc/handle_hearing(datum/source, list/hearing_args)
+	UnregisterSignal(owner, COMSIG_MOVABLE_HEAR)
 
 //Called when speaking
 /datum/brain_trauma/proc/handle_speech(datum/source, list/speech_args)
 	UnregisterSignal(owner, COMSIG_MOB_SAY)
+
 
 //Called when hugging. expand into generally interacting, where future coders could switch the intent?
 /datum/brain_trauma/proc/on_hug(mob/living/hugger, mob/living/hugged)

--- a/code/datums/brain_damage/hypnosis.dm
+++ b/code/datums/brain_damage/hypnosis.dm
@@ -48,6 +48,5 @@
 			if(2)
 				new /datum/hallucination/chat(owner, TRUE, FALSE, "<span class='hypnophrase'>[hypnotic_phrase]</span>")
 
-/datum/brain_trauma/hypnosis/on_hear(message, speaker, message_language, raw_message, radio_freq)
-	message = target_phrase.Replace(message, "<span class='hypnophrase'>$1</span>")
-	return message
+/datum/brain_trauma/hypnosis/handle_hearing(datum/source, list/hearing_args)
+	hearing_args[HEARING_MESSAGE] = target_phrase.Replace(hearing_args[HEARING_MESSAGE], "<span class='hypnophrase'>$1</span>")

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -76,19 +76,18 @@
 							freak_out(I)
 							return
 
-/datum/brain_trauma/mild/phobia/on_hear(message, speaker, message_language, raw_message, radio_freq)
+/datum/brain_trauma/mild/phobia/handle_hearing(datum/source, list/hearing_args)
 	if(!owner.can_hear() || world.time < next_scare) //words can't trigger you if you can't hear them *taps head*
-		return message
+		return
 	if(HAS_TRAIT(owner, TRAIT_FEARLESS))
-		return message
+		return
 	for(var/word in trigger_words)
 		var/regex/reg = regex("(\\b|\\A)[REGEX_QUOTE(word)]'?s*(\\b|\\Z)", "i")
 
-		if(findtext(raw_message, reg))
+		if(findtext(hearing_args[HEARING_RAW_MESSAGE], reg))
 			addtimer(CALLBACK(src, .proc/freak_out, null, word), 10) //to react AFTER the chat message
-			message = reg.Replace(message, "<span class='phobia'>$1</span>")
+			hearing_args[HEARING_MESSAGE] = reg.Replace(hearing_args[HEARING_MESSAGE], "<span class='phobia'>$1</span>")
 			break
-	return message
 
 /datum/brain_trauma/mild/phobia/handle_speech(datum/source, list/speech_args)
 	if(HAS_TRAIT(owner, TRAIT_FEARLESS))

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -191,13 +191,13 @@
 /datum/brain_trauma/severe/split_personality/brainwashing/on_life()
 	return //no random switching
 
-/datum/brain_trauma/severe/split_personality/brainwashing/on_hear(message, speaker, message_language, raw_message, radio_freq)
+/datum/brain_trauma/split_personality/brainwashing/handle_hearing(datum/source, list/hearing_args)
 	if(HAS_TRAIT(owner, TRAIT_DEAF) || owner == speaker)
-		return message
+		return
+	var/message = hearing_args[HEARING_MESSAGE]
 	if(findtext(message, codeword))
-		message = replacetext(message, codeword, "<span class='warning'>[codeword]</span>")
+		hearing_args[HEARING_MESSAGE] = replacetext(message, codeword, "<span class='warning'>[codeword]</span>")
 		addtimer(CALLBACK(src, /datum/brain_trauma/severe/split_personality.proc/switch_personalities), 10)
-	return message
 
 /datum/brain_trauma/severe/split_personality/brainwashing/handle_speech(datum/source, list/speech_args)
 	if(findtext(speech_args[SPEECH_MESSAGE], codeword))

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -191,8 +191,8 @@
 /datum/brain_trauma/severe/split_personality/brainwashing/on_life()
 	return //no random switching
 
-/datum/brain_trauma/split_personality/brainwashing/handle_hearing(datum/source, list/hearing_args)
-	if(HAS_TRAIT(owner, TRAIT_DEAF) || owner == speaker)
+/datum/brain_trauma/severe/split_personality/brainwashing/handle_hearing(datum/source, list/hearing_args)
+	if(HAS_TRAIT(owner, TRAIT_DEAF) || owner == hearing_args[HEARING_SPEAKER])
 		return
 	var/message = hearing_args[HEARING_MESSAGE]
 	if(findtext(message, codeword))

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -53,7 +53,6 @@
 		RegisterSignal(parent, COMSIG_MOB_ALLOWED, .proc/check_access)
 		RegisterSignal(parent, COMSIG_LIVING_ELECTROCUTE_ACT, .proc/on_shock)
 		RegisterSignal(parent, COMSIG_LIVING_MINOR_SHOCK, .proc/on_minor_shock)
-		RegisterSignal(parent, COMSIG_MOVABLE_HEAR, .proc/on_hear)
 		RegisterSignal(parent, COMSIG_SPECIES_GAIN, .proc/check_viable_biotype)
 		RegisterSignal(parent, COMSIG_NANITE_SIGNAL, .proc/receive_signal)
 		RegisterSignal(parent, COMSIG_NANITE_COMM_SIGNAL, .proc/receive_comm_signal)
@@ -196,11 +195,6 @@
 	for(var/X in programs)
 		var/datum/nanite_program/NP = X
 		NP.on_death(gibbed)
-
-/datum/component/nanites/proc/on_hear(datum/source, message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
-	for(var/X in programs)
-		var/datum/nanite_program/NP = X
-		NP.on_hear(message, speaker, message_language, raw_message, radio_freq, spans, message_mode)
 
 /datum/component/nanites/proc/receive_signal(datum/source, code, source = "an unidentified source")
 	for(var/X in programs)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -675,7 +675,7 @@
 /datum/status_effect/trance/proc/hypnotize(datum/source, list/hearing_args)
 	if(!owner.can_hear())
 		return
-	if(speaker == owner)
+	if(hearing_args[HEARING_SPEAKER] == owner)
 		return
 	var/mob/living/carbon/C = owner
 	C.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY) //clear previous hypnosis

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -672,14 +672,14 @@
 		owner.remove_client_colour(/datum/client_colour/monochrome)
 	to_chat(owner, "<span class='warning'>You snap out of your trance!</span>")
 
-/datum/status_effect/trance/proc/hypnotize(datum/source, message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
+/datum/status_effect/trance/proc/hypnotize(datum/source, list/hearing_args)
 	if(!owner.can_hear())
 		return
 	if(speaker == owner)
 		return
 	var/mob/living/carbon/C = owner
 	C.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY) //clear previous hypnosis
-	addtimer(CALLBACK(C, /mob/living/carbon.proc/gain_trauma, /datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY, raw_message), 10)
+	addtimer(CALLBACK(C, /mob/living/carbon.proc/gain_trauma, /datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY, hearing_args[HEARING_RAW_MESSAGE]), 10)
 	addtimer(CALLBACK(C, /mob/living.proc/Stun, 60, TRUE, TRUE), 15) //Take some time to think about it
 	qdel(src)
 

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -127,6 +127,18 @@
 	alert_type = null
 	var/mob/living/listening_in
 
+/datum/status_effect/bugged/on_apply(mob/living/new_owner, mob/living/tracker)
+	. = ..()
+	if (.)
+		RegisterSignal(new_owner, COMSIG_MOB_HEAR, .proc/handle_hearing)
+
+/datum/status_effect/bugged/on_remove()
+	. = ..()
+	UnregisterSignal(owner, COMSIG_MOB_HEAR)
+
+/datum/status_effect/bugged/proc/handle_hearing(datum/source, list/hearing_args)
+	listening_in.show_message(hearing_args[HEARING_MESSAGE])
+
 /datum/status_effect/bugged/on_creation(mob/living/new_owner, mob/living/tracker)
 	. = ..()
 	if(.)

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -130,11 +130,11 @@
 /datum/status_effect/bugged/on_apply(mob/living/new_owner, mob/living/tracker)
 	. = ..()
 	if (.)
-		RegisterSignal(new_owner, COMSIG_MOB_HEAR, .proc/handle_hearing)
+		RegisterSignal(new_owner, COMSIG_MOVABLE_HEAR, .proc/handle_hearing)
 
 /datum/status_effect/bugged/on_remove()
 	. = ..()
-	UnregisterSignal(owner, COMSIG_MOB_HEAR)
+	UnregisterSignal(owner, COMSIG_MOVABLE_HEAR)
 
 /datum/status_effect/bugged/proc/handle_hearing(datum/source, list/hearing_args)
 	listening_in.show_message(hearing_args[HEARING_MESSAGE])

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -29,7 +29,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	send_speech(message, 7, src, , spans, message_language=language)
 
 /atom/movable/proc/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
-	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, message, speaker, message_language, raw_message, radio_freq, spans, message_mode)
+	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)
 
 /atom/movable/proc/can_speak()
 	return 1

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -24,6 +24,7 @@
 	if(give_objectives)
 		forge_traitor_objectives()
 	finalize_traitor()
+	RegisterSignal(owner.current, COMSIG_MOVABLE_HEAR, .proc/handle_hearing)
 	..()
 
 /datum/antagonist/traitor/apply_innate_effects()
@@ -48,12 +49,18 @@
 		A.verbs -= /mob/living/silicon/ai/proc/choose_modules
 		A.malf_picker.remove_malf_verbs(A)
 		qdel(A.malf_picker)
-
+	UnregisterSignal(owner.current, COMSIG_MOVABLE_HEAR, .proc/handle_hearing)
 	SSticker.mode.traitors -= owner
 	if(!silent && owner.current)
 		to_chat(owner.current,"<span class='userdanger'> You are no longer the [special_role]! </span>")
 	owner.special_role = null
 	..()
+
+/datum/antagonist/traitor/proc/handle_hearing(datum/source, list/hearing_args)
+	var/message = hearing_args[HEARING_MESSAGE]
+	message = GLOB.syndicate_code_phrase_regex.Replace(message, "<span class='blue'>$1</span>")
+	message = GLOB.syndicate_code_response_regex.Replace(message, "<span class='red'>$1</span>")
+	hearing_args[HEARING_MESSAGE] = message
 
 /datum/antagonist/traitor/proc/add_objective(datum/objective/O)
 	objectives += O

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -187,23 +187,10 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 	if(!target)
 		return
 
-	//Ok so I did my best but I accept that some calls to this will be for shit like sound and images
-	//It stands that we PROBABLY don't want to output those to the browser output so just handle them here
-	if (istype(target, /savefile))
-		CRASH("Invalid message! [message]")
-
-	if(!istext(message))
-		if (istype(message, /image) || istype(message, /sound))
-			CRASH("Invalid message! [message]")
-		return
-
 	if(target == world)
 		target = GLOB.clients
 
 	var/original_message = message
-	//Some macros remain in the string even after parsing and fuck up the eventual output
-	message = replacetext(message, "\improper", "")
-	message = replacetext(message, "\proper", "")
 	if(handle_whitespace)
 		message = replacetext(message, "\n", "<br>")
 		message = replacetext(message, "\t", "[GLOB.TAB][GLOB.TAB]")

--- a/code/modules/mob/living/carbon/say.dm
+++ b/code/modules/mob/living/carbon/say.dm
@@ -20,9 +20,6 @@
 		. = initial(dt.flags) & TONGUELESS_SPEECH
 
 /mob/living/carbon/hear_intercept(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
-	var/datum/status_effect/bugged/B = has_status_effect(STATUS_EFFECT_BUGGED)
-	if(B)
-		B.listening_in.show_message(message)
 	for(var/T in get_traumas())
 		var/datum/brain_trauma/trauma = T
 		message = trauma.on_hear(message, speaker, message_language, raw_message, radio_freq)

--- a/code/modules/mob/living/carbon/say.dm
+++ b/code/modules/mob/living/carbon/say.dm
@@ -20,10 +20,6 @@
 		. = initial(dt.flags) & TONGUELESS_SPEECH
 
 /mob/living/carbon/hear_intercept(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
-	for(var/T in get_traumas())
-		var/datum/brain_trauma/trauma = T
-		message = trauma.on_hear(message, speaker, message_language, raw_message, radio_freq)
-
 	if (src.mind.has_antag_datum(/datum/antagonist/traitor))
 		message = GLOB.syndicate_code_phrase_regex.Replace(message, "<span class='blue'>$1</span>")
 		message = GLOB.syndicate_code_response_regex.Replace(message, "<span class='red'>$1</span>")

--- a/code/modules/mob/living/carbon/say.dm
+++ b/code/modules/mob/living/carbon/say.dm
@@ -18,10 +18,3 @@
 		. = T.could_speak_in_language(dt)
 	else
 		. = initial(dt.flags) & TONGUELESS_SPEECH
-
-/mob/living/carbon/hear_intercept(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
-	if (src.mind.has_antag_datum(/datum/antagonist/traitor))
-		message = GLOB.syndicate_code_phrase_regex.Replace(message, "<span class='blue'>$1</span>")
-		message = GLOB.syndicate_code_response_regex.Replace(message, "<span class='red'>$1</span>")
-
-	return message

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -231,6 +231,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	// Recompose message for AI hrefs, language incomprehension.
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode)
+	SEND_SIGNAL(src, COMSIG_MOB_HEAR, args)
 	message = hear_intercept(message, speaker, message_language, raw_message, radio_freq, spans, message_mode)
 
 	show_message(message, 2, deaf_message, deaf_type)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -232,12 +232,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	// Recompose message for AI hrefs, language incomprehension.
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)
-	message = hear_intercept(message, speaker, message_language, raw_message, radio_freq, spans, message_mode)
 
 	show_message(message, 2, deaf_message, deaf_type)
-	return message
-
-/mob/living/proc/hear_intercept(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
 	return message
 
 /mob/living/send_speech(message, message_range = 6, obj/source = src, bubble_type = bubble_icon, list/spans, datum/language/message_language=null, message_mode)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -231,7 +231,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	// Recompose message for AI hrefs, language incomprehension.
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode)
-	SEND_SIGNAL(src, COMSIG_MOB_HEAR, args)
+	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)
 	message = hear_intercept(message, speaker, message_language, raw_message, radio_freq, spans, message_mode)
 
 	show_message(message, 2, deaf_message, deaf_type)

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -205,9 +205,6 @@
 /datum/nanite_program/proc/on_death()
 	return
 
-/datum/nanite_program/proc/on_hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
-	return
-
 /datum/nanite_program/proc/software_error(type)
 	if(!type)
 		type = rand(1,5)
@@ -255,4 +252,3 @@
 			return "Trigger"
 		if(NANITE_TIMER_RESET)
 			return "Reset Activation Timer"
-

--- a/code/modules/research/nanites/nanite_programs/sensor.dm
+++ b/code/modules/research/nanites/nanite_programs/sensor.dm
@@ -378,15 +378,12 @@
 	target.sentence = sentence
 	target.inclusive = inclusive
 
-/datum/nanite_program/sensor/voice/on_hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
+/datum/nanite_program/sensor/voice/on_hear(datum/source, list/hearing_args)
 	if(!sentence)
 		return
-	//To make it not case sensitive
-	var/low_message = lowertext(raw_message)
-	var/low_sentence = lowertext(sentence)
 	if(inclusive)
-		if(findtext(low_message, low_sentence))
+		if(findtextEx(hearing_args[RAW_MESSAGE], sentence))
 			send_code()
 	else
-		if(low_message == low_sentence)
+		if(hearing_args[RAW_MESSAGE] == sentence)
 			send_code()

--- a/code/modules/research/nanites/nanite_programs/sensor.dm
+++ b/code/modules/research/nanites/nanite_programs/sensor.dm
@@ -345,6 +345,13 @@
 	var/sentence = ""
 	var/inclusive = TRUE
 
+/datum/nanite_program/sensor/voice/on_mob_add()
+	. = ..()
+	RegisterSignal(host_mob, COMSIG_MOVABLE_HEAR, .proc/on_hear)
+
+/datum/nanite_program/sensor/voice/Destroy()
+	UnregisterSignal(host_mob, COMSIG_MOVABLE_HEAR, .proc/on_hear)
+
 /datum/nanite_program/sensor/voice/set_extra_setting(user, setting)
 	if(setting == "Sent Code")
 		var/new_code = input(user, "Set the sent code (1-9999):", name, null) as null|num
@@ -378,12 +385,12 @@
 	target.sentence = sentence
 	target.inclusive = inclusive
 
-/datum/nanite_program/sensor/voice/on_hear(datum/source, list/hearing_args)
+/datum/nanite_program/sensor/voice/proc/on_hear(datum/source, list/hearing_args)
 	if(!sentence)
 		return
 	if(inclusive)
-		if(findtextEx(hearing_args[RAW_MESSAGE], sentence))
+		if(findtextEx(hearing_args[HEARING_RAW_MESSAGE], sentence))
 			send_code()
 	else
-		if(hearing_args[RAW_MESSAGE] == sentence)
+		if(hearing_args[HEARING_RAW_MESSAGE] == sentence)
 			send_code()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. hear_intercept is removed in favor of having the things that care register for the COMSIG_MOVABLE_HEAR signal instead.
2. The signal has been changed to be like the speech one with an args list.
3. Nanite datums no longer register for the hearing signal just in case, only the voice sensor nanite program does. 
4. Dead code has been removed from to_chat, the savefile/sound checks being just-in-case boilerplate checks made during the conversion to to_chat, the replacetexts sidestepping a byond bug that was fixed in 512.1420.

## Changelog
:cl: Naksu
code: hearing code should now be more better
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
