### PR TITLE
Fixes teleport armor traitor objective

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -84,7 +84,7 @@
 
 /datum/objective_item/steal/reactive
 	name = "the reactive teleport armor."
-	targetitem = /obj/item/clothing/suit/armor/reactive
+	targetitem = /obj/item/clothing/suit/armor/reactive/teleport
 	difficulty = 5
 	excludefromjob = list("Research Director")
 


### PR DESCRIPTION
Currently, antags can use empty anomaly armors or other types (like stealth/tesla) to complete the teleport armor theft objective. This PR properly restricts it to the /teleport subtype.

## Changelog
:cl:
fix: Incomplete and non-teleport reactive armors can no longer be used to complete the traitor objective.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
