### PR TITLE
Can now pick up defib paddles seperately

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -3,7 +3,7 @@
 
 /obj/item/defibrillator
 	name = "defibrillator"
-	desc = "A device that delivers powerful shocks to detachable paddles that resuscitate incapacitated patients."
+	desc = "A device that delivers powerful shocks to detachable paddles that resuscitate incapacitated patients. Ctrl-click to remove the paddles from the defibrillator."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "defibunit"
 	item_state = "defibunit"
@@ -79,6 +79,10 @@
 
 /obj/item/defibrillator/ui_action_click()
 	toggle_paddles()
+
+/obj/item/defibrillator/CtrlClick()
+	if(ishuman(usr) && Adjacent(usr))
+		toggle_paddles()
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/defibrillator/attack_hand(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it possible to pick up defibrillator paddles with Ctrl Click
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You no longer have to look like this when saving peoples lives
![image](https://user-images.githubusercontent.com/30060146/60224985-e3e9c780-9852-11e9-8294-4b8abf8845c1.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: You can now pick up the paddles from defibrillators by ctrl clicking them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
