### PR TITLE
Thermite tweaks.

### DIFF
--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -67,7 +67,7 @@
 		master.burn_tile()
 		if(user)
 			master.add_hiddenprint(user)
-	QDEL_IN(fakefire, CLAMP(amount, 50, 100)) //I think 10 seconds is long enough as a maximum value
+	QDEL_IN(fakefire, 100)
 	qdel(src)
 
 /datum/component/thermite/proc/clean_react(datum/source, strength)

--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -1,6 +1,7 @@
 /datum/component/thermite
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 	var/amount
+	var/burn_coeff
 	var/overlay
 
 	var/static/list/blacklist = typecacheof(list(
@@ -15,7 +16,7 @@
 		/turf/closed/indestructible,
 		/turf/open/indestructible)
 		)
-	
+
 	var/static/list/resistlist = typecacheof(
 		/turf/closed/wall/r_wall
 		)
@@ -23,10 +24,13 @@
 /datum/component/thermite/Initialize(_amount)
 	if(!istype(parent, /turf) || blacklist[parent.type])
 		return COMPONENT_INCOMPATIBLE
+
 	if(immunelist[parent.type])
-		_amount*=0 //Yeah the overlay can still go on it and be cleaned but you arent burning down a diamond wall
-	if(resistlist[parent.type])
-		_amount*=0.25
+		burn_coeff = 0 //Yeah the overlay can still go on it and be cleaned but you arent burning down a diamond wall
+	else if(resistlist[parent.type])
+		burn_coeff = 0.25
+	else
+		burn_coeff = 1
 
 	amount = _amount*10
 
@@ -58,15 +62,13 @@
 
 	playsound(master, 'sound/items/welder.ogg', 100, 1)
 
-	if(amount >= 50)
-		var/burning_time = max(100, 100-amount)
+	if(amount * burn_coeff >= 50)
 		master = master.Melt()
 		master.burn_tile()
 		if(user)
 			master.add_hiddenprint(user)
-		QDEL_IN(fakefire, burning_time)
-	else
-		QDEL_IN(fakefire, 50)
+	QDEL_IN(fakefire, CLAMP(amount, 50, 100)) //I think 10 seconds is long enough as a maximum value
+	qdel(src)
 
 /datum/component/thermite/proc/clean_react(datum/source, strength)
 	//Thermite is just some loose powder, you could probably clean it with your hands. << todo?

--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -67,7 +67,7 @@
 		master.burn_tile()
 		if(user)
 			master.add_hiddenprint(user)
-	QDEL_IN(fakefire, 100)
+	QDEL_IN(fakefire, 10 SECONDS)
 	qdel(src)
 
 /datum/component/thermite/proc/clean_react(datum/source, strength)


### PR DESCRIPTION
## About The Pull Request

Tweaks thermite in a few ways.

The burn length of thermite is now always 10 seconds, and that's actually the intended behaviour.

The thermite component now gets deleted after burning up.

closes #44944

## Why It's Good For The Game

The original code was just really odd. I think this is an improvement over that.

## Changelog
:cl:
fix: Thermite now gets deleted properly after burning up.
/:cl: