### PR TITLE
Adds stats to creation/destruction of cleanable decals and trash on station

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -25,6 +25,14 @@
 		if(LAZYLEN(diseases_to_add))
 			AddComponent(/datum/component/infective, diseases_to_add)
 
+	if(is_station_level(z))
+		SSblackbox.record_feedback("tally", "station_mess_created", 1, name)
+
+/obj/effect/decal/cleanable/Destroy()
+	if(is_station_level(z))
+		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
+	return ..()
+
 /obj/effect/decal/cleanable/proc/replace_decal(obj/effect/decal/cleanable/C) // Returns true if we should give up in favor of the pre-existing decal
 	if(mergeable_decal)
 		return TRUE

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -25,11 +25,13 @@
 		if(LAZYLEN(diseases_to_add))
 			AddComponent(/datum/component/infective, diseases_to_add)
 
-	if(is_station_level(z))
+	var/area/A = get_area(src)
+	if(is_station_level(z) && !istype(A, /area/maintenance))
 		SSblackbox.record_feedback("tally", "station_mess_created", 1, name)
 
 /obj/effect/decal/cleanable/Destroy()
-	if(is_station_level(z))
+	var/area/A = get_area(src)
+	if(is_station_level(initial(z)) && !istype(A, /area/maintenance))
 		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
 	return ..()
 

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -25,13 +25,13 @@
 		if(LAZYLEN(diseases_to_add))
 			AddComponent(/datum/component/infective, diseases_to_add)
 
-	var/area/A = get_area(src)
-	if(is_station_level(z) && !istype(A, /area/maintenance))
+	var/turf/T = get_turf(src)
+	if(is_station_level(T.z))
 		SSblackbox.record_feedback("tally", "station_mess_created", 1, name)
 
 /obj/effect/decal/cleanable/Destroy()
-	var/area/A = get_area(src)
-	if(is_station_level(initial(z)) && !istype(A, /area/maintenance))
+	var/turf/T = get_turf(src)
+	if(is_station_level(T.z))
 		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
 	return ..()
 

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -270,6 +270,15 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	if (icon_prefix)
 		icon_state = "[icon_prefix][icon_state]"
 
+	if(is_station_level(z))
+		SSblackbox.record_feedback("tally", "station_mess_created", 1, name)
+
+/obj/item/shard/Destroy()
+	. = ..()
+
+	if(is_station_level(initial(z)))
+		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
+
 /obj/item/shard/afterattack(atom/A as mob|obj, mob/user, proximity)
 	. = ..()
 	if(!proximity || !(src in user))

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -270,13 +270,15 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	if (icon_prefix)
 		icon_state = "[icon_prefix][icon_state]"
 
-	if(is_station_level(z))
+	var/area/A = get_area(src)
+	if(is_station_level(z) && !istype(A, /area/maintenance))
 		SSblackbox.record_feedback("tally", "station_mess_created", 1, name)
 
 /obj/item/shard/Destroy()
 	. = ..()
 
-	if(is_station_level(initial(z)))
+	var/area/A = get_area(src)
+	if(is_station_level(initial(z)) && !istype(A, /area/maintenance))
 		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
 
 /obj/item/shard/afterattack(atom/A as mob|obj, mob/user, proximity)

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -270,15 +270,15 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	if (icon_prefix)
 		icon_state = "[icon_prefix][icon_state]"
 
-	var/area/A = get_area(src)
-	if(is_station_level(z) && !istype(A, /area/maintenance))
+	var/turf/T = get_turf(src)
+	if(is_station_level(T.z))
 		SSblackbox.record_feedback("tally", "station_mess_created", 1, name)
 
 /obj/item/shard/Destroy()
 	. = ..()
 
-	var/area/A = get_area(src)
-	if(is_station_level(initial(z)) && !istype(A, /area/maintenance))
+	var/turf/T = get_turf(src)
+	if(is_station_level(T.z))
 		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
 
 /obj/item/shard/afterattack(atom/A as mob|obj, mob/user, proximity)

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -7,7 +7,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 
-/obj/item/trash/Initialize()
+/obj/item/trash/Initialize(mapload)
 	var/area/A = get_area(src)
 	if(is_station_level(z) && !istype(A, /area/maintenance))
 		SSblackbox.record_feedback("tally", "station_mess_created", 1, name)

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -8,14 +8,14 @@
 	resistance_flags = FLAMMABLE
 
 /obj/item/trash/Initialize(mapload)
-	var/area/A = get_area(src)
-	if(is_station_level(z) && !istype(A, /area/maintenance))
+	var/turf/T = get_turf(src)
+	if(is_station_level(T.z))
 		SSblackbox.record_feedback("tally", "station_mess_created", 1, name)
 	return ..()
 
 /obj/item/trash/Destroy()
-	var/area/A = get_area(src)
-	if(is_station_level(initial(z)) && !istype(A, /area/maintenance))
+	var/turf/T = get_turf(src)
+	if(is_station_level(T.z))
 		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
 	return ..()
 

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -7,6 +7,16 @@
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 
+/obj/item/trash/Initialize()
+	if(is_station_level(z))
+		SSblackbox.record_feedback("tally", "station_mess_created", 1, name)
+	return ..()
+
+/obj/item/trash/Destroy()
+	if(is_station_level(initial(z)))
+		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
+	return ..()
+
 /obj/item/trash/raisins
 	name = "\improper 4no raisins"
 	icon_state= "4no_raisins"

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -8,12 +8,14 @@
 	resistance_flags = FLAMMABLE
 
 /obj/item/trash/Initialize()
-	if(is_station_level(z))
+	var/area/A = get_area(src)
+	if(is_station_level(z) && !istype(A, /area/maintenance))
 		SSblackbox.record_feedback("tally", "station_mess_created", 1, name)
 	return ..()
 
 /obj/item/trash/Destroy()
-	if(is_station_level(initial(z)))
+	var/area/A = get_area(src)
+	if(is_station_level(initial(z)) && !istype(A, /area/maintenance))
 		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
 	return ..()
 

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -37,7 +37,8 @@
 /obj/item/ammo_casing/Destroy()
 	. = ..()
 
-	if(!BB && is_station_level(initial(z)))
+	var/area/A = get_area(src)
+	if(!BB && is_station_level(initial(z)) && !istype(A, /area/maintenance))
 		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
 
 /obj/item/ammo_casing/update_icon()

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -34,6 +34,12 @@
 	setDir(pick(GLOB.alldirs))
 	update_icon()
 
+/obj/item/ammo_casing/Destroy()
+	. = ..()
+
+	if(!BB && is_station_level(initial(z)))
+		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
+
 /obj/item/ammo_casing/update_icon()
 	..()
 	icon_state = "[initial(icon_state)][BB ? "-live" : ""]"

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -37,8 +37,8 @@
 /obj/item/ammo_casing/Destroy()
 	. = ..()
 
-	var/area/A = get_area(src)
-	if(!BB && is_station_level(initial(z)) && !istype(A, /area/maintenance))
+	var/turf/T = get_turf(src)
+	if(!BB && is_station_level(T.z))
 		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
 
 /obj/item/ammo_casing/update_icon()

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -55,6 +55,8 @@
 		BB.preparePixelProjectile(target, user, params, spread)
 	BB.fire(null, direct_target)
 	BB = null
+	if(is_station_level(z))
+		SSblackbox.record_feedback("tally", "station_mess_created", 1, name)
 	return TRUE
 
 /obj/item/ammo_casing/proc/spread(turf/target, turf/current, distro)

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -55,9 +55,6 @@
 		BB.preparePixelProjectile(target, user, params, spread)
 	BB.fire(null, direct_target)
 	BB = null
-	var/area/A = get_area(src)
-	if(is_station_level(z) && !istype(A, /area/maintenance))
-		SSblackbox.record_feedback("tally", "station_mess_created", 1, name)
 	return TRUE
 
 /obj/item/ammo_casing/proc/spread(turf/target, turf/current, distro)

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -55,7 +55,8 @@
 		BB.preparePixelProjectile(target, user, params, spread)
 	BB.fire(null, direct_target)
 	BB = null
-	if(is_station_level(z))
+	var/area/A = get_area(src)
+	if(is_station_level(z) && !istype(A, /area/maintenance))
 		SSblackbox.record_feedback("tally", "station_mess_created", 1, name)
 	return TRUE
 

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -316,6 +316,9 @@
 			CB.forceMove(drop_location())
 			CB.bounce_away(FALSE, NONE)
 			num_unloaded++
+			var/turf/T = get_turf(drop_location())
+			if(is_station_level(T.z))
+				SSblackbox.record_feedback("tally", "station_mess_created", 1, CB.name)
 		if (num_unloaded)
 			to_chat(user, "<span class='notice'>You unload [num_unloaded] [cartridge_wording]\s from [src].</span>")
 			playsound(user, eject_sound, eject_sound_volume, eject_sound_vary)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Keeps track of how many messes are created and removed on the station. I'm adding this because I don't think janitor roles can keep on top of the mess on the station with the way their equipment is currently balanced and I'd like to see what the difference is between messes created and messes destroyed.

I've never added stats before, so I might've done something wrong (I don't even know if I'm allowed to add stats given it seems like more of a database/administration thing). If there's a better way of doing this, let me know.

Let me know if there's a common item of trash I've missed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's useful for seeing how wide the margin is between the creation and removal of mess on the station.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds stat tracking for the creation/destruction of trash and cleanable decals (e.g. blood)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
