### PR TITLE
Adds Clarification on Why Specifically What You Said Is Morally Reprehensible

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -78,3 +78,6 @@
 #define MAX_NAME_LEN			42
 #define MAX_BROADCAST_LEN		512
 #define MAX_CHARTER_LEN			80
+
+// Maximum censored messages in a 60 second span, kick on exceeding.
+#define CENSOR_MESSAGE_LIMIT	25

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -75,3 +75,6 @@
 	var/datum/player_details/player_details //these persist between logins/logouts during the same round.
 
 	var/list/char_render_holders			//Should only be a key-value list of north/south/east/west = obj/screen.
+
+	// Catches naughty users who want to abuse the censor system
+	var/censoredMessageCounter = 0

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -118,16 +118,18 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		if(bad_message_start)
 			// Catch potential baddies
 			var/client/C = src.client
+			if (C.censoredMessageCounter == 0) // Add 60-second timeout for baddy catching
+				addtimer(CALLBACK(C, /client/proc/ResetCensorAbuseCounter), 600)
+			
 			C.censoredMessageCounter++
+
 			if (C.censoredMessageCounter > CENSOR_MESSAGE_LIMIT)
 				to_chat(C, "<span class='userdanger'>You have exceeded the limit of [CENSOR_MESSAGE_LIMIT] censored messages in 60 seconds and have been disconnected. Administrators have been notified of this event.</span><br><span class='danger'>You may reconnect via the button in the file menu or by <b><u><a href='byond://winset?command=.reconnect'>clicking here to reconnect</a></u></b>.</span>")
 				QDEL_IN(C, 1) //to ensure they get our message before getting disconnected
 				message_admins("[key_name(src)] has been kicked for exceeding the limit of [CENSOR_MESSAGE_LIMIT] censored messages in 60 seconds.")
 			else if (C.censoredMessageCounter > CENSOR_MESSAGE_LIMIT - 5)
 				to_chat(C, "<span class='warning'>You are approaching the limit of [CENSOR_MESSAGE_LIMIT] censored messages in 60 seconds. You will be disconnected if you exceed this limit.</span>")
-			else if (C.censoredMessageCounter == 0)
-				addtimer(CALLBACK(C, /client/proc/ResetCensorAbuseCounter), 600)
-
+			
 			// let's try to be a bit more informative!
 			var/warning_message = "<span class='warning'>That message contained a word prohibited in IC chat! Consider reviewing the server rules.</br>The bolded terms are blocked: &quot;"
 			warning_message += BuildFilterResponse(message, config.ic_filter_regex)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -95,7 +95,17 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	if(GLOB.in_character_filter.len && !forced)
 		if(findtext(message, config.ic_filter_regex))
-			to_chat(src, "<span class='warning'>That message contained a word prohibited in IC chat! Consider reviewing the server rules.</span>")
+			// let's try to be a bit more informative!
+			var/warning_message = "<span class='warning'>That message contained a word prohibited in IC chat! Consider reviewing the server rules.</br>The bolded terms are disallowed: &quot;"
+			var/list/words = splittext(message, " ")
+			for (var/word in words)
+				if (findtext(word, config.ic_filter_regex))
+					warning_message = "[warning_message]<b>[word]</b> "
+				else
+					warning_message = "[warning_message][word] "
+
+			warning_message = trim(warning_message)
+			to_chat(src, "[warning_message]&quot;</span>")
 			return
 
 	var/datum/saymode/saymode = SSradio.saymodes[talk_key]

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -129,7 +129,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 				addtimer(CALLBACK(C, /client/proc/ResetCensorAbuseCounter), 600)
 
 			// let's try to be a bit more informative!
-			var/warning_message = "<span class='warning'>That message contained a word prohibited in IC chat! Consider reviewing the server rules.</br>The bolded terms are disallowed: &quot;"
+			var/warning_message = "<span class='warning'>That message contained a word prohibited in IC chat! Consider reviewing the server rules.</br>The bolded terms are blocked: &quot;"
 			warning_message += BuildFilterResponse(message, config.ic_filter_regex)
 			warning_message = trim(warning_message)
 			to_chat(C, "[warning_message]&quot;</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added an additional portion to the filter message to help clarify why a message was filtered from IC chat.
![epic screenshot](https://imgur.com/kje14B2.png)

I additionally added a system to ensure users are discouraged from abusing this system, as requested by Oranges, through kicking if hitting the censor over 25 times in 60 seconds.
![image](https://user-images.githubusercontent.com/10467687/59956839-592b5600-9469-11e9-8883-b15a25993ec2.png)

Finally, I removed this filtering from mobs without clients, as Oranges agreed this was unnecessary.
![image](https://user-images.githubusercontent.com/10467687/59956854-719b7080-9469-11e9-89e9-919cc226fb81.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Please oh god why are my messages being blocked???? where are the rules????? adminhelp?????
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: When the server denies your free speech you are now given the privilege of knowing why.
add: When users abuse these new privileges excessively within 60 seconds they will be disconnected from the server.
tweak: IC chat censors now only apply to mobs with clients.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
