### PR TITLE
The prebuilt robot suit now looks correct.

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -38,6 +38,7 @@
 	chest = new(src)
 	chest.wired = TRUE
 	chest.cell = new /obj/item/stock_parts/cell/high/plus(chest)
+	update_icon()
 
 /obj/item/robot_suit/update_icon()
 	cut_overlays()


### PR DESCRIPTION
## Changelog
:cl:
fix: A freshly spawned in prebuilt robot suit now has the correct icon.
/:cl:
