### PR TITLE
Lizardwine drink crafting fix

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -291,7 +291,7 @@
 	subcategory = CAT_MISCFOOD
 
 
-/datum/crafting_recipe/food/lizardwine
+/datum/crafting_recipe/lizardwine
 	name = "Lizard wine"
 	time = 40
 	reqs = list(
@@ -299,6 +299,7 @@
 		/datum/reagent/consumable/ethanol = 100
 	)
 	result = /obj/item/reagent_containers/food/drinks/bottle/lizardwine
+	category = CAT_FOOD
 	subcategory = CAT_MISCFOOD
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR fixes an issue with a Lizardwine drink crafting, where a final bottle of Lizardwine would contain 100u of Lizardwine and 100u of Ethanol. This was caused by how food crafting recipes work, where reagents used in the crafting are transferred into the final product. 

Making Lizardwine a normal recipe, and assigning it a food category manually fixes this.

Fixes #30455

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Another bug down.

## Changelog
:cl: Arkatos
fix: Fixed an issue with a Lizardwine drink crafting, where a final product would contain unwated 100u of Ethanol.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
