### PR TITLE
Fixes #42319, closes bold tag for IRC admin pms

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -146,7 +146,7 @@
 
 	if(irc)
 		to_chat(src, "<span class='notice'>PM to-<b>Admins</b>: <span class='linkify'>[rawmsg]</span></span>")
-		var/datum/admin_help/AH = admin_ticket_log(src, "<font color='red'>Reply PM from-<b>[key_name(src, TRUE, TRUE)] to <i>IRC</i>: [keywordparsedmsg]</font>")
+		var/datum/admin_help/AH = admin_ticket_log(src, "<font color='red'>Reply PM from-<b>[key_name(src, TRUE, TRUE)]</b> to <i>IRC</i>: [keywordparsedmsg]</font>")
 		ircreplyamount--
 		send2irc("[AH ? "#[AH.id] " : ""]Reply: [ckey]", rawmsg)
 	else

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -118,6 +118,9 @@
 	if(brainmob) //if we aren't trying to heal the brain, pass the attack onto the brainmob.
 		O.attack(brainmob, user) //Oh noooeeeee
 
+        if((O.force == 0) || (O.item_flags & NOBLUDGEON))
+            return // it's okay, we're saved
+
 	damaged_brain = TRUE //brain was attacked, they're pretty fragile.
 
 /obj/item/organ/brain/examine(mob/user)


### PR DESCRIPTION
Adds a missing closing bold tag to fix the formatting of IRC admin PMs.
Fixes https://github.com/tgstation/tgstation/issues/42319