### PR TITLE
adds antitox

### DIFF
--- a/code/modules/hydroponics/grown/cocoa_vanilla.dm
+++ b/code/modules/hydroponics/grown/cocoa_vanilla.dm
@@ -39,7 +39,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/vanillapod
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/consumable/vanilla = 0.25, /datum/reagent/consumable/nutriment = 0.1)
+	reagents_add = list(/datum/reagent/consumable/vanilla = 0.25, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/medicine/antitoxin= 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/vanillapod
 	seed = /obj/item/seeds/cocoapod/vanillapod


### PR DESCRIPTION
:cl: Hits and Shellspeed
add: adds antitoxin to the vanilla pod
/:cl:
why?
because botany can produce all other trekchems, save antitoxin, and while charcoal is generally more useful, antitoxin still has a few advantages, like making tricord.