### PR TITLE
Allows for removing lightbulbs w/o gloves (burns hands) and adds time for lightbulb removals (3 seconds for resisting heat, 25 for tk and 10 for bare hands)

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -653,20 +653,19 @@
 
 		if(prot > 0 || HAS_TRAIT(user, TRAIT_RESISTHEAT) || HAS_TRAIT(user, TRAIT_RESISTHEATHANDS))
 			if(do_after(user, 30, target = src))
-			to_chat(user, "<span class='notice'>You remove the light [fitting].</span>")
+				to_chat(user, "<span class='notice'>You remove the light [fitting].</span>")
 		else if(istype(user) && user.dna.check_mutation(TK))
 			if(do_after(user, 25, target = src))
-			to_chat(user, "<span class='notice'>You telekinetically remove the light [fitting].</span>")
+				to_chat(user, "<span class='notice'>You telekinetically remove the light [fitting].</span>")
 		else
 			if(do_after(user, 100, target = src))
-			to_chat(user, "<span class='warning'>You remove the light [fitting], but you burn your hand on it!</span>")
-
-			var/obj/item/bodypart/affecting = H.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
-			if(affecting && affecting.receive_damage( 0, 20 ))		// 20 burn damage
-				H.update_damage_overlays()
+				to_chat(user, "<span class='warning'>You remove the light [fitting], but you burn your hand on it!</span>")
+				var/obj/item/bodypart/affecting = H.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
+				if(affecting && affecting.receive_damage( 0, 20 ))		// 20 burn damage
+					H.update_damage_overlays()
 	else
 		if(do_after(user, 30, target = src))
-		to_chat(user, "<span class='notice'>You remove the light [fitting].</span>")
+			to_chat(user, "<span class='notice'>You remove the light [fitting].</span>")
 	// create a light tube/bulb item and put it in the user's hand
 	drop_light_tube(user)
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -651,18 +651,21 @@
 		else
 			prot = 1
 
-		if(prot > 0 || HAS_TRAIT(user, TRAIT_RESISTHEAT) || HAS_TRAIT(user, TRAIT_RESISTHEATHANDS) || prob(25))
+		if(prot > 0 || HAS_TRAIT(user, TRAIT_RESISTHEAT) || HAS_TRAIT(user, TRAIT_RESISTHEATHANDS))
+			if(do_after(user, 30, target = src))
 			to_chat(user, "<span class='notice'>You remove the light [fitting].</span>")
 		else if(istype(user) && user.dna.check_mutation(TK))
+			if(do_after(user, 25, target = src))
 			to_chat(user, "<span class='notice'>You telekinetically remove the light [fitting].</span>")
 		else
-			to_chat(user, "<span class='warning'>You try to remove the light [fitting], but you burn your hand on it!</span>")
+			if(do_after(user, 100, target = src))
+			to_chat(user, "<span class='warning'>You remove the light [fitting], but you burn your hand on it!</span>")
 
 			var/obj/item/bodypart/affecting = H.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
-			if(affecting && affecting.receive_damage( 0, 5 ))		// 5 burn damage
+			if(affecting && affecting.receive_damage( 0, 20 ))		// 20 burn damage
 				H.update_damage_overlays()
-			return				// if burned, don't remove the light
 	else
+		if(do_after(user, 30, target = src))
 		to_chat(user, "<span class='notice'>You remove the light [fitting].</span>")
 	// create a light tube/bulb item and put it in the user's hand
 	drop_light_tube(user)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -651,7 +651,7 @@
 		else
 			prot = 1
 
-		if(prot > 0 || HAS_TRAIT(user, TRAIT_RESISTHEAT) || HAS_TRAIT(user, TRAIT_RESISTHEATHANDS))
+		if(prot > 0 || HAS_TRAIT(user, TRAIT_RESISTHEAT) || HAS_TRAIT(user, TRAIT_RESISTHEATHANDS) || prob(25))
 			to_chat(user, "<span class='notice'>You remove the light [fitting].</span>")
 		else if(istype(user) && user.dna.check_mutation(TK))
 			to_chat(user, "<span class='notice'>You telekinetically remove the light [fitting].</span>")


### PR DESCRIPTION
## About The Pull Request

you can remove a lightbulb from its fitting without any protection after 10 seconds, does 20 burn damage, now with tk it takes 2.5 seconds and with protection 3 seconds

## Why It's Good For The Game

its easier to escape permabrig than regular brig, which there is no way of without another person's help/some implants and stuff. this can obviously be stopped by the sec team/warden, just gives a chance to the single guy in brig without a timer set when all of sec are going somewhere

## Changelog
:cl:
balance: nanotrasens brand new mk.2 light bulbs allow you to remove them without any protection, although they do take some time now
/:cl:
