### PR TITLE
Fixes livers not being damaged by toxins

### DIFF
--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -32,17 +32,14 @@
 			var/provide_pain_message = HAS_NO_TOXIN
 			if(filterToxins && !HAS_TRAIT(owner, TRAIT_TOXINLOVER))
 				//handle liver toxin filtration
-				for(var/I in C.reagents.reagent_list)
-					var/datum/reagent/pickedreagent = I
-					if(istype(pickedreagent, /datum/reagent/toxin))
-						var/thisamount = C.reagents.get_reagent_amount(pickedreagent)
-						if (thisamount <= toxTolerance && thisamount)
-							C.reagents.remove_reagent(pickedreagent, 1)
-						else
-							damage += (thisamount*toxLethality)
-							var/datum/reagent/toxin/found_toxin = pickedreagent
-							if(provide_pain_message != HAS_PAINFUL_TOXIN)
-								provide_pain_message = found_toxin.silent_toxin ? HAS_SILENT_TOXIN : HAS_PAINFUL_TOXIN
+				for(var/datum/reagent/toxin/T in C.reagents.reagent_list)
+					var/thisamount = C.reagents.get_reagent_amount(T.type)
+					if (thisamount <= toxTolerance && thisamount)
+						C.reagents.remove_reagent(T.type, 1)
+					else
+						damage += (thisamount*toxLethality)
+						if(provide_pain_message != HAS_PAINFUL_TOXIN)
+							provide_pain_message = T.silent_toxin ? HAS_SILENT_TOXIN : HAS_PAINFUL_TOXIN
 
 			//metabolize reagents
 			C.reagents.metabolize(C, can_overdose=TRUE)

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -34,7 +34,7 @@
 				//handle liver toxin filtration
 				for(var/datum/reagent/toxin/T in C.reagents.reagent_list)
 					var/thisamount = C.reagents.get_reagent_amount(T.type)
-					if (thisamount <= toxTolerance && thisamount)
+					if (thisamount && thisamount <= toxTolerance)
 						C.reagents.remove_reagent(T.type, 1)
 					else
 						damage += (thisamount*toxLethality)


### PR DESCRIPTION
:cl:
fix: Fixed livers not being damaged by toxins
/:cl:
Fixes #44270

`get_reagent_amount` and `remove_reagent` expect types not references
https://github.com/tgstation/tgstation/blob/4bc7b04386f58faf05779ffd09ff241d0d7add23/code/modules/reagents/chemistry/holder.dm#L674
https://github.com/tgstation/tgstation/blob/4bc7b04386f58faf05779ffd09ff241d0d7add23/code/modules/reagents/chemistry/holder.dm#L628

Also replaced a type-less loop followed by a type check with a typed loop