### PR TITLE
Agent card automatically assigns your account number on first time use + change it anytime

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -185,24 +185,29 @@
 
 	return TRUE
 
+/obj/item/card/id/proc/set_new_account(mob/living/user)
+	var/new_bank_id = input(user, "Enter your account ID number.", "Account Reclamation", 111111) as num
+	if(!alt_click_can_use_id(user))
+		return
+	if(!new_bank_id || new_bank_id < 111111 || new_bank_id > 999999)
+		to_chat(user, "<span class='warning'>The account ID number needs to be between 111111 and 999999.</span>")
+		return
+	for(var/A in SSeconomy.bank_accounts)
+		var/datum/bank_account/B = A
+		if(B.account_id == new_bank_id)
+			B.bank_cards += src
+			registered_account = B
+			to_chat(user, "<span class='notice'>The provided account has been linked to this ID card.</span>")
+			return
+	to_chat(user, "<span class='warning'>The account ID number provided is invalid.</span>")
+	return
+
 /obj/item/card/id/AltClick(mob/living/user)
 	if(!alt_click_can_use_id(user))
 		return
+
 	if(!registered_account)
-		var/new_bank_id = input(user, "Enter your account ID number.", "Account Reclamation", 111111) as num
-		if(!alt_click_can_use_id(user))
-			return
-		if(!new_bank_id || new_bank_id < 111111 || new_bank_id > 999999)
-			to_chat(user, "<span class='warning'>The account ID number needs to be between 111111 and 999999.</span>")
-			return
-		for(var/A in SSeconomy.bank_accounts)
-			var/datum/bank_account/B = A
-			if(B.account_id == new_bank_id)
-				B.bank_cards += src
-				registered_account = B
-				to_chat(user, "<span class='notice'>The provided account has been linked to this ID card.</span>")
-				return
-		to_chat(user, "<span class='warning'>The account ID number provided is invalid.</span>")
+		set_new_account(user)
 		return
 
 	if (world.time < registered_account.withdrawDelay)
@@ -307,12 +312,15 @@ update_label("John Doe", "Clowny")
 
 /obj/item/card/id/syndicate/attack_self(mob/user)
 	if(isliving(user) && user.mind)
+		var/first_use = registered_name ? FALSE : TRUE
 		if(!(user.mind.special_role || anyone)) //Unless anyone is allowed, only syndies can use the card, to stop metagaming.
-			if(!registered_name) //If a non-syndie is the first to forge an unassigned agent ID, then anyone can forge it.
+			if(first_use) //If a non-syndie is the first to forge an unassigned agent ID, then anyone can forge it.
 				anyone = TRUE
 			else
 				return ..()
-		if(alert(user, "Action", "Agent ID", "Show", "Forge") == "Forge")
+
+		var/popup_input = alert(user, "Action", "Agent ID", "Show", "Forge", "Change Account ID")
+		if(popup_input == "Forge")
 			var/t = copytext(sanitize(input(user, "What name would you like to put on this card?", "Agent card name", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name))as text | null),1,26)
 			if(!t || t == "Unknown" || t == "floor" || t == "wall" || t == "r-wall") //Same as mob/dead/new_player/prefrences.dm
 				if (t)
@@ -327,6 +335,16 @@ update_label("John Doe", "Clowny")
 			assignment = u
 			update_label()
 			to_chat(user, "<span class='notice'>You successfully forge the ID card.</span>")
+			
+			// First time use automatically sets the account id to the user.
+			if (first_use && !registered_account)
+				if(ishuman(user))
+					var/mob/living/carbon/human/accountowner = user
+					registered_account = accountowner.account_id
+					to_chat(user, "<span class='notice'>Your account number has been automatically assigned.</span>")
+
+		else if (popup_input == "Change Account ID")
+			set_new_account(user)
 			return
 	return ..()
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -191,6 +191,7 @@
 	var/datum/bank_account/old_account = registered_account
 
 	var/new_bank_id = input(user, "Enter your account ID number.", "Account Reclamation", 111111) as num
+
 	if(!alt_click_can_use_id(user))
 		return
 	if(!new_bank_id || new_bank_id < 111111 || new_bank_id > 999999)
@@ -199,6 +200,7 @@
 	if (registered_account && registered_account.account_id == new_bank_id)
 		to_chat(user, "<span class='warning'>The account ID was already assigned to this card.</span>")
 		return
+
 	for(var/A in SSeconomy.bank_accounts)
 		var/datum/bank_account/B = A
 		if(B.account_id == new_bank_id)
@@ -208,7 +210,9 @@
 			B.bank_cards += src
 			registered_account = B
 			to_chat(user, "<span class='notice'>The provided account has been linked to this ID card.</span>")
+
 			return TRUE
+			
 	to_chat(user, "<span class='warning'>The account ID number provided is invalid.</span>")
 	return
 
@@ -358,7 +362,6 @@ update_label("John Doe", "Clowny")
 							registered_account = account
 							to_chat(user, "<span class='notice'>Your account number has been automatically assigned.</span>")
 			return
-
 		else if (popup_input == "Change Account ID")
 			set_new_account(user)
 			return

--- a/code/modules/antagonists/traitor/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/syndicate_contract.dm
@@ -149,7 +149,7 @@
 					C.registered_account.adjust_money(ransom * 0.35)
 
 					C.registered_account.bank_card_talk("We've processed the ransom, agent. Here's your cut - your balance is now \
-					$[C.registered_account.account_balance].")
+					$[C.registered_account.account_balance].", TRUE)
 
 // They're off to holding - handle the return timer and give some text about what's going on.
 /datum/syndicate_contract/proc/handleVictimExperience(var/mob/living/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Agent cards now set its account number information to yours on first forge, and gives a new button when forging to set a new account ID.

I also force the ransom payment alert even if you have the "income alert" preference off for the contract system. Very minor so isn't included in changelog, just another QoL thing.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Nobody ever sets their agent card to have their account number, and the agent card can basically forge everything but give itself a new account number, which feels like a reasonable addition to give. Mostly just a QoL change for it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Agent card sets its account ID automatically on first time use
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
