### PR TITLE
makes the death commandos have centcom jumpsuits

### DIFF
--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -369,7 +369,7 @@
 /datum/outfit/death_commando
 	name = "Death Commando"
 
-	uniform = /obj/item/clothing/under/color/green
+	uniform = /obj/item/clothing/under/rank/centcom_commander
 	suit = /obj/item/clothing/suit/space/hardsuit/deathsquad
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = /obj/item/clothing/gloves/combat


### PR DESCRIPTION
## About The Pull Request

makes the death commandos have centcom jumpsuits instead of green ones

## Why It's Good For The Game

why do they have green

## Changelog
:cl:
fix: Centcom's Death Commando got a paycheck and jumpsuits of quality more similar to the rest of Centcom's staf- KS13 DOESN'T EXIST, THERE IS NO SUCH THING AS A DEATH COMMANDO
/:cl:

