### PR TITLE
Security can access gulag equipment reclaimer

### DIFF
--- a/code/game/machinery/gulag_item_reclaimer.dm
+++ b/code/game/machinery/gulag_item_reclaimer.dm
@@ -30,7 +30,7 @@
 	obj_flags |= EMAGGED
 
 /obj/machinery/gulag_item_reclaimer/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/card/id/prisoner))
+	if(istype(I, /obj/item/card/id))
 		if(!inserted_id)
 			if(!user.transferItemToLoc(I, src))
 				return

--- a/code/game/machinery/gulag_item_reclaimer.dm
+++ b/code/game/machinery/gulag_item_reclaimer.dm
@@ -87,7 +87,7 @@
 				usr.put_in_hands(inserted_id)
 				inserted_id = null
 			else
-				var/obj/item/I = usr.is_holding_item_of_type(/obj/item/card/id/prisoner)
+				var/obj/item/I = usr.is_holding_item_of_type(/obj/item/card/id)
 				if(I)
 					if(!usr.transferItemToLoc(I, src))
 						return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Only allowed prisoner ids to be put into the machine, now any ID can be inserted. The system already properly checks for the required access needed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #45268

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Security can access gulag equipment reclaim
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
