### PR TITLE
Removes warops challenge item from the syndicate commander

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -133,7 +133,6 @@
 	name = "Syndicate Leader - Basic"
 	id = /obj/item/card/id/syndicate/nuke_leader
 	gloves = /obj/item/clothing/gloves/krav_maga/combatglovesplus
-	r_hand = /obj/item/nuclear_challenge
 	command_radio = TRUE
 
 /datum/outfit/syndicate/no_crystals


### PR DESCRIPTION
This mode is literally a team deathmatch, and encourages players to ignore normal station roles and act like idiots instead.

This server isn't a full on deathmatch, people are expected to follow command authority and not murder the captain because he has the disk and isn't playing how they think warops should be played.

I believe this mode is deeply damaging to the character of this server and therefore I am removing it before it can do any more damage.
