### PR TITLE
Click messages 

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -8,7 +8,7 @@
 	var/triggered = 0
 
 /obj/effect/mine/proc/mineEffect(mob/victim)
-	to_chat(victim, "<span class='danger'>*click*</span>")
+	to_chat(victim, "<span class='italics'>\The [src] clicks!</span>")
 
 /obj/effect/mine/Crossed(AM as mob|obj)
 	if(isturf(loc))

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -203,7 +203,7 @@
 		return
 	src.add_fingerprint(user)
 	if (src.bullets < 1)
-		user.show_message("<span class='warning'>*click*</span>", 2)
+		audible_message("<span class='italics'>\The [src] clicks!</span>", 2)
 		playsound(src, 'sound/weapons/gun_dry_fire.ogg', 30, TRUE)
 		return
 	playsound(user, 'sound/weapons/gunshot.ogg', 100, 1)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -203,7 +203,9 @@
 		return
 	src.add_fingerprint(user)
 	if (src.bullets < 1)
-		audible_message("<span class='italics'>\The [src] clicks!</span>", 2)
+		user.visible_message("<span class='italics'>[user]'s [src.name] clicks!</span>", \
+							"<span class='italics'>\The [src] clicks!</span>", \
+							"<span class='italics'>You hear a click!</span>", COMBAT_MESSAGE_RANGE)
 		playsound(src, 'sound/weapons/gun_dry_fire.ogg', 30, TRUE)
 		return
 	playsound(user, 'sound/weapons/gunshot.ogg', 100, 1)

--- a/code/modules/antagonists/clockcult/clock_structures/trap_triggers/pressure_sensor.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/trap_triggers/pressure_sensor.dm
@@ -20,6 +20,6 @@
 		var/mob/living/L = AM
 		if(L.stat || L.m_intent == MOVE_INTENT_WALK || !(L.mobility_flags & MOBILITY_STAND))
 			return
-		audible_message("<i>*click*</i>")
+		audible_message("<span class='italics'>\The [src] clicks!</span>")
 		playsound(src, 'sound/items/screwdriver2.ogg', 50, TRUE)
 		activate()

--- a/code/modules/antagonists/clockcult/clock_structures/trap_triggers/pressure_sensor.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/trap_triggers/pressure_sensor.dm
@@ -20,6 +20,8 @@
 		var/mob/living/L = AM
 		if(L.stat || L.m_intent == MOVE_INTENT_WALK || !(L.mobility_flags & MOBILITY_STAND))
 			return
-		audible_message("<span class='italics'>\The [src] clicks!</span>")
+		to_chat(AM, "<span class='italics'>\The [src] clicks!</span>", \
+					"<span class='italics'>\The [src] beneath [AM] clicks!</span>", \
+					"<span class='italics'>You hear a click!</span>")
 		playsound(src, 'sound/items/screwdriver2.ogg', 50, TRUE)
 		activate()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -147,8 +147,7 @@
 	return TRUE
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
-	audible_message("<span class='italics'>\The [src] clicks!</span>")
-	user.visible_message("<span class='italics'>[user]'s [src] clicks!</span>", "<span class='italics'>\The [src] clicks!</span>", null, COMBAT_MESSAGE_RANGE)
+	user.visible_message("<span class='italics'>[user]'s [src] clicks!</span>", null, "<span class='italics'>\The [src] clicks!</span>", COMBAT_MESSAGE_RANGE)
 	playsound(src, dry_fire_sound, 30, TRUE)
 
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -147,7 +147,9 @@
 	return TRUE
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
-	user.visible_message("<span class='italics'>[user]'s [src] clicks!</span>", null, "<span class='italics'>\The [src] clicks!</span>", COMBAT_MESSAGE_RANGE)
+	user.visible_message("<span class='italics'>[user]'s [src.name] clicks!</span>", \
+						"<span class='italics'>\The [src] clicks!</span>", \
+						"<span class='italics'>\The [src] clicks!</span>", COMBAT_MESSAGE_RANGE)
 	playsound(src, dry_fire_sound, 30, TRUE)
 
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -149,7 +149,7 @@
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
 	user.visible_message("<span class='italics'>[user]'s [src.name] clicks!</span>", \
 						"<span class='italics'>\The [src] clicks!</span>", \
-						"<span class='italics'>\The [src] clicks!</span>", COMBAT_MESSAGE_RANGE)
+						"<span class='italics'>You hear a click!</span>", COMBAT_MESSAGE_RANGE)
 	playsound(src, dry_fire_sound, 30, TRUE)
 
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -147,7 +147,8 @@
 	return TRUE
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
-	to_chat(user, "<span class='danger'>*click*</span>")
+	audible_message("<span class='italics'>\The [src] clicks!</span>")
+	user.visible_message("<span class='italics'>[user]'s [src] clicks!</span>", "<span class='italics'>\The [src] clicks!</span>", null, COMBAT_MESSAGE_RANGE)
 	playsound(src, dry_fire_sound, 30, TRUE)
 
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -222,7 +222,9 @@
 				chambered = null
 				return
 
-		audible_message("<span class='italics'>\The [src] clicks!</span>")
+		visible_message("<span class='italics'>[user]'s [src.name] clicks!</span>", \
+							"<span class='italics'>\The [src] clicks!</span>", \
+							"<span class='italics'>You hear a click!</span>", COMBAT_MESSAGE_RANGE)
 		playsound(src, dry_fire_sound, 30, TRUE)
 
 /obj/item/gun/ballistic/revolver/russian/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -222,7 +222,7 @@
 				chambered = null
 				return
 
-		user.visible_message("<span class='danger'>*click*</span>")
+		audible_message("<span class='italics'>\The [src] clicks!</span>")
 		playsound(src, dry_fire_sound, 30, TRUE)
 
 /obj/item/gun/ballistic/revolver/russian/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes various in-game \*click*-messages to visible messages which tell the hearer more about what's happening (EDIT: that is, if you can see what's happening). Affects mines, toy guns, pressure sensors and guns.

Before:
![Capture2](https://user-images.githubusercontent.com/5420151/59777669-c13d3900-92bd-11e9-9f5b-bf4c5933da6b.PNG)


After:
![Capture1](https://user-images.githubusercontent.com/5420151/59777676-c306fc80-92bd-11e9-9d6b-b22c88f640d2.PNG)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Clears up the confusion about where the hell did that \*click* just come from.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

