### PR TITLE
Fixes SSU's entering a broken state when their maintenace panel is open at the end of a decontamination cycle.

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -397,8 +397,8 @@ Class Procs:
 			panel_open = FALSE
 			icon_state = icon_state_closed
 			to_chat(user, "<span class='notice'>You close the maintenance hatch of [src].</span>")
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/machinery/proc/default_change_direction_wrench(mob/user, obj/item/I)
 	if(panel_open && I.tool_behaviour == TOOL_WRENCH)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -13,26 +13,37 @@
 	var/obj/item/storage = null
 								// if you add more storage slots, update cook() to clear their radiation too.
 
-	var/suit_type = null //! What type of spacesuit the unit starts with when spawned.
-	var/helmet_type = null //! What type of space helmet the unit starts with when spawned.
-	var/mask_type = null //! What type of breathmask the unit starts with when spawned.
-	var/storage_type = null //! What type of additional item the unit starts with when spawned.
+	/// What type of spacesuit the unit starts with when spawned.
+	var/suit_type = null
+	/// What type of space helmet the unit starts with when spawned.
+	var/helmet_type = null
+	/// What type of breathmask the unit starts with when spawned.
+	var/mask_type = null
+	/// What type of additional item the unit starts with when spawned.
+	var/storage_type = null
 
 	state_open = FALSE
-	var/locked = FALSE //! If the SSU's doors are locked closed. Can be toggled manually via the UI, but is also locked automatically when the UV decontamination sequence is running.
+	/// If the SSU's doors are locked closed. Can be toggled manually via the UI, but is also locked automatically when the UV decontamination sequence is running.
+	var/locked = FALSE
 	panel_open = FALSE
-	var/safeties = TRUE //! If safety wire is cut/pulsed, the SSU can run the decontamination sequence while occupied by a mob. The mob will be burned during every cycle of cook().
+	/// If the safety wire is cut/pulsed, the SSU can run the decontamination sequence while occupied by a mob. The mob will be burned during every cycle of cook().
+	var/safeties = TRUE
 
-	var/uv = FALSE //! If UV decontamination sequence is running. See cook()
-	var/uv_super = FALSE /*!
-							* If the SSU's hack wire is cut/pulsed.
-							* Modifies effects of cook()
-							* * If FALSE, decontamination sequence will clear radiation for all atoms (and their contents) contained inside the unit, and burn any mobs inside.
-							* * If TRUE, decontamination sequence will delete all items contained within, and if occupied by a mob, intensifies burn damage delt. All wires will be cut at the end.
-							*/
-	var/uv_cycles = 6 //! How many cycles remain for the decontamination sequence.
-	var/message_cooldown //! Cooldown for occupant breakout messages via relaymove()
-	var/breakout_time = 300 //! How long it takes to break out of the SSU.
+	/// If UV decontamination sequence is running. See cook()
+	var/uv = FALSE
+	/**
+	* If the hack wire is cut/pulsed.
+	* Modifies effects of cook()
+	* * If FALSE, decontamination sequence will clear radiation for all atoms (and their contents) contained inside the unit, and burn any mobs inside.
+	* * If TRUE, decontamination sequence will delete all items contained within, and if occupied by a mob, intensifies burn damage delt. All wires will be cut at the end.
+	*/
+	var/uv_super = FALSE
+	/// How many cycles remain for the decontamination sequence.
+	var/uv_cycles = 6
+	/// Cooldown for occupant breakout messages via relaymove()
+	var/message_cooldown
+	/// How long it takes to break out of the SSU.
+	var/breakout_time = 300
 
 /obj/machinery/suit_storage_unit/standard_unit
 	suit_type = /obj/item/clothing/suit/space/eva

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -13,26 +13,26 @@
 	var/obj/item/storage = null
 								// if you add more storage slots, update cook() to clear their radiation too.
 
-	var/suit_type = null /// What type of spacesuit the unit starts with when spawned.
-	var/helmet_type = null /// What type of space helmet the unit starts with when spawned.
-	var/mask_type = null /// What type of breathmask the unit starts with when spawned.
-	var/storage_type = null /// What type of additional item the unit starts with when spawned.
+	var/suit_type = null //! What type of spacesuit the unit starts with when spawned.
+	var/helmet_type = null //! What type of space helmet the unit starts with when spawned.
+	var/mask_type = null //! What type of breathmask the unit starts with when spawned.
+	var/storage_type = null //! What type of additional item the unit starts with when spawned.
 
 	state_open = FALSE
-	var/locked = FALSE /// If the SSU's doors are locked closed. Can be toggled manually via the UI, but is also locked automatically when the UV decontamination sequence is running.
+	var/locked = FALSE //! If the SSU's doors are locked closed. Can be toggled manually via the UI, but is also locked automatically when the UV decontamination sequence is running.
 	panel_open = FALSE
-	var/safeties = TRUE /// If safety wire is cut/pulsed, the SSU can run the decontamination sequence while occupied by a mob. The mob will be burned during every cycle of cook().
+	var/safeties = TRUE //! If safety wire is cut/pulsed, the SSU can run the decontamination sequence while occupied by a mob. The mob will be burned during every cycle of cook().
 
-	var/uv = FALSE /// If UV decontamination sequence is running. See cook()
-	var/uv_super = FALSE /**
+	var/uv = FALSE //! If UV decontamination sequence is running. See cook()
+	var/uv_super = FALSE /*!
 							* If the SSU's hack wire is cut/pulsed.
 							* Modifies effects of cook()
 							* * If FALSE, decontamination sequence will clear radiation for all atoms (and their contents) contained inside the unit, and burn any mobs inside.
 							* * If TRUE, decontamination sequence will delete all items contained within, and if occupied by a mob, intensifies burn damage delt. All wires will be cut at the end.
 							*/
-	var/uv_cycles = 6 /// How many cycles remain for the decontamination sequence.
-	var/message_cooldown /// Cooldown for occupant breakout messages via relaymove()
-	var/breakout_time = 300 /// How long it takes to break out of the SSU.
+	var/uv_cycles = 6 //! How many cycles remain for the decontamination sequence.
+	var/message_cooldown //! Cooldown for occupant breakout messages via relaymove()
+	var/breakout_time = 300 //! How long it takes to break out of the SSU.
 
 /obj/machinery/suit_storage_unit/standard_unit
 	suit_type = /obj/item/clothing/suit/space/eva

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -371,6 +371,17 @@
 
 	return ..()
 
+/*	ref tg-git issue #45036
+	screwdriving it open while it's running a decontamination sequence without closing the panel prior to finish
+	causes the SSU to break due to state_open being set to TRUE at the end, and the panel becoming inaccessible.
+*/
+/obj/machinery/suit_storage_unit/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/I)
+	if(!(flags_1 & NODECONSTRUCT_1) && I.tool_behaviour == TOOL_SCREWDRIVER && uv)
+		to_chat(user, "<span class='warning'>It might not be wise to fiddle with [src] while it's running...</span>")
+		return TRUE
+	return ..()
+
+
 /obj/machinery/suit_storage_unit/default_pry_open(obj/item/I)//needs to check if the storage is locked.
 	. = !(state_open || panel_open || is_operational() || locked || (flags_1 & NODECONSTRUCT_1)) && I.tool_behaviour == TOOL_CROWBAR
 	if(.)


### PR DESCRIPTION
Fixes #45036

:cl: ShizCalev
fix: Suit storage units can no longer have their maintenance panel opened while running a decontamination sequence, causing the machine to enter a broken state.
/:cl:

Also added documentation for all the vars.