### PR TITLE
Tweaks the damage that podpeople take from being low on food

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -311,7 +311,7 @@
 			H.adjustOxyLoss(-1)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
-		H.take_overall_damage(2,0)
+		H.take_overall_damage(1,1, 0, BODYPART_ORGANIC)
 
 /datum/species/golem/wood/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.type == /datum/reagent/toxin/plantbgone)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -41,7 +41,7 @@
 			H.adjustOxyLoss(-1)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
-		H.take_overall_damage(2,0)
+		H.take_overall_damage(1,1, 0, BODYPART_ORGANIC)
 
 /datum/species/pod/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.type == /datum/reagent/toxin/plantbgone)


### PR DESCRIPTION
## About The Pull Request

This PR makes the damage over time that podpeople take from being low on food be more consistent with the damage that shadowpeople take from being in light by making it not affect non-organic limbs (why would a podperson starving cause their prosthetic limbs to begin to shrivel up?) and making it be a mixture of brute and burn damage (instead of just brute damage).

## Why It's Good For The Game

I was doing some codediving for Crosoak over on the /tg/station Discord when I discovered that the damage that podpeople take from being low on food didn't only affect organic limbs like their healing from being in light (and the healing from being in a coffin that vampires get, the healing from being in darkness that shadowpeople get, and the damage from being in light that shadowpeople get) did. This PR changes that to be more consistent with other racial damage and healing over time. It also changes the damage done by it from two brute damage per tick to one brute damage and one burn damage per tick(,) to match the damage that shadowpeople (the "opposites" of podpeople, IMO) take from being in light.

## Changelog
:cl: ATHATH
tweak: podpeople and wooden golems now take 1 brute damage per tick and 1 burn damage per tick while low on food instead of 2 brute damage per tick
fix: the damage that podpeople and wooden golems take while low on food now only affects their organic limbs
/:cl: