### PR TITLE
pirate suit storage unit now has pirate space suits

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -108,6 +108,11 @@
 	suit_type = /obj/item/clothing/suit/radiation
 	helmet_type = /obj/item/clothing/head/radiation
 	storage_type = /obj/item/geiger_counter
+	
+/obj/machinery/suit_storage_unit/pirate
+	suit_type = /obj/item/clothing/suit/space/pirate
+	helmet_type = /obj/item/clothing/helmet/space/pirate/bandana
+	storage_type = /obj/item/tank/jetpack
 
 /obj/machinery/suit_storage_unit/open
 	state_open = TRUE

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -111,7 +111,7 @@
 	
 /obj/machinery/suit_storage_unit/pirate
 	suit_type = /obj/item/clothing/suit/space/pirate
-	helmet_type = /obj/item/clothing/helmet/space/pirate/bandana
+	helmet_type = /obj/item/clothing/head/helmet/space/pirate/bandana
 	storage_type = /obj/item/tank/jetpack
 
 /obj/machinery/suit_storage_unit/open

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -200,13 +200,6 @@
 	id = "pirateship"
 	rechargeTime = 3 MINUTES
 
-/obj/machinery/suit_storage_unit/pirate
-	suit_type = /obj/item/clothing/suit/space
-	helmet_type = /obj/item/clothing/head/helmet/space
-	mask_type = /obj/item/clothing/mask/breath
-	storage_type = /obj/item/tank/internals/oxygen
-
-
 /obj/machinery/loot_locator
 	name = "Booty Locator"
 	desc = "This sophisticated machine scans the nearby space for items of value."


### PR DESCRIPTION
## About The Pull Request

pirate suit storage unit now has pirate space suits also moves the unit from the pirate file into the suit storage unit file

## Why It's Good For The Game

why do pirates get old eva suit instead of piratesuits why do they get breathing masks they dont even BREATHE
also gives them a buff in the form of jetpack but i think its fine since everyone always arms up for pirates and they are 3 or less against whole crew

## Changelog
:cl:
balance: pirate suit storage units now have the pirate space suits and a jetpack
/:cl:

