### PR TITLE
Replaces vitiligo, revitiligo with two new symptoms: disfiguration and polyvitiligo.

### DIFF
--- a/code/datums/diseases/advance/symptoms/disfiguration.dm
+++ b/code/datums/diseases/advance/symptoms/disfiguration.dm
@@ -37,6 +37,7 @@ BONUS
 	switch(A.stage)
 		if(5)
 			ADD_TRAIT(M, TRAIT_DISFIGURED, DISEASE_TRAIT)
+			M.visible_message("<span class='warning'>[M]'s face appears to cave in!</span>", "<span class='notice'>You feel your face crumple and cave in!</span>")
 		else
 			M.visible_message("<span class='warning'>[M]'s face begins to contort...</span>", "<span class='notice'>Your face feels wet and malleable...</span>")
 

--- a/code/datums/diseases/advance/symptoms/disfiguration.dm
+++ b/code/datums/diseases/advance/symptoms/disfiguration.dm
@@ -1,0 +1,48 @@
+/*
+//////////////////////////////////////
+Disfiguration
+
+	Hidden.
+	No change to resistance.
+	Increases stage speed.
+	Slightly increases transmittability.
+	Critical Level.
+
+BONUS
+	Adds disfiguration trait making the mob appear as "Unknown" to others.
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/disfiguration
+
+	name = "Disfiguration"
+	desc = "The virus liquefies facial muscles, disfiguring the host."
+	stealth = 2
+	resistance = 0
+	stage_speed = 3
+	transmittable = 1
+	level = 5
+	severity = 1
+	symptom_delay_min = 25
+	symptom_delay_max = 75
+
+/datum/symptom/disfiguration/Activate(datum/disease/advance/A)
+	if(!..())
+		return
+	var/mob/living/M = A.affected_mob
+	if (HAS_TRAIT(M, TRAIT_DISFIGURED))
+		return
+	switch(A.stage)
+		if(5)
+			ADD_TRAIT(M, TRAIT_DISFIGURED, DISEASE_TRAIT)
+		else
+			M.visible_message("<span class='warning'>[M]'s face begins to contort...</span>", "<span class='notice'>Your face feels wet and malleable...</span>")
+
+
+/datum/symptom/disfiguration/End(datum/disease/advance/A)
+	if(!..())
+		return
+	var/mob/living/carbon/M = A.affected_mob
+	if(M && HAS_TRAIT(M, TRAIT_DISFIGURED))
+		REMOVE_TRAIT(M, TRAIT_DISFIGURED, DISEASE_TRAIT)

--- a/code/datums/diseases/advance/symptoms/disfiguration.dm
+++ b/code/datums/diseases/advance/symptoms/disfiguration.dm
@@ -28,7 +28,8 @@ BONUS
 	symptom_delay_max = 75
 
 /datum/symptom/disfiguration/Activate(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
 	var/mob/living/M = A.affected_mob
 	if (HAS_TRAIT(M, TRAIT_DISFIGURED))
@@ -41,8 +42,8 @@ BONUS
 
 
 /datum/symptom/disfiguration/End(datum/disease/advance/A)
-	if(!..())
+	. = ..()
+	if(!.)
 		return
-	var/mob/living/carbon/M = A.affected_mob
-	if(M && HAS_TRAIT(M, TRAIT_DISFIGURED))
-		REMOVE_TRAIT(M, TRAIT_DISFIGURED, DISEASE_TRAIT)
+	if(A.affected_mob)
+		REMOVE_TRAIT(A.affected_mob, TRAIT_DISFIGURED, DISEASE_TRAIT)

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -1,68 +1,22 @@
 /*
 //////////////////////////////////////
-Vitiligo
+Polyvitiligo
 
-	Hidden.
-	No change to resistance.
-	Increases stage speed.
-	Slightly increases transmittability.
-	Critical Level.
-
-BONUS
-	Makes the mob lose skin pigmentation.
-
-//////////////////////////////////////
-*/
-
-/datum/symptom/vitiligo
-
-	name = "Vitiligo"
-	desc = "The virus destroys skin pigment cells, causing rapid loss of pigmentation in the host."
-	stealth = 2
-	resistance = 0
-	stage_speed = 3
-	transmittable = 1
-	level = 5
-	severity = 1
-	symptom_delay_min = 25
-	symptom_delay_max = 75
-
-/datum/symptom/vitiligo/Activate(datum/disease/advance/A)
-	if(!..())
-		return
-	var/mob/living/M = A.affected_mob
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.skin_tone == "albino")
-			return
-		switch(A.stage)
-			if(5)
-				H.skin_tone = "albino"
-				H.update_body(0)
-			else
-				H.visible_message("<span class='warning'>[H] looks a bit pale...</span>", "<span class='notice'>Your skin suddenly appears lighter...</span>")
-
-
-/*
-//////////////////////////////////////
-Revitiligo
-
-	Slightly noticable.
+	Noticeable.
 	Increases resistance.
 	Increases stage speed slightly.
 	Increases transmission.
 	Critical Level.
 
 BONUS
-	Makes the mob gain skin pigmentation.
+	Makes the mob gain colorful reagent.
 
 //////////////////////////////////////
 */
 
-/datum/symptom/revitiligo
-
-	name = "Revitiligo"
-	desc = "The virus causes increased production of skin pigment cells, making the host's skin grow darker over time."
+/datum/symptom/polyvitiligo
+	name = "Polyvitiligo"
+	desc = "The virus replaces the melanin in the skin with colorful reagent."
 	stealth = -1
 	resistance = 3
 	stage_speed = 1
@@ -72,17 +26,13 @@ BONUS
 	symptom_delay_min = 7
 	symptom_delay_max = 14
 
-/datum/symptom/revitiligo/Activate(datum/disease/advance/A)
+/datum/symptom/polyvitiligo/Activate(datum/disease/advance/A)
 	if(!..())
 		return
 	var/mob/living/M = A.affected_mob
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.skin_tone == "african2")
-			return
-		switch(A.stage)
-			if(5)
-				H.skin_tone = "african2"
-				H.update_body(0)
-			else
-				H.visible_message("<span class='warning'>[H] looks a bit dark...</span>", "<span class='notice'>Your skin suddenly appears darker...</span>")
+	switch(A.stage)
+		if(5)
+			M.reagents.add_reagent(/datum/reagent/colorful_reagent, 30)
+		else
+			if (prob(50)) // spam
+				M.visible_message("<span class='warning'>[M] looks rather vibrant...</span>", "<span class='notice'>The colors, man, the colors...</span>")

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -32,7 +32,8 @@ BONUS
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)
 		if(5)
-			var/color = pick(subtypesof(/datum/reagent/colorful_reagent/crayonpowder))
+			var/static/list/banned_reagents = list(/datum/reagent/colorful_reagent/crayonpowder/invisible, /datum/reagent/colorful_reagent/crayonpowder/white)
+			var/color = pick(subtypesof(/datum/reagent/colorful_reagent/crayonpowder) - banned_reagents)
 			if(M.reagents.total_volume <= (M.reagents.maximum_volume/10)) // no flooding humans with 1000 units of colorful reagent
 				M.reagents.add_reagent(color, 5)
 		else

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -9,14 +9,14 @@ Polyvitiligo
 	Critical Level.
 
 BONUS
-	Makes the mob gain colorful reagent.
+	Makes the mob gain a random crayon powder colorful reagent.
 
 //////////////////////////////////////
 */
 
 /datum/symptom/polyvitiligo
 	name = "Polyvitiligo"
-	desc = "The virus replaces the melanin in the skin with colorful reagent."
+	desc = "The virus replaces the melanin in the skin with reactive pigment."
 	stealth = -1
 	resistance = 3
 	stage_speed = 1
@@ -32,7 +32,9 @@ BONUS
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)
 		if(5)
-			M.reagents.add_reagent(/datum/reagent/colorful_reagent, 30)
+			var/color = pick(subtypesof(/datum/reagent/colorful_reagent/crayonpowder))
+			if(M.reagents.total_volume <= (M.reagents.maximum_volume/10)) // no flooding humans with 1000 units of colorful reagent
+				M.reagents.add_reagent(color, 5)
 		else
 			if (prob(50)) // spam
 				M.visible_message("<span class='warning'>[M] looks rather vibrant...</span>", "<span class='notice'>The colors, man, the colors...</span>")

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -75,7 +75,7 @@
 /datum/symptom/proc/generate_threshold_desc()
 	return
 
-/datum/symptom/proc/OnAdd(datum/disease/advance/A)		//Overload when a symptom needs to be active before processing, like changing biotypes. 
+/datum/symptom/proc/OnAdd(datum/disease/advance/A)		//Overload when a symptom needs to be active before processing, like changing biotypes.
 	return
 
 /datum/symptom/proc/OnRemove(datum/disease/advance/A)	//But dont forget to remove them too.

--- a/code/modules/antagonists/disease/disease_abilities.dm
+++ b/code/modules/antagonists/disease/disease_abilities.dm
@@ -27,8 +27,8 @@ new /datum/disease_ability/symptom/medium/nano_boost,
 new /datum/disease_ability/symptom/medium/nano_destroy,
 new /datum/disease_ability/symptom/medium/viraladaptation,
 new /datum/disease_ability/symptom/medium/viralevolution,
-new /datum/disease_ability/symptom/medium/vitiligo,
-new /datum/disease_ability/symptom/medium/revitiligo,
+new /datum/disease_ability/symptom/medium/disfiguration,
+new /datum/disease_ability/symptom/medium/polyvitiligo,
 new /datum/disease_ability/symptom/medium/itching,
 new /datum/disease_ability/symptom/medium/heal/weight_loss,
 new /datum/disease_ability/symptom/medium/heal/sensory_restoration,
@@ -373,11 +373,11 @@ new /datum/disease_ability/symptom/powerful/youth
 /datum/disease_ability/symptom/medium/viralevolution
 	symptoms = list(/datum/symptom/viralevolution)
 
-/datum/disease_ability/symptom/medium/vitiligo
-	symptoms = list(/datum/symptom/vitiligo)
+/datum/disease_ability/symptom/medium/polyvitiligo
+	symptoms = list(/datum/symptom/polyvitiligo)
 
-/datum/disease_ability/symptom/medium/revitiligo
-	symptoms = list(/datum/symptom/revitiligo)
+/datum/disease_ability/symptom/medium/disfiguration
+	symptoms = list(/datum/symptom/disfiguration)
 
 /datum/disease_ability/symptom/medium/itching
 	symptoms = list(/datum/symptom/itching)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1274,9 +1274,6 @@
 	color = "#FFFFFF" // white
 	random_color_list = list("#FFFFFF") //doesn't actually change appearance at all
 
-
-
-
 //////////////////////////////////Hydroponics stuff///////////////////////////////
 
 /datum/reagent/plantnutriment

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -448,6 +448,7 @@
 #include "code\datums\diseases\advance\symptoms\confusion.dm"
 #include "code\datums\diseases\advance\symptoms\cough.dm"
 #include "code\datums\diseases\advance\symptoms\deafness.dm"
+#include "code\datums\diseases\advance\symptoms\disfiguration.dm"
 #include "code\datums\diseases\advance\symptoms\dizzy.dm"
 #include "code\datums\diseases\advance\symptoms\fever.dm"
 #include "code\datums\diseases\advance\symptoms\fire.dm"


### PR DESCRIPTION
## About The Pull Request

Replaces vitiligo and revitiligo with two new symptoms:

1. Polyvitiligo: Adds a random crayon powder (a subtype of colorful reagent) to the host causing a color changing effect. 
2. Disfiguration: Makes the host disfigured, causing them to appear as Unknown. (I originally said prosopagnosia but it turns out that trait doesn't affect what you see while mousing over mobs, so it is kind of pointless as a symptom.) 

**NOTE:** I didn't touch the stats, they have the exact same stats as vitiligo and revitiligo. The only difference is I added a prob(50) to one of the visible_messages because it was extremely spammy in testing.

A remake of https://github.com/tgstation/tgstation/pull/45245, substantially different enough that I figured it would be best to just make a new PR instead of dealing with the merge conflict.

## Why It's Good For The Game

- The vitiligo and revitiligo symptoms have no use to legit virologists and very little use to antagonists, their primary purpose is to griff, and not even the kind of griff that results in interesting "minor IC crime."
- Their other primary purpose is to set off a chain reaction of 3edgy racist memes that derail the round into permanent obnoxiousness. 
- These replacement symptoms preserve the (somewhat niche) functionality of making people difficult to tell apart, as well as the (more important) use of buffing viruses.
- The creator himself said the original symptoms were a "joke symptom I threw in as an afterthought": https://github.com/tgstation/tgstation/pull/7197

## Changelog
:cl: bandit
del: Cosmetic mutations have been observed in vitiligo-related viral strains.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
