### PR TITLE
Give blood brothers traitor HUD

### DIFF
--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(huds, list(
 	ANTAG_HUD_SINTOUCHED = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_SOULLESS = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_CLOCKWORK = new/datum/atom_hud/antag(),
-	ANTAG_HUD_BROTHER = new/datum/atom_hud/antag/hidden(),
+	ANTAG_HUD_BROTHER = new/datum/atom_hud/antag,
 	ANTAG_HUD_HIVE = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_OBSESSED = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_FUGITIVE = new/datum/atom_hud/antag(),

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(huds, list(
 	ANTAG_HUD_SINTOUCHED = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_SOULLESS = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_CLOCKWORK = new/datum/atom_hud/antag(),
-	ANTAG_HUD_BROTHER = new/datum/atom_hud/antag,
+	ANTAG_HUD_BROTHER = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_HIVE = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_OBSESSED = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_FUGITIVE = new/datum/atom_hud/antag(),

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -49,7 +49,9 @@
 	var/miming = 0 // Mime's vow of silence
 	var/list/antag_datums
 	var/antag_hud_icon_state = null //this mind's ANTAG_HUD should have this icon_state
-	var/datum/atom_hud/antag/antag_hud = null //this mind's antag HUD
+	var/team_antag_hud_icon_state = null //this mind's ANTAG_HUD should have this icon_state
+	var/datum/atom_hud/antag/antag_hud = null //this mind's global antag HUD
+	var/datum/atom_hud/antag/team_antag_hud = null //this mind's antag HUD
 	var/damnation_type = 0
 	var/datum/mind/soulOwner //who owns the soul.  Under normal circumstances, this will point to src
 	var/hasSoul = TRUE // If false, renders the character unable to sell their soul.
@@ -103,7 +105,8 @@
 	if(new_character.mind)								//disassociate any mind currently in our new body's mind variable
 		new_character.mind.current = null
 
-	var/datum/atom_hud/antag/hud_to_transfer = antag_hud//we need this because leave_hud() will clear this list
+	var/datum/atom_hud/antag/global_hud_to_transfer = antag_hud //we need these because leave_hud() will clear this list
+	var/datum/atom_hud/antag/team_hud_to_transfer = team_antag_hud
 	var/mob/living/old_current = current
 	if(current)
 		current.transfer_observers_to(new_character)	//transfer anyone observing the old character to the new one
@@ -115,7 +118,7 @@
 	if(iscarbon(new_character))
 		var/mob/living/carbon/C = new_character
 		C.last_mind = src
-	transfer_antag_huds(hud_to_transfer)				//inherit the antag HUD
+	transfer_antag_huds(global_hud_to_transfer, team_hud_to_transfer)				//inherit the antag HUD
 	transfer_actions(new_character)
 	transfer_martial_arts(new_character)
 	RegisterSignal(new_character, COMSIG_MOB_DEATH, .proc/set_death_time)

--- a/code/modules/antagonists/_common/antag_hud.dm
+++ b/code/modules/antagonists/_common/antag_hud.dm
@@ -64,8 +64,8 @@
 	set_antag_hud(current, antag_hud_icon_state)
 	set_antag_hud(current, team_antag_hud_icon_state, TRUE)
 
-	if(newhud)
-		newhud.join_hud(current)
+	if(global_newhud)
+		global_newhud.join_hud(current)
 	if(team_newhud)
 		team_newhud.join_hud(current)
 

--- a/code/modules/antagonists/_common/antag_hud.dm
+++ b/code/modules/antagonists/_common/antag_hud.dm
@@ -1,20 +1,33 @@
 /datum/atom_hud/antag
 	hud_icons = list(ANTAG_HUD)
 	var/self_visible = TRUE
+	var/team_hud = FALSE
 
 /datum/atom_hud/antag/hidden
 	self_visible = FALSE
 
+/datum/atom_hud/antag/team
+	team_hud = TRUE
+
 /datum/atom_hud/antag/proc/join_hud(mob/M)
+	var/datum/atom_hud/antag/mind_hud = M.mind.antag_hud
+	
+	if (team_hud)
+		mind_hud = M.mind.team_antag_hud
+		
 	//sees_hud should be set to 0 if the mob does not get to see it's own hud type.
 	if(!istype(M))
 		CRASH("join_hud(): [M] ([M.type]) is not a mob!")
-	if(M.mind.antag_hud) //note: please let this runtime if a mob has no mind, as mindless mobs shouldn't be getting antagged
-		M.mind.antag_hud.leave_hud(M)
+	if(mind_hud) //note: please let this runtime if a mob has no mind, as mindless mobs shouldn't be getting antagged
+		mind_hud.leave_hud(M)
 	add_to_hud(M)
 	if(self_visible)
 		add_hud_to(M)
-	M.mind.antag_hud = src
+
+	if (!team_hud)
+		M.mind.antag_hud = src
+	else
+		M.mind.team_antag_hud = src
 
 /datum/atom_hud/antag/proc/leave_hud(mob/M)
 	if(!M)
@@ -24,28 +37,37 @@
 	remove_from_hud(M)
 	remove_hud_from(M)
 	if(M.mind)
-		M.mind.antag_hud = null
-
-
+		if (!team_hud)
+			M.mind.antag_hud = null
+		else
+			M.mind.team_antag_hud = null
+		
 //GAME_MODE PROCS
 //called to set a mob's antag icon state
-/proc/set_antag_hud(mob/M, new_icon_state)
+/proc/set_antag_hud(mob/M, new_icon_state, team_hud=FALSE)
 	if(!istype(M))
 		CRASH("set_antag_hud(): [M] ([M.type]) is not a mob!")
 	var/image/holder = M.hud_list[ANTAG_HUD]
 	if(holder)
 		holder.icon_state = new_icon_state
 	if(M.mind || new_icon_state) //in mindless mobs, only null is acceptable, otherwise we're antagging a mindless mob, meaning we should runtime
-		M.mind.antag_hud_icon_state = new_icon_state
-
+		if (!team_hud)
+			M.mind.antag_hud_icon_state = new_icon_state
+		else
+			M.mind.team_antag_hud_icon_state = new_icon_state
 
 //MIND PROCS
 //these are called by mind.transfer_to()
-/datum/mind/proc/transfer_antag_huds(datum/atom_hud/antag/newhud)
+/datum/mind/proc/transfer_antag_huds(datum/atom_hud/antag/global_newhud, datum/atom_hud/antag/team_newhud)
 	leave_all_antag_huds()
+	
 	set_antag_hud(current, antag_hud_icon_state)
+	set_antag_hud(current, team_antag_hud_icon_state, TRUE)
+
 	if(newhud)
 		newhud.join_hud(current)
+	if(team_newhud)
+		team_newhud.join_hud(current)
 
 /datum/mind/proc/leave_all_antag_huds()
 	for(var/datum/atom_hud/antag/hud in GLOB.huds)

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -7,10 +7,17 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	var/member_name = "member"
 	var/list/objectives = list() //common objectives, these won't be added or removed automatically, subtypes handle this, this is here for bookkeeping purposes.
 	var/show_roundend_report = TRUE
+	var/has_hud = FALSE /// Does the team have its own HUD?
+	var/hud_icon_state = "traitor" /// Default icon
+	var/datum/atom_hud/antag/team_hud /// HUD datum
 
 /datum/team/New(starting_members)
 	. = ..()
 	GLOB.antagonist_teams += src
+
+	if (has_hud)
+		team_hud = new /datum/atom_hud/antag
+	
 	if(starting_members)
 		if(islist(starting_members))
 			for(var/datum/mind/M in starting_members)
@@ -26,6 +33,10 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	return members.len == 1
 
 /datum/team/proc/add_member(datum/mind/new_member)
+	if (has_hud)
+		team_hud.join_hud(new_member.current)
+		set_antag_hud(new_member.current, hud_icon_state)
+
 	members |= new_member
 
 /datum/team/proc/remove_member(datum/mind/member)

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -9,15 +9,16 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	var/show_roundend_report = TRUE
 	var/has_hud = FALSE /// Does the team have its own HUD?
 	var/hud_icon_state = "traitor" /// Default icon
-	var/datum/atom_hud/antag/team_hud /// HUD datum
+	var/datum/atom_hud/antag/team_hud = new/// HUD datum
 
 /datum/team/New(starting_members)
 	. = ..()
 	GLOB.antagonist_teams += src
 
 	if (has_hud)
-		team_hud = new /datum/atom_hud/antag
-	
+		team_hud.self_visible = TRUE
+		GLOB.huds += team_hud
+
 	if(starting_members)
 		if(islist(starting_members))
 			for(var/datum/mind/M in starting_members)
@@ -40,6 +41,10 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	members |= new_member
 
 /datum/team/proc/remove_member(datum/mind/member)
+	if (has_hud)
+		team_hud.leave_hud(member.current)
+		set_antag_hud(member.current, null)
+
 	members -= member
 
 //Display members/victory/failure/objectives for the team

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	var/show_roundend_report = TRUE
 	var/has_hud = FALSE /// Does the team have its own HUD?
 	var/hud_icon_state = "traitor" /// Default icon
-	var/datum/atom_hud/antag/team_hud = new/// HUD datum
+	var/datum/atom_hud/antag/team/team_hud = new /// HUD datum
 
 /datum/team/New(starting_members)
 	. = ..()
@@ -36,14 +36,14 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 /datum/team/proc/add_member(datum/mind/new_member)
 	if (has_hud)
 		team_hud.join_hud(new_member.current)
-		set_antag_hud(new_member.current, hud_icon_state)
+		set_antag_hud(new_member.current, hud_icon_state, TRUE)
 
 	members |= new_member
 
 /datum/team/proc/remove_member(datum/mind/member)
 	if (has_hud)
 		team_hud.leave_hud(member.current)
-		set_antag_hud(member.current, null)
+		set_antag_hud(member.current, null, TRUE)
 
 	members -= member
 

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -89,6 +89,9 @@
 /datum/team/brother_team
 	name = "brotherhood"
 	member_name = "blood brother"
+	has_hud = TRUE
+	hud_icon_state = "brother"
+
 	var/meeting_area
 	var/static/meeting_areas = list("The Bar", "Dorms", "Escape Dock", "Arrivals", "Holodeck", "Primary Tool Storage", "Recreation Area", "Chapel", "Library")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives a similar HUD that the nukies get with each other to blood brothers.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Team antag, just following along with others of the same sort.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Blood brothers have a HUD to see each other. They get little hearts, it's cute.
code: Antag team HUD support.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
