### PR TITLE
Fixes negative armor on objects.

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -32,7 +32,7 @@
 	if(damage_flag)
 		armor_protection = armor.getRating(damage_flag)
 	if(armor_protection)		//Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
-		armor_protection = CLAMP(armor_protection - armour_penetration, 0, 100)
+		armor_protection = CLAMP(armor_protection - armour_penetration, min(armor_protection, 0), 100)
 	return round(damage_amount * (100 - armor_protection)*0.01, DAMAGE_PRECISION)
 
 //the sound played when the obj is damaged.


### PR DESCRIPTION
## About The Pull Request

Negative armor on objects now properly increases the damage taken.

## Why It's Good For The Game

Items have been designed with this in mind, but it never actually worked. At least not for objects.

## Changelog
:cl:
fix: Negative armor on objects now increases damage taken.
/:cl:
