### PR TITLE
Removes an infective GetComponent

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -255,6 +255,9 @@
 //Food
 #define COMSIG_FOOD_EATEN "food_eaten"		//from base of obj/item/reagent_containers/food/snacks/attack(): (mob/living/eater, mob/feeder)
 
+//Gibs
+#define COMSIG_GIBS_STREAK "gibs_streak"						// from base of /obj/effect/decal/cleanable/blood/gibs/streak(): (list/directions, list/diseases)
+
 //Mood
 #define COMSIG_ADD_MOOD_EVENT "add_mood" //Called when you send a mood event from anywhere in the code.
 #define COMSIG_CLEAR_MOOD_EVENT "clear_mood" //Called when you clear a mood event from anywhere in the code.

--- a/code/datums/components/infective.dm
+++ b/code/datums/components/infective.dm
@@ -21,6 +21,7 @@
 	RegisterSignal(parent, COMSIG_MOVABLE_IMPACT_ZONE, .proc/try_infect_impact_zone)
 	RegisterSignal(parent, COMSIG_FOOD_EATEN, .proc/try_infect_eat)
 	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean)
+	RegisterSignal(parent, COMSIG_GIBS_STREAK, .proc/try_infect_streak)
 
 /datum/component/infective/proc/try_infect_eat(datum/source, mob/living/eater, mob/living/feeder)
 	for(var/V in diseases)
@@ -72,6 +73,9 @@
 /datum/component/infective/proc/try_infect_crossed(datum/source, atom/movable/M)
 	if(isliving(M))
 		try_infect(M, BODY_ZONE_PRECISE_L_FOOT)
+
+/datum/component/infective/proc/try_infect_streak(datum/source, list/directions, list/output_diseases)
+	output_diseases |= diseases
 
 /datum/component/infective/proc/try_infect(mob/living/L, target_zone)
 	for(var/V in diseases)

--- a/code/datums/components/infective.dm
+++ b/code/datums/components/infective.dm
@@ -12,16 +12,22 @@
 	if(expire_in)
 		expire_time = world.time + expire_in
 		QDEL_IN(src, expire_in)
+	
+	if(!ismovableatom(parent))
+		return COMPONENT_INCOMPATIBLE
+	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean)
 	RegisterSignal(parent, COMSIG_MOVABLE_BUCKLE, .proc/try_infect_buckle)
 	RegisterSignal(parent, COMSIG_MOVABLE_BUMP, .proc/try_infect_collide)
 	RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/try_infect_crossed)
-	RegisterSignal(parent, COMSIG_ITEM_ATTACK_ZONE, .proc/try_infect_attack_zone)
-	RegisterSignal(parent, COMSIG_ITEM_ATTACK, .proc/try_infect_attack)
-	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/try_infect_equipped)
 	RegisterSignal(parent, COMSIG_MOVABLE_IMPACT_ZONE, .proc/try_infect_impact_zone)
-	RegisterSignal(parent, COMSIG_FOOD_EATEN, .proc/try_infect_eat)
-	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean)
-	RegisterSignal(parent, COMSIG_GIBS_STREAK, .proc/try_infect_streak)
+	if(isitem(parent))
+		RegisterSignal(parent, COMSIG_ITEM_ATTACK_ZONE, .proc/try_infect_attack_zone)
+		RegisterSignal(parent, COMSIG_ITEM_ATTACK, .proc/try_infect_attack)
+		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/try_infect_equipped)
+		if(istype(parent, /obj/item/reagent_containers/food/snacks))
+			RegisterSignal(parent, COMSIG_FOOD_EATEN, .proc/try_infect_eat)
+	else if(istype(parent, /obj/effect/decal/cleanable/blood/gibs))
+		RegisterSignal(parent, COMSIG_GIBS_STREAK, .proc/try_infect_streak)
 
 /datum/component/infective/proc/try_infect_eat(datum/source, mob/living/eater, mob/living/feeder)
 	for(var/V in diseases)

--- a/code/datums/components/infective.dm
+++ b/code/datums/components/infective.dm
@@ -6,7 +6,7 @@
 
 /datum/component/infective/Initialize(list/datum/disease/_diseases, expire_in)
 	if(islist(_diseases))
-		diseases = diseases
+		diseases = _diseases
 	else
 		diseases = list(_diseases)
 	if(expire_in)

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -78,15 +78,13 @@
 	. = ..()
 
 /obj/effect/decal/cleanable/blood/gibs/proc/streak(list/directions)
-	set waitfor = 0
+	set waitfor = FALSE
+	var/list/diseases = list()
+	SEND_SIGNAL(src, COMSIG_GIBS_STREAK, directions, diseases)
 	var/direction = pick(directions)
-	for(var/i = 0, i < pick(1, 200; 2, 150; 3, 50), i++)
+	for(var/i in 0 to pick(0, 200; 1, 150; 2, 50))
 		sleep(2)
 		if(i > 0)
-			var/list/datum/disease/diseases
-			var/datum/component/infective/infective = GetComponent(/datum/component/infective)
-			if(infective)
-				diseases = infective.diseases
 			new /obj/effect/decal/cleanable/blood/splatter(loc, diseases)
 		if(!step_to(src, get_step(src, direction), 0))
 			break


### PR DESCRIPTION
One of the various GetComponent calls used on duplicate enabled components which causes potential bugs.

In this case it's likely this fixes a bug with diseases not spreading properly if gibs were infected multiple times.

Also fixes the infective component not working at all when given a list of diseases