### PR TITLE
fixes grilles not updating cables

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -18,8 +18,8 @@
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
 
 /obj/structure/grille/Destroy()
-	. = ..()
 	update_cable_icons_on_turf(get_turf(src))
+	return ..()
 
 /obj/structure/grille/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -17,17 +17,9 @@
 	var/broken_type = /obj/structure/grille/broken
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
 
-/obj/structure/grille/Initialize()
-	. = ..()
-	var/obj/structure/cable/C = locate(/obj/structure/cable) in loc
-	if(C)
-		C.update_icon()
-
 /obj/structure/grille/Destroy()
 	. = ..()
-	var/obj/structure/cable/C = locate(/obj/structure/cable) in loc
-	if(C)
-		C.update_icon()
+	update_cable_icons_on_turf(get_turf(src))
 
 /obj/structure/grille/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -17,6 +17,18 @@
 	var/broken_type = /obj/structure/grille/broken
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
 
+/obj/structure/grille/Initialize()
+	. = ..()
+	var/obj/structure/cable/C = locate(/obj/structure/cable) in loc
+	if(C)
+		C.update_icon()
+
+/obj/structure/grille/Destroy()
+	. = ..()
+	var/obj/structure/cable/C = locate(/obj/structure/cable) in loc
+	if(C)
+		C.update_icon()
+
 /obj/structure/grille/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()
 	update_icon()


### PR DESCRIPTION
## About The Pull Request

Fixes cables not updating nodes when grilles are destroyed

## Changelog
:cl:
fix: Cable nodes now visually update after grilles are built and destroyed
/:cl:
