### PR TITLE
New chems have more reasonable ODs

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1404,7 +1404,7 @@
 #undef PERF_BASE_DAMAGE
 
 //Injectables!
-//These are shitty chems for medibots and borgs to use in place of the old trekchems. They're limited to injection only, hence the name.
+//These are shitty chems
 
 /datum/reagent/medicine/sanguiose
 	name = "Sanguiose"
@@ -1454,8 +1454,8 @@
 	. = 1
 
 /datum/reagent/medicine/frogenite/overdose_process(mob/living/M)
-	M.adjustOxyLoss(15,0)
-	M.reagents.remove_reagent(type, metabolization_rate*10) // Reused code from syndicate nanites meant to purge the chem quickly.
+	M.adjustOxyLoss(3,0)
+	M.reagents.remove_reagent(type, metabolization_rate*2) // Reused code from syndicate nanites meant to purge the chem quickly.
 	to_chat(M, "<span class='notice'>You feel like you aren't getting any oxygen!</span>")
 	..()
 	. = 1
@@ -1463,7 +1463,7 @@
 /datum/reagent/medicine/frogenite/on_transfer(atom/A, method=TOUCH, volume) // Borrowed from whoever made charcoal injection or pill only and modified so it doesn't add a reagent.
 	if(method == INJECT || !iscarbon(A)) //the atom not the charcoal
 		return
-	A.reagents.remove_reagent(type, volume) 
+	A.reagents.remove_reagent(type, volume)
 	..()
 
 /datum/reagent/medicine/ferveatium
@@ -1486,8 +1486,8 @@
 	. = 1
 
 /datum/reagent/medicine/ferveatium/overdose_process(mob/living/M)
-	M.adjustFireLoss(15,0)
-	M.reagents.remove_reagent(type, metabolization_rate*10) // Reused code from syndicate nanites meant to purge the chem quickly.
+	M.adjustFireLoss(3,0)
+	M.reagents.remove_reagent(type, metabolization_rate*2) // Reused code from syndicate nanites meant to purge the chem quickly.
 	to_chat(M, "<span class='notice'>You feel like you are melting!</span>")
 	..()
 	. = 1
@@ -1497,5 +1497,3 @@
 		return
 	A.reagents.remove_reagent(type, volume)
 	..()
-
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

frogenite OD does3  oxyloss a tick and metab rate is sped up by 2 on OD
ferv OD does 3  burn a tick and metab rate is sped up by 2 on OD



## Why It's Good For The Game

incredibly unfair OD, you die very, very quick, and often dont even have time to call out. easily mass produced too so not fun!

## Changelog
:cl:
balance: frogenite and ferveatium have much tamer ODs now, dealing fifth of the former damage, with lesser metab rates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
