### PR TITLE
EMPs now randomize suit sensors if they're on

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -53,12 +53,12 @@
 		sensor_mode = pick(SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS, SENSOR_COORDS)
 
 /obj/item/clothing/under/emp_act()
+	. = ..()
 	if(has_sensor > NO_SENSORS)
 		sensor_mode = pick(SENSOR_OFF, SENSOR_OFF, SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS)
 		if(ismob(loc))
 			var/mob/M = loc
 			to_chat(M,"<span class='warning'>The sensors on the [src] change rapidly!</span>")
-	..()
 
 /obj/item/clothing/under/equipped(mob/user, slot)
 	..()

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -52,6 +52,14 @@
 		//make the sensor mode favor higher levels, except coords.
 		sensor_mode = pick(SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS, SENSOR_COORDS)
 
+/obj/item/clothing/under/emp_act()
+	if(has_sensor > NO_SENSORS)
+		sensor_mode = pick(SENSOR_OFF, SENSOR_OFF, SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS)
+		if(ismob(loc))
+			var/mob/M = loc
+			to_chat(M,"<span class='warning'>The sensors on the [src] change rapidly!</span>")
+	..()
+
 /obj/item/clothing/under/equipped(mob/user, slot)
 	..()
 	if(adjusted)


### PR DESCRIPTION
## About The Pull Request
Makes suit sensors react to EMPs

## Why It's Good For The Game
It's just a cool feature and since jumpsuits can have their sensors broken by damage I don't see why they wouldn't be impacted by EMPs if they were on

## Changelog
:cl:
add: suit sensors are now randomized when caught in an EMP
/:cl:
