### PR TITLE
Fixes cables not being pulled into singularities correctly

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -81,8 +81,9 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 		if(linked_dirs & check_dir)
 			var/TB = get_step(loc, check_dir)
 			var/obj/structure/cable/C = locate(/obj/structure/cable) in TB
-			C.linked_dirs &= ~inverse
-			C.update_icon()
+			if(C)
+				C.linked_dirs &= ~inverse
+				C.update_icon()
 
 	if(powernet)
 		cut_cable_from_powernet()				// update the powernets


### PR DESCRIPTION
Closes #44818 

## About The Pull Request

I assumed this sanity check wasn't needed, but singularities rip up so much it can result in situations where it is.
The qdel was runtiming and not deleting the cables, cables now should be sucked up correctly.

## Changelog
:cl:
fix: Singularities now properly pull in cables
/:cl: