### PR TITLE
Examine fixes

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/_blobstrain.dm
+++ b/code/modules/antagonists/blob/blobstrains/_blobstrain.dm
@@ -72,3 +72,6 @@ GLOBAL_LIST_INIT(valid_blobstrains, subtypesof(/datum/blobstrain) - list(/datum/
 
 /datum/blobstrain/proc/emp_reaction(obj/structure/blob/B, severity, coefficient = 1) //when the blob is hit with an emp, do this
 	return
+
+/datum/blobstrain/proc/examine(mob/user)
+	return list("<b>Progress to Critical Mass:</b> <span class='notice'>[overmind.blobs_legit.len]/[overmind.blobwincount].</span>")

--- a/code/modules/antagonists/blob/blobstrains/debris_devourer.dm
+++ b/code/modules/antagonists/blob/blobstrains/debris_devourer.dm
@@ -43,4 +43,21 @@
 	var/obj/structure/blob/core/core = overmind.blob_core
 	return round(max((coefficient*damage)-min(coefficient*DEBRIS_DENSITY, 10), 0)) // reduce damage taken by items per blob, up to 10
 
+/datum/blobstrain/debris_devourer/examine(mob/user)
+	. = ..()
+	var/obj/structure/blob/core/core = overmind.blob_core
+	if (isobserver(user))
+		. += "<span class='notice'>Absorbed debris is currently reducing incoming damage by [round(max(min(DEBRIS_DENSITY, 10),0))]</span>"
+	else
+		switch (round(max(min(DEBRIS_DENSITY, 10),0)))
+			if (0)
+				. += "<span class='notice'>There is not currently enough absorbed debris to reduce damage.</span>"
+			if (1 to 3)
+				. += "<span class='notice'>Absorbed debris is currently reducing incoming damage by a very low amount.</span>" // these roughly correspond with force description strings
+			if (4 to 7)
+				. += "<span class='notice'>Absorbed debris is currently reducing incoming damage by a low amount.</span>"
+			if (8 to 10)
+				. += "<span class='notice'>Absorbed debris is currently reducing incoming damage by a medium amount.</span>"
+
+
 #undef DEBRIS_DENSITY

--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -240,9 +240,9 @@
 /obj/structure/blob/proc/chemeffectreport(mob/user)
 	. = list()
 	if(overmind)
-		. += "<b>Material: <font color=\"[overmind.blobstrain.color]\">[overmind.blobstrain.name]</font><span class='notice'>.</span></b>"
-		. += "<b>Material Effects:</b> <span class='notice'>[overmind.blobstrain.analyzerdescdamage]</span>"
-		. += "<b>Material Properties:</b> <span class='notice'>[overmind.blobstrain.analyzerdesceffect]</span>"
+		. += list("<b>Material: <font color=\"[overmind.blobstrain.color]\">[overmind.blobstrain.name]</font><span class='notice'>.</span></b>",
+		"<b>Material Effects:</b> <span class='notice'>[overmind.blobstrain.analyzerdescdamage]</span>",
+		"<b>Material Properties:</b> <span class='notice'>[overmind.blobstrain.analyzerdesceffect]</span>")
 	else
 		. += "<b>No Material Detected!</b>"
 

--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -311,14 +311,14 @@
 	if(user.research_scanner || hud_to_check.hudusers[user])
 		. += "<b>Your HUD displays an extensive report...</b><br>"
 		if(overmind)
-			. += "<b>Progress to Critical Mass:</b> <span class='notice'>[overmind.blobs_legit.len]/[overmind.blobwincount].</span>"
+			. += overmind.blobstrain.examine(user)
 		else
 			. += "<b>Core neutralized. Critical mass no longer attainable.</b>"
 		. += chemeffectreport(user)
 		. += typereport(user)
 	else
-		if(isobserver(user) && overmind)
-			. += "<b>Progress to Critical Mass:</b> <span class='notice'>[overmind.blobs_legit.len]/[overmind.blobwincount].</span>"
+		if((user == overmind || isobserver(user)) && overmind)
+			. += overmind.blobstrain.examine(user)
 		. += "It seems to be made of [get_chem_name()]."
 
 /obj/structure/blob/proc/scannerreport()

--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -240,16 +240,16 @@
 /obj/structure/blob/proc/chemeffectreport(mob/user)
 	. = list()
 	if(overmind)
-		. += {"<b>Material: <font color=\"[overmind.blobstrain.color]\">[overmind.blobstrain.name]</font><span class='notice'>.</span></b>\n
-				<b>Material Effects:</b> <span class='notice'>[overmind.blobstrain.analyzerdescdamage]</span>\n
-				<b>Material Properties:</b> <span class='notice'>[overmind.blobstrain.analyzerdesceffect]</span>"}
+		. += "<b>Material: <font color=\"[overmind.blobstrain.color]\">[overmind.blobstrain.name]</font><span class='notice'>.</span></b>"
+		. += "<b>Material Effects:</b> <span class='notice'>[overmind.blobstrain.analyzerdescdamage]</span>"
+		. += "<b>Material Properties:</b> <span class='notice'>[overmind.blobstrain.analyzerdesceffect]</span>"
 	else
-		. += "<b>No Material Detected!</b><br>"
+		. += "<b>No Material Detected!</b>"
 
 /obj/structure/blob/proc/typereport(mob/user)
-	return list({"<b>Blob Type:</b> <span class='notice'>[uppertext(initial(name))]</span>\n
-		<b>Health:</b> <span class='notice'>[obj_integrity]/[max_integrity]</span>\n
-		<b>Effects:</b> <span class='notice'>[scannerreport()]</span>"})
+	return list("<b>Blob Type:</b> <span class='notice'>[uppertext(initial(name))]</span>",
+							"<b>Health:</b> <span class='notice'>[obj_integrity]/[max_integrity]</span>",
+							"<b>Effects:</b> <span class='notice'>[scannerreport()]</span>")
 
 
 /obj/structure/blob/attack_animal(mob/living/simple_animal/M)


### PR DESCRIPTION
I was a little too eager with multilining some things and the tabs then get converted into non-breaking spaces in output. 

This PR is somewhat of a work in progress, I'll add some more things as they crop up.

## Changelog
:cl: Naksu
fix: Fixed some examine messages I broke earlier.
tweak: Slightly refactored blob examine code, debris devourer blobstrain now shows the acquired damage reduction for observers, the blob, and medhud owners.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
