### PR TITLE
Makes the identification console automatically log off

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -12,7 +12,6 @@
 #define IDLE_POWER_USE 1
 #define ACTIVE_POWER_USE 2
 
-
 //bitflags for door switches.
 #define OPEN	(1<<0)
 #define IDSCAN	(1<<1)
@@ -31,6 +30,11 @@
 #define SMELTER			(1<<7) 	//uses various minerals
 #define NANITE_COMPILER  (1<<8) //Prints nanite disks
 //Note: More than one of these can be added to a design but imprinter and lathe designs are incompatable.
+
+//Authorization
+#define LOGGED_OFF 0
+#define LOGGED_DEPARTMENT 1
+#define LOGGED_ALL 2
 
 //Modular computer/NTNet defines
 
@@ -66,6 +70,7 @@
 #define PROGRAM_CONSOLE	(1<<0)
 #define PROGRAM_LAPTOP	(1<<1)
 #define PROGRAM_TABLET	(1<<2)
+
 //Program states
 #define PROGRAM_STATE_KILLED 0
 #define PROGRAM_STATE_BACKGROUND 1

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -616,6 +616,8 @@ Class Procs:
 		inserted_scan_id.forceMove(drop_location())
 		if(!issilicon(user) && Adjacent(user))
 			user.put_in_hands(inserted_scan_id)
+		if(authenticated)
+			authenticated = 0
 		inserted_scan_id = null
 		user.visible_message("<span class='notice'>[user] gets an ID card from the console.</span>", \
 							"<span class='notice'>You get the ID card from the console.</span>")
@@ -656,11 +658,9 @@ Class Procs:
 		return
 	if(inserted_modify_id)
 		id_eject_modify(user)
-		authenticated = FALSE
 		return
 	if(inserted_scan_id)
 		id_eject_scan(user)
-		authenticated = FALSE
 		return
 	if(inserted_prisoner_id)
 		id_eject_prisoner(user)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -617,7 +617,7 @@ Class Procs:
 		if(!issilicon(user) && Adjacent(user))
 			user.put_in_hands(inserted_scan_id)
 		if(authenticated)
-			authenticated = 0
+			authenticated = LOGGED_OFF
 		inserted_scan_id = null
 		user.visible_message("<span class='notice'>[user] gets an ID card from the console.</span>", \
 							"<span class='notice'>You get the ID card from the console.</span>")

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -9,10 +9,6 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 #define JOB_MAX_POSITIONS -1 // Trying to reduce the number of slots below that of current holders of that job, or trying to open more slots than allowed
 #define JOB_DENIED 0
 
-#define LOGGED_OFF 0
-#define LOGGED_DEPARTMENT 1
-#define LOGGED_ALL 2
-
 /obj/machinery/computer/card
 	name = "identification console"
 	desc = "You can use this to manage jobs and ID access."

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -324,7 +324,6 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 				id_insert_modify(usr)
 		if ("inserted_scan_id")
 			if (inserted_scan_id)
-				authenticated = LOGGED_OFF
 				id_eject_scan(usr)
 			else
 				id_insert_scan(usr)


### PR DESCRIPTION
Makes the identification console automatically log off always when the scan-id is ejected.
Also changes authenticated magic numbers to defines.

Closes #45661
