### PR TITLE
Fixes permeability protection runtime

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -88,7 +88,7 @@
 	else
 		return initial(pixel_x)
 
-/mob/living/carbon/alien/humanoid/get_permeability_protection(list/target_zones)
+/mob/living/carbon/alien/humanoid/get_permeability_protection(list/target_zones = list(HANDS = 0, CHEST = 0, GROIN = 0, LEGS = 0, FEET = 0, ARMS = 0, HEAD = 0))
 	return 0.8
 
 /mob/living/carbon/alien/humanoid/alien_evolve(mob/living/carbon/alien/humanoid/new_xeno)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -909,7 +909,7 @@
 	return 1
 
 //used in datum/reagents/reaction() proc
-/mob/living/proc/get_permeability_protection(list/target_zones)
+/mob/living/proc/get_permeability_protection(list/target_zones = list(HANDS = 0, CHEST = 0, GROIN = 0, LEGS = 0, FEET = 0, ARMS = 0, HEAD = 0))
 	return 0
 
 /mob/living/proc/harvest(mob/living/user) //used for extra objects etc. in butchering


### PR DESCRIPTION
Reagent code no longer runtimes when calling on objects cast as
mob/living when they're mob/living/carbon due to inheriting the parent
procs default arguments instead
```
[23:33:02] Runtime in carbon.dm,620: list index out of bounds
  proc name: get permeability protection (/mob/living/carbon/get_permeability_protection)
  usr: JuhanSuman/(Sid Boyebin)
  usr.loc: (Custodial Closet (149, 108, 2))
  src: Sid Boyebin (/mob/living/carbon/human)
  src.loc: the floor (149,108,2) (/turf/open/floor/plasteel)
  call stack:
  Sid Boyebin (/mob/living/carbon/human): get permeability protection(null)
  /datum/reagents (/datum/reagents): reaction(Sid Boyebin (/mob/living/carbon/human), 3, 1, 1)
  the space cleaner (/obj/item/reagent_containers/spray/cleaner): do spray(the toolbelt (/obj/item/storage/belt/utility), 5, the chemicals (/obj/effect/decal/chempuff), 1, 1, Sid Boyebin (/mob/living/carbon/human))
[23:33:03] Runtime in carbon.dm,620: list index out of bounds
```