### PR TITLE
Buffs mime bullets

### DIFF
--- a/code/modules/projectiles/projectile/bullets/special.dm
+++ b/code/modules/projectiles/projectile/bullets/special.dm
@@ -18,7 +18,7 @@
 // Mime
 
 /obj/item/projectile/bullet/mime
-	damage = 20
+	damage = 40
 
 /obj/item/projectile/bullet/mime/on_hit(atom/target, blocked = FALSE)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

this is my first PR oh geez oh fugg

This PR increases the damage dealt by mime bullets from 20 damage to 40 damage.

## Why It's Good For The Game

Mime bullets are fired by two weapons in the game (the Finger Guns spell and the Reticence's Quietus carbine), both of which are drastically in need of a buff due to the absolutely abysmal damage dealt by mime bullets.

As mentioned earlier, mime bullets currently deal 20 damage each. For comparison, 10mm stechkin bullets (the "standard" stechkin bullets) deal 30 damage each and the .357 bullets that the syndicate revolver fires deal 60 damage each. In exchange for its pathetic damage output, a mime bullet mutes targets for 10 seconds upon every hit. And before you ask, no, it doesn't stack past 10 seconds. Because of course it doesn't.

The Finger Guns spell (which traitor mimes can learn if they buy the Guide to Advanced Mimery series) allows its caster to fire 3 mime bullets before needing to go on cooldown for 30 seconds. In case you don't want to do some basic math, 3*20=60. That's right, a once-per-30-seconds volley from a Finger Guns spell cannot bring a (full health) naked monkeyman down to even 1/3 of its above-crit health if every shot from it hits the monkeyman at point blank range. That is just PATHETIC, and it's really sad to see a new mime traitor player think that their ability that is supposed to create a GUN has a half-decent damage output.

The Reticence, however, has things even worse: its default carbine can only fire one mime bullet every THREE SECONDS. Since the Quietus's ammo capacity is 6, that means that even if you hit every shot in a solo fight against a (full health) monkeyman wearing basic (roundstart) sec armor, you will have to RELOAD YOUR CARBINE MID-FIGHT in order to even knock that monkeyman into crit (even if you reload instantly, the fight will still take at least 20 seconds due to the Quietus's 3 second cooldown between shots). Right now, people who TC trade for a Reticence are better off immediately ditching their Quietus gun and grabbing literally any other mech gun from robotics (except maybe a plasma cutter), which I think is a bit sad, seeing as how the Quietus could offer a very interesting and unique playstyle for a Reticence mech's pilot if it wasn't absolute garbage.

After this buff, a volley from a mime's Finger Guns spell will be able to knock a (full health) naked monkeyman into crit if all three shots from it hit. It will still be unable to knock someone (with full health) who is wearing basic (roundstart) sec armor into crit in a single volley without assistance from other weapons/outside sources, however, giving its unique muteness effect some time to shine as you rush in with a melee weapon or the like (the muteness will also have time to shine if you miss one of your three shots (but not if you miss all of them, I suppose), which you most likely will do if your target isn't braindead and you aren't a combat god). Also, the Reticence's Quietus carbine won't take an actual century to kill people, instead taking a mere 9 seconds (minimum, assuming no outside factors) to knock a (full health) naked monkeyman into crit.

EDIT: People on Discord and in the comments section of this PR that 40 damage is the slowdown threshold, so this PR will make a single mime bullet slow down a (full health) unarmored target with a single hit. If people feel like this PR would make Finger Guns too strong, some potential Finger Guns nerfs have been proposed in the comments section by me and others.

## Changelog
:cl: ATHATH
balance: Doubled the damage of the bullets fired by the Finger Guns spell (from the Guide to Advanced Mimery Vol 2 book) and the Reticence's unique carbine.
/:cl: