### PR TITLE
Contract reinforcement antag datum + round end 

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -8,7 +8,6 @@
 //then you MUST update the database!
 #define ROLE_SYNDICATE			"Syndicate"
 #define ROLE_TRAITOR			"Traitor"
-#define ROLE_CONTRACTORSUPPORT	"Contractor Support Unit"
 #define ROLE_OPERATIVE			"Operative"
 #define ROLE_CHANGELING			"Changeling"
 #define ROLE_WIZARD				"Wizard"

--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -8,6 +8,7 @@
 //then you MUST update the database!
 #define ROLE_SYNDICATE			"Syndicate"
 #define ROLE_TRAITOR			"Traitor"
+#define ROLE_CONTRACTORSUPPORT	"Contractor Support Unit"
 #define ROLE_OPERATIVE			"Operative"
 #define ROLE_CHANGELING			"Changeling"
 #define ROLE_WIZARD				"Wizard"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -312,6 +312,7 @@
 	roundend_report.set_content(content)
 	roundend_report.stylesheets = list()
 	roundend_report.add_stylesheet("roundend", 'html/browser/roundend.css')
+	roundend_report.add_stylesheet("fontawesome", 'html/font-awesome/css/all.min.css')
 	roundend_report.open(FALSE)
 
 /datum/controller/subsystem/ticker/proc/personal_report(client/C, popcount)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -312,7 +312,7 @@
 	roundend_report.set_content(content)
 	roundend_report.stylesheets = list()
 	roundend_report.add_stylesheet("roundend", 'html/browser/roundend.css')
-	roundend_report.add_stylesheet("fontawesome", 'html/font-awesome/css/all.min.css')
+	roundend_report.add_stylesheet("font-awesome", 'html/font-awesome/css/all.min.css')
 	roundend_report.open(FALSE)
 
 /datum/controller/subsystem/ticker/proc/personal_report(client/C, popcount)

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -44,7 +44,9 @@
 		stylesheets["spritesheet_[sheet.name].css"] = "data/spritesheets/[sheet.name]"
 	else
 		stylesheets["[ckey(name)].css"] = file
-		register_asset("[ckey(name)].css", file)
+
+		if (!SSassets.cache[asset_name])
+			register_asset("[ckey(name)].css", file)
 
 /datum/browser/proc/add_script(name, file)
 	scripts["[ckey(name)].js"] = file

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -43,7 +43,7 @@
 		var/datum/asset/spritesheet/sheet = name
 		stylesheets["spritesheet_[sheet.name].css"] = "data/spritesheets/[sheet.name]"
 	else
-		var/asset_name = "[ckey(name)].css"
+		var/asset_name = "[name].css"
 		
 		stylesheets[asset_name] = file
 

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -43,10 +43,12 @@
 		var/datum/asset/spritesheet/sheet = name
 		stylesheets["spritesheet_[sheet.name].css"] = "data/spritesheets/[sheet.name]"
 	else
-		stylesheets["[ckey(name)].css"] = file
+		var/asset_name = "[ckey(name)].css"
+		
+		stylesheets[asset_name] = file
 
 		if (!SSassets.cache[asset_name])
-			register_asset("[ckey(name)].css", file)
+			register_asset(asset_name, file)
 
 /datum/browser/proc/add_script(name, file)
 	scripts["[ckey(name)].js"] = file

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -579,6 +579,10 @@
 	if(!(has_antag_datum(/datum/antagonist/traitor)))
 		add_antag_datum(/datum/antagonist/traitor)
 
+/datum/mind/proc/make_Contractor_Support()
+	if(!(has_antag_datum(/datum/antagonist/traitor/contractor_support)))
+		add_antag_datum(/datum/antagonist/traitor/contractor_support)
+
 /datum/mind/proc/make_Changeling()
 	var/datum/antagonist/changeling/C = has_antag_datum(/datum/antagonist/changeling)
 	if(!C)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -409,19 +409,7 @@
 
 	var/special_role_text = lowertext(name)
 
-	var/completed_contracts = 0
-	var/tc_total = contract_TC_payed_out + contract_TC_to_redeem
-	for (var/datum/syndicate_contract/contract in assigned_contracts)
-		if (contract.status == CONTRACT_STATUS_COMPLETE)
-			completed_contracts++
-
-
-	if (completed_contracts > 0)
-		var/pluralCheck = "contract"
-		if (completed_contracts > 1)
-			pluralCheck = "contracts"
-		result += "<br>Completed <span class='greentext'>[completed_contracts]</span> [pluralCheck] for a total of \
-					<span class='greentext'>[tc_total] TC</span>!<br>"
+	result += contractor_round_end()
 
 	if(traitorwin)
 		result += "<span class='greentext'>The [special_role_text] was successful!</span>"
@@ -430,6 +418,31 @@
 		SEND_SOUND(owner.current, 'sound/ambience/ambifailure.ogg')
 
 	return result.Join("<br>")
+
+/datum/antagonist/traitor/proc/contractor_round_end()
+	var/completed_contracts = 0
+	var/tc_total = contract_TC_payed_out + contract_TC_to_redeem
+	for (var/datum/syndicate_contract/contract in assigned_contracts)
+		if (contract.status == CONTRACT_STATUS_COMPLETE)
+			completed_contracts++
+
+	if (completed_contracts > 0)
+		var/contractor_item_icons = "" // Icons of purchases
+		var/contractor_support_unit // Set if they had a support unit - and shows appended to their contracts completed
+
+		for (var/datum/contractor_item/contractor_purchase in contractor_hub.purchased_items
+			contractor_item_icons += "<span class='tooltip_container'>\[<i class="fas [item_icon]"></i><span class='tooltip_hover'><b>[name]</b><br>[cost]<br>[desc]</span></span>"
+			
+			if (istype(contractor_purchase, ))
+
+		var/pluralCheck = "contract"
+		if (completed_contracts > 1)
+			pluralCheck = "contracts"
+
+		result += "<br>Completed <span class='greentext'>[completed_contracts]</span> [pluralCheck] for a total of \
+					<span class='greentext'>[tc_total] TC</span>! [contractor_support_unit]<br>"
+
+	return result
 
 /datum/antagonist/traitor/roundend_report_footer()
 	var/phrases = jointext(GLOB.syndicate_code_phrase, ", ")

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -446,7 +446,7 @@
 
 	if (contractor_hub.purchased_items.len)
 		result += contractor_item_icons
-		result += "<br>(Used [total_spent_rep] Rep)"
+		result += "<br>(used [total_spent_rep] Rep)"
 	result += "<br>"
 	if (completed_contracts > 0)
 		var/pluralCheck = "contract"

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -442,7 +442,7 @@
 		/// Special case for reinforcements, we want to show their ckey and name on round end.
 		if (istype(contractor_purchase, /datum/contractor_item/contractor_partner))
 			var/datum/contractor_item/contractor_partner/partner = contractor_purchase
-			contractor_support_unit += "[partner.partner_mind.key] played [partner.partner_mind.current.name], their contractor support unit."
+			contractor_support_unit += "<b>[partner.partner_mind.key]</b> played <b>[partner.partner_mind.current.name]</b>, their contractor support unit."
 
 	if (contractor_hub.purchased_items.len)
 		result += contractor_item_icons

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -442,7 +442,7 @@
 		/// Special case for reinforcements, we want to show their ckey and name on round end.
 		if (istype(contractor_purchase, /datum/contractor_item/contractor_partner))
 			var/datum/contractor_item/contractor_partner/partner = contractor_purchase
-			contractor_support_unit += "<b>[partner.partner_mind.key]</b> played <b>[partner.partner_mind.current.name]</b>, their contractor support unit."
+			contractor_support_unit += "<br><b>[partner.partner_mind.key]</b> played <b>[partner.partner_mind.current.name]</b>, their contractor support unit."
 
 	if (contractor_hub.purchased_items.len)
 		result += contractor_item_icons
@@ -453,8 +453,8 @@
 		if (completed_contracts > 1)
 			pluralCheck = "contracts"
 
-		result += "<br>Completed <span class='greentext'>[completed_contracts]</span> [pluralCheck] for a total of \
-					<span class='greentext'>[tc_total] TC</span>! <br><br>[contractor_support_unit]<br>"
+		result += "Completed <span class='greentext'>[completed_contracts]</span> [pluralCheck] for a total of \
+					<span class='greentext'>[tc_total] TC</span>![contractor_support_unit]<br>"
 
 	return result
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -419,28 +419,42 @@
 
 	return result.Join("<br>")
 
+/// Proc detailing contract kit buys/completed contracts/additional info
 /datum/antagonist/traitor/proc/contractor_round_end()
+	var result = ""
+	var total_spent_rep = 0
+
 	var/completed_contracts = 0
 	var/tc_total = contract_TC_payed_out + contract_TC_to_redeem
 	for (var/datum/syndicate_contract/contract in assigned_contracts)
 		if (contract.status == CONTRACT_STATUS_COMPLETE)
 			completed_contracts++
 
+	var/contractor_item_icons = "<br>" // Icons of purchases
+	var/contractor_support_unit = "" // Set if they had a support unit - and shows appended to their contracts completed
+
+	/// Get all the icons/total cost for all our items bought
+	for (var/datum/contractor_item/contractor_purchase in contractor_hub.purchased_items)
+		contractor_item_icons += "<span class='tooltip_container'>\[ <i class=\"fas [contractor_purchase.item_icon]\"></i><span class='tooltip_hover'><b>[contractor_purchase.name] - [contractor_purchase.cost] Rep</b><br><br>[contractor_purchase.desc]</span> \]</span>"
+		
+		total_spent_rep += contractor_purchase.cost
+
+		/// Special case for reinforcements, we want to show their ckey and name on round end.
+		if (istype(contractor_purchase, /datum/contractor_item/contractor_partner))
+			var/datum/contractor_item/contractor_partner/partner = contractor_purchase
+			contractor_support_unit += "[partner.partner_mind.key] played [partner.partner_mind.current.name], their contractor support unit."
+
+	if (contractor_hub.purchased_items.len)
+		result += contractor_item_icons
+		result += "<br>(Used [total_spent_rep] Rep)"
+	result += "<br>"
 	if (completed_contracts > 0)
-		var/contractor_item_icons = "" // Icons of purchases
-		var/contractor_support_unit // Set if they had a support unit - and shows appended to their contracts completed
-
-		for (var/datum/contractor_item/contractor_purchase in contractor_hub.purchased_items
-			contractor_item_icons += "<span class='tooltip_container'>\[<i class="fas [item_icon]"></i><span class='tooltip_hover'><b>[name]</b><br>[cost]<br>[desc]</span></span>"
-			
-			if (istype(contractor_purchase, ))
-
 		var/pluralCheck = "contract"
 		if (completed_contracts > 1)
 			pluralCheck = "contracts"
 
 		result += "<br>Completed <span class='greentext'>[completed_contracts]</span> [pluralCheck] for a total of \
-					<span class='greentext'>[tc_total] TC</span>! [contractor_support_unit]<br>"
+					<span class='greentext'>[tc_total] TC</span>! <br><br>[contractor_support_unit]<br>"
 
 	return result
 
@@ -449,7 +463,7 @@
 	var/responses = jointext(GLOB.syndicate_code_response, ", ")
 
 	var message = "<br><b>The code phrases were:</b> <span class='bluetext'>[phrases]</span><br>\
-								<b>The code responses were:</b> <span class='redtext'>[responses]</span><br>"
+					<b>The code responses were:</b> <span class='redtext'>[responses]</span><br>"
 
 	return message
 

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -1,10 +1,27 @@
+/// Support unit gets it's own very basic antag datum for admin logging.
+/datum/antagonist/traitor/contractor_support
+	name = "Contractor Support Unit"
+	job_rank = ROLE_CONTRACTORSUPPORT
+	special_role = ROLE_CONTRACTORSUPPORT
+	antag_moodlet = /datum/mood_event/focused
+
+	show_in_roundend = FALSE /// We're already adding them in to the contractor's roundend.
+	give_objectives = TRUE /// We give them their own custom objective.
+	show_in_antagpanel = FALSE /// Not a proper/full antag.
+	should_equip = FALSE /// Don't give them an uplink.
+
+	var/datum/team/contractor_team/contractor_team
+
+/// Team for storing both the contractor and their support unit - only really for the HUD and admin logging.
+/datum/team/contractor_team
+	show_roundend_report = FALSE
+
 /datum/contractor_hub
 	var/contract_rep = 0
 	var/list/hub_items = list()
 	var/list/purchased_items = list()
 
 	var/static/list/contractor_items = typecacheof(/datum/contractor_item/, TRUE)
-
 
 /datum/contractor_hub/proc/create_hub_items()
 	for(var/path in contractor_items)
@@ -42,8 +59,7 @@
 	item_icon = "fa-user-friends"
 	limited = 1
 	cost = 2
-	var/played_by_key /// Used for round end screen to display ckey
-	var/contractor_support_mob_name /// Used for round end screen to display their mob name
+	var/datum/mind/partner_mind = null
 
 /datum/contractor_item/contractor_partner/handle_purchase(var/datum/contractor_hub/hub, mob/living/user)
 	. = ..()
@@ -62,6 +78,7 @@
 			// refund and add the limit back.
 			limited += 1
 			hub.contract_rep += cost
+			hub.purchased_items -= src
 
 /datum/outfit/contractor_partner
 	name = "Contractor Support Unit"
@@ -83,7 +100,7 @@
 	. = ..()
 	var/obj/item/clothing/mask/cigarette/syndicate/cig = H.get_item_by_slot(SLOT_WEAR_MASK)
 
-	// pre-light their cig for extra badass
+	// pre-light their cig
 	cig.light()
 
 /datum/contractor_item/contractor_partner/proc/spawn_contractor_partner(mob/living/user, key)
@@ -96,8 +113,9 @@
 
 	arrival_pod.style = STYLE_SYNDICATE
 	arrival_pod.explosionSize = list(0,0,0,1)
+	arrival_pod.bluespace = TRUE
 
-	var/turf/free_location = find_obstruction_free_location(3, user)
+	var/turf/free_location = find_obstruction_free_location(2, user)
 
 	// We really want to send them - if we can't find a nice location just land it on top of them.
 	if (!free_location)
@@ -106,14 +124,12 @@
 	partner.forceMove(arrival_pod)
 	partner.ckey = key
 
-	played_by_key = key
-	contractor_support_mob_name = partner.real_name
+	/// We give a reference to the mind that'll be the support unit
+	partner_mind = partner.mind
+	partner_mind.make_Contractor_Support()
 
-	// flavour text
-	to_chat(partner, "<span class='big bold'>You are the Syndicate agent that answered the requested for backup.</span><span class='big'> <span class='danger'><b>Your mission is to support the specialist agent, [user.real_name], anyway possible - you must stay with them, and follow any orders they give.</b></span><br>\
-	<br>\
-	<span class='danger'><b>Work as a team with your assigned agent, their mission comes first above all else.</b></span></span>")
-	partner.playsound_local(partner, 'sound/ambience/antag/tatoralert.ogg', 100)
+	to_chat(partner_mind.current, "\n<span class='alertwarning'>[user.real_name] is your superior. Follow any, and all orders given by them. You're here to support their mission only.</span>")
+	to_chat(partner_mind.current, "<span class='alertwarning'>Should they perish, or be otherwise unavailable, you're to assist other active agents in this mission area to the best of your ability.</span>\n\n")
 
 	new /obj/effect/DPtarget(free_location, arrival_pod)
 
@@ -144,7 +160,7 @@
 	else if (limited == 0)
 		return FALSE
 
-	purchased_items.Add(src)
+	hub.purchased_items.Add(src)
 
 	if (item && ispath(item))
 		var/atom/item_to_create = new item(get_turf(user))

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -1,8 +1,6 @@
 /// Support unit gets it's own very basic antag datum for admin logging.
 /datum/antagonist/traitor/contractor_support
 	name = "Contractor Support Unit"
-	job_rank = ROLE_CONTRACTORSUPPORT
-	special_role = ROLE_CONTRACTORSUPPORT
 	antag_moodlet = /datum/mood_event/focused
 
 	show_in_roundend = FALSE /// We're already adding them in to the contractor's roundend.

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -42,6 +42,8 @@
 	item_icon = "fa-user-friends"
 	limited = 1
 	cost = 2
+	var/played_by_key /// Used for round end screen to display ckey
+	var/contractor_support_mob_name /// Used for round end screen to display their mob name
 
 /datum/contractor_item/contractor_partner/handle_purchase(var/datum/contractor_hub/hub, mob/living/user)
 	. = ..()
@@ -104,6 +106,9 @@
 	partner.forceMove(arrival_pod)
 	partner.ckey = key
 
+	played_by_key = key
+	contractor_support_mob_name = partner.real_name
+
 	// flavour text
 	to_chat(partner, "<span class='big bold'>You are the Syndicate agent that answered the requested for backup.</span><span class='big'> <span class='danger'><b>Your mission is to support the specialist agent, [user.real_name], anyway possible - you must stay with them, and follow any orders they give.</b></span><br>\
 	<br>\
@@ -138,6 +143,8 @@
 		limited -= 1
 	else if (limited == 0)
 		return FALSE
+
+	purchased_items.Add(src)
 
 	if (item && ispath(item))
 		var/atom/item_to_create = new item(get_turf(user))

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -16,6 +16,16 @@
 /datum/team/contractor_team
 	show_roundend_report = FALSE
 
+/datum/antagonist/traitor/contractor_support/forge_traitor_objectives()
+	var/datum/objective/generic_objective = new
+
+	generic_objective.name = "Follow Contractor's Orders"
+	generic_objective.explanation_text = "Follow your orders. Assist agents in this mission area."
+
+	generic_objective.completed = TRUE
+
+	add_objective(generic_objective)
+
 /datum/contractor_hub
 	var/contract_rep = 0
 	var/list/hub_items = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives the contract kit reinforcement its own antag datum for admin logging, and also lets them get codewords.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The buyable reinforcement from the contract kit didn't have a datum or any text on round end, this just stops any confusion. We also show contract kit buys etc as well.

Fixes #45278

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Contractor buys show on roundend
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
