### PR TITLE
Twisted construction fixes

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -558,6 +558,7 @@
 	desc = "Corrupts certain metalic objects on contact."
 	invocation = "Ethra p'ni dedol!"
 	color = "#000000" // black
+	var/channeling = FALSE
 
 /obj/item/melee/blood_magic/construction/examine(mob/user)
 	. = ..()
@@ -570,6 +571,9 @@
 
 /obj/item/melee/blood_magic/construction/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(proximity_flag && iscultist(user))
+		if(channeling)
+			to_chat(user, "<span class='cultitalic'>You are already invoking twisted construction!</span>")
+			return
 		var/turf/T = get_turf(target)
 		if(istype(target, /obj/item/stack/sheet/metal))
 			var/obj/item/stack/sheet/candidate = target
@@ -592,6 +596,7 @@
 		else if(istype(target,/mob/living/silicon/robot))
 			var/mob/living/silicon/robot/candidate = target
 			if(candidate.mmi)
+				channeling = TRUE
 				user.visible_message("<span class='danger'>A dark cloud emanates from [user]'s hand and swirls around [candidate]!</span>")
 				playsound(T, 'sound/machines/airlock_alien_prying.ogg', 80, 1)
 				var/prev_color = candidate.color
@@ -611,7 +616,9 @@
 					uses--
 					candidate.mmi = null
 					qdel(candidate)
+					channeling = FALSE
 				else
+					channeling = FALSE
 					candidate.color = prev_color
 					return
 			else
@@ -619,7 +626,9 @@
 				to_chat(user, "<span class='warning'>A dark cloud emanates from you hand and swirls around [candidate] - twisting it into a construct shell!</span>")
 				new /obj/structure/constructshell(T)
 				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
+				qdel(candidate)
 		else if(istype(target,/obj/machinery/door/airlock))
+			channeling = TRUE
 			playsound(T, 'sound/machines/airlockforced.ogg', 50, 1)
 			do_sparks(5, TRUE, target)
 			if(do_after(user, 50, target = user))
@@ -627,7 +636,9 @@
 				uses--
 				user.visible_message("<span class='warning'>Black ribbons suddenly emanate from [user]'s hand and cling to the airlock - twisting and corrupting it!</span>")
 				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
+				channeling = FALSE
 			else
+				channeling = FALSE
 				return
 		else
 			to_chat(user, "<span class='warning'>The spell will not work on [target]!</span>")

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -604,6 +604,9 @@
 				if(do_after(user, 90, target = candidate))
 					candidate.emp_act(EMP_HEAVY)
 					var/construct_class = alert(user, "Please choose which type of construct you wish to create.",,"Juggernaut","Wraith","Artificer")
+					if(QDELETED(candidate))
+						channeling = FALSE
+						return
 					user.visible_message("<span class='danger'>The dark cloud receedes from what was formerly [candidate], revealing a\n [construct_class]!</span>")
 					switch(construct_class)
 						if("Juggernaut")
@@ -632,6 +635,9 @@
 			playsound(T, 'sound/machines/airlockforced.ogg', 50, 1)
 			do_sparks(5, TRUE, target)
 			if(do_after(user, 50, target = user))
+				if(QDELETED(target))
+					channeling = FALSE
+					return
 				target.narsie_act()
 				uses--
 				user.visible_message("<span class='warning'>Black ribbons suddenly emanate from [user]'s hand and cling to the airlock - twisting and corrupting it!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR fixes three issues regarding twisted construction cult spell:

1) Added sanity checks while doing do_after channeling. It is no longer possible to be channeling multiple times at once, which lead to duplicit constructs, wrongly assigned black outlines and God knows what else.

2) When using twisted construction on an empty AI cyborg shell, the original shell remained while construct shell was created. This is fixed now and the original shell is now properly deleted when the process is complete.

3) If the object that is being transformed is deleted before the transformation is complete, the spell will not progress further instead of doing nothing and wasting a charge.

Fixes #39464

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Cult bugs bad :hear_no_evil:

## Changelog
:cl: Arkatos
fix: You can no longer use twisted construction cult spell while already channeling it on another object.
fix: Twisted construction cult spell now properly deletes empty AI cyborg shell when it is transformed into construct shell.
fix: Objects that are destroyed while being transformed by twisted construction cult spell will no longer progress the spell further and waste a spell charge.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
