### PR TITLE
Makes nuclear particles no longer give toxin damage directly.

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -55,6 +55,7 @@
 /obj/item/projectile/beam/xray
 	name = "\improper X-ray beam"
 	icon_state = "xray"
+	flag = "rad"
 	damage = 15
 	irradiate = 300
 	range = 15

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -3,6 +3,7 @@
 	name = "nuclear particle"
 	icon_state = "nuclear_particle"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	flag = "rad"
 	irradiate = 5000
 	speed = 0.4
 	hitsound = 'sound/weapons/emitter2.ogg'

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -3,8 +3,8 @@
 	name = "nuclear particle"
 	icon_state = "nuclear_particle"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	damage = 10
-	damage_type = TOX
+	damage = 20
+	damage_type = STAMINA
 	irradiate = 2500 //enough to knockdown and induce vomiting
 	speed = 0.4
 	hitsound = 'sound/weapons/emitter2.ogg'

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -3,9 +3,7 @@
 	name = "nuclear particle"
 	icon_state = "nuclear_particle"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	damage = 20
-	damage_type = STAMINA
-	irradiate = 2500 //enough to knockdown and induce vomiting
+	irradiate = 5000
 	speed = 0.4
 	hitsound = 'sound/weapons/emitter2.ogg'
 	impact_type = /obj/effect/projectile/impact/xray


### PR DESCRIPTION
## About The Pull Request

Nuclear particles dealing straight toxin is slightly redundant, and it circumvents radiation equipment. Not good. Closes https://github.com/tgstation/tgstation/issues/41502

## Why It's Good For The Game

Nuclear particles shouldn't kill people through rad suits.

## Changelog
:cl:
balance: Nuclear particles irradiate more, but no longer deal toxin damage directly, and roll for rad protection.
balance: X-ray beams now roll for rad-armour, meaning they penetrate laser armour but are completely negated by rad-suits.
/:cl: