### PR TITLE
Removes the fully-stocked free nanomed from mining capsules

### DIFF
--- a/_maps/templates/shelter_1.dmm
+++ b/_maps/templates/shelter_1.dmm
@@ -28,9 +28,6 @@
 /area/survivalpod)
 "g" = (
 /obj/machinery/stasis/survival_pod,
-/obj/machinery/vending/wallmed/survival_pod{
-	pixel_x = -24
-	},
 /turf/open/floor/pod,
 /area/survivalpod)
 "h" = (

--- a/_maps/templates/shelter_2.dmm
+++ b/_maps/templates/shelter_2.dmm
@@ -51,9 +51,6 @@
 /area/survivalpod)
 "k" = (
 /obj/machinery/stasis/survival_pod,
-/obj/machinery/vending/wallmed/survival_pod{
-	pixel_x = -24
-	},
 /turf/open/floor/pod,
 /area/survivalpod)
 "l" = (

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -151,13 +151,6 @@
 /obj/machinery/stasis/survival_pod/update_icon()
 	return
 
-//NanoMed
-/obj/machinery/vending/wallmed/survival_pod
-	name = "survival pod medical supply"
-	desc = "Wall-mounted Medical Equipment dispenser. This one seems just a tiny bit smaller."
-	refill_canister = null
-	onstation = FALSE
-
 //Computer
 /obj/item/gps/computer
 	name = "pod computer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the nanomed someone added that gives every miner 5 brute and burn patches, 2 charcoal pills and 2 brute and burn sprays for free. Not that they even needed it.
This leaves miners with survival medipens, donk pockets, cactus fruits, miner's salve, legion cores and ruins loot.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Naksu
del: Free nanomeds have been removed from mining capsules
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
