### PR TITLE
Change Cult Conversion To Be Holy-Based rather than Strict Role Checks

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -16,7 +16,7 @@
 	if(!istype(M))
 		return FALSE
 	if(M.mind)
-		if(ishuman(M) && (M.mind.assigned_role in list("Captain", "Chaplain")))
+		if(ishuman(M) && (M.mind.isholy))
 			return FALSE
 		if(specific_cult && specific_cult.is_sacrifice_target(M.mind))
 			return FALSE


### PR DESCRIPTION
## About The Pull Request

previously cult conversion checked for mind role chaplain or captain but now it checks if the persons mind is holy

## Why It's Good For The Game

why cant the captan be cult if they manage to remove his mindshield why can holy people that arent chaplain be cult ooga???

## Changelog
:cl:
balance: Reports say the cult of Nar'Sie has gotten stronger, and can now convert the captain when he doesn't have his mindshield. To prepare against this, the CentCom religious division has trained their special holy people against conversions
/:cl:

