### PR TITLE
Syndicate Revolver/357 Ammo Nerfs

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -35,7 +35,7 @@
 			new /obj/item/clothing/glasses/thermal/syndi(src)
 			
 		if("guns") // 28 tc now
-			new /obj/item/gun/ballistic/revolver(src)
+			new /obj/item/gun/ballistic/revolver/syndicate(src)
 			new /obj/item/ammo_box/a357(src)
 			new /obj/item/ammo_box/a357(src)
 			new /obj/item/card/emag(src)

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -15,6 +15,7 @@
 	tac_reloads = FALSE
 	var/spin_delay = 10
 	var/recent_spin = 0
+	recoil = 1
 
 /obj/item/gun/ballistic/revolver/chamber_round(spin_cylinder = TRUE)
 	if(spin_cylinder)

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -15,7 +15,6 @@
 	tac_reloads = FALSE
 	var/spin_delay = 10
 	var/recent_spin = 0
-	recoil = 1
 
 /obj/item/gun/ballistic/revolver/chamber_round(spin_cylinder = TRUE)
 	if(spin_cylinder)
@@ -134,6 +133,8 @@
 			to_chat(user, "<span class='notice'>You remove the modifications on [src]. Now it will fire .38 rounds.</span>")
 	return TRUE
 
+/obj/item/gun/ballistic/revolver/syndicate
+	recoil = 1
 
 /obj/item/gun/ballistic/revolver/mateba
 	name = "\improper Unica 6 auto-revolver"

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -58,3 +58,5 @@
 /obj/item/projectile/bullet/a357
 	name = ".357 bullet"
 	damage = 60
+	armour_penetration = -25
+	

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -456,7 +456,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 2
 	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/dangerous/revolver
+/datum/uplink_item/dangerous/revolver/syndicate
 	name = "Syndicate Revolver"
 	desc = "A brutally simple Syndicate revolver that fires .357 Magnum rounds and has 7 chambers."
 	item = /obj/item/gun/ballistic/revolver

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -456,10 +456,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 2
 	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/dangerous/revolver/syndicate
+/datum/uplink_item/dangerous/revolver
 	name = "Syndicate Revolver"
 	desc = "A brutally simple Syndicate revolver that fires .357 Magnum rounds and has 7 chambers."
-	item = /obj/item/gun/ballistic/revolver
+	item = /obj/item/gun/ballistic/revolver/syndicate
 	cost = 13
 	surplus = 50
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives Syndicate Revolver a minor recoil (screen shake), and 357 ammo is worse at armored opponents. 

## Why It's Good For The Game

Syndicate Revolver is a cancer weapon that somehow has made it this far without further nerfs, probably due to the honor (or ignorance) of players to not buy it. It doesn't matter whether or not you have HOS armor or are unarmed, you'll be dropped in 3 shots tops, and unlimited ammo can be printed. Its by far the strongest weapon you can purchase in the uplink, and is really unfair considering the current disabler nerfs. My PR makes it a bit harder to aim, and gives security members a fighting chance by making the bullets a bit worse against armor. 

## Changelog
:cl:
balance: The Syndicate Revolver now has a recoil
balance: 357 ammo is now worse at penetrating armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
