### PR TITLE
Adds the feeedback column to `admin`

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,15 +1,22 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.2; The query to update the schema revision table is:
+The latest database version is 5.3; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 2);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 3);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 2);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 3);
 
 In any query remember to add a prefix to the table names if you use one.
 
 ----------------------------------------------------
 
+Version 5.3, 6 July 2019, by Atlanta-Ned
+Added a `feedback` column to the admin table, used for linking to individual admin feedback threads. This is mostly a TG feature, but database disparity has reared its ugly head elsewhere so this is being pushed.
+
+ALTER TABLE `admin`
+  ADD `feedback` VARCHAR(255)  NULL  DEFAULT NULL  AFTER `rank`;
+
+----------------------------------------------------
 
 Version 5.2, 30 May 2019, by AffectedArc07
 Added a field to the `player` table to track ckey and discord ID relationships

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -11,10 +11,9 @@ In any query remember to add a prefix to the table names if you use one.
 ----------------------------------------------------
 
 Version 5.3, 6 July 2019, by Atlanta-Ned
-Added a `feedback` column to the admin table, used for linking to individual admin feedback threads. This is mostly a TG feature, but database disparity has reared its ugly head elsewhere so this is being pushed.
+Added a `feedback` column to the admin table, used for linking to individual admin feedback threads. Currently this is only used for statistics tracking tools such as Statbus and isn't used by the game.
 
-ALTER TABLE `admin`
-  ADD `feedback` VARCHAR(255)  NULL  DEFAULT NULL  AFTER `rank`;
+ALTER TABLE `admin` ADD `feedback` VARCHAR(255) NULL DEFAULT NULL AFTER `rank`;
 
 ----------------------------------------------------
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -19,6 +19,7 @@ DROP TABLE IF EXISTS `admin`;
 CREATE TABLE `admin` (
   `ckey` varchar(32) NOT NULL,
   `rank` varchar(32) NOT NULL,
+  `feedback` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`ckey`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -19,6 +19,7 @@ DROP TABLE IF EXISTS `SS13_admin`;
 CREATE TABLE `SS13_admin` (
   `ckey` varchar(32) NOT NULL,
   `rank` varchar(32) NOT NULL,
+  `feedback` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`ckey`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -1,7 +1,7 @@
 //Update this whenever the db schema changes
 //make sure you add an update to the schema_version stable in the db changelog
 #define DB_MAJOR_VERSION 5
-#define DB_MINOR_VERSION 2
+#define DB_MINOR_VERSION 3
 
 
 //Timing subsystem


### PR DESCRIPTION
This column already exists on tg, but was never properly added to the SQL changelogs. This omission has caused issues with downstream servers communicating with 3rd party applications.

EDIT: To reiterate: this column is ONLY used on tg and downstreams have NOT missed a critical update. This is only used (at the moment) for working with external 3rd party tools.