### PR TITLE
Changes how disease biotypes are added

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -355,8 +355,7 @@
 	return id
 
 
-// Add a symptom, if it is over the limit (with a small chance to be able to go over)
-// we take a random symptom away and add the new one.
+// Add a symptom, if it is over the limit we take a random symptom away and add the new one.
 /datum/disease/advance/proc/AddSymptom(datum/symptom/S)
 
 	if(HasSymptom(S))
@@ -364,6 +363,7 @@
 
 	if(symptoms.len < (VIRUS_SYMPTOM_LIMIT - 1) + rand(-1, 1))
 		symptoms += S
+		S.OnAdd(src)
 	else
 		RemoveSymptom(pick(symptoms))
 		symptoms += S
@@ -371,12 +371,14 @@
 // Simply removes the symptom.
 /datum/disease/advance/proc/RemoveSymptom(datum/symptom/S)
 	symptoms -= S
+	S.OnRemove(src)
 
 // Neuter a symptom, so it will only affect stats
 /datum/disease/advance/proc/NeuterSymptom(datum/symptom/S)
 	if(!S.neutered)
 		S.neutered = TRUE
 		S.name += " (neutered)"
+		S.OnRemove(src)
 
 /*
 

--- a/code/datums/diseases/advance/symptoms/species.dm
+++ b/code/datums/diseases/advance/symptoms/species.dm
@@ -8,11 +8,13 @@
 	level = 5
 	severity = 0
 
-/datum/symptom/undead_adaptation/Start(datum/disease/advance/A)
-	if(!..())
-		return
+/datum/symptom/undead_adaptation/OnAdd(datum/disease/advance/A)
 	A.process_dead = TRUE
 	A.infectable_biotypes |= MOB_UNDEAD
+
+/datum/symptom/undead_adaptation/OnRemove(datum/disease/advance/A)
+	A.process_dead = FALSE
+	A.infectable_biotypes -= MOB_UNDEAD
 
 /datum/symptom/inorganic_adaptation
 	name = "Inorganic Biology"
@@ -24,7 +26,11 @@
 	level = 5
 	severity = 0
 
-/datum/symptom/inorganic_adaptation/Start(datum/disease/advance/A)
-	if(!..())
-		return
+/datum/symptom/inorganic_adaptation/OnAdd(datum/disease/advance/A)
 	A.infectable_biotypes |= MOB_INORGANIC
+	message_admins("[src]'s OnAdd() ran successfully")
+
+/datum/symptom/inorganic_adaptation/OnRemove(datum/disease/advance/A)
+	A.infectable_biotypes -= MOB_INORGANIC
+	message_admins("[src]'s OnRemove() ran successfully")
+

--- a/code/datums/diseases/advance/symptoms/species.dm
+++ b/code/datums/diseases/advance/symptoms/species.dm
@@ -28,9 +28,7 @@
 
 /datum/symptom/inorganic_adaptation/OnAdd(datum/disease/advance/A)
 	A.infectable_biotypes |= MOB_INORGANIC
-	message_admins("[src]'s OnAdd() ran successfully")
 
 /datum/symptom/inorganic_adaptation/OnRemove(datum/disease/advance/A)
 	A.infectable_biotypes -= MOB_INORGANIC
-	message_admins("[src]'s OnRemove() ran successfully")
 

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -74,3 +74,9 @@
 
 /datum/symptom/proc/generate_threshold_desc()
 	return
+
+/datum/symptom/proc/OnAdd(datum/disease/advance/A)		//Overload when a symptom needs to be active before processing, like changing biotypes. 
+	return
+
+/datum/symptom/proc/OnRemove(datum/disease/advance/A)	//But dont forget to remove them too.
+	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
@ATH1909 pointed out this was being weird. Currently inorganic biology and necrotic metabolism doesnt allow for the first infection to be inorganic or (un)dead due to not adding the traits until somone has been infected. Add in a mess of copied diseases that aren't the exact same, and you got a very unintuitive mess of disease cultures of the same disease with different infection traits. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes an oversight.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Inorganic Biology and Necrotic Metabolism virus symptoms now take effect immediately, allowing for direct infection of the relevant species.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
