### PR TITLE
callbacks will refuse to call procs on a qdeleted target

### DIFF
--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -62,7 +62,7 @@
 /world/proc/ImmediateInvokeAsync(thingtocall, proctocall, ...)
 	set waitfor = FALSE
 
-	if (!thingtocall)
+	if (!thingtocall || QDELETED(thingtocall))
 		return
 
 	var/list/calling_arguments = length(args) > 2 ? args.Copy(3) : null
@@ -82,7 +82,7 @@
 					return world.PushUsr(arglist(list(M, src) + args))
 				return world.PushUsr(M, src)
 
-	if (!object)
+	if (!object || QDELETED(object))
 		return
 
 	var/list/calling_arguments = arguments


### PR DESCRIPTION
This prevents addtimer and other async invokers from calling a proc on
an object that is now qdeleted. (Note that addtimer refuses to add new timers for items that are qdeleted, but will happily allow existing ones to continue calling)

This cleans up a whole class of bugs where people call addtimer or
INVOKEASYNC and don't have the target proc check QDELETED

in my opinion, there are no valid reasons for any timing subsystem or
callback to invoke a proc on a now soft deleted object, anything that
cared about it should have noticed when it was soft deleted.

Further more, I like the property that, if my object is soft deleted, I can guarantee that any timer based or async procs that were scheduled for future execution will auto abort.


This is a significant and serious change, so I would appreciate feedback from @MrStonedOne and @tgstation/commit-access 

edit: Yeah I know it's broken, I'll have to type it at a later point if this is decided to be a good idea or not