### PR TITLE
You Can No Longer Infinitely Purify a Soulstone + Cult Can't Use Purified Soulstones

### DIFF
--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -205,7 +205,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			user.visible_message("<span class='notice'>[user] has purified the [sword]!</span>")
 			qdel(sword)
 
-	else if(istype(A, /obj/item/soulstone) && !iscultist(user) && SS.purified != TRUE)
+	else if(istype(A, /obj/item/soulstone) && !iscultist(user) && A.purified != TRUE)
 		var/obj/item/soulstone/SS = A
 		to_chat(user, "<span class='notice'>You begin to exorcise [SS].</span>")
 		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -205,7 +205,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			user.visible_message("<span class='notice'>[user] has purified the [sword]!</span>")
 			qdel(sword)
 
-	else if(istype(A, /obj/item/soulstone) && !iscultist(user) && !A.purified)
+	else if(istype(A, /obj/item/soulstone) && !iscultist(user) && SS.purified != TRUE)
 		var/obj/item/soulstone/SS = A
 		to_chat(user, "<span class='notice'>You begin to exorcise [SS].</span>")
 		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -205,7 +205,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			user.visible_message("<span class='notice'>[user] has purified the [sword]!</span>")
 			qdel(sword)
 
-	else if(istype(A, /obj/item/soulstone) && !iscultist(user) && A.purified != TRUE)
+	else if(istype(A, /obj/item/soulstone) && !iscultist(user) && !/obj/item/soulstone.purified)
 		var/obj/item/soulstone/SS = A
 		to_chat(user, "<span class='notice'>You begin to exorcise [SS].</span>")
 		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -205,7 +205,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			user.visible_message("<span class='notice'>[user] has purified the [sword]!</span>")
 			qdel(sword)
 
-	else if(istype(A, /obj/item/soulstone) && !iscultist(user))
+	else if(istype(A, /obj/item/soulstone) && !iscultist(user) && SS.purified = FALSE)
 		var/obj/item/soulstone/SS = A
 		to_chat(user, "<span class='notice'>You begin to exorcise [SS].</span>")
 		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -205,7 +205,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			user.visible_message("<span class='notice'>[user] has purified the [sword]!</span>")
 			qdel(sword)
 
-	else if(istype(A, /obj/item/soulstone) && !iscultist(user) && SS.purified = FALSE)
+	else if(istype(A, /obj/item/soulstone) && !iscultist(user) && !SS.purified)
 		var/obj/item/soulstone/SS = A
 		to_chat(user, "<span class='notice'>You begin to exorcise [SS].</span>")
 		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -205,22 +205,23 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			user.visible_message("<span class='notice'>[user] has purified the [sword]!</span>")
 			qdel(sword)
 
-	else if(istype(A, /obj/item/soulstone) && !iscultist(user) && !/obj/item/soulstone.purified)
+	else if(istype(A, /obj/item/soulstone) && !iscultist(user))
 		var/obj/item/soulstone/SS = A
-		to_chat(user, "<span class='notice'>You begin to exorcise [SS].</span>")
-		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)
-		if(do_after(user, 40, target = SS))
-			playsound(src,'sound/effects/pray_chaplain.ogg',60,1)
-			SS.usability = TRUE
-			SS.purified = TRUE
-			SS.icon_state = "purified_soulstone"
-			for(var/mob/M in SS.contents)
-				if(M.mind)
-					SS.icon_state = "purified_soulstone2"
-			for(var/mob/living/simple_animal/shade/EX in SS)
-				EX.icon_state = "ghost1"
-				EX.name = "Purified [EX.name]"				
-			user.visible_message("<span class='notice'>[user] has purified the [SS]!</span>")
+		if(!SS.purified)
+			to_chat(user, "<span class='notice'>You begin to exorcise [SS].</span>")
+			playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)
+			if(do_after(user, 40, target = SS))
+				playsound(src,'sound/effects/pray_chaplain.ogg',60,1)
+				SS.usability = TRUE
+				SS.purified = TRUE
+				SS.icon_state = "purified_soulstone"
+				for(var/mob/M in SS.contents)
+					if(M.mind)
+						SS.icon_state = "purified_soulstone2"
+				for(var/mob/living/simple_animal/shade/EX in SS)
+					EX.icon_state = "ghost1"
+					EX.name = "Purified [EX.name]"				
+				user.visible_message("<span class='notice'>[user] has purified the [SS]!</span>")
 			
 /obj/item/storage/book/bible/booze
 	desc = "To be applied to the head repeatedly."

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -205,7 +205,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			user.visible_message("<span class='notice'>[user] has purified the [sword]!</span>")
 			qdel(sword)
 
-	else if(istype(A, /obj/item/soulstone) && !iscultist(user) && !SS.purified)
+	else if(istype(A, /obj/item/soulstone) && !iscultist(user) && !A.purified)
 		var/obj/item/soulstone/SS = A
 		to_chat(user, "<span class='notice'>You begin to exorcise [SS].</span>")
 		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -207,21 +207,22 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 
 	else if(istype(A, /obj/item/soulstone) && !iscultist(user))
 		var/obj/item/soulstone/SS = A
-		if(!SS.purified)
-			to_chat(user, "<span class='notice'>You begin to exorcise [SS].</span>")
-			playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)
-			if(do_after(user, 40, target = SS))
-				playsound(src,'sound/effects/pray_chaplain.ogg',60,1)
-				SS.usability = TRUE
-				SS.purified = TRUE
-				SS.icon_state = "purified_soulstone"
-				for(var/mob/M in SS.contents)
-					if(M.mind)
-						SS.icon_state = "purified_soulstone2"
-				for(var/mob/living/simple_animal/shade/EX in SS)
-					EX.icon_state = "ghost1"
-					EX.name = "Purified [EX.name]"				
-				user.visible_message("<span class='notice'>[user] has purified the [SS]!</span>")
+		if(SS.purified)
+			return
+		to_chat(user, "<span class='notice'>You begin to exorcise [SS].</span>")
+		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)
+		if(do_after(user, 40, target = SS))
+			playsound(src,'sound/effects/pray_chaplain.ogg',60,1)
+			SS.usability = TRUE
+			SS.purified = TRUE
+			SS.icon_state = "purified_soulstone"
+			for(var/mob/M in SS.contents)
+				if(M.mind)
+					SS.icon_state = "purified_soulstone2"
+			for(var/mob/living/simple_animal/shade/EX in SS)
+				EX.icon_state = "ghost1"
+				EX.name = "Purified [initial(name)]"				
+			user.visible_message("<span class='notice'>[user] has purified the [SS]!</span>")
 			
 /obj/item/storage/book/bible/booze
 	desc = "To be applied to the head repeatedly."

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -202,7 +202,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 				SS.release_shades(user)
 				qdel(SS)
 			new /obj/item/nullrod/claymore(get_turf(sword))
-			user.visible_message("<span class='notice'>[user] has purified the [sword]!</span>")
+			user.visible_message("<span class='notice'>[user] has purified [sword]!</span>")
 			qdel(sword)
 
 	else if(istype(A, /obj/item/soulstone) && !iscultist(user))
@@ -222,7 +222,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			for(var/mob/living/simple_animal/shade/EX in SS)
 				EX.icon_state = "ghost1"
 				EX.name = "Purified [initial(EX.name)]"				
-			user.visible_message("<span class='notice'>[user] has purified the [SS]!</span>")
+			user.visible_message("<span class='notice'>[user] has purified [SS]!</span>")
 			
 /obj/item/storage/book/bible/booze
 	desc = "To be applied to the head repeatedly."

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -221,7 +221,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 					SS.icon_state = "purified_soulstone2"
 			for(var/mob/living/simple_animal/shade/EX in SS)
 				EX.icon_state = "ghost1"
-				EX.name = "Purified [initial(name)]"				
+				EX.name = "Purified [initial(EX.name)]"				
 			user.visible_message("<span class='notice'>[user] has purified the [SS]!</span>")
 			
 /obj/item/storage/book/bible/booze

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -278,7 +278,7 @@
 		SSticker.mode.add_cultist(S.mind, 0)
 	S.cancel_camera()
 	name = "soulstone: Shade of [T.real_name]"
-	if(purified)
+	if(SS.purified)
 		icon_state = "purified_soulstone2"
 		S.icon_state = "ghost1"
 		S.name = "Purified [S.name]"

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -281,7 +281,7 @@
 	if(purified)
 		icon_state = "purified_soulstone2"
 		S.icon_state = "ghost1"
-		S.name = "Purified [EX.name]"
+		S.name = "Purified [S.name]"
 	else
 		icon_state = "soulstone2"
 	if(U && (iswizard(U) || usability))

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -280,6 +280,8 @@
 	name = "soulstone: Shade of [T.real_name]"
 	if(purified)
 		icon_state = "purified_soulstone2"
+		S.icon_state = "ghost1"
+		S.name = "Purified [EX.name]"
 	else
 		icon_state = "soulstone2"
 	if(U && (iswizard(U) || usability))

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -278,10 +278,8 @@
 		SSticker.mode.add_cultist(S.mind, 0)
 	S.cancel_camera()
 	name = "soulstone: Shade of [T.real_name]"
-	if(SS.purified)
+	if(purified)
 		icon_state = "purified_soulstone2"
-		S.icon_state = "ghost1"
-		S.name = "Purified [S.name]"
 	else
 		icon_state = "soulstone2"
 	if(U && (iswizard(U) || usability))

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -74,7 +74,7 @@
 			to_chat(user, "<span class='cultlarge'>\"Come now, do not capture your bretheren's soul.\"</span>")
 			return
 	if(purified && iscultist(user))
-		to_chat(user, "<span class='warning'>\"Holy magic resides within the stone, you cannot use it.\"</span>")
+		to_chat(user, "<span class='warning'>Holy magic resides within the stone, you cannot use it.</span>")
 		return
 	log_combat(user, M, "captured [M.name]'s soul", src)
 	transfer_soul("VICTIM", M, user)
@@ -89,7 +89,7 @@
 		to_chat(user, "<span class='userdanger'>Your body is wracked with debilitating pain!</span>")
 		return
 	if(purified && iscultist(user))
-		to_chat(user, "<span class='warning'>\"Holy magic resides within the stone, you cannot use it.\"</span>")
+		to_chat(user, "<span class='warning'>Holy magic resides within the stone, you cannot use it.</span>")
 		return
 	release_shades(user)
 
@@ -134,7 +134,7 @@
 			user.Dizzy(30)
 			return
 		if(SS.purified && iscultist(user))
-			to_chat(user, "<span class='warning'>\"Holy magic resides within the stone, you cannot use it.\"</span>")
+			to_chat(user, "<span class='warning'>Holy magic resides within the stone, you cannot use it.</span>")
 			return
 		SS.transfer_soul("CONSTRUCT",src,user)
 		SS.was_used()

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -73,6 +73,9 @@
 		if(iscultist(user))
 			to_chat(user, "<span class='cultlarge'>\"Come now, do not capture your bretheren's soul.\"</span>")
 			return
+	if(purified && iscultist(user))
+		to_chat(user, "<span class='warning'>\"Holy magic resides within the stone, you cannot use it.\"</span>")
+		return
 	log_combat(user, M, "captured [M.name]'s soul", src)
 	transfer_soul("VICTIM", M, user)
 
@@ -84,6 +87,9 @@
 	if(!iscultist(user) && !iswizard(user) && !usability)
 		user.Unconscious(100)
 		to_chat(user, "<span class='userdanger'>Your body is wracked with debilitating pain!</span>")
+		return
+	if(purified && iscultist(user))
+		to_chat(user, "<span class='warning'>\"Holy magic resides within the stone, you cannot use it.\"</span>")
 		return
 	release_shades(user)
 
@@ -126,6 +132,9 @@
 		if(!iscultist(user) && !iswizard(user) && !SS.purified)
 			to_chat(user, "<span class='danger'>An overwhelming feeling of dread comes over you as you attempt to place the soulstone into the shell. It would be wise to be rid of this quickly.</span>")
 			user.Dizzy(30)
+			return
+		if(purified && iscultist(user))
+			to_chat(user, "<span class='warning'>\"Holy magic resides within the stone, you cannot use it.\"</span>")
 			return
 		SS.transfer_soul("CONSTRUCT",src,user)
 		SS.was_used()

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -133,7 +133,7 @@
 			to_chat(user, "<span class='danger'>An overwhelming feeling of dread comes over you as you attempt to place the soulstone into the shell. It would be wise to be rid of this quickly.</span>")
 			user.Dizzy(30)
 			return
-		if(purified && iscultist(user))
+		if(SS.purified && iscultist(user))
 			to_chat(user, "<span class='warning'>\"Holy magic resides within the stone, you cannot use it.\"</span>")
 			return
 		SS.transfer_soul("CONSTRUCT",src,user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #44678
Closes #44751

## Why It's Good For The Game

Bad code is bad. I'm working on other bug fixes but they are taking longer, I'd rather fix what I can in the meantime than have it remain bad for a long amount of time before getting fixed. 

## Changelog
:cl:
fix: You can no longer infinitely purify a soulstone.
fix: Cultists can't use purified soulstones anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
