### PR TITLE
Adds a species randomizer to character setting screen

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -223,8 +223,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<table width='100%'><tr><td width='24%' valign='top'>"
 
 			dat += "<b>Species:</b><BR><a href='?_src_=prefs;preference=species;task=input'>[pref_species.name]</a><BR>"
-			dat += "<a href='?_src_=prefs;preference=species;task=random_race'>Random Species</A> "
-			dat += "<a href='?_src_=prefs;preference=species'>Always Random Species: [be_random_species ? "Yes" : "No"]</A><br>"
+			dat += "<a href='?_src_=prefs;preference=rand_species;task=random_race'>Random Species</A> "
+			dat += "<a href='?_src_=prefs;preference=rand_species'>Always Random Species: [be_random_species ? "Yes" : "No"]</A><br>"
 
 			dat += "<b>Underwear:</b><BR><a href ='?_src_=prefs;preference=underwear;task=input'>[underwear]</a><BR>"
 			dat += "<b>Undershirt:</b><BR><a href ='?_src_=prefs;preference=undershirt;task=input'>[undershirt]</a><BR>"
@@ -1414,7 +1414,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("all")
 					be_random_body = !be_random_body
 
-				if("species")
+				if("rand_species")
 					be_random_species = !be_random_species
 
 				if("hear_midis")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -51,6 +51,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/real_name						//our character's name
 	var/be_random_name = 0				//whether we'll have a random name every round
 	var/be_random_body = 0				//whether we'll have a random body every round
+	var/be_random_species = 0			//whether we'll be a random species every round
 	var/gender = MALE					//gender of character (well duh)
 	var/age = 30						//age of character
 	var/underwear = "Nude"				//underwear type
@@ -222,6 +223,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<table width='100%'><tr><td width='24%' valign='top'>"
 
 			dat += "<b>Species:</b><BR><a href='?_src_=prefs;preference=species;task=input'>[pref_species.name]</a><BR>"
+			dat += "<a href='?_src_=prefs;preference=species;task=random_race'>Random Species</A> "
+			dat += "<a href='?_src_=prefs;preference=species'>Always Random Species: [be_random_species ? "Yes" : "No"]</A><br>"
 
 			dat += "<b>Underwear:</b><BR><a href ='?_src_=prefs;preference=underwear;task=input'>[underwear]</a><BR>"
 			dat += "<b>Undershirt:</b><BR><a href ='?_src_=prefs;preference=undershirt;task=input'>[undershirt]</a><BR>"
@@ -1016,7 +1019,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					jumpsuit_style = pick(GLOB.jumpsuitlist)
 				if("all")
 					random_character()
-
+		if ("random_race")
+			random_species()
 		if("input")
 
 			if(href_list["preference"] in GLOB.preferences_custom_names)
@@ -1410,6 +1414,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("all")
 					be_random_body = !be_random_body
 
+				if("species")
+					be_random_species = !be_random_species
+
 				if("hear_midis")
 					toggles ^= SOUND_MIDI
 
@@ -1496,6 +1503,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	if(be_random_body)
 		random_character(gender)
+
+	if(be_random_species)
+		random_species()
 
 	if(roundstart_checks)
 		if(CONFIG_GET(flag/humans_need_surnames) && (pref_species.id == "human"))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -989,6 +989,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		return TRUE
 
 	switch(href_list["task"])
+		if ("random_race")
+			random_species()
+
 		if("random")
 			switch(href_list["preference"])
 				if("name")
@@ -1019,8 +1022,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					jumpsuit_style = pick(GLOB.jumpsuitlist)
 				if("all")
 					random_character()
-		if ("random_race")
-			random_species()
+
 		if("input")
 
 			if(href_list["preference"] in GLOB.preferences_custom_names)
@@ -1408,14 +1410,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					else
 						be_special += be_special_type
 
+				if("rand_species")
+					be_random_species = !be_random_species
+
 				if("name")
 					be_random_name = !be_random_name
 
 				if("all")
 					be_random_body = !be_random_body
-
-				if("rand_species")
-					be_random_species = !be_random_species
 
 				if("hear_midis")
 					toggles ^= SOUND_MIDI
@@ -1498,14 +1500,15 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	return 1
 
 /datum/preferences/proc/copy_to(mob/living/carbon/human/character, icon_updates = 1, roundstart_checks = TRUE)
+
+	if(be_random_species)
+		random_species()
+		
 	if(be_random_name)
 		real_name = pref_species.random_name(gender)
 
 	if(be_random_body)
 		random_character(gender)
-
-	if(be_random_species)
-		random_species()
 
 	if(roundstart_checks)
 		if(CONFIG_GET(flag/humans_need_surnames) && (pref_species.id == "human"))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -181,15 +181,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<table width='100%'><tr><td width='75%' valign='top'>"
 			if(is_banned_from(user.ckey, "Appearance"))
 				dat += "<b>You are banned from using custom names and appearances. You can continue to adjust your characters, but you will be randomised once you join the game.</b><br>"
-			if (!be_random_species) 	// don't let random species choose their own name
+			if (!be_random_species) 	// don't let random species choose their name
 				dat += "<a href='?_src_=prefs;preference=name;task=random'>Random Name</A> "
 				dat += "<a href='?_src_=prefs;preference=name'>Always Random Name: [be_random_name ? "Yes" : "No"]</a><BR>"
 				dat += "<b>Name:</b> "
 				dat += "<a href='?_src_=prefs;preference=name;task=input'>[real_name]</a><BR>"
 			else
-				dat += "<b>Name Randomized (always random species)"
-				dat += "<br>"
-
+				dat += "<b>Name Randomized (always random species)</b><br>"
 
 			if(!(AGENDER in pref_species.species_traits))
 				var/dispGender

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -181,11 +181,15 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<table width='100%'><tr><td width='75%' valign='top'>"
 			if(is_banned_from(user.ckey, "Appearance"))
 				dat += "<b>You are banned from using custom names and appearances. You can continue to adjust your characters, but you will be randomised once you join the game.</b><br>"
-			dat += "<a href='?_src_=prefs;preference=name;task=random'>Random Name</A> "
-			dat += "<a href='?_src_=prefs;preference=name'>Always Random Name: [be_random_name ? "Yes" : "No"]</a><BR>"
+			if (!be_random_species) 	// don't let random species choose their own name
+				dat += "<a href='?_src_=prefs;preference=name;task=random'>Random Name</A> "
+				dat += "<a href='?_src_=prefs;preference=name'>Always Random Name: [be_random_name ? "Yes" : "No"]</a><BR>"
+				dat += "<b>Name:</b> "
+				dat += "<a href='?_src_=prefs;preference=name;task=input'>[real_name]</a><BR>"
+			else
+				dat += "<b>Name Randomized (always random species)"
+				dat += "<br>"
 
-			dat += "<b>Name:</b> "
-			dat += "<a href='?_src_=prefs;preference=name;task=input'>[real_name]</a><BR>"
 
 			if(!(AGENDER in pref_species.species_traits))
 				var/dispGender
@@ -1502,6 +1506,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/proc/copy_to(mob/living/carbon/human/character, icon_updates = 1, roundstart_checks = TRUE)
 
 	if(be_random_species)
+		be_random_name = 1
 		random_species()
 		
 	if(be_random_name)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -283,6 +283,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["real_name"]			>> real_name
 	S["name_is_always_random"] >> be_random_name
 	S["body_is_always_random"] >> be_random_body
+	S["species_is_always_random"] >> be_random_species
 	S["gender"]				>> gender
 	S["age"]				>> age
 	S["hair_color"]			>> hair_color
@@ -355,6 +356,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	be_random_name	= sanitize_integer(be_random_name, 0, 1, initial(be_random_name))
 	be_random_body	= sanitize_integer(be_random_body, 0, 1, initial(be_random_body))
+	be_random_species	= sanitize_integer(be_random_species, 0, 1, initial(be_random_species))
 
 	if(gender == MALE)
 		hair_style			= sanitize_inlist(hair_style, GLOB.hair_styles_male_list)
@@ -419,6 +421,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["real_name"]			, real_name)
 	WRITE_FILE(S["name_is_always_random"] , be_random_name)
 	WRITE_FILE(S["body_is_always_random"] , be_random_body)
+	WRITE_FILE(S["species_is_always_random"] , be_random_species)
 	WRITE_FILE(S["gender"]				, gender)
 	WRITE_FILE(S["age"]				, age)
 	WRITE_FILE(S["hair_color"]			, hair_color)

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -20,6 +20,10 @@
 	features = random_features()
 	age = rand(AGE_MIN,AGE_MAX)
 
+/datum/preferences/proc/random_species()
+	var/rando_race = pick(GLOB.roundstart_races)
+	pref_species = new rando_race()
+
 /datum/preferences/proc/update_preview_icon()
 	// Determine what job is marked as 'High' priority, and dress them up as such.
 	var/datum/job/previewJob

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -21,8 +21,8 @@
 	age = rand(AGE_MIN,AGE_MAX)
 
 /datum/preferences/proc/random_species()
-	var/rando_race = pick(GLOB.roundstart_races)
-	pref_species = new rando_race()
+	var/random_species_type = GLOB.species_list[pick(GLOB.roundstart_races)]
+	pref_species = new random_species_type
 
 /datum/preferences/proc/update_preview_icon()
 	// Determine what job is marked as 'High' priority, and dress them up as such.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pretty self explanatory. It adds a random species and always random species button to the character settings/preview screen. It cycles between any species enabled for roundstart.

It does not randomize the body (as there is already a button for that, just figure somebody would ask).

![buttons](https://user-images.githubusercontent.com/52540478/62313700-9dd5e400-b44e-11e9-869d-58423bfb3f0e.JPG)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We're finally able to have a totally randomized character each game. Will allow for a little more fun to be had when making characters.

It will most likely also increase the species variety on the station (looking at you, ethereal).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: There is now a randomize species button in the character settings/preview screen.
/:cl: