### PR TITLE
nerfs cakehat for realsies

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -16466,7 +16466,6 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -31
 	},
-/obj/item/clothing/head/hardhat/cakehat,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -21683,7 +21683,6 @@
 /area/crew_quarters/bar/atrium)
 "aTJ" = (
 /obj/structure/table/wood,
-/obj/item/clothing/head/hardhat/cakehat,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -39929,7 +39929,10 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/item/twohanded/required/kirbyplants,
+/obj/item/twohanded/required/kirbyplants{
+	desc = "A reminder of why we can't have nice things.";
+	name = "Potty the plant"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "bIu" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -39918,8 +39918,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bIt" = (
-/obj/structure/table,
-/obj/item/clothing/head/hardhat/cakehat,
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
@@ -39931,6 +39929,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "bIu" = (

--- a/code/modules/food_and_drinks/food/snacks_cake.dm
+++ b/code/modules/food_and_drinks/food/snacks_cake.dm
@@ -175,10 +175,11 @@
 
 /obj/item/reagent_containers/food/snacks/store/cake/birthday
 	name = "birthday cake"
-	desc = "Happy Birthday little clown..."
+	desc = "Happy Birthday! You get an awesome gift if you eat this whole!"
 	icon_state = "birthdaycake"
-	slice_path = /obj/item/reagent_containers/food/snacks/cakeslice/birthday
+	slice_path = /obj/item/reagent_containers/food/snacks/cakeslice/birthday //super sekrit club
 	slices_num = 5
+	trash = /obj/item/clothing/head/hardhat/cakehat
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 7, /datum/reagent/consumable/sprinkles = 10, /datum/reagent/consumable/nutriment/vitamin = 5)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 20, /datum/reagent/consumable/sprinkles = 10, /datum/reagent/consumable/nutriment/vitamin = 5)
 	tastes = list("cake" = 5, "sweetness" = 1)

--- a/code/modules/food_and_drinks/food/snacks_cake.dm
+++ b/code/modules/food_and_drinks/food/snacks_cake.dm
@@ -177,9 +177,9 @@
 	name = "birthday cake"
 	desc = "Happy Birthday! You get an awesome gift if you eat this whole!"
 	icon_state = "birthdaycake"
-	slice_path = /obj/item/reagent_containers/food/snacks/cakeslice/birthday //super sekrit club
+	slice_path = /obj/item/reagent_containers/food/snacks/cakeslice/birthday
 	slices_num = 5
-	trash = /obj/item/clothing/head/hardhat/cakehat
+	trash = /obj/item/clothing/head/hardhat/cakehat //super sekrit club
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 7, /datum/reagent/consumable/sprinkles = 10, /datum/reagent/consumable/nutriment/vitamin = 5)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 20, /datum/reagent/consumable/sprinkles = 10, /datum/reagent/consumable/nutriment/vitamin = 5)
 	tastes = list("cake" = 5, "sweetness" = 1)

--- a/code/modules/food_and_drinks/food/snacks_cake.dm
+++ b/code/modules/food_and_drinks/food/snacks_cake.dm
@@ -175,15 +175,18 @@
 
 /obj/item/reagent_containers/food/snacks/store/cake/birthday
 	name = "birthday cake"
-	desc = "Happy Birthday! You get an awesome gift if you eat this whole!"
+	desc = "Happy Birthday little clown..."
 	icon_state = "birthdaycake"
 	slice_path = /obj/item/reagent_containers/food/snacks/cakeslice/birthday
 	slices_num = 5
-	trash = /obj/item/clothing/head/hardhat/cakehat //super sekrit club
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 7, /datum/reagent/consumable/sprinkles = 10, /datum/reagent/consumable/nutriment/vitamin = 5)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 20, /datum/reagent/consumable/sprinkles = 10, /datum/reagent/consumable/nutriment/vitamin = 5)
 	tastes = list("cake" = 5, "sweetness" = 1)
 	foodtype = GRAIN | DAIRY | JUNKFOOD | SUGAR
+
+/obj/item/reagent_containers/food/snacks/store/cake/birthday/microwave_act(obj/machinery/microwave/M) //super sekrit club
+	new /obj/item/clothing/head/hardhat/cakehat(get_turf(src))
+	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/cakeslice/birthday
 	name = "birthday cake slice"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
@@ -69,8 +69,10 @@
 /datum/crafting_recipe/food/birthdaycake
 	name = "Birthday cake"
 	reqs = list(
-		/obj/item/clothing/head/hardhat/cakehat = 1,
-		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1
+		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1,
+		/obj/item/candle = 1,
+		/datum/reagent/consumable/sugar = 5,
+		/datum/reagent/consumable/caramel = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/birthday
 	subcategory = CAT_CAKE


### PR DESCRIPTION
## GAMERS

For too long have we taken the omnipotence of the cakehat for granted. We just went there... and took it, not thinking about the consequences to our actions! I say, NO MORE! The cakehat will no longer be available to the lazy and the unrobust spessman. Only truly skilled and gifted people will now get to enjoy the cakehats wonderous embrace.

## Changelog
:cl:
add: You now get the cakehat by cooking a whole birthday cake.
del: The cakehat has been removed from all maps.
tweak: Birthday cake recipe no longer requires a cakehat. It now needs a candle, sugar and caramel.
add: Metastation bar now has a new plant. Her name is Potty.
/:cl:
