### PR TITLE
Mark Python files as being space-indented in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ indent_size = 4
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.py]
+indent_style = space


### PR DESCRIPTION
vscode putting tabs in my space-indented python files because we accidentally told it to