### PR TITLE
Chemistry lab on metastation gets a table in place of the lower disposal bin

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -51315,16 +51315,10 @@
 /area/medical/chemistry)
 "chd" = (
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = 8;
 	pixel_y = 2
 	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/yellow{
@@ -54347,22 +54341,21 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cnI" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cnJ" = (
-/obj/machinery/disposal/bin{
-	pixel_x = 5
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cnK" = (


### PR DESCRIPTION
## About The Pull Request

This PR aims to make a QoL change for the chemist that gets the lower spot on the metastation chemistry lab.

This is how it looks now:
![chemtablebef1](https://user-images.githubusercontent.com/48154165/60189637-88f3a880-9831-11e9-81fa-178af69e94db.PNG)
![chemtablebef2](https://user-images.githubusercontent.com/48154165/60189650-901ab680-9831-11e9-94e6-90e59379ee7d.PNG)

This is how I made it look:
![chemtableaft1](https://user-images.githubusercontent.com/48154165/60189694-a58fe080-9831-11e9-858c-2c7ea795f690.PNG)
![chemtableaft2](https://user-images.githubusercontent.com/48154165/60189701-a88ad100-9831-11e9-969d-99bfbcb007e3.PNG)


## Why It's Good For The Game

When I play chemist and get the lower spot my biggest problem is the lack of table to place my beakers on. Instead there is a disposal bin that rarely ever use, even if I have to throw something away, there always is the other one in the upper part of chemistry. I feel like this is a major QoL change for the chemist that gets the lower spot. 

## Changelog
:cl:wejreggin2
tweak: replaced the lower disposal bin in chemistry with a glass table and put half of the top table contents on it (metastation).
/:cl:
