### PR TITLE
Adds SHOULD_CALL_PARENT to Destroy()

### DIFF
--- a/code/controllers/globals.dm
+++ b/code/controllers/globals.dm
@@ -20,9 +20,10 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 
 	Initialize()
 
-/datum/controller/global_vars/Destroy()
-	//fuck off kevinz
-	return QDEL_HINT_IWILLGC
+/datum/controller/global_vars/Destroy(force)
+	if(!force)
+		return QDEL_HINT_IWILLGC
+	return ..()
 
 /datum/controller/global_vars/stat_entry()
 	if(!statclick)

--- a/code/controllers/globals.dm
+++ b/code/controllers/globals.dm
@@ -21,9 +21,9 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 	Initialize()
 
 /datum/controller/global_vars/Destroy(force)
-	if(!force)
-		return QDEL_HINT_IWILLGC
-	return ..()
+	// This is done to prevent an exploit where admins can get around protected vars
+	SHOULD_CALL_PARENT(0)
+	return QDEL_HINT_IWILLGC
 
 /datum/controller/global_vars/stat_entry()
 	if(!statclick)

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -70,6 +70,7 @@
   * Returns QDEL_HINT_QUEUE
   */ 
 /datum/proc/Destroy(force=FALSE, ...)
+	SHOULD_CALL_PARENT(1)
 	tag = null
 	datum_flags &= ~DF_USE_TAG //In case something tries to REF us
 	weak_reference = null	//ensure prompt GCing of weakref.

--- a/code/datums/position_point_vector.dm
+++ b/code/datums/position_point_vector.dm
@@ -208,6 +208,7 @@
 
 /datum/point/vector/processed/Destroy()
 	STOP_PROCESSING(SSprojectiles, src)
+	return ..()
 
 /datum/point/vector/processed/proc/start()
 	last_process = world.time

--- a/code/datums/weakrefs.dm
+++ b/code/datums/weakrefs.dm
@@ -16,8 +16,10 @@
 /datum/weakref/New(datum/thing)
 	reference = REF(thing)
 
-/datum/weakref/Destroy()
-	return QDEL_HINT_LETMELIVE	//Let BYOND autoGC thiswhen nothing is using it anymore.
+/datum/weakref/Destroy(force)
+	if(!force)
+		return QDEL_HINT_LETMELIVE	//Let BYOND autoGC thiswhen nothing is using it anymore.
+	return ..()
 
 /datum/weakref/proc/resolve()
 	var/datum/D = locate(reference)

--- a/code/datums/weakrefs.dm
+++ b/code/datums/weakrefs.dm
@@ -19,6 +19,8 @@
 /datum/weakref/Destroy(force)
 	if(!force)
 		return QDEL_HINT_LETMELIVE	//Let BYOND autoGC thiswhen nothing is using it anymore.
+	var/datum/target = resolve()
+	target?.weak_reference = null
 	return ..()
 
 /datum/weakref/proc/resolve()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -437,6 +437,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	return ..()
 
 /client/Destroy()
+	. = ..() //Even though we're going to be hard deleted there are still some things that want to know the destroy is happening
 	return QDEL_HINT_HARDDEL_NOW
 
 /client/proc/set_client_age_from_db(connectiontopic)


### PR DESCRIPTION
Timers, signals, and components need to know when the thing they're attached to is getting destroyed or bad things happen. Since any datum can make use of these every destroy needs to call parent.

The first commit is intentionally failing as it only adds the requirement. The second commit fixes the issues.