### PR TITLE
Makes the daniel shuttle admin only.

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -358,7 +358,7 @@
 	description = "How was space work today? Oh, pretty good. We got a new space station and the company will make a lot of money. What space station? I cannot tell you; it's space confidential. \
 	Aw, come space on. Why not? No, I can't. Anyway, how is your space roleplay life?"
 	admin_notes = "Tiny, with a single airlock and wooden walls. What could go wrong?"
-	credit_cost = -5000
+	can_be_bought = FALSE
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/goon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This makes the Oh hi daniel shuttle only available to admins. Players will no longer be able to purchase it for -5000 credits like they do every single round.

## Why It's Good For The Game
This is a complete grief and "lynch me" shuttle that players constantly mash and has been the source of untold pain and suffering for over a year, and is probably one of the most infamous things goofball has added to the game. It's not completely gone, admins can still make it happen if they want, but this PR helps prevents some extremely obvious griefing by the players.

## Changelog
:cl: WJohnston
del: The Daniel shuttle can no longer be purchased and is now admin only.
/:cl:

Oranges approved 👏 