### PR TITLE
Fixes mindshield implanters breaking when used on headrevs/hiveminds

### DIFF
--- a/code/game/objects/items/implants/implant_mindshield.dm
+++ b/code/game/objects/items/implants/implant_mindshield.dm
@@ -39,7 +39,7 @@
 				target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel something interfering with your mental conditioning, but you resist it!</span>")
 			removed(target, 1)
 			qdel(src)
-			return FALSE
+			return TRUE //the implant is still used
 
 		var/datum/antagonist/hivevessel/woke = target.is_wokevessel()
 		if(is_hivemember(target))


### PR DESCRIPTION
## About The Pull Request

Fixes #43059
I honestly didn't know the implant was supposed to be used up but it seems like it was intended to be. I set the FALSE to TRUE because it is being used up and that way implants can properly handle using it up. If people think that they're not supposed to be used up then I would be open to properly fixing the code so mindshield implanters don't break when they're used on a headrev/hivemind.

## Changelog
:cl: Garen7
fix: Mindshield implants are properly used up when injecting a headrev/hivemind with one.
/:cl: