### PR TITLE
Fixes Corazone not stabilizing liverless people.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1195,12 +1195,12 @@
 	color = "#F5F5F5"
 	self_consuming = TRUE
 
-/datum/reagent/medicine/corazone/on_mob_metabolize(mob/living/M)
+/datum/reagent/medicine/corazone/on_mob_add(mob/living/M)
 	..()
 	ADD_TRAIT(M, TRAIT_STABLEHEART, type)
 	ADD_TRAIT(M, TRAIT_STABLELIVER, type)
 
-/datum/reagent/medicine/corazone/on_mob_end_metabolize(mob/living/M)
+/datum/reagent/medicine/corazone/on_mob_delete(mob/living/M)
 	REMOVE_TRAIT(M, TRAIT_STABLEHEART, type)
 	REMOVE_TRAIT(M, TRAIT_STABLELIVER, type)
 	..()


### PR DESCRIPTION
## About The Pull Request
What's said on the tin. Corazone's stabilizing effects currently gets deactivated by livers going K.I.A. instead of carrying on as the drug self-metabolizes, due to a slip up of #44500.

## Why It's Good For The Game
Bugfixing.

## Changelog
:cl:
fix: Fixes corazone not stabilizing people with dead or missing livers.
/:cl: