### PR TITLE
[Ready] Code Bounty: Fake Virus Event

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -97,6 +97,8 @@
 
 #define STATUS_EFFECT_STASIS /datum/status_effect/incapacitating/stasis //Halts biological functions like bleeding, chemical processing, blood regeneration, walking, etc
 
+#define STATUS_EFFECT_FAKE_VIRUS /datum/status_effect/fake_virus //gives you fluff messages for cough, sneeze, headache, etc but without an actual virus
+
 /////////////
 // NEUTRAL //
 /////////////

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -412,7 +412,7 @@
 	for(var/d in GLOB.alldirs)
 		new /obj/effect/temp_visual/dir_setting/bloodsplatter(T, d)
 	playsound(T, "desceration", 100, TRUE, -1)
-	
+
 /mob/living/proc/apply_necropolis_curse(set_curse)
 	var/datum/status_effect/necropolis_curse/C = has_status_effect(STATUS_EFFECT_NECROPOLIS_CURSE)
 	if(!set_curse)
@@ -432,7 +432,7 @@
 	var/effect_last_activation = 0
 	var/effect_cooldown = 100
 	var/obj/effect/temp_visual/curse/wasting_effect = new
-	
+
 /datum/status_effect/necropolis_curse/hivemind
 	id = "hivecurse"
 	duration = 600
@@ -740,3 +740,46 @@
 	name = "TO THE STARS AND BEYOND!"
 	desc = "I must go, my people need me!"
 	icon_state = "high"
+
+/datum/status_effect/fake_virus
+	id = "fake_virus"
+	duration = 1800//3 minutes
+	status_type = STATUS_EFFECT_REPLACE
+	tick_interval = 1
+	alert_type = null
+	var/msg_stage = 0//so you dont get the most intense messages immediately
+
+/datum/status_effect/fake_virus/tick()
+	var/fake_msg = ""
+	var/fake_emote = ""
+	switch(msg_stage)
+		if(0 to 300)
+			if(prob(1))
+				fake_msg = pick("<span class='warning'>[pick("Your head hurts.", "Your head pounds.")]</span>",
+				"<span class='warning'>[pick("You're having difficulty breathing.", "Your breathing becomes heavy.")]</span>",
+				"<span class='warning'>[pick("You feel dizzy.", "Your head spins.")]</span>",
+				"<span notice='warning'>[pick("You swallow excess mucus.", "You lightly cough.")]</span>",
+				"<span class='warning'>[pick("Your head hurts.", "Your mind blanks for a moment.")]</span>",
+				"<span class='warning'>[pick("Your throat hurts.", "You clear your throat.")]</span>")
+		if(301 to 600)
+			if(prob(2))
+				fake_msg = pick("<span class='warning'>[pick("Your head hurts a lot.", "Your head pounds incessantly.")]</span>",
+				"<span class='warning'>[pick("Your windpipe feels like a straw.", "Your breathing becomes tremendously difficult.")]</span>",
+				"<span class='warning'>You feel very [pick("dizzy","woozy","faint")].</span>",
+				"<span class='warning'>[pick("You hear a ringing in your ear.", "Your ears pop.")]</span>",
+				"<span class='warning'>You nod off for a moment.</span>")
+		else
+			if(prob(3))
+				if(prob(50))// coin flip to throw a message or an emote
+					fake_msg = pick("<span class='userdanger'>[pick("Your head hurts!", "You feel a burning knife inside your brain!", "A wave of pain fills your head!")]</span>",
+					"<span class='userdanger'>[pick("Your lungs hurt!", "It hurts to breathe!")]</span>",
+					"<span class='warning'>[pick("You feel nauseated.", "You feel like you're going to throw up!")]</span>")
+				else
+					fake_emote = pick("cough", "sniff", "sneeze")
+
+	if(fake_emote)
+		owner.emote(fake_emote)
+	else if(fake_msg)
+		to_chat(owner, fake_msg)
+
+	msg_stage++

--- a/code/modules/events/fake_virus.dm
+++ b/code/modules/events/fake_virus.dm
@@ -1,0 +1,19 @@
+/datum/round_event_control/fake_virus
+	name = "Fake Virus"
+	typepath = /datum/round_event/fake_virus
+	weight = 20
+
+/datum/round_event/fake_virus/start()
+	var/list/fake_virus_victims = list()
+	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
+		if(!H.client || H.stat == DEAD || H.InCritical())
+			continue
+		fake_virus_victims += H
+
+	var/defacto_min = min(3, LAZYLEN(fake_virus_victims))
+	if(defacto_min)// event will hit 1-3 people by default, but will do 1-2 or just 1 if only those many candidates are available
+		for(var/i=1; i<=rand(1,defacto_min); i++)
+			var/mob/living/carbon/human/hypochondriac = pick(fake_virus_victims)
+			hypochondriac.apply_status_effect(STATUS_EFFECT_FAKE_VIRUS)
+			fake_virus_victims -= hypochondriac
+			announce_to_ghosts(hypochondriac)

--- a/code/modules/events/fake_virus.dm
+++ b/code/modules/events/fake_virus.dm
@@ -10,6 +10,7 @@
 			continue
 		fake_virus_victims += H
 
+	//first we do hard status effect victims
 	var/defacto_min = min(3, LAZYLEN(fake_virus_victims))
 	if(defacto_min)// event will hit 1-3 people by default, but will do 1-2 or just 1 if only those many candidates are available
 		for(var/i=1; i<=rand(1,defacto_min); i++)
@@ -17,3 +18,14 @@
 			hypochondriac.apply_status_effect(STATUS_EFFECT_FAKE_VIRUS)
 			fake_virus_victims -= hypochondriac
 			announce_to_ghosts(hypochondriac)
+
+	//then we do light one-message victims who simply cough or whatever once (have to repeat the process since the last operation modified our candidates list)
+	defacto_min = min(5, LAZYLEN(fake_virus_victims))
+	if(defacto_min)
+		for(var/i=1; i<=rand(1,defacto_min); i++)
+			var/mob/living/carbon/human/onecoughman = pick(fake_virus_victims)
+			if(prob(25))//1/4 odds to get a spooky message instead of coughing out loud
+				addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, onecoughman, "<span class='warning'>[pick("Your head hurts.", "Your head pounds.")]</span>"), rand(30,150))
+			else
+				addtimer(CALLBACK(onecoughman, .mob/proc/emote, pick("cough", "sniff", "sneeze")), rand(30,150))//deliver the message with a slightly randomized time interval so there arent multiple people coughing at the exact same time
+			fake_virus_victims -= onecoughman

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1676,6 +1676,7 @@
 #include "code\modules\events\disease_outbreak.dm"
 #include "code\modules\events\dust.dm"
 #include "code\modules\events\electrical_storm.dm"
+#include "code\modules\events\fake_virus.dm"
 #include "code\modules\events\false_alarm.dm"
 #include "code\modules\events\fugitive_spawning.dm"
 #include "code\modules\events\ghost_role.dm"


### PR DESCRIPTION
**What is it**
A new event that will target 1-3 people randomly. The fluff text/emotes from multiple viruses (such as coughing, sneezing, dizziness, confusion, vomiting (just the fluff text no actual vomit), etc) will be thrown at the victims as with a regular virus, but they will not actually be suffering from a virus.

The way it works is that it gives a 3 minute invisible status effect that will throw random spooky messages with increasing spookiness over time (like a real virus would). After the 3 minutes is up, the status effect vanishes and it's like you were never even afflicted. Also, after the 1-3 random people are given this status effect, 1-5 more are made to cough/sneeze/etc exactly once with a randomized brief delay.

**Purpose**
This should hopefully make people stop and think before immediately going to lynch the virologist when they see a "You feel lightheaded!" message. Adds paranoia.

:cl:
add: A new Fake Virus event that makes you think you have a virus when you don't
/:cl:
