### PR TITLE
Cat 2 Med downside tweak.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -190,6 +190,7 @@
 #define ABSTRACT_ITEM_TRAIT "abstract-item"
 #define STATUS_EFFECT_TRAIT "status-effect"
 #define CLOTHING_TRAIT "clothing"
+#define MEDICINE_TRAIT "medicine" //Medical side effects.
 
 // unique trait sources, still defines
 #define CLONING_POD_TRAIT "cloning-pod"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -190,7 +190,6 @@
 #define ABSTRACT_ITEM_TRAIT "abstract-item"
 #define STATUS_EFFECT_TRAIT "status-effect"
 #define CLOTHING_TRAIT "clothing"
-#define MEDICINE_TRAIT "medicine" //Medical side effects.
 
 // unique trait sources, still defines
 #define CLONING_POD_TRAIT "cloning-pod"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -230,3 +230,6 @@
 #define ANTI_DROP_IMPLANT_TRAIT "anti-drop-implant"
 #define HIVEMIND_ONE_MIND_TRAIT "one_mind"
 #define VR_ZONE_TRAIT "vr_zone_trait"
+#define SANGUIOSE_TRAIT "sanguiose"
+#define FROGENITE_TRAIT "frogenite"
+#define FERVEATIUM_TRAIT "ferveatium"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1418,7 +1418,7 @@
 
 /datum/reagent/medicine/sanguiose/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-1, 0)
-	if(prob(33))
+	if(prob(1))
 		ADD_TRAIT(M, TRAIT_MUTE, MEDICINE_TRAIT)
 	//Removes blood
 	..()
@@ -1451,7 +1451,7 @@
 
 /datum/reagent/medicine/frogenite/on_mob_life(mob/living/carbon/M) //Reuses code done by cobby in Perflu to convert burn damage to oxygen, Meant to simunlate a chemical reaction to remove oxygen from the body.
 	M.adjustFireLoss(-1, 0)
-	if(prob(33))
+	if(prob(1))
 		//Adds blindness witha  33% chance
 		ADD_TRAIT(M, TRAIT_BLIND, MEDICINE_TRAIT)
 	..()
@@ -1486,7 +1486,7 @@
 
 /datum/reagent/medicine/ferveatium/on_mob_life(mob/living/carbon/M) //Reuses code done by cobby in Perflu to convert burn damage to oxygen, Meant to simunlate a chemical reaction to remove oxygen from the body.
 	M.adjustToxLoss(-1, 0)
-	if(prob(33))
+	if(prob(1))
 		//Adds fatness with a 33% chance probability.
 		ADD_TRAIT(M, TRAIT_FAT, MEDICINE_TRAIT)
 	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1408,20 +1408,26 @@
 
 /datum/reagent/medicine/sanguiose
 	name = "Sanguiose"
-	description = "A chemical developed to aid in the butchering proccess, it causes a chemical reaction which consumes blood and oxygen while healing cuts, bruises, and other similar injuries,"
+	description = "A chemical developed to aid in the butchering proccess, it causes a chemical reaction which heals bruises and other similar injuries. Has a moderate chance of causing muteness in the user."
 	reagent_state = LIQUID
 	color = "#FF6464"
 	metabolization_rate = 0.5* REAGENTS_METABOLISM
 	overdose_threshold = 25
 	taste_description = "salty"
+	
 
 /datum/reagent/medicine/sanguiose/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-1, 0)
-	M.adjustOxyLoss(0.25,0)
-	M.blood_volume -= 1 //Removes blood
+	if(prob(33))
+		ADD_TRAIT(M, TRAIT_MUTE)
+	//Removes blood
 	..()
 	. = 1
 
+/datum/reagent/medicine/sanguiose/on_mob_delete(mob/living/L)
+	. = ..()
+	if(HAS_TRAIT_FROM(L, TRAIT_MUTE, src))
+		REMOVE_TRAIT(L, TRAIT_MUTE)
 /datum/reagent/medicine/sanguiose/overdose_process(mob/living/M)
 	M.adjustOxyLoss(3,0)
 	M.blood_volume -= 2 //I hope you like blood.
@@ -1436,7 +1442,7 @@
 
 /datum/reagent/medicine/frogenite
 	name = "Frogenite"
-	description = "An industrial cryostorage chemical previously used for preservation and storage. It removes oxygen from the body and heals to prevent and heal burns. If too much is injected the reaction will speed up dramatically removing all oxygen quickly."
+	description = "An industrial cryostorage chemical previously used for preservation and storage. It heals burns, but has a moderate chance of inducing temporary blindness. If too much is injected the medication will start freezing the hemoglobin reducing blood oxygen oxygen quickly."
 	reagent_state = LIQUID
 	color = "#00FFFF"
 	metabolization_rate = 0.5* REAGENTS_METABOLISM
@@ -1444,14 +1450,18 @@
 	taste_description = "Oil"
 
 /datum/reagent/medicine/frogenite/on_mob_life(mob/living/carbon/M) //Reuses code done by cobby in Perflu to convert burn damage to oxygen, Meant to simunlate a chemical reaction to remove oxygen from the body.
-	var/firecalc = 1*REM*current_cycle
 	M.adjustFireLoss(-1, 0)
-	if (firecalc <10)
-		M.adjustOxyLoss(firecalc*0.15, 0)
-	if (firecalc >= 10)
-		M.adjustOxyLoss(1.5,0)
+	if(prob(33))
+		//Adds blindness witha  33% chance
+		ADD_TRAIT(M, TRAIT_BLIND)
 	..()
 	. = 1
+
+/datum/reagent/medicine/frogenite/on_mob_delete(mob/living/L)
+	. = ..()
+	if(HAS_TRAIT_FROM(L, TRAIT_BLIND, src))
+		//removes blindness if trait comes from the medicine
+		REMOVE_TRAIT(L, TRAIT_BLIND)
 
 /datum/reagent/medicine/frogenite/overdose_process(mob/living/M)
 	M.adjustOxyLoss(15,0)
@@ -1468,7 +1478,7 @@
 
 /datum/reagent/medicine/ferveatium
 	name = "Ferveatium"
-	description = "A chemical previously used to cook questionable meat, it has come to enjoy a new life as a treatment for many poisons."
+	description = "A chemical previously used to cook questionable meat, it has come to enjoy a new life as a treatment for many poisons. Use has a slight chance of causing the patient to feel lethargic and slow."
 	reagent_state = LIQUID
 	color = "#00FFFF"
 	metabolization_rate = 0.5* REAGENTS_METABOLISM
@@ -1476,14 +1486,17 @@
 	taste_description = "Fire"
 
 /datum/reagent/medicine/ferveatium/on_mob_life(mob/living/carbon/M) //Reuses code done by cobby in Perflu to convert burn damage to oxygen, Meant to simunlate a chemical reaction to remove oxygen from the body.
-	var/toxcalc = 1*REM*current_cycle
 	M.adjustToxLoss(-1, 0)
-	if (toxcalc <10)
-		M.adjustFireLoss(toxcalc/10, 0)
-	if (toxcalc >= 10)
-		M.adjustFireLoss(1,0)
+	if(prob(33))
+		//Adds fatness with a 33% chance probability.
+		ADD_TRAIT(M, TRAIT_FAT)
 	..()
 	. = 1
+
+/datum/reagent/medicine/ferveatium/on_mob_delete(mob/living/L)
+	. = ..()
+	if(HAS_TRAIT_FROM(L, TRAIT_FAT, src))
+		REMOVE_TRAIT(L, TRAIT_FAT)
 
 /datum/reagent/medicine/ferveatium/overdose_process(mob/living/M)
 	M.adjustFireLoss(15,0)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1415,7 +1415,6 @@
 	overdose_threshold = 25
 	taste_description = "salty"
 	
-
 /datum/reagent/medicine/sanguiose/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-1, 0)
 	if(prob(1))

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1417,8 +1417,8 @@
 	
 /datum/reagent/medicine/sanguiose/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-1, 0)
-	if(prob(1))
-		//Adds deafness with a 1% chance
+	if(prob(2))
+		//Adds deafness with a 2% chance
 		ADD_TRAIT(M, TRAIT_DEAF, SANGUIOSE_TRAIT)
 	..()
 	. = 1
@@ -1450,8 +1450,8 @@
 
 /datum/reagent/medicine/frogenite/on_mob_life(mob/living/carbon/M) //Reuses code done by cobby in Perflu to convert burn damage to oxygen, Meant to simunlate a chemical reaction to remove oxygen from the body.
 	M.adjustFireLoss(-1, 0)
-	if(prob(1))
-		//Adds blindness witha  1% chance
+	if(prob(2))
+		//Adds blindness witha 2% chance
 		ADD_TRAIT(M, TRAIT_BLIND, FROGENITE_TRAIT)
 	..()
 	. = 1
@@ -1485,8 +1485,8 @@
 
 /datum/reagent/medicine/ferveatium/on_mob_life(mob/living/carbon/M) //Reuses code done by cobby in Perflu to convert burn damage to oxygen, Meant to simunlate a chemical reaction to remove oxygen from the body.
 	M.adjustToxLoss(-1, 0)
-	if(prob(1))
-		//Adds fatness with a 1% chance probability.
+	if(prob(2))
+		//Adds fatness with a 2% chance probability.
 		ADD_TRAIT(M, TRAIT_FAT, FERVEATIUM_TRAIT)
 	..()
 	. = 1

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1408,7 +1408,7 @@
 
 /datum/reagent/medicine/sanguiose
 	name = "Sanguiose"
-	description = "A chemical developed to aid in the butchering proccess, it causes a chemical reaction which heals bruises and other similar injuries. Has a moderate chance of causing muteness in the user."
+	description = "A chemical developed to aid in the butchering proccess, it causes a chemical reaction which heals bruises and other similar injuries. Has a moderate chance of causing deafness in the user."
 	reagent_state = LIQUID
 	color = "#FF6464"
 	metabolization_rate = 0.5* REAGENTS_METABOLISM

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1419,15 +1419,15 @@
 /datum/reagent/medicine/sanguiose/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-1, 0)
 	if(prob(33))
-		ADD_TRAIT(M, TRAIT_MUTE)
+		ADD_TRAIT(M, TRAIT_MUTE, MEDICINE_TRAIT)
 	//Removes blood
 	..()
 	. = 1
 
 /datum/reagent/medicine/sanguiose/on_mob_delete(mob/living/L)
 	. = ..()
-	if(HAS_TRAIT_FROM(L, TRAIT_MUTE, src))
-		REMOVE_TRAIT(L, TRAIT_MUTE)
+	//removes trait if it comes from the medicine trait.
+	REMOVE_TRAIT(L, TRAIT_MUTE, MEDICINE_TRAIT)
 /datum/reagent/medicine/sanguiose/overdose_process(mob/living/M)
 	M.adjustOxyLoss(3,0)
 	M.blood_volume -= 2 //I hope you like blood.
@@ -1453,15 +1453,14 @@
 	M.adjustFireLoss(-1, 0)
 	if(prob(33))
 		//Adds blindness witha  33% chance
-		ADD_TRAIT(M, TRAIT_BLIND)
+		ADD_TRAIT(M, TRAIT_BLIND, MEDICINE_TRAIT)
 	..()
 	. = 1
 
 /datum/reagent/medicine/frogenite/on_mob_delete(mob/living/L)
 	. = ..()
-	if(HAS_TRAIT_FROM(L, TRAIT_BLIND, src))
-		//removes blindness if trait comes from the medicine
-		REMOVE_TRAIT(L, TRAIT_BLIND)
+	//removes blindness if trait comes from the medicine
+	REMOVE_TRAIT(L, TRAIT_BLIND, MEDICINE_TRAIT)
 
 /datum/reagent/medicine/frogenite/overdose_process(mob/living/M)
 	M.adjustOxyLoss(15,0)
@@ -1489,14 +1488,14 @@
 	M.adjustToxLoss(-1, 0)
 	if(prob(33))
 		//Adds fatness with a 33% chance probability.
-		ADD_TRAIT(M, TRAIT_FAT)
+		ADD_TRAIT(M, TRAIT_FAT, MEDICINE_TRAIT)
 	..()
 	. = 1
 
 /datum/reagent/medicine/ferveatium/on_mob_delete(mob/living/L)
 	. = ..()
-	if(HAS_TRAIT_FROM(L, TRAIT_FAT, src))
-		REMOVE_TRAIT(L, TRAIT_FAT)
+	//removes the fat trait.
+	REMOVE_TRAIT(L, TRAIT_FAT, MEDICINE_TRAIT)
 
 /datum/reagent/medicine/ferveatium/overdose_process(mob/living/M)
 	M.adjustFireLoss(15,0)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1419,15 +1419,15 @@
 /datum/reagent/medicine/sanguiose/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-1, 0)
 	if(prob(1))
-		ADD_TRAIT(M, TRAIT_MUTE, MEDICINE_TRAIT)
-	//Removes blood
+		//Adds deafness with a 1% chance
+		ADD_TRAIT(M, TRAIT_DEAF, SANGUIOSE_TRAIT)
 	..()
 	. = 1
 
 /datum/reagent/medicine/sanguiose/on_mob_delete(mob/living/L)
 	. = ..()
 	//removes trait if it comes from the medicine trait.
-	REMOVE_TRAIT(L, TRAIT_MUTE, MEDICINE_TRAIT)
+	REMOVE_TRAIT(L, TRAIT_DEAF, SANGUIOSE_TRAIT)
 /datum/reagent/medicine/sanguiose/overdose_process(mob/living/M)
 	M.adjustOxyLoss(3,0)
 	M.blood_volume -= 2 //I hope you like blood.
@@ -1452,15 +1452,15 @@
 /datum/reagent/medicine/frogenite/on_mob_life(mob/living/carbon/M) //Reuses code done by cobby in Perflu to convert burn damage to oxygen, Meant to simunlate a chemical reaction to remove oxygen from the body.
 	M.adjustFireLoss(-1, 0)
 	if(prob(1))
-		//Adds blindness witha  33% chance
-		ADD_TRAIT(M, TRAIT_BLIND, MEDICINE_TRAIT)
+		//Adds blindness witha  1% chance
+		ADD_TRAIT(M, TRAIT_BLIND, FROGENITE_TRAIT)
 	..()
 	. = 1
 
 /datum/reagent/medicine/frogenite/on_mob_delete(mob/living/L)
 	. = ..()
 	//removes blindness if trait comes from the medicine
-	REMOVE_TRAIT(L, TRAIT_BLIND, MEDICINE_TRAIT)
+	REMOVE_TRAIT(L, TRAIT_BLIND, FROGENITE_TRAIT)
 
 /datum/reagent/medicine/frogenite/overdose_process(mob/living/M)
 	M.adjustOxyLoss(15,0)
@@ -1487,15 +1487,15 @@
 /datum/reagent/medicine/ferveatium/on_mob_life(mob/living/carbon/M) //Reuses code done by cobby in Perflu to convert burn damage to oxygen, Meant to simunlate a chemical reaction to remove oxygen from the body.
 	M.adjustToxLoss(-1, 0)
 	if(prob(1))
-		//Adds fatness with a 33% chance probability.
-		ADD_TRAIT(M, TRAIT_FAT, MEDICINE_TRAIT)
+		//Adds fatness with a 1% chance probability.
+		ADD_TRAIT(M, TRAIT_FAT, FERVEATIUM_TRAIT)
 	..()
 	. = 1
 
 /datum/reagent/medicine/ferveatium/on_mob_delete(mob/living/L)
 	. = ..()
 	//removes the fat trait.
-	REMOVE_TRAIT(L, TRAIT_FAT, MEDICINE_TRAIT)
+	REMOVE_TRAIT(L, TRAIT_FAT, FERVEATIUM_TRAIT)
 
 /datum/reagent/medicine/ferveatium/overdose_process(mob/living/M)
 	M.adjustFireLoss(15,0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This removes the damage dealing from the newly added cat 2s and replaces them with side effects that are less extreme.

Sanguiose now has a 2% chance per tick of rendering the patient deaf
Frogenite now has a 2% chance per tick of making you blind.
Ferveatium now has a 2% chance per tick of making you fat.

This effect is removed after the medication has left the system, making the patient go back to normal.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This removes weird philosophical problems related to cyborgs injecting stuff into people that causes direct physical harm, and also makes the downsides to these medications _fun_ instead of just something that is annoying for both the patient and doctor.

This also prevents medibots from literally killing people. They already had an OD problem, giving them damage swap chems is just asking for trouble.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Sanguiose now has a 2% chance per tick of making the patient deaf, and no longer deals blood loss.
tweak: Frogenite now has a 2% chance per tick of making the patient blind, and no longer deals oxy damage.
tweak: Ferveatium now has a 2% chance per tick  of making the patient feel fat, and no longer deals burn damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
