### PR TITLE
Trash from food no longer teleports.

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -71,10 +71,11 @@ All foods are distributed among various categories. Use common sense.
 	if(!eater)
 		return
 	if(!reagents.total_volume)
-		var/obj/item/trash_item = generate_trash(eater)
+		var/mob/living/location = loc
+		var/obj/item/trash_item = generate_trash(location)
 		qdel(src)
-		eater.put_in_hands(trash_item)
-
+		if(istype(location))
+			location.put_in_hands(trash_item)
 
 /obj/item/reagent_containers/food/snacks/attack_self(mob/user)
 	return


### PR DESCRIPTION
## About The Pull Request

Trash from food no longer magically teleports into the hands of the eater. This happened usually happened when people forcefed you candy.

## Why It's Good For The Game

It's just odd that this happenes. If I shove a candy bar into someones face IRL, the packaging doesn't teleport into their hands. I tested that.

## Changelog
:cl:
fix: Trash from food now gets generated at the location of the food item, instead of in the hands of the eater.
/:cl:
