### PR TITLE
Nerfs Summon Magic version of Curse of the Barnyard for non-wizards

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -117,6 +117,7 @@
 /obj/item/book/granter/spell
 	var/spell
 	var/spellname = "conjure bugs"
+	var/novicespell
 
 /obj/item/book/granter/spell/already_known(mob/user)
 	if(!spell)
@@ -136,7 +137,11 @@
 
 /obj/item/book/granter/spell/on_reading_finished(mob/user)
 	to_chat(user, "<span class='notice'>You feel like you've experienced enough to cast [spellname]!</span>")
-	var/obj/effect/proc_holder/spell/S = new spell
+	var/obj/effect/proc_holder/spell/S
+	if(novicespell && !(ROLE_WIZARD in user.faction))
+		S = new novicespell
+	else
+		S = new spell
 	user.mind.AddSpell(S)
 	user.log_message("learned the spell [spellname] ([S])", LOG_ATTACK, color="orange")
 	onlearned(user)
@@ -259,6 +264,7 @@
 
 /obj/item/book/granter/spell/barnyard
 	spell = /obj/effect/proc_holder/spell/targeted/barnyardcurse
+	novicespell = /obj/effect/proc_holder/spell/targeted/barnyardcurse/novice
 	spellname = "barnyard"
 	icon_state ="bookhorses"
 	desc = "This book is more horse than your mind has room for."

--- a/code/modules/spells/spell_types/barnyard.dm
+++ b/code/modules/spells/spell_types/barnyard.dm
@@ -11,6 +11,8 @@
 	invocation_type = "shout"
 	range = 7
 	cooldown_min = 30
+	var/mask_integrity //how hard the mask is to destroy
+	var/mask_internals = FALSE //can the mask be used with internals
 	selection_type = "range"
 	var/static/list/compatible_mobs_typecache = typecacheof(list(/mob/living/carbon/human, /mob/living/carbon/monkey))
 
@@ -42,10 +44,22 @@
 
 	var/choice = pick(masks)
 	var/obj/item/clothing/mask/magichead = new choice(get_turf(target))
+	if(mask_integrity)
+		magichead.max_integrity = mask_integrity
+		magichead.obj_integrity = mask_integrity
+	if(mask_internals)
+		magichead.clothing_flags += MASKINTERNALS
 	target.visible_message("<span class='danger'>[target]'s face bursts into flames, and a barnyard animal's head takes its place!</span>", \
 						   "<span class='danger'>Your face burns up, and shortly after the fire you realise you have the face of a barnyard animal!</span>")
 	if(!target.dropItemToGround(target.wear_mask))
 		qdel(target.wear_mask)
 	target.equip_to_slot_if_possible(magichead, SLOT_WEAR_MASK, 1, 1)
 
+
 	target.flash_act()
+
+/obj/effect/proc_holder/spell/targeted/barnyardcurse/novice
+	range = 2
+	charge_max	= 300
+	mask_integrity = 50
+	mask_internals = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1. Adds support for weaker versions of spellbook spells for non-wizards
2. Adds vars to change Curse of the Barnyard mask durability and internals compatibility
2. Adds a weaker version of spellbook Curse of the Barnyard for non-wizards with reduced range, a longer cooldown and masks that are easier to destroy and work as internals.
4. This doesn't touch the wizard version of the spell

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I've always hated Curse of the Barnyard.

1. Prevents internals use (die in breached areas)
2. Can't talk/scream for help
3. 7 tile range so it's easy to get people with and hard to tell who's doing it
5. Time-consuming and unintuitive to remove
6. Easily given back to people who've already removed it

I don't mind that the wizard gets it but if random people can get it through summon magic and run around giving it to everyone it should be nerfed for them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Nerfed Summon Magic version of Curse of the Barnyard for non-wizards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
