### PR TITLE
[Ready] Adds organic slurry, induces vomiting

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -113,6 +113,11 @@
 	foodtype = GROSS | MEAT | RAW
 	grind_results = list(/datum/reagent/blood = 20, /datum/reagent/liquidgibs = 5)
 
+/obj/item/reagent_containers/food/snacks/deadmouse/examine(mob/user)
+	. = ..()
+	if (reagents?.has_reagent(/datum/reagent/yuck) || reagents?.has_reagent(/datum/reagent/fuel))
+		. += "<span class='warning'>It's dripping with fuel and smells terrible.</span>"
+
 /obj/item/reagent_containers/food/snacks/deadmouse/attackby(obj/item/I, mob/user, params)
 	if(I.is_sharp() && user.a_intent == INTENT_HARM)
 		if(isturf(loc))
@@ -121,6 +126,19 @@
 			qdel(src)
 		else
 			to_chat(user, "<span class='warning'>You need to put [src] on a surface to butcher it!</span>")
+	else
+		return ..()
+
+/obj/item/reagent_containers/food/snacks/deadmouse/afterattack(obj/target, mob/living/user, proximity_flag)
+	if(proximity_flag && reagents && target.is_open_container())
+		// is_open_container will not return truthy if target.reagents doesn't exist
+		var/datum/reagents/target_reagents = target.reagents
+		var/fuel_amount = reagents.maximum_volume - reagents.total_volume * (4 / 3)
+		if(target_reagents.has_reagent(/datum/reagent/fuel) && target_reagents.trans_id_to(src, /datum/reagent/fuel, fuel_amount))
+			to_chat(user, "<span class='notice'>You dip [src] into [target].</span>")
+			reagents.trans_id_to(target, /datum/reagent/yuck, reagents.get_reagent_amount(/datum/reagent/yuck))
+		else
+			to_chat(user, "<span class='warning'>That's a terrible idea.</span>")
 	else
 		return ..()
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -133,10 +133,10 @@
 	if(proximity_flag && reagents && target.is_open_container())
 		// is_open_container will not return truthy if target.reagents doesn't exist
 		var/datum/reagents/target_reagents = target.reagents
-		var/fuel_amount = reagents.maximum_volume - reagents.total_volume * (4 / 3)
-		if(target_reagents.has_reagent(/datum/reagent/fuel) && target_reagents.trans_id_to(src, /datum/reagent/fuel, fuel_amount))
+		var/trans_amount = reagents.maximum_volume - reagents.total_volume * (4 / 3)
+		if(target_reagents.has_reagent(/datum/reagent/fuel) && target_reagents.trans_to(src, trans_amount))
 			to_chat(user, "<span class='notice'>You dip [src] into [target].</span>")
-			reagents.trans_id_to(target, /datum/reagent/yuck, reagents.get_reagent_amount(/datum/reagent/yuck))
+			reagents.trans_to(target, reagents.total_volume)
 		else
 			to_chat(user, "<span class='warning'>That's a terrible idea.</span>")
 	else

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1761,7 +1761,7 @@
 		if(prob(8))
 			var/dread = pick("Something is moving in your stomach...", \
 				"A wet growl echoes from your stomach...", \
-				"For a moment you feel like [get_area(C)] is moving, but it's your stomach...")
+				"For a moment you feel like your surroundings are moving, but it's your stomach...")
 			to_chat(C, "<span class='userdanger'>[dread]</span>")
 			yuck_cycle = current_cycle
 	else

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1736,3 +1736,44 @@
 	color = "#ED2939"
 	taste_description = "upside down"
 	can_synth = FALSE
+
+/// Improvised reagent that induces vomiting. Created by dipping a dead mouse in welder fluid.
+/datum/reagent/yuck
+	name = "Organic Slurry"
+	description = "A mixture of various colors of fluid. Induces vomiting."
+	glass_name = "glass of ...yuck!"
+	glass_desc = "It smells like a carcass, and doesn't look much better."
+	color = "#545000"
+	taste_description = "insides"
+	taste_mult = 4
+	can_synth = FALSE
+	metabolization_rate = 0.4 * REAGENTS_METABOLISM
+	var/yuck_cycle = 0 //! The `current_cycle` when puking starts.
+
+/datum/reagent/yuck/on_mob_add(mob/living/L)
+	if(HAS_TRAIT(src, TRAIT_NOHUNGER)) //they can't puke
+		holder.del_reagent(type)
+
+#define PUKE_CYCLES 3 		// every X cycle is a puke
+#define PUKES_TO_STUN 3 	// hit this amount of pukes in a row to start stunning
+/datum/reagent/yuck/on_mob_life(mob/living/carbon/C)
+	if(!yuck_cycle)
+		if(prob(8))
+			var/dread = pick("Something is moving in your stomach...", \
+				"A wet growl echoes from your stomach...", \
+				"For a moment you feel like [get_area(C)] is moving, but it's your stomach...")
+			to_chat(C, "<span class='userdanger'>[dread]</span>")
+			yuck_cycle = current_cycle
+	else
+		var/yuck_cycles = current_cycle - yuck_cycle
+		if(yuck_cycles % PUKE_CYCLES == 0)
+			holder.remove_reagent(type, 5)
+			C.vomit(rand(14, 26), stun = yuck_cycles >= PUKE_CYCLES * PUKES_TO_STUN)
+	if(holder)
+		return ..()
+#undef PUKE_CYCLES
+#undef PUKES_TO_STUN
+
+/datum/reagent/yuck/on_mob_end_metabolize(mob/living/L)
+	yuck_cycle = 0 // reset vomiting
+	return ..()

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -601,3 +601,10 @@
 	id = /datum/reagent/pax
 	results = list(/datum/reagent/pax = 3)
 	required_reagents  = list(/datum/reagent/toxin/mindbreaker = 1, /datum/reagent/medicine/synaptizine = 1, /datum/reagent/water = 1)
+
+/datum/chemical_reaction/yuck
+	name = "Organic Fluid"
+	id = /datum/reagent/yuck
+	results = list(/datum/reagent/yuck = 4)
+	required_reagents = list(/datum/reagent/fuel = 3)
+	required_container = /obj/item/reagent_containers/food/snacks/deadmouse


### PR DESCRIPTION
## About The Pull Request

This adds a new chem called organic slurry that induces vomiting in the user who drinks it.
You make this chem by dipping a dead mouse into welding fuel.

It doesn't start vomiting immediately, rolling an 8% check each cycle. It metabolizes 60% slower to compensate. After the check passes, it will keep vomiting every third cycle.
You aren't stunned for the first 2 vomits, but 3 in a row will start stunning you until the chem is out.
Vomiting removes 5 units of the chem (this happens even if you're starving and can't vomit), and your hunger loss for each vomit is a range between 14 and 26.

## Why It's Good For The Game

@ExcessiveUseOfCobblestone Wanted a category 1 method for healing toxin damage. This is a category 2 method, but is designed to be easy to make, so may be considered similar or equivalent to category 1. Any crew member can make this if they have any form of maintenance access, even just their department doors.

## Changelog
:cl: JJRcop
add: New Organic Slurry created by dipping a dead mouse in welding fuel. It induces vomiting.
/:cl: