### PR TITLE
Replaces a pair of insulated gloves on metastation with budget insulated gloves.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -5046,10 +5046,10 @@
 /area/maintenance/port)
 "akp" = (
 /obj/structure/rack,
-/obj/item/clothing/gloves/color/yellow,
 /obj/item/mop,
 /obj/item/bikehorn/rubberducky,
 /obj/effect/spawner/lootdrop/maintenance/two,
+/obj/item/clothing/gloves/color/fyellow,
 /obj/item/grenade/empgrenade,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the gloves in north maint storage with budgets

this is not related to the b&e plans go away fwooshposters, meta just needs less ez greytide loot.

## Why It's Good For The Game

Giving assistants a free pair of gloves because ??? is stupid
It's time to start cutting back on meta's free consistent loot.

## Changelog
:cl:
balance: less free gloves for assistants on metastation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
