### PR TITLE
Makes beepsky smash less real

### DIFF
--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -195,6 +195,7 @@
 	gain_text = "<span class='warning'>Justice is coming for you.</span>"
 	lose_text = "<span class='notice'>You were absolved for your crimes.</span>"
 	clonable = FALSE
+	random_gain = FALSE
 	var/obj/effect/hallucination/simple/securitron/beepsky
 
 /datum/brain_trauma/special/beepsky/on_gain()
@@ -211,24 +212,26 @@
 	..()
 
 /datum/brain_trauma/special/beepsky/on_life()
+	if(QDELETED(beepsky) || !beepsky.loc || beepsky.z != owner.z)
+		QDEL_NULL(beepsky)
+		if(prob(30))
+			create_securitron()
+		else
+			return
 	if(get_dist(owner, beepsky) >= 10 && prob(20))
 		QDEL_NULL(beepsky)
 		create_securitron()
 	if(owner.stat != CONSCIOUS)
 		if(prob(20))
-			playsound(owner, 'sound/voice/beepsky/iamthelaw.ogg', 50)
+			owner.playsound_local(beepsky, 'sound/voice/beepsky/iamthelaw.ogg', 50)
 		return
-	if(QDELETED(beepsky) || !beepsky.loc || beepsky.z != owner.z)
-		QDEL_NULL(beepsky)
-		create_securitron()
 	if(get_dist(owner, beepsky) <= 1)
-		playsound(owner, 'sound/weapons/egloves.ogg', 50)
-		owner.visible_message("<span class='warning'>[owner] tries to fight the law.</span>", "<span class='userdanger'>You feel the fist of the LAW.</span>")
-		owner.take_bodypart_damage(0,0,rand(30, 50))
+		owner.playsound_local(owner, 'sound/weapons/egloves.ogg', 50)
+		owner.visible_message("<span class='warning'>[owner]'s body jerks as if it was shocked.</span>", "<span class='userdanger'>You feel the fist of the LAW.</span>")
+		owner.take_bodypart_damage(0,0,rand(40, 70))
 		QDEL_NULL(beepsky)
-		create_securitron()
 	if(prob(20) && get_dist(owner, beepsky) <= 8)
-		playsound(owner, 'sound/voice/beepsky/criminal.ogg', 40)
+		owner.playsound_local(beepsky, 'sound/voice/beepsky/criminal.ogg', 40)
 	..()
 
 /obj/effect/hallucination/simple/securitron
@@ -247,7 +250,7 @@
 	if(prob(60))
 		forceMove(get_step_towards(src, victim))
 		if(prob(5))
-			say("Level 10 infraction alert!")
+			to_chat(victim, "<span class='name'>[name]</span> exclaims, \"<span class='robotic'>Level 10 infraction alert!\"</span>")
 
 /obj/effect/hallucination/simple/securitron/Destroy()
 	STOP_PROCESSING(SSfastprocess,src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the beepsky spawned from beepsky smash properly undetectable from others.
Removed the beepsky trauma from the random trauma pool.
Makes the beepskys spawn less often, but increased their damage in return, making it less spammy.
Fixes  #44246

## Why It's Good For The Game

Hallucinations should never affect or be detectable by others unless they are special or magic.

## Changelog
:cl: XDTM
fix: Beepskys spawned from Beepsky Smash can no longer be heard by bystanders.
fix: The beepsky smash trauma can no longer be gained as a special trauma.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
