### PR TITLE
Removes the HOPCURITY

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -54,7 +54,6 @@
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/clothing/glasses/sunglasses(src)
 	new /obj/item/restraints/handcuffs/cable/zipties(src)
-	new /obj/item/gun/energy/e_gun(src)
 	new /obj/item/clothing/neck/petcollar(src)
 	new /obj/item/pet_carrier(src)
 	new /obj/item/door_remote/civillian(src)


### PR DESCRIPTION
## About The Pull Request
Removes the HoP's Energy gun

## Why It's Good For The Game
HoPcurity has gotten bad. The HoP players have tossed their toys out of the playbox so often, I think it's time we take the toy away.
## Changelog
:cl:
tweak: Removed the HoP's personal laser gun
/:cl: