### PR TITLE
[WIP] Refactors Life()

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -2,6 +2,12 @@
 
 //Misc mob defines
 
+//Mob Process_Living defines
+#define MOBFLAG_DEAD		(1 << 0)
+#define MOBFLAG_QDELETED	(1 << 1)
+#define MOBFLAG_KILLALL		(1 << 2)
+#define MOBFLAG_UPDATE_HEALTH (1 << 2)
+
 //Ready states at roundstart for mob/dead/new_player
 #define PLAYER_NOT_READY 0
 #define PLAYER_READY_TO_PLAY 1
@@ -274,9 +280,6 @@
 // AI Toggles
 #define AI_CAMERA_LUMINOSITY	5
 #define AI_VOX // Comment out if you don't want VOX to be enabled and have players download the voice sounds.
-
-// /obj/item/bodypart on_mob_life() retval flag
-#define BODYPART_LIFE_UPDATE_HEALTH (1<<0)
 
 #define MAX_REVIVE_FIRE_DAMAGE 180
 #define MAX_REVIVE_BRUTE_DAMAGE 180

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -3,10 +3,11 @@
 //Misc mob defines
 
 //Mob Process_Living defines
-#define MOBFLAG_DEAD		(1 << 0)
-#define MOBFLAG_QDELETED	(1 << 1)
-#define MOBFLAG_KILLALL		(1 << 2)
-#define MOBFLAG_UPDATE_HEALTH (1 << 2)
+#define MOBFLAG_DEAD		(1 << 0) //This flag gets added to . if the mob has died during the proc.
+#define MOBFLAG_DELETED		(1 << 1) //This flag gets added to the mob if the mob has been deleted during the proc.
+#define MOBFLAG_UPDATE_HEALTH (1 << 2) //Only used by humans. This flag makes updates the damage overlays after life is done. More things should use this.
+
+#define MOBFLAGS_DEAD_OR_DEL (MOBFLAG_DEAD|MOBFLAG_DELETED)
 
 //Ready states at roundstart for mob/dead/new_player
 #define PLAYER_NOT_READY 0

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -34,7 +34,7 @@ SUBSYSTEM_DEF(mobs)
 		var/mob/living/L = currentrun[currentrun.len]
 		currentrun.len--
 		if(L)
-			L.Life(seconds, times_fired)
+			L.Process_Living(seconds, times_fired)
 		else
 			GLOB.mob_living_list.Remove(L)
 		if (MC_TICK_CHECK)

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -120,11 +120,11 @@
 
 /mob/living/split_personality/Process_Living()
 	. = ..()
-	if(. & MOBFLAG_QDELETED)
+	if(. & MOBFLAG_DELETED)
 		return
 	if(QDELETED(body))
 		qdel(src) //in case trauma deletion doesn't already do it
-		. |= MOBFLAG_QDELETED
+		. |= MOBFLAG_DELETED
 	if((body.stat == DEAD && trauma.owner_backseat == src))
 		trauma.switch_personalities()
 		qdel(trauma)

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -118,10 +118,13 @@
 		trauma = _trauma
 	return ..()
 
-/mob/living/split_personality/Life()
+/mob/living/split_personality/Process_Living()
+	. = ..()
+	if(. & MOBFLAG_QDELETED)
+		return
 	if(QDELETED(body))
 		qdel(src) //in case trauma deletion doesn't already do it
-
+		. |= MOBFLAG_QDELETED
 	if((body.stat == DEAD && trauma.owner_backseat == src))
 		trauma.switch_personalities()
 		qdel(trauma)
@@ -130,8 +133,6 @@
 	if(!body.client && trauma.initialized)
 		trauma.switch_personalities()
 		qdel(trauma)
-
-	..()
 
 /mob/living/split_personality/Login()
 	..()

--- a/code/modules/VR/vr_human.dm
+++ b/code/modules/VR/vr_human.dm
@@ -21,7 +21,7 @@
 	revert_to_reality()
 	return ..()
 
-/mob/living/carbon/human/virtual_reality/Life()
+/mob/living/carbon/human/virtual_reality/Process_Living()
 	. = ..()
 	if(real_mind)
 		var/mob/living/real_me = real_mind.current

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -101,7 +101,10 @@
 		factory.spores += src
 	. = ..()
 
-/mob/living/simple_animal/hostile/blob/blobspore/Life()
+/mob/living/simple_animal/hostile/blob/blobspore/Process_Living()
+	. = ..()
+	if(. & MOBFLAG_QDELETED|MOBFLAG_DEAD|MOBFLAG_KILLALL)
+		return
 	if(!is_zombie && isturf(src.loc))
 		for(var/mob/living/carbon/human/H in view(src,1)) //Only for corpse right next to/on same tile
 			if(H.stat == DEAD)
@@ -109,7 +112,7 @@
 				break
 	if(factory && z != factory.z)
 		death()
-	..()
+		. |= MOBFLAG_DEAD
 
 /mob/living/simple_animal/hostile/blob/blobspore/proc/Zombify(mob/living/carbon/human/H)
 	is_zombie = 1
@@ -225,8 +228,11 @@
 	else
 		pass_flags &= ~PASSBLOB
 
-/mob/living/simple_animal/hostile/blob/blobbernaut/Life()
-	if(..())
+/mob/living/simple_animal/hostile/blob/blobbernaut/Process_Living()
+	. = ..()
+	if(. & MOBFLAG_QDELETED|MOBFLAG_DEAD|MOBFLAG_KILLALL)
+		return
+	else //Fuck me if I remove this nesting.
 		var/list/blobs_in_area = range(2, src)
 		if(independent)
 			return // strong independent blobbernaut that don't need no blob

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -103,7 +103,7 @@
 
 /mob/living/simple_animal/hostile/blob/blobspore/Process_Living()
 	. = ..()
-	if(. & MOBFLAG_QDELETED|MOBFLAG_DEAD|MOBFLAG_KILLALL)
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(!is_zombie && isturf(src.loc))
 		for(var/mob/living/carbon/human/H in view(src,1)) //Only for corpse right next to/on same tile
@@ -230,40 +230,39 @@
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/Process_Living()
 	. = ..()
-	if(. & MOBFLAG_QDELETED|MOBFLAG_DEAD|MOBFLAG_KILLALL)
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
-	else //Fuck me if I remove this nesting.
-		var/list/blobs_in_area = range(2, src)
-		if(independent)
-			return // strong independent blobbernaut that don't need no blob
-		var/damagesources = 0
-		if(!(locate(/obj/structure/blob) in blobs_in_area))
-			damagesources++
-		if(!factory)
-			damagesources++
-		else
-			if(locate(/obj/structure/blob/core) in blobs_in_area)
-				adjustHealth(-maxHealth*0.1)
-				var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(src)) //hello yes you are being healed
-				if(overmind)
-					H.color = overmind.blobstrain.complementary_color
-				else
-					H.color = "#000000"
-			if(locate(/obj/structure/blob/node) in blobs_in_area)
-				adjustHealth(-maxHealth*0.05)
-				var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(src))
-				if(overmind)
-					H.color = overmind.blobstrain.complementary_color
-				else
-					H.color = "#000000"
-		if(damagesources)
-			for(var/i in 1 to damagesources)
-				adjustHealth(maxHealth*0.025) //take 2.5% of max health as damage when not near the blob or if the naut has no factory, 5% if both
-			var/image/I = new('icons/mob/blob.dmi', src, "nautdamage", MOB_LAYER+0.01)
-			I.appearance_flags = RESET_COLOR
+	var/list/blobs_in_area = range(2, src)
+	if(independent)
+		return // strong independent blobbernaut that don't need no blob
+	var/damagesources = 0
+	if(!(locate(/obj/structure/blob) in blobs_in_area))
+		damagesources++
+	if(!factory)
+		damagesources++
+	else
+		if(locate(/obj/structure/blob/core) in blobs_in_area)
+			adjustHealth(-maxHealth*0.1)
+			var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(src)) //hello yes you are being healed
 			if(overmind)
-				I.color = overmind.blobstrain.complementary_color
-			flick_overlay_view(I, src, 8)
+				H.color = overmind.blobstrain.complementary_color
+			else
+				H.color = "#000000"
+		if(locate(/obj/structure/blob/node) in blobs_in_area)
+			adjustHealth(-maxHealth*0.05)
+			var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(src))
+			if(overmind)
+				H.color = overmind.blobstrain.complementary_color
+			else
+				H.color = "#000000"
+	if(damagesources)
+		for(var/i in 1 to damagesources)
+			adjustHealth(maxHealth*0.025) //take 2.5% of max health as damage when not near the blob or if the naut has no factory, 5% if both
+		var/image/I = new('icons/mob/blob.dmi', src, "nautdamage", MOB_LAYER+0.01)
+		I.appearance_flags = RESET_COLOR
+		if(overmind)
+			I.color = overmind.blobstrain.complementary_color
+		flick_overlay_view(I, src, 8)
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = ..()

--- a/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
@@ -34,8 +34,10 @@
 	if(!shield_health)
 		return "<span class='warning'>Its shield has been destroyed!</span>"
 
-/mob/living/simple_animal/hostile/clockwork/marauder/Life()
-	..()
+/mob/living/simple_animal/hostile/clockwork/marauder/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD|MOBFLAG_KILLALL))
+		return
 	if(!GLOB.ratvar_awakens && health / maxHealth <= MARAUDER_SLOWDOWN_PERCENTAGE)
 		speed = initial(speed) + 1 //Yes, this slows them down
 	else

--- a/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
@@ -36,7 +36,7 @@
 
 /mob/living/simple_animal/hostile/clockwork/marauder/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD|MOBFLAG_KILLALL))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(!GLOB.ratvar_awakens && health / maxHealth <= MARAUDER_SLOWDOWN_PERCENTAGE)
 		speed = initial(speed) + 1 //Yes, this slows them down

--- a/code/modules/antagonists/devil/imp/imp.dm
+++ b/code/modules/antagonists/devil/imp/imp.dm
@@ -44,8 +44,10 @@
 	..()
 	boost = world.time + 30
 
-/mob/living/simple_animal/imp/Life()
-	..()
+/mob/living/simple_animal/imp/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD|MOBFLAG_KILLALL))
+		return
 	if(boost<world.time)
 		speed = 1
 	else

--- a/code/modules/antagonists/devil/imp/imp.dm
+++ b/code/modules/antagonists/devil/imp/imp.dm
@@ -46,7 +46,7 @@
 
 /mob/living/simple_animal/imp/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD|MOBFLAG_KILLALL))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(boost<world.time)
 		speed = 1

--- a/code/modules/antagonists/devil/true_devil/_true_devil.dm
+++ b/code/modules/antagonists/devil/true_devil/_true_devil.dm
@@ -188,8 +188,9 @@
 							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 							visible_message("<span class='danger'>[M] has attempted to disarm [src]!</span>")
 
+/// devils do not need to breathe
 /mob/living/carbon/true_devil/handle_breathing()
-	// devils do not need to breathe
+	return
 
 /mob/living/carbon/true_devil/is_literate()
 	return TRUE

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -105,7 +105,7 @@
 		mind.add_antag_datum(/datum/antagonist/revenant)
 
 //Life, Stat, Hud Updates, and Say
-/mob/living/simple_animal/revenant/Life()
+/mob/living/simple_animal/revenant/Process_Living()
 	if(stasis)
 		return
 	if(revealed && essence <= 0)
@@ -125,7 +125,7 @@
 		update_action_buttons_icon() //because we update something required by our spells in life, we need to update our buttons
 	update_spooky_icon()
 	update_health_hud()
-	..()
+	. = ..()
 
 /mob/living/simple_animal/revenant/Stat()
 	..()

--- a/code/modules/holiday/halloween.dm
+++ b/code/modules/holiday/halloween.dm
@@ -138,7 +138,7 @@
 
 /mob/living/simple_animal/shade/howling_ghost/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD|MOBFLAG_KILLALL))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	timer--
 	if(prob(20))

--- a/code/modules/holiday/halloween.dm
+++ b/code/modules/holiday/halloween.dm
@@ -136,8 +136,10 @@
 	status_flags |= GODMODE
 	timer = rand(1,15)
 
-/mob/living/simple_animal/shade/howling_ghost/Life()
-	..()
+/mob/living/simple_animal/shade/howling_ghost/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD|MOBFLAG_KILLALL))
+		return
 	timer--
 	if(prob(20))
 		roam()
@@ -205,11 +207,10 @@
 /mob/living/simple_animal/hostile/retaliate/clown/insane/ex_act()
 	return
 
-/mob/living/simple_animal/hostile/retaliate/clown/insane/Life()
+/mob/living/simple_animal/hostile/retaliate/clown/insane/Process_Living()
 	timer--
 	if(target)
 		stalk()
-	return
 
 /mob/living/simple_animal/hostile/retaliate/clown/insane/proc/stalk()
 	var/mob/living/M = target

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -22,6 +22,8 @@
 			blood_volume += 0.1 // regenerate blood VERY slowly
 			if(blood_volume < BLOOD_VOLUME_OKAY)
 				adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.02, 1))
+				if(stat == DEAD)
+					return MOBFLAG_DEAD
 
 // Takes care blood loss and regeneration
 /mob/living/carbon/human/handle_blood()
@@ -71,6 +73,8 @@
 			if(-INFINITY to BLOOD_VOLUME_SURVIVE)
 				if(!HAS_TRAIT(src, TRAIT_NODEATH))
 					death()
+		if(stat == DEAD)
+			. |= MOBFLAG_DEAD
 
 		var/temp_bleed = 0
 		//Bleeding out

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -1,7 +1,7 @@
 
 /mob/living/brain/Life()
 	. = ..()
-	if(. (MOBFLAG_QDELETED|MOBFLAG_DEAD))
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD))
 		return
 	handle_emp_damage()
 

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -1,11 +1,8 @@
 
 /mob/living/brain/Life()
-	set invisibility = 0
-	if (notransform)
-		return
-	if(!loc)
-		return
 	. = ..()
+	if(. (MOBFLAG_QDELETED|MOBFLAG_DEAD))
+		return
 	handle_emp_damage()
 
 /mob/living/brain/update_stat()

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -1,7 +1,7 @@
 
 /mob/living/brain/Life()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	handle_emp_damage()
 

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -80,6 +80,8 @@
 					apply_damage(HEAT_DAMAGE_LEVEL_2, BURN)
 	else
 		clear_alert("alien_fire")
+	if(stat == DEAD)
+		return MOBFLAG_DEAD
 
 /mob/living/carbon/alien/reagent_check(datum/reagent/R) //can metabolize all reagents
 	return 0

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -1,7 +1,7 @@
 
 /mob/living/carbon/alien/larva/Life()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(amount_grown < max_grown)
 		amount_grown++

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -1,14 +1,11 @@
 
-
 /mob/living/carbon/alien/larva/Life()
-	set invisibility = 0
-	if (notransform)
+	. = ..()
+	if(. (MOBFLAG_QDELETED|MOBFLAG_DEAD))
 		return
-	if(..() && !IS_IN_STASIS(src)) //not dead and not in stasis
-		// GROW!
-		if(amount_grown < max_grown)
-			amount_grown++
-			update_icons()
+	if(amount_grown < max_grown)
+		amount_grown++
+		update_icons()
 
 
 /mob/living/carbon/alien/larva/update_stat()

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -1,7 +1,7 @@
 
 /mob/living/carbon/alien/larva/Life()
 	. = ..()
-	if(. (MOBFLAG_QDELETED|MOBFLAG_DEAD))
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD))
 		return
 	if(amount_grown < max_grown)
 		amount_grown++

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,6 +1,8 @@
-/mob/living/carbon/alien/Life()
+/mob/living/carbon/alien/Process_Living(seconds, times_fired)
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+		return
 	findQueen()
-	return..()
 
 /mob/living/carbon/alien/check_breath(datum/gas_mixture/breath)
 	if(status_flags & GODMODE)
@@ -39,7 +41,7 @@
 	handle_breath_temperature(breath)
 
 /mob/living/carbon/alien/handle_status_effects()
-	..()
+	. = ..()
 	//natural reduction of movement delay due to stun.
 	if(move_delay_add > 0)
 		move_delay_add = max(0, move_delay_add - rand(1, 2))

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/alien/Process_Living(seconds, times_fired)
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+	if(. & MOBFLAG_DELETED)
 		return
 	findQueen()
 

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -11,7 +11,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	in_use = FALSE
 	return ..()
 
-/mob/living/carbon/human/dummy/Life()
+/mob/living/carbon/human/dummy/Process_Living()
 	return
 
 /mob/living/carbon/human/dummy/proc/wipe_state()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -20,23 +20,23 @@
 
 /mob/living/carbon/human/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+	if(. & MOBFLAG_DELETED)
 		return
 	//Update our name based on whether our face is obscured/disfigured
 	. |= dna.species.spec_life(src) // for mutantraces
-	if(. & MOBFLAG_QDELETED)
+	if(. & MOBFLAG_DELETED)
 		return
 	name = get_visible_name()
 
 mob/living/carbon/human/Life()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	for(var/datum/mutation/human/HM in dna.mutations) // Handle active genes
 		HM.on_life()
 	if(stat == DEAD) //Workaround. This will get removed later (TM)
 		. |= MOBFLAG_DEAD
-	if(. & MOBFLAG_DEAD)
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	. |= handle_embedded_objects()
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -742,6 +742,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		var/takes_crit_damage = (!HAS_TRAIT(H, TRAIT_NOCRITDAMAGE))
 		if((H.health < H.crit_threshold) && takes_crit_damage)
 			H.adjustBruteLoss(1)
+			if(H.stat == DEAD)
+				return MOBFLAG_DEAD
 
 /datum/species/proc/spec_death(gibbed, mob/living/carbon/human/H)
 	return
@@ -1568,11 +1570,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 //BREATHING//
 /////////////
 
-/datum/species/proc/breathe(mob/living/carbon/human/H)
-	if(HAS_TRAIT(H, TRAIT_NOBREATH))
-		return TRUE
-
-
 /datum/species/proc/handle_environment(datum/gas_mixture/environment, mob/living/carbon/human/H)
 	if(!environment)
 		return
@@ -1672,6 +1669,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			else
 				H.adjustBruteLoss(LOW_PRESSURE_DAMAGE * H.physiology.pressure_mod)
 				H.throw_alert("pressure", /obj/screen/alert/lowpressure, 2)
+	if(H.stat == DEAD)
+		return MOBFLAG_DEAD
 
 //////////
 // FIRE //

--- a/code/modules/mob/living/carbon/human/species_types/angel.dm
+++ b/code/modules/mob/living/carbon/human/species_types/angel.dm
@@ -41,6 +41,7 @@
 
 /datum/species/angel/spec_life(mob/living/carbon/human/H)
 	HandleFlight(H)
+	. = ..()
 
 /datum/species/angel/proc/HandleFlight(mob/living/carbon/human/H)
 	if(H.movement_type & FLYING)

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -45,13 +45,16 @@
 	..()
 
 /datum/species/dullahan/spec_life(mob/living/carbon/human/H)
+	. = ..()
 	if(QDELETED(myhead))
 		myhead = null
 		H.gib()
+		return . | MOBFLAG_QDELETED
 	var/obj/item/bodypart/head/head2 = H.get_bodypart(BODY_ZONE_HEAD)
 	if(head2)
 		myhead = null
 		H.gib()
+		return . | MOBFLAG_QDELETED
 
 /datum/species/dullahan/proc/update_vision_perspective(mob/living/carbon/human/H)
 	var/obj/item/organ/eyes/eyes = H.getorganslot(ORGAN_SLOT_EYES)

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -49,12 +49,12 @@
 	if(QDELETED(myhead))
 		myhead = null
 		H.gib()
-		return . | MOBFLAG_QDELETED
+		return . | MOBFLAG_DELETED
 	var/obj/item/bodypart/head/head2 = H.get_bodypart(BODY_ZONE_HEAD)
 	if(head2)
 		myhead = null
 		H.gib()
-		return . | MOBFLAG_QDELETED
+		return . | MOBFLAG_DELETED
 
 /datum/species/dullahan/proc/update_vision_perspective(mob/living/carbon/human/H)
 	var/obj/item/organ/eyes/eyes = H.getorganslot(ORGAN_SLOT_EYES)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -95,6 +95,7 @@
 	var/datum/action/innate/ignite/ignite
 
 /datum/species/golem/plasma/spec_life(mob/living/carbon/human/H)
+	. = ..()
 	if(H.bodytemperature > 750)
 		if(!boom_warning && H.on_fire)
 			to_chat(H, "<span class='userdanger'>You feel like you could blow up at any moment!</span>")
@@ -108,9 +109,10 @@
 		explosion(get_turf(H),1,2,4,flame_range = 5)
 		if(H)
 			H.gib()
+			return . | MOBFLAG_QDELETED
 	if(H.fire_stacks < 2) //flammable
 		H.adjust_fire_stacks(1)
-	..()
+
 
 /datum/species/golem/plasma/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	..()
@@ -312,6 +314,8 @@
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
 		H.take_overall_damage(2,0)
+	if(H.stat == DEAD)
+		return MOBFLAG_DEAD
 
 /datum/species/golem/wood/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.type == /datum/reagent/toxin/plantbgone)
@@ -333,13 +337,13 @@
 	special_names = list("Oxide", "Rod", "Meltdown", "235")
 
 /datum/species/golem/uranium/spec_life(mob/living/carbon/human/H)
+	. = ..()
 	if(!active)
 		if(world.time > last_event+30)
 			active = 1
 			radiation_pulse(H, 50)
 			last_event = world.time
 			active = null
-	..()
 
 //Immune to physical bullets and resistant to brute, but very vulnerable to burn damage. Dusts on death.
 /datum/species/golem/sand
@@ -569,6 +573,7 @@
 			last_banana = world.time
 
 /datum/species/golem/bananium/spec_life(mob/living/carbon/human/H)
+	. = ..()
 	if(!active)
 		if(world.time > last_honk + honkooldown)
 			active = 1
@@ -576,7 +581,6 @@
 			last_honk = world.time
 			honkooldown = rand(20, 80)
 			active = null
-	..()
 
 /datum/species/golem/bananium/spec_death(gibbed, mob/living/carbon/human/H)
 	playsound(get_turf(H), 'sound/misc/sadtrombone.ogg', 70, 0)
@@ -731,9 +735,9 @@
 	return golem_name
 
 /datum/species/golem/cloth/spec_life(mob/living/carbon/human/H)
+	. = ..()
 	if(H.fire_stacks < 1)
 		H.adjust_fire_stacks(1) //always prone to burning
-	..()
 
 /datum/species/golem/cloth/spec_death(gibbed, mob/living/carbon/human/H)
 	if(gibbed)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -109,7 +109,7 @@
 		explosion(get_turf(H),1,2,4,flame_range = 5)
 		if(H)
 			H.gib()
-			return . | MOBFLAG_QDELETED
+			return . | MOBFLAG_DELETED
 	if(H.fire_stacks < 2) //flammable
 		H.adjust_fire_stacks(1)
 

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -34,6 +34,7 @@
 	C.faction |= "slime"
 
 /datum/species/jelly/spec_life(mob/living/carbon/human/H)
+	. = ..()
 	if(H.stat == DEAD) //can't farm slime jelly from a dead slime/jelly person indefinitely
 		return
 	if(!H.blood_volume)
@@ -167,14 +168,13 @@
 	bodies = old_species.bodies
 
 /datum/species/jelly/slime/spec_life(mob/living/carbon/human/H)
+	. = ..()
 	if(H.blood_volume >= BLOOD_VOLUME_SLIME_SPLIT)
 		if(prob(5))
 			to_chat(H, "<span class='notice'>You feel very bloated!</span>")
 	else if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
 		H.blood_volume += 3
 		H.adjust_nutrition(-2.5)
-
-	..()
 
 /datum/action/innate/split_body
 	name = "Split Body"

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -23,6 +23,7 @@
 	outfit_important_for_life = /datum/outfit/plasmaman
 
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H)
+	. = ..()
 	var/datum/gas_mixture/environment = H.loc.return_air()
 	var/atmos_sealed = FALSE
 	if (H.wear_suit && H.head && istype(H.wear_suit, /obj/item/clothing) && istype(H.head, /obj/item/clothing))

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -26,6 +26,7 @@
 	C.faction -= "vines"
 
 /datum/species/pod/spec_life(mob/living/carbon/human/H)
+	. = ..()
 	if(H.stat == DEAD)
 		return
 	var/light_amount = 0 //how much light there is in the place, affects receiving nutrition and healing
@@ -42,6 +43,8 @@
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
 		H.take_overall_damage(2,0)
+		if(H.stat == DEAD)
+			return MOBFLAG_DEAD
 
 /datum/species/pod/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.type == /datum/reagent/toxin/plantbgone)

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -16,13 +16,17 @@
 
 
 /datum/species/shadow/spec_life(mob/living/carbon/human/H)
+	. = ..()
 	var/turf/T = H.loc
 	if(istype(T))
 		var/light_amount = T.get_lumcount()
 
 		if(light_amount > SHADOW_SPECIES_LIGHT_THRESHOLD) //if there's enough light, start dying
 			H.take_overall_damage(1,1, 0, BODYPART_ORGANIC)
-		else if (light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD) //heal in the dark
+			if(H.stat == DEAD)
+				return MOBFLAG_DEAD | .
+			return
+		if (light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD) //heal in the dark
 			H.heal_overall_damage(1,1, 0, BODYPART_ORGANIC)
 
 /datum/species/shadow/check_roundstart_eligible()

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -51,7 +51,7 @@
 		if(H)
 			H.shape.dust() //make sure we're killing the bat if you are out of blood, if you don't it creates weird situations where the bat is alive but the caster is dusted.
 		C.dust()
-		return . | MOBFLAG_QDELETED
+		return . | MOBFLAG_DELETED
 	var/area/A = get_area(C)
 	if(istype(A, /area/chapel))
 		to_chat(C, "<span class='warning'>You don't belong here!</span>")

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -51,12 +51,15 @@
 		if(H)
 			H.shape.dust() //make sure we're killing the bat if you are out of blood, if you don't it creates weird situations where the bat is alive but the caster is dusted.
 		C.dust()
+		return . | MOBFLAG_QDELETED
 	var/area/A = get_area(C)
 	if(istype(A, /area/chapel))
 		to_chat(C, "<span class='warning'>You don't belong here!</span>")
 		C.adjustFireLoss(20)
 		C.adjust_fire_stacks(6)
 		C.IgniteMob()
+		if(C.stat == DEAD)
+			return . | MOBFLAG_DEAD
 
 /datum/species/vampire/check_species_weakness(obj/item/weapon, mob/living/attacker)
 	if(istype(weapon, /obj/item/nullrod/whip))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -1,10 +1,10 @@
 /mob/living/carbon/Process_Living(seconds, times_fired)
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+	if(. & MOBFLAG_DELETED)
 		return
 	if(!IS_IN_STASIS(src)) //Ugly, but it has to be here.
 		. |= handle_diseases()
-		if(. & MOBFLAG_QDELETED)
+		if(. & MOBFLAG_DELETED)
 			return
 	if(damageoverlaytemp)
 		damageoverlaytemp = 0
@@ -18,25 +18,25 @@
 
 /mob/living/carbon/Life(seconds, times_fired)
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	. |= handle_organs()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD)) //Apparently some organs gib you.
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	. |= handle_blood()
-	if(. & MOBFLAG_DEAD) //Apparently some organs gib you.
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	. |= handle_bodyparts()
 	if(. & MOBFLAG_UPDATE_HEALTH)
 		update_stamina() //needs to go before updatehealth to remove stamcrit
 		updatehealth()
-	if(. & MOBFLAG_DEAD)
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	. |= handle_brain_damage()
-	if(. & MOBFLAG_DEAD)
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	. |= handle_breathing(times_fired)
-	if(. & MOBFLAG_DEAD)
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	. |= handle_heart()
 
@@ -335,7 +335,7 @@
 		var/obj/item/organ/O = V
 		O.on_life()
 	if(QDELETED(src)) //Ugly but I will get something better later.
-		return MOBFLAG_QDELETED
+		return MOBFLAG_DELETED
 	if(stat == DEAD)
 		return MOBFLAG_DEAD
 
@@ -674,7 +674,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 	if(chest.cremation_progress >= 100)
 		visible_message("<span class='warning'>[src]'s body crumbles into a pile of ash!</span>")
 		dust(TRUE, TRUE)
-		return MOBFLAG_QDELETED
+		return MOBFLAG_DELETED
 
 ////////////////
 //BRAIN DAMAGE//

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -3,30 +3,28 @@
 /mob/living/carbon/monkey
 
 
-/mob/living/carbon/monkey/Life()
-	set invisibility = 0
-
-	if (notransform)
+/mob/living/carbon/monkey/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
 		return
-
-	if(..() && !IS_IN_STASIS(src))
-
-		if(!client)
-			if(stat == CONSCIOUS)
-				if(on_fire || buckled || restrained())
-					if(!resisting && prob(MONKEY_RESIST_PROB))
-						resisting = TRUE
-						walk_to(src,0)
-						resist()
-				else if(resisting)
-					resisting = FALSE
-				else if((mode == MONKEY_IDLE && !pickupTarget && !prob(MONKEY_SHENANIGAN_PROB)) || !handle_combat())
-					if(prob(25) && (mobility_flags & MOBILITY_MOVE) && isturf(loc) && !pulledby)
-						step(src, pick(GLOB.cardinals))
-					else if(prob(1))
-						emote(pick("scratch","jump","roll","tail"))
-			else
-				walk_to(src,0)
+	if(client)
+		return
+	if(stat != CONSCIOUS)
+		return
+	if(on_fire || buckled || restrained())
+		if(!resisting && prob(MONKEY_RESIST_PROB))
+			resisting = TRUE
+			walk_to(src,0)
+			resist()
+	else if(resisting)
+		resisting = FALSE
+	else if((mode == MONKEY_IDLE && !pickupTarget && !prob(MONKEY_SHENANIGAN_PROB)) || !handle_combat())
+		if(prob(25) && (mobility_flags & MOBILITY_MOVE) && isturf(loc) && !pulledby)
+			step(src, pick(GLOB.cardinals))
+		else if(prob(1))
+			emote(pick("scratch","jump","roll","tail"))
+	else
+		walk_to(src,0)
 
 /mob/living/carbon/monkey/handle_mutations_and_radiation()
 	if(radiation)
@@ -131,8 +129,8 @@
 		else
 			adjustBruteLoss( LOW_PRESSURE_DAMAGE )
 			throw_alert("pressure", /obj/screen/alert/lowpressure, 2)
-
-	return
+	if(stat == DEAD)
+		return MOBFLAG_DEAD
 
 /mob/living/carbon/monkey/handle_random_events()
 	if (prob(1) && prob(2))

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -5,7 +5,7 @@
 
 /mob/living/carbon/monkey/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(client)
 		return

--- a/code/modules/mob/living/carbon/monkey/punpun.dm
+++ b/code/modules/mob/living/carbon/monkey/punpun.dm
@@ -31,7 +31,7 @@
 	if(relic_mask)
 		equip_to_slot_or_del(new relic_mask, SLOT_WEAR_MASK)
 
-/mob/living/carbon/monkey/punpun/Life()
+/mob/living/carbon/monkey/punpun/Process_Living()
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory(FALSE, FALSE)
 		memory_saved = TRUE

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -27,7 +27,7 @@
 		log_game("Z-TRACKING: [src] of type [src.type] has a Z-registration despite not having a client.")
 		update_z(null)
 	if(notransform || !loc)
-		. |= MOBFLAG_KILLALL
+		. |= MOBFLAG_DELETED //We are basically deleted at that point, we shouldn't be doing stuff.
 		return
 	if(digitalinvis) //TO-DO: Get rid of this somehow.
 		handle_diginvis()
@@ -36,7 +36,7 @@
 	//Here is where the fun begins
 	if(!IS_IN_STASIS(src) && !(. & MOBFLAG_DEAD))
 		. |= Life(seconds, times_fired)
-	if(. & MOBFLAG_QDELETED)
+	if(. & MOBFLAG_DELETED)
 		return
 	var/datum/gas_mixture/environment = loc.return_air()
 	if(environment)
@@ -49,10 +49,10 @@
 ///Called if the mob isn't in stasis AND alive.
 /mob/living/proc/Life(seconds, times_fired)
 	. |= handle_mutations_and_radiation()
-	if(. & MOBFLAG_DEAD)
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	. |= handle_status_effects() //all special effects, stun, knockdown, jitteryness, hallucination, sleeping, etc
-	if(. & MOBFLAG_DEAD)
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	handle_random_events() //Only used by carbons right now, but there is value in this being on living.
 	handle_traits() // eye, ear, brain damages

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -3,52 +3,35 @@
 #define POWER_RESTORATION_SEARCH_APC 2
 #define POWER_RESTORATION_APC_FOUND 3
 
-/mob/living/silicon/ai/Life()
-	if (stat == DEAD)
-		return
-	else //I'm not removing that shitton of tabs, unneeded as they are. -- Urist
-		//Being dead doesn't mean your temperature never changes
-
-		update_gravity(mob_has_gravity())
-
-		handle_status_effects()
-
-		if(malfhack && malfhack.aidisabled)
-			deltimer(malfhacking)
-			// This proc handles cleanup of screen notifications and
-			// messenging the client
-			malfhacked(malfhack)
-
-		if(isturf(loc) && (QDELETED(eyeobj) || !eyeobj.loc))
-			view_core()
-
-		if(machine)
-			machine.check_eye(src)
-
-		// Handle power damage (oxy)
-		if(aiRestorePowerRoutine)
-			// Lost power
-			if (!battery)
-				to_chat(src, "<span class='warning'>Your backup battery's output drops below usable levels. It takes only a moment longer for your systems to fail, corrupted and unusable.</span>")
-				adjustOxyLoss(200)
-			else
-				battery --
+/mob/living/silicon/ai/Process_Living()
+	. = ..()
+	if(malfhack && malfhack.aidisabled)
+		deltimer(malfhacking)
+		// This proc handles cleanup of screen notifications and
+		// messenging the client
+		malfhacked(malfhack)
+	if(isturf(loc) && (QDELETED(eyeobj) || !eyeobj.loc))
+		view_core()
+	if(machine)
+		machine.check_eye(src)
+	if(aiRestorePowerRoutine) // Handle power damage (oxy)
+		if (!battery) // Lost power
+			to_chat(src, "<span class='warning'>Your backup battery's output drops below usable levels. It takes only a moment longer for your systems to fail, corrupted and unusable.</span>")
+			adjustOxyLoss(200)
 		else
-			// Gain Power
-			if (battery < 200)
-				battery ++
-
-		if(!lacks_power())
-			var/area/home = get_area(src)
-			if(home.powered(EQUIP))
-				home.use_power(1000, EQUIP)
-
-			if(aiRestorePowerRoutine >= POWER_RESTORATION_SEARCH_APC)
-				ai_restore_power()
-				return
-
-		else if(!aiRestorePowerRoutine)
-			ai_lose_power()
+			battery --
+	else
+		if (battery < 200)// Gain Power
+			battery ++
+	if(!lacks_power())
+		var/area/home = get_area(src)
+		if(home.powered(EQUIP))
+			home.use_power(1000, EQUIP)
+		if(aiRestorePowerRoutine >= POWER_RESTORATION_SEARCH_APC)
+			ai_restore_power()
+			return
+	else if(!aiRestorePowerRoutine)
+		ai_lose_power()
 
 /mob/living/silicon/ai/proc/lacks_power()
 	var/turf/T = get_turf(src)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -130,7 +130,7 @@
 
 /mob/living/silicon/pai/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(hacking)
 		process_hack()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -128,10 +128,19 @@
 	emittersemicd = TRUE
 	addtimer(CALLBACK(src, .proc/emittercool), 600)
 
-/mob/living/silicon/pai/Life()
+/mob/living/silicon/pai/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 	if(hacking)
 		process_hack()
-	return ..()
+	if(cable)
+		if(get_dist(src, cable) > 1)
+			var/turf/T = get_turf(src.loc)
+			T.visible_message("<span class='warning'>[src.cable] rapidly retracts back into its spool.</span>", "<span class='italics'>You hear a click and the sound of wire spooling rapidly.</span>")
+			qdel(src.cable)
+			cable = null
+	silent = max(silent - 1, 0)
 
 /mob/living/silicon/pai/proc/process_hack()
 
@@ -263,18 +272,6 @@
 /mob/living/silicon/pai/examine(mob/user)
 	. = ..()
 	. += "A personal AI in holochassis mode. Its master ID string seems to be [master]."
-
-/mob/living/silicon/pai/Life()
-	if(stat == DEAD)
-		return
-	if(cable)
-		if(get_dist(src, cable) > 1)
-			var/turf/T = get_turf(src.loc)
-			T.visible_message("<span class='warning'>[src.cable] rapidly retracts back into its spool.</span>", "<span class='italics'>You hear a click and the sound of wire spooling rapidly.</span>")
-			qdel(src.cable)
-			cable = null
-	silent = max(silent - 1, 0)
-	. = ..()
 
 /mob/living/silicon/pai/updatehealth()
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -1,21 +1,18 @@
-/mob/living/silicon/robot/Life()
-	set invisibility = 0
-	if (src.notransform)
+/mob/living/silicon/robot/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
 		return
-
-	..()
-	adjustOxyLoss(-10) //we're a robot!
+	adjustOxyLoss(-10) //we're a robot! Yes so what the fuck why and how? This comment doesn't help.
 	handle_robot_hud_updates()
 	handle_robot_cell()
 
 /mob/living/silicon/robot/proc/handle_robot_cell()
-	if(stat != DEAD)
-		if(low_power_mode)
-			if(cell && cell.charge)
-				low_power_mode = 0
-				update_headlamp()
-		else if(stat == CONSCIOUS)
-			use_power()
+	if(low_power_mode)
+		if(cell && cell.charge)
+			low_power_mode = 0
+			update_headlamp()
+	else if(stat == CONSCIOUS)
+		use_power()
 
 /mob/living/silicon/robot/proc/use_power()
 	if(cell && cell.charge)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -1,6 +1,6 @@
 /mob/living/silicon/robot/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	adjustOxyLoss(-10) //we're a robot! Yes so what the fuck why and how? This comment doesn't help.
 	handle_robot_hud_updates()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -58,6 +58,10 @@
 	diag_hud_set_status()
 	diag_hud_set_health()
 
+///Attention fucko, this is important. Life is like super out and only used for things that are actually alive. Use Process_Living instead
+/mob/living/silicon/Life()
+	return
+
 /mob/living/silicon/med_hud_set_health()
 	return //we use a different hud
 

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -103,13 +103,13 @@
 	Read_Memory()
 	. = ..()
 
-/mob/living/simple_animal/pet/cat/Runtime/Life()
+/mob/living/simple_animal/pet/cat/Runtime/Process_Living()
 	if(!cats_deployed && SSticker.current_state >= GAME_STATE_SETTING_UP)
 		Deploy_The_Cats()
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory()
 		memory_saved = TRUE
-	..()
+	. = ..()
 
 /mob/living/simple_animal/pet/cat/Runtime/make_babies()
 	var/mob/baby = ..()
@@ -165,7 +165,10 @@
 	gold_core_spawnable = NO_SPAWN
 	unique_pet = TRUE
 
-/mob/living/simple_animal/pet/cat/Life()
+/mob/living/simple_animal/pet/cat/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 	if(!stat && !buckled && !client)
 		if(prob(1))
 			emote("me", 1, pick("stretches out for a belly rub.", "wags its tail.", "lies down."))
@@ -200,8 +203,6 @@
 				if (T.cooldown < (world.time - 400))
 					emote("me", 1, "bats \the [T] around with its paw!")
 					T.cooldown = world.time
-
-	..()
 
 	make_babies()
 
@@ -276,9 +277,9 @@
 		to_chat(src, "<span class='notice'>Your name is now <b>\"new_name\"</b>!</span>")
 		name = new_name
 
-/mob/living/simple_animal/pet/cat/cak/Life()
-	..()
-	if(stat)
+/mob/living/simple_animal/pet/cat/cak/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
 		return
 	if(health < maxHealth)
 		adjustBruteLoss(-8) //Fast life regen

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -167,7 +167,7 @@
 
 /mob/living/simple_animal/pet/cat/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(!stat && !buckled && !client)
 		if(prob(1))
@@ -279,7 +279,7 @@
 
 /mob/living/simple_animal/pet/cat/cak/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(health < maxHealth)
 		adjustBruteLoss(-8) //Fast life regen

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -21,10 +21,12 @@
 	var/obj/item/inventory_mask
 	gold_core_spawnable = FRIENDLY_SPAWN
 
-/mob/living/simple_animal/crab/Life()
-	..()
+/mob/living/simple_animal/crab/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 	//CRAB movement
-	if(!ckey && !stat)
+	if(!ckey)
 		if(isturf(loc) && !resting && !buckled)		//This is so it only moves if it's not inside a closet, gentics machine, etc.
 			turns_since_move++
 			if(turns_since_move >= turns_per_move)

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -23,7 +23,7 @@
 
 /mob/living/simple_animal/crab/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	//CRAB movement
 	if(!ckey)

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -419,7 +419,7 @@
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/Process_Living() //God help us, this proc gave me cancer.
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	//Feeding, chasing food, FOOOOODDDD
 	if(!resting && !buckled)
@@ -491,7 +491,7 @@
 
 /mob/living/simple_animal/pet/dog/corgi/narsie/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	for(var/mob/living/simple_animal/pet/P in range(1, src))
 		if(P != src && prob(5))
@@ -619,9 +619,8 @@
 
 /mob/living/simple_animal/pet/dog/corgi/Lisa/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
-
 	make_babies()
 
 	if(!stat && !resting && !buckled)
@@ -634,7 +633,7 @@
 
 /mob/living/simple_animal/pet/dog/pug/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 
 	if(!stat && !resting && !buckled)

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -364,7 +364,7 @@
 		desc = "At a ripe old age of [record_age] Ian's not as spry as he used to be, but he'll always be the HoP's beloved corgi." //RIP
 		turns_per_move = 20
 
-/mob/living/simple_animal/pet/dog/corgi/Ian/Life()
+/mob/living/simple_animal/pet/dog/corgi/Ian/Process_Living()
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory(FALSE)
 		memory_saved = TRUE
@@ -417,11 +417,12 @@
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))
 
-/mob/living/simple_animal/pet/dog/corgi/Ian/Life()
-	..()
-
+/mob/living/simple_animal/pet/dog/corgi/Ian/Process_Living() //God help us, this proc gave me cancer.
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 	//Feeding, chasing food, FOOOOODDDD
-	if(!stat && !resting && !buckled)
+	if(!resting && !buckled)
 		turns_since_scan++
 		if(turns_since_scan > 5)
 			turns_since_scan = 0
@@ -488,8 +489,10 @@
 	nofur = TRUE
 	unique_pet = TRUE
 
-/mob/living/simple_animal/pet/dog/corgi/narsie/Life()
-	..()
+/mob/living/simple_animal/pet/dog/corgi/narsie/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 	for(var/mob/living/simple_animal/pet/P in range(1, src))
 		if(P != src && prob(5))
 			visible_message("<span class='warning'>[src] devours [P]!</span>", \
@@ -614,8 +617,10 @@
 		return
 	..()
 
-/mob/living/simple_animal/pet/dog/corgi/Lisa/Life()
-	..()
+/mob/living/simple_animal/pet/dog/corgi/Lisa/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 
 	make_babies()
 
@@ -627,8 +632,10 @@
 					setDir(i)
 					sleep(1)
 
-/mob/living/simple_animal/pet/dog/pug/Life()
-	..()
+/mob/living/simple_animal/pet/dog/pug/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 
 	if(!stat && !resting && !buckled)
 		if(prob(1))

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -44,7 +44,7 @@
 
 /mob/living/simple_animal/hostile/retaliate/goat/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	//chance to go crazy and start wacking stuff
 	if(!enemies.len && prob(1))
@@ -154,7 +154,7 @@
 
 /mob/living/simple_animal/cow/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(stat == CONSCIOUS)
 		udder.generateMilk()
@@ -223,7 +223,7 @@
 
 /mob/living/simple_animal/chick/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(!ckey)
 		amount_grown += rand(1,2)
@@ -233,7 +233,7 @@
 
 /mob/living/simple_animal/chick/holo/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+	if(. & MOBFLAG_DELETED)
 		return
 	amount_grown = 0
 
@@ -303,9 +303,9 @@
 	else
 		..()
 
-/mob/living/simple_animal/chicken/Process_Living()
+/mob/living/simple_animal/chicken/Life()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if((prob(3) && eggsleft > 0) && egg_type)
 		visible_message("<span class='alertalien'>[src] [pick(layMessage)]</span>")

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -42,17 +42,18 @@
 	udder = null
 	return ..()
 
-/mob/living/simple_animal/hostile/retaliate/goat/Life()
+/mob/living/simple_animal/hostile/retaliate/goat/Process_Living()
 	. = ..()
-	if(.)
-		//chance to go crazy and start wacking stuff
-		if(!enemies.len && prob(1))
-			Retaliate()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
+	//chance to go crazy and start wacking stuff
+	if(!enemies.len && prob(1))
+		Retaliate()
 
-		if(enemies.len && prob(10))
-			enemies = list()
-			LoseTarget()
-			src.visible_message("<span class='notice'>[src] calms down.</span>")
+	if(enemies.len && prob(10))
+		enemies = list()
+		LoseTarget()
+		src.visible_message("<span class='notice'>[src] calms down.</span>")
 	if(stat == CONSCIOUS)
 		udder.generateMilk()
 		eat_plants()
@@ -151,8 +152,10 @@
 	else
 		return ..()
 
-/mob/living/simple_animal/cow/Life()
+/mob/living/simple_animal/cow/Process_Living()
 	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 	if(stat == CONSCIOUS)
 		udder.generateMilk()
 
@@ -218,18 +221,20 @@
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(0, 10)
 
-/mob/living/simple_animal/chick/Life()
-	. =..()
-	if(!.)
+/mob/living/simple_animal/chick/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
 		return
-	if(!stat && !ckey)
+	if(!ckey)
 		amount_grown += rand(1,2)
 		if(amount_grown >= 100)
 			new /mob/living/simple_animal/chicken(src.loc)
 			qdel(src)
 
-/mob/living/simple_animal/chick/holo/Life()
-	..()
+/mob/living/simple_animal/chick/holo/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+		return
 	amount_grown = 0
 
 /mob/living/simple_animal/chicken
@@ -298,11 +303,11 @@
 	else
 		..()
 
-/mob/living/simple_animal/chicken/Life()
-	. =..()
-	if(!.)
+/mob/living/simple_animal/chicken/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
 		return
-	if((!stat && prob(3) && eggsleft > 0) && egg_type)
+	if((prob(3) && eggsleft > 0) && egg_type)
 		visible_message("<span class='alertalien'>[src] [pick(layMessage)]</span>")
 		eggsleft--
 		var/obj/item/E = new egg_type(get_turf(src))

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -128,7 +128,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 
 /mob/living/simple_animal/hostile/guardian/Process_Living()//Dies if the summoner dies
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+	if(. & MOBFLAG_DELETED)
 		return
 	update_health_hud() //we need to update all of our health displays to match our summoner and we can't practically give the summoner a hook to do it
 	med_hud_set_health()
@@ -145,11 +145,13 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 			summoner.dust()
 			death(TRUE)
 			qdel(src)
+			. |= MOBFLAG_DELETED
 	else
 		to_chat(src, "<span class='danger'>Your summoner has died!</span>")
 		visible_message("<span class='danger'><B>[src] dies along with its user!</B></span>")
 		death(TRUE)
 		qdel(src)
+		. |= MOBFLAG_DELETED
 	snapback()
 
 /mob/living/simple_animal/hostile/guardian/Stat()

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -126,8 +126,10 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	to_chat(src, "<span class='holoparasite'>While personally invincible, you will die if [summoner.real_name] does, and any damage dealt to you will have a portion passed on to [summoner.p_them()] as you feed upon [summoner.p_them()] to sustain yourself.</span>")
 	to_chat(src, playstyle_string)
 
-/mob/living/simple_animal/hostile/guardian/Life() //Dies if the summoner dies
+/mob/living/simple_animal/hostile/guardian/Process_Living()//Dies if the summoner dies
 	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+		return
 	update_health_hud() //we need to update all of our health displays to match our summoner and we can't practically give the summoner a hook to do it
 	med_hud_set_health()
 	med_hud_set_status()

--- a/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
@@ -22,7 +22,7 @@
 
 /mob/living/simple_animal/hostile/guardian/assassin/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+	if(. & MOBFLAG_DELETED)
 		return
 	updatestealthalert()
 	if(loc == summoner && toggle)

--- a/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
@@ -20,8 +20,10 @@
 	. = ..()
 	stealthcooldown = 0
 
-/mob/living/simple_animal/hostile/guardian/assassin/Life()
+/mob/living/simple_animal/hostile/guardian/assassin/Process_Living()
 	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+		return
 	updatestealthalert()
 	if(loc == summoner && toggle)
 		ToggleMode(0)

--- a/code/modules/mob/living/simple_animal/guardian/types/charger.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/charger.dm
@@ -16,7 +16,7 @@
 
 /mob/living/simple_animal/hostile/guardian/charger/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+	if(. & MOBFLAG_DELETED)
 		return
 	if(ranged_cooldown <= world.time)
 		if(!chargealert)

--- a/code/modules/mob/living/simple_animal/guardian/types/charger.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/charger.dm
@@ -14,8 +14,10 @@
 	var/charging = 0
 	var/obj/screen/alert/chargealert
 
-/mob/living/simple_animal/hostile/guardian/charger/Life()
+/mob/living/simple_animal/hostile/guardian/charger/Process_Living()
 	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+		return
 	if(ranged_cooldown <= world.time)
 		if(!chargealert)
 			chargealert = throw_alert("charge", /obj/screen/alert/cancharge)

--- a/code/modules/mob/living/simple_animal/guardian/types/fire.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/fire.dm
@@ -14,7 +14,7 @@
 
 /mob/living/simple_animal/hostile/guardian/fire/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+	if(. & MOBFLAG_DELETED)
 		return
 	if(summoner)
 		summoner.ExtinguishMob()

--- a/code/modules/mob/living/simple_animal/guardian/types/fire.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/fire.dm
@@ -12,8 +12,10 @@
 	tech_fluff_string = "<span class='holoparasite'>Boot sequence complete. Crowd control modules activated. Holoparasite swarm online.</span>"
 	carp_fluff_string = "<span class='holoparasite'>CARP CARP CARP! You caught one! OH GOD, EVERYTHING'S ON FIRE. Except you and the fish.</span>"
 
-/mob/living/simple_animal/hostile/guardian/fire/Life()
+/mob/living/simple_animal/hostile/guardian/fire/Process_Living()
 	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+		return
 	if(summoner)
 		summoner.ExtinguishMob()
 		summoner.adjust_fire_stacks(-20)

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -159,7 +159,7 @@
 
 /mob/living/simple_animal/hostile/carp/megacarp/Life()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(regen_cooldown < world.time)
 		heal_overall_damage(4)

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -159,6 +159,8 @@
 
 /mob/living/simple_animal/hostile/carp/megacarp/Life()
 	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD))
+		return
 	if(regen_cooldown < world.time)
 		heal_overall_damage(4)
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -65,7 +65,7 @@
 
 /mob/living/simple_animal/hostile/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	walk(src, 0) //stops walking
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -63,11 +63,11 @@
 	targets_from = null
 	return ..()
 
-/mob/living/simple_animal/hostile/Life()
+/mob/living/simple_animal/hostile/Process_Living()
 	. = ..()
-	if(!.) //dead
-		walk(src, 0) //stops walking
-		return 0
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
+	walk(src, 0) //stops walking
 
 /mob/living/simple_animal/hostile/handle_automated_action()
 	if(AIStatus == AI_OFF)

--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -24,9 +24,9 @@
 
 /mob/living/simple_animal/hostile/illusion/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+	if(. & MOBFLAG_DELETED)
 		return
-	if(world.time > life_span)
+	if(world.time > life_span) //Someone turn this into a timer.
 		death()
 
 

--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -22,8 +22,10 @@
 	deathmessage = "vanishes into thin air! It was a fake!"
 
 
-/mob/living/simple_animal/hostile/illusion/Life()
-	..()
+/mob/living/simple_animal/hostile/illusion/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+		return
 	if(world.time > life_span)
 		death()
 

--- a/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
@@ -165,9 +165,11 @@
 		if(!hopping)
 			Hop()
 
-/mob/living/simple_animal/hostile/jungle/leaper/Life()
+/mob/living/simple_animal/hostile/jungle/leaper/Process_Living()
 	. = ..()
-	update_icons()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+		return
+	update_icons() //If anyone sees this, please try to remove this one day.
 
 /mob/living/simple_animal/hostile/jungle/leaper/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	if(prob(33) && !ckey)

--- a/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
@@ -167,7 +167,7 @@
 
 /mob/living/simple_animal/hostile/jungle/leaper/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+	if(. & MOBFLAG_DELETED)
 		return
 	update_icons() //If anyone sees this, please try to remove this one day.
 

--- a/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
@@ -26,8 +26,10 @@
 
 	do_footstep = TRUE
 
-/mob/living/simple_animal/hostile/jungle/mega_arachnid/Life()
-	..()
+/mob/living/simple_animal/hostile/jungle/mega_arachnid/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 	if(target && ranged_cooldown > world.time && iscarbon(target))
 		var/mob/living/carbon/C = target
 		if(!C.legcuffed && C.health < 50)

--- a/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
@@ -28,7 +28,7 @@
 
 /mob/living/simple_animal/hostile/jungle/mega_arachnid/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(target && ranged_cooldown > world.time && iscarbon(target))
 		var/mob/living/carbon/C = target

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -539,7 +539,7 @@ Difficulty: Hard
 		return TRUE
 	return ..()
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/Life()
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/Process_Living()
 	return
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -378,7 +378,7 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(spawned_beacon && !QDELETED(spawned_beacon) && !client)
 		if(target || loc == spawned_beacon.loc)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -376,9 +376,11 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/burst(turf/original, spread_speed)
 	hierophant_burst(src, original, burst_range, spread_speed)
 
-/mob/living/simple_animal/hostile/megafauna/hierophant/Life()
+/mob/living/simple_animal/hostile/megafauna/hierophant/Process_Living()
 	. = ..()
-	if(. && spawned_beacon && !QDELETED(spawned_beacon) && !client)
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
+	if(spawned_beacon && !QDELETED(spawned_beacon) && !client)
 		if(target || loc == spawned_beacon.loc)
 			timeout_time = initial(timeout_time)
 		else

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -73,13 +73,14 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 		step(R, ddir) //Step the swarmers, instead of spawning them there, incase the turf is solid
 
 
-/mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon/Life()
+/mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon/Process_Living()
 	. = ..()
-	if(.)
-		var/createtype = GetUncappedAISwarmerType()
-		if(createtype && world.time > swarmer_spawn_cooldown && GLOB.AISwarmers.len < (GetTotalAISwarmerCap()*0.5))
-			swarmer_spawn_cooldown = world.time + swarmer_spawn_cooldown_amt
-			new createtype(loc)
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
+	var/createtype = GetUncappedAISwarmerType()
+	if(createtype && world.time > swarmer_spawn_cooldown && GLOB.AISwarmers.len < (GetTotalAISwarmerCap()*0.5))
+		swarmer_spawn_cooldown = world.time + swarmer_spawn_cooldown_amt
+		new createtype(loc)
 
 
 /mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon/adjustHealth(amount, updating_health = TRUE, forced = FALSE)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -75,7 +75,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 
 /mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	var/createtype = GetUncappedAISwarmerType()
 	if(createtype && world.time > swarmer_spawn_cooldown && GLOB.AISwarmers.len < (GetTotalAISwarmerCap()*0.5))

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -112,8 +112,10 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 		overlay_googly_eyes = FALSE
 	CopyObject(copy, creator, destroy_original)
 
-/mob/living/simple_animal/hostile/mimic/copy/Life()
-	..()
+/mob/living/simple_animal/hostile/mimic/copy/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+		return
 	if(idledamage && !target && !ckey) //Objects eventually revert to normal if no one is around to terrorize
 		adjustBruteLoss(1)
 	for(var/mob/living/M in contents) //a fix for animated statues from the flesh to stone spell

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -114,7 +114,7 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 
 /mob/living/simple_animal/hostile/mimic/copy/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+	if(. & MOBFLAG_DELETED)
 		return
 	if(idledamage && !target && !ckey) //Objects eventually revert to normal if no one is around to terrorize
 		adjustBruteLoss(1)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -39,7 +39,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/goliath/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	handle_preattack()
 
@@ -130,7 +130,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(!isturf(loc))
 		return

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -37,8 +37,10 @@
 
 	do_footstep = TRUE
 
-/mob/living/simple_animal/hostile/asteroid/goliath/Life()
+/mob/living/simple_animal/hostile/asteroid/goliath/Process_Living()
 	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 	handle_preattack()
 
 /mob/living/simple_animal/hostile/asteroid/goliath/proc/handle_preattack()
@@ -126,23 +128,24 @@
 	var/turf/last_location
 	var/tentacle_recheck_cooldown = 100
 
-/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient/Life()
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient/Process_Living()
 	. = ..()
-	if(!.) // dead
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
 		return
-	if(isturf(loc))
-		if(!LAZYLEN(cached_tentacle_turfs) || loc != last_location || tentacle_recheck_cooldown <= world.time)
-			LAZYCLEARLIST(cached_tentacle_turfs)
-			last_location = loc
-			tentacle_recheck_cooldown = world.time + initial(tentacle_recheck_cooldown)
-			for(var/turf/open/T in orange(4, loc))
-				LAZYADD(cached_tentacle_turfs, T)
-		for(var/t in cached_tentacle_turfs)
-			if(isopenturf(t))
-				if(prob(10))
-					new /obj/effect/temp_visual/goliath_tentacle(t, src)
-			else
-				cached_tentacle_turfs -= t
+	if(!isturf(loc))
+		return
+	if(!LAZYLEN(cached_tentacle_turfs) || loc != last_location || tentacle_recheck_cooldown <= world.time)
+		LAZYCLEARLIST(cached_tentacle_turfs)
+		last_location = loc
+		tentacle_recheck_cooldown = world.time + initial(tentacle_recheck_cooldown)
+		for(var/turf/open/T in orange(4, loc))
+			LAZYADD(cached_tentacle_turfs, T)
+	for(var/t in cached_tentacle_turfs)
+		if(isopenturf(t))
+			if(prob(10))
+				new /obj/effect/temp_visual/goliath_tentacle(t, src)
+		else
+			cached_tentacle_turfs -= t
 
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/tendril
 	fromtendril = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -111,7 +111,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen/Life()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(udder.reagents.total_volume == udder.reagents.maximum_volume) //Only breed when we're full.
 		make_babies()
@@ -137,7 +137,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch/Life()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	growth++
 	if(growth > 50) //originally used a timer for this but was more problem that it's worth.

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -110,7 +110,9 @@
 	gender = FEMALE
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen/Life()
-	..()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD))
+		return
 	if(udder.reagents.total_volume == udder.reagents.maximum_volume) //Only breed when we're full.
 		make_babies()
 
@@ -134,7 +136,9 @@
 	update_transform()
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch/Life()
-	..()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_DEAD))
+		return
 	growth++
 	if(growth > 50) //originally used a timer for this but was more problem that it's worth.
 		growUp()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -183,7 +183,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(isturf(loc))
 		for(var/mob/living/carbon/human/H in view(src,1)) //Only for corpse right next to/on same tile
@@ -203,7 +203,7 @@
 	L.stored_mob = H
 	H.forceMove(L)
 	qdel(src)
-	return MOBFLAG_QDELETED
+	return MOBFLAG_DELETED
 
 //Advanced Legion is slightly tougher to kill and can raise corpses (revive other legions)
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/advanced

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -181,12 +181,14 @@
 	robust_searching = 1
 	var/can_infest_dead = FALSE
 
-/mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/Life()
+/mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 	if(isturf(loc))
 		for(var/mob/living/carbon/human/H in view(src,1)) //Only for corpse right next to/on same tile
 			if(H.stat == UNCONSCIOUS || (can_infest_dead && H.stat == DEAD))
-				infest(H)
-	..()
+				. |= infest(H)
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/proc/infest(mob/living/carbon/human/H)
 	visible_message("<span class='warning'>[name] burrows into the flesh of [H]!</span>")
@@ -201,6 +203,7 @@
 	L.stored_mob = H
 	H.forceMove(L)
 	qdel(src)
+	return MOBFLAG_QDELETED
 
 //Advanced Legion is slightly tougher to kill and can raise corpses (revive other legions)
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/advanced

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -46,7 +46,7 @@
 
 /mob/living/simple_animal/hostile/mushroom/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	adjustBruteLoss(-2)
 

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -44,10 +44,11 @@
 	else
 		. += "<span class='info'>It looks like it's been roughed up.</span>"
 
-/mob/living/simple_animal/hostile/mushroom/Life()
-	..()
-	if(!stat)//Mushrooms slowly regenerate if conscious, for people who want to save them from being eaten
-		adjustBruteLoss(-2)
+/mob/living/simple_animal/hostile/mushroom/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
+	adjustBruteLoss(-2)
 
 /mob/living/simple_animal/hostile/mushroom/Initialize()//Makes every shroom a little unique
 	melee_damage_lower += rand(3, 5)

--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -44,7 +44,7 @@
 
 /mob/living/simple_animal/hostile/netherworld/migo/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(prob(10))
 		var/chosen_sound = pick(migo_sounds)

--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -42,9 +42,9 @@
 	var/chosen_sound = pick(migo_sounds)
 	playsound(src, chosen_sound, 50, TRUE)
 
-/mob/living/simple_animal/hostile/netherworld/migo/Life()
-	..()
-	if(stat)
+/mob/living/simple_animal/hostile/netherworld/migo/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
 		return
 	if(prob(10))
 		var/chosen_sound = pick(migo_sounds)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -47,8 +47,10 @@
 	..()
 	playsound(src.loc, 'sound/items/bikehorn.ogg', 50, 1)
 
-/mob/living/simple_animal/hostile/retaliate/clown/Life()
+/mob/living/simple_animal/hostile/retaliate/clown/Process_Living()
 	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 	if(banana_time && banana_time < world.time)
 		var/turf/T = get_turf(src)
 		var/list/adjacent =  T.GetAtmosAdjacentTurfs(1)
@@ -73,8 +75,10 @@
 	emote_see = list("bubbles", "oozes")
 	loot = list(/obj/item/clothing/mask/gas/clown_hat, /obj/effect/particle_effect/foam)
 
-/mob/living/simple_animal/hostile/retaliate/clown/lube/Life()
+/mob/living/simple_animal/hostile/retaliate/clown/lube/Process_Living()
 	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+		return
 	var/turf/open/OT = get_turf(src)
 	if(isopenturf(OT))
 		OT.MakeSlippery(TURF_WET_LUBE, 100)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -49,7 +49,7 @@
 
 /mob/living/simple_animal/hostile/retaliate/clown/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(banana_time && banana_time < world.time)
 		var/turf/T = get_turf(src)
@@ -75,9 +75,9 @@
 	emote_see = list("bubbles", "oozes")
 	loot = list(/obj/item/clothing/mask/gas/clown_hat, /obj/effect/particle_effect/foam)
 
-/mob/living/simple_animal/hostile/retaliate/clown/lube/Process_Living()
+/mob/living/simple_animal/hostile/retaliate/clown/lube/Process_Living() //Someone move this to Moved(), or better yet, add the snailcrawl component to this.
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+	if(. & MOBFLAG_DELETED)
 		return
 	var/turf/open/OT = get_turf(src)
 	if(isopenturf(OT))

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -79,8 +79,10 @@
 		return 0
 	return ..()
 
-/mob/living/simple_animal/hostile/statue/Life()
-	..()
+/mob/living/simple_animal/hostile/statue/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 	if(!client && target) // If we have a target and we're AI controlled
 		var/mob/watching = can_be_seen()
 		// If they're not our target

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -81,7 +81,7 @@
 
 /mob/living/simple_animal/hostile/statue/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(!client && target) // If we have a target and we're AI controlled
 		var/mob/watching = can_be_seen()

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -40,8 +40,10 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	del_on_death = 1
 
-/mob/living/simple_animal/hostile/tree/Life()
-	..()
+/mob/living/simple_animal/hostile/tree/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+		return
 	if(isopenturf(loc))
 		var/turf/open/T = src.loc
 		if(T.air && T.air.gases[/datum/gas/carbon_dioxide])

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -42,7 +42,7 @@
 
 /mob/living/simple_animal/hostile/tree/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL))
+	if(. & MOBFLAG_DELETED)
 		return
 	if(isopenturf(loc))
 		var/turf/open/T = src.loc

--- a/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
@@ -44,12 +44,12 @@
 	QDEL_NULL(E)
 	return ..()
 
-/mob/living/simple_animal/hostile/asteroid/fugu/Life()
+/mob/living/simple_animal/hostile/asteroid/fugu/Process_Living()
 	if(!wumbo)
 		inflate_cooldown = max((inflate_cooldown - 1), 0)
 	if(target && AIStatus == AI_ON)
 		E.Activate()
-	..()
+	. = ..()
 
 /mob/living/simple_animal/hostile/asteroid/fugu/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && wumbo)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -353,7 +353,7 @@
  */
 /mob/living/simple_animal/parrot/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	//Sprite update for when a parrot gets pulled
 	if(pulledby && !stat && parrot_state != PARROT_WANDER)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -351,9 +351,10 @@
 /*
  * AI - Not really intelligent, but I'm calling it AI anyway.
  */
-/mob/living/simple_animal/parrot/Life()
-	..()
-
+/mob/living/simple_animal/parrot/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+		return
 	//Sprite update for when a parrot gets pulled
 	if(pulledby && !stat && parrot_state != PARROT_WANDER)
 		if(buckled)
@@ -895,11 +896,11 @@
 
 	. = ..()
 
-/mob/living/simple_animal/parrot/Poly/Life()
+/mob/living/simple_animal/parrot/Poly/Process_Living()
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory(FALSE)
 		memory_saved = TRUE
-	..()
+	. = ..()
 
 /mob/living/simple_animal/parrot/Poly/death(gibbed)
 	if(!memory_saved)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -146,7 +146,7 @@
 
 
 /mob/living/simple_animal/handle_status_effects()
-	..()
+	. = ..()
 	if(stuttering)
 		stuttering = 0
 
@@ -261,6 +261,8 @@
 		adjustHealth(unsuitable_atmos_damage)
 
 	handle_temperature_damage()
+	if(stat == DEAD)
+		return MOBFLAG_DEAD
 
 /mob/living/simple_animal/proc/handle_temperature_damage()
 	if((bodytemperature < minbodytemp) || (bodytemperature > maxbodytemp))

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -7,22 +7,23 @@
 	var/SStun = 0 // stun variable
 
 
-/mob/living/simple_animal/slime/Life()
-	set invisibility = 0
-	if (notransform)
+/mob/living/simple_animal/slime/Process_Living()
+	. = ..()
+	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
 		return
-	if(..())
-		if(buckled)
-			handle_feeding()
-		if(!stat) // Slimes in stasis don't lose nutrition, don't change mood and don't respond to speech
-			handle_nutrition()
-			if(QDELETED(src)) // Stop if the slime split during handle_nutrition()
-				return
-			reagents.remove_all(0.5 * REAGENTS_METABOLISM * reagents.reagent_list.len) //Slimes are such snowflakes
-			handle_targets()
-			if (!ckey)
-				handle_mood()
-				handle_speech()
+	if(buckled)
+		handle_feeding()
+	if(!stat) // Slimes in stasis don't lose nutrition, don't change mood and don't respond to speech
+		handle_nutrition()
+		if(QDELETED(src)) // Stop if the slime split during handle_nutrition() Yeah, no, this needs some work
+			return
+		reagents.remove_all(0.5 * REAGENTS_METABOLISM * reagents.reagent_list.len) //Slimes are such snowflakes
+		handle_targets()
+		if (!ckey)
+			handle_mood()
+			handle_speech()
+		if(prob(30))
+			adjustBruteLoss(-1)
 
 // Unlike most of the simple animals, slimes support UNCONSCIOUS
 /mob/living/simple_animal/slime/update_stat()
@@ -148,11 +149,9 @@
 			stat = CONSCIOUS
 			update_mobility()
 			regenerate_icons()
-
+	else
+		. = MOBFLAG_DEAD
 	updatehealth()
-
-
-	return //TODO: DEFERRED
 
 /mob/living/simple_animal/slime/proc/adjust_body_temperature(current, loc_temp, boost)
 	var/temperature = current
@@ -170,11 +169,6 @@
 		temperature = max(loc_temp, temperature-change)
 	temp_change = (temperature - current)
 	return temp_change
-
-/mob/living/simple_animal/slime/handle_status_effects()
-	..()
-	if(prob(30) && !stat)
-		adjustBruteLoss(-1)
 
 /mob/living/simple_animal/slime/proc/handle_feeding()
 	if(!ismob(buckled))

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -9,7 +9,7 @@
 
 /mob/living/simple_animal/slime/Process_Living()
 	. = ..()
-	if(. & (MOBFLAG_QDELETED|MOBFLAG_KILLALL|MOBFLAG_DEAD))
+	if(. & MOBFLAGS_DEAD_OR_DEL)
 		return
 	if(buckled)
 		handle_feeding()

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -139,7 +139,7 @@
 /obj/item/bodypart/proc/on_life(stam_regen)
 	if(stamina_dam > DAMAGE_PRECISION && stam_regen)					//DO NOT update health here, it'll be done in the carbon's life.
 		heal_damage(0, 0, INFINITY, null, FALSE)
-		. |= BODYPART_LIFE_UPDATE_HEALTH
+		. |= MOBFLAG_UPDATE_HEALTH
 
 //Applies brute and burn damage to the organ. Returns 1 if the damage-icon states changed at all.
 //Damage will not exceed max_damage using this proc


### PR DESCRIPTION
## About The Pull Request

This is highly WIP.

The idea is to use a bunch of flags during the Life proc (now renamed Process_Living) to determine if the process should continue or not. This is to cut down on QDELETED(src) and stat == DEAD calls, squash some issues with inheritance and improve overall ease of reading for this proc.
Also adds the Life proc which now gets called only if the mob is alive and not in stasis.

Does the current version of this break everything? Probably. This definitly needs a testmerge. 

The new code also moves around some of the order in which stuff gets called and makes the whole process a lot more easy to follow.

This also has moves the handle_heart proc to carbon level, which I will probably move back later because this is supposed to be code improvement.

## Changelog

will be added at a later date.
