### PR TITLE
Hivemind Awakening Log Fix

### DIFF
--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -185,6 +185,7 @@
 	ADD_TRAIT(C, TRAIT_NOLIMBDISABLE, HIVEMIND_ONE_MIND_TRAIT)
 	ADD_TRAIT(C, TRAIT_NOHUNGER, HIVEMIND_ONE_MIND_TRAIT)
 	ADD_TRAIT(C, TRAIT_NODISMEMBER, HIVEMIND_ONE_MIND_TRAIT)
+	log_game("[key_name(owner)] has awakened vessels.")
 
 /datum/antagonist/hivemind/proc/go_back_to_sleep()
 	if(!active_one_mind)

--- a/code/modules/antagonists/hivemind/vessel.dm
+++ b/code/modules/antagonists/hivemind/vessel.dm
@@ -33,8 +33,9 @@
 	else
 		var/datum/objective/brainwashing/obj = new(objective)
 		vessel.objectives += obj
-		var/message = " has been brainwashed with the following objectives: [objective]."
+		var/message = " has been awoken with the following objectives: [objective]."
 		deadchat_broadcast(message, "<b>[M]</b>", follow_target = M, turf_target = get_turf(M), message_type=DEADCHAT_REGULAR)
+		log_game("[key_name(M)] has been awoken with the following objectives: [objective]")
 	if(!M.has_antag_datum(/datum/antagonist/hivevessel))
 		M.add_antag_datum(vessel)
 


### PR DESCRIPTION
Signed-off-by: Space Prius <bubba041102@gmail.com>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #44603 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows admins to see when vessels have been awoken and also lists their objective in the game log.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
bugfix: Fixed bug where hivemind vessel awakening would not be logged.
bugfix: Fixed bug where awoken hivemind vessel objectives would not be logged.
tweak: slightly modified the deadchat text for awakening.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
