### PR TITLE
Sentient disease cures consistently harder, fixes uncurable diseases

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -33,7 +33,7 @@
 	var/mutable = TRUE //set to FALSE to prevent most in-game methods of altering the disease via virology
 	var/oldres
 
-	// The order goes from easy to cure to hard to cure. Keep in mind that sentient diseases pick two cures, ensure they wont react away in bodies.
+	// The order goes from easy to cure to hard to cure. Keep in mind that sentient diseases pick two cures from tier 6 and up, ensure they wont react away in bodies.
 	var/static/list/advance_cures = 	list(
 									list(	// level 1
 										/datum/reagent/copper, /datum/reagent/silver, /datum/reagent/iodine, /datum/reagent/iron, /datum/reagent/carbon

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -33,7 +33,7 @@
 	var/mutable = TRUE //set to FALSE to prevent most in-game methods of altering the disease via virology
 	var/oldres
 
-	// The order goes from easy to cure to hard to cure.
+	// The order goes from easy to cure to hard to cure. Keep in mind that sentient diseases pick two cures, ensure they wont react away in bodies.
 	var/static/list/advance_cures = 	list(
 									list(	// level 1
 										/datum/reagent/copper, /datum/reagent/silver, /datum/reagent/iodine, /datum/reagent/iron, /datum/reagent/carbon

--- a/code/modules/antagonists/disease/disease_disease.dm
+++ b/code/modules/antagonists/disease/disease_disease.dm
@@ -51,7 +51,7 @@
 	if(cures.len)
 		return
 	var/list/not_used = advance_cures.Copy()
-	not_used.Cut(1, 6)
+	not_used.Cut(1, 6)	// Removes the first five tiers of cures.
 	cures = list(pick(pick_n_take(not_used)), pick(pick_n_take(not_used)))
 
 	// Get the cure name from the cure_id

--- a/code/modules/antagonists/disease/disease_disease.dm
+++ b/code/modules/antagonists/disease/disease_disease.dm
@@ -51,6 +51,7 @@
 	if(cures.len)
 		return
 	var/list/not_used = advance_cures.Copy()
+	not_used.Cut(1, 6)
 	cures = list(pick(pick_n_take(not_used)), pick(pick_n_take(not_used)))
 
 	// Get the cure name from the cure_id


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #45139
Forgot mixing in body was a thing. I am taking this opportunity to do something I have wanted to do for a while: make the sentient disease cures harder. This change removes the first five tiers of cures from SD available cures, preventing an unlucky SD from getting carbon and bromine as their cure and at the same time gets rid of the problematic chems from the issue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix, sentient disease buff
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Sentient diseases can no longer pick two cures that react and disappear when eaten.
balance: Sentient disease cures are now consistently harder, will only pick cures from tier 6 and up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
