### PR TITLE
Fixes clones DNA sequences being linked

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -344,7 +344,7 @@
 		updateappearance(icon_update=0)
 
 	if(LAZYLEN(mutation_index))
-		dna.mutation_index = mutation_index
+		dna.mutation_index = mutation_index.Copy()
 		domutcheck()
 
 	if(mrace || newfeatures || ui)


### PR DESCRIPTION
closes #44941
oops
Fixes clones and clonee's their sequence always being exactly the same because I forgot to copy a list, instead of share it.
:cl:
fix: Clones no longer have their genetic sequence quantum garble fucked together
/:cl: