### PR TITLE
Anti-magic items now work properly in the suit storage slot

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -30,6 +30,7 @@
 #define ITEM_SLOT_NECK			(1<<13)
 #define ITEM_SLOT_HANDS			(1<<14)
 #define ITEM_SLOT_BACKPACK		(1<<15)
+#define ITEM_SLOT_SUITSTORE		(1<<16)
 
 //SLOTS
 #define SLOT_BACK			1
@@ -88,6 +89,8 @@
 			. = ITEM_SLOT_POCKET
 		if(SLOT_HANDS)
 			. = ITEM_SLOT_HANDS
+		if(SLOT_S_STORE)
+			. = ITEM_SLOT_SUITSTORE
 		if(SLOT_IN_BACKPACK)
 			. = ITEM_SLOT_BACKPACK
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR adds ITEM_SLOT_SUITSTORE bitfield, which was missing from defines and as a result, anti-magic items such as nullrods were not protecting their users properly when worn in the suit storage slot.

Fixes #45081

## Why It's Good For The Game

Bugs bad and cult nerf I guess.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
fix: Anti-magic items, such as nullrods, will now correctly protect their users from magic when they are worn in the suit storage slot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
