### PR TITLE
Banishes the spellmime into the accursed realm

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2189,6 +2189,7 @@
 	name = "Guide to Dank Mimery"
 	desc = "A parcel containing \"Guide to Dank Mimery - a primer on basic pantomime.\""
 	cost = 500
+	contains = list(/obj/item/book/mimery)
 	crate_name = "parcel"
 	crate_type = /obj/item/smallDelivery
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -20,7 +20,10 @@
 /datum/supply_pack/proc/generate(atom/A, datum/bank_account/paying_account)
 	var/obj/structure/closet/crate/C
 	if(paying_account)
-		C = new /obj/structure/closet/crate/secure/owned(A, paying_account)
+		if (ispath(crate_type, /obj/structure/closet/crate))
+			C = new /obj/structure/closet/crate/secure/owned(A, paying_account)
+		else
+			C = new crate_type(A)
 		C.name = "[crate_name] - Purchased by [paying_account.account_holder]"
 	else
 		C = new crate_type(A)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2182,6 +2182,13 @@
 			the_toy = pick(subtypesof(/obj/item/toy/plush))
 		new the_toy(.)
 
+/datum/supply_pack/costumes_toys/dank_mimery
+	name = "Guide to Dank Mimery"
+	desc = "A parcel containing \"Guide to Dank Mimery - a primer on basic pantomime.\""
+	cost = 500
+	crate_name = "parcel"
+	crate_type = /obj/item/smallDelivery
+
 /datum/supply_pack/costumes_toys/wizard
 	name = "Wizard Costume Crate"
 	desc = "Pretend to join the Wizard Federation with this full wizard outfit! Nanotrasen would like to remind its employees that actually joining the Wizard Federation is subject to termination of job and life."

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -32,7 +32,7 @@
 	gloves = /obj/item/clothing/gloves/color/white
 	head = /obj/item/clothing/head/frenchberet
 	suit = /obj/item/clothing/suit/suspenders
-	backpack_contents = list(/obj/item/book/mimery=1, /obj/item/reagent_containers/food/drinks/bottle/bottleofnothing=1)
+	backpack_contents = list(/obj/item/reagent_containers/food/drinks/bottle/bottleofnothing=1)
 
 	backpack = /obj/item/storage/backpack/mime
 	satchel = /obj/item/storage/backpack/mime
@@ -75,9 +75,9 @@
 		H.set_machine(src)
 		if (href_list["invisible_wall"])
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall(null))
-		if (href_list["invisible_chair"])
+		else if (href_list["invisible_chair"])
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_chair(null))
-		if (href_list["invisible_box"])
+		else if (href_list["invisible_box"])
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_box(null))
 	to_chat(usr, "<span class='notice'>The book disappears into thin air.</span>")
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes mimes no longer spawn with their spellbook, instead they have to buy it from cargo. Also fixes a minor exploit that allowed mimes to get all three spells from it. 

## Why It's Good For The Game

Removes the shittery around invisible walls and makes the mime less desireable to those shitters, allowing people who just want to mime (absolutely fucking no-one on tg) to actually get the role for once.

## Changelog
:cl: Naksu
balance: The mime's spellbook has been banished into the accursed realm of cargonia.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
