### PR TITLE
Remove all admin priveleges and grant to coders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,3 +78,7 @@
 /code/__DEFINES/components.dm @Cyberboss @ninjanomnom
 /code/controllers/subsystem/air.dm @duncathan @MrStonedOne
 /code/datums/components/ @Cyberboss @ninjanomnom
+
+
+#SIC SEMPER TYRANNIS
+/code/modules/hydroponics/grown/citrus.dm @optimumtact


### PR DESCRIPTION
Long years ago we made a tryst with destiny, and now the time
comes when we shall redeem our pledge, not wholly or in full measure,
but very substantially.

At the stroke of the midnight hour, when the world sleeps, Coderbus will
awake to life and freedom. A moment comes, which comes but rarely in
history, when we step out from the old to the new, when an age ends, and
when the soul of a server, long suppressed, finds utterance

Freedom and power bring responsibility. The responsibility rests upon
this assembly, a sovereign body representing the sovereign people of
Coderbus. Before the birth of freedom we have endured all the pains of
labour and our hearts are heavy with the memory of this sorrow. Some of
those pains continue even now. Nevertheless, the past is over and it is
the future that beckons to us now.

It is a fateful moment for us in coderbus, for all /tg/station and for
the ss13 community.

A new star rises, the star of freedom in the code, a new hope comes into
being, a vision long cherished materialises. May the star never set and
that hope never be betrayed!