### PR TITLE
Add Copy Machines to HoP office

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -51335,6 +51335,11 @@
 "nbv" = (
 /turf/closed/wall,
 /area/science/explab)
+"ndR" = (
+/obj/structure/cable,
+/obj/machinery/photocopier,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/hop)
 "neA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -79435,7 +79440,7 @@ bmo
 bnR
 bpe
 bqB
-bqq
+ndR
 btD
 buO
 bwk

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -14826,10 +14826,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aKA" = (
-/obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
+/obj/structure/cable,
+/obj/machinery/photocopier,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "aKB" = (
@@ -14857,6 +14858,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "aKF" = (
@@ -30253,20 +30255,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"buK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hop)
-"buL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hop)
 "buM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -30274,6 +30262,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "buN" = (
@@ -33634,6 +33623,7 @@
 	name = "Head of Personnel's Private Quarters";
 	req_access_txt = "57"
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bCn" = (
@@ -96505,8 +96495,8 @@ aKv
 aKA
 aKE
 bCm
-buK
-buL
+buS
+buT
 bCk
 anl
 aXc

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -32977,6 +32977,8 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "bsO" = (
+/obj/structure/cable,
+/obj/machinery/photocopier,
 /mob/living/simple_animal/pet/dog/corgi/Ian,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -10361,11 +10361,16 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aBz" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
 /obj/item/storage/secure/safe{
 	pixel_x = -22;
 	pixel_y = 4
+	},
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	layer = 2.9
+	},
+/obj/item/pen{
+	layer = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -10977,17 +10982,12 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aCP" = (
-/obj/structure/table/wood,
-/obj/item/pen{
-	layer = 4
-	},
 /obj/machinery/keycard_auth{
 	pixel_x = -26;
 	pixel_y = 6
 	},
-/obj/item/paper_bin{
-	layer = 2.9
-	},
+/obj/structure/cable,
+/obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aCQ" = (
@@ -54576,6 +54576,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qaQ" = (
+/obj/structure/table/wood,
+/obj/item/pen{
+	layer = 4
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = -26;
+	pixel_y = 6
+	},
+/obj/item/paper_bin{
+	layer = 2.9
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "qbp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/meter,
@@ -87981,7 +87995,7 @@ aQS
 aRQ
 aSN
 aPE
-aPE
+qaQ
 aWd
 aXb
 aRN


### PR DESCRIPTION
Signed-off-by: Space Prius <bubba041102@gmail.com>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So this is a repost of the last one due to the last one not working right, this one has a much smaller commit size.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds photocopiers to the HoP office in all maps, why is it not here in the first place, even the HoS office has one.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Added photocopier to HoP office in Metastation, BoxStation, PubbyStation, and DonutStation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
