### PR TITLE
Allows Summon Magic spellbooks to be upgraded for higher level spells

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -39,3 +39,5 @@ GLOBAL_LIST_EMPTY(ai_status_displays)
 
 GLOBAL_LIST_EMPTY(mob_spawners) 		    // All mob_spawn objects
 GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/computer/station_alert
+
+GLOBAL_LIST_EMPTY(spellbooks)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -607,8 +607,10 @@
 	add_antag_datum(head)
 	special_role = ROLE_REV_HEAD
 
-/datum/mind/proc/AddSpell(obj/effect/proc_holder/spell/S)
+/datum/mind/proc/AddSpell(obj/effect/proc_holder/spell/S, slevel)
 	spell_list += S
+	if(slevel)
+		S.UpdateSpellLevel(slevel)
 	S.action.Grant(current)
 
 /datum/mind/proc/owns_soul()

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -150,7 +150,7 @@
 					to_chat(user,"<span class='notice'>You're already far more versed in this spell than this flimsy how-to book can provide.</span>")
 				else
 					to_chat(user,"<span class='notice'>You've already read this one.</span>")
-				return TRUE
+			return TRUE
 	return FALSE
 
 /obj/item/book/granter/spell/on_reading_start(mob/user)
@@ -160,12 +160,10 @@
 	for(var/obj/effect/proc_holder/spell/knownspell in user.mind.spell_list)
 		if(knownspell.type == spell)
 			user.mind.RemoveSpell(knownspell)
-			to_chat(user, "<span class='notice'>You feel like you've experienced enough to cast [spellname]!</span>")
-		else
-			to_chat(user, "<span class='notice'>You feel like you've experienced enough to cast [spellname]!</span>")
 	var/obj/effect/proc_holder/spell/S = new spell
 	user.mind.AddSpell(S, spell_level)
-	user.log_message("learned the spell [spellname] ([S])", LOG_ATTACK, color="orange")
+	to_chat(user, "<span class='notice'>You feel like you've experienced enough to cast [S.name]!</span>")
+	user.log_message("learned the spell [S.name] ([S])", LOG_ATTACK, color="orange")
 	onlearned(user)
 
 /obj/item/book/granter/spell/recoil(mob/user)

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -119,9 +119,14 @@
 	var/spellname = "conjure bugs"
 	var/spell_level = 0
 
-/obj/item/book/granter/spell/New()
-	..()
+/obj/item/book/granter/spell/Initialize()
+	. = ..()
+	GLOB.spellbooks += src
 	update_name()
+
+/obj/item/book/granter/spell/Destroy()
+	. = ..()
+	GLOB.spellbooks -= src
 
 /obj/item/book/granter/spell/proc/update_name()
 	var/obj/effect/proc_holder/spell/S = new spell
@@ -130,11 +135,15 @@
 	name = "spellbook of [S.name]"
 	qdel(S)
 
-/obj/item/book/granter/spell/proc/level_up_book()
-	spell_level += 1
-	used = FALSE
+/obj/item/book/granter/spell/proc/level_up_book(amount, message)
+	spell_level += amount
 	update_name()
+	used = FALSE
 	icon_state = initial(icon_state)
+
+	if(message)
+		playsound(get_turf(src), 'sound/magic/charge.ogg', 50, 1)
+		src.visible_message("<span class='notice'>[src] glows in a white light!</span>")
 
 /obj/item/book/granter/spell/attack_self(mob/user)
 	update_name()

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -136,7 +136,10 @@
 	qdel(S)
 
 /obj/item/book/granter/spell/proc/level_up_book(amount, message)
-	spell_level += amount
+	if(spell_level + amount > spell.level_max)
+		spell_level = spell.level_max
+	else
+		spell_level += amount
 	update_name()
 	used = FALSE
 	icon_state = initial(icon_state)

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -37,24 +37,9 @@
 				to_chat(user,  "<span class='warning'>This spell cannot be improved further.</span>")
 				return FALSE
 			else
-				aspell.name = initial(aspell.name)
-				aspell.spell_level++
-				aspell.charge_max = round(initial(aspell.charge_max) - aspell.spell_level * (initial(aspell.charge_max) - aspell.cooldown_min)/ aspell.level_max)
-				if(aspell.charge_max < aspell.charge_counter)
-					aspell.charge_counter = aspell.charge_max
-				switch(aspell.spell_level)
-					if(1)
-						to_chat(user, "<span class='notice'>You have improved [aspell.name] into Efficient [aspell.name].</span>")
-						aspell.name = "Efficient [aspell.name]"
-					if(2)
-						to_chat(user, "<span class='notice'>You have further improved [aspell.name] into Quickened [aspell.name].</span>")
-						aspell.name = "Quickened [aspell.name]"
-					if(3)
-						to_chat(user, "<span class='notice'>You have further improved [aspell.name] into Free [aspell.name].</span>")
-						aspell.name = "Free [aspell.name]"
-					if(4)
-						to_chat(user, "<span class='notice'>You have further improved [aspell.name] into Instant [aspell.name].</span>")
-						aspell.name = "Instant [aspell.name]"
+				var/old_name = aspell.name
+				aspell.UpdateSpellLevel(aspell.spell_level + 1)
+				to_chat(user, "<span class='notice'>You have [aspell.spell_level == 1 ? "improved" : "further improved"] [old_name] into [aspell.name].</span>")
 				if(aspell.spell_level >= aspell.level_max)
 					to_chat(user, "<span class='notice'>This spell cannot be strengthened any further.</span>")
 				SSblackbox.record_feedback("nested tally", "wizard_spell_improved", 1, list("[name]", "[aspell.spell_level]"))
@@ -62,6 +47,7 @@
 	//No same spell found - just learn it
 	SSblackbox.record_feedback("tally", "wizard_spell_learned", 1, name)
 	user.mind.AddSpell(S)
+	S.nameSpell()
 	to_chat(user, "<span class='notice'>You have learned [S.name].</span>")
 	return TRUE
 
@@ -556,7 +542,7 @@
 	return TRUE
 
 /obj/item/spellbook
-	name = "spell book"
+	name = "spellbook"
 	desc = "An unearthly tome that glows with power."
 	icon = 'icons/obj/library.dmi'
 	icon_state ="book"

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -128,7 +128,7 @@
 	to_chat(owner, "<span class='boldannounce'>You are the Space Wizard!</span>")
 	to_chat(owner, "<B>The Space Wizards Federation has given you the following tasks:</B>")
 	owner.announce_objectives()
-	to_chat(owner, "You will find a list of available spells in your spell book. Choose your magic arsenal carefully.")
+	to_chat(owner, "You will find a list of available spells in your spellbook. Choose your magic arsenal carefully.")
 	to_chat(owner, "The spellbook is bound to you, and others cannot use it.")
 	to_chat(owner, "In your pockets you will find a teleport scroll. Use it as needed.")
 	to_chat(owner,"<B>Remember:</B> do not forget to prepare your spells.")

--- a/code/modules/events/wizard/aid.dm
+++ b/code/modules/events/wizard/aid.dm
@@ -36,3 +36,5 @@
 			for(var/obj/effect/proc_holder/spell/S in L.mind.spell_list)
 				S.UpdateSpellLevel(S.spell_level + 1)
 			to_chat(L, "<span class='notice'>You suddenly feel more competent with your casting!</span>")
+	for(var/obj/item/book/granter/spell/B in GLOB.spellbooks)
+		B.level_up_book(1, TRUE)

--- a/code/modules/events/wizard/aid.dm
+++ b/code/modules/events/wizard/aid.dm
@@ -34,25 +34,5 @@
 		var/mob/living/L = i
 		if(L.mind && L.mind.spell_list.len != 0)
 			for(var/obj/effect/proc_holder/spell/S in L.mind.spell_list)
-				S.name = initial(S.name)
-				S.spell_level++
-				if(S.spell_level >= 6 || S.charge_max <= 0) //Badmin checks, these should never be a problem in normal play
-					continue
-				if(S.level_max <= 0)
-					continue
-				S.charge_max = round(initial(S.charge_max) - S.spell_level * (initial(S.charge_max) - S.cooldown_min) / S.level_max)
-				if(S.charge_max < S.charge_counter)
-					S.charge_counter = S.charge_max
-				switch(S.spell_level)
-					if(1)
-						S.name = "Efficient [S.name]"
-					if(2)
-						S.name = "Quickened [S.name]"
-					if(3)
-						S.name = "Free [S.name]"
-					if(4)
-						S.name = "Instant [S.name]"
-					if(5)
-						S.name = "Ludicrous [S.name]"
-
+				S.UpdateSpellLevel(S.spell_level + 1)
 			to_chat(L, "<span class='notice'>You suddenly feel more competent with your casting!</span>")

--- a/code/modules/events/wizard/aid.dm
+++ b/code/modules/events/wizard/aid.dm
@@ -37,4 +37,4 @@
 				S.UpdateSpellLevel(S.spell_level + 1)
 			to_chat(L, "<span class='notice'>You suddenly feel more competent with your casting!</span>")
 	for(var/obj/item/book/granter/spell/B in GLOB.spellbooks)
-		B.level_up_book(1, TRUE)
+		B.level_up_book(pick(1,2), TRUE)

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -525,6 +525,52 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			return FALSE
 	return TRUE
 
+/obj/effect/proc_holder/spell/proc/UpdateSpellLevel(new_level)
+	if(new_level == spell_level)
+		return
+
+	if(level_max < 0)
+		return
+
+	var/old_level = spell_level
+
+	new_level = CLAMP(new_level,0,level_max)
+
+	var/upgrade_amount
+	if(new_level < old_level)
+		spell_level = 0
+		charge_max = initial(charge_max)
+		upgrade_amount = new_level
+	else
+		upgrade_amount = new_level - old_level
+
+	for(var/i=0,i<upgrade_amount,i++)
+		LevelUpSpell()
+
+	if(charge_max < charge_counter)
+		charge_counter = charge_max
+
+	nameSpell()
+
+/obj/effect/proc_holder/spell/proc/LevelUpSpell()
+	spell_level++
+	charge_max = round(initial(charge_max) - spell_level * (initial(charge_max) - cooldown_min)/level_max)
+
+/obj/effect/proc_holder/spell/proc/nameSpell()
+	switch(spell_level)
+		if(0)
+			name = "[initial(name)]"
+		if(1)
+			name = "Efficient [initial(name)]"
+		if(2)
+			name = "Quickened [initial(name)]"
+		if(3)
+			name = "Free [initial(name)]"
+		if(4)
+			name = "Instant [initial(name)]"
+		if(5)
+			name = "Ludicrous [initial(name)]"
+
 /obj/effect/proc_holder/spell/self //Targets only the caster. Good for buffs and heals, but probably not wise for fireballs (although they usually fireball themselves anyway, honke)
 	range = -1 //Duh
 

--- a/code/modules/spells/spell_types/barnyard.dm
+++ b/code/modules/spells/spell_types/barnyard.dm
@@ -13,8 +13,6 @@
 	cooldown_min = 30
 	selection_type = "range"
 	var/static/list/compatible_mobs_typecache = typecacheof(list(/mob/living/carbon/human, /mob/living/carbon/monkey))
-	var/mask_integrity //how easy the mask is to destory
-	var/mask_internals = FALSE //does the mask work as internals
 
 	action_icon_state = "barn"
 
@@ -44,11 +42,6 @@
 
 	var/choice = pick(masks)
 	var/obj/item/clothing/mask/magichead = new choice(get_turf(target))
-	if(mask_integrity)
-		magichead.max_integrity = mask_integrity
-		magichead.obj_integrity = mask_integrity
-	if(mask_internals)
-		magichead.clothing_flags += MASKINTERNALS
 	target.visible_message("<span class='danger'>[target]'s face bursts into flames, and a barnyard animal's head takes its place!</span>", \
 						   "<span class='danger'>Your face burns up, and shortly after the fire you realise you have the face of a barnyard animal!</span>")
 	if(!target.dropItemToGround(target.wear_mask))

--- a/code/modules/spells/spell_types/barnyard.dm
+++ b/code/modules/spells/spell_types/barnyard.dm
@@ -13,6 +13,8 @@
 	cooldown_min = 30
 	selection_type = "range"
 	var/static/list/compatible_mobs_typecache = typecacheof(list(/mob/living/carbon/human, /mob/living/carbon/monkey))
+	var/mask_integrity //how easy the mask is to destory
+	var/mask_internals = FALSE //does the mask work as internals
 
 	action_icon_state = "barn"
 
@@ -42,6 +44,11 @@
 
 	var/choice = pick(masks)
 	var/obj/item/clothing/mask/magichead = new choice(get_turf(target))
+	if(mask_integrity)
+		magichead.max_integrity = mask_integrity
+		magichead.obj_integrity = mask_integrity
+	if(mask_internals)
+		magichead.clothing_flags += MASKINTERNALS
 	target.visible_message("<span class='danger'>[target]'s face bursts into flames, and a barnyard animal's head takes its place!</span>", \
 						   "<span class='danger'>Your face burns up, and shortly after the fire you realise you have the face of a barnyard animal!</span>")
 	if(!target.dropItemToGround(target.wear_mask))

--- a/code/modules/spells/spell_types/charge.dm
+++ b/code/modules/spells/spell_types/charge.dm
@@ -43,12 +43,14 @@
 					to_chat(L, "<span class='notice'>This book is infinite use and can't be recharged, yet the magic has improved the book somehow...</span>")
 					burnt_out = TRUE
 					I.pages_to_mastery--
+					I.level_up_book()
 					break
 				if(prob(80))
 					L.visible_message("<span class='warning'>[I] catches fire!</span>")
 					qdel(I)
 				else
 					I.used = FALSE
+					I.level_up_book()
 					charged_item = I
 					break
 			else if(istype(item, /obj/item/gun/magic))

--- a/code/modules/spells/spell_types/charge.dm
+++ b/code/modules/spells/spell_types/charge.dm
@@ -45,7 +45,7 @@
 					I.pages_to_mastery--
 					I.level_up_book(1, FALSE)
 					break
-				if(prob(80))
+				if(prob(50))
 					L.visible_message("<span class='warning'>[I] catches fire!</span>")
 					qdel(I)
 				else

--- a/code/modules/spells/spell_types/charge.dm
+++ b/code/modules/spells/spell_types/charge.dm
@@ -43,14 +43,14 @@
 					to_chat(L, "<span class='notice'>This book is infinite use and can't be recharged, yet the magic has improved the book somehow...</span>")
 					burnt_out = TRUE
 					I.pages_to_mastery--
-					I.level_up_book()
+					I.level_up_book(1, FALSE)
 					break
 				if(prob(80))
 					L.visible_message("<span class='warning'>[I] catches fire!</span>")
 					qdel(I)
 				else
 					I.used = FALSE
-					I.level_up_book()
+					I.level_up_book(1, FALSE)
 					charged_item = I
 					break
 			else if(istype(item, /obj/item/gun/magic))

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -146,6 +146,11 @@ GLOBAL_VAR_INIT(summon_magic_triggered, FALSE)
 	var/obj/item/M = new magic_type(get_turf(H))
 	playsound(get_turf(H),'sound/magic/summon_magic.ogg', 50, 1)
 
+	if(M.type == /obj/item/book/granter/spell && prob(SPECIALIST_MAGIC_PROB))
+		var/obj/item/book/granter/spell/S = M
+		S.level_up_book(4,FALSE)
+		lucky = TRUE
+
 	var/in_hand = H.put_in_hands(M)
 
 	to_chat(H, "<span class='warning'>\A [M] appears [in_hand ? "in your hand" : "at your feet"]!</span>")

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -146,10 +146,18 @@ GLOBAL_VAR_INIT(summon_magic_triggered, FALSE)
 	var/obj/item/M = new magic_type(get_turf(H))
 	playsound(get_turf(H),'sound/magic/summon_magic.ogg', 50, 1)
 
-	if(M.type == /obj/item/book/granter/spell && prob(SPECIALIST_MAGIC_PROB))
+	if(M.type == /obj/item/book/granter/spell)
 		var/obj/item/book/granter/spell/S = M
-		S.level_up_book(4,FALSE)
-		lucky = TRUE
+		if(prob(SPECIALIST_MAGIC_PROB))
+			S.level_up_book(4,FALSE)
+			lucky = TRUE
+		else if(prob(10))
+			S.level_up_book(3,FALSE)
+		else if(prob(40))
+			S.level_up_book(2,FALSE)
+		else if(prob(50))
+			S.level_up_book(1,FALSE)
+
 
 	var/in_hand = H.put_in_hands(M)
 

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -68,21 +68,11 @@
 
 
 /obj/effect/proc_holder/spell/targeted/smoke/lesser //Chaplain smoke book
-	name = "Smoke"
+	name = "Lesser Smoke"
 	desc = "This spell spawns a small cloud of choking smoke at your location."
-
-	school = "conjuration"
 	charge_max = 360
-	clothes_req = FALSE
-	invocation = "none"
-	invocation_type = "none"
-	range = -1
-	include_user = TRUE
-
 	smoke_spread = 1
 	smoke_amt = 2
-
-	action_icon_state = "smoke"
 
 /obj/effect/proc_holder/spell/targeted/emplosion/disable_tech
 	name = "Disable Tech"
@@ -280,7 +270,7 @@
 		var/atom/movable/AM = am
 		if(AM == user || AM.anchored)
 			continue
-		
+
 		if(ismob(AM))
 			var/mob/M = AM
 			if(M.anti_magic_check(anti_magic_check, FALSE))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Gameplay
- Summon magic spellbooks can now give different levels of spell from 0 to 4, same as the wizard's spellbook
- Higher level spellbooks can be obtained using charge, through the improved casting event or a lucky spawn
- Used spellbooks upgraded through charge or improved casting become reusable
- Charge has a 50% chance of failure or 0% if it isn't a one use book (so varedited, same as it was to make them read faster)
- 2% chance (specialist magic probability) that summon magic spawned spellbooks upgrade to level 4 on spawn, the other levels range from 10% - 50%
- Spellbooks are now affected by the improved casting summon event, which causes them to increase 1-2 levels each time
- Using a higher levelled spellbook while knowing a lower levelled version of the spell upgrades the spell
- Using a lower levelled spellbook while knowing a higher version does nothing

### Other
- Creates a specific spell naming proc, spell level setting proc and spell levelling proc to avoid copypasted code
- Changes improved casting summon event and wizard spellbook to use above procs, removing copypasted code
- Changes spellbook to one word in files to be consistent
- Removes duplicated code in lesser smoke spell
- Renames the lesser "Smoke" spell to "Lesser Smoke" to distinguish it (it's possible to get them both at once)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Admins can spawn spellbooks and edit their variables to give people higher levelled spells
- Crew can upgrade spellbooks to get higher levelled spells, which previously only wizards had access to
- Cleans up some messy and copypasted code

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
add: Summon Magic spellbooks can now give different levels of spell (0 is default, up to 4)
add: The Charge spell has a 50% chance of upgrading a spellbook one level
add: The Improved Casting Summon Event upgrades spellbooks 1-2 levels each time
add: 2% chance (specialist magic probability) of spellbooks becoming level 4 on spawn, lower levels range between 10% - 50% (and you aren't guaranteed to get a book in the first place)
add: Used spellbooks become reusable when upgraded
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
