### PR TITLE
Spending of tank don't change distribute_pressure.

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -219,10 +219,9 @@
 		return null
 
 	var/tank_pressure = air_contents.return_pressure()
-	if(tank_pressure < distribute_pressure)
-		distribute_pressure = tank_pressure
+	var/actual_distribute_pressure = CLAMP(tank_pressure, 0, distribute_pressure)
 
-	var/moles_needed = distribute_pressure*volume_to_return/(R_IDEAL_GAS_EQUATION*air_contents.temperature)
+	var/moles_needed = actual_distribute_pressure*volume_to_return/(R_IDEAL_GAS_EQUATION*air_contents.temperature)
 
 	return remove_air(moles_needed)
 


### PR DESCRIPTION
## About The Pull Request
Spending of tank don't change distribute_pressure.
Tank still give max of available pressure.
## Why It's Good For The Game
No need set your favored tank pressure if you spend all tank.
## Changelog
:cl:
add: Spending of tank don't change distribute_pressure.
/:cl:
