### PR TITLE
Fix quickdraw hotkeys working while incapacitated

### DIFF
--- a/code/modules/keybindings/bindings_human.dm
+++ b/code/modules/keybindings/bindings_human.dm
@@ -2,6 +2,8 @@
 	if(client.keys_held["Shift"])
 		switch(_key)
 			if("E") // Put held thing in belt or take out most recent thing from belt
+				if(incapacitated())
+					return
 				var/obj/item/thing = get_active_held_item()
 				var/obj/item/equipped_belt = get_item_by_slot(SLOT_BELT)
 				if(!equipped_belt) // We also let you equip a belt like this
@@ -31,6 +33,8 @@
 				return
 
 			if("B") // Put held thing in backpack or take out most recent thing from backpack
+				if(incapacitated())
+					return
 				var/obj/item/thing = get_active_held_item()
 				var/obj/item/equipped_back = get_item_by_slot(SLOT_BACK)
 				if(!equipped_back) // We also let you equip a backpack like this


### PR DESCRIPTION
## About The Pull Request

Fixes #44275 

## Changelog
:cl: Garen
fix: Fixes being able to pull from belt/backpack when you are stunned or cuffed.
/:cl:

The check for incapacitated is normally done in the click proc since that way its checked on all of attack_hand, attackby, etc.. The keybinding uses attack_hand instead of the click proc because it would go through as a shift click and examine the item instead of grabbing it if the click proc was used.