### PR TITLE
[Genetics] Joker Return Rate Tuned

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -2,7 +2,7 @@
 #define NUMBER_OF_BUFFERS 3
 #define SCRAMBLE_TIMEOUT 600
 #define JOKER_TIMEOUT 12000					//20 minutes
-#define JOKER_UPGRADE 1800
+#define JOKER_UPGRADE 3000
 
 #define RADIATION_STRENGTH_MAX 15
 #define RADIATION_STRENGTH_MULTIPLIER 1			//larger has more range
@@ -717,7 +717,7 @@
 						I.research = TRUE
 						if(connected)
 							I.damage_coeff = connected.damage_coeff*4
-							injectorready = world.time + INJECTOR_TIMEOUT * (1 - 0.1 * connected.precision_coeff) //precision_coeff being the manipulator rating
+							injectorready = world.time + INJECTOR_TIMEOUT * (1 - 0.1 * connected.precision_coeff) //precision_coeff being the matter bin rating
 						else
 							injectorready = world.time + INJECTOR_TIMEOUT
 		if("mutator")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Since the change / nerf to Genetic Sequence Analyzers, Genetics seems to be a lot slower than it should be. Some rounds nowadays, it can take Geneticists over an hour to get one or two desirable traits, which can be due to there being only one Geneticist working, which slows down progression compared to two of them both solving genes, or having bad RNG on the amount of X pairs to name a few possible problems. 

To counter the issue of possible bad RNG or heavy workloads, I thought of two solutions. 

One:  Changing the rate of Joker's coming back, which helps solve multiple pairs of X's. 

Two:  Increasing the buffer size on the Genetic Sequence Analyzer, so it can hold more than just one person's sequence at a time, thus reducing the amount of run time a Geneticist would need to make by scanning one person, return to the lab and add to the database, scan another person, add them to the database, and so forth. This solution would have worked a bit similarly to the third party tool that got the scanning tool nerfed to begin with, but at least using the mechanics in game instead of outside materials. 

Only one of those things I have an idea how to do, thus resulting in solution one.

I have modified the Joker return rate based on upgraded parts within the formula, bumping the JOKER_UPGRADE value from 1800 to 3000. So after the first Joker appears 20 minutes into the round, since I didn't change the JOKER_TIMEOUT, it will return once again at the specified time based on the current tier of Matter Bin within the DNA scanner connected to the computer. I also corrected the comment within the code that claimed the precision_coeff being based on manipulator value, when it is actually based on the matter bin value in the DNA Scanner. 

= Before = 

Tier 1: 12,000 = 20 minutes 
Tier 2: 10,200 = 17 minutes
Tier 3: 8,400  = 14 minutes
Tier 4: 6,600 = 11 minutes 

= After = 

Tier 1: 12,000 = 20 minutes
Tier 2: 9,000 = 15 minutes
Tier 3: 6,000 = 10 minutes
Tier 4: 3,000 = 5 minutes

~~With how the formula for this is currently written, tier one parts in the DNA Scanner already increased the amount of time it took for jokers to return, so with my proposed change, Jokers would actually take longer to come back if the Scanners are never upgraded.~~ On the up side, everything is in a nice interval of 5 minutes between tier upgrades, ~~save for tier one due to the formula.~~ While testing my change, however, the timer for Jokers coming back doesn't start until after the one joker you can keep stored in a machine is spent. So if there has been an upgrade done to the machine before spending or obtaining the first joker, then the time until the next joker after that would be that of the tier in place. 

Example: If you upgrade the matter bin to tier 3 at 18 minutes into the round, and you spend the first joker at 21 minutes, the next one should return at 31 minutes. 

## Why It's Good For The Game

This can help Geneticists possibly obtain whatever desirable trait faster, by potentially reducing the amount of RNG and troubleshooting when solving genes with multiple X pairs. Their machines will still require upgraded parts to benefit from this, which helps balance things out instead of flat out lowering the JOKER_TIMEOUT variable, and they are still subject to the RNG of finding the Mutation with the desired gene in the first place. 

## Changelog
:cl:
tweak: Further research into Matter Bins has increased their efficiency in solving missing genomes within DNA Scanning machines, revealing elusive "Joker" genes more often.
code: Fixed a comment about the precision_coeff referring to the wrong part it is associated to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
