### PR TITLE
Atmos can no longer pass through shuttle engines.

### DIFF
--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -17,6 +17,7 @@
 	anchored = TRUE
 	var/engine_power = 1
 	var/state = ENGINE_WELDED //welding shmelding
+	CanAtmosPass = ATMOS_PASS_NO
 
 //Ugh this is a lot of copypasta from emitters, welding need some boilerplate reduction
 /obj/structure/shuttle/engine/can_be_unfasten_wrench(mob/user, silent)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so shuttle engines now block atmos from passing through them.

## Why It's Good For The Game

Seems a bit dumb that on some shuttles the only thing blocking space from the interior of the shuttle is a line of directional reinforced windows. Then the giant engines don't somehow block atmos from moving as well.

## Changelog
:cl:

tweak: /obj/structure/shuttle/engine and its children now block atmos from passing through them.

/:cl:

