### PR TITLE
Collars can now be worn again

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/pet.dm
+++ b/code/modules/mob/living/simple_animal/friendly/pet.dm
@@ -24,7 +24,7 @@
 		fully_replace_character_name(null, "\proper [P.tagname]")
 
 /mob/living/simple_animal/pet/attackby(obj/item/O, mob/user, params)
-	if(istype(O, /obj/item/clothing/neck/petcollar) && !pcollar && collar_type)
+	if(istype(O, /obj/item/clothing/neck/petcollar) && !pcollar)
 		add_collar(O, user)
 		return
 


### PR DESCRIPTION
...by pets. Fixes https://github.com/tgstation/tgstation/issues/43696. 

Basically it was checking for the existence of a collar sprite, but regenerate_icons is the only place the sprite is referenced and it has a check already.