### PR TITLE
Fixes default borg module runtime

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -767,7 +767,7 @@
 	qdel(src)
 
 /mob/living/silicon/robot/modules
-	var/set_module = null
+	var/set_module = /obj/item/robot_module
 
 /mob/living/silicon/robot/modules/Initialize()
 	. = ..()


### PR DESCRIPTION
Runtime doesn't happen during normal gameplay, this particular object can only be created by spawning it in. Still no reason to have it runtime.