### PR TITLE
New green slime mutation toxins

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -514,6 +514,12 @@
 	race = /datum/species/android
 	mutationtext = "<span class='danger'>The pain subsides. You feel... artificial.</span>"
 
+/datum/reagent/mutationtoxin/ethereal
+	name = "Ethereal Mutation Toxin"
+	description = "An etherealizing toxin."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/ethereal
+	mutationtext = "<span class='danger'>The pain subsides. You feel... charged.</span>"
 
 //BLACKLISTED RACES
 /datum/reagent/mutationtoxin/skeleton

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -70,6 +70,38 @@
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/green
 
+/datum/chemical_reaction/slime/slimefelinid
+	name = "Felinid Mutation Toxin"
+	id = "felinidmuttoxin"
+	results = list(/datum/reagent/mutationtoxin/felinid = 1)
+	required_reagents = list(/datum/reagent/consumable/sodiumchloride = 1, /datum/reagent/drug/happiness = 1)
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimemoth
+	name = "Moth Mutation Toxin"
+	id = "mothmuttoxin"
+	results = list(/datum/reagent/mutationtoxin/moth = 1)
+	required_reagents = list(/datum/reagent/pax = 1)
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimeethereal
+	name = "Ethereal Mutation Toxin"
+	id = "etherealmuttoxin"
+	results = list(/datum/reagent/mutationtoxin/ethereal = 1)
+	required_reagents = list(/datum/reagent/teslium = 1)
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimefly
+	name = "Fly Mutation Toxin"
+	id = "flymuttoxin"
+	results = list(/datum/reagent/mutationtoxin/fly = 1)
+	required_reagents = list(/datum/reagent/toxin/bad_food = 1)
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
 //Metal
 /datum/chemical_reaction/slime/slimemetal
 	name = "Slime Metal"


### PR DESCRIPTION
Commision by @Arathian
:cl:
add: Adds new green slime mutation toxins. Teslium for ethereal, Bad food for fly, Pax for moths, happines and salt for felinids.
/:cl:
