### PR TITLE
Makes cosmos bedsheets creatable

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -266,7 +266,7 @@
 			to_chat(user, "<span class='warning'>\The [W] is stuck to your hand, you cannot put it in the washing machine!</span>")
 			return 1
 
-		if(istype(W, /obj/item/toy/crayon) || istype(W, /obj/item/stamp) || istype(W, /obj/item/reagent_containers/food/snacks/grown/rainbow_flower))
+		if(istype(W, /obj/item/toy/crayon) || istype(W, /obj/item/stamp) || istype(W, /obj/item/reagent_containers/food/snacks/grown/rainbow_flower) || istype(W, /obj/item/stack/ore/bluespace_crystal))
 			color_source = W
 		update_icon()
 

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -4,6 +4,7 @@
 	desc = "A glowing bluespace crystal, not much is known about how they work. It looks very delicate."
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "bluespace_crystal"
+	item_color = "cosmos"
 	singular_name = "bluespace crystal"
 	w_class = WEIGHT_CLASS_TINY
 	materials = list(MAT_BLUESPACE=MINERAL_MATERIAL_AMOUNT)


### PR DESCRIPTION
This PR adds the cosmos item color to bluespace crystals. This means that if you use a BS crystal to wash a bedsheet you get the highly-prized cosmos bedsheet.

## Changelog
:cl: Dorsidwarf
add: Nanotrasen washing machines can now extract the raw power of the cosmos from bluespace crystals.  
/:cl:
