### PR TITLE
Fix showing agent ID cards while incapacitated

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -368,6 +368,8 @@ update_label()
 				return ..()
 
 		var/popup_input = alert(user, "Action", "Agent ID", "Show", "Forge", "Change Account ID")
+		if(user.incapacitated())
+			return
 		if(popup_input == "Forge")
 			var/t = copytext(sanitize(input(user, "What name would you like to put on this card?", "Agent card name", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name))as text | null),1,26)
 			if(!t || t == "Unknown" || t == "floor" || t == "wall" || t == "r-wall") //Same as mob/dead/new_player/prefrences.dm


### PR DESCRIPTION
Fixes #44694

Looks like there was no incapacitated check after the alert