### PR TITLE
Exit from mecha in zero gravity now instant.

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -986,7 +986,7 @@
 /obj/mecha/container_resist(mob/living/user)
 	is_currently_ejecting = TRUE
 	to_chat(occupant, "<span class='notice'>You begin the ejection procedure. Equipment is disabled during this process. Hold still to finish ejecting.</span>")
-	if(do_after(occupant,exit_delay, target = src))
+	if(do_after(occupant, has_gravity() ? exit_delay : 0 , target = src))
 		to_chat(occupant, "<span class='notice'>You exit the mech.</span>")
 		go_out()
 	else


### PR DESCRIPTION
## About The Pull Request
fix#44024
Exit from mecha in zero gravity now instant.
## Why It's Good For The Game
Bad when you cant exit from spacedrifting mecha.
## Changelog
:cl:
fix: Now you can exit from mecha drifting in zero gravity.
/:cl: