### PR TITLE
Small dish drive improvements

### DIFF
--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -10,12 +10,17 @@
 	density = FALSE
 	circuit = /obj/item/circuitboard/machine/dish_drive
 	pass_flags = PASSTABLE
-	var/static/list/item_types = list(/obj/item/trash/waffles,
+	var/static/list/collectable_items = list(/obj/item/trash/waffles,
 		/obj/item/trash/plate,
 		/obj/item/trash/tray,
 		/obj/item/reagent_containers/glass/bowl,
 		/obj/item/reagent_containers/food/drinks/drinkingglass,
 		/obj/item/kitchen/fork,
+		/obj/item/shard,
+		/obj/item/broken_bottle)
+	var/static/list/disposable_items = list(/obj/item/trash/waffles,
+		/obj/item/trash/plate,
+		/obj/item/trash/tray,
 		/obj/item/shard,
 		/obj/item/broken_bottle)
 	var/time_since_dishes = 0
@@ -42,7 +47,7 @@
 	flick("synthesizer_beam", src)
 
 /obj/machinery/dish_drive/attackby(obj/item/I, mob/living/user, params)
-	if(is_type_in_list(I, item_types) && user.a_intent != INTENT_HARM)
+	if(is_type_in_list(I, collectable_items) && user.a_intent != INTENT_HARM)
 		if(!user.transferItemToLoc(I, src))
 			return
 		to_chat(user, "<span class='notice'>You put [I] in [src], and it's beamed into energy!</span>")
@@ -81,7 +86,7 @@
 	if(!suction_enabled)
 		return
 	for(var/obj/item/I in view(4, src))
-		if(is_type_in_list(I, item_types) && I.loc != src && (!I.reagents || !I.reagents.total_volume))
+		if(is_type_in_list(I, collectable_items) && I.loc != src && (!I.reagents || !I.reagents.total_volume))
 			if(I.Adjacent(src))
 				visible_message("<span class='notice'>[src] beams up [I]!</span>")
 				I.forceMove(src)
@@ -109,13 +114,17 @@
 			visible_message("<span class='warning'>[src] buzzes. There are no disposal bins in range!</span>")
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
 		return
+	var/disposed = 0
 	for(var/obj/item/I in contents)
-		I.forceMove(bin)
-		use_power(active_power_usage)
-	visible_message("<span class='notice'>[src] [pick("whooshes", "bwooms", "fwooms", "pshooms")] and beams its stored dishes into the nearby [bin.name].</span>")
-	playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
-	playsound(bin, 'sound/items/pshoom.ogg', 50, TRUE)
-	Beam(bin, icon_state = "rped_upgrade", time = 5)
-	bin.update_icon()
-	flick("synthesizer_beam", src)
+		if(is_type_in_list(I, disposable_items))
+			I.forceMove(bin)
+			use_power(active_power_usage)
+			disposed++
+	if (disposed)
+		visible_message("<span class='notice'>[src] [pick("whooshes", "bwooms", "fwooms", "pshooms")] and beams [disposed] stored item\s into the nearby [bin.name].</span>")
+		playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
+		playsound(bin, 'sound/items/pshoom.ogg', 50, TRUE)
+		Beam(bin, icon_state = "rped_upgrade", time = 5)
+		bin.update_icon()
+		flick("synthesizer_beam", src)
 	time_since_dishes = world.time + 600

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1052,3 +1052,19 @@
 		/obj/item/stock_parts/micro_laser/quadultra = 3,
 		/obj/item/stock_parts/matter_bin/bluespace = 3)
 	generate_items_inside(items_inside,src)
+
+/obj/item/storage/box/dishdrive
+	name = "DIY Dish Drive Kit"
+	desc = "Contains everything you need to build your own Dish Drive!"
+	custom_premium_price = 200
+
+/obj/item/storage/box/dishdrive/PopulateContents()
+	var/static/items_inside = list(
+		/obj/item/stack/sheet/metal/five = 1,
+		/obj/item/stack/cable_coil/five = 1,
+		/obj/item/circuitboard/machine/dish_drive = 1,
+		/obj/item/stack/sheet/glass = 1,
+		/obj/item/stock_parts/manipulator = 1,
+		/obj/item/stock_parts/matter_bin = 2,
+		/obj/item/screwdriver = 1)
+	generate_items_inside(items_inside,src)

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -224,6 +224,7 @@
 					/obj/item/clothing/glasses/sunglasses/reagent = 1,
 					/obj/item/clothing/neck/petcollar = 1,
 					/obj/item/storage/belt/bandolier = 1)
+	premium = list(/obj/item/storage/box/dishdrive = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/bar_wardrobe
 	payment_department = ACCOUNT_SRV
 /obj/item/vending_refill/wardrobe/bar_wardrobe


### PR DESCRIPTION
The dish drive is a neat little machine but it has a few quirks that makes it a bit of a pain to use, so that's what I'm looking to fix. 

Dish drive will still collect but no longer throw away your still perfectly usable dinnerware. Glasses are not disposable, despite what your average bar patron would like you to believe.

The bardrobe now sells a premium box with all the parts you need to build the dish drive (the board alone can still be found in the free category). Saves you the trouble of running around the station looking for parts instead of serving your patrons, but it's quite expensive. Make sure to tip your bartender.
:cl:
add: DIY Dish Drive Kit now available at your local bardrobe. Start saving those tips!
tweak: The Dish Drive no longer sends reusable items into the disposal bin
/:cl:
