### PR TITLE
Allows blacklisting words from IC chat via config

### DIFF
--- a/code/_globalvars/lists/names.dm
+++ b/code/_globalvars/lists/names.dm
@@ -49,3 +49,5 @@ GLOBAL_LIST_INIT(preferences_custom_names, list(
 	"religion" = list("pref_name" = "Chaplain religion", "qdesc" = "religion" , "allow_numbers" = TRUE , "group" = "chaplain", "allow_null" = FALSE),
 	"deity" = list("pref_name" = "Chaplain deity", "qdesc" = "deity", "allow_numbers" = TRUE , "group" = "chaplain", "allow_null" = FALSE)
 	))
+
+GLOBAL_LIST_EMPTY(in_character_filter)

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -49,6 +49,7 @@
 	loadmaplist(CONFIG_MAPS_FILE)
 	LoadMOTD()
 	LoadPolicy()
+	LoadChatFilter()
 
 /datum/controller/configuration/proc/full_wipe()
 	if(IsAdminAdvancedProcCall())
@@ -249,7 +250,7 @@
 Policy file should be a json file with a single object.
 Value is raw html.
 
-Possible keywords : 
+Possible keywords :
 Job titles / Assigned roles (ghost spawners for example) : Assistant , Captain , Ash Walker
 Mob types : /mob/living/simple_animal/hostile/carp
 Antagonist types : /datum/antagonist/highlander
@@ -395,3 +396,18 @@ Example config:
 				continue
 			runnable_modes[M] = probabilities[M.config_tag]
 	return runnable_modes
+
+/datum/controller/configuration/proc/LoadChatFilter()
+	GLOB.in_character_filter = list()
+
+	if(!fexists("[directory]/in_character_filter.txt"))
+		return
+
+	log_config("Loading config file in_character_filter.txt...")
+
+	for(var/line in world.file2list("[directory]/in_character_filter.txt"))
+		if(!line)
+			continue
+		if(findtextEx(line,"#",1,2))
+			continue
+		GLOB.in_character_filter += line

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -21,6 +21,8 @@
 	var/motd
 	var/policy
 
+	var/static/regex/ic_filter_regex
+
 /datum/controller/configuration/proc/admin_reload()
 	if(IsAdminAdvancedProcCall())
 		return
@@ -411,3 +413,6 @@ Example config:
 		if(findtextEx(line,"#",1,2))
 			continue
 		GLOB.in_character_filter += line
+
+	if(!ic_filter_regex && GLOB.in_character_filter.len)
+		ic_filter_regex = regex("\\b([jointext(GLOB.in_character_filter, "|")])\\b", "i")

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -95,7 +95,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	if(GLOB.in_character_filter.len && !forced)
 		if(findtext(message, config.ic_filter_regex))
-			to_chat(src, "<span class='warning'>That message contained a word prohibited in IC chat!</span>")
+			to_chat(src, "<span class='warning'>That message contained a word prohibited in IC chat! Consider reviewing the server rules.</span>")
 			return
 
 	var/datum/saymode/saymode = SSradio.saymodes[talk_key]

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -93,8 +93,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(!message || message == "")
 		return
 
-	var/static/regex/netspeak = regex("\\b(lol|brb|wtf|idk|omg|lmao|btw|ikr|rofl|tbh|nvm|thx|afaik)\\b", "i")
-	if(findtext(message, netspeak))
+	var/static/regex/netspeak = regex("\\b(lol|brb|wtf|idk|omg|lmao|btw|ikr|rofl|tbh|nvm|thx|afaik|ooc|ic|pls|plz)\\b", "i")
+	if(!derpspeech && findtext(message, netspeak))
 		to_chat(src, "<span class='warning'>Netspeak is not permitted in character!</span>")
 		return
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -94,8 +94,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		return
 
 	if(GLOB.in_character_filter.len && !forced)
-		var/regex/filter = regex("\\b([jointext(GLOB.in_character_filter, "|")])\\b", "i")
-		if(findtext(message, filter))
+		if(findtext(message, config.ic_filter_regex))
 			to_chat(src, "<span class='warning'>That message contained a word prohibited in IC chat!</span>")
 			return
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -93,10 +93,11 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(!message || message == "")
 		return
 
-	var/static/regex/netspeak = regex("\\b(lol|brb|wtf|idk|omg|lmao|btw|ikr|rofl|tbh|nvm|thx|afaik|ooc|ic|pls|plz)\\b", "i")
-	if(!derpspeech && findtext(message, netspeak))
-		to_chat(src, "<span class='warning'>Netspeak is not permitted in character!</span>")
-		return
+	if(GLOB.in_character_filter.len)
+		var/regex/filter = regex("\\b([jointext(GLOB.in_character_filter, "|")])\\b", "i")
+		if(!derpspeech && findtext(message, filter))
+			to_chat(src, "<span class='warning'>That message contained a word prohibited in IC chat!</span>")
+			return
 
 	var/datum/saymode/saymode = SSradio.saymodes[talk_key]
 	var/message_mode = get_message_mode(message)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -93,6 +93,11 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(!message || message == "")
 		return
 
+	var/static/regex/netspeak = regex("\\b(lol|brb|wtf|idk|omg|lmao|btw|ikr|rofl|tbh|nvm|thx|afaik)\\b", "i")
+	if(findtext(message, netspeak))
+		to_chat(src, "<span class='warning'>Netspeak is not permitted in character!</span>")
+		return
+
 	var/datum/saymode/saymode = SSradio.saymodes[talk_key]
 	var/message_mode = get_message_mode(message)
 	var/original_message = message

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -93,9 +93,9 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(!message || message == "")
 		return
 
-	if(GLOB.in_character_filter.len)
+	if(GLOB.in_character_filter.len && !forced)
 		var/regex/filter = regex("\\b([jointext(GLOB.in_character_filter, "|")])\\b", "i")
-		if(!derpspeech && findtext(message, filter))
+		if(findtext(message, filter))
 			to_chat(src, "<span class='warning'>That message contained a word prohibited in IC chat!</span>")
 			return
 

--- a/config/in_character_filter.txt
+++ b/config/in_character_filter.txt
@@ -1,0 +1,7 @@
+###############################################################################################
+# Words that will block in character chat messages from sending.                              #
+# Case is not important. Commented-out examples are listed below, just remove the "#".        #
+###############################################################################################
+#lol
+#omg
+#wtf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

~~Blocks netspeak in IC using regex.~~ Implements a config file for filtering IC, for the purpose of blocking netspeak. It's still allowed in asay/dsay/ooc/etc. I'm aware that this list is not exhaustive and that it can be fairly easily bypassed. But this blocks most of the common occurrences so it'll make life easier for admins, and it'll be obvious when people are intentionally breaking the rule by bypassing it.

It also doesn't block words that contain blacklisted words in them. For example, "lol" (if configured) would be blocked but "lollygagging" would not.

I expect this to cause at least three (3) angry rants on reddit.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Netspeak in IC is against the rules. MUH IMMERSHUN, and all that.


#### EDIT: I'm too lazy to rewrite the whole PR desc, but this is now a generic IC blacklist that is edited via config. It's no longer specifically targeting netspeak. It is not blocking anything by default.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: ike709
add: IC chat can now be filtered via config to prevent things like netspeak or anything else against the rules.
/:cl: