### PR TITLE
Adds "empty" cloning

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -140,35 +140,37 @@
 	return examine(user)
 
 //Start growing a human clone in the pod!
-/obj/machinery/clonepod/proc/growclone(clonename, ui, mutation_index, mindref, last_death, datum/species/mrace, list/features, factions, list/quirks, datum/bank_account/insurance, list/traumas)
+/obj/machinery/clonepod/proc/growclone(clonename, ui, mutation_index, mindref, last_death, datum/species/mrace, list/features, factions, list/quirks, datum/bank_account/insurance, list/traumas, empty)
 	if(panel_open)
 		return NONE
 	if(mess || attempting)
 		return NONE
-	clonemind = locate(mindref) in SSticker.minds
-	if(!istype(clonemind))	//not a mind
-		return NONE
-	if(clonemind.last_death != last_death) //The soul has advanced, the record has not.
-		return NONE
-	if(!QDELETED(clonemind.current))
-		if(clonemind.current.stat != DEAD)	//mind is associated with a non-dead body
+
+	if(!empty) //Doesn't matter if we're just making a copy
+		clonemind = locate(mindref) in SSticker.minds
+		if(!istype(clonemind))	//not a mind
 			return NONE
-		if(clonemind.current.suiciding) // Mind is associated with a body that is suiciding.
+		if(clonemind.last_death != last_death) //The soul has advanced, the record has not.
 			return NONE
-	if(!clonemind.active)
-		// get_ghost() will fail if they're unable to reenter their body
-		var/mob/dead/observer/G = clonemind.get_ghost()
-		if(!G)
+		if(!QDELETED(clonemind.current))
+			if(clonemind.current.stat != DEAD)	//mind is associated with a non-dead body
+				return NONE
+			if(clonemind.current.suiciding) // Mind is associated with a body that is suiciding.
+				return NONE
+		if(!clonemind.active)
+			// get_ghost() will fail if they're unable to reenter their body
+			var/mob/dead/observer/G = clonemind.get_ghost()
+			if(!G)
+				return NONE
+			if(G.suiciding) // The ghost came from a body that is suiciding.
+				return NONE
+		if(clonemind.damnation_type) //Can't clone the damned.
+			INVOKE_ASYNC(src, .proc/horrifyingsound)
+			mess = TRUE
+			icon_state = "pod_g"
+			update_icon()
 			return NONE
-		if(G.suiciding) // The ghost came from a body that is suiciding.
-			return NONE
-	if(clonemind.damnation_type) //Can't clone the damned.
-		INVOKE_ASYNC(src, .proc/horrifyingsound)
-		mess = TRUE
-		icon_state = "pod_g"
-		update_icon()
-		return NONE
-	current_insurance = insurance
+		current_insurance = insurance
 	attempting = TRUE //One at a time!!
 	countdown.start()
 
@@ -204,15 +206,16 @@
 	ADD_TRAIT(H, TRAIT_NOCRITDAMAGE, CLONING_POD_TRAIT)
 	H.Unconscious(80)
 
-	clonemind.transfer_to(H)
+	if(!empty)
+		clonemind.transfer_to(H)
 
-	if(grab_ghost_when == CLONER_FRESH_CLONE)
-		H.grab_ghost()
-		to_chat(H, "<span class='notice'><b>Consciousness slowly creeps over you as your body regenerates.</b><br><i>So this is what cloning feels like?</i></span>")
+		if(grab_ghost_when == CLONER_FRESH_CLONE)
+			H.grab_ghost()
+			to_chat(H, "<span class='notice'><b>Consciousness slowly creeps over you as your body regenerates.</b><br><i>So this is what cloning feels like?</i></span>")
 
-	if(grab_ghost_when == CLONER_MATURE_CLONE)
-		H.ghostize(TRUE)	//Only does anything if they were still in their old body and not already a ghost
-		to_chat(H.get_ghost(TRUE), "<span class='notice'>Your body is beginning to regenerate in a cloning pod. You will become conscious when it is complete.</span>")
+		if(grab_ghost_when == CLONER_MATURE_CLONE)
+			H.ghostize(TRUE)	//Only does anything if they were still in their old body and not already a ghost
+			to_chat(H.get_ghost(TRUE), "<span class='notice'>Your body is beginning to regenerate in a cloning pod. You will become conscious when it is complete.</span>")
 
 	if(H)
 		H.faction |= factions

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -211,6 +211,7 @@
 
 				if(scanner_occupant)
 					dat += "<a href='byond://?src=[REF(src)];scan=1'>Start Scan</a>"
+					dat += "<a href='byond://?src=[REF(src)];scan=1;body_only=1'>Body-Only Scan</a>"
 					dat += "<br><a href='byond://?src=[REF(src)];lock=1'>[scanner.locked ? "Unlock Scanner" : "Lock Scanner"]</a>"
 				else
 					dat += "<span class='linkOff'>Start Scan</span>"
@@ -238,8 +239,11 @@
 			if (!active_record)
 				dat += "<font class='bad'>Record not found.</font>"
 			else
-				dat += "<h4>[active_record.fields["name"]]</h4>"
-				dat += "Scan ID [active_record.fields["id"]] <a href='byond://?src=[REF(src)];clone=[active_record.fields["id"]]'>Clone</a> <a href='byond://?src=[REF(src)];clone=[active_record.fields["id"]];empty=TRUE'>Empty Clone</a><br>"
+				var/body_only = active_record.fields["body_only"]
+				dat += "<h4>[active_record.fields["name"]][body_only ? " - BODY-ONLY" : ""]</h4>"
+				dat += "Scan ID [active_record.fields["id"]] \
+					[!body_only ? "<a href='byond://?src=[REF(src)];clone=[active_record.fields["id"]]'>Clone</a>" : "" ]\
+				 	<a href='byond://?src=[REF(src)];clone=[active_record.fields["id"]];empty=TRUE'>Empty Clone</a><br>"
 
 				var/obj/item/implant/health/H = locate(active_record.fields["imp"])
 
@@ -347,14 +351,14 @@
 
 	else if ((href_list["scan"]) && !isnull(scanner) && scanner.is_operational())
 		scantemp = ""
-
+		var/body_only = href_list["body_only"]
 		loading = TRUE
 		updateUsrDialog()
 		playsound(src, 'sound/machines/terminal_prompt.ogg', 50, 0)
 		say("Initiating scan...")
 
 		spawn(20)
-			scan_occupant(scanner.occupant, usr)
+			scan_occupant(scanner.occupant, usr, body_only)
 
 			loading = FALSE
 			updateUsrDialog()
@@ -389,6 +393,8 @@
 				if(C)
 					if(check_access(C))
 						has_access = TRUE
+			if(active_record.fields["body_only"]) //Body-only scans are not as important and can be deleted freely
+				has_access = TRUE
 			if(has_access)
 				temp = "Delete record?"
 				menu = 4
@@ -464,6 +470,9 @@
 		var/empty = href_list["empty"]
 		//Look for that player! They better be dead!
 		if(C)
+			if(C.fields["body_only"] && !empty)
+				temp = "<font class='bad'>Cannot initiate regular cloning with body-only scans.</font>"
+				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 			var/obj/machinery/clonepod/pod = GetAvailablePod()
 			var/success = FALSE
 			//Can't clone without someone to clone.  Or a pod.  Or if the pod is busy. Or full of gibs.
@@ -514,7 +523,7 @@
 	updateUsrDialog()
 	return
 
-/obj/machinery/computer/cloning/proc/scan_occupant(occupant, mob/M)
+/obj/machinery/computer/cloning/proc/scan_occupant(occupant, mob/M, body_only)
 	var/mob/living/mob_occupant = get_mob_or_brainmob(occupant)
 	var/datum/dna/dna
 	var/datum/bank_account/has_bank_account
@@ -535,7 +544,7 @@
 		scantemp = "<font class='bad'>Unable to locate valid genetic data.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 		return
-	if(mob_occupant.suiciding || mob_occupant.hellbound)
+	if(!body_only && (mob_occupant.suiciding || mob_occupant.hellbound))
 		scantemp = "<font class='bad'>Subject's brain is not responding to scanning stimuli.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 		return
@@ -547,11 +556,11 @@
 		scantemp = "<font class='bad'>Subject's DNA is damaged beyond any hope of recovery.</font>"
 		playsound(src, 'sound/machines/terminal_alert.ogg', 50, 0)
 		return
-	if (isnull(mob_occupant.mind))
+	if (!body_only && isnull(mob_occupant.mind))
 		scantemp = "<font class='bad'>Mental interface failure.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 		return
-	if(SSeconomy.full_ancap)
+	if(!body_only && SSeconomy.full_ancap)
 		if(!has_bank_account)
 			scantemp = "<font class='average'>Subject is either missing an ID card with a bank account on it, or does not have an account to begin with. Please ensure the ID card is on the body before attempting to scan.</font>"
 			playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
@@ -589,22 +598,29 @@
 	R.fields["bank_account"] = has_bank_account
 	R.fields["mindref"] = "[REF(mob_occupant.mind)]"
 	R.fields["last_death"] = mob_occupant.stat == DEAD ? mob_occupant.mind.last_death : -1
+	R.fields["body_only"] = body_only
 
-   //Add an implant if needed
-	var/obj/item/implant/health/imp
-	for(var/obj/item/implant/health/HI in mob_occupant.implants)
-		imp = HI
-		break
-	if(!imp)
-		imp = new /obj/item/implant/health(mob_occupant)
-		imp.implant(mob_occupant)
-	R.fields["imp"] = "[REF(imp)]"
-	var/old_record = find_record("mindref", REF(mob_occupant.mind), records)
+	if(!body_only)
+	    //Add an implant if needed
+		var/obj/item/implant/health/imp
+		for(var/obj/item/implant/health/HI in mob_occupant.implants)
+			imp = HI
+			break
+		if(!imp)
+			imp = new /obj/item/implant/health(mob_occupant)
+			imp.implant(mob_occupant)
+		R.fields["imp"] = "[REF(imp)]"
+
+	var/datum/data/record/old_record = find_record("mindref", REF(mob_occupant.mind), records)
+	if(body_only)
+		old_record = find_record("UE", dna.unique_enzymes, records) //Body-only records cannot be identified by mind, so we use the DNA
+		if(old_record && ((old_record.fields["UI"] != dna.uni_identity) || (!old_record.fields["body_only"]))) //Never overwrite a mind-and-body record if it exists
+			old_record = null
 	if(old_record)
 		records -= old_record
 		scantemp = "Record updated."
 	else
 		scantemp = "Subject successfully scanned."
 	records += R
-	log_cloning("[M ? key_name(M) : "Autoprocess"] added the record of [key_name(mob_occupant)] to [src] at [AREACOORD(src)].")
+	log_cloning("[M ? key_name(M) : "Autoprocess"] added the [body_only ? "body-only " : ""]record of [key_name(mob_occupant)] to [src] at [AREACOORD(src)].")
 	playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds Empty Cloning functionality to cloning consoles. Selecting a record and Empty Cloning it creates a clone of the record without pulling its mind into it, and therefore also bypassing the usual restrictions.
It does not put random minds in it like the experimental cloner; it simply creates a mindless replica.

UPDATE: Cloners can now also do BODY-ONLY scans, which are clearly marked as such in the records database. These can only be used for empty cloning, but do not require the body to have a functioning mind for the scan. They can be deleted without access if they're cluttering the list, and will not overwrite an existing full record if one exists.

**Potential future additions to this PR:**
- Making the cloning scanner able to scan soulless bodies, for Empty Cloning only. DONE
- Making it possible to clone from a DNA disk.
- Warning signs in case of mistakes.

## Why It's Good For The Game

Monkey-cloning was always an option, but kind of unintuitive and rather complicated when you consider you have literal cloning technology one room over.
Can be used to create clone armies, or to pre-prepare a replacement body for a crewmember (and potentially add augments, surgical buffs, and so on) to swap them into at a later time.

## Changelog
:cl:
add: Cloners now have the option to "Empty Clone" a record, creating a mindless replica of that person.
add: To aid the above function, cloners can now do Body-Only scans, which can be used to create empty clones but not real clones, but bypass the sentience restrictions on scans. They can also be deleted without requiring access.
/:cl:

