### PR TITLE
Uncurses take_damage and documents obj_defense.dm

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -1,25 +1,24 @@
 
-//the essential proc to call when an obj must receive damage of any kind.
-/obj/proc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
+///the essential proc to call when an obj must receive damage of any kind.
+/obj/proc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE, attack_dir, armour_penetration = 0)
 	if(QDELETED(src))
 		stack_trace("[src] taking damage after deletion")
 		return
 	if(sound_effect)
 		play_attack_sound(damage_amount, damage_type, damage_flag)
-	if(!(resistance_flags & INDESTRUCTIBLE) && obj_integrity > 0)
-		damage_amount = run_obj_armor(damage_amount, damage_type, damage_flag, attack_dir, armour_penetration)
-		if(damage_amount >= DAMAGE_PRECISION)
-			. = damage_amount
-			var/old_integ = obj_integrity
-			obj_integrity = max(old_integ - damage_amount, 0)
-			if(obj_integrity <= 0)
-				var/int_fail = integrity_failure
-				if(int_fail && old_integ > int_fail)
-					obj_break(damage_flag)
-				obj_destruction(damage_flag)
-			else if(integrity_failure)
-				if(obj_integrity <= integrity_failure)
-					obj_break(damage_flag)
+	if((resistance_flags & INDESTRUCTIBLE) || obj_integrity <= 0)
+		return
+	damage_amount = run_obj_armor(damage_amount, damage_type, damage_flag, attack_dir, armour_penetration)
+	if(damage_amount < DAMAGE_PRECISION)
+		return
+	. = damage_amount
+	obj_integrity = max(obj_integrity - damage_amount, 0)
+	//BREAKING FIRST
+	if(integrity_failure && obj_integrity <= integrity_failure)
+		obj_break(damage_flag)
+	//DESTROYING SECOND
+	if(obj_integrity <= 0)
+		obj_destruction(damage_flag)
 
 //returns the damage value of the attack after processing the obj's various armor protections
 /obj/proc/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir, armour_penetration = 0)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -266,9 +266,9 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	else
 		deconstruct(FALSE)
 
-/*changes max_integrity while retaining current health percentage
- *returns TRUE if the obj broke, FALSE otherwise
- */
+/**changes max_integrity while retaining current health percentage
+  *returns TRUE if the obj broke, FALSE otherwise
+  */
 /obj/proc/modify_max_integrity(new_max, can_break = TRUE, damage_type = BRUTE, new_failure_integrity = null)
 	var/current_integrity = obj_integrity
 	var/current_max = max_integrity

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -20,7 +20,7 @@
 	if(obj_integrity <= 0)
 		obj_destruction(damage_flag)
 
-//returns the damage value of the attack after processing the obj's various armor protections
+///returns the damage value of the attack after processing the obj's various armor protections
 /obj/proc/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir, armour_penetration = 0)
 	switch(damage_type)
 		if(BRUTE)
@@ -34,7 +34,7 @@
 		armor_protection = CLAMP(armor_protection - armour_penetration, min(armor_protection, 0), 100)
 	return round(damage_amount * (100 - armor_protection)*0.01, DAMAGE_PRECISION)
 
-//the sound played when the obj is damaged.
+///the sound played when the obj is damaged.
 /obj/proc/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)
 		if(BRUTE)
@@ -73,6 +73,7 @@
 	if(!QDELETED(src)) //Bullet on_hit effect might have already destroyed this object
 		take_damage(P.damage, P.damage_type, P.flag, 0, turn(P.dir, 180), P.armour_penetration)
 
+///Called to get the damage that hulks will deal to the damage.
 /obj/proc/hulk_damage()
 	return 150 //the damage hulks do on punches to this object, is affected by melee armor
 
@@ -168,7 +169,7 @@
 
 GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/effects/effects.dmi', "acid"))
 
-//the obj's reaction when touched by acid
+///the obj's reaction when touched by acid
 /obj/acid_act(acidpwr, acid_volume)
 	if(!(resistance_flags & UNACIDABLE) && acid_volume)
 
@@ -180,7 +181,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 			acid_level = min(acid_level + acidpwr * acid_volume, acid_cap)
 		return 1
 
-//the proc called by the acid subsystem to process the acid that's on the obj
+///the proc called by the acid subsystem to process the acid that's on the obj
 /obj/proc/acid_processing()
 	. = 1
 	if(!(resistance_flags & ACID_PROOF))
@@ -195,13 +196,14 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	if(!acid_level)
 		return 0
 
-//called when the obj is destroyed by acid.
+///called when the obj is destroyed by acid.
 /obj/proc/acid_melt()
 	SSacid.processing -= src
 	deconstruct(FALSE)
 
 //// FIRE
 
+///Called when the obj is exposed to fire.
 /obj/fire_act(exposed_temperature, exposed_volume)
 	if(isturf(loc))
 		var/turf/T = loc
@@ -215,18 +217,20 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		add_overlay(GLOB.fire_overlay, TRUE)
 		return 1
 
-//called when the obj is destroyed by fire
+///called when the obj is destroyed by fire
 /obj/proc/burn()
 	if(resistance_flags & ON_FIRE)
 		SSfire_burning.processing -= src
 	deconstruct(FALSE)
 
+///Called when the obj is no longer on fire.
 /obj/proc/extinguish()
 	if(resistance_flags & ON_FIRE)
 		resistance_flags &= ~ON_FIRE
 		cut_overlay(GLOB.fire_overlay, TRUE)
 		SSfire_burning.processing -= src
 
+///Called when the obj is hit by a tesla bolt.
 /obj/proc/tesla_act(power, tesla_flags, shocked_targets)
 	obj_flags |= BEING_SHOCKED
 	var/power_bounced = power / 2
@@ -234,7 +238,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	addtimer(CALLBACK(src, .proc/reset_shocked), 10)
 
 //The surgeon general warns that being buckled to certain objects receiving powerful shocks is greatly hazardous to your health
-//Only tesla coils and grounding rods currently call this because mobs are already targeted over all other objects, but this might be useful for more things later.
+///Only tesla coils and grounding rods currently call this because mobs are already targeted over all other objects, but this might be useful for more things later.
 /obj/proc/tesla_buckle_check(var/strength)
 	if(has_buckled_mobs())
 		for(var/m in buckled_mobs)
@@ -244,16 +248,16 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 /obj/proc/reset_shocked()
 	obj_flags &= ~BEING_SHOCKED
 
-//the obj is deconstructed into pieces, whether through careful disassembly or when destroyed.
+///the obj is deconstructed into pieces, whether through careful disassembly or when destroyed.
 /obj/proc/deconstruct(disassembled = TRUE)
 	SEND_SIGNAL(src, COMSIG_OBJ_DECONSTRUCT, disassembled)
 	qdel(src)
 
-//what happens when the obj's health is below integrity_failure level.
+///what happens when the obj takes damage and integrity is below integrity_failure level afterwards.
 /obj/proc/obj_break(damage_flag)
 	return
 
-//what happens when the obj's integrity reaches zero.
+///what happens when the obj's integrity reaches zero.
 /obj/proc/obj_destruction(damage_flag)
 	if(damage_flag == "acid")
 		acid_melt()
@@ -262,8 +266,9 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	else
 		deconstruct(FALSE)
 
-//changes max_integrity while retaining current health percentage
-//returns TRUE if the obj broke, FALSE otherwise
+/*changes max_integrity while retaining current health percentage
+ *returns TRUE if the obj broke, FALSE otherwise
+ */
 /obj/proc/modify_max_integrity(new_max, can_break = TRUE, damage_type = BRUTE, new_failure_integrity = null)
 	var/current_integrity = obj_integrity
 	var/current_max = max_integrity
@@ -283,6 +288,6 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		return TRUE
 	return FALSE
 
-//returns how much the object blocks an explosion
+///returns how much the object blocks an explosion. Currently not implemented
 /obj/proc/GetExplosionBlock()
 	CRASH("Unimplemented GetExplosionBlock()")

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -266,9 +266,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	else
 		deconstruct(FALSE)
 
-/**changes max_integrity while retaining current health percentage
-  *returns TRUE if the obj broke, FALSE otherwise
-  */
+///changes max_integrity while retaining current health percentage, returns TRUE if the obj got broken.
 /obj/proc/modify_max_integrity(new_max, can_break = TRUE, damage_type = BRUTE, new_failure_integrity = null)
 	var/current_integrity = obj_integrity
 	var/current_max = max_integrity
@@ -288,6 +286,6 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		return TRUE
 	return FALSE
 
-///returns how much the object blocks an explosion. Currently not implemented
+///returns how much the object blocks an explosion. Used by subtypes.
 /obj/proc/GetExplosionBlock()
 	CRASH("Unimplemented GetExplosionBlock()")

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -73,7 +73,7 @@
 	if(!QDELETED(src)) //Bullet on_hit effect might have already destroyed this object
 		take_damage(P.damage, P.damage_type, P.flag, 0, turn(P.dir, 180), P.armour_penetration)
 
-///Called to get the damage that hulks will deal to the damage.
+///Called to get the damage that hulks will deal to the obj.
 /obj/proc/hulk_damage()
 	return 150 //the damage hulks do on punches to this object, is affected by melee armor
 

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -253,7 +253,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	SEND_SIGNAL(src, COMSIG_OBJ_DECONSTRUCT, disassembled)
 	qdel(src)
 
-///what happens when the obj takes damage and integrity is below integrity_failure level afterwards.
+///called after the obj takes damage and integrity is below integrity_failure level
 /obj/proc/obj_break(damage_flag)
 	return
 


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

The original take_damage proc defined vars for no good reason had some duplicate code and wasn't very readible.

If you are wondering why it calls obj_break every time it takes damage while below integrity_failure, that's the way it used to be. Most (if not all) stuff that takes advantage of this functionality already accounts for this.

## Changelog
:cl:
code: Improved the take_damage proc for objs.
/:cl:
