### PR TITLE
miasma temp and pressure

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -360,9 +360,14 @@
 		return
 
 	var/turf/T = get_turf(H)
+
+	if(!istype(T) || T.return_air().return_pressure() > (WARNING_HIGH_PRESSURE - 10))
+		return
+
 	var/datum/gas_mixture/stank = new
 	ADD_GAS(/datum/gas/miasma, stank.gases)
 	stank.gases[/datum/gas/miasma][MOLES] = MIASMA_HYGIENE_MOLES
+	stank.temperature = T20C
 	T.assume_air(stank)
 	T.air_update_turf()
 

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -367,7 +367,7 @@
 	var/datum/gas_mixture/stank = new
 	ADD_GAS(/datum/gas/miasma, stank.gases)
 	stank.gases[/datum/gas/miasma][MOLES] = MIASMA_HYGIENE_MOLES
-	stank.temperature = T20C
+	stank.temperature = BODYTEMP_NORMAL
 	T.assume_air(stank)
 	T.air_update_turf()
 

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -14,12 +14,13 @@
 	var/atom/A = parent
 
 	var/turf/open/T = get_turf(A)
-	if(!istype(T))
+	if(!istype(T) || T.return_air().return_pressure() > (WARNING_HIGH_PRESSURE - 10))
 		return
 
 	var/datum/gas_mixture/stank = new
 	ADD_GAS(/datum/gas/miasma, stank.gases)
 	stank.gases[/datum/gas/miasma][MOLES] = amount
+	stank.temperature = T20C // otherwise we have gas below 2.7K which will break our lag generator
 	T.assume_air(stank)
 	T.air_update_turf()
 

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -20,7 +20,7 @@
 	var/datum/gas_mixture/stank = new
 	ADD_GAS(/datum/gas/miasma, stank.gases)
 	stank.gases[/datum/gas/miasma][MOLES] = amount
-	stank.temperature = T20C // otherwise we have gas below 2.7K which will break our lag generator
+	stank.temperature = BODYTEMP_NORMAL // otherwise we have gas below 2.7K which will break our lag generator
 	T.assume_air(stank)
 	T.air_update_turf()
 


### PR DESCRIPTION
## About The Pull Request
Miasma now spawns at normal bodytemp or 310.15 kelvin instead of 0 kelvin and it stops spawning above 315 kpa


## Why It's Good For The Game
Having a way to make something below 0 kelvin is very bad in many ways, also miasma requiring pressure conditions will only effect people directly trying to farm miasma from monkey rooms or etc


## Changelog
:cl: granpawalton
tweak: miasma now only spawns below 315 kpa
fix: miasma now spawns at room temperature instead of 0 kelvin
/:cl: