### PR TITLE
Gives the mime two new spells: Invisible Chair and Invisible Box. [READY]

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -86,7 +86,7 @@
 
 /obj/item/storage/box/mime/attack_hand(mob/user)
 	..()
-	if(user.mind.assigned_role == "Mime")
+	if(user.mind.miming)
 		alpha = 255
 
 /obj/item/storage/box/mime/handle_drop

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -74,8 +74,27 @@
 		return 0
 	return ..()
 
+//Mime spell boxes
+
+/obj/item/storage/box/mime
+	name = "invisible box"
+	desc = "Unfortunately not large enough to trap the mime."
+	foldable = null
+	icon_state = "box"
+	item_state = null
+	alpha = 0
+
+/obj/item/storage/box/mime/attack_hand(mob/user)
+	..()
+	if(user.mind.assigned_role == "Mime")
+		alpha = 255
+
+/obj/item/storage/box/mime/handle_drop
+	alpha = 0
+	..()
 
 //Disk boxes
+
 /obj/item/storage/box/disks
 	name = "diskette box"
 	illustration = "disk_kit"

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -89,8 +89,9 @@
 	if(user.mind.miming)
 		alpha = 255
 
-/obj/item/storage/box/mime/handle_drop
-	alpha = 0
+/obj/item/storage/box/mime/Moved(oldLoc, dir)
+	if (iscarbon(oldLoc))
+		alpha = 0
 	..()
 
 //Disk boxes

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -427,3 +427,18 @@
 	buildstacktype = null
 	item_chair = null
 	flags_1 = NODECONSTRUCT_1
+
+/obj/structure/chair/mime
+	name = "invisible chair"
+	desc = "The mime needs to sit down and shut up."
+	anchored = FALSE
+	icon_state = null
+	buildstacktype = null
+	item_chair = null
+	flags_1 = NODECONSTRUCT_1
+
+/obj/structure/chair/mime/post_buckle_mob(mob/living/M)
+	M.pixel_y += 5
+
+/obj/structure/chair/mime/post_unbuckle_mob(mob/living/M)
+	M.pixel_y -= 5

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -428,15 +428,6 @@
 	item_chair = null
 	flags_1 = NODECONSTRUCT_1
 
-/obj/structure/chair/mime
-	name = "invisible chair"
-	desc = "The mime needs to sit down and shut up."
-	anchored = FALSE
-	icon_state = null
-	buildstacktype = null
-	item_chair = null
-	flags_1 = NODECONSTRUCT_1
-
 /obj/structure/chair/mime/post_buckle_mob(mob/living/M)
 	M.pixel_y += 5
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -418,3 +418,12 @@
 	. = ..()
 	if(has_gravity())
 		playsound(src, 'sound/machines/clockcult/integration_cog_install.ogg', 50, TRUE)
+
+/obj/structure/chair/mime
+	name = "invisible chair"
+	desc = "The mime needs to sit down and shut up."
+	anchored = FALSE
+	icon_state = null
+	buildstacktype = null
+	item_chair = null
+	flags_1 = NODECONSTRUCT_1

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -69,7 +69,7 @@
 	if (usr.stat || usr.restrained() || src.loc != usr)
 		return
 	if (!ishuman(usr))
-		return 1
+		return
 	var/mob/living/carbon/human/H = usr
 	if(H.is_holding(src) && H.mind)
 		H.set_machine(src)

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -32,7 +32,7 @@
 	gloves = /obj/item/clothing/gloves/color/white
 	head = /obj/item/clothing/head/frenchberet
 	suit = /obj/item/clothing/suit/suspenders
-	backpack_contents = list(/obj/item/reagent_containers/food/drinks/bottle/bottleofnothing=1)
+	backpack_contents = list(/obj/item/book/mimery=1, /obj/item/reagent_containers/food/drinks/bottle/bottleofnothing=1)
 
 	backpack = /obj/item/storage/backpack/mime
 	satchel = /obj/item/storage/backpack/mime
@@ -45,7 +45,39 @@
 		return
 
 	if(H.mind)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall(null))
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak(null))
 		H.mind.miming = 1
 
+/obj/item/book/mimery
+	name = "Guide to Dank Mimery"
+	desc = "A primer on basic pantomime."
+	icon_state ="bookmime"
+
+/obj/item/book/mimery/attack_self(mob/user,)
+	user.set_machine(src)
+	var/dat = "<B>Book of Dank Mimery</B><BR>"
+	dat += "Teaches one of three classic pantomime routines, allowing a practiced mime to conjure invisible objects into corporeal existence.<BR>"
+	dat += "Once you have chosen your routine, this book will have no more to say to you.<BR>"
+	dat += "<HR>"
+	dat += "<A href='byond://?src=[REF(src)];invisible_wall=1'>Invisible Wall</A><BR>"
+	dat += "<A href='byond://?src=[REF(src)];invisible_chair=1'>Invisible Chair</A><BR>"
+	dat += "<A href='byond://?src=[REF(src)];invisible_box=1'>Invisible Box</A><BR>"
+	user << browse(dat, "window=book")
+
+/obj/item/book/mimery/Topic(href, href_list)
+	..()
+	if (usr.stat || usr.restrained() || src.loc != usr)
+		return
+	if (!ishuman(usr))
+		return 1
+	var/mob/living/carbon/human/H = usr
+	if(H.is_holding(src) && H.mind)
+		H.set_machine(src)
+		if (href_list["invisible_wall"])
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall(null))
+		if (href_list["invisible_chair"])
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_chair(null))
+		if (href_list["invisible_box"])
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_box(null))
+	to_chat(usr, "<span class='notice'>The book disappears into thin air.</span>")
+	qdel(src)

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -55,9 +55,9 @@
 
 /obj/item/book/mimery/attack_self(mob/user,)
 	user.set_machine(src)
-	var/dat = "<B>Book of Dank Mimery</B><BR>"
+	var/dat = "<B>Guide to Dank Mimery</B><BR>"
 	dat += "Teaches one of three classic pantomime routines, allowing a practiced mime to conjure invisible objects into corporeal existence.<BR>"
-	dat += "Once you have chosen your routine, this book will have no more to say to you.<BR>"
+	dat += "Once you have mastered your routine, this book will have no more to say to you.<BR>"
 	dat += "<HR>"
 	dat += "<A href='byond://?src=[REF(src)];invisible_wall=1'>Invisible Wall</A><BR>"
 	dat += "<A href='byond://?src=[REF(src)];invisible_chair=1'>Invisible Chair</A><BR>"

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -96,7 +96,7 @@
 		if(!usr.mind.miming)
 			to_chat(usr, "<span class='notice'>You must dedicate yourself to silence first.</span>")
 			return
-		invocation = "<B>[usr.real_name]</B> moves [usr.p_their()] hands around in the shape of a box."
+		invocation = "<B>[usr.real_name]</B> moves [usr.p_their()] hands in the shape of a cube, pressing a box out of the air."
 	else
 		invocation_type ="none"
 	..()

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall
 	name = "Invisible Wall"
-	desc = "The mime's performance transmutates into physical reality."
+	desc = "The mime's performance transmutates a wall into physical reality."
 	school = "mime"
 	panel = "Mime"
 	summon_type = list(/obj/effect/forcefield/mime)
@@ -23,6 +23,78 @@
 			to_chat(usr, "<span class='notice'>You must dedicate yourself to silence first.</span>")
 			return
 		invocation = "<B>[usr.real_name]</B> looks as if a wall is in front of [usr.p_them()]."
+	else
+		invocation_type ="none"
+	..()
+
+/obj/effect/proc_holder/spell/aoe_turf/conjure/mime_chair
+	name = "Invisible Chair"
+	desc = "The mime's performance transmutates a chair into physical reality."
+	school = "mime"
+	panel = "Mime"
+	summon_type = list(/obj/structure/chair/mime)
+	invocation_type = "emote"
+	invocation_emote_self = "<span class='notice'>You conjure an invisible chair and sit down.</span>"
+	summon_lifespan = 250
+	charge_max = 300
+	clothes_req = FALSE
+	antimagic_allowed = TRUE
+	range = 0
+	cast_sound = null
+	human_req = TRUE
+
+	action_icon_state = "mime"
+	action_background_icon_state = "bg_mime"
+
+/obj/effect/proc_holder/spell/aoe_turf/conjure/mime_chair/Click()
+	if(usr && usr.mind)
+		if(!usr.mind.miming)
+			to_chat(usr, "<span class='notice'>You must dedicate yourself to silence first.</span>")
+			return
+		invocation = "<B>[usr.real_name]</B> pulls out an invisible chair and sits down."
+	else
+		invocation_type ="none"
+	..()
+
+/obj/effect/proc_holder/spell/aoe_turf/conjure/mime_chair/cast(list/targets,mob/user = usr)
+	..()
+	var/turf/T = user.loc
+	for (var/obj/structure/chair/A in T)
+		if (is_type_in_list(A, summon_type))
+			A.setDir(user.dir)
+			A.buckle_mob(user)
+
+/obj/effect/proc_holder/spell/aoe_turf/conjure/mime_box
+	name = "Invisible Box"
+	desc = "The mime's performance transmutates a box into physical reality."
+	school = "mime"
+	panel = "Mime"
+	summon_type = list(/obj/item/storage/box/mime)
+	invocation_type = "emote"
+	invocation_emote_self = "<span class='notice'>You conjure up an invisible box, large enough to store a few things.</span>"
+	summon_lifespan = 250
+	charge_max = 300
+	clothes_req = FALSE
+	antimagic_allowed = TRUE
+	range = 0
+	cast_sound = null
+	human_req = TRUE
+
+	action_icon_state = "mime"
+	action_background_icon_state = "bg_mime"
+
+/obj/effect/proc_holder/spell/aoe_turf/conjure/mime_box/cast(list/targets,mob/user = usr)
+	..()
+	var/turf/T = user.loc
+	for (var/obj/item/storage/box/mime/B in T)
+		addtimer(CALLBACK(B, /obj/item/storage/box/mime/.proc/emptyStorage, FALSE), (summon_lifespan - 1))
+
+/obj/effect/proc_holder/spell/aoe_turf/conjure/mime_box/Click()
+	if(usr && usr.mind)
+		if(!usr.mind.miming)
+			to_chat(usr, "<span class='notice'>You must dedicate yourself to silence first.</span>")
+			return
+		invocation = "<B>[usr.real_name]</B> moves [usr.p_their()] hands around in the shape of a box."
 	else
 		invocation_type ="none"
 	..()

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -87,6 +87,8 @@
 	..()
 	var/turf/T = user.loc
 	for (var/obj/item/storage/box/mime/B in T)
+		user.put_in_hands(B)
+		B.alpha = 255
 		addtimer(CALLBACK(B, /obj/item/storage/box/mime/.proc/emptyStorage, FALSE), (summon_lifespan - 1))
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_box/Click()


### PR DESCRIPTION
## About The Pull Request

- Adds two new mime spells to the game. Both work like the invisible wall, i.e. they spawn an invisible item for a limited amount of time:
- **Invisible Chair:** Summons a chair and has the mime sit in it. Perfect for crowded shuttles or staying put.
- **Invisible Box:** Everyone's favorite stock mime routine! The mime summons a box (invisible to everyone but him, although you do get the message once spawned) that can store small items. When it disappears, the items are dropped.
- To prevent massively overpowered mimes, the mime gets a spellbook at roundstart from which he can choose only one out of the three mime spells.

## Why It's Good For The Game

The mime doesn't get nearly as much cool stuff as the clown, and these are pretty common pantomime routines to riff off.

## Changelog
:cl:
add: After receiving many complaints about mimes who never pantomime, Nanotrasen has liquidated its mime personnel and hired new mimes who know more routines.
add: The mime gets the choice of two new spells: Invisible Chair and Invisible Box. They work much like the Invisible Wall spell does and disappear after a short span of time. The invisible chair can be buckled to like usual chairs; the box works like a standard inventory box item. 
tweak: Mime spells are now granted via a spellbook that starts out in the mime's inventory. Mimes can choose one of these three.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
