### PR TITLE
Simple animals that are dead have a message on examine.

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -121,6 +121,11 @@
 
 	return ..()
 
+mob/living/simple_animal/examine(mob/user)
+	. = ..()
+	if(stat == DEAD)
+		. += "<span class='warning'>Upon closer examination, it appears to be dead.</span>"
+
 /mob/living/simple_animal/initialize_footstep()
 	if(do_footstep)
 		..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -121,7 +121,7 @@
 
 	return ..()
 
-mob/living/simple_animal/examine(mob/user)
+/mob/living/simple_animal/examine(mob/user)
 	. = ..()
 	if(stat == DEAD)
 		. += "<span class='deadsay'>Upon closer examination, [p_they()] appear[p_s()] to be dead.</span>"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -124,7 +124,7 @@
 mob/living/simple_animal/examine(mob/user)
 	. = ..()
 	if(stat == DEAD)
-		. += "<span class='warning'>Upon closer examination, it appears to be dead.</span>"
+		. += "<span class='deadsay'>Upon closer examination, [p_they()] appear[p_s()] to be dead.</span>"
 
 /mob/living/simple_animal/initialize_footstep()
 	if(do_footstep)


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/24752.

Why this is helpful for the game: Gives palliative care to an oldass bug that needs to die.

Because this bug is old as fuck, someone in the comments mentions this being bad for drones. Drones have since had a custom message added, but this PR doesn't change it since the drone proc doesn't call the parent.

If there are other simple animal mobs that would benefit from a custom message (i.e. if they can't be "dead" per se) please let me know.

:cl: bandit
fix: After years of arduous training, Nanotrasen crew can now tell whether an animal is dead by examining it.
/:cl: