### PR TITLE
Mining Base Changes: Less empty office, more stuff, stuff that used to be is back

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1898,7 +1898,7 @@
 /area/mine/living_quarters)
 "fd" = (
 /obj/machinery/camera{
-	c_tag = "Storage";
+	c_tag = "Public Shuttle Lobby";
 	network = list("mine")
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -3560,7 +3560,7 @@
 /area/mine/laborcamp/security)
 "qt" = (
 /obj/structure/cable,
-/obj/structure/closet/secure_closet/miner/unlocked,
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "rj" = (
@@ -3805,6 +3805,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Labor Camp Security Office";
+	dir = 1;
+	network = list("labor")
+	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "Fe" = (
@@ -3823,14 +3828,9 @@
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
 "Gn" = (
-/obj/structure/closet/secure_closet/miner/unlocked,
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"Gw" = (
-/obj/structure/cable,
-/obj/machinery/camera,
-/turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
 "GI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10654,7 +10654,7 @@ yr
 yr
 yr
 za
-Gw
+ch
 QN
 oW
 sM

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -3559,8 +3559,8 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "qt" = (
-/obj/structure/cable,
-/obj/structure/closet/secure_closet/miner,
+/obj/structure/table,
+/obj/item/cigbutt,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "rj" = (
@@ -3828,7 +3828,7 @@
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
 "Gn" = (
-/obj/structure/closet/secure_closet/miner,
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "GI" = (
@@ -4068,6 +4068,11 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
+"TC" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "TP" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -4220,10 +4225,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"XP" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Storage"
+"Xx" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"Ym" = (
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -8861,8 +8871,8 @@ aj
 aj
 aj
 aj
-ai
 ab
+ai
 aj
 aj
 aj
@@ -9118,9 +9128,9 @@ aj
 GJ
 aj
 ab
-ai
-ai
 ab
+ai
+ai
 aj
 aj
 ab
@@ -9374,10 +9384,10 @@ bZ
 aj
 aj
 aj
-ai
-ai
-ai
 ab
+ab
+ai
+ai
 ab
 ab
 ab
@@ -9631,8 +9641,8 @@ Hd
 FF
 Hd
 nI
-cM
-cM
+TC
+TC
 cM
 ab
 ab
@@ -9888,7 +9898,7 @@ cG
 QQ
 Hd
 qt
-Gn
+rj
 Gn
 cM
 VY
@@ -10144,7 +10154,7 @@ bw
 Hx
 oU
 Hd
-rj
+Ym
 rj
 eM
 cM
@@ -10401,9 +10411,9 @@ ch
 GI
 Fd
 Hd
-cM
-XP
-cM
+Xx
+rj
+dZ
 cM
 uJ
 nI

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -502,27 +502,16 @@
 	name = "Labor Camp APC";
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/mine/laborcamp)
 "bB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/toilet{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/closet/secure_closet/labor_camp_security,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/mine/laborcamp/security)
 "bC" = (
 /obj/machinery/airalarm{
@@ -735,19 +724,15 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "cc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -761,34 +746,32 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Labor Camp Security APC";
-	pixel_x = 24
+	pixel_x = 0;
+	pixel_y = 24
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "cf" = (
+/obj/machinery/computer/secure_data{
+	dir = 2
+	},
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "cg" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+/obj/machinery/computer/security/labor{
+	dir = 2
 	},
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
@@ -879,20 +862,15 @@
 /area/lavaland/surface/outdoors)
 "cB" = (
 /obj/structure/chair/office{
-	dir = 4
+	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "cC" = (
-/obj/machinery/computer/security/labor{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/structure/table,
 /obj/effect/turf_decal/tile/red,
-/obj/structure/cable,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "cD" = (
@@ -918,6 +896,13 @@
 /area/mine/production)
 "cG" = (
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/freezer/gulag_fridge,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1885,6 +1870,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "fb" = (
@@ -1898,6 +1884,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "fc" = (
@@ -2093,6 +2080,7 @@
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe,
 /obj/item/mining_scanner,
+/obj/item/flashlight,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "fB" = (
@@ -2345,11 +2333,15 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "gn" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
+/area/mine/living_quarters)
 "go" = (
 /obj/structure/stone_tile/block,
 /turf/open/lava/smooth/lava_land_surface,
@@ -2537,6 +2529,12 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
+"ip" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "ir" = (
 /obj/structure/stone_tile/slab/cracked{
 	dir = 5
@@ -2639,13 +2637,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"jh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/freezer/gulag_fridge,
-/turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
 "jk" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding_tile,
@@ -2694,15 +2685,15 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ju" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
+/area/mine/living_quarters)
 "jx" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -3513,6 +3504,11 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
+"nI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "oL" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -3522,9 +3518,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"oO" = (
+/obj/structure/table,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"oU" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp/security)
 "oW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
@@ -3536,23 +3553,20 @@
 /area/mine/production)
 "pV" = (
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door/airlock{
+	name = "Restroom"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "qt" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/miner/unlocked,
 /turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
+/area/mine/living_quarters)
+"rj" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "sa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3618,15 +3632,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"up" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "uG" = (
-/obj/structure/table,
-/obj/machinery/recharger,
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -3641,7 +3647,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/mine/laborcamp/security)
+/area/mine/living_quarters)
 "vb" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/shower{
@@ -3658,7 +3664,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
+/area/mine/living_quarters)
 "wj" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/purple{
@@ -3670,22 +3676,25 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/closed/wall,
 /area/mine/living_quarters)
-"xU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "yk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
+/area/mine/living_quarters)
 "yr" = (
 /turf/closed/wall/r_wall,
 /area/mine/laborcamp)
+"za" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp/security)
 "zn" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -3699,45 +3708,21 @@
 /area/mine/production)
 "zo" = (
 /obj/machinery/computer/prisoner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
-"zO" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Monitoring";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "zX" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/pen,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/closet/secure_closet/labor_camp_security,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "Aw" = (
@@ -3756,15 +3741,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"AU" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
 "AW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -3783,10 +3759,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"Bx" = (
-/obj/machinery/vending/security,
-/turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
 "Co" = (
 /obj/machinery/computer/shuttle/mining/common{
 	dir = 4
@@ -3807,8 +3779,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
+/area/mine/living_quarters)
 "Es" = (
 /obj/machinery/door/window/southright,
 /obj/machinery/shower{
@@ -3826,6 +3799,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Fd" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp/security)
 "Fe" = (
 /obj/structure/sink{
 	dir = 8;
@@ -3841,6 +3822,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
+"Gn" = (
+/obj/structure/closet/secure_closet/miner/unlocked,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Gw" = (
 /obj/structure/cable,
 /obj/machinery/camera,
@@ -3863,6 +3848,15 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
+"GN" = (
+/obj/structure/table,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Hd" = (
 /turf/closed/wall/r_wall,
 /area/mine/laborcamp/security)
@@ -3889,6 +3883,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Iq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/security/glass{
+	name = "Labor Camp Monitoring";
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp/security)
 "Iv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -3900,32 +3904,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
-"Jf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"JZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
 "Kb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3973,6 +3951,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
+"Nt" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "NC" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -3985,13 +3969,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Pa" = (
-/obj/machinery/computer/secure_data{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/structure/table,
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/recharger,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "Pl" = (
@@ -4026,6 +4006,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
+"QQ" = (
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/mine/laborcamp/security)
+"QW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Rx" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel,
@@ -4042,11 +4040,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"RJ" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
 "RO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4054,7 +4047,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
+/area/mine/living_quarters)
 "SJ" = (
 /obj/structure/statue{
 	desc = "A lifelike statue of a horrifying monster.";
@@ -4107,6 +4100,23 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/mine/living_quarters)
+"UH" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp/security)
+"UJ" = (
+/obj/machinery/vending/security,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "UQ" = (
 /obj/effect/turf_decal/tile/brown,
@@ -4131,12 +4141,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"Vv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
 "VP" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -4153,14 +4157,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/mine/laborcamp/security)
-"We" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
+/area/mine/living_quarters)
 "Wp" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -4223,6 +4220,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"XP" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Storage"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "YA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -4231,12 +4235,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
+/area/mine/living_quarters)
 "YY" = (
 /obj/machinery/camera{
 	c_tag = "Crew Area";
@@ -4244,7 +4244,7 @@
 	network = list("mine")
 	},
 /turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
+/area/mine/living_quarters)
 "Zf" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningbathroom";
@@ -9629,11 +9629,11 @@ Hd
 Hd
 Hd
 FF
-FF
-FF
-ca
-ad
-ai
+Hd
+nI
+cM
+cM
+cM
 ab
 ab
 ab
@@ -9883,14 +9883,14 @@ az
 az
 yr
 cb
-bh
+UJ
 cG
-bh
-We
+QQ
+Hd
 qt
-ca
-ai
-ab
+Gn
+Gn
+cM
 VY
 ab
 ab
@@ -10142,12 +10142,12 @@ bL
 cc
 bw
 Hx
-bh
-ch
-bh
-ca
-ab
-ab
+oU
+Hd
+rj
+rj
+eM
+cM
 UA
 ab
 ab
@@ -10399,15 +10399,15 @@ yr
 cd
 ch
 GI
-bh
-ch
-bM
-ca
-FF
-FF
+Fd
+Hd
+cM
+XP
+cM
+cM
 uJ
-FF
-ca
+nI
+cM
 ab
 ab
 ab
@@ -10653,18 +10653,18 @@ bl
 yr
 yr
 yr
-Hd
+za
 Gw
 QN
 oW
-ch
-Vv
+sM
+eL
 gn
-bh
-bh
+ec
+dZ
 yk
 ju
-ca
+cM
 ab
 ab
 ab
@@ -10910,18 +10910,18 @@ bl
 yr
 by
 pV
-ch
+UH
 ch
 iM
 sa
-sa
-sa
+Iq
+QW
 vW
-sa
-sa
+QW
+QW
 RO
 YY
-ca
+cM
 ab
 ab
 ab
@@ -11166,19 +11166,19 @@ aW
 bm
 yr
 bB
-bM
-cf
-ch
-AW
-RJ
-jh
-AU
-Bx
-Dh
-bM
-YA
-JZ
 ca
+cf
+bh
+AW
+bM
+sM
+dZ
+dZ
+Dh
+Nt
+YA
+dZ
+cM
 cM
 cM
 xi
@@ -11432,12 +11432,12 @@ cQ
 cQ
 cQ
 cQ
-sM
-zO
-sM
+ip
+YA
+dZ
 cM
 Lg
-dZ
+kO
 Co
 kO
 eL
@@ -11689,9 +11689,9 @@ cQ
 dg
 dg
 cQ
-up
-Jf
-xU
+dZ
+Cw
+dZ
 cM
 fa
 dZ
@@ -12723,8 +12723,8 @@ eM
 cM
 fd
 fq
-fB
-fB
+oO
+GN
 fB
 ku
 cM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes parts of the mining base introduced in #44769. Readds the spare mining lockers on base, so now you can get your extra mining gear like in the old days.
Add chairs and tables to the public lobby, flashlights to bring them on par with the gulag kits, two extra gpses and emergency oxygen tanks.
Also makes the security office waaaaay smaller than the overly large size that it was.
Before:
![qqI5vUA](https://user-images.githubusercontent.com/49726786/61174169-ecedcf00-a59c-11e9-8565-8dbf0aab9045.png)
After:
![8Rdudov](https://user-images.githubusercontent.com/49726786/61174171-f4ad7380-a59c-11e9-9b90-494b1ea1a1f9.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We already have public mining, might as well make it better. Adds back the lockers that I'm sure everyone missed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Furniture and mining items in public mining lobby
del: The unnecessary amount of space in mining security
tweak: Tweaked the shape of the base slightly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
