### PR TITLE
Better sheath

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -76,6 +76,12 @@
 		final_block_chance = 0 //Don't bring a sword to a gunfight
 	return ..()
 
+/obj/item/melee/sabre/on_exit_storage(datum/component/storage/concrete/S)
+	playsound(src, 'sound/items/unsheath.ogg', 25, 1)
+
+/obj/item/melee/sabre/on_enter_storage(datum/component/storage/concrete/S)
+	playsound(src, 'sound/items/sheath.ogg', 25, 1)
+
 /obj/item/melee/sabre/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is trying to cut off all [user.p_their()] limbs with [src]! it looks like [user.p_theyre()] trying to commit suicide!</span>")
 	var/i = 0

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -77,12 +77,12 @@
 	return ..()
 
 /obj/item/melee/sabre/on_exit_storage(datum/component/storage/concrete/S)
-	var/obj/item/storage/belt/sheath/B = S.real_location()
+	var/obj/item/storage/belt/sheath/sabre/B = S.real_location()
 	if(istype(B))
 		playsound(src, 'sound/items/unsheath.ogg', 25, 1)
 
 /obj/item/melee/sabre/on_enter_storage(datum/component/storage/concrete/S)
-	var/obj/item/storage/belt/sheath/B = S.real_location()
+	var/obj/item/storage/belt/sheath/sabre/B = S.real_location()
 	if(istype(B))
 		playsound(src, 'sound/items/sheath.ogg', 25, 1)
 

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -76,18 +76,6 @@
 		final_block_chance = 0 //Don't bring a sword to a gunfight
 	return ..()
 
-/obj/item/melee/sabre/on_exit_storage(obj/item/storage/S)
-	..()
-	var/obj/item/storage/belt/sabre/B = S
-	if(istype(B))
-		playsound(B, 'sound/items/unsheath.ogg', 25, 1)
-
-/obj/item/melee/sabre/on_enter_storage(obj/item/storage/S)
-	..()
-	var/obj/item/storage/belt/sabre/B = S
-	if(istype(B))
-		playsound(B, 'sound/items/sheath.ogg', 25, 1)
-
 /obj/item/melee/sabre/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is trying to cut off all [user.p_their()] limbs with [src]! it looks like [user.p_theyre()] trying to commit suicide!</span>")
 	var/i = 0

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -77,10 +77,14 @@
 	return ..()
 
 /obj/item/melee/sabre/on_exit_storage(datum/component/storage/concrete/S)
-	playsound(src, 'sound/items/unsheath.ogg', 25, 1)
+	var/obj/item/storage/belt/sheath/B = S.real_location()
+	if(istype(B))
+		playsound(src, 'sound/items/unsheath.ogg', 25, 1)
 
 /obj/item/melee/sabre/on_enter_storage(datum/component/storage/concrete/S)
-	playsound(src, 'sound/items/sheath.ogg', 25, 1)
+	var/obj/item/storage/belt/sheath/B = S.real_location()
+	if(istype(B))
+		playsound(src, 'sound/items/sheath.ogg', 25, 1)
 
 /obj/item/melee/sabre/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is trying to cut off all [user.p_their()] limbs with [src]! it looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -642,7 +642,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	var/hold_type
 
-/obj/item/storage/belt/sheath/Initialize()
+/obj/item/storage/belt/sheath/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 1

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -636,50 +636,63 @@
 	item_state = "fannypack_yellow"
 	item_color = "yellow"
 
-/obj/item/storage/belt/sabre
-	name = "sabre sheath"
-	desc = "An ornate sheath designed to hold an officer's blade."
+/obj/item/storage/belt/sheath
 	icon_state = "sheath"
 	item_state = "sheath"
 	w_class = WEIGHT_CLASS_BULKY
+	var/hold_type
 
-/obj/item/storage/belt/sabre/ComponentInitialize()
+/obj/item/storage/belt/sheath/Initialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 1
 	STR.rustle_sound = FALSE
 	STR.max_w_class = WEIGHT_CLASS_BULKY
 	STR.set_holdable(list(
-		/obj/item/melee/sabre
+		hold_type
 		))
+	update_icon()
 
-/obj/item/storage/belt/sabre/examine(mob/user)
-	. = ..()
-	if(length(contents))
-		. += "<span class='notice'>Alt-click it to quickly draw the blade.</span>"
+/obj/item/storage/belt/sheath/attack_hand(mob/user)
+	if(loc == user)
+		if(!iscarbon(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
+			return
+		if(length(contents))
+			user.visible_message("<span class='notice'>[user] takes \the [contents[1]] out of \the [src].</span>", "<span class='notice'>You take [contents[1]] out of [src].</span>")
+			user.put_in_hands(contents[1])
+			playsound(src, 'sound/items/unsheath.ogg', 25, TRUE)
+			update_icon()
+			return
+	return ..()
 
-/obj/item/storage/belt/sabre/AltClick(mob/user)
-	if(!iscarbon(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
+/obj/item/storage/belt/sheath/attackby(obj/item/I, mob/living/user)
+	if(!istype(I, hold_type))
+		to_chat(user, "<span class='warning'>\The [I] doesn't seem to fit into \the [src]...</span>")
 		return
-	if(length(contents))
-		var/obj/item/I = contents[1]
-		user.visible_message("[user] takes [I] out of [src].", "<span class='notice'>You take [I] out of [src].</span>")
-		user.put_in_hands(I)
+	if(user.transferItemToLoc(I, src))
+		playsound(src, 'sound/items/sheath.ogg', 25, TRUE)
+		user.visible_message("<span class='notice'>[user] puts \the [I] into \the [src].</span>", "<span class='notice'>You take \the [contents[1]] out of \the [src].</span>")
 		update_icon()
-	else
-		to_chat(user, "[src] is empty.")
+		return
+	return ..()
 
-/obj/item/storage/belt/sabre/update_icon()
-	icon_state = "sheath"
-	item_state = "sheath"
-	if(contents.len)
-		icon_state += "-sabre"
-		item_state += "-sabre"
+/obj/item/storage/belt/sheath/update_icon()
+	if(!length(contents))
+		icon_state = initial(icon_state)
+		item_state = initial(icon_state)
+	else
+		icon_state = "[initial(icon_state)]-sabre"
+		item_state = "[initial(icon_state)]-sabre"
 	if(loc && isliving(loc))
 		var/mob/living/L = loc
 		L.regenerate_icons()
-	..()
+	return ..()
 
-/obj/item/storage/belt/sabre/PopulateContents()
-	new /obj/item/melee/sabre(src)
+/obj/item/storage/belt/sheath/PopulateContents()
+	new hold_type(src)
 	update_icon()
+
+/obj/item/storage/belt/sheath/sabre
+	name = "sabre sheath"
+	desc = "An ornate sheath designed to hold an officer's blade."
+	hold_type = /obj/item/melee/sabre

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -36,8 +36,8 @@
 	return ..()
 
 /obj/item/storage/contents_explosion(severity, target)
-//Cyberboss says: "USE THIS TO FILL IT, NOT INITIALIZE OR NEW"
 
+//Cyberboss says: "USE THIS TO FILL IT, NOT INITIALIZE OR NEW"
 /obj/item/storage/proc/PopulateContents()
 
 /obj/item/storage/proc/emptyStorage()

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -28,7 +28,7 @@
 	new /obj/item/clothing/glasses/sunglasses/gar/supergar(src)
 	new /obj/item/clothing/gloves/color/captain(src)
 	new /obj/item/restraints/handcuffs/cable/zipties(src)
-	new /obj/item/storage/belt/sabre(src)
+	new /obj/item/storage/belt/sheath/sabre(src)
 	new /obj/item/gun/energy/e_gun(src)
 	new /obj/item/door_remote/captain(src)
 	new /obj/item/card/id/captains_spare(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the captain's saber sheath less shitty.
Click to remove the sword, click the sheath with the sword to put it back. Click drag it to hand to get it out of slots, you know the drill.
It's still a one slot storage so all hotkeys still work.

Also fixed an absolutely ancient bug where the sheath wasn't playing sound effects for drawing and removing the sword

## Why It's Good For The Game

less clunk
fix bug
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: streamlined the captain's saber sheath
fix: captain's saber sheath plays sounds like it should
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
