### PR TITLE
[wip]blueaspace ship beacon

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -11,6 +11,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/list/mobile = list()
 	var/list/stationary = list()
+	var/list/beacons = list()
 	var/list/transit = list()
 
 	var/list/transit_requesters = list()
@@ -127,7 +128,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/threshold = CONFIG_GET(number/emergency_shuttle_autocall_threshold)
 	if(!threshold)
 		return
-	
+
 	var/alive = 0
 	for(var/I in GLOB.player_list)
 		var/mob/M = I

--- a/code/game/machinery/Beacon.dm
+++ b/code/game/machinery/Beacon.dm
@@ -9,6 +9,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 0
 	var/obj/item/beacon/Beacon
+	var/id
 
 /obj/machinery/bluespace_beacon/Initialize()
 	. = ..()
@@ -17,8 +18,10 @@
 	Beacon.invisibility = INVISIBILITY_MAXIMUM
 
 	hide(T.intact)
+	SSshuttle.beacons += src
 
 /obj/machinery/bluespace_beacon/Destroy()
+	SSshuttle.beacons -= src
 	QDEL_NULL(Beacon)
 	return ..()
 

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -8,6 +8,7 @@
 	var/shuttlePortId = ""
 	var/shuttlePortName = "custom location"
 	var/list/jumpto_ports = list() //hashset of ports to jump to and ignore for collision purposes
+	var/list/beacon_codes = list() //hashset of beacon to jump to
 	var/obj/docking_port/stationary/my_port //the custom docking port placed by this console
 	var/obj/docking_port/mobile/shuttle_port //the mobile docking port of the connected shuttle
 	var/view_range = 7
@@ -327,7 +328,15 @@
 		if(console.z_lock.len && !(S.z in console.z_lock))
 			continue
 		if(console.jumpto_ports[S.id])
-			L[S.name] = S
+			L["([L.len])[S.name]"] = S
+	for(var/V in SSshuttle.beacons)
+		if(!V)
+			continue
+		var/obj/machinery/bluespace_beacon/B = V
+		//if(console.z_lock.len && !(B.z in console.z_lock))
+		//	continue
+		//if(B.id && console.beacon_codes[B.id])
+		L["([L.len])[B.name]"] = B
 
 	playsound(console, 'sound/machines/terminal_prompt.ogg', 25, 0)
 	var/selected = input("Choose location to jump to", "Locations", null) as null|anything in L


### PR DESCRIPTION
## About The Pull Request

blueaspace ship beacon allow to jump docker camera to it

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: blueaspace ship beacon that allow ship to fly to it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
