### PR TITLE
Holy melons work in pockets again

### DIFF
--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -63,7 +63,7 @@
 	var/uses = 1
 	if(seed)
 		uses = round(seed.potency / 20)
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, ITEM_SLOT_HANDS, uses, TRUE, CALLBACK(src, .proc/block_magic), CALLBACK(src, .proc/expire)) //deliver us from evil o melon god
+	AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, null, uses, TRUE, CALLBACK(src, .proc/block_magic), CALLBACK(src, .proc/expire)) //deliver us from evil o melon god
 
 /obj/item/reagent_containers/food/snacks/grown/holymelon/proc/block_magic(mob/user, major)
 	if(major)


### PR DESCRIPTION
## About The Pull Request

Makes holy melons still provide anti-magic protection while pocketed.

## Why It's Good For The Game

Holy melons already take some cooperation from chemistry and botany as well as a fair bit of time to grow.

Along with the nerf that keeps the melons as a limited use item, I think that they should be treated as legit anti-magic item, and so should have a consistent behaviour as the null rod.

## Changelog
:cl:
balance: Holy melons work in pockets again
/:cl: