### PR TITLE
Disguised syndicate saboteur cyborgs now use the regular cyborg speech icon.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -103,9 +103,10 @@
 	savedName = user.name
 	user.name = friendlyName
 	user.module.cyborg_base_icon = disguise
+	user.bubble_icon = "robot"
 	active = TRUE
 	user.update_icons()
-	
+
 	if(listeningTo == user)
 		return
 	if(listeningTo)
@@ -121,6 +122,7 @@
 	do_sparks(5, FALSE, user)
 	user.name = savedName
 	user.module.cyborg_base_icon = initial(user.module.cyborg_base_icon)
+	user.bubble_icon = "syndibot"
 	active = FALSE
 	user.update_icons()
 	src.user = user


### PR DESCRIPTION
## About The Pull Request

See title. Fixes https://github.com/tgstation/tgstation/issues/41586.

## Why It's Good For The Game

Fixes a bug, closes an issue without tagging oranges

## Changelog
:cl: bandit
fix: Disguised syndicate saboteur cyborgs now use the regular cyborg speech icon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
