### PR TITLE
Stasis beds now are surgery-friendly

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -113,6 +113,8 @@
 
 	if(locate(/obj/structure/table/optable, T))
 		propability = 1
+	else if(locate(/obj/machinery/sleeper, T))
+		propability = 0.9
 	else if(locate(/obj/structure/table, T))
 		propability = 0.8
 	else if(locate(/obj/structure/bed, T))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -113,7 +113,7 @@
 
 	if(locate(/obj/structure/table/optable, T))
 		propability = 1
-	else if(locate(/obj/machinery/sleeper, T))
+	else if(locate(/obj/machinery/stasis, T))
 		propability = 0.9
 	else if(locate(/obj/structure/table, T))
 		propability = 0.8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a modifier to probability for SBs, making them better than both tables and beds but not as good as dedicated surgery tables.

## Why It's Good For The Game
It allows for a decision making process that previously would rarely exist since a 0% bonus compared to a 100% bonus is pretty steep (if you knew it didn't have one). Now you trade 10% for the perks of being in stasis.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: CobbyzzzZzzz
balance: Stasis are now the second best option for surgery probability (surgical tables are still number 1)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
