### PR TITLE
The clown car waddles

### DIFF
--- a/code/datums/components/waddling.dm
+++ b/code/datums/components/waddling.dm
@@ -3,7 +3,7 @@
 
 /datum/component/waddling/Initialize()
 	. = ..()
-	if(!isatom(parent))
+	if(!ismovableatom(parent))
 		return COMPONENT_INCOMPATIBLE
 	if(isliving(parent))
 		RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED), .proc/LivingWaddle)

--- a/code/datums/components/waddling.dm
+++ b/code/datums/components/waddling.dm
@@ -1,15 +1,22 @@
 /datum/component/waddling
-    dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
 /datum/component/waddling/Initialize()
-    if(!isliving(parent))
-        return COMPONENT_INCOMPATIBLE
-    RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED), .proc/Waddle)
+	. = ..()
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+	if(isliving(parent))
+		RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED), .proc/LivingWaddle)
+	else
+		RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED), .proc/Waddle)
+
+/datum/component/waddling/proc/LivingWaddle()
+	var/mob/living/L = parent
+	if(L.incapacitated() || !(L.mobility_flags & MOBILITY_STAND))
+		return
+	Waddle()
 
 /datum/component/waddling/proc/Waddle()
-    var/mob/living/L = parent
-    if(L.incapacitated() || !(L.mobility_flags & MOBILITY_STAND))
-        return
-    animate(L, pixel_z = 4, time = 0)
-    animate(pixel_z = 0, transform = turn(matrix(), pick(-12, 0, 12)), time=2)
-    animate(pixel_z = 0, transform = matrix(), time = 0)
+	animate(parent, pixel_z = 4, time = 0)
+	animate(pixel_z = 0, transform = turn(matrix(), pick(-12, 0, 12)), time=2)
+	animate(pixel_z = 0, transform = matrix(), time = 0)

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -89,6 +89,7 @@
 	to_chat(user, "<span class='danger'>You scramble the clowncar child safety lock and a panel with 6 colorful buttons appears!</span>")
 	initialize_controller_action_type(/datum/action/vehicle/sealed/RollTheDice, VEHICLE_CONTROL_DRIVE)
 	initialize_controller_action_type(/datum/action/vehicle/sealed/Cannon, VEHICLE_CONTROL_DRIVE)
+	AddComponent(/datum/component/waddling)
 
 /obj/vehicle/sealed/car/clowncar/Destroy()
   playsound(src, 'sound/vehicles/clowncar_fart.ogg', 100)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Emagged clown cars now get the waddle.
Also, all atoms can waddle now. Waddling ghosts and more in bound.

## Why It's Good For The Game

It should have been like this from the start, this is actually a fix.

## Changelog
:cl:
add: Emagged clown cars are more scary now.
/:cl:
