### PR TITLE
Virus cures no longer reshuffle while in hosts

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -31,7 +31,6 @@
 	var/id = ""
 	var/processing = FALSE
 	var/mutable = TRUE //set to FALSE to prevent most in-game methods of altering the disease via virology
-	var/oldres
 
 	// The order goes from easy to cure to hard to cure.
 	var/static/list/advance_cures = 	list(
@@ -240,7 +239,10 @@
 		cure_chance = 15 - CLAMP(properties["resistance"], -5, 5) // can be between 10 and 20
 		stage_prob = max(properties["stage_rate"], 2)
 		SetSeverity(properties["severity"])
-		GenerateCure(properties)
+		message_admins("Refresh() called on [src], [cures.len] cures in the list.")
+		if(!cures.len)
+			message_admins("GenerateCure() getting called, cures.len = [cures.len]")
+			GenerateCure(properties)
 	else
 		CRASH("Our properties were empty or null!")
 
@@ -289,15 +291,13 @@
 			severity = "Unknown"
 
 
-// Will generate a random cure, the less resistance the symptoms have, the harder the cure.
+// Will generate a random cure, the more resistance the symptoms have, the harder the cure.
 /datum/disease/advance/proc/GenerateCure()
-	if(properties && properties.len)
+	message_admins("GenerateCure() ran with [cures.len] cures.")
+	if(properties && properties.len && !cures.len)
 		var/res = CLAMP(properties["resistance"] - (symptoms.len / 2), 1, advance_cures.len)
-		if(res == oldres)
-			return
 		cures = list(pick(advance_cures[res]))
-		oldres = res
-
+		message_admins("GenerateCure() picked [cures[1]]")
 		// Get the cure name from the cure_id
 		var/datum/reagent/D = GLOB.chemical_reagents_list[cures[1]]
 		cure_text = D.name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I forgot to copy over the oldres var, so any new infection was susceptible to a cure reroll on the same resistance level when someone **renamed a different disease**. :eyes: I also removed the unecessary refreshing of every disease which ended up triggering this, we should only be refreshing if something is done to the disease in question. 

Fixes #45014
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Disease cures should now stay the same for all infected mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
