### PR TITLE
Makes cleanbots clean slightly faster

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -206,18 +206,19 @@
 
 /mob/living/simple_animal/bot/cleanbot/UnarmedAttack(atom/A)
 	if(istype(A, /obj/effect/decal/cleanable))
-		anchored = TRUE
+		icon_state = "cleanbot-c"
 		mode = BOT_CLEANING
-		if(isturf(A.loc))
-			var/atom/movable/AM = A
-			if(istype(AM, /obj/effect/decal/cleanable))
-				visible_message("<span class='notice'>[src] cleans up [A].</span>")
-				for(var/obj/effect/decal/cleanable/C in A.loc)
-					qdel(C)
+		if(do_after(src, 1, target = A))
+			if(isturf(A.loc))
+				var/atom/movable/AM = A
+				if(istype(AM, /obj/effect/decal/cleanable))
+					visible_message("<span class='notice'>[src] cleans up [A].</span>")
+					for(var/obj/effect/decal/cleanable/C in A.loc)
+						qdel(C)
 
-		anchored = FALSE
 		target = null
 		mode = BOT_IDLE
+		icon_state = "cleanbot[on]"
 	else if(istype(A, /obj/item) || istype(A, /obj/effect/decal/remains))
 		visible_message("<span class='danger'>[src] sprays hydrofluoric acid at [A]!</span>")
 		playsound(src, 'sound/effects/spray2.ogg', 50, 1, -6)

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -14,7 +14,7 @@
 	model = "Cleanbot"
 	bot_core_type = /obj/machinery/bot_core/cleanbot
 	window_id = "autoclean"
-	window_name = "Automatic Station Cleaner v1.2"
+	window_name = "Automatic Station Cleaner v1.3"
 	pass_flags = PASSMOB
 	path_image_color = "#993299"
 
@@ -207,21 +207,17 @@
 /mob/living/simple_animal/bot/cleanbot/UnarmedAttack(atom/A)
 	if(istype(A, /obj/effect/decal/cleanable))
 		anchored = TRUE
-		icon_state = "cleanbot-c"
-		visible_message("<span class='notice'>[src] begins to clean up [A].</span>")
 		mode = BOT_CLEANING
-		spawn(50)
-			if(mode == BOT_CLEANING)
-				if(A && isturf(A.loc))
-					var/atom/movable/AM = A
-					if(istype(AM, /obj/effect/decal/cleanable))
-						for(var/obj/effect/decal/cleanable/C in A.loc)
-							qdel(C)
+		if(isturf(A.loc))
+			var/atom/movable/AM = A
+			if(istype(AM, /obj/effect/decal/cleanable))
+				visible_message("<span class='notice'>[src] cleans up [A].</span>")
+				for(var/obj/effect/decal/cleanable/C in A.loc)
+					qdel(C)
 
-				anchored = FALSE
-				target = null
-			mode = BOT_IDLE
-			icon_state = "cleanbot[on]"
+		anchored = FALSE
+		target = null
+		mode = BOT_IDLE
 	else if(istype(A, /obj/item) || istype(A, /obj/effect/decal/remains))
 		visible_message("<span class='danger'>[src] sprays hydrofluoric acid at [A]!</span>")
 		playsound(src, 'sound/effects/spray2.ogg', 50, 1, -6)

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -200,23 +200,28 @@
 		target_types += /obj/effect/decal/cleanable/crayon
 
 	if(trash)
-		target_types += /obj/item/trash
+		target_types = list(
+		/obj/item/trash,
+		/obj/item/reagent_containers/food/snacks/deadmouse
+		)
 
 	target_types = typecacheof(target_types)
 
 /mob/living/simple_animal/bot/cleanbot/UnarmedAttack(atom/A)
-	if(istype(A, /obj/effect/decal/cleanable))
+	if(is_cleanable(A))
 		icon_state = "cleanbot-c"
 		mode = BOT_CLEANING
-		if(do_after(src, 1, target = A))
-			if(isturf(A.loc))
-				var/atom/movable/AM = A
-				if(istype(AM, /obj/effect/decal/cleanable))
-					visible_message("<span class='notice'>[src] cleans up [A].</span>")
-					for(var/obj/effect/decal/cleanable/C in A.loc)
-						qdel(C)
 
-		target = null
+		var/turf/T = get_turf(A)
+		if(do_after(src, 1, target = T))
+			SEND_SIGNAL(T, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
+			visible_message("<span class='notice'>[src] cleans \the [T].</span>")
+			for(var/atom/dirtything in T)
+				if(is_cleanable(dirtything))
+					qdel(dirtything)
+
+			target = null
+
 		mode = BOT_IDLE
 		icon_state = "cleanbot[on]"
 	else if(istype(A, /obj/item) || istype(A, /obj/effect/decal/remains))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cleanbots have always been mostly useless. This makes them slightly less useless.

the rate at which they clean
![](https://i.imgur.com/HSrdXIu.gif)

using a body with low blood to outpace four of them
![](https://i.imgur.com/JuMlsZd.gif)

I've since restored the cleaning animation. It's much shorter.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Closes the margin between the rate of mess and the rate of cleaning slightly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
balance: Cleanbots clean slightly faster. They also treat dead rats they kill like trash now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
