### PR TITLE
Map fixes round 2

### DIFF
--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -38274,6 +38274,7 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bMI" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6123,7 +6123,6 @@
 /area/centcom/ferry)
 "om" = (
 /obj/machinery/computer/card/centcom,
-/obj/item/card/id/centcom,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "on" = (
@@ -7924,18 +7923,11 @@
 /area/centcom/ferry)
 "ry" = (
 /obj/machinery/computer/card/centcom,
-/obj/item/card/id/centcom,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
 	name = "Research Monitor";
 	network = list("rd","minisat");
 	pixel_y = 28
-	},
-/obj/machinery/button/door/indestructible{
-	id = "adminvault";
-	name = "Secure Storage";
-	pixel_x = 24;
-	req_access_txt = "109"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
@@ -8482,6 +8474,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/item/storage/box/ids{
+	pixel_x = 6;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "sB" = (
@@ -8572,10 +8568,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/poddoor{
-	id = "adminvault";
-	name = "Administrative Secure Storage"
+/obj/machinery/door/airlock/vault{
+	req_access_txt = "109"
 	},
+/obj/machinery/door/poddoor/shutters/indestructible,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "sI" = (

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -22,7 +22,9 @@
 	opacity = 0
 
 /obj/machinery/door/poddoor/ert
+	name = "hardened blast door"
 	desc = "A heavy duty blast door that only opens for dire emergencies."
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 //special poddoors that open when emergency shuttle docks at centcom
 /obj/machinery/door/poddoor/shuttledock

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -11,3 +11,7 @@
 	icon_state = "open"
 	density = FALSE
 	opacity = 0
+
+/obj/machinery/door/poddoor/shutters/indestructible
+	name = "hardened shutters"
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF


### PR DESCRIPTION
The donut AI chamber SMES was missing a cable underneath it; that way, it wouldn't connect to the local APC.
CentCom vault is now secured by the old vault door plus indestructible shutters that can be removed or opened by admins. 
In case someone uses one of the 314432 exploits to get to CentCom, I made the ERT shutters indestructible and replaced the all access IDs with a box of ID cards.

Fixes: #43937
Fixes: #44901

## Changelog
:cl: Denton
fix: Donutstation: The AI chamber SMES is now correctly connected to the AI APC.
tweak: CentCom: Made the ERT pod doors and vault shutters bomb proof. Replaced loose CentCom ID cards with a box of IDs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
