### PR TITLE
Fixed supply shuttle safety warning

### DIFF
--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -6,8 +6,8 @@
 	var/requestonly = FALSE
 	var/contraband = FALSE
 	var/safety_warning = "For safety reasons, the automated supply shuttle \
-		cannot transport live organisms, human remains, classified nuclear weaponry \
-		or homing beacons."
+		cannot transport live organisms, human remains, classified nuclear weaponry, \
+		homing beacons or machinery housing any form of artificial intelligence."
 	var/blockade_warning = "Bluespace instability detected. Shuttle movement impossible."
 
 	light_color = "#E2853D"//orange


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When trying to transport players with the cargo shuttle it will give a warning and prevent sending the shuttle centcom. This is done to prevent players from getting transported to the centcom base.
![image](https://user-images.githubusercontent.com/33846895/61173388-eb1f0e00-a592-11e9-8502-116980f36594.png)

When you put a cyborg or active AI on the shuttle this warning will also be displayed (which is intended), however the warning does not mention AI / cyborgs which may confuse players.

This pull request expands the message to include "machinery with artificial intelligence".
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Avoids confusion when players try to ship a cyborg or AI to centcom.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Gamer025
fix: Changed the cargo shuttle warning to mention cyborgs / AI as non transportable beings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
