### PR TITLE
Fixed the PDA messaging servers on box and donut

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -40463,7 +40463,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "ccg" = (
-/obj/machinery/telecomms/message_server,
+/obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "cch" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -36311,6 +36311,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bIk" = (
+/obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bIl" = (


### PR DESCRIPTION
## About The Pull Request
Box had the wrong type for the PDA messaging server and donut didn't have one meaning you couldn't send PDA messages.

## Why It's Good For The Game
Its good that PDA messages work.

## Changelog
:cl:
fix: Fixed PDA messaging on box and donut.
/:cl: