### PR TITLE
Fixes a problem with the moodie icons.

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -3,10 +3,10 @@
 
 /datum/component/mood
 	var/mood //Real happiness
-	var/sanity = 100 //Current sanity
+	var/sanity = SANITY_NEUTRAL //Current sanity
 	var/shown_mood //Shown happiness, this is what others can see when they try to examine you, prevents antag checking by noticing traitors are always very happy.
 	var/mood_level = 5 //To track what stage of moodies they're on
-	var/sanity_level = 5 //To track what stage of sanity they're on
+	var/sanity_level = 2 //To track what stage of sanity they're on
 	var/mood_modifier = 1 //Modifier to allow certain mobs to be less affected by moodlets
 	var/list/datum/mood_event/mood_events = list()
 	var/insanity_effect = 0 //is the owner being punished for low mood? If so, how much?


### PR DESCRIPTION
## About The Pull Request

fixes #45249 

## Why It's Good For The Game

Bug bad?

Yes, two is correct. Having exactly SANITY_NEUTRAL (100) will result in slightly positive sanity.

## Changelog
:cl:
fix: The mood face now has the correct icon at roundstart.
/:cl:
