### PR TITLE
Adds more box crafting types to cardboard 

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -343,7 +343,7 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	new/datum/stack_recipe("folder", /obj/item/folder), \
 	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4), \
 	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5), \
-	))
+))
 
 /obj/item/stack/sheet/cardboard	//BubbleWrap //it's cardboard you fuck
 	name = "cardboard"

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -317,11 +317,12 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
  * Cardboard
  */
 GLOBAL_LIST_INIT(cardboard_recipes, list ( \
+	new/datum/stack_recipe("folder", /obj/item/folder), \
 	new/datum/stack_recipe("box", /obj/item/storage/box), \
 	new/datum/stack_recipe("light tubes", /obj/item/storage/box/lights/tubes), \
 	new/datum/stack_recipe("light bulbs", /obj/item/storage/box/lights/bulbs), \
 	new/datum/stack_recipe("disk box", /obj/item/storage/box/disks), \
-	new/datum/stack_recipe("pillbittle box", /obj/item/storage/box/pillbottles), \	
+	new/datum/stack_recipe("pillbittle box", /obj/item/storage/box/pillbottles), \
 	new/datum/stack_recipe("beaker box", /obj/item/storage/box/beakers), \
 	new/datum/stack_recipe("mouse traps", /obj/item/storage/box/mousetraps), \
 	new/datum/stack_recipe("candle box", /obj/item/storage/fancy/candle_box), \
@@ -335,12 +336,11 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	new/datum/stack_recipe("rubber shot ammo box", /obj/item/storage/box/rubbershot), \
 	new/datum/stack_recipe("bean bag ammo box", /obj/item/storage/box/beanbag), \
 	new/datum/stack_recipe("syringe box", /obj/item/storage/box/syringes), \
-	new/datum/stack_recipe("flashbang bpx", /obj/item/storage/box/flashbangs), \
+	new/datum/stack_recipe("flashbang box", /obj/item/storage/box/flashbangs), \
 	new/datum/stack_recipe("flashes box", /obj/item/storage/box/flashes), \
 	null, \
 	new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3), \
 	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg), \
-	new/datum/stack_recipe("folder", /obj/item/folder), \
 	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4), \
 	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5), \
 ))

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -331,7 +331,6 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	new/datum/stack_recipe("donut box", /obj/item/storage/fancy/donut_box), \
 	new/datum/stack_recipe("egg box", /obj/item/storage/fancy/egg_box), \
 	null, \
-	new/datum/stack_recipe("sec box", /obj/item/storage/box/seclooking), \
 	new/datum/stack_recipe("lethal ammo box", /obj/item/storage/box/lethalshot), \
 	new/datum/stack_recipe("rubber shot ammo box", /obj/item/storage/box/rubbershot), \
 	new/datum/stack_recipe("bean bag ammo box", /obj/item/storage/box/beanbag), \

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -320,17 +320,26 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	new/datum/stack_recipe("box", /obj/item/storage/box), \
 	new/datum/stack_recipe("light tubes", /obj/item/storage/box/lights/tubes), \
 	new/datum/stack_recipe("light bulbs", /obj/item/storage/box/lights/bulbs), \
+	new/datum/stack_recipe("disk box", /obj/item/storage/box/disks), \
+	new/datum/stack_recipe("pillbittle box", /obj/item/storage/box/pillbottles), \	
+	new/datum/stack_recipe("beaker box", /obj/item/storage/box/beakers), \
 	new/datum/stack_recipe("mouse traps", /obj/item/storage/box/mousetraps), \
+	new/datum/stack_recipe("pizza box", /obj/item/pizzabox), \
+	null, \
+	new/datum/stack_recipe("sec box", /obj/item/storage/box/seclooking), \
+	new/datum/stack_recipe("lethal ammo box", /obj/item/storage/box/lethalshot), \
+	new/datum/stack_recipe("rubber shot ammo box", /obj/item/storage/box/rubbershot), \
+	new/datum/stack_recipe("bean bag ammo box", /obj/item/storage/box/beanbag), \
+	new/datum/stack_recipe("syringe box", /obj/item/storage/box/syringes), \
+	new/datum/stack_recipe("flashbang bpx", /obj/item/storage/box/flashbangs), \
+	new/datum/stack_recipe("flashes box", /obj/item/storage/box/flashes), \
+	null, \
 	new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3), \
 	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg), \
-	new/datum/stack_recipe("pizza box", /obj/item/pizzabox), \
-	new/datum/stack_recipe("donut box", /obj/item/storage/fancy/donut_box), \
-	new/datum/stack_recipe("egg box", /obj/item/storage/fancy/egg_box), \
-	new/datum/stack_recipe("candle box", /obj/item/storage/fancy/candle_box), \
 	new/datum/stack_recipe("folder", /obj/item/folder), \
 	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4), \
-	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5), \
-))
+	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5) \
+	))
 
 /obj/item/stack/sheet/cardboard	//BubbleWrap //it's cardboard you fuck
 	name = "cardboard"

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -322,7 +322,7 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	new/datum/stack_recipe("light tubes", /obj/item/storage/box/lights/tubes), \
 	new/datum/stack_recipe("light bulbs", /obj/item/storage/box/lights/bulbs), \
 	new/datum/stack_recipe("disk box", /obj/item/storage/box/disks), \
-	new/datum/stack_recipe("pillbittle box", /obj/item/storage/box/pillbottles), \
+	new/datum/stack_recipe("pillbottle box", /obj/item/storage/box/pillbottles), \
 	new/datum/stack_recipe("beaker box", /obj/item/storage/box/beakers), \
 	new/datum/stack_recipe("mouse traps", /obj/item/storage/box/mousetraps), \
 	new/datum/stack_recipe("candle box", /obj/item/storage/fancy/candle_box), \

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -324,7 +324,11 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	new/datum/stack_recipe("pillbittle box", /obj/item/storage/box/pillbottles), \	
 	new/datum/stack_recipe("beaker box", /obj/item/storage/box/beakers), \
 	new/datum/stack_recipe("mouse traps", /obj/item/storage/box/mousetraps), \
+	new/datum/stack_recipe("candle box", /obj/item/storage/fancy/candle_box), \
+	null, \
 	new/datum/stack_recipe("pizza box", /obj/item/pizzabox), \
+	new/datum/stack_recipe("donut box", /obj/item/storage/fancy/donut_box), \
+	new/datum/stack_recipe("egg box", /obj/item/storage/fancy/egg_box), \
 	null, \
 	new/datum/stack_recipe("sec box", /obj/item/storage/box/seclooking), \
 	new/datum/stack_recipe("lethal ammo box", /obj/item/storage/box/lethalshot), \
@@ -338,7 +342,7 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg), \
 	new/datum/stack_recipe("folder", /obj/item/folder), \
 	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4), \
-	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5) \
+	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5), \
 	))
 
 /obj/item/stack/sheet/cardboard	//BubbleWrap //it's cardboard you fuck


### PR DESCRIPTION
Clearly the best idea

## About The Pull Request

Simply makes more types of boxes craftable via cardboard

## Why It's Good For The Game

I thought I already added these, I don't know why I didn't!
Anywho Its to help inventory management. As well as helps other people maybe know what your keeping at a glace in your bag! This also helps warden/barkeep get more thematic ammo boxes rather then using normal boxes/paper bags.

## Changelog
:cl:
add: cardboard box options
/:cl: