### PR TITLE
Removes lightbulb in viro

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -52051,13 +52051,6 @@
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"ybI" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "ydA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -92339,7 +92332,7 @@ bOr
 bOt
 bOr
 bRQ
-ybI
+bOr
 bSQ
 bNj
 bNs


### PR DESCRIPTION
## About The Pull Request

Fixes #45277
Literally just removes the lightbulb. It didn't use to be there and I have never noticed issues with lighting in boxstation viro.

## Why It's Good For The Game

Rogue lightbulb man bad.

## Changelog
:cl:
fix: Virology on Boxstation has lost its science defying lightbulb. This is a sad day for virologists as a whole.
/:cl:
