### PR TITLE
Random pixel shift for dropped/thrown objects

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -284,7 +284,8 @@
 		if(I.loc != real_location)
 			continue
 		remove_from_storage(I, target)
-		I.random_pixel_offset(10)
+		I.pixel_x = rand(-10,10)
+		I.pixel_y = rand(-10,10)
 		if(trigger_on_found && I.on_found())
 			return FALSE
 		if(TICK_CHECK)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -284,6 +284,7 @@
 		if(I.loc != real_location)
 			continue
 		remove_from_storage(I, target)
+		I.random_pixel_offset(10)
 		if(trigger_on_found && I.on_found())
 			return FALSE
 		if(TICK_CHECK)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -374,7 +374,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(item_flags & DROPDEL)
 		qdel(src)
 	item_flags &= ~IN_INVENTORY
-	random_pixel_offset()
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED,user)
 
 // called just as an item is picked up (loc is not yet changed)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -374,7 +374,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(item_flags & DROPDEL)
 		qdel(src)
 	item_flags &= ~IN_INVENTORY
-	pixelOffset()
+	random_pixel_offset()
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED,user)
 
 // called just as an item is picked up (loc is not yet changed)
@@ -539,7 +539,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		. = callback.Invoke()
 	item_flags &= ~IN_INVENTORY
 	if(!pixel_y && !pixel_x)
-		pixelOffset()
+		random_pixel_offset()
 
 
 /obj/item/proc/remove_item_from_storage(atom/newLoc) //please use this if you're going to snowflake an item out of a obj/item/storage
@@ -801,6 +801,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	return owner.dropItemToGround(src)
 
 ///adds a random pixel offset, for non-precise item placement such as throwing or dropping to the ground
-/obj/item/proc/pixelOffset()
+/obj/item/proc/random_pixel_offset()
 	pixel_x = rand(-8,8)
 	pixel_y = rand(-8,8)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -800,6 +800,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/doStrip(mob/stripper, mob/owner)
 	return owner.dropItemToGround(src)
 
+///adds a random pixel offset, for non-precise item placement such as throwing or dropping to the ground
 /obj/item/proc/pixelOffset()
 	pixel_x = rand(-8,8)
 	pixel_y = rand(-8,8)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -538,7 +538,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		. = callback.Invoke()
 	item_flags &= ~IN_INVENTORY
 	if(!pixel_y && !pixel_x)
-		random_pixel_offset()
+		random_pixel_offset(6)
 
 
 /obj/item/proc/remove_item_from_storage(atom/newLoc) //please use this if you're going to snowflake an item out of a obj/item/storage
@@ -800,6 +800,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	return owner.dropItemToGround(src)
 
 ///adds a random pixel offset, for non-precise item placement such as throwing or dropping to the ground
-/obj/item/proc/random_pixel_offset()
-	pixel_x = rand(-8,8)
-	pixel_y = rand(-8,8)
+/obj/item/proc/random_pixel_offset(maxoffset)
+	pixel_x = rand(-maxoffset,maxoffset)
+	pixel_y = rand(-maxoffset,maxoffset)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -538,7 +538,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		. = callback.Invoke()
 	item_flags &= ~IN_INVENTORY
 	if(!pixel_y && !pixel_x)
-		random_pixel_offset(6)
+		random_pixel_offset(8)
 
 
 /obj/item/proc/remove_item_from_storage(atom/newLoc) //please use this if you're going to snowflake an item out of a obj/item/storage

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -538,7 +538,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if (callback) //call the original callback
 		. = callback.Invoke()
 	item_flags &= ~IN_INVENTORY
-	if(!pixel_y || !pixel_x)
+	if(!pixel_y && !pixel_x)
 		pixelOffset()
 
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -375,6 +375,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		qdel(src)
 	item_flags &= ~IN_INVENTORY
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED,user)
+	pixel_x = rand(-8,8)
+	pixel_y = rand(-8,8)
 
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -538,7 +538,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		. = callback.Invoke()
 	item_flags &= ~IN_INVENTORY
 	if(!pixel_y && !pixel_x)
-		random_pixel_offset(8)
+		pixel_x = rand(-8,8)
+		pixel_y = rand(-8,8)
 
 
 /obj/item/proc/remove_item_from_storage(atom/newLoc) //please use this if you're going to snowflake an item out of a obj/item/storage
@@ -798,8 +799,3 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 /obj/item/proc/doStrip(mob/stripper, mob/owner)
 	return owner.dropItemToGround(src)
-
-///adds a random pixel offset, for non-precise item placement such as throwing or dropping to the ground
-/obj/item/proc/random_pixel_offset(maxoffset)
-	pixel_x = rand(-maxoffset,maxoffset)
-	pixel_y = rand(-maxoffset,maxoffset)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -374,9 +374,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(item_flags & DROPDEL)
 		qdel(src)
 	item_flags &= ~IN_INVENTORY
+	pixelOffset()
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED,user)
-	pixel_x = rand(-8,8)
-	pixel_y = rand(-8,8)
 
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
@@ -539,6 +538,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if (callback) //call the original callback
 		. = callback.Invoke()
 	item_flags &= ~IN_INVENTORY
+	if(!pixel_y || !pixel_x)
+		pixelOffset()
+
 
 /obj/item/proc/remove_item_from_storage(atom/newLoc) //please use this if you're going to snowflake an item out of a obj/item/storage
 	if(!newLoc)
@@ -797,3 +799,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 /obj/item/proc/doStrip(mob/stripper, mob/owner)
 	return owner.dropItemToGround(src)
+
+/obj/item/proc/pixelOffset()
+	pixel_x = rand(-8,8)
+	pixel_y = rand(-8,8)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -34,8 +34,8 @@ LINEN BINS
 	if(layer == initial(layer))
 		layer = ABOVE_MOB_LAYER
 		to_chat(user, "<span class='notice'>You cover yourself with [src].</span>")
-		src.pixel_x = 0
-		src.pixel_y = 0
+		pixel_x = 0
+		pixel_y = 0
 	else
 		layer = initial(layer)
 		to_chat(user, "<span class='notice'>You smooth [src] out beneath you.</span>")

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -34,6 +34,8 @@ LINEN BINS
 	if(layer == initial(layer))
 		layer = ABOVE_MOB_LAYER
 		to_chat(user, "<span class='notice'>You cover yourself with [src].</span>")
+		src.pixel_x = 0
+		src.pixel_y = 0
 	else
 		layer = initial(layer)
 		to_chat(user, "<span class='notice'>You smooth [src] out beneath you.</span>")

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -292,7 +292,8 @@
 //for when you want the item to end up on the ground
 //will force move the item to the ground and call the turf's Entered
 /mob/proc/dropItemToGround(obj/item/I, force = FALSE)
-	I.random_pixel_offset(6)
+	I.pixel_x = rand(-6,6)
+	I.pixel_y = rand(-6,6)
 	return doUnEquip(I, force, drop_location(), FALSE)
 
 //for when the item will be immediately placed in a loc other than the ground

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -292,7 +292,7 @@
 //for when you want the item to end up on the ground
 //will force move the item to the ground and call the turf's Entered
 /mob/proc/dropItemToGround(obj/item/I, force = FALSE)
-	I.random_pixel_offset()
+	I.random_pixel_offset(8)
 	return doUnEquip(I, force, drop_location(), FALSE)
 
 //for when the item will be immediately placed in a loc other than the ground

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -292,7 +292,7 @@
 //for when you want the item to end up on the ground
 //will force move the item to the ground and call the turf's Entered
 /mob/proc/dropItemToGround(obj/item/I, force = FALSE)
-	I.random_pixel_offset(8)
+	I.random_pixel_offset(6)
 	return doUnEquip(I, force, drop_location(), FALSE)
 
 //for when the item will be immediately placed in a loc other than the ground

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -292,6 +292,7 @@
 //for when you want the item to end up on the ground
 //will force move the item to the ground and call the turf's Entered
 /mob/proc/dropItemToGround(obj/item/I, force = FALSE)
+	I.random_pixel_offset()
 	return doUnEquip(I, force, drop_location(), FALSE)
 
 //for when the item will be immediately placed in a loc other than the ground


### PR DESCRIPTION
:cl:
add: Objects dropped and thrown will have a slight random pixel offset
/:cl:

Makes discarded objects (either dropped or thrown, manually or by explosions and such) look more organic, less likely to require alt clicking to see obscured objects when there's a lot of items on a single tile
![Screenshot_1](https://user-images.githubusercontent.com/38563876/61161002-2c1b1200-a502-11e9-987a-196c276deb6c.png)
