### PR TITLE
Some stealth box changes

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -506,6 +506,7 @@
 		else
 			to_chat(owner, "<span class='warning'>Your hands are full!</span>")
 
+///MGS BOX!
 /datum/action/item_action/agent_box
 	name = "Deploy Box"
 	desc = "Find inner peace, here, in the box."
@@ -513,22 +514,30 @@
 	background_icon_state = "bg_agent"
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "deploy_box"
+	///Cooldown between deploys. Uses world.time
 	var/cooldown = 0
-	var/obj/structure/closet/cardboard/agent/box
+	///The type of closet this action spawns.
+	var/boxtype = /obj/structure/closet/cardboard/agent
 
+///Handles opening and closing the box.
 /datum/action/item_action/agent_box/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
-	if(QDELETED(box))
-		if(cooldown < world.time - 100)
-			box = new(owner.drop_location())
-			owner.forceMove(box)
-			cooldown = world.time
-			owner.playsound_local(box, 'sound/misc/box_deploy.ogg', 50, TRUE)
-	else
-		owner.forceMove(box.drop_location())
+	if(istype(owner.loc, /obj/structure/closet/cardboard/agent))
+		var/obj/structure/closet/cardboard/agent/box = owner.loc
 		owner.playsound_local(box, 'sound/misc/box_deploy.ogg', 50, TRUE)
-		QDEL_NULL(box)
+		box.open()
+		return
+	//Box closing from here on out.
+	if(!isturf(owner.loc)) //Don't let the player use this to escape mechs/welded closets.
+		to_chat(owner, "<span class = 'notice'>You need more space to activate this implant.</span>")
+		return
+	if(cooldown < world.time - 100)
+		var/box = new boxtype(owner.drop_location())
+		owner.forceMove(box)
+		cooldown = world.time
+		owner.playsound_local(box, 'sound/misc/box_deploy.ogg', 50, TRUE)
 
 //Preset for spells
 /datum/action/spell_action


### PR DESCRIPTION
## About The Pull Request

Table of contents:
You can no longer deploy the box while you are inside of something. Fixes #45288
The box should no longer get hard deleted when someone else opens it.
The box now alerts people to you, even if you are the one who opened it.

## Why It's Good For The Game

First one is obvious, exploit bad. You should just teleport out of mechs and welded lockers.
Second one also obvious.
Third one is because I did that on accident while testing and found it very flavourful. Feels a lot more like a sneak box if you always get the reveal animation with the red exclamation mark.

## Changelog
:cl:
fix: You can no longer activate the stealth implant while inside of other objects.
balance: Leaving the stealth box always alerts nearby players.
/:cl: