### PR TITLE
Adds logging for pyroclastic slimes.

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -281,11 +281,12 @@
 	S.rabid = TRUE
 	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
 	S.Evolve()
-	
+
 	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a pyroclastic anomaly slime?", ROLE_PAI, null, null, 100, S, POLL_IGNORE_PYROSLIME)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/chosen = pick(candidates)
 		S.key = chosen.key
+		log_game("[key_name(S.key)] was made into a slime by pyroclastic anomaly.")
 
 /////////////////////
 

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -286,7 +286,7 @@
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/chosen = pick(candidates)
 		S.key = chosen.key
-		log_game("[key_name(S.key)] was made into a slime by pyroclastic anomaly.")
+		log_game("[key_name(S.key)] was made into a slime by pyroclastic anomaly at [AREACOORD(T)].")
 
 /////////////////////
 


### PR DESCRIPTION
## About The Pull Request
Slimes spawned from pyroclastic anomalies are now logged to game.log.

## Why It's Good For The Game

Makes it easier for admins to investigate whether a slime killing people is a pyroclastic slime or not.