### PR TITLE
Stasis calls end_metabolism on reagent holder

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -103,6 +103,7 @@
 /datum/status_effect/incapacitating/stasis/on_creation(mob/living/new_owner, set_duration, updating_canmove)
         . = ..()
         update_time_of_death()
+        owner.reagents?.end_metabolization(owner, FALSE)
 
 /datum/status_effect/incapacitating/stasis/tick()
         update_time_of_death()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -586,7 +586,7 @@
 	toxpwr = 0
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 
-/datum/reagent/toxin/amanitin/on_mob_end_metabolize(mob/living/M)
+/datum/reagent/toxin/amanitin/on_mob_delete(mob/living/M)
 	var/toxdamage = current_cycle*3*REM
 	M.log_message("has taken [toxdamage] toxin damage from amanitin toxin", LOG_ATTACK)
 	M.adjustToxLoss(toxdamage)


### PR DESCRIPTION
## About The Pull Request

Stasis already stopped metabolism but didn't let the reagents know that. Now they know.

Amanitin was reverted to use `on_mob_delete` instead of `on_mob_end_metabolism`. This means it won't trigger the toxin damage until all of it is gone, even if metabolism is paused.

## Why It's Good For The Game

Fixes #43974, potentially other unreported issues.

## Changelog
:cl: JJRcop
fix: Stasis lets reagents know processing was stopped, fixing some issues.
tweak: Amanitin's damage only triggers when it is completely removed from your system, not when processing stops.
/:cl: