### PR TITLE
Makes a crapload of new cardboard boxes craftable.

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -356,19 +356,42 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
  * Cardboard
  */
 GLOBAL_LIST_INIT(cardboard_recipes, list ( \
-	new/datum/stack_recipe("box", /obj/item/storage/box), \
-	new/datum/stack_recipe("light tubes", /obj/item/storage/box/lights/tubes), \
-	new/datum/stack_recipe("light bulbs", /obj/item/storage/box/lights/bulbs), \
-	new/datum/stack_recipe("mouse traps", /obj/item/storage/box/mousetraps), \
-	new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3), \
-	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg), \
-	new/datum/stack_recipe("pizza box", /obj/item/pizzabox), \
-	new/datum/stack_recipe("donut box", /obj/item/storage/fancy/donut_box), \
-	new/datum/stack_recipe("egg box", /obj/item/storage/fancy/egg_box), \
-	new/datum/stack_recipe("candle box", /obj/item/storage/fancy/candle_box), \
-	new/datum/stack_recipe("folder", /obj/item/folder), \
-	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4), \
-	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5), \
+	new/datum/stack_recipe("box", /obj/item/storage/box),							\
+	new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3),	\
+	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg),	\
+	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5),		\
+	null, \
+
+	new/datum/stack_recipe("pizza box", /obj/item/pizzabox),	\
+	new/datum/stack_recipe("folder", /obj/item/folder),			\
+	null, \
+
+	new/datum/stack_recipe_list("fancy boxes", list(
+		new /datum/stack_recipe("donut box", /obj/item/storage/fancy/donut_box),	\
+		new /datum/stack_recipe("egg box", /obj/item/storage/fancy/egg_box),		\
+		null, \
+
+		new /datum/stack_recipe("lethal ammo box", /obj/item/storage/box/lethalshot),		\
+		new /datum/stack_recipe("rubber shot ammo box", /obj/item/storage/box/rubbershot),	\
+		new /datum/stack_recipe("bean bag ammo box", /obj/item/storage/box/beanbag),		\
+		new /datum/stack_recipe("flashbang box", /obj/item/storage/box/flashbangs),			\
+		new /datum/stack_recipe("flashes box", /obj/item/storage/box/flashes),				\
+		null, \
+
+		new /datum/stack_recipe("pillbottle box", /obj/item/storage/box/pillbottles),	\
+		new /datum/stack_recipe("beaker box", /obj/item/storage/box/beakers),			\
+		new /datum/stack_recipe("syringe box", /obj/item/storage/box/syringes),			\
+		null, \
+
+		new /datum/stack_recipe("disk box", /obj/item/storage/box/disks),				\
+		new /datum/stack_recipe("light tubes box", /obj/item/storage/box/lights/tubes),	\
+		new /datum/stack_recipe("light bulbs box", /obj/item/storage/box/lights/bulbs),	\
+		new /datum/stack_recipe("mouse traps box", /obj/item/storage/box/mousetraps),	\
+		new /datum/stack_recipe("candle box", /obj/item/storage/fancy/candle_box)
+		)),
+
+	null, \
 ))
 
 /obj/item/stack/sheet/cardboard	//BubbleWrap //it's cardboard you fuck

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -355,43 +355,53 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 /*
  * Cardboard
  */
-GLOBAL_LIST_INIT(cardboard_recipes, list ( \
-	new/datum/stack_recipe("box", /obj/item/storage/box),									\
-	new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3),			\
-	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg),			\
+GLOBAL_LIST_INIT(cardboard_recipes, list (														\
+	new/datum/stack_recipe("box", /obj/item/storage/box),										\
+	new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3),				\
+	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg),				\
 	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5),				\
-	null, \
+	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5),					\
+	null,																						\
 
-	new/datum/stack_recipe("pizza box", /obj/item/pizzabox),								\
-	new/datum/stack_recipe("folder", /obj/item/folder),										\
-	null, \
-
+	new/datum/stack_recipe("pizza box", /obj/item/pizzabox),									\
+	new/datum/stack_recipe("folder", /obj/item/folder),											\
+	null,																						\
+	//TO-DO: Find a proper way to just change the illustration on the box. Code isn't the issue, input is.
 	new/datum/stack_recipe_list("fancy boxes", list(
-		new /datum/stack_recipe("donut box", /obj/item/storage/fancy/donut_box),			\
-		new /datum/stack_recipe("egg box", /obj/item/storage/fancy/egg_box),				\
-		null, \
+		new /datum/stack_recipe("donut box", /obj/item/storage/fancy/donut_box),				\
+		new /datum/stack_recipe("egg box", /obj/item/storage/fancy/egg_box),					\
+		new /datum/stack_recipe("donk-pockets box", /obj/item/storage/box/donkpockets),			\
+		new /datum/stack_recipe("monkey cube box", /obj/item/storage/box/monkeycubes),			\
+		null,																					\
 
-		new /datum/stack_recipe("lethal ammo box", /obj/item/storage/box/lethalshot),		\
-		new /datum/stack_recipe("rubber shot ammo box", /obj/item/storage/box/rubbershot),	\
-		new /datum/stack_recipe("bean bag ammo box", /obj/item/storage/box/beanbag),		\
-		new /datum/stack_recipe("flashbang box", /obj/item/storage/box/flashbangs),			\
-		new /datum/stack_recipe("flashes box", /obj/item/storage/box/flashes),				\
-		null, \
+		new /datum/stack_recipe("lethal ammo box", /obj/item/storage/box/lethalshot),			\
+		new /datum/stack_recipe("rubber shot ammo box", /obj/item/storage/box/rubbershot),		\
+		new /datum/stack_recipe("bean bag ammo box", /obj/item/storage/box/beanbag),			\
+		new /datum/stack_recipe("flashbang box", /obj/item/storage/box/flashbangs),				\
+		new /datum/stack_recipe("flashes box", /obj/item/storage/box/flashes),					\
+		new /datum/stack_recipe("handcuffs box", /obj/item/storage/box/handcuffs),				\
+		new /datum/stack_recipe("ID card box", /obj/item/storage/box/ids),						\
+		new /datum/stack_recipe("PDA box", /obj/item/storage/box/PDAs),							\
+		null,																					\
 
-		new /datum/stack_recipe("pillbottle box", /obj/item/storage/box/pillbottles),		\
-		new /datum/stack_recipe("beaker box", /obj/item/storage/box/beakers),				\
-		new /datum/stack_recipe("syringe box", /obj/item/storage/box/syringes),				\
-		null, \
+		new /datum/stack_recipe("pillbottle box", /obj/item/storage/box/pillbottles),			\
+		new /datum/stack_recipe("beaker box", /obj/item/storage/box/beakers),					\
+		new /datum/stack_recipe("syringe box", /obj/item/storage/box/syringes),					\
+		new /datum/stack_recipe("latex gloves box", /obj/item/storage/box/gloves),				\
+		new /datum/stack_recipe("sterile masks box", /obj/item/storage/box/masks),				\
+		new /datum/stack_recipe("body bag box", /obj/item/storage/box/bodybags),					\
+		new /datum/stack_recipe("perscription glasses box", /obj/item/storage/box/rxglasses),	\
+		null,																					\
 
-		new /datum/stack_recipe("disk box", /obj/item/storage/box/disks),					\
-		new /datum/stack_recipe("light tubes box", /obj/item/storage/box/lights/tubes),		\
-		new /datum/stack_recipe("light bulbs box", /obj/item/storage/box/lights/bulbs),		\
-		new /datum/stack_recipe("mouse traps box", /obj/item/storage/box/mousetraps),		\
+		new /datum/stack_recipe("disk box", /obj/item/storage/box/disks),						\
+		new /datum/stack_recipe("light tubes box", /obj/item/storage/box/lights/tubes),			\
+		new /datum/stack_recipe("light bulbs box", /obj/item/storage/box/lights/bulbs),			\
+		new /datum/stack_recipe("mixed lights box", /obj/item/storage/box/lights/mixed),		\
+		new /datum/stack_recipe("mouse traps box", /obj/item/storage/box/mousetraps),			\
 		new /datum/stack_recipe("candle box", /obj/item/storage/fancy/candle_box)
 		)),
 
-	null, \
+	null,																						\
 ))
 
 /obj/item/stack/sheet/cardboard	//BubbleWrap //it's cardboard you fuck

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -356,20 +356,20 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
  * Cardboard
  */
 GLOBAL_LIST_INIT(cardboard_recipes, list ( \
-	new/datum/stack_recipe("box", /obj/item/storage/box),							\
-	new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3),	\
-	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg),	\
+	new/datum/stack_recipe("box", /obj/item/storage/box),									\
+	new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3),			\
+	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg),			\
 	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5),		\
+	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5),				\
 	null, \
 
-	new/datum/stack_recipe("pizza box", /obj/item/pizzabox),	\
-	new/datum/stack_recipe("folder", /obj/item/folder),			\
+	new/datum/stack_recipe("pizza box", /obj/item/pizzabox),								\
+	new/datum/stack_recipe("folder", /obj/item/folder),										\
 	null, \
 
 	new/datum/stack_recipe_list("fancy boxes", list(
-		new /datum/stack_recipe("donut box", /obj/item/storage/fancy/donut_box),	\
-		new /datum/stack_recipe("egg box", /obj/item/storage/fancy/egg_box),		\
+		new /datum/stack_recipe("donut box", /obj/item/storage/fancy/donut_box),			\
+		new /datum/stack_recipe("egg box", /obj/item/storage/fancy/egg_box),				\
 		null, \
 
 		new /datum/stack_recipe("lethal ammo box", /obj/item/storage/box/lethalshot),		\
@@ -379,15 +379,15 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 		new /datum/stack_recipe("flashes box", /obj/item/storage/box/flashes),				\
 		null, \
 
-		new /datum/stack_recipe("pillbottle box", /obj/item/storage/box/pillbottles),	\
-		new /datum/stack_recipe("beaker box", /obj/item/storage/box/beakers),			\
-		new /datum/stack_recipe("syringe box", /obj/item/storage/box/syringes),			\
+		new /datum/stack_recipe("pillbottle box", /obj/item/storage/box/pillbottles),		\
+		new /datum/stack_recipe("beaker box", /obj/item/storage/box/beakers),				\
+		new /datum/stack_recipe("syringe box", /obj/item/storage/box/syringes),				\
 		null, \
 
-		new /datum/stack_recipe("disk box", /obj/item/storage/box/disks),				\
-		new /datum/stack_recipe("light tubes box", /obj/item/storage/box/lights/tubes),	\
-		new /datum/stack_recipe("light bulbs box", /obj/item/storage/box/lights/bulbs),	\
-		new /datum/stack_recipe("mouse traps box", /obj/item/storage/box/mousetraps),	\
+		new /datum/stack_recipe("disk box", /obj/item/storage/box/disks),					\
+		new /datum/stack_recipe("light tubes box", /obj/item/storage/box/lights/tubes),		\
+		new /datum/stack_recipe("light bulbs box", /obj/item/storage/box/lights/bulbs),		\
+		new /datum/stack_recipe("mouse traps box", /obj/item/storage/box/mousetraps),		\
 		new /datum/stack_recipe("candle box", /obj/item/storage/fancy/candle_box)
 		)),
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #44651

It's like that PR. Only slightly better sorted. I mean, it's kinda rude to do... I feel bad now.

Also fixes an inconsistency with large cardboard boxes. You can now only craft one of them on the same tile, like with all other closets.

## Why It's Good For The Game

![cardboard](https://user-images.githubusercontent.com/47324920/59966974-f64ac500-9523-11e9-92ad-98474cb0f9be.PNG)
It's a bit more flavourful. Gives cardboard more stuff to do.

## Changelog
:cl: Trilbyspaceclone and nemvar
add: You can now craft more fancy boxes with cardboard.
/:cl: