### PR TITLE
Russian Revolver spin fix

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -167,7 +167,7 @@
 	var/spun = FALSE
 
 /obj/item/gun/ballistic/revolver/russian/do_spin()
-	..()
+	. = ..()
 	spun = TRUE
 
 /obj/item/gun/ballistic/revolver/russian/attackby(obj/item/A, mob/user, params)

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -13,6 +13,7 @@
 	internal_magazine = TRUE
 	bolt_type = BOLT_TYPE_NO_BOLT
 	tac_reloads = FALSE
+	current_skin = "Default"
 	var/spin_delay = 10
 	var/recent_spin = 0
 
@@ -79,6 +80,7 @@
 	icon_state = "detective"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
 	obj_flags = UNIQUE_RENAME
+	current_skin = FALSE
 	unique_reskin = list("Default" = "detective",
 						"Fitz Special" = "detective_fitz",
 						"Police Positive Special" = "detective_police",

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -13,7 +13,6 @@
 	internal_magazine = TRUE
 	bolt_type = BOLT_TYPE_NO_BOLT
 	tac_reloads = FALSE
-	current_skin = "Default"
 	var/spin_delay = 10
 	var/recent_spin = 0
 
@@ -80,7 +79,6 @@
 	icon_state = "detective"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
 	obj_flags = UNIQUE_RENAME
-	current_skin = FALSE
 	unique_reskin = list("Default" = "detective",
 						"Fitz Special" = "detective_fitz",
 						"Police Positive Special" = "detective_police",


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Thanks to @4dplanner in the discord for helping me with this! Apparently this just changes the do_spin() proc to return true, or something like that. Main thing is the russian revolver now works!

Also noticed that the "It can be spun with alt+click"-message didn't show up, so I added the current_skin = "Default" to all revolvers (except the Detective's, which can be reskinned and is supposed to show a different message upon examining before reskinning).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the russian revolver work again.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: the russian revolver's chamber can be spun again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Closes #43976
Closes #43563
