### PR TITLE
Fixes interaction between job-based IDs and agent cards

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -103,4 +103,4 @@
 
 /obj/item/storage/wallet/random/PopulateContents()
 	new /obj/item/holochip(src, rand(5,30))
-	update_icon()
+	icon_state = "wallet"

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -257,6 +257,13 @@
 	..()
 	var/obj/item/card/id/agent_card = target
 	if(istype(agent_card))
+		var/obj/item/card/id/copied_card = picked_item
+		if(istype(copied_card))
+			agent_card.uses_overlays = copied_card.uses_overlays
+			agent_card.id_type_name = copied_card.id_type_name
+		else
+			agent_card.uses_overlays = FALSE
+			agent_card.id_type_name = copied_card.name
 		agent_card.update_label()
 
 /datum/action/item_action/chameleon/change/id/apply_job_data(datum/job/job_datum)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes interaction between #45112 and #45113 which I forgot about where agent IDs would draw overlays regardless of whether the ID they're disguised as is designed for it.
Fixes random wallet map icons staying after initialization
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Agent cards won't try to draw their job on top of IDs which aren't meant for it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
Nah
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
