### PR TITLE
you can now get an advanced camera console

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -31,6 +31,7 @@
 
 /obj/machinery/computer/camera_advanced/syndie
 	icon_keyboard = "syndie_key"
+	circuit = /obj/item/circuitboard/computer/advanced_camera
 
 /obj/machinery/computer/camera_advanced/proc/CreateEye()
 	eyeobj = new()

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -415,6 +415,11 @@
 	name = "Security Cameras (Computer Board)"
 	icon_state = "security"
 	build_path = /obj/machinery/computer/security
+	
+/obj/item/circuitboard/computer/advanced_camera
+	name = "Advanced Camera Console (Computer Board)"
+	icon_state = "security"
+	build_path = /obj/machinery/computer/camera_advanced/syndie
 
 //Service
 

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -303,3 +303,11 @@
 	build_path = /obj/item/circuitboard/computer/nanite_cloud_controller
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	
+/datum/design/board/advanced_camera
+	name = "Computer Design (Advanced Camera Console)"
+	desc = "Allows for the construction of circuit boards used to build advanced camera consoles."
+	id = "advanced_camera"
+	build_path = /obj/item/circuitboard/computer/advanced_camera
+	category = list("Computer Boards")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1012,7 +1012,7 @@
 	display_name = "Illegal Technology"
 	description = "Dangerous research used to create dangerous objects."
 	prereq_ids = list("adv_engi", "adv_weaponry", "explosive_weapons")
-	design_ids = list("decloner", "borg_syndicate_module", "ai_cam_upgrade", "suppressor", "largecrossbow", "donksofttoyvendor", "donksoft_refill")
+	design_ids = list("decloner", "borg_syndicate_module", "ai_cam_upgrade", "suppressor", "largecrossbow", "donksofttoyvendor", "donksoft_refill", "advanced_camera")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 	hidden = TRUE


### PR DESCRIPTION
## About The Pull Request

you can get an advanced camera console from illegal tech

## Why It's Good For The Game

allows for checking on station better without those shitty ass dropdown menus if illegal tech is obtained
is under illegal tech because only syndies use the consoles and the ai camera upgrade is there so makes sense

## Changelog
:cl:
add: You can now get an advanced camera console from the security lathe after illegal technology has been obtained.
/:cl:
