### PR TITLE
puts message spam from not having keys on a vehicle on cooldown

### DIFF
--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -60,7 +60,9 @@
 
 /obj/vehicle/ridden/driver_move(mob/user, direction)
 	if(key_type && !is_key(inserted_key))
-		to_chat(user, "<span class='warning'>[src] has no key inserted!</span>")
+		if(message_cooldown < world.time)
+			to_chat(user, "<span class='warning'>[src] has no key inserted!</span>")
+			message_cooldown = world.time + 5 SECONDS
 		return FALSE
 	if(legs_required)
 		var/how_many_legs = user.get_num_legs()

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -14,7 +14,6 @@ Format:
 endmap
 
 map boxstation
-	default
 	#voteweight 1.5
 	votable
 endmap
@@ -40,6 +39,7 @@ map donutstation
 endmap
 
 map runtimestation
+	default
 endmap
 
 map multiz_debug

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -14,6 +14,7 @@ Format:
 endmap
 
 map boxstation
+	default
 	#voteweight 1.5
 	votable
 endmap
@@ -39,7 +40,6 @@ map donutstation
 endmap
 
 map runtimestation
-	default
 endmap
 
 map multiz_debug


### PR DESCRIPTION
:cl:
fix: trying to ride a vehicle without key no longer spams you with messages
/:cl: