### PR TITLE
makes the networked fibers blob color not look as a dead blob

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/networked_fibers.dm
+++ b/code/modules/antagonists/blob/blobstrains/networked_fibers.dm
@@ -29,7 +29,7 @@
 /datum/reagent/blob/networked_fibers
 	name = "Networked Fibers"
 	taste_description = "efficiency"
-	color = "#4F441"
+	color = "#4F4441"
 
 /datum/reagent/blob/networked_fibers/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()

--- a/code/modules/antagonists/blob/blobstrains/networked_fibers.dm
+++ b/code/modules/antagonists/blob/blobstrains/networked_fibers.dm
@@ -6,8 +6,8 @@
 	effectdesc = "will move your core when manually expanding near it."
 	analyzerdescdamage = "Does high brute and burn damage."
 	analyzerdesceffect = "Is highly mobile and generates resources rapidly."
-	color = "#CDC0B0"
-	complementary_color = "#FFF68F"
+	color = "#4F4441"
+	complementary_color = "#414C4F"
 	reagent = /datum/reagent/blob/networked_fibers
 
 /datum/blobstrain/reagent/networked_fibers/expand_reaction(obj/structure/blob/B, obj/structure/blob/newB, turf/T, mob/camera/blob/O)
@@ -29,7 +29,7 @@
 /datum/reagent/blob/networked_fibers
 	name = "Networked Fibers"
 	taste_description = "efficiency"
-	color = "#CDC0B0"
+	color = "#4F441"
 
 /datum/reagent/blob/networked_fibers/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()


### PR DESCRIPTION
:cl:
tweak: networked fibers color is now dark grey
/:cl:
the old color (almost white) was too similar to a dead blob

new color: 
![www](https://user-images.githubusercontent.com/33834933/61062610-d3168580-a3fe-11e9-84c0-02c0dcb3b366.jpg)
