### PR TITLE
Wallet QOL improvements

### DIFF
--- a/code/datums/components/storage/concrete/wallet.dm
+++ b/code/datums/components/storage/concrete/wallet.dm
@@ -1,0 +1,18 @@
+/datum/component/storage/concrete/wallet/on_alt_click(datum/source, mob/user)
+	if(!isliving(user) || !user.CanReach(parent))
+		return
+	if(locked)
+		to_chat(user, "<span class='warning'>[parent] seems to be locked!</span>")
+		return
+
+	var/obj/item/storage/wallet/A = parent
+	if(istype(A) && A.front_id && !issilicon(user))
+		var/obj/item/I = A.front_id
+		A.add_fingerprint(user)
+		remove_from_storage(I, get_turf(user))
+		if(!user.put_in_hands(I))
+			to_chat(user, "<span class='notice'>You fumble for [I] and it falls on the floor.</span>")
+			return
+		user.visible_message("<span class='warning'>[user] draws [I] from [parent]!</span>", "<span class='notice'>You draw [I] from [parent].</span>")
+		return
+	..()

--- a/code/datums/components/storage/concrete/wallet.dm
+++ b/code/datums/components/storage/concrete/wallet.dm
@@ -6,7 +6,7 @@
 		return
 
 	var/obj/item/storage/wallet/A = parent
-	if(istype(A) && A.front_id && !issilicon(user))
+	if(istype(A) && A.front_id && !issilicon(user) && !(A.item_flags & IN_STORAGE)) //if it's a wallet in storage seeing the full inventory is more useful
 		var/obj/item/I = A.front_id
 		A.add_fingerprint(user)
 		remove_from_storage(I, get_turf(user))

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -281,10 +281,14 @@
 	if(job)
 		add_overlays += mutable_appearance(icon, "id[job]")
 	add_overlay(add_overlays)
+	update_in_wallet(add_overlays)
+
+/obj/item/card/id/proc/update_in_wallet(overlays)
 	if(istype(loc, /obj/item/storage/wallet))
 		var/obj/item/storage/wallet/powergaming = loc
 		if(powergaming.front_id == src)
-			powergaming.update_icon(add_overlays)
+			powergaming.update_label()
+			powergaming.update_icon(overlays)
 
 /obj/item/card/id/proc/get_cached_flat_icon()
 	if(!cached_flat_icon)
@@ -305,8 +309,8 @@ update_label()
 
 /obj/item/card/id/proc/update_label()
 	var/blank = !registered_name
-	update_icon(blank)
 	name = "[blank ? id_type_name : "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"]"
+	update_icon(blank)
 
 /obj/item/card/id/silver
 	name = "silver identification card"

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -5,6 +5,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	resistance_flags = FLAMMABLE
 	slot_flags = ITEM_SLOT_ID
+	component_type = /datum/component/storage/concrete/wallet
 
 	var/obj/item/card/id/front_id = null
 	var/obj/item/card/id/cached_front_id = null
@@ -13,7 +14,7 @@
 
 /obj/item/storage/wallet/ComponentInitialize()
 	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage/concrete/wallet)
 	STR.max_items = 4
 	STR.set_holdable(list(
 		/obj/item/stack/spacecash,
@@ -58,6 +59,7 @@
 		if(H.wear_id == src)
 			H.sec_hud_set_ID()
 	update_icon()
+	update_label()
 
 /obj/item/storage/wallet/Entered(atom/movable/AM)
 	. = ..()
@@ -88,6 +90,17 @@
 	if(front_id)
 		return "[icon2html(get_cached_flat_icon(), user)] [thats? "That's ":""][get_examine_name(user)]" //displays all overlays in chat
 	return ..()
+
+/obj/item/storage/wallet/proc/update_label()
+	if(front_id)
+		name = "wallet displaying [front_id]"
+	else
+		name = "wallet"
+
+/obj/item/storage/wallet/examine()
+	. = ..()
+	if(front_id)
+		. += "<span class='notice'>Alt-click to remove the id.</span>"
 
 /obj/item/storage/wallet/GetID()
 	return front_id

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -116,4 +116,4 @@
 
 /obj/item/storage/wallet/random/PopulateContents()
 	new /obj/item/holochip(src, rand(5,30))
-	update_icon()
+	icon_state = "wallet"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -416,6 +416,7 @@
 #include "code\datums\components\storage\concrete\pockets.dm"
 #include "code\datums\components\storage\concrete\rped.dm"
 #include "code\datums\components\storage\concrete\stack.dm"
+#include "code\datums\components\storage\concrete\wallet.dm"
 #include "code\datums\diseases\_disease.dm"
 #include "code\datums\diseases\_MobProcs.dm"
 #include "code\datums\diseases\anxiety.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Wallet names include the name of the displayed ID (now that it's actually visible on the icon)
Wallets can be alt-clicked to remove it. Alt-clicking a wallet without a displayed ID or one inside a container opens its inventory like usual.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
IDs displayed in wallets count as worn IDs in a lot of ways (identifying people's names, providing secHUD jobs, etc) but don't actually display the name on examine. I think this should be more consistent.
Alt-clicking whatever is worn in an ID slot to remove the actual ID is something everyone's used to, so wallets should have the same behavior.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now tell which ID a wallet has displayed.
tweak: Alt-click a wallet to remove the displayed ID. If there is none or it's inside a container - it just shows the inventory as usual.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
