### PR TITLE
The Chemistry Lab now has reinforced walls

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5145,6 +5145,9 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"akS" = (
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "akT" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 3";
@@ -85930,15 +85933,15 @@ aJC
 aHP
 aHP
 aHP
-bfF
-bfF
-bfF
-bfF
-bfF
-bfF
-bfF
-bfF
-bfF
+akS
+akS
+akS
+akS
+akS
+akS
+akS
+akS
+akS
 bqM
 brV
 bof
@@ -86187,7 +86190,7 @@ aJC
 bcq
 bcq
 bcq
-bfF
+akS
 nQI
 bio
 bgF
@@ -86444,7 +86447,7 @@ aJC
 aYV
 aYV
 aYV
-bfF
+akS
 bgZ
 bin
 bin
@@ -86701,7 +86704,7 @@ aJC
 aYV
 aYV
 aYV
-bfF
+akS
 bhc
 bip
 bgP
@@ -86958,7 +86961,7 @@ aJC
 aYV
 aYV
 ber
-bfF
+akS
 bhb
 bip
 bjO
@@ -87215,7 +87218,7 @@ bbx
 aYV
 aYV
 aYV
-bfF
+akS
 bhd
 bis
 bjR
@@ -87472,13 +87475,13 @@ aQg
 aYV
 aYV
 bes
-bfF
-bfF
+akS
+akS
 bir
 bjQ
 blh
-bfF
-bfF
+akS
+akS
 bfF
 bfF
 bqU

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -42,6 +42,30 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
+"aah" = (
+/turf/closed/wall/r_wall,
+/area/medical/medbay/central)
+"aai" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
+"aaj" = (
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
+"aak" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
+"aal" = (
+/obj/structure/sign/departments/chemistry,
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
+"aam" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/medical/central)
+"aan" = (
+/turf/closed/wall/r_wall,
+/area/medical/genetics/cloning)
 "aao" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -84871,10 +84895,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
-"dbi" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall,
-/area/medical/chemistry)
 "dbj" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -85798,9 +85818,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"dcM" = (
-/turf/closed/wall,
-/area/medical/chemistry)
 "dcN" = (
 /obj/structure/table/glass,
 /obj/item/assembly/igniter,
@@ -86652,10 +86669,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"der" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/medical/chemistry)
 "des" = (
 /obj/structure/table/glass,
 /obj/item/clipboard,
@@ -87198,10 +87211,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"dfv" = (
-/obj/structure/sign/departments/chemistry,
-/turf/closed/wall,
-/area/medical/chemistry)
 "dfw" = (
 /obj/machinery/light{
 	dir = 8
@@ -156275,15 +156284,15 @@ cSC
 cUr
 cWh
 cND
-cPy
+aah
 dba
-dcM
+aaj
 dba
-dfv
+aal
 dgT
 dio
 dkf
-inw
+aam
 inw
 dpg
 inw
@@ -156532,15 +156541,15 @@ cSD
 cUs
 cWi
 cXF
-cPy
+aah
 dbb
 dcN
 del
-dcM
+aaj
 dgU
 dip
 dba
-inw
+aam
 dng
 dph
 dqU
@@ -156797,7 +156806,7 @@ dfw
 dgV
 diq
 dkg
-inw
+aam
 dnh
 dpi
 dqV
@@ -157054,7 +157063,7 @@ den
 dgW
 dir
 dkh
-inw
+aam
 dni
 dpj
 dqW
@@ -157568,7 +157577,7 @@ dfy
 dgY
 den
 dkj
-inw
+aam
 dnk
 dpl
 dqY
@@ -157817,7 +157826,7 @@ cSF
 cUx
 cQU
 cXK
-cPy
+aah
 dbg
 dcS
 dcS
@@ -157825,7 +157834,7 @@ dcS
 dgZ
 dcS
 dkk
-dlV
+aan
 dlV
 dlV
 dlV
@@ -158331,11 +158340,11 @@ cSF
 cUx
 cQU
 cXM
-cPy
-dbi
-dcM
-der
-dcM
+aah
+aai
+aaj
+aak
+aaj
 dhb
 diu
 dkm

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -5,6 +5,9 @@
 "aab" = (
 /turf/closed/wall,
 /area/space/nearstation)
+"aac" = (
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "aad" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -27,6 +30,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"aag" = (
+/obj/structure/sign/departments/medbay/alt,
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "aah" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -18403,10 +18410,6 @@
 "aUk" = (
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
-"aUl" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall,
-/area/medical/chemistry)
 "aUm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78046,7 +78049,7 @@ aJH
 aII
 beT
 aHW
-aHW
+aac
 azH
 bCg
 bba
@@ -78297,13 +78300,13 @@ aXn
 aVV
 aJz
 aGo
-aHW
+aac
 aHW
 aIB
 aIp
 beU
 kcl
-aHW
+aac
 aSs
 bGC
 bba
@@ -78554,13 +78557,13 @@ aXs
 aGZ
 aJX
 esN
-aHW
+aac
 bTc
 aIp
 aIp
 beV
 aUF
-aHW
+aac
 aSt
 sjP
 bba
@@ -78811,13 +78814,13 @@ aXt
 aHa
 aJY
 bya
-aHW
+aac
 aIt
 aIC
 aIJ
 beV
 aUa
-aHW
+aac
 aUm
 sjP
 bbb
@@ -79074,7 +79077,7 @@ aIp
 bdZ
 beW
 aUA
-aHW
+aac
 bCg
 sjP
 sjP
@@ -79331,7 +79334,7 @@ aIp
 beF
 bes
 bGG
-aHW
+aac
 bCg
 aBx
 ahT
@@ -79588,7 +79591,7 @@ aIp
 beG
 bet
 aUB
-aHW
+aac
 bCg
 bSU
 ahT
@@ -79839,13 +79842,13 @@ aUQ
 aGu
 aUQ
 aTV
-aHW
+aac
 aIA
 aID
 beX
 aIp
 aUb
-aHW
+aac
 bCg
 bTb
 ahT
@@ -80096,13 +80099,13 @@ aXC
 aHc
 aXM
 aUt
-aHW
+aac
 aIp
 aIp
 bfj
 aIp
 aUE
-aHW
+aac
 bCg
 bKa
 ahT
@@ -80353,13 +80356,13 @@ bts
 aHd
 aXN
 aHN
-aUl
+aag
 aGS
 aUx
 bpv
 aIp
 aIp
-aHW
+aac
 bCg
 ahT
 ahT
@@ -80616,7 +80619,7 @@ aHn
 bfn
 aIR
 aJf
-aHW
+aac
 bCg
 ahT
 bRt
@@ -80873,7 +80876,7 @@ aTK
 bfI
 aHn
 aNO
-aHW
+aac
 bCg
 ahT
 akT

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -773,6 +773,16 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"abT" = (
+/obj/structure/sign/directions/medical{
+	pixel_y = -7
+	},
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
+"abU" = (
+/obj/structure/sign/departments/chemistry,
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "abV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light/small{
@@ -896,6 +906,9 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
+"acl" = (
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "acm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -49965,16 +49978,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"cfV" = (
-/obj/structure/sign/directions/medical{
-	pixel_y = -7
-	},
-/turf/closed/wall,
-/area/medical/chemistry)
-"cfW" = (
-/obj/structure/sign/departments/chemistry,
-/turf/closed/wall,
-/area/medical/chemistry)
 "cfX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -50018,9 +50021,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"cga" = (
-/turf/closed/wall,
 /area/medical/chemistry)
 "cgb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -100611,16 +100611,16 @@ cak
 cbV
 cdA
 ceF
-cfV
-cga
+abT
+acl
 civ
 cfY
 cls
-cga
-cga
-cga
-cga
-cga
+acl
+acl
+acl
+acl
+acl
 csD
 ctA
 cuu
@@ -100868,7 +100868,7 @@ cal
 cbW
 cdB
 ceG
-cfW
+abU
 chb
 ciw
 cjS
@@ -100877,7 +100877,7 @@ cmz
 cnH
 coT
 cqr
-cga
+acl
 csE
 ctA
 cuv
@@ -101391,7 +101391,7 @@ cmB
 cnJ
 coV
 cqt
-cga
+acl
 cKJ
 ctB
 cuw
@@ -101648,7 +101648,7 @@ cmC
 cnK
 coW
 cqu
-cga
+acl
 csH
 ctC
 cux
@@ -101901,11 +101901,11 @@ chf
 ciA
 cjW
 clw
-cga
+acl
 cnL
 coX
 cnL
-cga
+acl
 cbC
 ctB
 cuy
@@ -102153,16 +102153,16 @@ bZb
 ccb
 cdF
 bZa
-cga
+acl
 cfX
-cga
+acl
 cfX
-cga
-cga
+acl
+acl
 cnM
 coY
 coY
-cga
+acl
 csI
 ctD
 cuz

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -63,6 +63,15 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
+"aah" = (
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
+"aai" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/department/engine)
 "abf" = (
 /obj/structure/bed,
 /turf/open/floor/plating,
@@ -26189,9 +26198,6 @@
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall,
 /area/medical/chemistry)
-"bpY" = (
-/turf/closed/wall,
-/area/medical/chemistry)
 "bqb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -28490,12 +28496,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"bvu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/department/engine)
 "bvw" = (
 /obj/machinery/computer/rdconsole/core{
 	dir = 4
@@ -87982,13 +87982,13 @@ bnF
 boL
 bpV
 bpV
-bpY
-bpY
+aah
+aah
 bvq
 bpX
-bpY
-bpY
-bpY
+aah
+aah
+aah
 bCw
 bDy
 bDy
@@ -88245,7 +88245,7 @@ bvr
 bwS
 byw
 bAe
-bpY
+aah
 bCx
 bDy
 bEI
@@ -88759,7 +88759,7 @@ bwU
 bsK
 bsK
 bAg
-bpY
+aah
 bCz
 bDy
 bEK
@@ -89016,7 +89016,7 @@ bvt
 bwV
 byy
 bAh
-bpY
+aah
 bCA
 bDy
 bEL
@@ -89273,7 +89273,7 @@ mcf
 nnf
 byz
 ooh
-bpY
+aah
 bCB
 dhz
 bEM
@@ -89522,15 +89522,15 @@ bjd
 bmA
 bmA
 bjd
-bpY
-bpY
-bpY
+aah
+aah
+aah
 pSc
 gGA
 bwW
 byA
 bAi
-bpY
+aah
 pwj
 bva
 bva
@@ -89781,13 +89781,13 @@ aBI
 bmB
 bva
 bsn
-bva
-bva
-bvu
-bva
-bva
-bva
-bva
+bBX
+bBX
+aai
+bBX
+bBX
+bBX
+bBX
 pwj
 hVx
 xDj


### PR DESCRIPTION
## About The Pull Request
See title,
yes I map merged

## Why It's Good For The Game
Chemistry has a much higher potential for danger than several other areas that were deemed worthy of reinforced walls, including but not limited to; R&D, Genetics, Robotics and the Nanite Lab.
This change would make Chemistry feel less flimsy and exposed, and would also help mitigate the effect of explosive mishaps on the surrounding hallway and medbay lobby thanks to dynamic explosions.

## Changelog
:cl:
add: Chemistry now has reinforced walls
/:cl: