### PR TITLE
Tweaks sawn off guns

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -151,6 +151,7 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 //Sawn off nerfs
 #define SAWN_OFF_ACC_PENALTY 25
 #define SAWN_OFF_RECOIL 1
+#define SAW_OFF_SHARPNESS_THRESHOLD 12 //How much force a sharp weapon needs to saw off a gun
 
 //Projectile Reflect
 #define REFLECT_NORMAL 				(1<<0)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -386,7 +386,9 @@
 
 
 
-/obj/item/gun/ballistic/proc/sawoff(mob/user)
+/obj/item/gun/ballistic/proc/sawoff(mob/user, obj/item/I)
+	if(!I.is_sharp() || I.force < SAW_OFF_SHARPNESS_THRESHOLD)
+		return
 	if(sawn_off)
 		to_chat(user, "<span class='warning'>\The [src] is already shortened!</span>")
 		return

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -400,7 +400,7 @@
 		user.visible_message("<span class='danger'>\The [src] goes off!</span>", "<span class='danger'>\The [src] goes off in your face!</span>")
 		return
 
-	if(do_after(user, 30, target = src))
+	if(do_after(user, max(30, 60 - I.force), target = src))
 		if(sawn_off)
 			return
 		user.visible_message("[user] shortens \the [src]!", "<span class='notice'>You shorten \the [src].</span>")

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -41,12 +41,7 @@
 
 /obj/item/gun/ballistic/shotgun/riot/attackby(obj/item/A, mob/user, params)
 	..()
-	if(istype(A, /obj/item/circular_saw) || istype(A, /obj/item/gun/energy/plasmacutter))
-		sawoff(user)
-	if(istype(A, /obj/item/melee/transforming/energy))
-		var/obj/item/melee/transforming/energy/W = A
-		if(W.active)
-			sawoff(user)
+	sawoff(user, A)
 
 // Automatic Shotguns//
 
@@ -172,12 +167,7 @@
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/attackby(obj/item/A, mob/user, params)
 	..()
-	if(istype(A, /obj/item/melee/transforming/energy))
-		var/obj/item/melee/transforming/energy/W = A
-		if(W.active)
-			sawoff(user)
-	if(istype(A, /obj/item/circular_saw) || istype(A, /obj/item/gun/energy/plasmacutter))
-		sawoff(user)
+	sawoff(user, A)
 
 // IMPROVISED SHOTGUN //
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes sawn off guns more sane. You can now use any sharp weapon with a force over 12 to saw off a gun. Items with lower force take longer.

Depending on #44791  getting merged, this might need changes.

## Why It's Good For The Game

This is a slightly more sane solution than what we used to have.

It also opens up more creativity. Stuff like katanas, butchers cleavers and combat knifes can now be used to saw off a shotgun.

## Changelog
:cl:
tweak: Any sharp object with a force over 12 can now be used to saw off a shotgun.
/:cl:
