### PR TITLE
Revert "Removes plasma man welding/flash protection"

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -41,7 +41,6 @@
 	icon_state = "plasmaman-helm"
 	item_state = "plasmaman-helm"
 	strip_delay = 80
-	flash_protect = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 100, "acid" = 75)
 	resistance_flags = FIRE_PROOF
 	var/brightness_on = 4 //luminosity when the light is on


### PR DESCRIPTION

## About The Pull Request

Reverts tgstation/tgstation#45369 because it was based on the flawed, meme concept that plasmamen are a powergamer race, despite the fact that there's very little instances of people actually powergaming with plasmamen, and instead of offering a solution that doesn't negatively impact all plasmaman players they just up and removed the welding protection of plasmaman helmets. 

## Why It's Good For The Game

Plasmamen now can only safely weld with use of welding goggles, a drastically limited item which makes it very difficult for a lot of roles to do their job without first running and begging science or engineering. In practice the flash protection isn't even strong against antags due to the brutemod. This shouldn't've been merged prior to toggleable welding screens being made.

## Changelog
:cl:
del: Reverts tgstation/tgstation#45369
/:cl: