### PR TITLE
Fix missing descriptions from the electromagnetic web blob strain

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/electromagnetic_web.dm
+++ b/code/modules/antagonists/blob/blobstrains/electromagnetic_web.dm
@@ -3,6 +3,10 @@
 	name = "Electromagnetic Web"
 	color = "#83ECEC"
 	complementary_color = "#EC8383"
+	description = "will do high burn damage and EMP targets."
+	effectdesc = "will also take massively increased damage and release an EMP when killed."
+	analyzerdescdamage = "Does low burn damage and EMPs targets."
+	analyzerdesceffect = "Is fragile to all types of damage, but takes massive damage from brute. In addition, releases a small EMP when killed."
 	reagent = /datum/reagent/blob/electromagnetic_web
 
 /datum/blobstrain/reagent/electromagnetic_web/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->



## Changelog
:cl: Naksu
fix: Electromagnetic web blob strain now has its in-game descriptions back.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
