### PR TITLE
fixes antimagic on a few projectiles

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -366,7 +366,7 @@
 		if(M.anti_magic_check())
 			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
 			qdel(src)
-			return
+			return BULLET_ACT_BLOCK
 	. = ..()
 
 
@@ -390,7 +390,7 @@
 		if(M.anti_magic_check())
 			M.visible_message("<span class='warning'>[src] vanishes on contact with [A]!</span>")
 			qdel(src)
-			return
+			return BULLET_ACT_BLOCK
 		if(!locker_temp_instance.insertion_allowed(M))
 			return ..()
 		M.forceMove(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

They did not return correctly, so they still applied parts of their effects. I also need to test removing the qdel, as it seems unnecessary and other magic projectiles without it are working while the ones with it aren't.

fixes #45400 