### PR TITLE
CE Blueprint Fixes

### DIFF
--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -42,15 +42,12 @@ SUBSYSTEM_DEF(icon_smooth)
 		CHECK_TICK
 	queue = blueprint_queue
 	blueprint_queue = list()
+	var/atom/movable/AM
+	var/turf/T
 	for(var/item in queue)
-		var/atom/movable/AM = item
-		var/image/I = new
-		var/turf/T = AM.loc
-		I.appearance = AM.appearance
-		I.appearance_flags = RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM
-		I.loc = AM.loc
-		I.setDir(AM.dir)
-		I.alpha = 128
-		LAZYADD(T.blueprint_data, I)
+		AM = item
+		T = AM.loc
+		if(T && AM)
+			T.add_blueprints(AM)
 
 	return ..()

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -5,6 +5,8 @@ SUBSYSTEM_DEF(icon_smooth)
 	priority = FIRE_PRIOTITY_SMOOTHING
 	flags = SS_TICKER
 
+	///Blueprints assemble an image of what pipes/manifolds/wires look like on initialization, and thus should be taken after everything's been smoothed
+	var/list/blueprint_queue = list()
 	var/list/smooth_queue = list()
 	var/list/deferred = list()
 
@@ -38,5 +40,17 @@ SUBSYSTEM_DEF(icon_smooth)
 			continue
 		smooth_icon(A)
 		CHECK_TICK
+	queue = blueprint_queue
+	blueprint_queue = list()
+	for(var/item in queue)
+		var/atom/movable/AM = item
+		var/image/I = new
+		var/turf/T = AM.loc
+		I.appearance = AM.appearance
+		I.appearance_flags = RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM
+		I.loc = AM.loc
+		I.setDir(AM.dir)
+		I.alpha = 128
+		LAZYADD(T.blueprint_data, I)
 
 	return ..()

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -27,7 +27,7 @@
 /obj/item/areaeditor/Topic(href, href_list)
 	if(..())
 		return TRUE
-	if(!usr.canUseTopic(src))
+	if(!usr.canUseTopic(src) || usr != loc)
 		usr << browse(null, "window=blueprints")
 		return TRUE
 	if(href_list["create_area"])
@@ -110,18 +110,26 @@
 
 	attack_self(usr) //this is not the proper way, but neither of the old update procs work! it's too ancient and I'm tired shush.
 
-/obj/item/areaeditor/blueprints/proc/get_images(turf/T, viewsize)
+/obj/item/areaeditor/blueprints/proc/get_images(mob/user, viewsize)
 	. = list()
-	for(var/turf/TT in range(viewsize, T))
-		if(TT.blueprint_data)
-			. += TT.blueprint_data
+	for(var/obj/O in orange(viewsize, user))
+		if(O.level != 1)
+			continue
+
+		if(O.invisibility == INVISIBILITY_MAXIMUM || HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
+			var/image/I = new(loc = get_turf(O))
+			var/mutable_appearance/MA = new(O)
+			MA.alpha = 128
+			MA.dir = O.dir
+			I.appearance = MA
+			. += I
 
 /obj/item/areaeditor/blueprints/proc/set_viewer(mob/user, message = "")
 	if(user && user.client)
 		if(viewing)
 			clear_viewer()
 		viewing = user.client
-		showing = get_images(get_turf(user), viewing.view)
+		showing = get_images(user, viewing.view)
 		viewing.images |= showing
 		if(message)
 			to_chat(user, message)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -110,26 +110,18 @@
 
 	attack_self(usr) //this is not the proper way, but neither of the old update procs work! it's too ancient and I'm tired shush.
 
-/obj/item/areaeditor/blueprints/proc/get_images(mob/user, viewsize)
+/obj/item/areaeditor/blueprints/proc/get_images(turf/T, viewsize)
 	. = list()
-	for(var/obj/O in orange(viewsize, user))
-		if(O.level != 1)
-			continue
-
-		if(O.invisibility == INVISIBILITY_MAXIMUM || HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
-			var/image/I = new(loc = get_turf(O))
-			var/mutable_appearance/MA = new(O)
-			MA.alpha = 128
-			MA.dir = O.dir
-			I.appearance = MA
-			. += I
+	for(var/turf/TT in range(viewsize, T))
+		if(TT.blueprint_data)
+			. += TT.blueprint_data
 
 /obj/item/areaeditor/blueprints/proc/set_viewer(mob/user, message = "")
 	if(user && user.client)
 		if(viewing)
 			clear_viewer()
 		viewing = user.client
-		showing = get_images(user, viewing.view)
+		showing = get_images(get_turf(user), viewing.view)
 		viewing.images |= showing
 		if(message)
 			to_chat(user, message)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -473,9 +473,21 @@
 	underlay_appearance.dir = adjacency_dir
 	return TRUE
 
+/turf/proc/add_blueprints(var/atom/movable/AM)
+	var/image/I = new
+	I.appearance = AM.appearance
+	I.appearance_flags = RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM
+	I.loc = src
+	I.setDir(AM.dir)
+	I.alpha = 128
+	LAZYADD(blueprint_data, I)
+
 /turf/proc/add_blueprints_preround(atom/movable/AM)
 	if(!SSticker.HasRoundStarted())
-		SSicon_smooth.blueprint_queue += AM
+		if(AM.layer == WIRE_LAYER)
+			SSicon_smooth.blueprint_queue += AM
+		else
+			add_blueprints(AM)
 
 /turf/proc/is_transition_turf()
 	return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -484,7 +484,7 @@
 
 /turf/proc/add_blueprints_preround(atom/movable/AM)
 	if(!SSticker.HasRoundStarted())
-		if(AM.layer == WIRE_LAYER)
+		if(AM.layer == WIRE_LAYER)	//wires connect to adjacent positions after its parent init, meaning we need to wait (in this case, until smoothing) to take its image
 			SSicon_smooth.blueprint_queue += AM
 		else
 			add_blueprints(AM)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -20,7 +20,6 @@
 	flags_1 = CAN_BE_DIRTY_1
 
 	var/list/image/blueprint_data //for the station blueprints, images of objects eg: pipes
-	var/list/atom/movable/blueprint_queue
 
 	var/explosion_level = 0	//for preventing explosion dodging
 	var/explosion_id = 0
@@ -474,32 +473,9 @@
 	underlay_appearance.dir = adjacency_dir
 	return TRUE
 
-///Certain sprites don't load properly upon init, so by queueing our orders we can wait until they have properly loaded in
-/turf/proc/add_blueprints_queue(atom/movable/AM)
-	if(!blueprint_queue)
-		addtimer(CALLBACK(src, .proc/add_blueprints), 50)
-	LAZYADD(blueprint_queue, AM)
-
-/turf/proc/add_blueprints()
-	if(SSticker.current_state == GAME_STATE_STARTUP)
-		addtimer(CALLBACK(src, .proc/add_blueprints), 50)
-	for(var/item in blueprint_queue)
-		var/atom/movable/AM = item
-		var/image/I = new
-		I.appearance = AM.appearance
-		I.appearance_flags = RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM
-		I.loc = src
-		I.setDir(AM.dir)
-		I.alpha = 128
-
-		LAZYADD(blueprint_data, I)
-
-	blueprint_queue.Cut()
-
-
 /turf/proc/add_blueprints_preround(atom/movable/AM)
 	if(!SSticker.HasRoundStarted())
-		add_blueprints_queue(AM)
+		SSicon_smooth.blueprint_queue += AM
 
 /turf/proc/is_transition_turf()
 	return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -20,6 +20,7 @@
 	flags_1 = CAN_BE_DIRTY_1
 
 	var/list/image/blueprint_data //for the station blueprints, images of objects eg: pipes
+	var/list/atom/movable/blueprint_queue
 
 	var/explosion_level = 0	//for preventing explosion dodging
 	var/explosion_id = 0
@@ -473,20 +474,32 @@
 	underlay_appearance.dir = adjacency_dir
 	return TRUE
 
-/turf/proc/add_blueprints(atom/movable/AM)
-	var/image/I = new
-	I.appearance = AM.appearance
-	I.appearance_flags = RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM
-	I.loc = src
-	I.setDir(AM.dir)
-	I.alpha = 128
+///Certain sprites don't load properly upon init, so by queueing our orders we can wait until they have properly loaded in
+/turf/proc/add_blueprints_queue(atom/movable/AM)
+	if(!blueprint_queue)
+		addtimer(CALLBACK(src, .proc/add_blueprints), 50)
+	LAZYADD(blueprint_queue, AM)
 
-	LAZYADD(blueprint_data, I)
+/turf/proc/add_blueprints()
+	if(SSticker.current_state == GAME_STATE_STARTUP)
+		addtimer(CALLBACK(src, .proc/add_blueprints), 50)
+	for(var/item in blueprint_queue)
+		var/atom/movable/AM = item
+		var/image/I = new
+		I.appearance = AM.appearance
+		I.appearance_flags = RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM
+		I.loc = src
+		I.setDir(AM.dir)
+		I.alpha = 128
+
+		LAZYADD(blueprint_data, I)
+
+	blueprint_queue.Cut()
 
 
 /turf/proc/add_blueprints_preround(atom/movable/AM)
 	if(!SSticker.HasRoundStarted())
-		add_blueprints(AM)
+		add_blueprints_queue(AM)
 
 /turf/proc/is_transition_turf()
 	return

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -18,7 +18,6 @@
 	var/mutable_appearance/center
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/New()
-	icon_state = ""
 	center = mutable_appearance(icon, "manifold_center")
 	return ..()
 

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
@@ -17,7 +17,6 @@
 	var/mutable_appearance/center
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/New()
-	icon_state = ""
 	center = mutable_appearance(icon, "manifold4w_center")
 	return ..()
 

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -22,7 +22,6 @@
  * This is true for the other manifolds (the 4 ways and the heat exchanges) too.
  */
 /obj/machinery/atmospherics/pipe/manifold/New()
-	icon_state = ""
 	center = mutable_appearance(icon, "manifold_center")
 	return ..()
 

--- a/code/modules/atmospherics/machinery/pipes/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold4w.dm
@@ -17,7 +17,6 @@
 	var/mutable_appearance/center
 
 /obj/machinery/atmospherics/pipe/manifold4w/New()
-	icon_state = ""
 	center = mutable_appearance(icon, "manifold4w_center")
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #45341 so that blueprints can no longer be used when not in-hand, and turfs now properly compile a list of the blueprint items it should hold by delaying when it retrieves this information, as objects such as manifolds and wires didn't initialize with their proper sprite.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: The CE's blueprints can no longer be used if not in-hand, and its scanning function has been fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
