### PR TITLE
Makes signal calls async again

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1592,4 +1592,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	else
 		return 0
 
+/proc/CallAsync(datum/source, proctype, list/arguments)
+	set waitfor = FALSE
+	return call(source, proctype)(arglist(arguments))
+
 #define TURF_FROM_COORDS_LIST(List) (locate(List[1], List[2], List[3]))

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -173,14 +173,14 @@
 		if(!C.signal_enabled)
 			return NONE
 		var/proctype = C.signal_procs[src][sigtype]
-		return NONE | call(C, proctype)(arglist(arguments))
+		return NONE | CallAsync(C, proctype, arguments)
 	. = NONE
 	for(var/I in target)
 		var/datum/C = I
 		if(!C.signal_enabled)
 			continue
 		var/proctype = C.signal_procs[src][sigtype]
-		. |= call(C, proctype)(arglist(arguments))
+		. |= CallAsync(C, proctype, arguments)
 
 // The type arg is casted so initial works, you shouldn't be passing a real instance into this
 /datum/proc/GetComponent(datum/component/c_type)


### PR DESCRIPTION
Accidentally forgot to `set waitfor = FALSE` for signal proc calls

:cl:
fix: Reproductive crossbreed extracts can be fed from the bio bag again
/:cl:

fixes #44797