### PR TITLE
Fixes some dropItemToGround runtimes

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -292,6 +292,8 @@
 //for when you want the item to end up on the ground
 //will force move the item to the ground and call the turf's Entered
 /mob/proc/dropItemToGround(obj/item/I, force = FALSE)
+	if(!I)
+		return FALSE
 	I.pixel_x = rand(-6,6)
 	I.pixel_y = rand(-6,6)
 	return doUnEquip(I, force, drop_location(), FALSE)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -292,10 +292,9 @@
 //for when you want the item to end up on the ground
 //will force move the item to the ground and call the turf's Entered
 /mob/proc/dropItemToGround(obj/item/I, force = FALSE)
-	if(!I)
-		return FALSE
-	I.pixel_x = rand(-6,6)
-	I.pixel_y = rand(-6,6)
+	if(I)
+		I.pixel_x = rand(-6,6)
+		I.pixel_y = rand(-6,6)
 	return doUnEquip(I, force, drop_location(), FALSE)
 
 //for when the item will be immediately placed in a loc other than the ground

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -289,13 +289,17 @@
 
 //The following functions are the same save for one small difference
 
-//for when you want the item to end up on the ground
-//will force move the item to the ground and call the turf's Entered
+/**
+  * Used to drop an item (if it exists) to the ground.
+  * * Will pass as TRUE is successfully dropped, or if there is no item to drop.
+  * * Will pass FALSE if the item can not be dropped due to TRAIT_NODROP via doUnEquip()
+  * If the item can be dropped, it will be forceMove()'d to the ground and the turf's Entered() will be called.
+*/
 /mob/proc/dropItemToGround(obj/item/I, force = FALSE)
-	if(I)
+	. = doUnEquip(I, force, drop_location(), FALSE)
+	if(. && I) //ensure the item exists and that it was dropped properly.
 		I.pixel_x = rand(-6,6)
 		I.pixel_y = rand(-6,6)
-	return doUnEquip(I, force, drop_location(), FALSE)
 
 //for when the item will be immediately placed in a loc other than the ground
 /mob/proc/transferItemToLoc(obj/item/I, newloc = null, force = FALSE)


### PR DESCRIPTION
```
[2019-07-17 15:56:51.211] runtime error: Cannot modify null.pixel_x.
 - proc name: dropItemToGround (/mob/proc/dropItemToGround)
 -   source file: inventory.dm,295
 -   usr: (src)
 -   src: Bob Shafton (/mob/living/carbon/human)
 -   src.loc: the floor (114,84,2) (/turf/open/floor/plasteel)
 -   call stack:
 - Bob Shafton (/mob/living/carbon/human): dropItemToGround(null, 0)
 - the drop (/obj/screen/drop): Click(null, "mapwindow.map", "icon-x=7;icon-y=12;left=1;scre...")
 - Comradehavoc (/client): Click(the drop (/obj/screen/drop), null, "mapwindow.map", "icon-x=7;icon-y=12;left=1;scre...")
 - 
```
```
[2019-07-17 15:58:40.441] runtime error: Cannot modify null.pixel_x.
 - proc name: dropItemToGround (/mob/proc/dropItemToGround)
 -   source file: inventory.dm,295
 -   usr: null
 -   src: Honkers (/mob/living/carbon/human)
 -   src.loc: space (104,188,2) (/turf/open/space)
 -   call stack:
 - Honkers (/mob/living/carbon/human): dropItemToGround(null, 0)
 - the left arm (/obj/item/bodypart/l_arm): set disabled(1)
 - the left arm (/obj/item/bodypart/l_arm): update disabled()
 - the left arm (/obj/item/bodypart/l_arm): receive damage(0.1, 0, 0, 0, 1, null)
 - Honkers (/mob/living/carbon/human): take overall damage(0.6, 0, 0, 1, null)
 - Honkers (/mob/living/carbon/human): adjustBruteLoss(4, 1, 0, null)
 - Human (/datum/species/human): handle environment(/datum/gas_mixture/immutable/s... (/datum/gas_mixture/immutable/space), Honkers (/mob/living/carbon/human))
 - Honkers (/mob/living/carbon/human): handle environment(/datum/gas_mixture/immutable/s... (/datum/gas_mixture/immutable/space))
 - Honkers (/mob/living/carbon/human): Life(2, 1726)
 - Honkers (/mob/living/carbon/human): Life(2, 1726)
 - Honkers (/mob/living/carbon/human): Life(2, 1726)
 - Mobs (/datum/controller/subsystem/mobs): fire(1)
 - Mobs (/datum/controller/subsystem/mobs): ignite(1)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop()
 - Master (/datum/controller/master): StartProcessing(0)
 - 
```
```
[2019-07-17 15:45:22.587] runtime error: Cannot modify null.pixel_x.
 - proc name: dropItemToGround (/mob/proc/dropItemToGround)
 -   source file: inventory.dm,295
 -   usr: Bella Rouge (/mob/living/carbon/human)
 -   src: Woodrow Moberly (/mob/living/carbon/human)
 -   usr.loc: the floor (93,93,2) (/turf/open/floor/plasteel/white)
 -   src.loc: the cloning pod (/obj/machinery/clonepod)
 -   call stack:
 - Woodrow Moberly (/mob/living/carbon/human): dropItemToGround(null, 1)
 - the left arm (/obj/item/bodypart/l_arm): drop limb(null)
 - the left arm (/obj/item/bodypart/l_arm): drop limb(null)
 - the cloning pod (/obj/machinery/clonepod): maim clone(Woodrow Moberly (/mob/living/carbon/human))
 - the cloning pod (/obj/machinery/clonepod): growclone("Hugh Mann", "63063029fbbb514bff1a0", /list (/list), "\[0x21001175]", 26616, Human (/datum/species/human), /list (/list), /list (/list), /list (/list), /datum/bank_account (/datum/bank_account), /list (/list), null)
 - grow clone from record(the cloning pod (/obj/machinery/clonepod), record (/datum/data/record), null)
 - the cloning console (/obj/machinery/computer/cloning): Topic("src=\[0x2006eb2];clone=56e0", /list (/list))
 - MortoSasye (/client): Topic("src=\[0x2006eb2];clone=56e0", /list (/list), the cloning console (/obj/machinery/computer/cloning))
 - MortoSasye (/client): Topic("src=\[0x2006eb2];clone=56e0", /list (/list), the cloning console (/obj/machinery/computer/cloning))
 - 
```

get_item_for_held_index / get_active_held_item can return nulls. The new drop pixel offset was causing runtimes because of this.