### PR TITLE
[Ready] Adds drone shell activation logging + admin notify

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -63,5 +63,5 @@
 	D.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
 	D.key = user.key
 	message_admins("[ADMIN_LOOKUPFLW(user)] has taken possession of \a [src] in [AREACOORD(src)].")
-	log_game("[key_name(user)] has taken possession of a [src] in [AREACOORD(src)].")
+	log_game("[key_name(user)] has taken possession of \a [src] in [AREACOORD(src)].")
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -62,4 +62,6 @@
 		D.equip_to_slot_or_del(new_hat, SLOT_HEAD)
 	D.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
 	D.key = user.key
+	message_admins("[ADMIN_LOOKUPFLW(user)] has taken possession of a [src] in [AREACOORD(target)].")
+	log_game("[key_name(user)] has taken possession of a [src] in [AREACOORD(target)].")
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -62,6 +62,6 @@
 		D.equip_to_slot_or_del(new_hat, SLOT_HEAD)
 	D.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
 	D.key = user.key
-	message_admins("[ADMIN_LOOKUPFLW(user)] has taken possession of a [src] in [AREACOORD(target)].")
-	log_game("[key_name(user)] has taken possession of a [src] in [AREACOORD(target)].")
+	message_admins("[ADMIN_LOOKUPFLW(user)] has taken possession of a [src] in [AREACOORD(src)].")
+	log_game("[key_name(user)] has taken possession of a [src] in [AREACOORD(src)].")
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -62,6 +62,6 @@
 		D.equip_to_slot_or_del(new_hat, SLOT_HEAD)
 	D.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
 	D.key = user.key
-	message_admins("[ADMIN_LOOKUPFLW(user)] has taken possession of a [src] in [AREACOORD(src)].")
+	message_admins("[ADMIN_LOOKUPFLW(user)] has taken possession of \a [src] in [AREACOORD(src)].")
 	log_game("[key_name(user)] has taken possession of a [src] in [AREACOORD(src)].")
 	qdel(src)


### PR DESCRIPTION
This PR adds drone shell activation logging + admin notify with the activation location, so that drones can't hop over to the station and claim that someone brought their inactive shell over to the station first.