### PR TITLE
Asteroid Shuttle is Now Free, but Only Purchasable After a Meteor Wave

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -216,7 +216,7 @@
 /datum/map_template/shuttle/emergency/meteor
 	suffix = "meteor"
 	name = "Asteroid With Engines Strapped To It"
-	description = "A hollowed out asteroid with engines strapped to it. Due to its size and difficulty in steering it, this shuttle may damage the docking area. Only available after a meteor wave, Centcomm won't let even a meteor wave go to waste."
+	description = "A hollowed out asteroid with engines strapped to it. Due to its size and difficulty in steering it, this shuttle may damage the docking area. Only available after a meteor wave, Centcomm won't let even an asteroid go to waste."
 	credit_cost = 0
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -216,7 +216,7 @@
 /datum/map_template/shuttle/emergency/meteor
 	suffix = "meteor"
 	name = "Asteroid With Engines Strapped To It"
-	description = "A hollowed out asteroid with engines strapped to it. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
+	description = "A hollowed out asteroid with engines strapped to it. Due to its size and difficulty in steering it, this shuttle may damage the docking area. Only available after a meteor wave, for both financial and practicality reasons."
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
 	credit_cost = 0
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -216,10 +216,15 @@
 /datum/map_template/shuttle/emergency/meteor
 	suffix = "meteor"
 	name = "Asteroid With Engines Strapped To It"
-	description = "A hollowed out asteroid with engines strapped to it, the hollowing procedure makes it very difficult to hijack but is very expensive. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
+	description = "A hollowed out asteroid with engines strapped to it. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
-	credit_cost = 15000
+	credit_cost = 0
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
+
+/datum/map_template/shuttle/emergency/meteor/prerequisites_met()
+	if("meteor" in SSshuttle.shuttle_purchase_requirements_met)
+		return TRUE
+	return FALSE
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -216,8 +216,7 @@
 /datum/map_template/shuttle/emergency/meteor
 	suffix = "meteor"
 	name = "Asteroid With Engines Strapped To It"
-	description = "A hollowed out asteroid with engines strapped to it. Due to its size and difficulty in steering it, this shuttle may damage the docking area. Only available after a meteor wave, for both financial and practicality reasons."
-	admin_notes = "This shuttle will likely crush escape, killing anyone there."
+	description = "A hollowed out asteroid with engines strapped to it. Due to its size and difficulty in steering it, this shuttle may damage the docking area. Only available after a meteor wave, Centcomm won't let even a meteor wave go to waste."
 	credit_cost = 0
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -52,6 +52,7 @@
 /datum/round_event/meteor_wave/tick()
 	if(ISMULTIPLE(activeFor, 3))
 		spawn_meteors(5, wave_type) //meteor list types defined in gamemode/meteor/meteors.dm
+		SSshuttle.shuttle_purchase_requirements_met |= "meteor"
 
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

I always thought the solution of just bumping up the price was lame, not to mention made 0 sense ICly (hollowing process is pricey when it takes 5 shots from plasma cutter?????). This still will decrease the amount of times its purchased (if anything its harder to get now) but now its more gimmicky, and makes a lot more sense (centcomm harvesting a nearby asteroid and throwing some engines on, so its free). 

## Changelog
:cl:
tweak: Asteroid With Engines Strapped to It shuttle can now be purchased for free, only after a meteor wave
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
