### PR TITLE
Fixes an issue with clown hulk simple mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -163,7 +163,6 @@
 	response_help = "tries desperately to appease"
 	response_disarm = "foolishly pushes"
 	response_harm = "angers"
-	access_card = ACCESS_THEATRE
 	speak = list("HONK", "Honk!", "HAUAUANK!!!", "GUUURRRRAAAHHH!!!")
 	emote_see = list("honks", "sweats", "grunts")
 	speak_chance = 5


### PR DESCRIPTION
## About The Pull Request

Clown hulks from the admin only simple mobs cause an error when trying to open access restricted doors, this fixes that.

## Why It's Good For The Game

bug fixes if anyone ever uses these

## Changelog
:cl: FlufflyCthulu
fix: Fixes an issue with clown hulk simple mobs
/:cl:
