### PR TITLE
Remove another source of /datum/reagent/vanilla ice cream

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -396,7 +396,7 @@
 		if(DISPENSE_ICECREAM_MODE)
 			L = new /obj/item/reagent_containers/food/snacks/icecream(T)
 			var/obj/item/reagent_containers/food/snacks/icecream/I = L
-			I.add_ice_cream(/datum/reagent/consumable/vanilla)
+			I.add_ice_cream("vanilla")
 			I.desc = "Eat the ice cream."
 
 	var/into_hands = FALSE


### PR DESCRIPTION
my bad

fixes #44462

## Changelog
:cl: Naksu
del: /datum/reagent/vanilla ice cream has been replaced with regular vanilla ice cream in the borgs' treat fabricator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
