### PR TITLE
Adds Snow Golems

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1032,6 +1032,9 @@
 
 /mob/living/carbon/human/species/golem/durathread
 	race = /datum/species/golem/durathread
+	
+/mob/living/carbon/human/species/golem/snow
+	race = /datum/species/golem/snow
 
 /mob/living/carbon/human/species/golem/clockwork
 	race = /datum/species/golem/clockwork

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1045,6 +1045,39 @@
 		L.apply_status_effect(/datum/status_effect/bonechill)
 		SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "spooked", /datum/mood_event/spooked)
 
+/datum/species/golem/snow
+	name = "Snow Golem"
+	id = "snow golem"
+	fixed_mut_color = "ebfcfc"
+	armor = 45 //down from 55
+	burnmod = 3 //melts easily
+	info_text = "As a <span class='danger'>Snow Golem</span>, you are extremely vulnerable to burn damage but you can generate snow and shoot out cryokinetic beams. You will also turn to snow when dying, preventing any form of recovery."
+	prefix = "Snow"
+	special_names = list("Flake", "Blizzard", "Storm")
+	
+	var/obj/effect/proc_holder/spell/targeted/conjure_item/snow/snow
+	var/obj/effect/proc_holder/spell/aimed/cryo/cryo
+
+/datum/species/golem/snow/spec_death(gibbed, mob/living/carbon/human/H)
+	H.visible_message("<span class='danger'>[H] turns into a brick of snow!</span>")
+	for(var/obj/item/W in H)
+		H.dropItemToGround(W)
+	for(var/i=1, i <= rand(3,5), i++)
+		new /obj/item/stack/sheet/mineral/snow(get_turf(H))
+	qdel(H)
+
+/datum/species/golem/snow/on_species_gain(mob/living/carbon/C, datum/species/old_species)
+	. = ..()
+	C.AddSpell(snow)
+	C.AddSpell(cryo)
+		
+/datum/species/golem/snow/on_species_loss(mob/living/carbon/C)
+	. = ..()
+	if(snow)
+		C.RemoveSpell(snow)
+	if(cryo)
+		C.RemoveSpell(cryo)
+
 /datum/species/golem/capitalist
 	name = "Capitalist Golem"
 	id = "capitalist golem"

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1069,6 +1069,7 @@
 
 /datum/species/golem/snow/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
+	C.weather_immunities |= "snow"
 	snow = new
 	snow.charge_counter = 0
 	C.AddSpell(snow)
@@ -1078,6 +1079,7 @@
 
 /datum/species/golem/snow/on_species_loss(mob/living/carbon/C)
 	. = ..()
+	C.weather_immunities -= "snow"
 	if(snow)
 		C.RemoveSpell(snow)
 	if(cryo)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1051,7 +1051,7 @@
 	fixed_mut_color = "ebfcfc"
 	armor = 45 //down from 55
 	burnmod = 3 //melts easily
-	info_text = "As a <span class='danger'>Snow Golem</span>, you are extremely vulnerable to burn damage but you can generate snow and shoot out cryokinetic beams. You will also turn to snow when dying, preventing any form of recovery."
+	info_text = "As a <span class='danger'>Snow Golem</span>, you are extremely vulnerable to burn damage but you can generate snow and shoot cryokinetic beams. You will also turn to snow when dying, preventing any form of recovery."
 	prefix = "Snow"
 	special_names = list("Flake", "Blizzard", "Storm")
 	
@@ -1059,11 +1059,12 @@
 	var/obj/effect/proc_holder/spell/aimed/cryo/cryo
 
 /datum/species/golem/snow/spec_death(gibbed, mob/living/carbon/human/H)
-	H.visible_message("<span class='danger'>[H] turns into a brick of snow!</span>")
+	H.visible_message("<span class='danger'>[H] turns into a pile of snow!</span>")
 	for(var/obj/item/W in H)
 		H.dropItemToGround(W)
 	for(var/i=1, i <= rand(3,5), i++)
 		new /obj/item/stack/sheet/mineral/snow(get_turf(H))
+	new /obj/item/reagent_containers/food/snacks/grown/carrot(get_turf(H))
 	qdel(H)
 
 /datum/species/golem/snow/on_species_gain(mob/living/carbon/C, datum/species/old_species)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1069,9 +1069,13 @@
 
 /datum/species/golem/snow/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
+	snow = new
+	snow.charge_counter = 0
 	C.AddSpell(snow)
+	cryo = new
+	cryo.charge_counter = 0
 	C.AddSpell(cryo)
-		
+
 /datum/species/golem/snow/on_species_loss(mob/living/carbon/C)
 	. = ..()
 	if(snow)

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -77,6 +77,7 @@
 		/obj/item/stack/sheet/bone					= /datum/species/golem/bone,
 		/obj/item/stack/sheet/durathread			= /datum/species/golem/durathread,
 		/obj/item/stack/sheet/cotton/durathread		= /datum/species/golem/durathread,
+		/obj/item/stack/sheet/mineral/snow			= /datum/species/golem/snow,
 		/obj/item/stack/sheet/capitalisium			= /datum/species/golem/capitalist,
 		/obj/item/stack/sheet/stalinium				= /datum/species/golem/soviet)
 


### PR DESCRIPTION
## About The Pull Request

this pr adds snow golems, they are made by using 10 sheets of snow on a golem shell
snow golems have slightly less armor than regular golems and get triple burn damage
they are immune to snowstorms, can create snowballs and have cryokinesis powers
on death they turn into a pile of snow and a carrot

## Why It's Good For The Game

more golem types are always fun
allows some possible interaction between xenobio and genetics
snow gang

## Changelog
:cl: Fikou
add: You can now make snow golems.
/:cl:
