### PR TITLE
Attaching something to a mech no longer autoselects it

### DIFF
--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -120,8 +120,6 @@
 	chassis = M
 	forceMove(M)
 	log_message("[src] initialized.", LOG_MECHA)
-	if(!M.selected && selectable)
-		M.selected = src
 	update_chassis_page()
 	return
 


### PR DESCRIPTION
:cl:
fix: attaching something to a mech wont auto select it
/:cl:
fixes: #44395