### PR TITLE
Clown Mutation (Clumsy) and Abnormal Mutations can no longer be cured.

### DIFF
--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -57,5 +57,5 @@
 
 	H.fully_replace_character_name(H.real_name, pick(GLOB.clown_names)) //rename the mob AFTER they're equipped so their ID gets updated properly.
 	H.dna.add_mutation(CLOWNMUT)
-	for(var/datum/mutation/human/clumsy in H.dna.mutations)
+	for(var/datum/mutation/human/clumsy/M in H.dna.mutations)
 		M.mutadone_proof = TRUE

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -57,3 +57,6 @@
 
 	H.fully_replace_character_name(H.real_name, pick(GLOB.clown_names)) //rename the mob AFTER they're equipped so their ID gets updated properly.
 	H.dna.add_mutation(CLOWNMUT)
+	for(var/datum/mutation/human/M in H.dna.mutations)
+		if(istype(M, /datum/mutation/human/clumsy))
+			M.mutadone_proof = TRUE

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -57,6 +57,5 @@
 
 	H.fully_replace_character_name(H.real_name, pick(GLOB.clown_names)) //rename the mob AFTER they're equipped so their ID gets updated properly.
 	H.dna.add_mutation(CLOWNMUT)
-	for(var/datum/mutation/human/M in H.dna.mutations)
-		if(istype(M, /datum/mutation/human/clumsy))
-			M.mutadone_proof = TRUE
+	for(var/datum/mutation/human/clumsy in H.dna.mutations)
+		M.mutadone_proof = TRUE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -890,7 +890,7 @@
 /datum/reagent/medicine/mutadone/on_mob_life(mob/living/carbon/M)
 	M.jitteriness = 0
 	if(M.has_dna())
-		M.dna.remove_all_mutations(mutadone = TRUE)
+		M.dna.remove_all_mutations(list(MUT_NORMAL, MUT_EXTRA), TRUE)
 	if(!QDELETED(M)) //We were a monkey, now a human
 		..()
 


### PR DESCRIPTION
## About The Pull Request

clown cant be cured from clusmy
fixes oversight in mutadone proof not working

## Why It's Good For The Game

clown that cures himself from clumsy is cringe

## Changelog
:cl:
fix: clowns cannot cure their clumsyness with mutadone anymore
fix: fixes mutadone proofness not working
balance: mutadone no longer cures "weird" mutations such as those you get from the wizard
/:cl:
