### PR TITLE
Fixes liver failure runtime and inconsistency

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -578,9 +578,9 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 /////////
 
 /mob/living/carbon/proc/handle_liver()
-	var/obj/item/organ/liver/liver = getorganslot(ORGAN_SLOT_LIVER)
-	if((!dna && !liver) || (NOLIVER in dna.species.species_traits))
+	if(!dna || (NOLIVER in dna.species?.species_traits))
 		return
+	var/obj/item/organ/liver/liver = getorganslot(ORGAN_SLOT_LIVER)
 	if(liver)
 		if(liver.damage >= liver.maxHealth)
 			liver.failing = TRUE


### PR DESCRIPTION
## About The Pull Request

handle_liver no longer runtimes for xenos.
Xenos will now never get a liver failure.

## Why It's Good For The Game

Xenos could get a liver failure from damage, but not from lack of liver. Didn't really make sense.

From what I've gathered this is the intended behaviour (#42247 relevant)

No changelog because the runtime prevented this from being an issue.
