### PR TITLE
Revert "AutoDrobes now have a premium psychedelic jumpsuit"

### DIFF
--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -133,7 +133,6 @@
 				   /obj/item/shield/riot/roman/fake = 1,
 				   /obj/item/clothing/suit/chaplainsuit/clownpriest = 1,
 				   /obj/item/clothing/head/clownmitre = 1,
-				   /obj/item/clothing/under/misc/psyche = 1,
 				   /obj/item/skub = 1)
 	refill_canister = /obj/item/vending_refill/autodrobe
 


### PR DESCRIPTION
Reverts tgstation/tgstation#45475

I thought that this was a jumpsuit sprite that apparently doesn't even exit. Mandela Effect is real, and I transported to a different dimension where everything is the same except that the tie die jumpsuit I was thinking of doesn't exist and there's an obnoxious strobing jumpsuit in its place.

The sprite that this actually is is incredibly obnoxious and should either be stupid expensive or just not in it, so clicking one button is much easier.