### PR TITLE
Avoid generating the atom colour list on the lighting object

### DIFF
--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -5,7 +5,7 @@
 
 	icon             = LIGHTING_ICON
 	icon_state       = "transparent"
-	color            = LIGHTING_BASE_MATRIX
+	color            = null //we manually set color in init instead
 	plane            = LIGHTING_PLANE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	layer            = LIGHTING_LAYER
@@ -17,6 +17,9 @@
 /atom/movable/lighting_object/Initialize(mapload)
 	. = ..()
 	verbs.Cut()
+	//We avoid setting this in the base as if we do then the parent atom handling will add_atom_color it and that
+	//is totally unsuitable for this object, as we are always changing it's colour manually
+	color = LIGHTING_BASE_MATRIX
 
 	myturf = loc
 	if (myturf.lighting_object)


### PR DESCRIPTION
This will save memory, and we're constantly manually modifying the
color of this atom all the time, so it makes no sense to bookkeep it in
the atom colour list (that's for restoring atom colors that are affected
by other effects)

I was going to use a flag on flags_1 to control the behaviour, but
they're all in use and I don't want to add flags_2
