### PR TITLE
Fixes Shotgun Cryostasis darts being named 'Shotgun Cryostatis darts'

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -324,10 +324,10 @@
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
-/datum/design/cryostatis_shotgun_dart
-	name = "Cryostatis Shotgun Dart"
-	desc = "A shotgun dart designed with similar internals to that of a cryostatis beaker, allowing reagents to not react when inside."
-	id = "shotgundartcryostatis"
+/datum/design/cryostasis_shotgun_dart
+	name = "Cryostasis Shotgun Dart"
+	desc = "A shotgun dart designed with similar internals to that of a cryostasis beaker, allowing reagents to not react when inside."
+	id = "shotgundartcryostasis"
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 3500)
 	build_path = /obj/item/ammo_casing/shotgun/dart/noreact

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -628,7 +628,7 @@
 	display_name = "Medical Weaponry"
 	description = "Weapons using medical technology."
 	prereq_ids = list("adv_biotech", "adv_weaponry")
-	design_ids = list("rapidsyringe", "shotgundartcryostatis")
+	design_ids = list("rapidsyringe", "shotgundartcryostasis")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
renames 'cryostatis' to 'cryostasis'


## About The Pull Request

fixes a little misspelling, seemed to have been present in all iterations of the item, and I quashed all the places I could find it misspelled

## Why It's Good For The Game

fixes a goofy misspelling

![](https://cdn.discordapp.com/attachments/558119380718714900/601214221786677261/unknown.png)

## Changelog
:cl:
fix: Someone down at CentCom called our darts 'cryostatis' darts, now we don't know what that is, but now the proper 'cryostasis' darts are available.
/:cl:
