### PR TITLE
Makes cybernetic heart better

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -156,8 +156,9 @@
 	synthetic = TRUE
 	var/dose_available = TRUE
 
-	var/epinid = /datum/reagent/medicine/epinephrine
-	var/epinamount = 15
+	var/reagid[] = list(/datum/reagent/medicine/epinephrine, /datum/reagent/medicine/omnizine, /datum/reagent/medicine/atropine, /datum/reagent/medicine/tricordrazine, /datum/reagent/medicine/salbutamol)
+	var/reagamount[] = list(15, 5, 10, 10, 15)
+	//length of each list must match. basic cybernetic heart will only add first element
 
 /obj/item/organ/heart/cybernetic/emp_act()
 	. = ..()
@@ -167,13 +168,13 @@
 
 /obj/item/organ/heart/cybernetic/on_life()
 	. = ..()
-	if(dose_available && owner.health <= owner.crit_threshold && !owner.reagents.has_reagent(epinid))
+	if(dose_available && owner.health <= owner.crit_threshold && !owner.reagents.has_reagent(reagid[1]))
 		to_chat(owner, "<span class='notice'>You hear a soft beep from your chest as your cybernetic heart activates.</span>")
 		used_dose()
 
 /obj/item/organ/heart/cybernetic/proc/used_dose()
 	dose_available = FALSE
-	owner.reagents.add_reagent(epinid, epinamount)
+	owner.reagents.add_reagent(reagid[1], reagamount[1])
 	addtimer(VARSET_CALLBACK(src, dose_available, TRUE), 10 MINUTES)
 
 /obj/item/organ/heart/cybernetic/upgraded
@@ -181,24 +182,12 @@
 	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of various healing reagents, used automatically after facing severe trauma. This upgraded model has a reduced cooldown time after use."
 	icon_state = "heart-c-u"
 
-	var/omniid = /datum/reagent/medicine/omnizine
-	var/atroid = /datum/reagent/medicine/atropine
-	var/tricid = /datum/reagent/medicine/tricordrazine
-	var/salbid = /datum/reagent/medicine/salbutamol
-
-	var/omniamount = 5
-	var/atroamount = 10
-	var/tricamount = 10
-	var/salbamount = 15
-
 /obj/item/organ/heart/cybernetic/upgraded/used_dose()
 	dose_available = FALSE
-	addtimer(VARSET_CALLBACK(src, dose_available, TRUE), 5 MINUTES)
-	owner.reagents.add_reagent(epinid, epinamount)
-	owner.reagents.add_reagent(omniid, omniamount)
-	owner.reagents.add_reagent(atroid, atroamount)
-	owner.reagents.add_reagent(tricid, tricamount)
-	owner.reagents.add_reagent(salbid, salbamount)
+	var/i
+	for(i=1, i < reagid.len, i++)
+		owner.reagents.add_reagent(reagid[i], reagamount[i])
+	addtimer(VARSET_CALLBACK(src, dose_available, TRUE), 10 MINUTES)
 
 /obj/item/organ/heart/freedom
 	name = "heart of freedom"

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -151,13 +151,13 @@
 
 /obj/item/organ/heart/cybernetic
 	name = "cybernetic heart"
-	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of epinephrine, used automatically after facing severe trauma."
+	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of epinephrine, used automatically after facing severe trauma. The epinephrine will slowly regenerate after use."
 	icon_state = "heart-c"
 	synthetic = TRUE
 	var/dose_available = TRUE
 
-	var/rid = /datum/reagent/medicine/epinephrine
-	var/ramount = 10
+	var/epinid = /datum/reagent/medicine/epinephrine
+	var/epinamount = 15
 
 /obj/item/organ/heart/cybernetic/emp_act()
 	. = ..()
@@ -167,21 +167,38 @@
 
 /obj/item/organ/heart/cybernetic/on_life()
 	. = ..()
-	if(dose_available && owner.stat == UNCONSCIOUS && !owner.reagents.has_reagent(rid))
-		owner.reagents.add_reagent(rid, ramount)
+	if(dose_available && owner.health <= owner.crit_threshold && !owner.reagents.has_reagent(epinid))
+		to_chat(owner, "<span class='notice'>You hear a soft beep from your chest as your cybernetic heart activates.</span>")
 		used_dose()
 
 /obj/item/organ/heart/cybernetic/proc/used_dose()
 	dose_available = FALSE
+	owner.reagents.add_reagent(epinid, epinamount)
+	addtimer(VARSET_CALLBACK(src, dose_available, TRUE), 10 MINUTES)
 
 /obj/item/organ/heart/cybernetic/upgraded
 	name = "upgraded cybernetic heart"
-	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of epinephrine, used automatically after facing severe trauma. This upgraded model can regenerate its dose after use."
+	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of various healing reagents, used automatically after facing severe trauma. This upgraded model has a reduced cooldown time after use."
 	icon_state = "heart-c-u"
 
+	var/omniid = /datum/reagent/medicine/omnizine
+	var/atroid = /datum/reagent/medicine/atropine
+	var/tricid = /datum/reagent/medicine/tricordrazine
+	var/salbid = /datum/reagent/medicine/salbutamol
+
+	var/omniamount = 5
+	var/atroamount = 10
+	var/tricamount = 10
+	var/salbamount = 15
+
 /obj/item/organ/heart/cybernetic/upgraded/used_dose()
-	. = ..()
+	dose_available = FALSE
 	addtimer(VARSET_CALLBACK(src, dose_available, TRUE), 5 MINUTES)
+	owner.reagents.add_reagent(epinid, epinamount)
+	owner.reagents.add_reagent(omniid, omniamount)
+	owner.reagents.add_reagent(atroid, atroamount)
+	owner.reagents.add_reagent(tricid, tricamount)
+	owner.reagents.add_reagent(salbid, salbamount)
 
 /obj/item/organ/heart/freedom
 	name = "heart of freedom"

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -179,7 +179,7 @@
 
 /obj/item/organ/heart/cybernetic/upgraded
 	name = "upgraded cybernetic heart"
-	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of various healing reagents, used automatically after facing severe trauma. This upgraded model has a reduced cooldown time after use."
+	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of various healing reagents, used automatically after facing severe trauma. The reagents will slowly regenerate after use."
 	icon_state = "heart-c-u"
 
 /obj/item/organ/heart/cybernetic/upgraded/used_dose()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the functionality of the cybernetic heart to make it better at keeping the player alive.
Basically adds some helpful reagents to the upgraded version of the cybernetic heart, alerts you when you use it, and makes both able to be recharged.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cybernetic organs are pretty useless right now and aren't used by players very often. Making the cybernetic organs actually useful would be good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added more chemicals to upgraded cybernetic heart: 5u Omnizine, 10u Atropine, 10u Tricordrazine, 15u Salbutamol.
add: User of the heart is notified when it releases chemicals.
tweak: Increased epinephrine from 10u to 15u for both hearts.
tweak: Heart now activates on crit instead of being unconscious.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
