### PR TITLE
Replaces callbacks in signals with simple proc paths

### DIFF
--- a/code/controllers/subsystem/vis_overlays.dm
+++ b/code/controllers/subsystem/vis_overlays.dm
@@ -7,12 +7,10 @@ SUBSYSTEM_DEF(vis_overlays)
 	var/list/vis_overlay_cache
 	var/list/unique_vis_overlays
 	var/list/currentrun
-	var/datum/callback/rotate_cb
 
 /datum/controller/subsystem/vis_overlays/Initialize()
 	vis_overlay_cache = list()
 	unique_vis_overlays = list()
-	rotate_cb = CALLBACK(src, .proc/rotate_vis_overlay)
 	return ..()
 
 /datum/controller/subsystem/vis_overlays/fire(resumed = FALSE)
@@ -57,7 +55,7 @@ SUBSYSTEM_DEF(vis_overlays)
 
 	if(!thing.managed_vis_overlays)
 		thing.managed_vis_overlays = list(overlay)
-		RegisterSignal(thing, COMSIG_ATOM_DIR_CHANGE, rotate_cb)
+		RegisterSignal(thing, COMSIG_ATOM_DIR_CHANGE, .proc/rotate_vis_overlay)
 	else
 		thing.managed_vis_overlays += overlay
 

--- a/code/datums/components/earprotection.dm
+++ b/code/datums/components/earprotection.dm
@@ -1,11 +1,11 @@
 /datum/component/wearertargeting/earprotection
 	signals = list(COMSIG_CARBON_SOUNDBANG)
 	mobtype = /mob/living/carbon
+	proctype = .proc/reducebang
 
 /datum/component/wearertargeting/earprotection/Initialize(_valid_slots)
 	. = ..()
 	valid_slots = _valid_slots
-	callback = CALLBACK(src, .proc/reducebang)
 
 /datum/component/wearertargeting/earprotection/proc/reducebang(datum/source, list/reflist)
 	reflist[1]--

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -2,8 +2,6 @@
 	can_transfer = TRUE
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 	var/list/orbiters
-	var/datum/callback/orbiter_spy
-	var/datum/callback/orbited_spy
 
 //radius: range to orbit at, radius of the circle formed by orbiting (in pixels)
 //clockwise: whether you orbit clockwise or anti clockwise
@@ -15,8 +13,6 @@
 		return COMPONENT_INCOMPATIBLE
 
 	orbiters = list()
-	orbiter_spy = CALLBACK(src, .proc/orbiter_move_react)
-	orbited_spy = CALLBACK(src, .proc/move_react)
 
 	var/atom/master = parent
 	master.orbiters = src
@@ -26,7 +22,7 @@
 /datum/component/orbiter/RegisterWithParent()
 	var/atom/target = parent
 	while(ismovableatom(target))
-		RegisterSignal(target, COMSIG_MOVABLE_MOVED, orbited_spy)
+		RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/move_react)
 		target = target.loc
 
 /datum/component/orbiter/UnregisterFromParent()
@@ -41,8 +37,6 @@
 	for(var/i in orbiters)
 		end_orbit(i)
 	orbiters = null
-	QDEL_NULL(orbiter_spy)
-	QDEL_NULL(orbited_spy)
 	return ..()
 
 /datum/component/orbiter/InheritComponent(datum/component/orbiter/newcomp, original, list/arguments)
@@ -65,7 +59,7 @@
 			orbiter.orbiting.end_orbit(orbiter)
 	orbiters[orbiter] = TRUE
 	orbiter.orbiting = src
-	RegisterSignal(orbiter, COMSIG_MOVABLE_MOVED, orbiter_spy)
+	RegisterSignal(orbiter, COMSIG_MOVABLE_MOVED, .proc/orbiter_move_react)
 	var/matrix/initial_transform = matrix(orbiter.transform)
 
 	// Head first!
@@ -121,7 +115,7 @@
 	if(orbited?.loc && orbited.loc != newturf) // We want to know when anything holding us moves too
 		var/atom/target = orbited.loc
 		while(ismovableatom(target))
-			RegisterSignal(target, COMSIG_MOVABLE_MOVED, orbited_spy, TRUE)
+			RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/move_react, TRUE)
 			target = target.loc
 
 	var/atom/curloc = master.loc

--- a/code/datums/components/wearertargeting.dm
+++ b/code/datums/components/wearertargeting.dm
@@ -3,7 +3,7 @@
 /datum/component/wearertargeting
 	var/list/valid_slots = list()
 	var/list/signals = list()
-	var/datum/callback/callback = CALLBACK(GLOBAL_PROC, .proc/pass)
+	var/proctype = .proc/pass
 	var/mobtype = /mob/living
 
 /datum/component/wearertargeting/Initialize()
@@ -14,13 +14,9 @@
 
 /datum/component/wearertargeting/proc/on_equip(datum/source, mob/equipper, slot)
 	if((slot in valid_slots) && istype(equipper, mobtype))
-		RegisterSignal(equipper, signals, callback, TRUE)
+		RegisterSignal(equipper, signals, proctype, TRUE)
 	else
 		UnregisterSignal(equipper, signals)
 
 /datum/component/wearertargeting/proc/on_drop(datum/source, mob/user)
 	UnregisterSignal(user, signals)
-
-/datum/component/wearertargeting/Destroy()
-	QDEL_NULL(callback) //is likely to ourselves.
-	return ..()

--- a/code/modules/mob/living/simple_animal/guardian/types/gravitokinetic.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/gravitokinetic.dm
@@ -9,11 +9,6 @@
 	carp_fluff_string = "<span class='holoparasite'>CARP CARP CARP! Caught one! It's a gravitokinetic carp! Now do you understand the gravity of the situation?</span>"
 	var/list/gravito_targets = list()
 	var/gravity_power_range = 10 //how close the stand must stay to the target to keep the heavy gravity
-	var/datum/callback/distance_check
-
-/mob/living/simple_animal/hostile/guardian/gravitokinetic/Initialize()
-	. = ..()
-	distance_check = CALLBACK(src, .proc/__distance_check)
 
 /mob/living/simple_animal/hostile/guardian/gravitokinetic/AttackingTarget()
 	. = ..()
@@ -48,7 +43,7 @@
 
 /mob/living/simple_animal/hostile/guardian/gravitokinetic/proc/add_gravity(atom/A, new_gravity = 2)
     var/datum/component/C = A.AddComponent(/datum/component/forced_gravity,new_gravity)
-    RegisterSignal(A, COMSIG_MOVABLE_MOVED, distance_check)
+    RegisterSignal(A, COMSIG_MOVABLE_MOVED, .proc/__distance_check)
     gravito_targets.Add(C)
     playsound(src, 'sound/effects/gravhit.ogg', 100, 1)
 


### PR DESCRIPTION
## About The Pull Request

This removes the use of callbacks in signals. There are multiple benefits and a couple downsides to this.

Pros:
- Less memory usage per registered signal
- Signal registration has slightly better performance
- Signal sending has an even smaller benefit to performance but the amount is so minuscule it doesn't really mean anything
- You can no longer register signals such that a third party is in charge of relaying a signal between two other objects. This prevents a whole class of qdel bugs.
- You can no longer provide static arguments to receiver procs. If you need a new argument then handle your state properly instead of hiding it in callbacks.
- Fixes one of the reasons that named arguments don't work in signals. Doesn't make them functional though (yet)

Cons:
- You can no longer call global procs with signals. This could be changed if we want this to be supported.
- You can no longer provide static arguments to receiver procs. This means you can't easily provide one off variables for a particular usage without new vars stored in the object itself.

Some really rough memory profiling shows that this saves about 20-30mb memory roundstart.

Also this pr fixes signals behaving slightly differently when called with one vs many receivers.
