### PR TITLE
Sanity is now capped.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -139,6 +139,7 @@
 #define MOOD_LEVEL_SAD4 -20
 
 //Sanity levels for humans
+#define SANITY_MAXIMUM 150
 #define SANITY_GREAT 125
 #define SANITY_NEUTRAL 100
 #define SANITY_DISTURBED 75

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -188,9 +188,9 @@
 		if(7)
 			setSanity(sanity+0.3)
 		if(8)
-			setSanity(sanity+0.4, maximum=INFINITY)
+			setSanity(sanity+0.4, maximum=SANITY_MAXIMUM)
 		if(9)
-			setSanity(sanity+0.6, maximum=INFINITY)
+			setSanity(sanity+0.6, maximum=SANITY_MAXIMUM)
 
 	HandleNutrition(owner)
 


### PR DESCRIPTION
## About The Pull Request

Fixies a fuckie wuckie caused by Floyd-chan bweing a baka. Sanaties is naow cappied at 150.

## Why It's Good For The Game

Infinite perfect sanity bad. Actual maximum sanity is up to debate if anyone has strong feeling on this.
Fixes #45391

## Changelog
:cl:
balance: Sanity is no longer uncapped. It's now capped at 150, whatever that means.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
