### PR TITLE
Nerfs reinforced bolas

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -351,7 +351,7 @@
 		C.update_inv_legcuffed()
 		SSblackbox.record_feedback("tally", "handcuffs", 1, type)
 		to_chat(C, "<span class='userdanger'>\The [src] ensnares you!</span>")
-		C.Paralyze(knockdown)
+		C.Knockdown(knockdown)
 		playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 
 /obj/item/restraints/legcuffs/bola/tactical//traitor variant
@@ -359,7 +359,7 @@
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
 	breakouttime = 70
-	knockdown = 20
+	knockdown = 35
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -260,7 +260,7 @@
 	desc = "A strong bola, bound with dark magic that allows it to pass harmlessly through Nar'Sien cultists. Throw it to trip and slow your victim."
 	icon_state = "bola_cult"
 	breakouttime = 60
-	knockdown = 20
+	knockdown = 30
 
 /obj/item/restraints/legcuffs/bola/cult/pickup(mob/living/user)
 	if(!iscultist(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reinforced and nar'sie bolas now knockdown instead of paralyze.

## Why It's Good For The Game

This is a nerf in the same vein as #45621
The reasoning is the same, at least in term of the nar'sie bola part.

For the reinforced bola, I basically only have to say that I and others have abused them a lot in the abscense of other reliable ranged stuns. You get a lot of them on a fairly cheap traitor item and I think they have a much healtier place in the game as a defensive item instead of something that you quickscope throw out of your bag in the hopes to cheese some spessmen.

## Changelog
:cl:
balance: Reinforced and Nar'Sie bolas now knockdown instead of paralyzing their target.
balance: It now takes longer to break out of reinforced bolas.
/:cl:
