### PR TITLE
Adds parent calls to almost all tool_acts

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -114,10 +114,12 @@
 	return FALSE
 
 /obj/machinery/sleeper/wrench_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(default_change_direction_wrench(user, I))
 		return TRUE
 
 /obj/machinery/sleeper/crowbar_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(default_pry_open(I))
 		return TRUE
 	if(default_deconstruction_crowbar(I))

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -194,24 +194,27 @@
 	return TRUE
 
 /obj/machinery/camera/wirecutter_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(!panel_open)
-		return FALSE
+		return
 	toggle_cam(user, 1)
 	obj_integrity = max_integrity //this is a pretty simplistic way to heal the camera, but there's no reason for this to be complex.
 	I.play_tool_sound(src)
 	return TRUE
 
 /obj/machinery/camera/multitool_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(!panel_open)
-		return FALSE
+		return
 
 	setViewRange((view_range == initial(view_range)) ? short_range : initial(view_range))
 	to_chat(user, "<span class='notice'>You [(view_range == initial(view_range)) ? "restore" : "mess up"] the camera's focus.</span>")
 	return TRUE
 
 /obj/machinery/camera/welder_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(!panel_open)
-		return FALSE
+		return
 
 	if(!I.tool_start_check(user, amount=0))
 		return TRUE

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -239,8 +239,9 @@
 	return TRUE
 
 /obj/structure/camera_assembly/wirecutter_act(mob/user, obj/item/I)
+	. = ..()
 	if(state != STATE_WIRED)
-		return FALSE
+		return
 
 	new /obj/item/stack/cable_coil(drop_location(), 2)
 	I.play_tool_sound(src)
@@ -249,8 +250,9 @@
 	return TRUE
 
 /obj/structure/camera_assembly/wrench_act(mob/user, obj/item/I)
+	. = ..()
 	if(state != STATE_WRENCHED)
-		return FALSE
+		return
 	I.play_tool_sound(src)
 	to_chat(user, "<span class='notice'>You detach [src] from its place.</span>")
 	new /obj/item/wallframe/camera(drop_location())

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -96,6 +96,7 @@
 	..()
 
 /obj/machinery/defibrillator_mount/multitool_act(mob/living/user, obj/item/multitool)
+	..()
 	if(!defib)
 		to_chat(user, "<span class='warning'>There isn't any defibrillator to clamp in!</span>")
 		return TRUE

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -127,6 +127,7 @@ Buildable meters
 	setDir(turn(dir,-90))
 
 /obj/item/pipe/wrench_act(mob/living/user, obj/item/wrench/W)
+	. = ..()
 	if(!isturf(loc))
 		return TRUE
 
@@ -196,7 +197,7 @@ Buildable meters
 	var/piping_layer = PIPING_LAYER_DEFAULT
 
 /obj/item/pipe_meter/wrench_act(mob/living/user, obj/item/wrench/W)
-
+	. = ..()
 	var/obj/machinery/atmospherics/pipe/pipe
 	for(var/obj/machinery/atmospherics/pipe/P in loc)
 		if(P.piping_layer == piping_layer)

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -79,6 +79,7 @@
 	return FALSE
 
 /obj/machinery/pipedispenser/wrench_act(mob/living/user, obj/item/I)
+	..()
 	if(default_unfasten_wrench(user, I, 40))
 		user << browse(null, "window=pipedispenser")
 

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -338,7 +338,8 @@
 
 
 /obj/machinery/power/shieldwallgen/wrench_act(mob/living/user, obj/item/I)
-	. = default_unfasten_wrench(user, I, 0)
+	. = ..()
+	. |= default_unfasten_wrench(user, I, 0)
 	var/turf/T = get_turf(src)
 	var/obj/structure/cable/C = locate(/obj/structure/cable) in T
 	C.update_icon()

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -126,11 +126,13 @@
 		thaw_them(L_occupant)
 
 /obj/machinery/stasis/screwdriver_act(mob/living/user, obj/item/I)
-	. = default_deconstruction_screwdriver(user, "stasis_maintenance", "stasis", I)
+	. = ..()
+	. |= default_deconstruction_screwdriver(user, "stasis_maintenance", "stasis", I)
 	update_icon()
 
 /obj/machinery/stasis/crowbar_act(mob/living/user, obj/item/I)
-	return default_deconstruction_crowbar(I)
+	. = ..()
+	return default_deconstruction_crowbar(I) || .
 
 /obj/machinery/stasis/nap_violation(mob/violator)
 	unbuckle_mob(violator, TRUE)

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -415,7 +415,7 @@
 	name = "Security Cameras (Computer Board)"
 	icon_state = "security"
 	build_path = /obj/machinery/computer/security
-	
+
 /obj/item/circuitboard/computer/advanced_camera
 	name = "Advanced Camera Console (Computer Board)"
 	icon_state = "security"
@@ -437,6 +437,7 @@
 	var/contraband = FALSE
 
 /obj/item/circuitboard/computer/cargo/multitool_act(mob/living/user)
+	. = ..()
 	if(!(obj_flags & EMAGGED))
 		contraband = !contraband
 		to_chat(user, "<span class='notice'>Receiver spectrum set to [contraband ? "Broad" : "Standard"].</span>")
@@ -454,6 +455,7 @@
 	build_path = /obj/machinery/computer/cargo/express
 
 /obj/item/circuitboard/computer/cargo/express/multitool_act(mob/living/user)
+	. = ..()
 	if (!(obj_flags & EMAGGED))
 		to_chat(user, "<span class='notice'>Routing protocols are already set to: \"factory defaults\".</span>")
 	else

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -843,6 +843,7 @@
 		/obj/item/stock_parts/manipulator = 1)
 
 /obj/item/circuitboard/machine/public_nanite_chamber/multitool_act(mob/living/user)
+	. = ..()
 	var/new_cloud = input("Set the public nanite chamber's Cloud ID (1-100).", "Cloud ID", cloud_id) as num|null
 	if(new_cloud == null)
 		return

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -64,6 +64,7 @@
 	return 0
 
 /obj/item/robot_suit/wrench_act(mob/living/user, obj/item/I) //Deconstucts empty borg shell. Flashes remain unbroken because they haven't been used yet
+	. = ..()
 	var/turf/T = get_turf(src)
 	if(l_leg || r_leg || chest || l_arm || r_arm || head)
 		if(I.use_tool(src, user, 5, volume=50))

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -26,6 +26,7 @@
 		pinnedLoc.forceMove(loc)
 
 /obj/item/target/welder_act(mob/living/user, obj/item/I)
+	..()
 	if(I.use_tool(src, user, 0, volume=40))
 		removeOverlays()
 		to_chat(user, "<span class='notice'>You slice off [src]'s uneven chunks of aluminium and scorch marks.</span>")

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -309,6 +309,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 		return ..()
 
 /obj/item/shard/welder_act(mob/living/user, obj/item/I)
+	..()
 	if(I.use_tool(src, user, 0, volume=50))
 		var/obj/item/stack/sheet/glass/NG = new (user.loc)
 		for(var/obj/item/stack/sheet/glass/G in user.loc)

--- a/code/game/objects/items/stacks/sheets/light.dm
+++ b/code/game/objects/items/stacks/sheets/light.dm
@@ -27,6 +27,7 @@
 		return ..()
 
 /obj/item/stack/light_w/wirecutter_act(mob/living/user, obj/item/I)
+	. = ..()
 	var/atom/Tsec = user.drop_location()
 	var/obj/item/stack/cable_coil/CC = new (Tsec, 5)
 	CC.add_fingerprint(user)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -245,7 +245,7 @@
 
 // Wirecutter behavior for girders
 /obj/structure/girder/wirecutter_act(mob/user, obj/item/tool)
-	. = FALSE
+	. = ..()
 	if(state == GIRDER_REINF_STRUTS)
 		to_chat(user, "<span class='notice'>You start removing the inner grille...</span>")
 		if(tool.use_tool(src, user, 40, volume=100))
@@ -257,7 +257,7 @@
 		return TRUE
 
 /obj/structure/girder/wrench_act(mob/user, obj/item/tool)
-	. = FALSE
+	. = ..()
 	if(state == GIRDER_DISPLACED)
 		if(!isfloorturf(loc))
 			to_chat(user, "<span class='warning'>A floor must be present to secure the girder!</span>")

--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -246,6 +246,7 @@
 	return ..()
 
 /obj/structure/guillotine/wrench_act(mob/living/user, obj/item/I)
+	. = ..()
 	if (current_action)
 		return
 

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -135,7 +135,7 @@
 	set_opacity(anchored ? !door_opened : FALSE)
 	air_update_turf(TRUE)
 
-/obj/structure/mineral_door/wrench_act(mob/living/user, obj/item/I),
+/obj/structure/mineral_door/wrench_act(mob/living/user, obj/item/I)
 	..()
 	default_unfasten_wrench(user, I, 40)
 	return TRUE

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -135,7 +135,8 @@
 	set_opacity(anchored ? !door_opened : FALSE)
 	air_update_turf(TRUE)
 
-/obj/structure/mineral_door/wrench_act(mob/living/user, obj/item/I)
+/obj/structure/mineral_door/wrench_act(mob/living/user, obj/item/I),
+	..()
 	default_unfasten_wrench(user, I, 40)
 	return TRUE
 
@@ -155,6 +156,7 @@
 		deconstruct(TRUE)
 
 /obj/structure/mineral_door/welder_act(mob/living/user, obj/item/I) //override if the door is supposed to be flammable.
+	..()
 	. = TRUE
 	if(anchored)
 		to_chat(user, "<span class='warning'>[src] is still firmly secured to the ground!</span>")

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -67,6 +67,7 @@
 	qdel(src)
 
 /obj/structure/mirror/welder_act(mob/living/user, obj/item/I)
+	..()
 	if(user.a_intent == INTENT_HARM)
 		return FALSE
 

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -382,5 +382,6 @@
 	song.interact(user)
 
 /obj/structure/piano/wrench_act(mob/living/user, obj/item/I)
+	..()
 	default_unfasten_wrench(user, I, 40)
 	return TRUE

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -38,6 +38,7 @@
 		return TRUE
 
 /obj/structure/plasticflaps/wirecutter_act(mob/living/user, obj/item/W)
+	. = ..()
 	if(!anchored)
 		user.visible_message("<span class='warning'>[user] cuts apart [src].</span>", "<span class='notice'>You start to cut apart [src].</span>", "You hear cutting.")
 		if(W.use_tool(src, user, 50, volume=100))
@@ -47,9 +48,7 @@
 			var/obj/item/stack/sheet/plastic/five/P = new(loc)
 			P.add_fingerprint(user)
 			qdel(src)
-			return TRUE
-		else
-			return TRUE
+		return TRUE
 
 /obj/structure/plasticflaps/proc/check_anchored_state(check_anchored)
 	if(anchored != check_anchored)

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -49,6 +49,7 @@
 		return ..()
 
 /obj/machinery/shower/wrench_act(mob/living/user, obj/item/I)
+	..()
 	to_chat(user, "<span class='notice'>You begin to adjust the temperature valve with \the [I]...</span>")
 	if(I.use_tool(src, user, 50))
 		switch(current_temperature)

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -41,6 +41,7 @@
 		icon_state = "[base_icon][flipped]"
 
 /obj/structure/c_transit_tube/wrench_act(mob/living/user, obj/item/I)
+	..()
 	if(!can_wrench_in_loc(user))
 		return
 	to_chat(user, "<span class='notice'>You start attaching the [name]...</span>")

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -404,10 +404,12 @@
 		return ..()
 
 /obj/structure/curtain/wrench_act(mob/living/user, obj/item/I)
+	..()
 	default_unfasten_wrench(user, I, 50)
 	return TRUE
 
 /obj/structure/curtain/wirecutter_act(mob/living/user, obj/item/I)
+	..()
 	if(anchored)
 		return TRUE
 

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -35,10 +35,12 @@
 			state = ENGINE_UNWRENCHED
 
 /obj/structure/shuttle/engine/wrench_act(mob/living/user, obj/item/I)
+	..()
 	default_unfasten_wrench(user, I)
 	return TRUE
 
 /obj/structure/shuttle/engine/welder_act(mob/living/user, obj/item/I)
+	. = ..()
 	switch(state)
 		if(ENGINE_UNWRENCHED)
 			to_chat(user, "<span class='warning'>The [src.name] needs to be wrenched to the floor!</span>")

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -161,7 +161,8 @@
 	return 0
 
 /turf/open/floor/crowbar_act(mob/living/user, obj/item/I)
-	return intact ? pry_tile(I, user) : FALSE
+	if(intact && pry_tile(I, user)
+		return TRUE
 
 /turf/open/floor/proc/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	if(T.turf_type == type)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -161,7 +161,7 @@
 	return 0
 
 /turf/open/floor/crowbar_act(mob/living/user, obj/item/I)
-	if(intact && pry_tile(I, user)
+	if(intact && pry_tile(I, user))
 		return TRUE
 
 /turf/open/floor/proc/try_replace_tile(obj/item/stack/tile/T, mob/user, params)

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -86,6 +86,7 @@
 			to_chat(user, "<span class='warning'>This section is too damaged to support a tile! Use a welder to fix the damage.</span>")
 
 /turf/open/floor/plating/welder_act(mob/living/user, obj/item/I)
+	..()
 	if((broken || burnt) && I.use_tool(src, user, 0, volume=80))
 		to_chat(user, "<span class='danger'>You fix some dents on the broken plating.</span>")
 		icon_state = icon_plating

--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -37,6 +37,7 @@
 	return
 
 /turf/open/floor/engine/wrench_act(mob/living/user, obj/item/I)
+	..()
 	to_chat(user, "<span class='notice'>You begin removing rods...</span>")
 	if(I.use_tool(src, user, 30, volume=80))
 		if(!istype(src, /turf/open/floor/engine))

--- a/code/modules/antagonists/clockcult/clock_structures/_trap_object.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/_trap_object.dm
@@ -28,6 +28,7 @@
 				. += "[O] ([distance == 0 ? "same tile" : "[distance] tiles [dir2text(get_dir(src, O))]"])"
 
 /obj/structure/destructible/clockwork/trap/wrench_act(mob/living/user, obj/item/I)
+	..()
 	if(!is_servant_of_ratvar(user))
 		return ..()
 	to_chat(user, "<span class='notice'>You break down the delicate components of [src] into brass.</span>")
@@ -57,6 +58,7 @@
 	..()
 
 /obj/structure/destructible/clockwork/trap/wirecutter_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(!is_servant_of_ratvar(user))
 		return
 	if(!wired_to.len)

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -30,6 +30,7 @@
 		add_overlay("bomb_assembly")
 
 /obj/item/onetankbomb/wrench_act(mob/living/user, obj/item/I)
+	..()
 	to_chat(user, "<span class='notice'>You disassemble [src]!</span>")
 	if(bombassembly)
 		bombassembly.forceMove(drop_location())
@@ -43,6 +44,7 @@
 	return TRUE
 
 /obj/item/onetankbomb/welder_act(mob/living/user, obj/item/I)
+	..()
 	. = FALSE
 	if(status)
 		to_chat(user, "<span class='notice'>[bombtank] already has a pressure hole!</span>")

--- a/code/modules/assembly/shock_kit.dm
+++ b/code/modules/assembly/shock_kit.dm
@@ -14,6 +14,7 @@
 	return ..()
 
 /obj/item/assembly/shock_kit/wrench_act(mob/living/user, obj/item/I)
+	..()
 	to_chat(user, "<span class='notice'>You disassemble [src].</span>")
 	if(part1)
 		part1.forceMove(drop_location())

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -71,6 +71,7 @@
 				. = TRUE
 
 /obj/item/assembly/voice/multitool_act(mob/living/user, obj/item/I)
+	..()
 	mode %= modes.len
 	mode++
 	to_chat(user, "<span class='notice'>You set [src] into [modes[mode]] mode.</span>")

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -247,6 +247,7 @@
 	update_icon()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/welder_act(mob/living/user, obj/item/I)
+	..()
 	if(!I.tool_start_check(user, amount=0))
 		return TRUE
 	to_chat(user, "<span class='notice'>You begin welding the vent...</span>")

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -263,6 +263,7 @@
 	update_icon_nopipes()
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/welder_act(mob/living/user, obj/item/I)
+	..()
 	if(!I.tool_start_check(user, amount=0))
 		return TRUE
 	to_chat(user, "<span class='notice'>Now welding the scrubber.</span>")

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -114,6 +114,7 @@
 	. += status()
 
 /obj/machinery/meter/wrench_act(mob/user, obj/item/I)
+	..()
 	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (I.use_tool(src, user, 40, volume=50))
 		user.visible_message(

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -289,6 +289,7 @@
 	qdel(src)
 
 /obj/machinery/portable_atmospherics/canister/welder_act(mob/living/user, obj/item/I)
+	..()
 	if(user.a_intent == INTENT_HARM)
 		return FALSE
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -349,7 +349,7 @@
 	return ..()
 
 /obj/item/clothing/head/helmet/screwdriver_act(mob/living/user, obj/item/I)
-	..()
+	. = ..()
 	if(can_flashlight && attached_light) //if it has a light but can_flashlight is false, the light is permanently attached.
 		I.play_tool_sound(src)
 		to_chat(user, "<span class='notice'>You unscrew [attached_light] from [src].</span>")

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -193,6 +193,7 @@
 	return TRUE
 
 /obj/item/clothing/head/warden/drill/wirecutter_act(mob/living/user, obj/item/I)
+	..()
 	if(mode != DRILL_CANADIAN)
 		to_chat(user, "<span class='danger'>You broke the voice circuit!</span>")
 		mode = DRILL_CANADIAN

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -62,6 +62,7 @@
 	return TRUE
 
 /obj/item/clothing/mask/gas/sechailer/wirecutter_act(mob/living/user, obj/item/I)
+	..()
 	if(aggressiveness != 4)
 		to_chat(user, "<span class='danger'>You broke the restrictor!</span>")
 		aggressiveness = 4

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -251,6 +251,7 @@
 	var/cargo_hold_id
 
 /obj/machinery/piratepad/multitool_act(mob/living/user, obj/item/multitool/I)
+	. = ..()
 	if (istype(I))
 		to_chat(user, "<span class='notice'>You register [src] in [I]s buffer.</span>")
 		I.buffer = src
@@ -272,6 +273,7 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/computer/piratepad_control/multitool_act(mob/living/user, obj/item/multitool/I)
+	. = ..()
 	if (istype(I) && istype(I.buffer,/obj/machinery/piratepad))
 		to_chat(user, "<span class='notice'>You link [src] with [I.buffer] in [I] buffer.</span>")
 		pad = I.buffer

--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -95,6 +95,7 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 		to_chat(user, "<span class='danger'>The machine needs at least 1 monkey worth of material to produce a monkey cube. It currently has [stored_matter].</span>")
 
 /obj/machinery/monkey_recycler/multitool_act(mob/living/user, obj/item/multitool/I)
+	. = ..()
 	if(istype(I))
 		to_chat(user, "<span class='notice'>You log [src] in the multitool's buffer.</span>")
 		I.buffer = src

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -161,6 +161,7 @@
 	pixel_y = -32
 
 /obj/item/gps/computer/wrench_act(mob/living/user, obj/item/I)
+	..()
 	if(flags_1 & NODECONSTRUCT_1)
 		return TRUE
 
@@ -240,6 +241,7 @@
 	qdel(src)
 
 /obj/structure/fans/wrench_act(mob/living/user, obj/item/I)
+	..()
 	if(flags_1 & NODECONSTRUCT_1)
 		return TRUE
 

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -80,7 +80,7 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 		var/sheets = round(amount) / MINERAL_MATERIAL_AMOUNT
 		var/ref = REF(M)
 		if (sheets)
-			if (sheets >= 1)	
+			if (sheets >= 1)
 				ui += "<a href='?src=[REF(src)];ejectsheet=[ref];eject_amt=1'>Eject</a>"
 			else
 				ui += "<span class='linkOff'>Eject</span>"
@@ -163,6 +163,7 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 		return TRUE
 
 /obj/machinery/ore_silo/multitool_act(mob/living/user, obj/item/multitool/I)
+	. = ..()
 	if (istype(I))
 		to_chat(user, "<span class='notice'>You log [src] in the multitool's buffer.</span>")
 		I.buffer = src

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -86,6 +86,7 @@
 			. += "<span class='notice'>There is \a [M] installed, using <b>[M.cost]%</b> capacity.</span>"
 
 /mob/living/simple_animal/hostile/mining_drone/welder_act(mob/living/user, obj/item/I)
+	..()
 	. = TRUE
 	if(mode == MINEDRONE_ATTACK)
 		to_chat(user, "<span class='warning'>[src] can't be repaired while in attack mode!</span>")

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -40,6 +40,7 @@
 		add_overlay(stack_overlays)
 
 /obj/item/stack/ore/welder_act(mob/living/user, obj/item/I)
+	..()
 	if(!refined_type)
 		return TRUE
 
@@ -451,6 +452,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 		..()
 
 /obj/item/coin/wirecutter_act(mob/living/user, obj/item/I)
+	..()
 	if(!string_attached)
 		return TRUE
 

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -49,6 +49,7 @@
 	return ..()
 
 /obj/item/computer_hardware/multitool_act(mob/living/user, obj/item/I)
+	..()
 	to_chat(user, "***** DIAGNOSTICS REPORT *****")
 	diagnostics(user)
 	to_chat(user, "******************************")

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -60,6 +60,7 @@
 		ours.id = id
 
 /obj/machinery/button/ticket_machine/multitool_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(I.tool_behaviour == TOOL_MULTITOOL)
 		var/obj/item/multitool/M = I
 		if(M.buffer && !istype(M.buffer, /obj/machinery/ticket_machine))

--- a/code/modules/plumbing/ducts.dm
+++ b/code/modules/plumbing/ducts.dm
@@ -205,6 +205,7 @@ All the important duct code:
 
 
 /obj/machinery/duct/wrench_act(mob/living/user, obj/item/I) //I can also be the RPD
+	..()
 	add_fingerprint(user)
 	I.play_tool_sound(src)
 	if(anchored)

--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -31,6 +31,7 @@
 	AddComponent(/datum/component/plumbing/simple_supply)
 
 /obj/machinery/plumbing/input/wrench_act(mob/living/user, obj/item/I)
+	..()
 	default_unfasten_wrench(user, I)
 	return TRUE
 
@@ -46,5 +47,6 @@
 	AddComponent(/datum/component/plumbing/simple_demand)
 
 /obj/machinery/plumbing/output/wrench_act(mob/living/user, obj/item/I)
+	..()
 	default_unfasten_wrench(user, I)
 	return TRUE

--- a/code/modules/plumbing/plumbers/acclimator.dm
+++ b/code/modules/plumbing/plumbers/acclimator.dm
@@ -27,6 +27,7 @@
 	AddComponent(/datum/component/plumbing/acclimator)
 
 /obj/machinery/plumbing/acclimator/wrench_act(mob/living/user, obj/item/I)
+	..()
 	default_unfasten_wrench(user, I)
 	return TRUE
 

--- a/code/modules/plumbing/plumbers/pumps.dm
+++ b/code/modules/plumbing/plumbers/pumps.dm
@@ -35,6 +35,7 @@
 	return ..()
 
 /obj/machinery/power/liquid_pump/wrench_act(mob/living/user, obj/item/I)
+	..()
 	default_unfasten_wrench(user, I)
 	return TRUE
 ///please note that the component has a hook in the parent call, wich handles activating and deactivating

--- a/code/modules/plumbing/plumbers/synthesizer.dm
+++ b/code/modules/plumbing/plumbers/synthesizer.dm
@@ -51,6 +51,7 @@
 	AddComponent(/datum/component/plumbing/simple_supply)
 
 /obj/machinery/plumbing/synthesizer/wrench_act(mob/living/user, obj/item/I)
+	..()
 	default_unfasten_wrench(user, I)
 	return TRUE
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -525,12 +525,14 @@
 		update_icon()
 
 /obj/machinery/power/apc/wirecutter_act(mob/living/user, obj/item/W)
+	. = ..()
 	if (terminal && opened)
 		terminal.dismantle(user, W)
 		return TRUE
 
 
 /obj/machinery/power/apc/welder_act(mob/living/user, obj/item/W)
+	. = ..()
 	if (opened && !has_electronics && !terminal)
 		if(!W.tool_start_check(user, amount=3))
 			return
@@ -718,7 +720,7 @@
 			if(stat & BROKEN)
 				to_chat(user, "<span class='warning'>[src]'s frame is too damaged to support a circuit.</span>")
 				return FALSE
-			return list("mode" = RCD_UPGRADE_SIMPLE_CIRCUITS, "delay" = 20, "cost" = 1)	
+			return list("mode" = RCD_UPGRADE_SIMPLE_CIRCUITS, "delay" = 20, "cost" = 1)
 		else if(!cell)
 			if(stat & MAINT)
 				to_chat(user, "<span class='warning'>There's no connector for a power cell.</span>")

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -193,6 +193,7 @@
 				C.generator = src
 
 /obj/machinery/power/generator/wrench_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(!panel_open)
 		return
 	anchored = !anchored
@@ -204,6 +205,7 @@
 	return TRUE
 
 /obj/machinery/power/generator/multitool_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(!anchored)
 		return
 	find_circs()

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -138,6 +138,7 @@
 		return ..()
 
 /obj/machinery/power/rad_collector/wrench_act(mob/living/user, obj/item/I)
+	..()
 	default_unfasten_wrench(user, I)
 	return TRUE
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -252,10 +252,12 @@
 			state = EMITTER_UNWRENCHED
 
 /obj/machinery/power/emitter/wrench_act(mob/living/user, obj/item/I)
+	..()
 	default_unfasten_wrench(user, I)
 	return TRUE
 
 /obj/machinery/power/emitter/welder_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(active)
 		to_chat(user, "Turn \the [src] off first.")
 		return TRUE

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -106,10 +106,12 @@ field_generator power level display
 			state = FG_UNSECURED
 
 /obj/machinery/field/generator/wrench_act(mob/living/user, obj/item/I)
+	..()
 	default_unfasten_wrench(user, I)
 	return TRUE
 
 /obj/machinery/field/generator/welder_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(active)
 		to_chat(user, "<span class='warning'>[src] needs to be off!</span>")
 		return TRUE

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -35,7 +35,7 @@
 	return ..()
 
 /obj/machinery/particle_accelerator/control_box/multitool_act(mob/living/user, obj/item/I)
-	..()
+	. = ..()
 	if(construction_state == PA_CONSTRUCTION_PANEL_OPEN)
 		wires.interact(user)
 		return TRUE

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -161,6 +161,7 @@
 
 /obj/machinery/power/smes/wirecutter_act(mob/living/user, obj/item/I)
 	//disassembling the terminal
+	. = ..()
 	if(terminal && panel_open)
 		terminal.dismantle(user, I)
 		return TRUE

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -623,6 +623,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		radiation_pulse(src, 150, 4)
 
 /obj/machinery/power/supermatter_crystal/wrench_act(mob/user, obj/item/tool)
+	..()
 	if (moveable)
 		default_unfasten_wrench(user, tool, time = 20)
 	return TRUE

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -77,5 +77,6 @@
 		qdel(src)
 
 /obj/machinery/power/terminal/wirecutter_act(mob/living/user, obj/item/I)
+	..()
 	dismantle(user, I)
 	return TRUE

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -191,6 +191,7 @@
 	desc = "A stationairy, plumbed, water tank."
 
 /obj/structure/reagent_dispensers/plumbed/wrench_act(mob/living/user, obj/item/I)
+	..()
 	default_unfasten_wrench(user, I)
 	return TRUE
 

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -110,6 +110,7 @@
 // wrench: (un)anchor
 // weldingtool: convert to real pipe
 /obj/structure/disposalconstruct/wrench_act(mob/living/user, obj/item/I)
+	..()
 	if(anchored)
 		anchored = FALSE
 		density = FALSE
@@ -155,6 +156,7 @@
 	return TRUE
 
 /obj/structure/disposalconstruct/welder_act(mob/living/user, obj/item/I)
+	..()
 	if(anchored)
 		if(!I.tool_start_check(user, amount=0))
 			return TRUE

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -67,6 +67,7 @@
 	qdel(H)
 
 /obj/structure/disposaloutlet/welder_act(mob/living/user, obj/item/I)
+	..()
 	if(!I.tool_start_check(user, amount=0))
 		return TRUE
 

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -140,6 +140,7 @@
 
 //welding tool: unfasten and convert to obj/disposalconstruct
 /obj/structure/disposalpipe/welder_act(mob/living/user, obj/item/I)
+	..()
 	if(!can_be_deconstructed(user))
 		return TRUE
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -198,9 +198,10 @@ Nothing else in the console has ID requirements.
 	return ..()
 
 /obj/machinery/computer/rdconsole/multitool_act(mob/user, obj/item/multitool/I)
+	. = ..()
 	var/lathe = linked_lathe && linked_lathe.multitool_act(user, I)
 	var/print = linked_imprinter && linked_imprinter.multitool_act(user, I)
-	return lathe || print
+	return lathe || print || .
 
 /obj/machinery/computer/rdconsole/proc/list_categories(list/categories, menu_num as num)
 	if(!categories)

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -170,6 +170,7 @@
 	..()
 
 /obj/machinery/computer/camera_advanced/xenobio/multitool_act(mob/living/user, obj/item/multitool/I)
+	. = ..()
 	if (istype(I) && istype(I.buffer,/obj/machinery/monkey_recycler))
 		to_chat(user, "<span class='notice'>You link [src] with [I.buffer] in [I] buffer.</span>")
 		connected_recycler = I.buffer

--- a/code/modules/shuttle/spaceship_navigation_beacon.dm
+++ b/code/modules/shuttle/spaceship_navigation_beacon.dm
@@ -13,7 +13,7 @@
 	idle_power_usage = 0
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/spaceship_navigation_beacon
-	
+
 	var/locked = FALSE //Locked beacons don't allow to jump to it.
 
 
@@ -40,12 +40,13 @@ obj/machinery/spaceship_navigation_beacon/emp_act()
 	update_icon()
 
 /obj/machinery/spaceship_navigation_beacon/multitool_act(mob/living/user, obj/item/multitool/I)
+	..()
 	if(panel_open)
 		var/new_name = "Beacon_[input("Enter the custom name for this beacon", "It be Beacon ..your input..") as text]"
 		if(new_name && Adjacent(user))
 			name = new_name
 			to_chat(user, "<span class='notice'>You change beacon name to [name].</span>")
-	else 
+	else
 		locked =!locked
 		to_chat(user, "<span class='notice'>You [locked ? "" : "un"]lock [src].</span>")
 	return TRUE

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -31,6 +31,7 @@
 	anchored = TRUE
 
 /obj/machinery/bsa/wrench_act(mob/living/user, obj/item/I)
+	..()
 	default_unfasten_wrench(user, I, 10)
 	return TRUE
 

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -122,6 +122,7 @@
 	icon_state = active ? "sat_active" : "sat_inactive"
 
 /obj/machinery/satellite/multitool_act(mob/living/user, obj/item/I)
+	..()
 	to_chat(user, "<span class='notice'>// NTSAT-[id] // Mode : [active ? "PRIMARY" : "STANDBY"] //[(obj_flags & EMAGGED) ? "DEBUG_MODE //" : ""]</span>")
 	return TRUE
 

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -151,6 +151,7 @@
 		return ..()
 
 /obj/item/bodypart/chest/robot/wirecutter_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(!wired)
 		return
 	. = TRUE
@@ -265,6 +266,7 @@
 	return ..()
 
 /obj/item/bodypart/head/robot/crowbar_act(mob/living/user, obj/item/I)
+	..()
 	if(flash1 || flash2)
 		I.play_tool_sound(src)
 		to_chat(user, "<span class='notice'>You remove the flash from [src].</span>")

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -12,6 +12,7 @@
 
 
 /obj/vehicle/ridden/scooter/wrench_act(mob/living/user, obj/item/I)
+	..()
 	to_chat(user, "<span class='notice'>You begin to remove the handlebars...</span>")
 	if(I.use_tool(src, user, 40, volume=50))
 		var/obj/vehicle/ridden/scooter/skateboard/S = new(drop_location())
@@ -129,6 +130,7 @@
 		return ..()
 
 /obj/item/scooter_frame/wrench_act(mob/living/user, obj/item/I)
+	..()
 	to_chat(user, "<span class='notice'>You deconstruct [src].</span>")
 	new /obj/item/stack/rods(drop_location(), 10)
 	I.play_tool_sound(src)

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -68,6 +68,7 @@
 	handle_rotation(newdir)
 
 /obj/vehicle/ridden/wheelchair/wrench_act(mob/living/user, obj/item/I)	//Attackby should stop it attacking the wheelchair after moving away during decon
+	..()
 	to_chat(user, "<span class='notice'>You begin to detach the wheels...</span>")
 	if(I.use_tool(src, user, 40, volume=50))
 		to_chat(user, "<span class='notice'>You detach the wheels and deconstruct the chair.</span>")

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -64,7 +64,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	///Last mob to shop with us
 	var/last_shopper
 
-	
+
 	/**
 	  * List of products this machine sells
 	  *
@@ -340,6 +340,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	return TRUE
 
 /obj/machinery/vending/wrench_act(mob/living/user, obj/item/I)
+	..()
 	if(panel_open)
 		default_unfasten_wrench(user, I, time = 60)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

title. Also fixes #45579

## Why It's Good For The Game

Would be neat for all those tool signals to actually work somewhat universally. There are some overrides where it isn't possible to call parent, but those are pretty sparse.

The general intent is that the tool signals don't stop other functionality of that tool_act, but do block everything that comes after them in the attack order.

I should have added this in the original PR. My bad.