### PR TITLE
Fixes a bug with armor zones.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -7,7 +7,7 @@
 			var/obj/item/bodypart/bp = def_zone
 			if(bp)
 				return checkarmor(def_zone, type)
-		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(def_zone))
+		var/obj/item/bodypart/affecting = get_bodypart(check_zone(def_zone))
 		if(affecting)
 			return checkarmor(affecting, type)
 		//If a specific bodypart is targetted, check how that bodypart is protected and return the value.


### PR DESCRIPTION
## About The Pull Request

Fixes a bug with human where sometimes the armor from the wrong bodypart gets used when they get attacked.

Fixes #28260.

## Why It's Good For The Game

Bugs bad. Also, armor code is highly cursed.

## Changelog
:cl:
fix: Humans now always use the correct value for limb armor.
/:cl:
