### PR TITLE
Adds screwdriver to emergency toolbox

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -44,6 +44,7 @@
 
 /obj/item/storage/toolbox/emergency/PopulateContents()
 	new /obj/item/crowbar/red(src)
+	new /obj/item/screwdriver(src)
 	new /obj/item/weldingtool/mini(src)
 	new /obj/item/extinguisher/mini(src)
 	switch(rand(1,3))


### PR DESCRIPTION
## About The Pull Request

Adds a screw driver to the emergency toolbox, allowing for emergency moving of r-windows and the grilles under them. Coincides with #45609

## Why It's Good For The Game

Allows removal of r-windows in a emergency, as per why the emergency toolbox exists, without dying cause you didn't powergame tools at round start.

## Changelog
:cl:
add: Added screwdriver to emergency toolbox for emergency r-window / grille moving.
/:cl:

