### PR TITLE
Fixes teleportation deleting mob spawners

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -15,6 +15,7 @@
 		)) - typecacheof(list(
 		/obj/effect/dummy/chameleon,
 		/obj/effect/wisp,
+		/obj/effect/mob_spawn,
 		))
 	if(delete_atoms[teleatom.type])
 		qdel(teleatom)


### PR DESCRIPTION
## About The Pull Request

Fixes #24352

## Changelog
:cl: XDTM
fix: Fixed teleportation deleting mob spawners like golem shells and ashwalker eggs.
/:cl:
