### PR TITLE
Restricts WIP pull requests and adds some guidelines regarding code unfinished in other ways

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -394,6 +394,10 @@ There is no strict process when it comes to merging pull requests. Pull requests
 
 * Please explain why you are submitting the pull request, and how you think your change will be beneficial to the game. Failure to do so will be grounds for rejecting the PR.
 
+* If your pull request is not finished make sure it is at least testable in a live environment. Pull requests that do not at least meet this requirement will be closed. You may request a maintainer reopen the pull request when you're ready, or make a new one.
+
+* Maintainers may close pull requests that are deemed to be substantialy flawed. For example pull requests which would need major rewrites to match our quality guidelines. You should take some time to discuss with maintainers or other contributors on how to improve the change.
+
 ## Porting features/sprites/sounds/tools from other codebases
 
 If you are porting features/tools from other codebases, you must give them credit where it's due. Typically, crediting them in your pull request and the changelog is the recommended way of doing it. Take note of what license they use though, porting stuff from AGPLv3 and GPLv3 codebases are allowed.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -396,7 +396,7 @@ There is no strict process when it comes to merging pull requests. Pull requests
 
 * If your pull request is not finished make sure it is at least testable in a live environment. Pull requests that do not at least meet this requirement will be closed. You may request a maintainer reopen the pull request when you're ready, or make a new one.
 
-* Maintainers may close pull requests that are deemed to be substantialy flawed. For example pull requests which would need major rewrites to match our quality guidelines. You should take some time to discuss with maintainers or other contributors on how to improve the change.
+* While we have no issue helping contributors (and especially new contributors) bring reasonably sized contributions up to standards via the pull request review process, larger contributions are expected to pass a higher bar of completeness and code quality *before* you open a pull request. Maintainers may close such pull requests that are deemed to be substantially flawed. You should take some time to discuss with maintainers or other contributors on how to improve the changes.
 
 ## Porting features/sprites/sounds/tools from other codebases
 


### PR DESCRIPTION
We've had many bad code changes get through pull requests because of the following:

1. Large and complex pull request gets created
2. It is flawed and is a massive pain to review to deal with those flaws
3. Reviews are nonetheless attempted (or not) and some things improve but is overall still flawed
4. After a while it gets pity merged or merged because we hope it will be improved later and because the maintainers reviewing it have become exhausted by that pr
5. We now have another pile of shitcode that never gets improved

Pull requests in the past tried by people who don't have enough experience with writing clean code depend on maintainers pointing out every flaw. This encourages contributors to not really care about improving themselves and just pr things that work technically. If they want to improve the very concept of how they achieve these large changes they should discuss these things ahead of time with others.

Merging these large changes that barely work hurts us more than we lose by not allowing these changes on principle. In the end we may even end up with our contributors caring more about the quality of their code.
