### PR TITLE
Makes surgery more stealthy

### DIFF
--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -44,7 +44,7 @@
 			table.computer = src
 			break
 
-/obj/machinery/computer/operating/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
+/obj/machinery/computer/operating/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.not_incapacitated_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "operating_computer", name, 350, 470, master_ui, state)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -126,17 +126,19 @@
 // vision_distance (optional) define how many tiles away the message can be seen.
 // ignored_mob (optional) doesn't show any message to a given mob if TRUE.
 
-/atom/proc/visible_message(message, self_message, blind_message, vision_distance, ignored_mob)
+/atom/proc/visible_message(message, self_message, blind_message, vision_distance, list/ignored_mobs)
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
+	if(!islist(ignored_mobs))
+		ignored_mobs = list(ignored_mobs)
 	var/range = 7
 	if(vision_distance)
 		range = vision_distance
 	for(var/mob/M in get_hearers_in_view(range, src))
 		if(!M.client)
 			continue
-		if(M == ignored_mob)
+		if(M in ignored_mobs)
 			continue
 		var/msg = message
 		if(M == src) //the src always see the main message or self message

--- a/code/modules/surgery/advanced/bioware/ligament_hook.dm
+++ b/code/modules/surgery/advanced/bioware/ligament_hook.dm
@@ -18,10 +18,14 @@
 	time = 125
 
 /datum/surgery_step/reshape_ligaments/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] starts reshaping [target]'s ligaments into a hook-like shape.", "<span class='notice'>You start reshaping [target]'s ligaments into a hook-like shape.</span>")
+	display_results(user, target, "<span class='notice'>You start reshaping [target]'s ligaments into a hook-like shape.</span>",
+		"[user] starts reshaping [target]'s ligaments into a hook-like shape.",
+		"[user] starts manipulating [target]'s ligaments.")
 
 /datum/surgery_step/reshape_ligaments/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] reshapes [target]'s ligaments into a connective hook!", "<span class='notice'>You reshape [target]'s ligaments into a connective hook!</span>")
+	display_results(user, target, "<span class='notice'>You reshape [target]'s ligaments into a connective hook!</span>",
+		"[user] reshapes [target]'s ligaments into a connective hook!",
+		"[user] finishes manipulating [target]'s ligaments.")
 	new /datum/bioware/hooked_ligaments(target)
 	return TRUE
 

--- a/code/modules/surgery/advanced/bioware/ligament_reinforcement.dm
+++ b/code/modules/surgery/advanced/bioware/ligament_reinforcement.dm
@@ -18,10 +18,14 @@
 	time = 125
 
 /datum/surgery_step/reinforce_ligaments/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] starts reinforce [target]'s ligaments.", "<span class='notice'>You start reinforcing [target]'s ligaments.</span>")
+	display_results(user, target, "<span class='notice'>You start reinforcing [target]'s ligaments.</span>",
+		"[user] starts reinforce [target]'s ligaments.",
+		"[user] starts manipulating [target]'s ligaments.")
 
 /datum/surgery_step/reinforce_ligaments/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] reinforces [target]'s ligaments!", "<span class='notice'>You reinforce [target]'s ligaments!</span>")
+	display_results(user, target, "<span class='notice'>You reinforce [target]'s ligaments!</span>",
+		"[user] reinforces [target]'s ligaments!",
+		"[user] finishes manipulating [target]'s ligaments.")
 	new /datum/bioware/reinforced_ligaments(target)
 	return TRUE
 

--- a/code/modules/surgery/advanced/bioware/nerve_grounding.dm
+++ b/code/modules/surgery/advanced/bioware/nerve_grounding.dm
@@ -17,10 +17,14 @@
 	time = 155
 
 /datum/surgery_step/ground_nerves/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] starts splicing together [target]'s nerves.", "<span class='notice'>You start splicing together [target]'s nerves.</span>")
+	display_results(user, target, "<span class='notice'>You start rerouting [target]'s nerves.</span>",
+		"[user] starts rerouting [target]'s nerves.",
+		"[user] starts manipulating [target]'s nervous system.")
 
 /datum/surgery_step/ground_nerves/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] successfully splices [target]'s nervous system!", "<span class='notice'>You successfully splice [target]'s nervous system!</span>")
+	display_results(user, target, "<span class='notice'>You successfully reroute [target]'s nervous system!</span>",
+		"[user] successfully reroutes [target]'s nervous system!",
+		"[user] finishes manipulating [target]'s nervous system.")
 	new /datum/bioware/grounded_nerves(target)
 	return TRUE
 

--- a/code/modules/surgery/advanced/bioware/nerve_splicing.dm
+++ b/code/modules/surgery/advanced/bioware/nerve_splicing.dm
@@ -17,10 +17,14 @@
 	time = 155
 
 /datum/surgery_step/splice_nerves/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] starts splicing together [target]'s nerves.", "<span class='notice'>You start splicing together [target]'s nerves.</span>")
+	display_results(user, target, "<span class='notice'>You start splicing together [target]'s nerves.</span>",
+		"[user] starts splicing together [target]'s nerves.",
+		"[user] starts manipulating [target]'s nervous system.")
 
 /datum/surgery_step/splice_nerves/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] successfully splices [target]'s nervous system!", "<span class='notice'>You successfully splice [target]'s nervous system!</span>")
+	display_results(user, target, "<span class='notice'>You successfully splice [target]'s nervous system!</span>",
+		"[user] successfully splices [target]'s nervous system!",
+		"[user] finishes manipulating [target]'s nervous system.")
 	new /datum/bioware/spliced_nerves(target)
 	return TRUE
 

--- a/code/modules/surgery/advanced/bioware/vein_threading.dm
+++ b/code/modules/surgery/advanced/bioware/vein_threading.dm
@@ -17,10 +17,14 @@
 	time = 125
 
 /datum/surgery_step/thread_veins/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] starts weaving [target]'s circulatory system.", "<span class='notice'>You start weaving [target]'s circulatory system.</span>")
+	display_results(user, target, "<span class='notice'>You start weaving [target]'s circulatory system.</span>",
+		"[user] starts weaving [target]'s circulatory system.",
+		"[user] starts manipulating [target]'s circulatory system.")
 
 /datum/surgery_step/thread_veins/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] weaves [target]'s circulatory system into a resistant mesh!", "<span class='notice'>You weave [target]'s circulatory system into a resistant mesh!</span>")
+	display_results(user, target, "<span class='notice'>You weave [target]'s circulatory system into a resistant mesh!</span>",
+		"[user] weaves [target]'s circulatory system into a resistant mesh!",
+		"[user] finishes manipulating [target]'s circulatory system.")
 	new /datum/bioware/threaded_veins(target)
 	return TRUE
 

--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -35,16 +35,20 @@
 	objective = stripped_input(user, "Choose the objective to imprint on your victim's brain.", "Brainwashing", null, MAX_MESSAGE_LEN)
 	if(!objective)
 		return -1
-	user.visible_message("[user] begins to tinker with [target]'s brain.", "<span class='notice'>You begin to brainwash [target]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to brainwash [target]...</span>",
+		"[user] begins to fix [target]'s brain.",
+		"[user] begins to perform surgery on [target]'s brain.")
 
 /datum/surgery_step/brainwash/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(!target.mind)
-		user.visible_message("[target] doesn't respond to the brainwashing, as if [target.p_they()] lacked a mind...")
+		to_chat(user, "<span class='warning'>[target] doesn't respond to the brainwashing, as if [target.p_they()] lacked a mind...</span>")
 		return FALSE
 	if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
-		user.visible_message("You hear a faint buzzing from a device inside [target]'s brain, and the brainwashing is erased.")
+		to_chat(user, "<span class='warning'>You hear a faint buzzing from a device inside [target]'s brain, and the brainwashing is erased.</span>")
 		return FALSE
-	user.visible_message("[user] successfully brainwashes [target]!", "<span class='notice'>You succeed in brainwashing [target].</span>")
+	display_results(user, target, "<span class='notice'>You succeed in brainwashing [target].</span>",
+		"[user] successfully fixes [target]'s brain!",
+		"[user] completes the surgery on [target]'s brain.")
 	to_chat(target, "<span class='userdanger'>A new compulsion fills your mind... you feel forced to obey it!</span>")
 	brainwash(target, objective)
 	message_admins("[ADMIN_LOOKUPFLW(user)] surgically brainwashed [ADMIN_LOOKUPFLW(target)] with the objective '[objective]'.")
@@ -53,7 +57,9 @@
 
 /datum/surgery_step/brainwash/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(target.getorganslot(ORGAN_SLOT_BRAIN))
-		user.visible_message("<span class='warning'>[user] damages some brain tissue!</span>", "<span class='warning'>You bruise some brain tissue!</span>")
+		display_results(user, target, "<span class='warning'>You screw up, bruising the brain tissue!</span>",
+			"<span class='warning'>[user] screws up, causing brain damage!</span>",
+			"[user] completes the surgery on [target]'s brain.")
 		target.adjustBrainLoss(40)
 	else
 		user.visible_message("<span class='warning'>[user] suddenly notices that the brain [user.p_they()] [user.p_were()] working on is not there anymore.", "<span class='warning'>You suddenly notice that the brain you were working on is not there anymore.</span>")

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -33,10 +33,14 @@
 	return TRUE
 
 /datum/surgery_step/lobotomize/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to cut a piece of [target]'s brain.", "<span class='notice'>You begin to cut a piece of [target]'s brain...</span>")
+	display_results(user, target, "<span class='notice'>You begin to perform a lobotomy on [target]'s brain...</span>",
+		"[user] begins to perform a lobotomy on [target]'s brain.",
+		"[user] begins to perform surgery on [target]'s brain.")
 
 /datum/surgery_step/lobotomize/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] successfully lobotomizes [target]!", "<span class='notice'>You succeed in lobotomizing [target].</span>")
+	display_results(user, target, "<span class='notice'>You succeed in lobotomizing [target].</span>",
+			"[user] successfully lobotomizes [target]!",
+			"[user] completes the surgery on [target]'s brain.")
 	target.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
 		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
@@ -51,7 +55,9 @@
 
 /datum/surgery_step/lobotomize/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(target.getorganslot(ORGAN_SLOT_BRAIN))
-		user.visible_message("<span class='warning'>[user] removes the wrong part, causing more damage!</span>", "<span class='warning'>You remove the wrong part, causing more damage!</span>")
+		display_results(user, target, "<span class='warning'>You remove the wrong part, causing more damage!</span>",
+			"[user] successfully lobotomizes [target]!",
+			"[user] completes the surgery on [target]'s brain.")
 		target.adjustBrainLoss(80)
 		switch(rand(1,3))
 			if(1)

--- a/code/modules/surgery/advanced/necrotic_revival.dm
+++ b/code/modules/surgery/advanced/necrotic_revival.dm
@@ -18,16 +18,20 @@
 
 /datum/surgery_step/bionecrosis
 	name = "start bionecrosis"
-	implements = list(/obj/item/hemostat = 100, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
+	implements = list(/obj/item/reagent_containers/syringe = 100, /obj/item/pen = 30)
 	time = 50
 	chems_needed = list(/datum/reagent/toxin/zombiepowder, /datum/reagent/medicine/rezadone)
 	require_all_chems = FALSE
 
 /datum/surgery_step/bionecrosis/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to stimulate [target]'s brain.", "<span class='notice'>You begin to stimulate [target]'s brain...</span>")
+	display_results(user, target, "<span class='notice'>You begin to grow a romerol tumor on [target]'s brain...</span>",
+		"[user] begins to tinker with [target]'s brain...",
+		"[user] begins to perform surgery on [target]'s brain.")
 
 /datum/surgery_step/bionecrosis/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] successfully grows a necrotic tumor on [target]'s brain!", "<span class='notice'>You succeed in growing a necrotic tumor on [target]'s brain.</span>")
+	display_results(user, target, "<span class='notice'>You succeed in growing a romerol tumor on [target]'s brain.</span>",
+		"[user] successfully grows a romerol tumor on [target]'s brain!",
+		"[user] completes the surgery on [target]'s brain.")
 	if(!target.getorganslot(ORGAN_SLOT_ZOMBIE))
 		var/obj/item/organ/zombie_infection/ZI = new()
 		ZI.Insert(target)

--- a/code/modules/surgery/advanced/pacification.dm
+++ b/code/modules/surgery/advanced/pacification.dm
@@ -24,14 +24,20 @@
 	time = 40
 
 /datum/surgery_step/pacify/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to reshape [target]'s brain.", "<span class='notice'>You begin to reshape [target]'s brain...</span>")
+	display_results(user, target, "<span class='notice'>You begin to pacify [target]...</span>",
+		"[user] begins to fix [target]'s brain.",
+		"[user] begins to perform surgery on [target]'s brain.")
 
 /datum/surgery_step/pacify/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] reshapes [target]'s brain!", "<span class='notice'>You succeed in reshaping [target]'s brain.</span>")
+	display_results(user, target, "<span class='notice'>You succeed in neurologically pacifying [target].</span>",
+		"[user] successfully fixes [target]'s brain!",
+		"[user] completes the surgery on [target]'s brain.")
 	target.gain_trauma(/datum/brain_trauma/severe/pacifism, TRAUMA_RESILIENCE_LOBOTOMY)
 	return TRUE
 
 /datum/surgery_step/pacify/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] reshapes [target]'s brain!", "<span class='notice'>You screwed up, and rewired [target]'s brain the wrong way around...</span>")
+	display_results(user, target, "<span class='notice'>You screw up, rewiring [target]'s brain the wrong way around...</span>",
+			"<span class='warning'>[user] screws up, causing brain damage!</span>",
+			"[user] completes the surgery on [target]'s brain.")
 	target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_LOBOTOMY)
 	return FALSE

--- a/code/modules/surgery/advanced/revival.dm
+++ b/code/modules/surgery/advanced/revival.dm
@@ -51,25 +51,31 @@
 			return FALSE
 
 /datum/surgery_step/revive/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] prepares to shock [target]'s brain with [tool].", "<span class='notice'>You prepare to give [target]'s brain the spark of life with [tool].</span>")
+	display_results(user, target, "<span class='notice'>You prepare to give [target]'s brain the spark of life with [tool].</span>",
+		"[user] prepares to shock [target]'s brain with [tool].",
+		"[user] prepares to shock [target]'s brain with [tool].")
 	target.notify_ghost_cloning("Someone is trying to zap your brain. Re-enter your corpse if you want to be revived!", source = target)
 
 /datum/surgery_step/revive/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] send a powerful shock to [target]'s brain with [tool]...", "<span class='notice'>You successfully shock [target]'s brain with [tool]...</span>")
+	display_results(user, target, "<span class='notice'>You successfully shock [target]'s brain with [tool]...</span>",
+		"[user] send a powerful shock to [target]'s brain with [tool]...",
+		"[user] send a powerful shock to [target]'s brain with [tool]...")
 	playsound(get_turf(target), 'sound/magic/lightningbolt.ogg', 50, 1)
 	target.adjustOxyLoss(-50, 0)
 	target.updatehealth()
 	if(target.revive())
-		user.visible_message("...[target] wakes up, alive and aware!", "<span class='notice'><b>IT'S ALIVE!</b></span>")
+		target.visible_message("...[target] wakes up, alive and aware!")
 		target.emote("gasp")
 		target.adjustBrainLoss(50, 199) //MAD SCIENCE
 		return TRUE
 	else
-		user.visible_message("...[target.p_they()] convulses, then lies still.")
+		target.visible_message("...[target.p_they()] convulses, then lies still.")
 		return FALSE
 
 /datum/surgery_step/revive/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] send a powerful shock to [target]'s brain with [tool], but [target.p_they()] doesn't react.", "<span class='notice'>You shock [target]'s brain with [tool], but [target.p_they()] doesn't react.</span>")
+	display_results(user, target, "<span class='notice'>You shock [target]'s brain with [tool], but [target.p_they()] doesn't react.</span>",
+		"[user] send a powerful shock to [target]'s brain with [tool], but [target.p_they()] doesn't react.",
+		"[user] send a powerful shock to [target]'s brain with [tool], but [target.p_they()] doesn't react.")
 	playsound(get_turf(target), 'sound/magic/lightningbolt.ogg', 50, 1)
 	target.adjustBrainLoss(15, 199)
 	return FALSE

--- a/code/modules/surgery/advanced/viral_bonding.dm
+++ b/code/modules/surgery/advanced/viral_bonding.dm
@@ -31,10 +31,14 @@
 	return TRUE
 
 /datum/surgery_step/viral_bond/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] starts heating [target]'s bone marrow with [tool]...", "<span class='notice'>You start heating [target]'s bone marrow with [tool]...</span>")
+	display_results(user, target, "<span class='notice'>You start heating [target]'s bone marrow with [tool]...</span>",
+		"[user] starts heating [target]'s bone marrow with [tool]...",
+		"[user] starts heating something in [target]'s chest with [tool]...")
 
 /datum/surgery_step/viral_bond/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[target]'s bone marrow begins pulsing slowly.", "<span class='notice'>[target]'s bone marrow begins pulsing slowly. The viral bonding is complete.</span>")
+	display_results(user, target, "<span class='notice'>[target]'s bone marrow begins pulsing slowly. The viral bonding is complete.</span>",
+		"[target]'s bone marrow begins pulsing slowly.",
+		"[user] finishes the operation.")
 	for(var/X in target.diseases)
 		var/datum/disease/D = X
 		D.carrier = TRUE

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -13,11 +13,15 @@
 	time = 64
 
 /datum/surgery_step/sever_limb/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to sever [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You begin to sever [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to sever [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to sever [target]'s [parse_zone(target_zone)]!",
+		"[user] begins to sever [target]'s [parse_zone(target_zone)]!")
 
 /datum/surgery_step/sever_limb/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/mob/living/carbon/human/L = target
-	user.visible_message("[user] severs [L]'s [parse_zone(target_zone)]!", "<span class='notice'>You sever [L]'s [parse_zone(target_zone)].</span>")
+	display_results(user, target, "<span class='notice'>You sever [L]'s [parse_zone(target_zone)].</span>",
+		"[user] severs [L]'s [parse_zone(target_zone)]!",
+		"[user] severs [L]'s [parse_zone(target_zone)]!")
 	if(surgery.operated_bodypart)
 		var/obj/item/bodypart/target_limb = surgery.operated_bodypart
 		target_limb.drop_limb()

--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -24,10 +24,14 @@
 	return TRUE
 
 /datum/surgery_step/fix_brain/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to fix [target]'s brain.", "<span class='notice'>You begin to fix [target]'s brain...</span>")
+	display_results(user, target, "<span class='notice'>You begin to fix [target]'s brain...</span>",
+		"[user] begins to fix [target]'s brain.",
+		"[user] begins to perform surgery on [target]'s brain.")
 
 /datum/surgery_step/fix_brain/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] successfully fixes [target]'s brain!", "<span class='notice'>You succeed in fixing [target]'s brain.</span>")
+	display_results(user, target, "<span class='notice'>You succeed in fixing [target]'s brain.</span>",
+		"[user] successfully fixes [target]'s brain!",
+		"[user] completes the surgery on [target]'s brain.")
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
 		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
 	target.adjustBrainLoss(-60)
@@ -36,7 +40,9 @@
 
 /datum/surgery_step/fix_brain/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(target.getorganslot(ORGAN_SLOT_BRAIN))
-		user.visible_message("<span class='warning'>[user] screws up, causing more damage!</span>", "<span class='warning'>You screw up, causing more damage!</span>")
+		display_results(user, target, "<span class='warning'>You screw up, causing more damage!</span>",
+			"<span class='warning'>[user] screws up, causing brain damage!</span>",
+			"[user] completes the surgery on [target]'s brain.")
 		target.adjustBrainLoss(60)
 		target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_LOBOTOMY)
 	else

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -23,9 +23,13 @@
 	var/obj/item/bodypart/chest/CH = target.get_bodypart(BODY_ZONE_CHEST)
 	IC = CH.cavity_item
 	if(tool)
-		user.visible_message("[user] begins to insert [tool] into [target]'s [target_zone].", "<span class='notice'>You begin to insert [tool] into [target]'s [target_zone]...</span>")
+		display_results(user, target, "<span class='notice'>You begin to insert [tool] into [target]'s [target_zone]...</span>",
+			"[user] begins to insert [tool] into [target]'s [target_zone].",
+			"[user] begins to insert [tool.w_class > WEIGHT_CLASS_SMALL ? tool : "something"] into [target]'s [target_zone].")
 	else
-		user.visible_message("[user] checks for items in [target]'s [target_zone].", "<span class='notice'>You check for items in [target]'s [target_zone]...</span>")
+		display_results(user, target, "<span class='notice'>You check for items in [target]'s [target_zone]...</span>",
+			"[user] checks for items in [target]'s [target_zone].",
+			"[user] looks for something in [target]'s [target_zone].")
 
 /datum/surgery_step/handle_cavity/success(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/obj/item/bodypart/chest/CH = target.get_bodypart(BODY_ZONE_CHEST)
@@ -34,13 +38,17 @@
 			to_chat(user, "<span class='warning'>You can't seem to fit [tool] in [target]'s [target_zone]!</span>")
 			return 0
 		else
-			user.visible_message("[user] stuffs [tool] into [target]'s [target_zone]!", "<span class='notice'>You stuff [tool] into [target]'s [target_zone].</span>")
+			display_results(user, target, "<span class='notice'>You stuff [tool] into [target]'s [target_zone].</span>",
+				"[user] stuffs [tool] into [target]'s [target_zone]!",
+				"[user] stuffs [tool.w_class > WEIGHT_CLASS_SMALL ? tool : "something"] into [target]'s [target_zone].")
 			user.transferItemToLoc(tool, target, TRUE)
 			CH.cavity_item = tool
 			return 1
 	else
 		if(IC)
-			user.visible_message("[user] pulls [IC] out of [target]'s [target_zone]!", "<span class='notice'>You pull [IC] out of [target]'s [target_zone].</span>")
+			display_results(user, target, "<span class='notice'>You pull [IC] out of [target]'s [target_zone].</span>",
+				"[user] pulls [IC] out of [target]'s [target_zone]!",
+				"[user] pulls [IC.w_class > WEIGHT_CLASS_SMALL ? IC : "something"] out of [target]'s [target_zone].")
 			user.put_in_hands(IC)
 			CH.cavity_item = null
 			return 1

--- a/code/modules/surgery/core_removal.dm
+++ b/code/modules/surgery/core_removal.dm
@@ -18,13 +18,17 @@
 	time = 16
 
 /datum/surgery_step/extract_core/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to extract a core from [target].", "<span class='notice'>You begin to extract a core from [target]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to extract a core from [target]...</span>",
+		"[user] begins to extract a core from [target].",
+		"[user] begins to extract a core from [target].")
 
 /datum/surgery_step/extract_core/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/mob/living/simple_animal/slime/slime = target
 	if(slime.cores > 0)
 		slime.cores--
-		user.visible_message("[user] successfully extracts a core from [target]!", "<span class='notice'>You successfully extract a core from [target]. [slime.cores] core\s remaining.</span>")
+		display_results(user, target, "<span class='notice'>You successfully extract a core from [target]. [slime.cores] core\s remaining.</span>",
+			"[user] successfully extracts a core from [target]!",
+			"[user] successfully extracts a core from [target]!")
 
 		new slime.coretype(slime.loc)
 

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -9,7 +9,9 @@
 	time = 16
 
 /datum/surgery_step/insert_pill/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to wedge \the [tool] in [target]'s [parse_zone(target_zone)].", "<span class='notice'>You begin to wedge [tool] in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to wedge [tool] in [target]'s [parse_zone(target_zone)]...</span>",
+			"[user] begins to wedge \the [tool] in [target]'s [parse_zone(target_zone)].",
+			"[user] begins to wedge something in [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/insert_pill/success(mob/user, mob/living/carbon/target, target_zone, var/obj/item/reagent_containers/pill/tool, datum/surgery/surgery)
 	if(!istype(tool))
@@ -22,7 +24,9 @@
 	P.target = tool
 	P.Grant(target)	//The pill never actually goes in an inventory slot, so the owner doesn't inherit actions from it
 
-	user.visible_message("[user] wedges \the [tool] into [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You wedge [tool] into [target]'s [parse_zone(target_zone)].</span>")
+	display_results(user, target, "<span class='notice'>You wedge [tool] into [target]'s [parse_zone(target_zone)].</span>",
+			"[user] wedges \the [tool] into [target]'s [parse_zone(target_zone)]!",
+			"[user] wedges something into [target]'s [parse_zone(target_zone)]!")
 	return 1
 
 /datum/action/item_action/hands_free/activate_pill

--- a/code/modules/surgery/eye_surgery.dm
+++ b/code/modules/surgery/eye_surgery.dm
@@ -19,10 +19,15 @@
 	return TRUE
 
 /datum/surgery_step/fix_eyes/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to fix [target]'s eyes.", "<span class='notice'>You begin to fix [target]'s eyes...</span>")
+	display_results(user, target, "<span class='notice'>You begin to fix [target]'s eyes...</span>",
+		"[user] begins to fix [target]'s eyes.",
+		"[user] begins to perform surgery on [target]'s eyes.")
 
 /datum/surgery_step/fix_eyes/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] successfully fixes [target]'s eyes!", "<span class='notice'>You succeed in fixing [target]'s eyes.</span>")
+	display_results(user, target, "<span class='notice'>You succeed in fixing [target]'s eyes.</span>",
+		"[user] successfully fixes [target]'s eyes!",
+		"[user] completes the surgery on [target]'s eyes.")
 	target.cure_blind(list(EYE_DAMAGE))
 	target.set_blindness(0)
 	target.cure_nearsighted(list(EYE_DAMAGE))
@@ -32,8 +37,12 @@
 
 /datum/surgery_step/fix_eyes/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(target.getorgan(/obj/item/organ/brain))
-		user.visible_message("<span class='warning'>[user] accidentally stabs [target] right in the brain!</span>", "<span class='warning'>You accidentally stab [target] right in the brain!</span>")
+		display_results(user, target, "<span class='warning'>You accidentally stab [target] right in the brain!</span>",
+			"<span class='warning'>[user] accidentally stabs [target] right in the brain!</span>",
+			"<span class='warning'>[user] accidentally stabs [target] right in the brain!</span>")
 		target.adjustBrainLoss(70)
 	else
-		user.visible_message("<span class='warning'>[user] accidentally stabs [target] right in the brain! Or would have, if [target] had a brain.</span>", "<span class='warning'>You accidentally stab [target] right in the brain! Or would have, if [target] had a brain.</span>")
+		display_results(user, target, "<span class='warning'>You accidentally stab [target] right in the brain! Or would have, if [target] had a brain.</span>",
+			"<span class='warning'>[user] accidentally stabs [target] right in the brain! Or would have, if [target] had a brain.</span>",
+			"<span class='warning'>[user] accidentally stabs [target] right in the brain!</span>")
 	return FALSE

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -38,7 +38,10 @@
 		woundtype = "bruises"
 	else //why are you trying to 0,0...?
 		woundtype = "burns"
-	user.visible_message("[user] attempts to patch some of [target]'s [woundtype].", "<span class='notice'>You attempt to patch some of [target]'s [woundtype].</span>")
+	display_results(user, target, "<span class='notice'>You attempt to patch some of [target]'s [woundtype].</span>",
+		"[user] attempts to patch some of [target]'s [woundtype].",
+		"[user] attempts to patch some of [target]'s [woundtype].")
+
 
 /datum/surgery_step/heal/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	if(..())
@@ -47,12 +50,17 @@
 				break
 
 /datum/surgery_step/heal/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] fixes some of [target]'s wounds.", "<span class='notice'>You succeed in fixing some of [target]'s wounds.</span>")
+	display_results(user, target, "<span class='notice'>You succeed in fixing some of [target]'s wounds.</span>",
+		"[user] fixes some of [target]'s wounds.",
+		"[user] fixes some of [target]'s wounds.")
 	target.heal_bodypart_damage(brutehealing,burnhealing)
 	return TRUE
 
 /datum/surgery_step/heal/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] screws up!", "<span class='warning'>You screwed up!</span>")
+	display_results(user, target, "<span class='warning'>You screwed up!</span>",
+		"[user] screws up!",
+		"[user] fixes some of [target]'s wounds.", TRUE)
 	target.take_bodypart_damage(5,0)
 	return FALSE
 

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -17,13 +17,19 @@
 		I = O
 		break
 	if(I)
-		user.visible_message("[user] begins to extract [I] from [target]'s [target_zone].", "<span class='notice'>You begin to extract [I] from [target]'s [target_zone]...</span>")
+		display_results(user, target, "<span class='notice'>You begin to extract [I] from [target]'s [target_zone]...</span>",
+			"[user] begins to extract [I] from [target]'s [target_zone].",
+			"[user] begins to extract something from [target]'s [target_zone].")
 	else
-		user.visible_message("[user] looks for an implant in [target]'s [target_zone].", "<span class='notice'>You look for an implant in [target]'s [target_zone]...</span>")
+		display_results(user, target, "<span class='notice'>You look for an implant in [target]'s [target_zone]...</span>",
+			"[user] looks for an implant in [target]'s [target_zone].",
+			"[user] looks for something in [target]'s [target_zone].")
 
 /datum/surgery_step/extract_implant/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(I)
-		user.visible_message("[user] successfully removes [I] from [target]'s [target_zone]!", "<span class='notice'>You successfully remove [I] from [target]'s [target_zone].</span>")
+		display_results(user, target, "<span class='notice'>You successfully remove [I] from [target]'s [target_zone].</span>",
+			"[user] successfully removes [I] from [target]'s [target_zone]!",
+			"[user] successfully removes something from [target]'s [target_zone]!")
 		I.removed(target)
 
 		var/obj/item/implantcase/case
@@ -36,7 +42,9 @@
 			case.imp = I
 			I.forceMove(case)
 			case.update_icon()
-			user.visible_message("[user] places [I] into [case]!", "<span class='notice'>You place [I] into [case].</span>")
+			display_results(user, target, "<span class='notice'>You place [I] into [case].</span>",
+				"[user] places [I] into [case]!",
+				"[user] places it into [case]!")
 		else
 			qdel(I)
 

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -11,8 +11,9 @@
 
 
 /datum/surgery_step/replace/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to sever the muscles on [target]'s [parse_zone(user.zone_selected)].", "<span class ='notice'>You begin to sever the muscles on [target]'s [parse_zone(user.zone_selected)]...</span>")
-
+	display_results(user, target, "<span class ='notice'>You begin to sever the muscles on [target]'s [parse_zone(user.zone_selected)]...</span>",
+		"[user] begins to sever the muscles on [target]'s [parse_zone(user.zone_selected)].",
+		"[user] begins an incision on [target]'s [parse_zone(user.zone_selected)].")
 
 /datum/surgery_step/replace_limb
 	name = "replace limb"
@@ -33,7 +34,9 @@
 		return -1
 	L = surgery.operated_bodypart
 	if(L)
-		user.visible_message("[user] begins to augment [target]'s [parse_zone(user.zone_selected)].", "<span class ='notice'>You begin to augment [target]'s [parse_zone(user.zone_selected)]...</span>")
+		display_results(user, target, "<span class ='notice'>You begin to augment [target]'s [parse_zone(user.zone_selected)]...</span>",
+			"[user] begins to augment [target]'s [parse_zone(user.zone_selected)] with [aug].",
+			"[user] begins to augment [target]'s [parse_zone(user.zone_selected)].")
 	else
 		user.visible_message("[user] looks for [target]'s [parse_zone(user.zone_selected)].", "<span class ='notice'>You look for [target]'s [parse_zone(user.zone_selected)]...</span>")
 
@@ -58,7 +61,9 @@
 			tool = tool.contents[1]
 		if(istype(tool) && user.temporarilyRemoveItemFromInventory(tool))
 			tool.replace_limb(target, TRUE)
-		user.visible_message("[user] successfully augments [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You successfully augment [target]'s [parse_zone(target_zone)].</span>")
+		display_results(user, target, "<span class='notice'>You successfully augment [target]'s [parse_zone(target_zone)].</span>",
+			"[user] successfully augments [target]'s [parse_zone(target_zone)] with [tool]!",
+			"[user] successfully augments [target]'s [parse_zone(target_zone)]!")
 		log_combat(user, target, "augmented", addition="by giving him new [parse_zone(target_zone)] INTENT: [uppertext(user.a_intent)]")
 	else
 		to_chat(user, "<span class='warning'>[target] has no organic [parse_zone(target_zone)] there!</span>")

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -17,9 +17,14 @@
 
 /datum/surgery_step/cut_fat/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] begins to cut away [target]'s excess fat.", "<span class='notice'>You begin to cut away [target]'s excess fat...</span>")
+	display_results(user, target, "<span class='notice'>You begin to cut away [target]'s excess fat...</span>",
+			"[user] begins to cut away [target]'s excess fat.",
+			"[user] begins to cut [target]'s [target_zone] with [tool].")
 
 /datum/surgery_step/cut_fat/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] cuts [target]'s excess fat loose!", "<span class='notice'>You cut [target]'s excess fat loose.</span>")
+	display_results(user, target, "<span class='notice'>You cut [target]'s excess fat loose.</span>",
+			"[user] cuts [target]'s excess fat loose!",
+			"[user] finishes the cut on [target]'s [target_zone].")
 	return 1
 
 //remove fat
@@ -29,10 +34,14 @@
 	time = 32
 
 /datum/surgery_step/remove_fat/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to extract [target]'s loose fat!", "<span class='notice'>You begin to extract [target]'s loose fat...</span>")
+	display_results(user, target, "<span class='notice'>You begin to extract [target]'s loose fat...</span>",
+			"[user] begins to extract [target]'s loose fat!",
+			"[user] begins to extract something from [target]'s [target_zone].")
 
 /datum/surgery_step/remove_fat/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] extracts [target]'s fat!", "<span class='notice'>You extract [target]'s fat.</span>")
+	display_results(user, target, "<span class='notice'>You extract [target]'s fat.</span>",
+			"[user] extracts [target]'s fat!",
+			"[user] extracts [target]'s fat!")
 	target.overeatduration = 0 //patient is unfatted
 	var/removednutriment = target.nutrition
 	target.set_nutrition(NUTRITION_LEVEL_WELL_FED)

--- a/code/modules/surgery/mechanic_steps.dm
+++ b/code/modules/surgery/mechanic_steps.dm
@@ -9,8 +9,9 @@
 	time = 24
 
 /datum/surgery_step/mechanic_open/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to unscrew the shell of [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to unscrew the shell of [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to unscrew the shell of [target]'s [parse_zone(target_zone)]...</span>",
+			"[user] begins to unscrew the shell of [target]'s [parse_zone(target_zone)].",
+			"[user] begins to unscrew the shell of [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/mechanic_incise/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.is_sharp())
@@ -29,8 +30,9 @@
 	time = 24
 
 /datum/surgery_step/mechanic_close/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to screw the shell of [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to screw the shell of [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to screw the shell of [target]'s [parse_zone(target_zone)]...</span>",
+			"[user] begins to screw the shell of [target]'s [parse_zone(target_zone)].",
+			"[user] begins to screw the shell of [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/mechanic_close/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.is_sharp())
@@ -47,8 +49,9 @@
 	time = 24
 
 /datum/surgery_step/prepare_electronics/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to prepare electronics in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to prepare electronics in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to prepare electronics in [target]'s [parse_zone(target_zone)]...</span>",
+			"[user] begins to prepare electronics in [target]'s [parse_zone(target_zone)].",
+			"[user] begins to prepare electronics in [target]'s [parse_zone(target_zone)].")
 
 //unwrench
 /datum/surgery_step/mechanic_unwrench
@@ -59,8 +62,9 @@
 	time = 24
 
 /datum/surgery_step/mechanic_unwrench/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to unwrench some bolts in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to unwrench some bolts in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to unwrench some bolts in [target]'s [parse_zone(target_zone)]...</span>",
+			"[user] begins to unwrench some bolts in [target]'s [parse_zone(target_zone)].",
+			"[user] begins to unwrench some bolts in [target]'s [parse_zone(target_zone)].")
 
 //wrench
 /datum/surgery_step/mechanic_wrench
@@ -71,8 +75,9 @@
 	time = 24
 
 /datum/surgery_step/mechanic_wrench/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to wrench some bolts in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to wrench some bolts in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to wrench some bolts in [target]'s [parse_zone(target_zone)]...</span>",
+			"[user] begins to wrench some bolts in [target]'s [parse_zone(target_zone)].",
+			"[user] begins to wrench some bolts in [target]'s [parse_zone(target_zone)].")
 
 //open hatch
 /datum/surgery_step/open_hatch
@@ -81,5 +86,6 @@
 	time = 10
 
 /datum/surgery_step/open_hatch/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to open the hatch holders in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to open the hatch holders in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to open the hatch holders in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to open the hatch holders in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to open the hatch holders in [target]'s [parse_zone(target_zone)].")

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -95,8 +95,9 @@
 			to_chat(user, "<span class='notice'>There is no room for [I] in [target]'s [parse_zone(target_zone)]!</span>")
 			return -1
 
-		user.visible_message("[user] begins to insert [tool] into [target]'s [parse_zone(target_zone)].",
-			"<span class='notice'>You begin to insert [tool] into [target]'s [parse_zone(target_zone)]...</span>")
+		display_results(user, target, "<span class='notice'>You begin to insert [tool] into [target]'s [parse_zone(target_zone)]...</span>",
+			"[user] begins to insert [tool] into [target]'s [parse_zone(target_zone)].",
+			"[user] begins to insert something into [target]'s [parse_zone(target_zone)].")
 
 	else if(implement_type in implements_extract)
 		current_type = "extract"
@@ -115,8 +116,9 @@
 				I = organs[I]
 				if(!I)
 					return -1
-				user.visible_message("[user] begins to extract [I] from [target]'s [parse_zone(target_zone)].",
-					"<span class='notice'>You begin to extract [I] from [target]'s [parse_zone(target_zone)]...</span>")
+				display_results(user, target, "<span class='notice'>You begin to extract [I] from [target]'s [parse_zone(target_zone)]...</span>",
+					"[user] begins to extract [I] from [target]'s [parse_zone(target_zone)].",
+					"[user] begins to extract something from [target]'s [parse_zone(target_zone)].")
 			else
 				return -1
 
@@ -136,17 +138,20 @@
 			I = tool
 		user.temporarilyRemoveItemFromInventory(I, TRUE)
 		I.Insert(target)
-		user.visible_message("[user] inserts [tool] into [target]'s [parse_zone(target_zone)]!",
-			"<span class='notice'>You insert [tool] into [target]'s [parse_zone(target_zone)].</span>")
+		display_results(user, target, "<span class='notice'>You insert [tool] into [target]'s [parse_zone(target_zone)].</span>",
+			"[user] inserts [tool] into [target]'s [parse_zone(target_zone)]!",
+			"[user] inserts something into [target]'s [parse_zone(target_zone)]!")
 
 	else if(current_type == "extract")
 		if(I && I.owner == target)
-			user.visible_message("[user] successfully extracts [I] from [target]'s [parse_zone(target_zone)]!",
-				"<span class='notice'>You successfully extract [I] from [target]'s [parse_zone(target_zone)].</span>")
+			display_results(user, target, "<span class='notice'>You successfully extract [I] from [target]'s [parse_zone(target_zone)].</span>",
+				"[user] successfully extracts [I] from [target]'s [parse_zone(target_zone)]!",
+				"[user] successfully extracts something from [target]'s [parse_zone(target_zone)]!")
 			log_combat(user, target, "surgically removed [I.name] from", addition="INTENT: [uppertext(user.a_intent)]")
 			I.Remove(target)
 			I.forceMove(get_turf(target))
 		else
-			user.visible_message("[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!",
-				"<span class='notice'>You can't extract anything from [target]'s [parse_zone(target_zone)]!</span>")
+			display_results(user, target, "<span class='notice'>You can't extract anything from [target]'s [parse_zone(target_zone)]!</span>",
+				"[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!",
+				"[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!")
 	return 0

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -7,8 +7,9 @@
 	time = 16
 
 /datum/surgery_step/incise/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to make an incision in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to make an incision in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to make an incision in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to make an incision in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to make an incision in [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/incise/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.is_sharp())
@@ -20,7 +21,9 @@
 	if ishuman(target)
 		var/mob/living/carbon/human/H = target
 		if (!(NOBLOOD in H.dna.species.species_traits))
-			H.visible_message("Blood pools around the incision in [H]'s [parse_zone(target_zone)].", "<span class='notice'>Blood pools around the incision in your [parse_zone(target_zone)].</span>")
+			display_results(user, target, "<span class='notice'>Blood pools around the incision in [H]'s [parse_zone(target_zone)].</span>",
+				"Blood pools around the incision in [H]'s [parse_zone(target_zone)].",
+				"")
 			H.bleed_rate += 3
 	return TRUE
 
@@ -31,8 +34,9 @@
 	time = 24
 
 /datum/surgery_step/clamp_bleeders/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to clamp bleeders in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to clamp bleeders in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to clamp bleeders in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to clamp bleeders in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to clamp bleeders in [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/clamp_bleeders/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(locate(/datum/surgery_step/saw) in surgery.steps)
@@ -49,8 +53,9 @@
 	time = 24
 
 /datum/surgery_step/retract_skin/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to retract the skin in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to retract the skin in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to retract the skin in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to retract the skin in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to retract the skin in [target]'s [parse_zone(target_zone)].")
 
 
 
@@ -62,8 +67,9 @@
 	time = 24
 
 /datum/surgery_step/close/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to mend the incision in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to mend the incision in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to mend the incision in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to mend the incision in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to mend the incision in [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/close/tool_check(mob/user, obj/item/tool)
 	if(implement_type == TOOL_WELDER || implement_type == /obj/item)
@@ -90,13 +96,15 @@
 	time = 54
 
 /datum/surgery_step/saw/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to saw through the bone in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to saw through the bone in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to saw through the bone in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to saw through the bone in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to saw through the bone in [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/saw/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	target.apply_damage(50, BRUTE, "[target_zone]")
-
-	user.visible_message("[user] saws [target]'s [parse_zone(target_zone)] open!", "<span class='notice'>You saw [target]'s [parse_zone(target_zone)] open.</span>")
+	display_results(user, target, "<span class='notice'>You saw [target]'s [parse_zone(target_zone)] open.</span>",
+		"[user] saws [target]'s [parse_zone(target_zone)] open!",
+		"[user] saws [target]'s [parse_zone(target_zone)] open!")
 	return 1
 
 //drill bone
@@ -106,10 +114,12 @@
 	time = 30
 
 /datum/surgery_step/drill/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to drill into the bone in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to drill into the bone in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to drill into the bone in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to drill into the bone in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to drill into the bone in [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/drill/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] drills into [target]'s [parse_zone(target_zone)]!",
-		"<span class='notice'>You drill into [target]'s [parse_zone(target_zone)].</span>")
+	display_results(user, target, "<span class='notice'>You drill into [target]'s [parse_zone(target_zone)].</span>",
+		"[user] drills into [target]'s [parse_zone(target_zone)]!",
+		"[user] drills into [target]'s [parse_zone(target_zone)]!")
 	return 1

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -11,11 +11,16 @@
 
 /datum/surgery_step/reshape_face/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] begins to alter [target]'s appearance.", "<span class='notice'>You begin to alter [target]'s appearance...</span>")
+	display_results(user, target, "<span class='notice'>You begin to alter [target]'s appearance...</span>",
+		"[user] begins to alter [target]'s appearance.",
+		"[user] begins to make an incision in [target]'s face.")
 
 /datum/surgery_step/reshape_face/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(HAS_TRAIT_FROM(target, TRAIT_DISFIGURED, TRAIT_GENERIC))
 		REMOVE_TRAIT(target, TRAIT_DISFIGURED, TRAIT_GENERIC)
-		user.visible_message("[user] successfully restores [target]'s appearance!", "<span class='notice'>You successfully restore [target]'s appearance.</span>")
+		display_results(user, target, "<span class='notice'>You successfully restore [target]'s appearance.</span>",
+			"[user] successfully restores [target]'s appearance!",
+			"[user] finishes the operation on [target]'s face.")
 	else
 		var/list/names = list()
 		if(!isabductor(user))
@@ -31,8 +36,17 @@
 		var/oldname = target.real_name
 		target.real_name = chosen_name
 		var/newname = target.real_name	//something about how the code handles names required that I use this instead of target.real_name
-		user.visible_message("[user] alters [oldname]'s appearance completely, [target.p_they()] is now [newname]!", "<span class='notice'>You alter [oldname]'s appearance completely, [target.p_they()] is now [newname].</span>")
+		display_results(user, target, "<span class='notice'>You alter [oldname]'s appearance completely, [target.p_they()] is now [newname].</span>",
+			"[user] alters [oldname]'s appearance completely, [target.p_they()] is now [newname]!",
+			"[user] finishes the operation on [target]'s face.")
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		H.sec_hud_set_ID()
-	return 1
+	return TRUE
+
+/datum/surgery_step/reshape_face/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(user, target, "<span class='warning'>You screw up, leaving [target]'s appearance disfigured!</span>",
+		"[user] screws up, disfiguring [target]'s appearance!",
+		"[user] finishes the operation on [target]'s face.")
+	ADD_TRAIT(target, TRAIT_DISFIGURED, TRAIT_GENERIC)
+	return FALSE

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -48,12 +48,16 @@
 					organ_rejection_dam = 30
 
 		if(target_zone == BP.body_zone) //so we can't replace a leg with an arm, or a human arm with a monkey arm.
-			user.visible_message("[user] begins to replace [target]'s [parse_zone(target_zone)].", "<span class ='notice'>You begin to replace [target]'s [parse_zone(target_zone)]...</span>")
+			display_results(user, target, "<span class ='notice'>You begin to replace [target]'s [parse_zone(target_zone)] with [tool]...</span>",
+				"[user] begins to replace [target]'s [parse_zone(target_zone)] with [tool].",
+				"[user] begins to replace [target]'s [parse_zone(target_zone)].")
 		else
 			to_chat(user, "<span class='warning'>[tool] isn't the right type for [parse_zone(target_zone)].</span>")
 			return -1
 	else if(target_zone == BODY_ZONE_L_ARM || target_zone == BODY_ZONE_R_ARM)
-		user.visible_message("[user] begins to attach [tool] onto [target].", "<span class='notice'>You begin to attach [tool] onto [target]...</span>")
+		display_results(user, target, "<span class='notice'>You begin to attach [tool] onto [target]...</span>",
+			"[user] begins to attach [tool] onto [target]'s [parse_zone(target_zone)].",
+			"[user] begins to attach something onto [target]'s [parse_zone(target_zone)].")
 	else
 		to_chat(user, "<span class='warning'>[tool] must be installed onto an arm.</span>")
 		return -1
@@ -69,13 +73,18 @@
 		L.attach_limb(target)
 		if(organ_rejection_dam)
 			target.adjustToxLoss(organ_rejection_dam)
-		user.visible_message("[user] successfully replaces [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You succeed in replacing [target]'s [parse_zone(target_zone)].</span>")
+		display_results(user, target, "<span class='notice'>You succeed in replacing [target]'s [parse_zone(target_zone)].</span>",
+			"[user] successfully replaces [target]'s [parse_zone(target_zone)] with [tool]!",
+			"[user] successfully replaces [target]'s [parse_zone(target_zone)]!")
 		return 1
 	else
 		var/obj/item/bodypart/L = target.newBodyPart(target_zone, FALSE, FALSE)
 		L.is_pseudopart = TRUE
 		L.attach_limb(target)
 		user.visible_message("[user] finishes attaching [tool]!", "<span class='notice'>You attach [tool].</span>")
+		display_results(user, target, "<span class='notice'>You attach [tool].</span>",
+			"[user] finishes attaching [tool]!",
+			"[user] finishes the attachment procedure!")
 		qdel(tool)
 		if(istype(tool, /obj/item/twohanded/required/chainsaw))
 			var/obj/item/mounted_chainsaw/new_arm = new(target)

--- a/code/modules/surgery/remove_embedded_object.dm
+++ b/code/modules/surgery/remove_embedded_object.dm
@@ -15,6 +15,9 @@
 	L = surgery.operated_bodypart
 	if(L)
 		user.visible_message("[user] looks for objects embedded in [target]'s [parse_zone(user.zone_selected)].", "<span class='notice'>You look for objects embedded in [target]'s [parse_zone(user.zone_selected)]...</span>")
+		display_results(user, target, "<span class='notice'>You look for objects embedded in [target]'s [parse_zone(user.zone_selected)]...</span>",
+			"[user] looks for objects embedded in [target]'s [parse_zone(user.zone_selected)].",
+			"[user] looks for something in [target]'s [parse_zone(user.zone_selected)].")
 	else
 		user.visible_message("[user] looks for [target]'s [parse_zone(user.zone_selected)].", "<span class='notice'>You look for [target]'s [parse_zone(user.zone_selected)]...</span>")
 
@@ -33,7 +36,9 @@
 				SEND_SIGNAL(H, COMSIG_CLEAR_MOOD_EVENT, "embedded")
 
 			if(objects > 0)
-				user.visible_message("[user] successfully removes [objects] objects from [H]'s [L]!", "<span class='notice'>You successfully remove [objects] objects from [H]'s [L.name].</span>")
+				display_results(user, target, "<span class='notice'>You successfully remove [objects] objects from [H]'s [L.name].</span>",
+					"[user] successfully removes [objects] objects from [H]'s [L]!",
+					"[user] successfully removes [objects] objects from [H]'s [L]!")
 			else
 				to_chat(user, "<span class='warning'>You find no objects embedded in [H]'s [L]!</span>")
 

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -92,15 +92,20 @@
 
 
 /datum/surgery_step/proc/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to perform surgery on [target].", "<span class='notice'>You begin to perform surgery on [target]...</span>")
-
+	display_results(user, target, "<span class='notice'>You begin to perform surgery on [target]...</span>",
+		"[user] begins to perform surgery on [target].",
+		"[user] begins to perform surgery on [target].")
 
 /datum/surgery_step/proc/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] succeeds!", "<span class='notice'>You succeed.</span>")
+	display_results(user, target, "<span class='notice'>You succeed.</span>",
+		"[user] succeeds!",
+		"[user] finishes.")
 	return TRUE
 
 /datum/surgery_step/proc/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("<span class='warning'>[user] screws up!</span>", "<span class='warning'>You screw up!</span>")
+	display_results(user, target, "<span class='warning'>You screw up!</span>",
+		"<span class='warning'>[user] screws up!</span>",
+		"[user] finishes.", TRUE) //By default the patient will notice if the wrong thing has been cut
 	return FALSE
 
 /datum/surgery_step/proc/tool_check(mob/user, obj/item/tool)
@@ -131,3 +136,11 @@
 			var/chemname = temp.name
 			chems += chemname
 	return english_list(chems, and_text = require_all_chems ? " and " : " or ")
+
+//Replaces visible_message during operations so only people looking over the surgeon can tell what they're doing, allowing for shenanigans.
+/datum/surgery_step/proc/display_results(mob/user, mob/living/carbon/target, self_message, detailed_message, vague_message, target_detailed = FALSE)
+	var/list/detailed_mobs = get_hearers_in_view(1, user) //Only the surgeon and people looking over his shoulder can see the operation clearly
+	if(!target_detailed)
+		detailed_mobs -= target //The patient can't see well what's going on, unless it's something like getting cut
+	user.visible_message(detailed_message, self_message, vision_distance = 1, ignored_mobs = target_detailed ? null : target)
+	user.visible_message(vague_message, "", ignored_mobs = detailed_mobs)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Part of #44440 

Surgery now gives detailed description to the surgeon and anyone within one tile of distance, and more vague or ambiguous descriptions to the patient and anyone further away. This can lead to a surgeon being able to perform a brainwashing in place of a brain surgery with nobody being the wiser, or implanting a different organ than the one agreed on, and so on.

## Changelog
:cl:
add: Surgery steps are now shown in detail only to the surgeon and anyone standing adjacent to them; the patient and people watching from further away get a more vague/ambiguous description.
/:cl:
