### PR TITLE
buffs mining tools

### DIFF
--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -91,8 +91,8 @@
 	w_class = WEIGHT_CLASS_HUGE //the epitome of power(gamer)tools is CHUNCKY
 	usesound = 'sound/weapons/sonic_jackhammer.ogg'
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
-	desc = "Cracks rocks with sonic blasts, and doubles as a demolition power tool for smashing walls."
-	force = 20
+	desc = "Cracks rocks with sonic blasts, and doubles as a demolition power tool for smashing walls. Specifically adjusted to that though, so you won't do much damage with it."
+	force = 10
 
 /obj/item/shovel
 	name = "shovel"

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -91,7 +91,7 @@
 	w_class = WEIGHT_CLASS_HUGE //the epitome of power(gamer)tools is CHUNCKY
 	usesound = 'sound/weapons/sonic_jackhammer.ogg'
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
-	desc = "Cracks rocks with sonic blasts, and doubles as a demolition power tool for smashing walls. Specifically adjusted to that though, so you won't do much damage with it."
+	desc = "Cracks rocks with sonic blasts, and doubles as a demolition power tool for smashing walls. Specifically adjusted to do that though, so you won't do much damage with it."
 	force = 10
 
 /obj/item/shovel

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -59,6 +59,7 @@
 	usesound = 'sound/weapons/drill.ogg'
 	hitsound = 'sound/weapons/drill.ogg'
 	desc = "An electric mining drill for the especially scrawny."
+	force = 17
 
 /obj/item/pickaxe/drill/cyborg
 	name = "cyborg mining drill"
@@ -74,11 +75,13 @@
 	icon_state = "diamonddrill"
 	toolspeed = 0.2
 	desc = "Yours is the drill that will pierce the heavens!"
+	force = 19
 
 /obj/item/pickaxe/drill/cyborg/diamond //This is the BORG version!
 	name = "diamond-tipped cyborg mining drill" //To inherit the NODROP_1 flag, and easier to change borg specific drill mechanics.
 	icon_state = "diamonddrill"
 	toolspeed = 0.2
+	force = 19
 
 /obj/item/pickaxe/drill/jackhammer
 	name = "sonic jackhammer"
@@ -89,6 +92,7 @@
 	usesound = 'sound/weapons/sonic_jackhammer.ogg'
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	desc = "Cracks rocks with sonic blasts, and doubles as a demolition power tool for smashing walls."
+	force = 20
 
 /obj/item/shovel
 	name = "shovel"


### PR DESCRIPTION
## About The Pull Request

buffs drill damage from pickaxe's 15 to 17, diamond drill from 15 to 19 and jackhammer nerfed from 15 to 10

## Why It's Good For The Game

a drill should do more damage than a pickaxe
jackhammer is griff tool and deservess less power
silver and diamond pickaxes deal more damage than regular pickaxe but drill variants always stay the same??

## Changelog
:cl:
balance: mining drills deal more damage, jackhammer deals less
/:cl:
