### PR TITLE
Normally non-dense mobs no longer block projectiles

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -543,6 +543,8 @@
 	else
 		var/mob/living/L = target
 		if(!direct_target)
+			if(!initial(L.density)) //If they're always non-dense (e.g. mice), the projectile can pass over
+				return FALSE
 			if(!CHECK_BITFIELD(L.mobility_flags, MOBILITY_USE | MOBILITY_STAND | MOBILITY_MOVE) || !(L.stat == CONSCIOUS))		//If they're able to 1. stand or 2. use items or 3. move, AND they are not softcrit,  they are not stunned enough to dodge projectiles passing over.
 				return FALSE
 	return TRUE


### PR DESCRIPTION
:cl:
fix: Normally non-dense mobs (e.g. mice, bees, drones) no longer block projectiles
/:cl:
Closes #44143
Closes #42656
Closes #44578
Closes #43804
Closes #44137

I don't know if this is a good idea to bring back but it keeps getting reported as a bug.

It seems the intention of #40931 was specifically to target crawling humans (or monkeys or whatever), so I'm labeling this as a fix, though a maintainer can change it if they disagree.