### PR TITLE
Decrease BYOS cost to 2500

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -180,11 +180,11 @@
 	name = "Build your own shuttle kit"
 	description = "For the enterprising shuttle engineer! The chassis will dock upon purchase, but launch will have to be authorized as usual via shuttle call. Comes stocked with construction materials."
 	admin_notes = "No brig, no medical facilities, no shuttle console."
-	credit_cost = 500
+	credit_cost = 2500
 
 /datum/map_template/shuttle/emergency/airless/prerequisites_met()
-	// first 10 minutes only
-	return world.time - SSticker.round_start_time < 6000
+	// first 10 minutes only(removed)
+	return world.time - SSticker.round_start_time < 99999999
 
 /datum/map_template/shuttle/emergency/airless/post_load()
 	. = ..()

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -180,7 +180,7 @@
 	name = "Build your own shuttle kit"
 	description = "For the enterprising shuttle engineer! The chassis will dock upon purchase, but launch will have to be authorized as usual via shuttle call. Comes stocked with construction materials."
 	admin_notes = "No brig, no medical facilities, no shuttle console."
-	credit_cost = 5000
+	credit_cost = 500
 
 /datum/map_template/shuttle/emergency/airless/prerequisites_met()
 	// first 10 minutes only


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pretty self explanatory. Changes the cost of the Build your own Shuttle from 5000 to 500.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's completely ludicrous to have a shuttle that has to be called within the first 10 minutes of the shift cost more funds than the station starts with. However, considering it comes with supplies and has certain benefits, it definitely shouldn't be free or give money either. This corrects the overcorrecting done with the previous BYOS balance change.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: DeeDubya
tweak: Decreased the cost of the BYOS from 5000 to 2500, and removed the time limit for purchasing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
