### PR TITLE
Fixes silicon items being destroyed by explosion epicenters

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -72,6 +72,9 @@
 /mob/living/silicon/contents_explosion(severity, target)
 	return
 
+/mob/living/silicon/prevent_content_explosion()
+	return TRUE
+
 /mob/living/silicon/proc/cancelAlarm()
 	return
 


### PR DESCRIPTION
:cl:
fix: Fixed silicon items (e.g. cyborg modules) being destroyed by explosion epicenters
/:cl:
Fixes #44131
Fixes #36310
Fixes #33175
Fixes #42727

For anyone unfamiliar with the explosion code, `prevent_content_explosion` is unrelated to `contents_explosion` which is why we have to override both.