### PR TITLE
buffs captain's and centcom jumpsuit

### DIFF
--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -22,6 +22,8 @@
 	icon_state = "captain"
 	item_state = "b_suit"
 	item_color = "captain"
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	strip_delay = 50
 	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
 

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -109,6 +109,7 @@
 	icon_state = "officer"
 	item_state = "g_suit"
 	item_color = "officer"
+	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/rank/centcom_commander
@@ -117,6 +118,7 @@
 	icon_state = "centcom"
 	item_state = "dg_suit"
 	item_color = "centcom"
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 
 /obj/item/clothing/under/space
 	name = "\improper NASA jumpsuit"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -110,6 +110,7 @@
 	item_state = "g_suit"
 	item_color = "officer"
 	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
+	strip_delay = 50
 	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/rank/centcom_commander
@@ -119,6 +120,7 @@
 	item_state = "dg_suit"
 	item_color = "centcom"
 	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	strip_delay = 60
 
 /obj/item/clothing/under/space
 	name = "\improper NASA jumpsuit"


### PR DESCRIPTION
## About The Pull Request

gives captain jumpsuit 5 brute protection and 50 fire and acid protection while increasing the strip delay to 50 like sec has
also gives the same but with 30 fire and acid protection to centcom officer jumpsuit (used by centcom officials and ert)
and gives same but with 10 brute protection and 60 strip delay like hos to the centcom commander jumpsuit (used by centcom commanders and death squad)

## Why It's Good For The Game

the highest ranking people should get some armor

## Changelog
:cl:
balance: Central Command finally used more of their budget on their highest ranking people's jumpsuits, maybe this will help a little, captain
/:cl:
