### PR TITLE
fixes traps

### DIFF
--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -94,11 +94,7 @@
 /obj/structure/trap/fire/trap_effect(mob/living/L)
 	to_chat(L, "<span class='danger'><B>Spontaneous combustion!</B></span>")
 	L.Paralyze(20)
-
-/obj/structure/trap/fire/flare()
-	..()
 	new /obj/effect/hotspot(get_turf(src))
-
 
 /obj/structure/trap/chill
 	name = "frost trap"
@@ -122,9 +118,6 @@
 	to_chat(L, "<span class='danger'><B>The ground quakes beneath your feet!</B></span>")
 	L.Paralyze(100)
 	L.adjustBruteLoss(35)
-
-/obj/structure/trap/damage/flare()
-	..()
 	var/obj/structure/flora/rock/giant_rock = new(get_turf(src))
 	QDEL_IN(giant_rock, 200)
 

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -14,7 +14,6 @@ Format:
 endmap
 
 map boxstation
-	default
 	#voteweight 1.5
 	votable
 endmap
@@ -40,6 +39,7 @@ map donutstation
 endmap
 
 map runtimestation
+	default
 endmap
 
 map multiz_debug

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -14,6 +14,7 @@ Format:
 endmap
 
 map boxstation
+	default
 	#voteweight 1.5
 	votable
 endmap
@@ -39,7 +40,6 @@ map donutstation
 endmap
 
 map runtimestation
-	default
 endmap
 
 map multiz_debug


### PR DESCRIPTION
fixes: #45646

some traps had stuff that should be in trap_effect() in the flare() proc so they would do some things even with antimagic (hotspots and creating the rock thing)

the issue report doesnt specificy what was wrong but i guess this? 