### PR TITLE
Gives teleporter circuit boards the science icon.

### DIFF
--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -155,11 +155,6 @@
 	icon_state = "engineering"
 	build_path = /obj/machinery/computer/station_alert
 
-/obj/item/circuitboard/computer/teleporter
-	name = "Teleporter (Computer Board)"
-	icon_state = "engineering"
-	build_path = /obj/machinery/computer/teleporter
-
 /obj/item/circuitboard/computer/turbine_computer
 	name = "Turbine Computer (Computer Board)"
 	icon_state = "engineering"
@@ -373,6 +368,11 @@
 	name = "Robotics Control (Computer Board)"
 	icon_state = "science"
 	build_path = /obj/machinery/computer/robotics
+
+/obj/item/circuitboard/computer/teleporter
+	name = "Teleporter (Computer Board)"
+	icon_state = "science"
+	build_path = /obj/machinery/computer/teleporter
 
 /obj/item/circuitboard/computer/xenobiology
 	name = "circuit board (Xenobiology Console)"

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -314,25 +314,6 @@
 	name = "\improper Departmental Techfab (Machine Board) - Engineering"
 	build_path = /obj/machinery/rnd/production/techfab/department/engineering
 
-/obj/item/circuitboard/machine/teleporter_hub
-	name = "Teleporter Hub (Machine Board)"
-	icon_state = "engineering"
-	build_path = /obj/machinery/teleport/hub
-	req_components = list(
-		/obj/item/stack/ore/bluespace_crystal = 3,
-		/obj/item/stock_parts/matter_bin = 1)
-	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)
-
-/obj/item/circuitboard/machine/teleporter_station
-	name = "Teleporter Station (Machine Board)"
-	icon_state = "engineering"
-	build_path = /obj/machinery/teleport/station
-	req_components = list(
-		/obj/item/stack/ore/bluespace_crystal = 2,
-		/obj/item/stock_parts/capacitor = 2,
-		/obj/item/stack/sheet/glass = 1)
-	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)
-
 /obj/item/circuitboard/machine/thermomachine
 	name = "Thermomachine (Machine Board)"
 	icon_state = "engineering"
@@ -894,6 +875,25 @@
 	name = "\improper Departmental Techfab (Machine Board) - Science"
 	icon_state = "science"
 	build_path = /obj/machinery/rnd/production/techfab/department/science
+
+/obj/item/circuitboard/machine/teleporter_hub
+	name = "Teleporter Hub (Machine Board)"
+	icon_state = "science"
+	build_path = /obj/machinery/teleport/hub
+	req_components = list(
+		/obj/item/stack/ore/bluespace_crystal = 3,
+		/obj/item/stock_parts/matter_bin = 1)
+	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)
+
+/obj/item/circuitboard/machine/teleporter_station
+	name = "Teleporter Station (Machine Board)"
+	icon_state = "science"
+	build_path = /obj/machinery/teleport/station
+	req_components = list(
+		/obj/item/stack/ore/bluespace_crystal = 2,
+		/obj/item/stock_parts/capacitor = 2,
+		/obj/item/stack/sheet/glass = 1)
+	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)
 
 //Security
 


### PR DESCRIPTION
## About The Pull Request

Changes teleporter circuit board icon states to science from engi.

## Why It's Good For The Game

Teleporters can also be associated with science but most importantly, the teleporter board is in the science stack in tech storage. Makes the colors mismatch less.

## Changelog
:cl:
tweak: Gives the teleporters circuit boards the science icon.
/:cl:
