### PR TITLE
Removes slaughterlings

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -129,10 +129,7 @@ Difficulty: Hard
 		blood_warp()
 
 	if(!BUBBLEGUM_SMASH)
-		if(prob(50 + anger_modifier))
-			triple_charge()
-		else
-			slaughterlings()
+		triple_charge()
 	else
 		if(prob(50 + anger_modifier))
 			hallucination_charge()
@@ -393,13 +390,6 @@ Difficulty: Hard
 	desc = "You're not quite sure how a signal can be bloody."
 	invisibility = 100
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/devour(mob/living/L)
-	var/turf/death_turf = get_turf(L)
-	. = ..()
-	if(. && death_turf)
-		for(var/i in 1 to 3)
-			new /mob/living/simple_animal/hostile/asteroid/hivelordbrood/slaughter(death_turf)
-
 /mob/living/simple_animal/hostile/megafauna/bubblegum/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE)
 	. = ..()
 	if(. > 0 && prob(25))
@@ -563,31 +553,3 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/try_bloodattack()
 	return
-
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/slaughterlings()
-	visible_message("<span class='danger'>[src] summons a shoal of slaughterlings!</span>")
-	var/max_amount = CLAMP(anger_modifier / 4, 3, 5)
-	for(var/H in get_pools(get_turf(src), 1))
-		if(!max_amount)
-			break
-		max_amount--
-		var/obj/effect/decal/cleanable/blood/B = H
-		new /mob/living/simple_animal/hostile/asteroid/hivelordbrood/slaughter(B.loc)
-	return max_amount
-
-/mob/living/simple_animal/hostile/asteroid/hivelordbrood/slaughter
-	name = "slaughterling"
-	desc = "Though not yet strong enough to create a true physical form, it's nonetheless determined to murder you."
-	icon_state = "bloodbrood"
-	icon_living = "bloodbrood"
-	icon_aggro = "bloodbrood"
-	attacktext = "pierces"
-	color = "#C80000"
-	density = FALSE
-	faction = list("mining", "boss")
-	weather_immunities = list("lava","ash")
-
-/mob/living/simple_animal/hostile/asteroid/hivelordbrood/slaughter/CanPass(atom/movable/mover, turf/target)
-	if(istype(mover, /mob/living/simple_animal/hostile/megafauna/bubblegum))
-		return TRUE
-	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Slaughterlings were readded to the bubblegum fight as an undocumented change in #44005. New bubble is fun and punishing, but holy shit did it not need near invisible mobs that block you while dodging and also prevent you from shooting the big guy. These only serve to draw out the fight, which can be catastrophic if no storm proof stuff spawned that round. They also dont work properly, as bubble will happily spawn 15+ of them every so often. 

I don't mind having new attacks added to bubblegum, but reviving the worst feature about old bubblegum for variety wasnt the right call. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes unfun and tedious shit from an otherwise fun fight.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
del: Removed Bubblegums ability to summon slaughterlings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
