### PR TITLE
Fixes muscled veins surgery

### DIFF
--- a/code/modules/surgery/advanced/bioware/muscled_veins.dm
+++ b/code/modules/surgery/advanced/bioware/muscled_veins.dm
@@ -6,7 +6,7 @@
 				/datum/surgery_step/clamp_bleeders,
 				/datum/surgery_step/incise,
 				/datum/surgery_step/incise,
-				/datum/surgery_step/thread_veins,
+				/datum/surgery_step/muscled_veins,
 				/datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
 	bioware_target = BIOWARE_CIRCULATION


### PR DESCRIPTION
:cl:
fix: Muscled veins surgery now functions as intended, giving the patient the ability to live without a heart
/:cl:

Fixes #45638

The surgery used the surgery step from the the thread veins surgery, probably just an oversight when copy-pasting.