### PR TITLE
Fixes some map issues on Pubby.

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -9973,6 +9973,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/keycard_auth{
+	pixel_x = 28;
+	pixel_y = 8
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "aAz" = (
@@ -20707,7 +20711,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bbo" = (
-/obj/item/clothing/head/hardhat/cakehat,
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet{
 	icon_state = "carpetsymbol"
@@ -35704,13 +35707,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	name = "Head of Security RC";
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -35718,6 +35714,13 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 3;
+	name = "Atmos RC";
+	pixel_x = 0;
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKV" = (
@@ -54299,18 +54302,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "qaQ" = (
-/obj/structure/table/wood,
 /obj/item/pen{
 	layer = 4
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = -26;
-	pixel_y = 6
 	},
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/turf/open/floor/wood,
+/turf/closed/wall,
 /area/crew_quarters/bar)
 "qbp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -35718,7 +35718,6 @@
 	department = "Atmospherics";
 	departmentType = 3;
 	name = "Atmos RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel,


### PR DESCRIPTION
## About The Pull Request

Fixes #45285
Replaces the rogue table with a wall.
Moved keycard auth console to the captains office. It didn't have one and it doesn't make sense in service.
Atmos no longer has the HOS request console.
ReMoVeD cAkEhAt

## Changelog
:cl:
fix: Fixed various inconsistencies and other oddness on Pubbystation.
/:cl: