### PR TITLE
Slows down natural blood generation

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -1,3 +1,5 @@
+#define BLOOD_REGEN_RATE 0.15
+
 /****************************************************
 				BLOOD SYSTEM
 ****************************************************/
@@ -49,7 +51,7 @@
 			if(satiety > 80)
 				nutrition_ratio *= 1.25
 			adjust_nutrition(-nutrition_ratio * HUNGER_FACTOR)
-			blood_volume = min(BLOOD_VOLUME_NORMAL, blood_volume + 0.5 * nutrition_ratio)
+			blood_volume = min(BLOOD_VOLUME_NORMAL, blood_volume + BLOOD_REGEN_RATE * nutrition_ratio)
 
 		//Effects of bloodloss
 		var/word = pick("dizzy","woozy","faint")

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -1,4 +1,5 @@
-#define BLOOD_REGEN_RATE 0.15
+#define BLOOD_REGEN_RATE 0.25 //multiplier for how much blood regenerates naturally
+#define BLOOD_REGEN_NUTRITION_RATE 0.5 //multiplier for how much nutrition is lost during natural blood regeneration
 
 /****************************************************
 				BLOOD SYSTEM
@@ -50,7 +51,7 @@
 					nutrition_ratio = 1
 			if(satiety > 80)
 				nutrition_ratio *= 1.25
-			adjust_nutrition(-nutrition_ratio * HUNGER_FACTOR)
+			adjust_nutrition(-nutrition_ratio * HUNGER_FACTOR * BLOOD_REGEN_NUTRITION_RATE)
 			blood_volume = min(BLOOD_VOLUME_NORMAL, blood_volume + BLOOD_REGEN_RATE * nutrition_ratio)
 
 		//Effects of bloodloss


### PR DESCRIPTION
:cl:
balance: Natural blood generation has been halved
/:cl:

Alternative to #44497

From testing, in an optimal situation it takes 5 minutes to go from a just above survivable blood level (475) to stable (560), hence blood loss can often be kept in check by stabilizing the symptoms for a short amount of time rather than tackling the issue directly

This retains the usefulness of salglu for stabilizing patients while making it much harder to rely solely on natural blood regeneration to do all the work without having to seek a proper treatment (particularly in severe cases)

Now a define cause they are fun, cool and easy to change