### PR TITLE
Fixes the ORM. And moves rotation to alt clicking.

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -50,6 +50,8 @@
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
 		. += "<span class='notice'>The status display reads: Smelting <b>[sheet_per_ore]</b> sheet(s) per piece of ore.<br>Ore pickup speed at <b>[ore_pickup_rate]</b>.</span>"
+	if(panel_open)
+		. += "<span class='notice'>Alt-click to rotate the input and output direction.</span>"
 
 /obj/machinery/mineral/ore_redemption/proc/smelt_ore(obj/item/stack/ore/O)
 	var/datum/component/material_container/mat_container = materials.mat_container
@@ -199,7 +201,10 @@
 
 	return ..()
 
-/obj/machinery/mineral/ore_redemption/multitool_act(mob/living/user, obj/item/multitool/I)
+/obj/machinery/mineral/ore_redemption/AltClick(mob/living/user)
+	..()
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	if (panel_open)
 		input_dir = turn(input_dir, -90)
 		output_dir = turn(output_dir, -90)
@@ -304,7 +309,7 @@
 					desired = input("How many sheets?", "How many sheets would you like to smelt?", 1) as null|num
 
 				var/sheets_to_remove = round(min(desired,50,stored_amount))
-				
+
 				var/count = mat_container.retrieve_sheets(sheets_to_remove, mat, get_step(src, output_dir))
 				var/list/mats = list()
 				mats[mat] = MINERAL_MATERIAL_AMOUNT


### PR DESCRIPTION
## About The Pull Request

See title. The ORM is now rotated by alt-clicking it while the panel is open. Since we no longer override multitool_act, this means that you can connect it to the silo again.

## Why It's Good For The Game

It's bad to have a lot unique functionality on the same tool, and multitools are a tad random for rotation anyhow (that's usually done by either alt clicking or wrenching)

Most importantly this fixes #45516

## Changelog
:cl:
fix: ORM can be connected to the ore silo once again.
tweak: You can now rotate the ORM by altclicking it while the panel is open. This action used to be done with a multitool.
/:cl: