### PR TITLE
remove special borg behaviour during surgery

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -89,8 +89,6 @@
 		var/obj/item/tool = user.get_active_held_item()
 		if(S.try_op(user, target, user.zone_selected, tool, src, try_to_fail))
 			return TRUE
-		if(iscyborg(user) && user.a_intent != INTENT_HARM) //to save asimov borgs a LOT of heartache
-			return TRUE
 		if(tool.item_flags & SURGICAL_TOOL) //Just because you used the wrong tool it doesn't mean you meant to whack the patient with it
 			to_chat(user, "<span class='warning'>This step requires a different tool!</span>")
 			return TRUE


### PR DESCRIPTION
## About The Pull Request
This will allow borgs to use health analyzers (and any other non-surgical tools) normally during surgery while using help-intent. The change that I'm removing is no longer relevant since https://github.com/tgstation/tgstation/pull/44482 supersedes it.

Fixes https://github.com/tgstation/tgstation/issues/43944

## Changelog
:cl:
fix: Borgs can use non-surgical tools on people who are in surgery while using help-intent
/:cl: