### PR TITLE
Swappers can no longer be sent on cargo shuttle.

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -25,7 +25,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/item/shared_storage,
 		/obj/structure/extraction_point,
 		/obj/machinery/syndicatebomb,
-		/obj/item/hilbertshotel
+		/obj/item/hilbertshotel,
+		/obj/item/swapper
 	)))
 
 /obj/docking_port/mobile/supply


### PR DESCRIPTION
## About The Pull Request
You can put quantum spin inverters in an anchored closet to teleport into CentCom which is of course bad.

## Why It's Good For The Game
exploits are bad.

## Changelog
:cl:
fix: Swappers can no longer be sent on the cargo shuttle.
/:cl: