### PR TITLE
Fix indentation error from circuit board colors PR

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -586,7 +586,7 @@
 			break
 	return ..()
 
-	/obj/item/circuitboard/machine/vending/donksofttoyvendor
+/obj/item/circuitboard/machine/vending/donksofttoyvendor
 	name = "Donksoft Toy Vendor (Machine Board)"
 	build_path = /obj/machinery/vending/donksofttoyvendor
 	req_components = list(


### PR DESCRIPTION
Only noticed this because I was seeing if dreamchecker still gave a clean result. Turns out no.

Introduced in #44738 