### PR TITLE
Chameleon ID and PDA improvements

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -212,7 +212,7 @@
 			to_chat(user, "<span class='notice'>The provided account has been linked to this ID card.</span>")
 
 			return TRUE
-			
+
 	to_chat(user, "<span class='warning'>The account ID number provided is invalid.</span>")
 	return
 
@@ -309,7 +309,7 @@ update_label("John Doe", "Clowny")
 
 /obj/item/card/id/syndicate/Initialize()
 	. = ..()
-	var/datum/action/item_action/chameleon/change/chameleon_action = new(src)
+	var/datum/action/item_action/chameleon/change/id/chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/card/id
 	chameleon_action.chameleon_name = "ID Card"
 	chameleon_action.initialize_disguises()
@@ -349,7 +349,7 @@ update_label("John Doe", "Clowny")
 			assignment = u
 			update_label()
 			to_chat(user, "<span class='notice'>You successfully forge the ID card.</span>")
-			
+
 			// First time use automatically sets the account id to the user.
 			if (first_use && !registered_account)
 				if(ishuman(user))

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -253,8 +253,6 @@
 /datum/action/item_action/chameleon/change/proc/apply_job_data(datum/job/job_datum)
 	return
 
-/datum/action/item_action/chameleon/change/id
-
 /datum/action/item_action/chameleon/change/id/update_item(obj/item/picked_item)
 	..()
 	var/obj/item/card/id/agent_card = target
@@ -264,10 +262,8 @@
 /datum/action/item_action/chameleon/change/id/apply_job_data(datum/job/job_datum)
 	..()
 	var/obj/item/card/id/agent_card = target
-	if(istype(agent_card))
+	if(istype(agent_card) && istype(job_datum))
 		agent_card.assignment = job_datum.title
-
-/datum/action/item_action/chameleon/change/pda
 
 /datum/action/item_action/chameleon/change/pda/update_item(obj/item/picked_item)
 	..()
@@ -279,7 +275,7 @@
 /datum/action/item_action/chameleon/change/pda/apply_job_data(datum/job/job_datum)
 	..()
 	var/obj/item/pda/agent_pda = target
-	if(istype(agent_pda))
+	if(istype(agent_pda) && istype(job_datum))
 		agent_pda.ownjob = job_datum.title
 
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -100,8 +100,9 @@
 	var/outfit_type = outfit_options[selected]
 	if(!outfit_type)
 		return FALSE
-	var/datum/outfit/O = new outfit_type()
+	var/datum/outfit/job/O = new outfit_type()
 	var/list/outfit_types = O.get_chameleon_disguise_info()
+	var/datum/job/job_datum = SSjob.GetJobType(O.jobtype)
 
 	for(var/V in user.chameleon_item_actions)
 		var/datum/action/item_action/chameleon/change/A = V
@@ -109,12 +110,14 @@
 		for(var/T in outfit_types)
 			for(var/name in A.chameleon_list)
 				if(A.chameleon_list[name] == T)
+					A.apply_job_data(job_datum)
 					A.update_look(user, T)
 					outfit_types -= T
 					done = TRUE
 					break
 			if(done)
 				break
+
 	//hardsuit helmets/suit hoods
 	if(O.toggle_helmet && (ispath(O.suit, /obj/item/clothing/suit/space/hardsuit) || ispath(O.suit, /obj/item/clothing/suit/hooded)) && ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -246,6 +249,39 @@
 		STOP_PROCESSING(SSprocessing, src)
 		return
 	random_look(owner)
+
+/datum/action/item_action/chameleon/change/proc/apply_job_data(datum/job/job_datum)
+	return
+
+/datum/action/item_action/chameleon/change/id
+
+/datum/action/item_action/chameleon/change/id/update_item(obj/item/picked_item)
+	..()
+	var/obj/item/card/id/agent_card = target
+	if(istype(agent_card))
+		agent_card.update_label()
+
+/datum/action/item_action/chameleon/change/id/apply_job_data(datum/job/job_datum)
+	..()
+	var/obj/item/card/id/agent_card = target
+	if(istype(agent_card))
+		agent_card.assignment = job_datum.title
+
+/datum/action/item_action/chameleon/change/pda
+
+/datum/action/item_action/chameleon/change/pda/update_item(obj/item/picked_item)
+	..()
+	var/obj/item/pda/agent_pda = target
+	if(istype(agent_pda))
+		agent_pda.update_label()
+		agent_pda.update_icon()
+
+/datum/action/item_action/chameleon/change/pda/apply_job_data(datum/job/job_datum)
+	..()
+	var/obj/item/pda/agent_pda = target
+	if(istype(agent_pda))
+		agent_pda.ownjob = job_datum.title
+
 
 /obj/item/clothing/under/chameleon
 //starts off as black
@@ -585,7 +621,7 @@
 
 /obj/item/pda/chameleon
 	name = "PDA"
-	var/datum/action/item_action/chameleon/change/chameleon_action
+	var/datum/action/item_action/chameleon/change/pda/chameleon_action
 
 /obj/item/pda/chameleon/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Chameleon IDs and PDAs will automatically update names and icons when changing disguise
They will also change the displayed job when switching outfits with the chameleon combo-action
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Chameleon IDs and PDAs reset to the default name if their appearance changes and need to be updated manually to display the proper label, which seems like a waste of time to me.
Changing the entire chameleon loadout is very sneaky and setting the appropriate job on the ID and PDA makes it sneakier.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Agent IDs and chameleon PDAs now automatically update their labels and icons when transforming.
tweak: Selecting a chameleon outfit will set equipped agent IDs and chameleon PDAs to display the appropriate job.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
