### PR TITLE
Fixes permeability runtime

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -617,14 +617,15 @@
 	else
 		. += INFINITY
 
-/mob/living/carbon/get_permeability_protection(list/target_zones = list(HANDS = 0, CHEST = 0, GROIN = 0, LEGS = 0, FEET = 0, ARMS = 0, HEAD = 0))
+/mob/living/carbon/get_permeability_protection(list/target_zones = list(HANDS,CHEST,GROIN,LEGS,FEET,ARMS,HEAD))
+	var/list/tally = list()
 	for(var/obj/item/I in get_equipped_items())
 		for(var/zone in target_zones)
 			if(I.body_parts_covered & zone)
-				target_zones[zone] = max(1 - I.permeability_coefficient, target_zones[zone])
+				tally["[zone]"] = max(1 - I.permeability_coefficient, target_zones["[zone]"])
 	var/protection = 0
-	for(var/zone in target_zones)
-		protection += target_zones[zone]
+	for(var/key in tally)
+		protection += tally[key]
 	protection *= INVERSE(target_zones.len)
 	return protection
 


### PR DESCRIPTION
Honestly should just use bitflag directly, but figuring out the coeff would be annoying since it has these two bit defines like LEGS