### PR TITLE
removes isflying helper proc

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -74,7 +74,7 @@
 			var/mob/buckled_to = M.buckled
 			if((!ismob(M.buckled) || (buckled_to.buckled != M)) && !droppable(M.buckled))
 				return FALSE
-		if(M.is_flying())
+		if(M.movement_type&FLYING)
 			return FALSE
 		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -74,7 +74,7 @@
 			var/mob/buckled_to = M.buckled
 			if((!ismob(M.buckled) || (buckled_to.buckled != M)) && !droppable(M.buckled))
 				return FALSE
-		if(M.movement_type&FLYING)
+		if(M.movement_type & FLYING)
 			return FALSE
 		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -15,5 +15,5 @@
 
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	var/mob/victim = AM
-	if(istype(victim) && !victim.is_flying() && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
+	if(istype(victim) && !victim.movement_type&FLYING && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
 		callback.Invoke(victim)

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -15,5 +15,5 @@
 
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	var/mob/victim = AM
-	if(istype(victim) && !victim.movement_type&FLYING && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
+	if(istype(victim) && !victim.movement_type & FLYING && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
 		callback.Invoke(victim)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -768,7 +768,7 @@
 				throw_alert("gravity", /obj/screen/alert/highgravity)
 	else
 		throw_alert("gravity", /obj/screen/alert/weightless)
-	if(!override && !movement_type&FLYING)
+	if(!override && !movement_type & FLYING)
 		float(!has_gravity)
 
 /mob/living/float(on)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -299,7 +299,7 @@
 				var/mob/living/carbon/C = L
 				if(HAS_TRAIT(src, TRAIT_STRONG_GRABBER))
 					C.grippedby(src)
-			
+
 			update_pull_movespeed()
 
 		set_pull_offsets(M, state)
@@ -768,7 +768,7 @@
 				throw_alert("gravity", /obj/screen/alert/highgravity)
 	else
 		throw_alert("gravity", /obj/screen/alert/weightless)
-	if(!override && !is_flying())
+	if(!override && !movement_type&FLYING)
 		float(!has_gravity)
 
 /mob/living/float(on)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -36,7 +36,7 @@
 	add_movespeed_modifier(MOVESPEED_ID_MOB_WALK_RUN_CONFIG_SPEED, TRUE, 100, override = TRUE, multiplicative_slowdown = mod)
 
 /mob/living/proc/update_turf_movespeed(turf/open/T)
-	if(isopenturf(T) && !is_flying())
+	if(isopenturf(T) && !movement_type&FLYING)
 		add_movespeed_modifier(MOVESPEED_ID_LIVING_TURF_SPEEDMOD, TRUE, 100, override = TRUE, multiplicative_slowdown = T.slowdown)
 	else
 		remove_movespeed_modifier(MOVESPEED_ID_LIVING_TURF_SPEEDMOD)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -36,7 +36,7 @@
 	add_movespeed_modifier(MOVESPEED_ID_MOB_WALK_RUN_CONFIG_SPEED, TRUE, 100, override = TRUE, multiplicative_slowdown = mod)
 
 /mob/living/proc/update_turf_movespeed(turf/open/T)
-	if(isopenturf(T) && !movement_type&FLYING)
+	if(isopenturf(T) && !movement_type & FLYING)
 		add_movespeed_modifier(MOVESPEED_ID_LIVING_TURF_SPEEDMOD, TRUE, 100, override = TRUE, multiplicative_slowdown = T.slowdown)
 	else
 		remove_movespeed_modifier(MOVESPEED_ID_LIVING_TURF_SPEEDMOD)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -441,12 +441,6 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 		message_admins("No ghosts were willing to take control of [ADMIN_LOOKUPFLW(M)])")
 		return FALSE
 
-/mob/proc/is_flying(mob/M = src)
-	if(M.movement_type & FLYING)
-		return 1
-	else
-		return 0
-
 /mob/proc/click_random_mob()
 	var/list/nearby_mobs = list()
 	for(var/mob/living/L in range(1, src))


### PR DESCRIPTION
## About The Pull Request

Removes the isflying helper proc.

## Why It's Good For The Game

It's so barely used and currently doesn't provide any real benefit. It's really inconsistent if isflying or movement_type&FLYING is used and there isn't really any reason why that should be the case.

This increases the overall readiblity of the code by removing a redudant proc.

## Changelog

not needed
