### PR TITLE
Fire Cremation

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -521,12 +521,12 @@
 	update_mobility()
 	if(((maxHealth - total_burn) < HEALTH_THRESHOLD_DEAD) && stat == DEAD )
 		become_husk("burn")
+
 	med_hud_set_health()
 	if(stat == SOFT_CRIT)
 		add_movespeed_modifier(MOVESPEED_ID_CARBON_SOFTCRIT, TRUE, multiplicative_slowdown = SOFTCRIT_ADD_SLOWDOWN)
 	else
 		remove_movespeed_modifier(MOVESPEED_ID_CARBON_SOFTCRIT, TRUE)
-
 
 /mob/living/carbon/update_stamina()
 	var/stam = getStaminaLoss()

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -1,19 +1,20 @@
 
 
-/mob/living/carbon/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked = FALSE, forced = FALSE)
+/mob/living/carbon/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked = FALSE, forced = FALSE, spread_damage = FALSE)
 	var/hit_percent = (100-blocked)/100
 	if(!damage || (!forced && hit_percent <= 0))
 		return 0
 
 	var/obj/item/bodypart/BP = null
-	if(isbodypart(def_zone)) //we specified a bodypart object
-		BP = def_zone
-	else
-		if(!def_zone)
-			def_zone = ran_zone(def_zone)
-		BP = get_bodypart(check_zone(def_zone))
-		if(!BP)
-			BP = bodyparts[1]
+	if(!spread_damage)
+		if(isbodypart(def_zone)) //we specified a bodypart object
+			BP = def_zone
+		else
+			if(!def_zone)
+				def_zone = ran_zone(def_zone)
+			BP = get_bodypart(check_zone(def_zone))
+			if(!BP)
+				BP = bodyparts[1]
 
 	var/damage_amount = forced ? damage : damage * hit_percent
 	switch(damagetype)

--- a/code/modules/mob/living/carbon/human/damage_procs.dm
+++ b/code/modules/mob/living/carbon/human/damage_procs.dm
@@ -1,5 +1,5 @@
 
 
-/mob/living/carbon/human/apply_damage(damage = 0,damagetype = BRUTE, def_zone = null, blocked = FALSE, forced = FALSE)
+/mob/living/carbon/human/apply_damage(damage = 0,damagetype = BRUTE, def_zone = null, blocked = FALSE, forced = FALSE, spread_damage = FALSE)
 	// depending on the species, it will run the corresponding apply_damage code there
-	return dna.species.apply_damage(damage, damagetype, def_zone, blocked, src, forced)
+	return dna.species.apply_damage(damage, damagetype, def_zone, blocked, src, forced, spread_damage)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1476,21 +1476,22 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			H.forcesay(GLOB.hit_appends)	//forcesay checks stat already.
 	return TRUE
 
-/datum/species/proc/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H, forced = FALSE)
+/datum/species/proc/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H, forced = FALSE, spread_damage = FALSE)
 	var/hit_percent = (100-(blocked+armor))/100
 	hit_percent = (hit_percent * (100-H.physiology.damage_resistance))/100
 	if(!damage || (!forced && hit_percent <= 0))
 		return 0
-
+	
 	var/obj/item/bodypart/BP = null
-	if(isbodypart(def_zone))
-		BP = def_zone
-	else
-		if(!def_zone)
-			def_zone = ran_zone(def_zone)
-		BP = H.get_bodypart(check_zone(def_zone))
-		if(!BP)
-			BP = H.bodyparts[1]
+	if(!spread_damage)
+		if(isbodypart(def_zone))
+			BP = def_zone
+		else
+			if(!def_zone)
+				def_zone = ran_zone(def_zone)
+			BP = H.get_bodypart(check_zone(def_zone))
+			if(!BP)
+				BP = H.bodyparts[1]
 
 	switch(damagetype)
 		if(BRUTE)
@@ -1610,7 +1611,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		burn_damage = burn_damage * heatmod * H.physiology.heat_mod
 		if (H.stat < UNCONSCIOUS && (prob(burn_damage) * 10) / 4) //40% for level 3 damage on humans
 			H.emote("scream")
-		H.apply_damage(burn_damage, BURN)
+		H.apply_damage(burn_damage, BURN, spread_damage = TRUE)
 
 	else if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT && !HAS_TRAIT(H, TRAIT_RESISTCOLD))
 		SEND_SIGNAL(H, COMSIG_CLEAR_MOOD_EVENT, "hot")

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -642,7 +642,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 					else
 						limb.drop_limb()
 						limb.visible_message("<span class='warning'>[src]'s [limb.name] detaches from [p_their()] body!</span>")
-				return
+			return
 	
 	//Burn the head last
 	var/obj/item/bodypart/head = get_bodypart(BODY_ZONE_HEAD)
@@ -656,7 +656,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 				else
 					head.drop_limb()
 					head.visible_message("<span class='warning'>[src]'s head detaches from [p_their()] body!</span>")
-			return
+		return
 
 	//Nothing left: dust the body, drop the items (if they're flammable they'll burn on their own)
 	if(prob(20))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -630,11 +630,14 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 	//Burn off limbs one by one
 	var/obj/item/bodypart/limb
 	var/list/limb_list = list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
-	while(LAZYLEN(limb_list))
-		limb = get_bodypart(pick_n_take(limb_list))
+	var/still_has_limbs = FALSE
+	for(var/zone in limb_list)
+		limb = get_bodypart(zone)
 		if(limb)
+			still_has_limbs = TRUE
 			if(limb.get_damage() >= limb.max_damage)
-				if(prob(25))
+				limb.cremation_progress += rand(2,5)
+				if(limb.cremation_progress >= 100)
 					if(limb.status == BODYPART_ORGANIC) //Non-organic limbs don't burn
 						limb.drop_limb()
 						limb.visible_message("<span class='warning'>[src]'s [limb.name] crumbles into ash!</span>")
@@ -642,13 +645,15 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 					else
 						limb.drop_limb()
 						limb.visible_message("<span class='warning'>[src]'s [limb.name] detaches from [p_their()] body!</span>")
-			return
-	
+	if(still_has_limbs)
+		return
+
 	//Burn the head last
 	var/obj/item/bodypart/head = get_bodypart(BODY_ZONE_HEAD)
 	if(head)
 		if(head.get_damage() >= head.max_damage)
-			if(prob(25))
+			head.cremation_progress += rand(2,5)
+			if(head.cremation_progress >= 100)
 				if(head.status == BODYPART_ORGANIC) //Non-organic limbs don't burn
 					head.drop_limb()
 					head.visible_message("<span class='warning'>[src]'s head crumbles into ash!</span>")
@@ -659,7 +664,8 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 		return
 
 	//Nothing left: dust the body, drop the items (if they're flammable they'll burn on their own)
-	if(prob(20))
+	chest.cremation_progress += rand(2,5)
+	if(chest.cremation_progress >= 100)
 		visible_message("<span class='warning'>[src]'s body crumbles into a pile of ash!</span>")
 		dust(TRUE, TRUE)
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -39,7 +39,8 @@
 	if(stat == DEAD)
 		stop_sound_channel(CHANNEL_HEARTBEAT)
 		LoadComponent(/datum/component/rot/corpse)
-		check_cremation()
+	
+	check_cremation()
 
 	//Updates the number of stored chemicals for powers
 	handle_changeling()

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -8,7 +8,7 @@
 	Returns
 	standard 0 if fail
 */
-/mob/living/proc/apply_damage(damage = 0,damagetype = BRUTE, def_zone = null, blocked = FALSE, forced = FALSE)
+/mob/living/proc/apply_damage(damage = 0,damagetype = BRUTE, def_zone = null, blocked = FALSE, forced = FALSE, spread_damage = FALSE)
 	var/hit_percent = (100-blocked)/100
 	if(!damage || (!forced && hit_percent <= 0))
 		return 0

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -32,6 +32,8 @@
 	var/max_stamina_damage = 0
 	var/max_damage = 0
 
+	var/cremation_progress = 0 //Gradually increases while burning when at full damage, destroys the limb when at 100
+
 	var/brute_reduction = 0 //Subtracted to brute damage taken
 	var/burn_reduction = 0	//Subtracted to burn damage taken
 
@@ -209,6 +211,7 @@
 		owner.updatehealth()
 	consider_processing()
 	update_disabled()
+	cremation_progress = 0
 	return update_bodypart_damage_state()
 
 //Returns total damage.

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -211,7 +211,7 @@
 		owner.updatehealth()
 	consider_processing()
 	update_disabled()
-	cremation_progress = 0
+	cremation_progress = min(0, cremation_progress - ((brute_dam + burn_dam)*(100/max_damage)))
 	return update_bodypart_damage_state()
 
 //Returns total damage.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bodies can now be cremated (dusted) by setting them on fire while their limbs are at maximum damage.
The process goes like this:
- Body needs to be on fire
- Chest needs to have maximum damage
- At this point, limbs with maximum damage will start to slowly burn off (or detach, if augmented). Burnt off limbs are deleted, detached limbs will remain.
- When no limbs are left, the head is eligible to burn off, same rules as above.
- When nothing is left, the body will (still gradually) dust, dropping any equipped items (that managed to survive the fire).

Every limb has a cremation counter that ticks up if the limb is at max damage and on fire, and is reduced when the limb is healed. Past a certain threshold, the cremation counter causes the limb to burn off and get deleted or detached.

Extra change: Damage from fire is now applied evenly across the body instead of picking a random limb, to make burning people for cremation more consistent. Without this change, damage tended to plateau after most limbs reached max damage.

Fixes #44755

## Why It's Good For The Game

A slow but effective way to dispose of corpses if you have time and access to fire. Makes sense to be able to burn off the evidence, after all.

It's also an extra way to kill off people with NODEATH if you dont have dismemberment tools, as they can be tossed into a fire until they become ash. So flooding the station with plasmafire is now an appropriate response to a zombie invasion.

You can now actually dispose of bodies in lava, instead of leaving a permanent ever-burning husk.

It's worth noting that unless done intentionally or literally swimming in plasmafire, this won't happen randomly.

## Changelog
:cl:
add: Bodies can now be manually cremated by setting them on fire while their limbs are fully damaged.
add: Cremation causes limbs to gradually burn off into ash; once none are left, the body is destroyed.
tweak: Fire damage is now evenly distributed instead of applied to a random limb every tick.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
