### PR TITLE
Generate documentation, deploy to gh-pages via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
             - python3-setuptools
       install:
         - tools/travis/install_build_tools.sh
-        - tools/travis/install_dreamchecker.sh
+        - tools/travis/install_spaceman_dmm.sh dreamchecker
       script:
         - tools/travis/check_filedirs.sh tgstation.dme
         - tools/travis/check_changelogs.sh
@@ -75,3 +75,19 @@ matrix:
       script:
         - tools/travis/dm.sh -DTRAVISBUILDING tgstation.dme || travis_terminate 1
         - tools/travis/run_server.sh
+
+    - name: "Generate Documentation"
+      # Only run for non-PR commits to the real master branch.
+      if: branch = master AND head_branch IS blank
+      install:
+        - tools/travis/install_spaceman_dmm.sh dmdoc
+      before_script:
+        # Travis checks out a hash, try to get back on a branch.
+        - git checkout -qf $(git name-rev --name-only HEAD) || true
+      script:
+        - ~/dmdoc
+      deploy:
+        provider: pages
+        skip_cleanup: true
+        local_dir: dmdoc
+        github_token: $DMDOC_GITHUB_TOKEN

--- a/tools/travis/install_dreamchecker.sh
+++ b/tools/travis/install_dreamchecker.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-source dependencies.sh
-
-wget -O ~/dreamchecker "https://github.com/SpaceManiac/SpacemanDMM/releases/download/$SPACEMAN_DMM_VERSION/dreamchecker"
-chmod +x ~/dreamchecker
-~/dreamchecker --version

--- a/tools/travis/install_spaceman_dmm.sh
+++ b/tools/travis/install_spaceman_dmm.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+source dependencies.sh
+
+wget -O ~/$1 "https://github.com/SpaceManiac/SpacemanDMM/releases/download/$SPACEMAN_DMM_VERSION/$1"
+chmod +x ~/$1
+~/$1 --version


### PR DESCRIPTION
* [x] **Requires special attention before merging.\***

Adds [dmdoc](https://github.com/SpaceManiac/SpacemanDMM/blob/master/src/dmdoc/README.md) generation and publishing to GitHub pages via Travis CI, in fulfillment of Cyberboss's dream.

Debatably useful but it turns out to be easy to add given that the documentation generator was already completed at Cyberboss's request.

Example of generated docs for /tg/station: https://hs.platymuus.com/dmdoc/tgstation/

Example of GitHub pages deployment: https://spacemaniac.github.io/test4dmdoc/

Travis logs: https://travis-ci.org/SpaceManiac/test4dmdoc
Demonstration that [branch](https://travis-ci.org/SpaceManiac/test4dmdoc/builds/554567832) and [PR](https://travis-ci.org/SpaceManiac/test4dmdoc/builds/554567867) skip the documentation job.

Travis docs for the gh-pages deployment feature: https://docs.travis-ci.com/user/deployment/pages/

**\*** Will require someone to generate a [personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) with only the "repo" scope and set `DMDOC_GITHUB_TOKEN` to it in the [Travis settings](https://travis-ci.org/tgstation/tgstation/settings). I would recommend the tgstation-server account. If you know a better way to do this, let me know.