### PR TITLE
Adds a chance of clowns spawning with bananium

### DIFF
--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -38,7 +38,7 @@
 		/obj/item/reagent_containers/spray/waterflower = 1,
 		/obj/item/reagent_containers/food/snacks/grown/banana = 1,
 		/obj/item/instrument/bikehorn = 1,
-		)
+	)
 
 	implants = list(/obj/item/implant/sad_trombone)
 
@@ -57,3 +57,8 @@
 
 	H.fully_replace_character_name(H.real_name, pick(GLOB.clown_names)) //rename the mob AFTER they're equipped so their ID gets updated properly.
 	H.dna.add_mutation(CLOWNMUT)
+
+	if(prob(20))	//20% chance the clown spawns with a single bananium sheet.
+		var/obj/item/stack/sheet/mineral/bananium/clowngold = new()
+		H.equip_to_slot_or_del(clowngold, SLOT_IN_BACKPACK)
+		to_chat(H, "<span class='nicegreen'>Your [H.back] feels heavier than usual.</span>")

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -38,7 +38,7 @@
 		/obj/item/reagent_containers/spray/waterflower = 1,
 		/obj/item/reagent_containers/food/snacks/grown/banana = 1,
 		/obj/item/instrument/bikehorn = 1,
-	)
+		)
 
 	implants = list(/obj/item/implant/sad_trombone)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a 1/5 chance that clowns spawn with a single sheet of bananium in their backpack. Not nearly enough for a honk mech or anything really useful, but allows a lucky clown to go print an air horn or a clown borg module once in a while.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bananium is fairly rarely seen brought back from mining/space, this single sheet could bring some clown variety. Hopefully.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
add: Particularly lucky clowns might now find a sheet of bananium in their backpack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
