### PR TITLE
Dumbness shouldn't drive...

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -952,7 +952,8 @@
 			return mmi_moved_inside(mmi_as_oc, user)
 		else
 			to_chat(user, "<span class='warning'>Occupant detected!</span>")
-			to_chat(user, "<span class='notice'>You stop inserting the MMI.</span>")
+	else
+		to_chat(user, "<span class='notice'>You stop inserting the MMI.</span>")
 	return FALSE
 
 /obj/mecha/proc/mmi_moved_inside(obj/item/mmi/mmi_as_oc, mob/user)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -893,12 +893,10 @@
 		log_message("Permission denied (Attached mobs).", LOG_MECHA)
 		return
 	if(HAS_TRAIT(user,TRAIT_DUMB))
-		to_chat(user, "<span class='warning'>This Mech will not let dumb people drive it")
+		to_chat(user, "<span class='warning'>This Mech will not let dumb people drive it</span>")
 		log_message("Permission denied (Drunk Driver) ", LOG_MECHA)
 		return
-
 	visible_message("[user] starts to climb into [name].")
-
 	if(do_after(user, enter_delay, target = src))
 		if(obj_integrity <= 0)
 			to_chat(user, "<span class='warning'>You cannot get in the [name], it has been destroyed!</span>")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -892,6 +892,10 @@
 		to_chat(user, "<span class='warning'>You can't enter the exosuit with other creatures attached to you!</span>")
 		log_message("Permission denied (Attached mobs).", LOG_MECHA)
 		return
+	if(HAS_TRAIT(user,TRAIT_DUMB))
+		to_chat(user, "<span class='warning'>This Mech will not let dumb people drive it")
+		log_message("Permission denied (Drunk Driver) ", LOG_MECHA)
+		return
 
 	visible_message("[user] starts to climb into [name].")
 
@@ -904,11 +908,12 @@
 			to_chat(user, "<span class='warning'>You can't enter the exosuit while buckled.</span>")
 		else if(user.has_buckled_mobs())
 			to_chat(user, "<span class='warning'>You can't enter the exosuit with other creatures attached to you!</span>")
+		else if(HAS_TRAIT(user,TRAIT_DUMB))
+			to_chat(user,"<span class='warning'>You can't drive dummy</span>")
 		else
 			moved_inside(user)
-	else
-		to_chat(user, "<span class='warning'>You stop entering the exosuit!</span>")
-	return
+			return
+		to_chat(user, "<span class='warning'>You stop entering the exosuit!</span>");
 
 /obj/mecha/proc/moved_inside(mob/living/carbon/human/H)
 	if(H && H.client && H in range(1))
@@ -949,8 +954,7 @@
 			return mmi_moved_inside(mmi_as_oc, user)
 		else
 			to_chat(user, "<span class='warning'>Occupant detected!</span>")
-	else
-		to_chat(user, "<span class='notice'>You stop inserting the MMI.</span>")
+			to_chat(user, "<span class='notice'>You stop inserting the MMI.</span>")
 	return FALSE
 
 /obj/mecha/proc/mmi_moved_inside(obj/item/mmi/mmi_as_oc, mob/user)


### PR DESCRIPTION
Prevents people with the Dumb Trait from piloting mecha

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Split off from RC-1 this isolation contains the idea that it's a slight oversight that people with the dumb trait can drive a highly complicated machine. We'll fix that
 (Note: I have no IDEA where to get the TRAIT_DUMB from naturally but I used it in my lockable schoolgirl branch to interact with this as well as a few other things that the flag came up on)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Piloting a Mech Suit shouldn't be so simple a dumb person can do it.

## Changelog
:cl:
tweak: Dumb People Can't Drive Mecha anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
