### PR TITLE
gives saboteur borg zipties

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -621,6 +621,7 @@
 		/obj/item/borg/sight/thermal,
 		/obj/item/construction/rcd/borg/syndicate,
 		/obj/item/pipe_dispenser,
+		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/extinguisher,
 		/obj/item/weldingtool/largetank/cyborg,
 		/obj/item/screwdriver/nuke,


### PR DESCRIPTION
## About The Pull Request

what title says

## Why It's Good For The Game

allows saboteur borgs to do some "stealthier" missions and gives it something to do, its the least used module and zipties for when a welder and fire extinguisher arent enough are cool

## Changelog
:cl:
add: saboteur b*rgs get zipties
/:cl:
