### PR TITLE
APCs produce a tesla shock when highly overcharged

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1257,11 +1257,9 @@
 			chargecount = 0
 
 		//if the cell is fully charged but there is too much excess power, the APC will produce a tesla shock
-		if(excess > (cell.maxcharge * 100))
-			if(cell.charge != cell.maxcharge)
-				return
+		if((excess > (cell.maxcharge * 100)) && (cell.charge == cell.maxcharge))
 			if(cell_type == /obj/item/stock_parts/cell/high/slime)
-				return
+				return TRUE
 			if(prob(50))
 				playsound(src, 'sound/magic/lightningshock.ogg', 100, 1, extrarange = 5)
 				tesla_zap(src, 5, avail() * 0.1, TESLA_MOB_DAMAGE | TESLA_OBJ_DAMAGE | TESLA_MOB_STUN | TESLA_ALLOW_DUPLICATES)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1256,6 +1256,16 @@
 			charging = 0
 			chargecount = 0
 
+		//if the cell is fully charged but there is too much excess power, the APC will produce a tesla shock
+		if(excess > (cell.maxcharge * 100))
+			if(cell.charge != cell.maxcharge)
+				return
+			if(cell_type == /obj/item/stock_parts/cell/high/slime)
+				return
+			if(prob(50))
+				playsound(src, 'sound/magic/lightningshock.ogg', 100, 1, extrarange = 5)
+				tesla_zap(src, 5, avail() * 0.1, TESLA_MOB_DAMAGE | TESLA_OBJ_DAMAGE | TESLA_MOB_STUN | TESLA_ALLOW_DUPLICATES)
+
 	else // no cell, switch everything off
 
 		charging = APC_NOT_CHARGING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
APCs will produce a tesla shock if they are fully charged and the excess power in the powernet is far above their max charge. Giving an APC a better cell will increase the range of safe operation. Charged slime cores will prevent shocks entirely.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Most rounds as engineer amount to setting up the sm/solars, maxing the SMES input/output and occasionally fixing stuff with little else of consequence. Creating a hazard to the amount of power dumped into the grid add an extra duty of making sure each SMES has been set responsibly and that no dirty traitors are going around hotwiring engines directly into the powernet.

TESTING AND FEEDBACK ARE APPRECIATED
I've done a bit of testing on my own to make sure it works, aside from a runtime related to an addtimer callback (will likely be fixed by #45432). I'd like some input on getting the balance right between the amount of excess power to trigger the shock and how much damage is dealt. Also would like to know if anything could be added/changed to make this more fun than obnoxious.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Nanotrasen would like to warn its engineers of the dangers in adding excessive amounts of power to the APC network.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
