### PR TITLE
Add periodic cleaning of several player-containing lists to server tasks

### DIFF
--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -16,8 +16,6 @@ SUBSYSTEM_DEF(server_maint)
 /datum/controller/subsystem/server_maint/Initialize(timeofday)
 	if (CONFIG_GET(flag/hub))
 		world.update_hub_visibility(TRUE)
-	if(listclearnulls(GLOB.player_list)) // Do this here on the sly
-		log_world("Found a null in player_list!")
 	return ..()
 
 /datum/controller/subsystem/server_maint/fire(resumed = FALSE)
@@ -26,7 +24,7 @@ SUBSYSTEM_DEF(server_maint)
 			log_world("Found a null in clients list!")
 		src.currentrun = GLOB.clients.Copy()
 
-		switch (cleanup_ticker) // do only one of these per fire()
+		switch (cleanup_ticker) // do only one of these at a time, once per 5 fires
 			if (0)
 				if(listclearnulls(GLOB.player_list))
 					log_world("Found a null in player_list!")

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -8,6 +8,7 @@ SUBSYSTEM_DEF(server_maint)
 	init_order = INIT_ORDER_SERVER_MAINT
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 	var/list/currentrun
+	var/cleanup_ticker = 0
 
 /datum/controller/subsystem/server_maint/PreInit()
 	world.hub_password = "" //quickly! before the hubbies see us.
@@ -15,6 +16,8 @@ SUBSYSTEM_DEF(server_maint)
 /datum/controller/subsystem/server_maint/Initialize(timeofday)
 	if (CONFIG_GET(flag/hub))
 		world.update_hub_visibility(TRUE)
+	if(listclearnulls(GLOB.player_list)) // Do this here on the sly
+		log_world("Found a null in player_list!")
 	return ..()
 
 /datum/controller/subsystem/server_maint/fire(resumed = FALSE)
@@ -22,6 +25,32 @@ SUBSYSTEM_DEF(server_maint)
 		if(listclearnulls(GLOB.clients))
 			log_world("Found a null in clients list!")
 		src.currentrun = GLOB.clients.Copy()
+
+		switch (cleanup_ticker) // do only one of these per fire()
+			if (0)
+				if(listclearnulls(GLOB.player_list))
+					log_world("Found a null in player_list!")
+				cleanup_ticker++
+			if (5)
+				if(listclearnulls(GLOB.mob_list))
+					log_world("Found a null in mob_list!")
+				cleanup_ticker++
+			if (10)
+				if(listclearnulls(GLOB.alive_mob_list))
+					log_world("Found a null in alive_mob_list!")
+				cleanup_ticker++
+			if (15)
+				if(listclearnulls(GLOB.suicided_mob_list))
+					log_world("Found a null in suicided_mob_list!")
+				cleanup_ticker++
+			if (20)
+				if(listclearnulls(GLOB.dead_mob_list))
+					log_world("Found a null in dead_mob_list!")
+				cleanup_ticker++
+			if (25)
+				cleanup_ticker = 0
+			else
+				cleanup_ticker++
 
 	var/list/currentrun = src.currentrun
 	var/round_started = SSticker.HasRoundStarted()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This "fixes" various bugs involving these lists, most importantly the player_list one that causes people to be unable to speak. 

## Changelog
:cl: Naksu
code: Server maintenance subsystem now clears a handful of lists containing players of nulls periodically
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
