### PR TITLE
Xenos no longer delay round end.

### DIFF
--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -31,7 +31,7 @@
 	return xeno_team
 
 //XENO
-/mob/living/carbon/alien/mind_initialize()
+/mob/living/carbon/alien/larva/mind_initialize()
 	..()
 	if(!mind.has_antag_datum(/datum/antagonist/xeno))
 		mind.add_antag_datum(/datum/antagonist/xeno)

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -12,6 +12,7 @@
 	name = "Xenomorph"
 	job_rank = ROLE_ALIEN
 	show_in_antagpanel = FALSE
+	prevent_roundtype_conversion = FALSE
 	var/datum/team/xeno/xeno_team
 
 /datum/antagonist/xeno/create_team(datum/team/xeno/new_team)
@@ -31,7 +32,7 @@
 	return xeno_team
 
 //XENO
-/mob/living/carbon/alien/larva/mind_initialize()
+/mob/living/carbon/alien/mind_initialize()
 	..()
 	if(!mind.has_antag_datum(/datum/antagonist/xeno))
 		mind.add_antag_datum(/datum/antagonist/xeno)


### PR DESCRIPTION
## About The Pull Request

Wizard rounds can now end even if there are xenos.

## Why It's Good For The Game

This fixes staff of change wizard delaying roundend.

## Changelog
:cl:
fix: Staff of change xenos no longer delay the end of wizard rounds.
/:cl:
