### PR TITLE
Gives service borgs pipe cleaners for wire art

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -113,6 +113,10 @@
 			S.cost = 1
 			S.source = get_or_create_estorage(/datum/robot_energy_storage/beacon)
 
+		else if(istype(S, /obj/item/stack/pipe_cleaner_coil))
+			S.cost = 1
+			S.source = get_or_create_estorage(/datum/robot_energy_storage/pipe_cleaner)
+
 		if(S && S.source)
 			S.materials = list()
 			S.is_cyborg = 1
@@ -480,7 +484,8 @@
 		/obj/item/lighter,
 		/obj/item/storage/bag/tray,
 		/obj/item/reagent_containers/borghypo/borgshaker,
-		/obj/item/borg/lollipop)
+		/obj/item/borg/lollipop,
+		/obj/item/stack/pipe_cleaner_coil/cyborg)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/borgshaker/hacked)
 	ratvar_modules = list(/obj/item/clockwork/slab/cyborg/service,
 		/obj/item/borg/sight/xray/truesight_lens)
@@ -687,3 +692,8 @@
 	max_energy = 30
 	recharge_rate = 1
 	name = "Marker Beacon Storage"
+
+/datum/robot_energy_storage/pipe_cleaner
+	max_energy = 50
+	recharge_rate = 2
+	name = "Pipe Cleaner Synthesizer"

--- a/code/modules/power/pipecleaners.dm
+++ b/code/modules/power/pipecleaners.dm
@@ -134,10 +134,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(T.intact)
 		return
 	if(W.tool_behaviour == TOOL_WIRECUTTER)
-		user.visible_message("[user] cuts the pipe cleaner.", "<span class='notice'>You cut the pipe cleaner.</span>")
-		stored.add_fingerprint(user)
-		investigate_log("was cut by [key_name(usr)] in [AREACOORD(src)]", INVESTIGATE_WIRES)
-		deconstruct()
+		cut_pipe_cleaner(user)
 		return
 
 	else if(istype(W, /obj/item/stack/pipe_cleaner_coil))
@@ -148,6 +145,12 @@ By design, d1 is the smallest direction and d2 is the highest
 		coil.pipe_cleaner_join(src, user)
 
 	add_fingerprint(user)
+
+/obj/structure/pipe_cleaner/proc/cut_pipe_cleaner(mob/user)
+	user.visible_message("[user] pulls up the pipe cleaner.", "<span class='notice'>You pull up the pipe cleaner.</span>")
+	stored.add_fingerprint(user)
+	investigate_log("was pulled up by [key_name(usr)] in [AREACOORD(src)]", INVESTIGATE_WIRES)
+	deconstruct()
 
 /obj/structure/pipe_cleaner/attackby(obj/item/W, mob/user, params)
 	handlecable(W, user, params)
@@ -162,6 +165,11 @@ By design, d1 is the smallest direction and d2 is the highest
 	stored.amount = length
 	stored.item_color = colorC
 	stored.update_icon()
+
+/obj/structure/pipe_cleaner/AltClick(mob/living/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
+	cut_pipe_cleaner(user)
 
 ///////////////////////////////////////////////
 // The pipe cleaner coil object, used for laying pipe cleaner


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives service borgs a pipe cleaner module for wire art.  However, as they don't have wirecutters, they won't be able to remove pipe cleaners they place.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Another thing to do as service borg.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Tetr4
add: Service borgs get pipe cleaners for wire art
add: you can altclick to pull up pipe cleaners
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
