### PR TITLE
Fixes revenants getting hit by projectiles

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -181,6 +181,11 @@
 /mob/living/simple_animal/revenant/ratvar_act()
 	return //clocks get out reee
 
+/mob/living/simple_animal/revenant/bullet_act()
+	if(!revealed || stasis)
+		return BULLET_ACT_FORCE_PIERCE
+	return ..()
+
 //damage, gibbing, and dying
 /mob/living/simple_animal/revenant/attackby(obj/item/W, mob/living/user, params)
 	. = ..()


### PR DESCRIPTION
:cl:
fix: Revenants will no longer be hit by projectiles while hidden
/:cl:
Closes #43804
Closes #44137

This is mostly if #44616 isn't liked, but it also fixes an edge case where a projectile could hit a revenant if the revenant was clicked on but became hidden before the projectile actually reached the revenant.