### PR TITLE
Replaces snowdin gas miners with gas turfs

### DIFF
--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -7784,7 +7784,7 @@
 	id_tag = "snowdin_toxins_out";
 	name = "toxin out"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/plasma,
 /area/awaymission/snowdin/post/engineering)
 "rN" = (
 /obj/machinery/air_sensor{
@@ -7792,7 +7792,7 @@
 	id_tag = "snowdin_toxins";
 	name = "gas sensor (toxins)"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/plasma,
 /area/awaymission/snowdin/post/engineering)
 "rO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -7801,7 +7801,7 @@
 	id_tag = "snowdin_oxygen_out";
 	name = "oxygen out"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/o2,
 /area/awaymission/snowdin/post/engineering)
 "rP" = (
 /obj/machinery/air_sensor{
@@ -7809,7 +7809,7 @@
 	id_tag = "snowdin_oxygen";
 	name = "gas sensor (oxygen)"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/o2,
 /area/awaymission/snowdin/post/engineering)
 "rQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -7818,7 +7818,7 @@
 	id_tag = "snowdin_nitrogen_out";
 	name = "nitrogen out"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/n2,
 /area/awaymission/snowdin/post/engineering)
 "rR" = (
 /obj/machinery/air_sensor{
@@ -7826,7 +7826,7 @@
 	id_tag = "snowdin_nitrogen";
 	name = "gas sensor (nitrogen)"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/n2,
 /area/awaymission/snowdin/post/engineering)
 "rS" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -7914,20 +7914,17 @@
 /turf/open/floor/engine,
 /area/awaymission/snowdin/post/engineering)
 "sh" = (
-/obj/machinery/atmospherics/miner/toxins,
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/plasma,
 /area/awaymission/snowdin/post/engineering)
 "si" = (
 /obj/machinery/light/small,
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/plasma,
 /area/awaymission/snowdin/post/engineering)
 "sj" = (
-/obj/machinery/atmospherics/miner/oxygen,
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/o2,
 /area/awaymission/snowdin/post/engineering)
 "sk" = (
-/obj/machinery/atmospherics/miner/nitrogen,
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/n2,
 /area/awaymission/snowdin/post/engineering)
 "sl" = (
 /obj/effect/turf_decal/stripes/line{
@@ -9887,11 +9884,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/cave)
 "yg" = (
-/turf/open/floor/engine/vacuum,
-/area/awaymission/snowdin/cave)
-"yh" = (
-/obj/machinery/atmospherics/miner/toxins,
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/plasma,
 /area/awaymission/snowdin/cave)
 "yi" = (
 /obj/effect/turf_decal/stripes/line{
@@ -10005,7 +9998,7 @@
 	id_tag = "snowdin_toxins_mine_1";
 	name = "toxin out"
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/plasma,
 /area/awaymission/snowdin/cave)
 "yv" = (
 /turf/closed/wall/mineral/snow,
@@ -10234,7 +10227,7 @@
 	id_tag = "snowdin_toxins_mine_1";
 	name = "toxin out"
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/plasma,
 /area/awaymission/snowdin/cave)
 "zc" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -13352,7 +13345,7 @@
 /turf/open/floor/plating/asteroid/snow,
 /area/awaymission/snowdin/cave/mountain)
 "Ho" = (
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/plasma,
 /area/awaymission/snowdin/outside)
 "Hp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -13361,7 +13354,7 @@
 	id_tag = "snowdin_toxins_mine_1";
 	name = "toxin out"
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/plasma,
 /area/awaymission/snowdin/outside)
 "Hq" = (
 /obj/effect/turf_decal/bot,
@@ -13484,10 +13477,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/mining_main)
-"HH" = (
-/obj/machinery/atmospherics/miner/toxins,
-/turf/open/floor/engine/vacuum,
-/area/awaymission/snowdin/outside)
 "HI" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister,
@@ -14287,6 +14276,10 @@
 "JQ" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/awaymission/snowdin/post/mining_main)
+"JT" = (
+/obj/machinery/light/small,
+/turf/open/floor/engine/o2,
+/area/awaymission/snowdin/post/engineering)
 "JU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -14778,6 +14771,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
+"Oo" = (
+/obj/machinery/light/small,
+/turf/open/floor/engine/n2,
+/area/awaymission/snowdin/post/engineering)
 "OF" = (
 /obj/machinery/door/airlock/external{
 	name = "Ready Room";
@@ -28459,7 +28456,7 @@ ae
 ae
 ae
 ai
-yh
+yg
 yg
 ai
 wQ
@@ -28698,9 +28695,9 @@ aj
 aj
 ai
 yg
-yh
 yg
-yh
+yg
+yg
 yg
 ai
 ae
@@ -29889,7 +29886,7 @@ qy
 ra
 rt
 rP
-si
+JT
 oW
 am
 am
@@ -30660,7 +30657,7 @@ qB
 rb
 rt
 rR
-si
+Oo
 oW
 ag
 af
@@ -31106,7 +31103,7 @@ Fx
 Fy
 GS
 Ho
-HH
+Ho
 tq
 ae
 ae
@@ -32391,7 +32388,7 @@ te
 Gw
 GS
 Ho
-HH
+Ho
 tq
 ae
 ae
@@ -32568,7 +32565,7 @@ ae
 ae
 ai
 yg
-yh
+yg
 ai
 ae
 ae
@@ -34093,7 +34090,7 @@ ae
 ae
 ae
 ai
-yh
+yg
 yg
 ai
 ae


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR replaces the snowdin away mission gas miners with regular atmos turfs (like in the atmos tanks).

## Why It's Good For The Game

Miners are awful gameplay wise since they are magical infinite gas spawners, they don't work half the time and we don't really need yet another z level to simulate atmos on.

## Changelog
:cl:
tweak: Replaced the snow in away mission's gas miners with gas turfs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
