### PR TITLE
random sentience event now has mulebots and vomit goose in the high priority list

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -11,6 +11,8 @@ GLOBAL_LIST_INIT(high_priority_sentience, typecacheof(list(
 	/mob/living/simple_animal/hostile/carp/cayenne,
 	/mob/living/simple_animal/butterfly,
 	/mob/living/simple_animal/hostile/retaliate/poison/snake,
+	/mob/living/simple_animal/hostile/retaliate/goose/vomit,
+	/mob/living/simple_animal/bot/mulebot,
 	/mob/living/simple_animal/bot/secbot/beepsky
 )))
 


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

vomit goose is a pet, mulebots have specific features that can only be accessed from random sentience, not pai and xenobio pots cant give it sentience so it can only do it on wizard rounds

## Changelog
:cl:
add: Birdboat and Mulebots now have a high priority of appearing in random sentience event
/:cl:
