### PR TITLE
Makes TRAIT_NOMETABOLISM mobs immune to clone damage

### DIFF
--- a/code/modules/mob/living/carbon/human/damage_procs.dm
+++ b/code/modules/mob/living/carbon/human/damage_procs.dm
@@ -3,3 +3,13 @@
 /mob/living/carbon/human/apply_damage(damage = 0,damagetype = BRUTE, def_zone = null, blocked = FALSE, forced = FALSE, spread_damage = FALSE)
 	// depending on the species, it will run the corresponding apply_damage code there
 	return dna.species.apply_damage(damage, damagetype, def_zone, blocked, src, forced, spread_damage)
+
+/mob/living/carbon/human/adjustCloneLoss(amount, updating_health = TRUE, forced = FALSE)
+	if(HAS_TRAIT(src, TRAIT_NOMETABOLISM))
+		return FALSE
+	return ..()
+
+/mob/living/carbon/human/setCloneLoss(amount, updating_health = TRUE, forced = FALSE)
+	if(HAS_TRAIT(src, TRAIT_NOMETABOLISM))
+		return FALSE
+	return ..()

--- a/code/modules/mob/living/carbon/human/damage_procs.dm
+++ b/code/modules/mob/living/carbon/human/damage_procs.dm
@@ -5,11 +5,11 @@
 	return dna.species.apply_damage(damage, damagetype, def_zone, blocked, src, forced, spread_damage)
 
 /mob/living/carbon/human/adjustCloneLoss(amount, updating_health = TRUE, forced = FALSE)
-	if(HAS_TRAIT(src, TRAIT_NOMETABOLISM))
+	if(!forced && HAS_TRAIT(src, TRAIT_NOMETABOLISM))
 		return FALSE
 	return ..()
 
 /mob/living/carbon/human/setCloneLoss(amount, updating_health = TRUE, forced = FALSE)
-	if(HAS_TRAIT(src, TRAIT_NOMETABOLISM))
+	if(!forced && HAS_TRAIT(src, TRAIT_NOMETABOLISM))
 		return FALSE
 	return ..()

--- a/code/modules/mob/living/carbon/human/damage_procs.dm
+++ b/code/modules/mob/living/carbon/human/damage_procs.dm
@@ -3,13 +3,3 @@
 /mob/living/carbon/human/apply_damage(damage = 0,damagetype = BRUTE, def_zone = null, blocked = FALSE, forced = FALSE, spread_damage = FALSE)
 	// depending on the species, it will run the corresponding apply_damage code there
 	return dna.species.apply_damage(damage, damagetype, def_zone, blocked, src, forced, spread_damage)
-
-/mob/living/carbon/human/adjustCloneLoss(amount, updating_health = TRUE, forced = FALSE)
-	if(!forced && HAS_TRAIT(src, TRAIT_NOMETABOLISM))
-		return FALSE
-	return ..()
-
-/mob/living/carbon/human/setCloneLoss(amount, updating_health = TRUE, forced = FALSE)
-	if(!forced && HAS_TRAIT(src, TRAIT_NOMETABOLISM))
-		return FALSE
-	return ..()

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -217,7 +217,7 @@
 	return cloneloss
 
 /mob/living/proc/adjustCloneLoss(amount, updating_health = TRUE, forced = FALSE)
-	if(!forced && (status_flags & GODMODE))
+	if(!forced && ((status_flags & GODMODE) || HAS_TRAIT(src, TRAIT_NOMETABOLISM)))
 		return FALSE
 	cloneloss = CLAMP((cloneloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
 	if(updating_health)
@@ -225,7 +225,7 @@
 	return amount
 
 /mob/living/proc/setCloneLoss(amount, updating_health = TRUE, forced = FALSE)
-	if(!forced && (status_flags & GODMODE))
+	if(!forced && ((status_flags & GODMODE) || HAS_TRAIT(src, TRAIT_NOMETABOLISM)))
 		return FALSE
 	cloneloss = amount
 	if(updating_health)


### PR DESCRIPTION
Fixes #45378

## Changelog
:cl:
fix: TRAIT_NOMETABOLISM species are now immune to clone damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
