### PR TITLE
fixes malf recalls not working at all while also nerfing them

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -271,7 +271,7 @@ SUBSYSTEM_DEF(shuttle)
 
 /datum/controller/subsystem/shuttle/proc/cancelEvac(mob/user)
 	if(!canRecall())
-		return
+		return FALSE
 	if(isAI(user))
 		minor_announce("The shuttle has been recalled at <span class='name'>[get_area_name(user, TRUE)]</span>. Have a secure day.")
 	emergency.cancel(get_area(user))

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -272,7 +272,7 @@ SUBSYSTEM_DEF(shuttle)
 /datum/controller/subsystem/shuttle/proc/cancelEvac(mob/user)
 	if(!canRecall())
 		return
-	if(isai(user))
+	if(isAI(user))
 		minor_announce("The shuttle has been recalled at <span class='name'>[get_area_name(user, TRUE)]</span>. Have a secure day.")
 	emergency.cancel(get_area(user))
 	log_game("[key_name(user)] has recalled the shuttle.")

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -270,12 +270,16 @@ SUBSYSTEM_DEF(shuttle)
 	src.emergency = src.backup_shuttle
 
 /datum/controller/subsystem/shuttle/proc/cancelEvac(mob/user)
-	if(canRecall())
-		emergency.cancel(get_area(user))
-		log_game("[key_name(user)] has recalled the shuttle.")
-		message_admins("[ADMIN_LOOKUPFLW(user)] has recalled the shuttle.")
-		deadchat_broadcast(" has recalled the shuttle from <span class='name'>[get_area_name(user, TRUE)]</span>.", "<span class='name'>[user.real_name]</span>", user)
-		return 1
+	if(!canRecall())
+		return
+	if(isai(user))
+		minor_announce("The shuttle has been recalled at <span class='name'>[get_area_name(user, TRUE)]</span>. Have a secure day.")
+	emergency.cancel(get_area(user))
+	log_game("[key_name(user)] has recalled the shuttle.")
+	message_admins("[ADMIN_LOOKUPFLW(user)] has recalled the shuttle.")
+	deadchat_broadcast(" has recalled the shuttle from <span class='name'>[get_area_name(user, TRUE)]</span>.", "<span class='name'>[user.real_name]</span>", user)
+	return TRUE
+	
 
 /datum/controller/subsystem/shuttle/proc/canRecall()
 	if(!emergency || emergency.mode != SHUTTLE_CALL || emergencyNoRecall || SSticker.mode.name == "meteor")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -889,6 +889,7 @@
 	to_chat(src, "You are also capable of hacking APCs, which grants you more points to spend on your Malfunction powers. The drawback is that a hacked APC will give you away if spotted by the crew. Hacking an APC takes 60 seconds.")
 	view_core() //A BYOND bug requires you to be viewing your core before your verbs update
 	verbs += /mob/living/silicon/ai/proc/choose_modules
+	verbs += /mob/living/silicon/ai/proc/ai_cancel_call
 	malf_picker = new /datum/module_picker
 
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -357,6 +357,7 @@
 
 /mob/living/silicon/ai/proc/ai_cancel_call()
 	set category = "Malfunction"
+	set name = "Cancel Shuttle Call"
 	if(control_disabled)
 		to_chat(src, "<span class='warning'>Wireless control is disabled!</span>")
 		return


### PR DESCRIPTION
## About The Pull Request

this pr fixes malf recall ability not showing up because it had no name (i think thats why)
it also nerfs it by announcing the place where the ai recalled the shuttle

## Why It's Good For The Game

dead code getting fixed

## Changelog
:cl:
fix: malf ais can now recall the shuttle
balance: using the recall ability tells the crew where you are though, so be strategic about it
/:cl:
