### PR TITLE
Fix mob fall in open space on zero gravity

### DIFF
--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -50,7 +50,7 @@
 	remove_movespeed_modifier(MOVESPEED_ID_PRONE_DRAGGING)
 
 /mob/living/can_zFall(turf/T, levels)
-	return !(movement_type & FLYING)
+	return ..() //!(movement_type & FLYING) 
 
 /mob/living/canZMove(dir, turf/target)
 	return can_zTravel(target, dir) && (movement_type & FLYING)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -50,7 +50,7 @@
 	remove_movespeed_modifier(MOVESPEED_ID_PRONE_DRAGGING)
 
 /mob/living/can_zFall(turf/T, levels)
-	return ..() //!(movement_type & FLYING) 
+	return ..()
 
 /mob/living/canZMove(dir, turf/target)
 	return can_zTravel(target, dir) && (movement_type & FLYING)


### PR DESCRIPTION
## About The Pull Request
fix#44679

## Why It's Good For The Game
Zero gravity is zero gravity. What push you to down in open space if there is no gravity?

## Changelog
:cl:
fix: Mob no more falling in zero gravity
/:cl:
