### PR TITLE
Makes plastic golems slightly transparent.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -812,7 +812,7 @@
 	id = "plastic golem"
 	prefix = "Plastic"
 	special_names = list("Sheet", "Bag", "Bottle")
-	fixed_mut_color = "fff"
+	fixed_mut_color = "fffa"
 	info_text = "As a <span class='danger'>Plastic Golem</span>, you are capable of ventcrawling and passing through plastic flaps as long as you are naked."
 
 /datum/species/golem/plastic/on_species_gain(mob/living/carbon/C, datum/species/old_species)


### PR DESCRIPTION
## About The Pull Request

see title
Fixes #27194

## Why It's Good For The Game

Looks kinda nifty.

## Changelog
:cl:
tweak: Plastic golems no longer look like titanium golems, they are now slightly transparent.
/:cl:
