### PR TITLE
Removes survival medipen from vendor. 

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -24,7 +24,6 @@
 		new /datum/data/mining_equipment("Shelter Capsule",				/obj/item/survivalcapsule,											400),
 		new /datum/data/mining_equipment("GAR Meson Scanners",			/obj/item/clothing/glasses/meson/gar,								500),
 		new /datum/data/mining_equipment("Explorer's Webbing",			/obj/item/storage/belt/mining,										500),
-		new /datum/data/mining_equipment("Survival Medipen",			/obj/item/reagent_containers/hypospray/medipen/survival,			500),
 		new /datum/data/mining_equipment("Brute First-Aid Kit",			/obj/item/storage/firstaid/brute,									600),
 		new /datum/data/mining_equipment("Tracking Implant Kit", 		/obj/item/storage/box/minertracker,									600),
 		new /datum/data/mining_equipment("Jaunter",						/obj/item/wormhole_jaunter,											750),


### PR DESCRIPTION
:cl: Hits
del: Removes mining survival pen from the vendor
/:cl:

In line with my views presented in my previous pr, I've foreseen that the mining pen will need removal.

why?
1, this prevents medbay from using their dept budget card on the vendor to buy tons of medipens and avoid having to use chemistry.
2, this encourages inter-dept cooperation, in that miners will now have to venture to chem and ask for a pillbottle of sali/oxand or whatever other chems they want for mining. This is a more natural form of dependency and may even lead to miners asking for mixes of adrenals too!