### PR TITLE
world.fps and SStimers safety check

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -202,7 +202,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)
 	// Set world options.
-	world.fps = CONFIG_GET(number/fps)
+	world.change_fps(CONFIG_GET(number/fps))
 	var/initialized_tod = REALTIMEOFDAY
 
 	if(sleep_offline_after_initializations)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -306,3 +306,14 @@ GLOBAL_VAR(restart_counter)
 	maxz++
 	SSmobs.MaxZChanged()
 	SSidlenpcpool.MaxZChanged()
+
+
+/world/proc/change_fps(new_value = 20)
+	if(new_value <= 0)
+		CRASH("change_fps() called with [new_value] new_value.")
+	if(fps == new_value)
+		return //No change required.
+
+	fps = new_value
+
+	SStimer?.reset_buckets()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -315,5 +315,18 @@ GLOBAL_VAR(restart_counter)
 		return //No change required.
 
 	fps = new_value
+	on_tickrate_change()
 
+
+/world/proc/change_tick_lag(new_value = 0.5)
+	if(new_value <= 0)
+		CRASH("change_tick_lag() called with [new_value] new_value.")
+	if(tick_lag == new_value)
+		return //No change required.
+
+	tick_lag = new_value
+	on_tickrate_change()
+
+
+/world/proc/on_tickrate_change()
 	SStimer?.reset_buckets()

--- a/code/modules/admin/verbs/fps.dm
+++ b/code/modules/admin/verbs/fps.dm
@@ -23,4 +23,4 @@
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Set Server FPS", "[new_fps]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 	CONFIG_SET(number/fps, new_fps)
-	world.fps = new_fps
+	world.change_fps(new_fps)


### PR DESCRIPTION
For more information on it:
https://github.com/tgstation/TerraGov-Marine-Corps/pull/2295

TL;DR: if you actually change `world.fps` without a check like this you can have SStimer lists runtiming out of bounds, breaking a lot of things.