### PR TITLE
Fixes gravitokinetic guardian effect lasting after death

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/types/gravitokinetic.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/gravitokinetic.dm
@@ -10,6 +10,7 @@
 	var/list/gravito_targets = list()
 	var/gravity_power_range = 10 //how close the stand must stay to the target to keep the heavy gravity
 
+///Removes gravity from affected mobs upon guardian death to prevent permanent effects
 /mob/living/simple_animal/hostile/guardian/gravitokinetic/death()
 	. = ..()
 	for(var/datum/component/C in gravito_targets)

--- a/code/modules/mob/living/simple_animal/guardian/types/gravitokinetic.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/gravitokinetic.dm
@@ -10,6 +10,11 @@
 	var/list/gravito_targets = list()
 	var/gravity_power_range = 10 //how close the stand must stay to the target to keep the heavy gravity
 
+/mob/living/simple_animal/hostile/guardian/gravitokinetic/death()
+	. = ..()
+	for(var/datum/component/C in gravito_targets)
+		remove_gravity(C)
+
 /mob/living/simple_animal/hostile/guardian/gravitokinetic/AttackingTarget()
 	. = ..()
 	if(isliving(target) && target != src)


### PR DESCRIPTION
:cl:
fix: Fixed gravitokinetic guardian's gravity effect remaining forever if the guardian dies.
/:cl:

Fixes #44326
Fixes #45033

Normally the effect dissipates when the guardian un-manifests or when it's victims move far enough away from it, so it makes sense to remove it immediately if the guardian dies.