### PR TITLE
Fixes devils dying due to liver failure.

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -39,7 +39,7 @@
 	if(stat == DEAD)
 		stop_sound_channel(CHANNEL_HEARTBEAT)
 		LoadComponent(/datum/component/rot/corpse)
-	
+
 	check_cremation()
 
 	//Updates the number of stored chemicals for powers
@@ -579,14 +579,16 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 //LIVER//
 /////////
 
+///Decides if the liver is failing or not.
 /mob/living/carbon/proc/handle_liver()
+	if(!dna)
+		return
 	var/obj/item/organ/liver/liver = getorganslot(ORGAN_SLOT_LIVER)
 	if(liver)
-		if(liver.damage >= liver.maxHealth)
-			liver.failing = TRUE
-			liver_failure()
-	else
-		liver_failure()
+		if(liver.damage < liver.maxHealth)
+			return
+		liver.failing = TRUE
+	liver_failure()
 
 /mob/living/carbon/proc/undergoing_liver_failure()
 	var/obj/item/organ/liver/liver = getorganslot(ORGAN_SLOT_LIVER)


### PR DESCRIPTION
## About The Pull Request

Devils (and xeno larvas, at least if they weren't immune to toxin anyways) no longer die due to missing liver.
Fixes #45286

## Why It's Good For The Game

Unused being broken bad? I guess?

## Changelog
:cl:
fix: Devils dying due to liver failure has been fixed.
/:cl: