### PR TITLE
Fix unreliability of dmdoc GitHub links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ matrix:
         - tools/travis/install_spaceman_dmm.sh dmdoc
       before_script:
         # Travis checks out a hash, try to get back on a branch.
-        - git checkout -qf $(git name-rev --name-only HEAD) || true
+        - git checkout $TRAVIS_BRANCH || true
       script:
         - ~/dmdoc
       deploy:


### PR DESCRIPTION
Minor unanticipated problem from #45047.

When a PR is merged, tgstation-server pushes a `[ci skip]` changelog commit immediately. When building the merge commit which precedes the changelog commit, the git within Travis has already fetched the changelog commit, meaning the merge commit is not the head of its branch anymore.

dmdoc reacts to this by failing to look up the remote URL for HEAD, because HEAD is not a branch, and disables GitHub permalinks.

For the dmdoc job only, always check out the latest `master` during the build, thus restoring GitHub permalinks to the generated documentation.