### PR TITLE
Add gh-pages domain, fix missing DEFINES folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,8 +86,10 @@ matrix:
         - git checkout $TRAVIS_BRANCH || true
       script:
         - ~/dmdoc
+        - touch dmdoc/.nojekyll
       deploy:
         provider: pages
         skip_cleanup: true
         local_dir: dmdoc
         github_token: $DMDOC_GITHUB_TOKEN
+        fqdn: codedocs.tgstation13.org


### PR DESCRIPTION
https://docs.travis-ci.com/user/deployment/pages/
> It is now possible to completely bypass Jekyll processing on [GitHub Pages](https://pages.github.com/) by creating a file named `.nojekyll` in the root of your pages repo and pushing it to GitHub. This should only be necessary if your site uses files or directories that start with underscores since Jekyll considers these to be special resources and does not copy them to the final site.

---

https://docs.travis-ci.com/user/deployment/pages/#further-configuration
> `fqdn`: Optional, sets a custom domain for your website, defaults to no custom domain support.