### PR TITLE
Singlecard description change

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -868,7 +868,7 @@
 
 /obj/item/toy/cards/singlecard
 	name = "card"
-	desc = "a card"
+	desc = "A playing card used to play card games like poker."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "singlecard_down_nanotrasen"
 	w_class = WEIGHT_CLASS_TINY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the description for singlecard (single playing card) to be more accurate.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Last round I noticed that the output from examining a playing card looked kinda wrong (mostly because of the lowercase a):
![image](https://user-images.githubusercontent.com/33846895/61246496-41d14700-a74f-11e9-80da-409aafa229a4.png)
Also the description wasn't really a description so expanded it to describe which kind of playing card it is (the standard playing card used for poker etc.):
![image](https://user-images.githubusercontent.com/33846895/61247285-0b94c700-a751-11e9-9f36-a5a98c5693bd.png)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Gamer025
spellcheck: Changed the description of single playing cards to be uppercase and more descriptive
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
