### PR TITLE
Refactors C4/X4

### DIFF
--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -197,8 +197,8 @@
 /area/awaymission/research/interior/engineering)
 "aL" = (
 /obj/structure/table,
-/obj/item/grenade/plastic/c4,
-/obj/item/grenade/plastic/c4,
+/obj/item/grenade/c4,
+/obj/item/grenade/c4,
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/mineral/plastitanium/red,
 /area/awaymission/research/interior/engineering)

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -11854,7 +11854,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/awaymission/snowdin/cave)
 "Ds" = (
-/obj/item/grenade/plastic/c4,
+/obj/item/grenade/c4,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4

--- a/_maps/RandomZLevels/spacebattle.dmm
+++ b/_maps/RandomZLevels/spacebattle.dmm
@@ -263,7 +263,7 @@
 /area/awaymission/spacebattle/syndicate2)
 "bl" = (
 /obj/structure/table/reinforced,
-/obj/item/grenade/plastic/c4,
+/obj/item/grenade/c4,
 /turf/open/floor/mineral/plastitanium/red,
 /area/awaymission/spacebattle/syndicate3)
 "bm" = (
@@ -272,7 +272,7 @@
 /area/awaymission/spacebattle/syndicate1)
 "bn" = (
 /obj/structure/table/reinforced,
-/obj/item/grenade/plastic/c4,
+/obj/item/grenade/c4,
 /turf/open/floor/mineral/plastitanium/red,
 /area/awaymission/spacebattle/syndicate1)
 "bo" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2441,7 +2441,7 @@
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/item/poster/random_contraband,
 /obj/item/clothing/suit/security/officer/russian,
-/obj/item/grenade/plastic/c4,
+/obj/item/grenade/c4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aik" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3237,9 +3237,9 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/flashbangs,
-/obj/item/grenade/plastic/x4,
-/obj/item/grenade/plastic/x4,
-/obj/item/grenade/plastic/x4,
+/obj/item/grenade/c4/x4,
+/obj/item/grenade/c4/x4,
+/obj/item/grenade/c4/x4,
 /obj/structure/table/reinforced,
 /obj/item/clothing/ears/earmuffs,
 /obj/structure/reagent_dispensers/peppertank{
@@ -8973,9 +8973,9 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/flashbangs,
-/obj/item/grenade/plastic/x4,
-/obj/item/grenade/plastic/x4,
-/obj/item/grenade/plastic/x4,
+/obj/item/grenade/c4/x4,
+/obj/item/grenade/c4/x4,
+/obj/item/grenade/c4/x4,
 /obj/structure/table/reinforced,
 /obj/item/clothing/ears/earmuffs,
 /obj/structure/reagent_dispensers/peppertank{
@@ -11193,10 +11193,10 @@
 /area/centcom/ferry)
 "zh" = (
 /obj/structure/table/reinforced,
-/obj/item/grenade/plastic/c4{
+/obj/item/grenade/c4{
 	pixel_x = 6
 	},
-/obj/item/grenade/plastic/c4{
+/obj/item/grenade/c4{
 	pixel_x = -4
 	},
 /obj/machinery/firealarm{

--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -1532,11 +1532,11 @@
 	pixel_y = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/grenade/plastic/c4,
-/obj/item/grenade/plastic/c4,
-/obj/item/grenade/plastic/c4,
-/obj/item/grenade/plastic/c4,
-/obj/item/grenade/plastic/c4,
+/obj/item/grenade/c4,
+/obj/item/grenade/c4,
+/obj/item/grenade/c4,
+/obj/item/grenade/c4,
+/obj/item/grenade/c4,
 /turf/open/floor/pod/dark,
 /area/shuttle/syndicate/armory)
 "dk" = (

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -945,11 +945,11 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/grenade/plastic/c4,
-/obj/item/grenade/plastic/c4,
-/obj/item/grenade/plastic/c4,
-/obj/item/grenade/plastic/c4,
-/obj/item/grenade/plastic/c4,
+/obj/item/grenade/c4,
+/obj/item/grenade/c4,
+/obj/item/grenade/c4,
+/obj/item/grenade/c4,
+/obj/item/grenade/c4,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -471,7 +471,7 @@
 	result = /obj/item/bombcore/chemical
 	reqs = list(
 		/obj/item/stock_parts/matter_bin = 1,
-		/obj/item/grenade/plastic/c4 = 1,
+		/obj/item/grenade/c4 = 1,
 		/obj/item/grenade/chem_grenade = 2
 	)
 	parts = list(/obj/item/stock_parts/matter_bin = 1, /obj/item/grenade/chem_grenade = 2)

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -1,8 +1,9 @@
 /datum/wires/explosive
-	var/duds_number = 2
+	var/duds_number = 2 // All "dud" wires cause an explosion when cut or pulsed
+	randomize = TRUE // Prevents wires from showing up on blueprints
 
 /datum/wires/explosive/New(atom/holder)
-	add_duds(duds_number) // In this case duds actually explode.
+	add_duds(duds_number) // Duds also explode here.
 	..()
 
 /datum/wires/explosive/on_pulse(index)
@@ -17,7 +18,6 @@
 /datum/wires/explosive/chem_grenade
 	duds_number = 1
 	holder_type = /obj/item/grenade/chem_grenade
-	randomize = TRUE
 	var/fingerprint
 
 /datum/wires/explosive/chem_grenade/interactable(mob/user)
@@ -54,11 +54,10 @@
 		G.landminemode = null
 		return S
 
-/datum/wires/explosive/c4
+/datum/wires/explosive/c4 // Also includes X4
 	holder_type = /obj/item/grenade/c4
-	randomize = TRUE
 
-/datum/wires/explosive/c4/interactable(mob/user) //No need to unscrew wire panels on plastic explosives
+/datum/wires/explosive/c4/interactable(mob/user) // No need to unscrew wire panels on plastic explosives
 	return TRUE
 
 /datum/wires/explosive/c4/explode()
@@ -67,7 +66,6 @@
 
 /datum/wires/explosive/pizza
 	holder_type = /obj/item/pizzabox
-	randomize = TRUE
 
 /datum/wires/explosive/pizza/New(atom/holder)
 	wires = list(

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -55,18 +55,15 @@
 		return S
 
 /datum/wires/explosive/c4
-	holder_type = /obj/item/grenade/plastic/c4
-	randomize = TRUE	//Same behaviour since no wire actually disarms it
+	holder_type = /obj/item/grenade/c4
+	randomize = TRUE
 
-/datum/wires/explosive/c4/interactable(mob/user)
-	var/obj/item/grenade/plastic/c4/P = holder
-	if(P.open_panel)
-		return TRUE
+/datum/wires/explosive/c4/interactable(mob/user) //No need to unscrew wire panels on plastic explosives
+	return TRUE
 
 /datum/wires/explosive/c4/explode()
-	var/obj/item/grenade/plastic/c4/P = holder
+	var/obj/item/grenade/c4/P = holder
 	P.prime()
-
 
 /datum/wires/explosive/pizza
 	holder_type = /obj/item/pizzabox

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -21,7 +21,7 @@
 /obj/item/grenade/c4/Initialize()
 	. = ..()
 	plastic_overlay = mutable_appearance(icon, "[item_state]2", HIGH_OBJ_LAYER)
-	wires = new /datum/wires/explosive/plastic(src)
+	wires = new /datum/wires/explosive/c4(src)
 
 /obj/item/grenade/c4/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -1,6 +1,6 @@
-/obj/item/grenade/plastic
-	name = "plastic explosive"
-	desc = "Used to put holes in specific areas without too much extra hole."
+/obj/item/grenade/c4
+	name = "C-4 charge"
+	desc = "Used to put holes in specific areas without too much extra hole. A saboteur's favorite."
 	icon_state = "plastic-explosive0"
 	item_state = "plastic-explosive"
 	lefthand_file = 'icons/mob/inhands/weapons/bombs_lefthand.dmi'
@@ -8,54 +8,42 @@
 	item_flags = NOBLUDGEON
 	flags_1 = NONE
 	det_time = 10
-	display_timer = 0
+	display_timer = FALSE
 	w_class = WEIGHT_CLASS_SMALL
+	gender = PLURAL
 	var/atom/target = null
 	var/mutable_appearance/plastic_overlay
-	var/obj/item/assembly_holder/nadeassembly = null
-	var/assemblyattacher
 	var/directional = FALSE
 	var/aim_dir = NORTH
 	var/boom_sizes = list(0, 0, 3)
-	var/can_attach_mob = FALSE
 	var/full_damage_on_mobs = FALSE
 
-/obj/item/grenade/plastic/Initialize()
+/obj/item/grenade/c4/Initialize()
 	. = ..()
 	plastic_overlay = mutable_appearance(icon, "[item_state]2", HIGH_OBJ_LAYER)
+	wires = new /datum/wires/explosive/plastic(src)
 
-/obj/item/grenade/plastic/ComponentInitialize()
+/obj/item/grenade/c4/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
 
-/obj/item/grenade/plastic/Destroy()
-	qdel(nadeassembly)
-	nadeassembly = null
+/obj/item/grenade/c4/Destroy()
+	qdel(wires)
+	wires = null
 	target = null
 	..()
 
-/obj/item/grenade/plastic/attackby(obj/item/I, mob/user, params)
-	if(!nadeassembly && istype(I, /obj/item/assembly_holder))
-		var/obj/item/assembly_holder/A = I
-		if(!user.transferItemToLoc(I, src))
-			return ..()
-		nadeassembly = A
-		A.master = src
-		assemblyattacher = user.ckey
-		to_chat(user, "<span class='notice'>You add [A] to the [name].</span>")
-		playsound(src, 'sound/weapons/tap.ogg', 20, 1)
-		update_icon()
-		return
-	if(nadeassembly && I.tool_behaviour == TOOL_WIRECUTTER)
-		I.play_tool_sound(src, 20)
-		nadeassembly.forceMove(get_turf(src))
-		nadeassembly.master = null
-		nadeassembly = null
-		update_icon()
-		return
-	..()
+/obj/item/grenade/c4/attackby(obj/item/I, mob/user, params)
+	if(I.tool_behaviour == TOOL_SCREWDRIVER)
+		to_chat(user, "<span class='notice'>The wire panel can be accessed without a screwdriver.</span>")
+	else if(is_wire_tool(I))
+		wires.interact(user)
+	else
+		return ..()
 
-/obj/item/grenade/plastic/prime()
+/obj/item/grenade/c4/prime()
+	if(QDELETED(src))
+		return
 	var/turf/location
 	if(target)
 		if(!QDELETED(target))
@@ -71,39 +59,23 @@
 			explosion(get_step(T, aim_dir), boom_sizes[1], boom_sizes[2], boom_sizes[3])
 		else
 			explosion(location, boom_sizes[1], boom_sizes[2], boom_sizes[3])
-	if(ismob(target))
-		var/mob/M = target
-		M.gib()
 	qdel(src)
 
 //assembly stuff
-/obj/item/grenade/plastic/receive_signal()
+/obj/item/grenade/c4/receive_signal()
 	prime()
 
-/obj/item/grenade/plastic/Crossed(atom/movable/AM)
-	if(nadeassembly)
-		nadeassembly.Crossed(AM)
-
-/obj/item/grenade/plastic/on_found(mob/finder)
-	if(nadeassembly)
-		nadeassembly.on_found(finder)
-
-/obj/item/grenade/plastic/attack_self(mob/user)
-	if(nadeassembly)
-		nadeassembly.attack_self(user)
-		return
+/obj/item/grenade/c4/attack_self(mob/user)
 	var/newtime = input(usr, "Please set the timer.", "Timer", 10) as num
 	if(user.get_active_held_item() == src)
 		newtime = CLAMP(newtime, 10, 60000)
 		det_time = newtime
 		to_chat(user, "Timer set for [det_time] seconds.")
 
-/obj/item/grenade/plastic/afterattack(atom/movable/AM, mob/user, flag)
+/obj/item/grenade/c4/afterattack(atom/movable/AM, mob/user, flag)
 	. = ..()
 	aim_dir = get_dir(user,AM)
 	if(!flag)
-		return
-	if(ismob(AM) && !can_attach_mob)
 		return
 
 	to_chat(user, "<span class='notice'>You start planting [src]. The timer is set to [det_time]...</span>")
@@ -127,13 +99,10 @@
 			I.embedding = I.embedding.setRating(embed_chance = 0)
 
 		target.add_overlay(plastic_overlay, TRUE)
-		if(!nadeassembly)
-			to_chat(user, "<span class='notice'>You plant the bomb. Timer counting down from [det_time].</span>")
-			addtimer(CALLBACK(src, .proc/prime), det_time*10)
-		else
-			qdel(src)	//How?
+		to_chat(user, "<span class='notice'>You plant the bomb. Timer counting down from [det_time].</span>")
+		addtimer(CALLBACK(src, .proc/prime), det_time*10)
 
-/obj/item/grenade/plastic/proc/shout_syndicate_crap(mob/M)
+/obj/item/grenade/c4/proc/shout_syndicate_crap(mob/M)
 	if(!M)
 		return
 	var/message_say = "FOR NO RAISIN!"
@@ -149,9 +118,23 @@
 			message_say = "FOR RATVAR!"
 		else if(UM.has_antag_datum(/datum/antagonist/rev))
 			message_say = "VIVA LA REVOLUTION!"
+		else if(UM.has_antag_datum(/datum/antagonist/brother))
+			message_say = "FOR MY BROTHER!"
+		else if(UM.has_antag_datum(/datum/antagonist/ninja))
+			message_say = "FOR THE SPIDER CLAN!"
+		else if(UM.has_antag_datum(/datum/antagonist/fugitive))
+			message_say = "FOR FREEDOM!"
+		else if(UM.has_antag_datum(/datum/antagonist/ashwalker))
+			message_say = "FOR THE TENDRIL!"
+		else if(UM.has_antag_datum(/datum/antagonist/ert))
+			message_say = "FOR NANOTRASEN!"
+		else if(UM.has_antag_datum(/datum/antagonist/pirate))
+			message_say = "FOR ME MATEYS!"
+		else if(UM.has_antag_datum(/datum/antagonist/wizard))
+			message_say = "FOR THE FEDERATION!"
 	M.say(message_say, forced="C4 suicide")
 
-/obj/item/grenade/plastic/suicide_act(mob/user)
+/obj/item/grenade/c4/suicide_act(mob/user)
 	message_admins("[ADMIN_LOOKUPFLW(user)] suicided with [src] at [ADMIN_VERBOSEJMP(user)]")
 	log_game("[key_name(user)] suicided with [src] at [AREACOORD(user)]")
 	user.visible_message("<span class='suicide'>[user] activates [src] and holds it above [user.p_their()] head! It looks like [user.p_theyre()] going out with a bang!</span>")
@@ -160,80 +143,14 @@
 	user.gib(1, 1)
 	qdel(src)
 
-/obj/item/grenade/plastic/update_icon()
-	if(nadeassembly)
-		icon_state = "[item_state]1"
-	else
-		icon_state = "[item_state]0"
-
-//////////////////////////
-///// The Explosives /////
-//////////////////////////
-
-/obj/item/grenade/plastic/c4
-	name = "C4"
-	desc = "Used to put holes in specific areas without too much extra hole. A saboteur's favorite."
-	gender = PLURAL
-	var/open_panel = 0
-	can_attach_mob = TRUE
-
-/obj/item/grenade/plastic/c4/Initialize()
-	. = ..()
-	wires = new /datum/wires/explosive/c4(src)
-
-/obj/item/grenade/plastic/c4/Destroy()
-	qdel(wires)
-	wires = null
-	target = null
-	return ..()
-
-/obj/item/grenade/plastic/c4/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] activates the [src.name] and holds it above [user.p_their()] head! It looks like [user.p_theyre()] going out with a bang!</span>")
-	shout_syndicate_crap(user)
-	target = user
-	message_admins("[ADMIN_LOOKUPFLW(user)] suicided with [name] at [ADMIN_VERBOSEJMP(src)]")
-	log_game("[key_name(user)] suicided with [name] at [AREACOORD(user)]")
-	sleep(10)
-	prime()
-	user.gib(1, 1)
-
-/obj/item/grenade/plastic/c4/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		open_panel = !open_panel
-		to_chat(user, "<span class='notice'>You [open_panel ? "open" : "close"] the wire panel.</span>")
-	else if(is_wire_tool(I))
-		wires.interact(user)
-	else
-		return ..()
-
-/obj/item/grenade/plastic/c4/prime()
-	if(QDELETED(src))
-		return
-	var/turf/location
-	if(target)
-		if(!QDELETED(target))
-			location = get_turf(target)
-			target.cut_overlay(plastic_overlay, TRUE)
-			if(!ismob(target) || full_damage_on_mobs)
-				target.ex_act(2, target)
-	else
-		location = get_turf(src)
-	if(location)
-		explosion(location,0,0,3)
-	qdel(src)
-
-/obj/item/grenade/plastic/c4/attack(mob/M, mob/user, def_zone)
-	return
-
 // X4 is an upgraded directional variant of c4 which is relatively safe to be standing next to. And much less safe to be standing on the other side of.
 // C4 is intended to be used for infiltration, and destroying tech. X4 is intended to be used for heavy breaching and tight spaces.
 // Intended to replace C4 for nukeops, and to be a randomdrop in surplus/random traitor purchases.
 
-/obj/item/grenade/plastic/x4
-	name = "X4"
+/obj/item/grenade/c4/x4
+	name = "X-4 charge"
 	desc = "A shaped high-explosive breaching charge. Designed to ensure user safety and wall nonsafety."
 	icon_state = "plasticx40"
 	item_state = "plasticx4"
-	gender = PLURAL
 	directional = TRUE
 	boom_sizes = list(0, 2, 5)

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -125,7 +125,7 @@
 		else if(UM.has_antag_datum(/datum/antagonist/fugitive))
 			message_say = "FOR FREEDOM!"
 		else if(UM.has_antag_datum(/datum/antagonist/ashwalker))
-			message_say = "FOR THE TENDRIL!"
+			message_say = "I HAVE NO IDEA WHAT THIS THING DOES!"
 		else if(UM.has_antag_datum(/datum/antagonist/ert))
 			message_say = "FOR NANOTRASEN!"
 		else if(UM.has_antag_datum(/datum/antagonist/pirate))

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -574,11 +574,11 @@
 
 /obj/item/storage/backpack/duffelbag/syndie/c4/PopulateContents()
 	for(var/i in 1 to 10)
-		new /obj/item/grenade/plastic/c4(src)
+		new /obj/item/grenade/c4(src)
 
 /obj/item/storage/backpack/duffelbag/syndie/x4/PopulateContents()
 	for(var/i in 1 to 3)
-		new /obj/item/grenade/plastic/x4(src)
+		new /obj/item/grenade/c4/x4(src)
 
 /obj/item/storage/backpack/duffelbag/syndie/firestarter
 	desc = "A large duffel bag containing a New Russian pyro backpack sprayer, Elite hardsuit, a Stechkin APS pistol, minibomb, ammo, and other equipment."

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -445,7 +445,7 @@
 		/obj/item/lighter,
 		/obj/item/multitool,
 		/obj/item/reagent_containers/food/drinks/bottle/molotov,
-		/obj/item/grenade/plastic/c4,
+		/obj/item/grenade/c4,
 		))
 
 /obj/item/storage/belt/grenade/full/PopulateContents()

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -42,7 +42,7 @@
 			new /obj/item/ammo_box/a357(src)
 			new /obj/item/ammo_box/a357(src)
 			new /obj/item/card/emag(src)
-			new /obj/item/grenade/plastic/c4(src)
+			new /obj/item/grenade/c4(src)
 			new /obj/item/clothing/gloves/color/latex/nitrile(src)
 			new /obj/item/clothing/mask/gas/clown_hat(src)
 			new /obj/item/clothing/under/suit/black_really(src)
@@ -90,8 +90,8 @@
 			new /obj/item/storage/toolbox/syndicate(src)
 
 		if("sabotage")
-			new /obj/item/grenade/plastic/c4 (src)
-			new /obj/item/grenade/plastic/c4 (src)
+			new /obj/item/grenade/c4 (src)
+			new /obj/item/grenade/c4 (src)
 			new /obj/item/doorCharge(src)
 			new /obj/item/doorCharge(src)
 			new /obj/item/camera_bug(src)
@@ -115,8 +115,8 @@
 			new /obj/item/implanter/explosive(src) // 2 tc
 			new /obj/item/ammo_box/magazine/m12g(src) // 2 tc
 			new /obj/item/ammo_box/magazine/m12g(src) // 2 tc
-			new /obj/item/grenade/plastic/c4 (src) // 1 tc
-			new /obj/item/grenade/plastic/c4 (src) // 1 tc
+			new /obj/item/grenade/c4 (src) // 1 tc
+			new /obj/item/grenade/c4 (src) // 1 tc
 			new /obj/item/card/emag(src) // 6 tc
 
 /obj/item/storage/box/syndicate/bundle_B/PopulateContents()

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -480,7 +480,7 @@
 				/obj/item/storage/firstaid/brute = 27,
 				/obj/item/storage/firstaid/fire = 27,
 				/obj/item/storage/toolbox/syndicate = 12,
-				/obj/item/grenade/plastic/c4 = 7,
+				/obj/item/grenade/c4 = 7,
 				/obj/item/grenade/clusterbuster/smoke = 15,
 				/obj/item/clothing/under/chameleon = 13,
 				/obj/item/clothing/shoes/chameleon/noslip = 10,

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -186,7 +186,7 @@
 	SEND_SIGNAL(sec_briefcase, COMSIG_TRY_STORAGE_INSERT, new /obj/item/gun/energy/kinetic_accelerator/crossbow, null, TRUE, TRUE)
 	SEND_SIGNAL(sec_briefcase, COMSIG_TRY_STORAGE_INSERT, new /obj/item/gun/ballistic/revolver/mateba, null, TRUE, TRUE)
 	SEND_SIGNAL(sec_briefcase, COMSIG_TRY_STORAGE_INSERT, new /obj/item/ammo_box/a357, null, TRUE, TRUE)
-	SEND_SIGNAL(sec_briefcase, COMSIG_TRY_STORAGE_INSERT, new /obj/item/grenade/plastic/x4, null, TRUE, TRUE)
+	SEND_SIGNAL(sec_briefcase, COMSIG_TRY_STORAGE_INSERT, new /obj/item/grenade/c4/x4, null, TRUE, TRUE)
 
 	var/obj/item/pda/heads/pda = H.belt
 	pda.owner = H.real_name
@@ -385,7 +385,7 @@
 		/obj/item/storage/firstaid/regular=1,\
 		/obj/item/storage/box/flashbangs=1,\
 		/obj/item/flashlight=1,\
-		/obj/item/grenade/plastic/x4=1)
+		/obj/item/grenade/c4/x4=1)
 
 /datum/outfit/death_commando/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -239,7 +239,7 @@
 //items that appear only in shuttle loan events
 
 /obj/item/storage/belt/fannypack/yellow/bee_terrorist/PopulateContents()
-	new /obj/item/grenade/plastic/c4 (src)
+	new /obj/item/grenade/c4 (src)
 	new /obj/item/reagent_containers/pill/cyanide(src)
 	new /obj/item/grenade/chem_grenade/facid(src)
 

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -222,7 +222,7 @@
 						to_chat(usr, "<span class='warning'>\The [item_to_add] is stuck to your hand, you cannot put it on [src]'s back!</span>")
 						return
 
-					if(istype(item_to_add, /obj/item/grenade/plastic)) // last thing he ever wears, I guess
+					if(istype(item_to_add, /obj/item/grenade/c4)) // last thing he ever wears, I guess
 						item_to_add.afterattack(src,usr,1)
 						return
 
@@ -257,7 +257,7 @@
 
 /mob/living/simple_animal/pet/dog/corgi/proc/place_on_head(obj/item/item_to_add, mob/user)
 
-	if(istype(item_to_add, /obj/item/grenade/plastic)) // last thing he ever wears, I guess
+	if(istype(item_to_add, /obj/item/grenade/c4)) // last thing he ever wears, I guess
 		item_to_add.afterattack(src,user,1)
 		return
 

--- a/code/modules/ninja/outfit.dm
+++ b/code/modules/ninja/outfit.dm
@@ -9,7 +9,7 @@
 	shoes = /obj/item/clothing/shoes/space_ninja
 	gloves = /obj/item/clothing/gloves/space_ninja
 	back = /obj/item/tank/jetpack/carbondioxide
-	l_pocket = /obj/item/grenade/plastic/x4
+	l_pocket = /obj/item/grenade/c4/x4
 	r_pocket = /obj/item/tank/internals/emergency_oxygen
 	internals_slot = SLOT_R_STORE
 	belt = /obj/item/energy_katana

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -890,7 +890,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "C-4 is plastic explosive of the common variety Composition C. You can use it to breach walls, sabotage equipment, or connect \
 			an assembly to it in order to alter the way it detonates. It can be attached to almost all objects and has a modifiable timer with a \
 			minimum setting of 10 seconds."
-	item = /obj/item/grenade/plastic/c4
+	item = /obj/item/grenade/c4
 	cost = 1
 
 /datum/uplink_item/explosives/c4bag

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -14,7 +14,6 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
-#include "_maps\runtimestation.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DEFINES\_globals.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -14,6 +14,7 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
+#include "_maps\runtimestation.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DEFINES\_globals.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR refactors plastic explosives:
* Generic plastic explosives got removed since they aren't used anywhere ingame and overlap with chemical grenades.
* Removed a bunch of duplicate code, why the hell were there even two suicide_act()?
* X4 now accepts assemblies and can be attached to mobs just like C4.
* C4 wires can be accessed without a screwdriver, just like in real life.
* Also added a few extra suicide_act() lines.

## Why It's Good For The Game

This brings X4 in line with C4 and removes a bunch of shitcode.

## Changelog
:cl:
fix: X4 now has a wire panel that lets you attach assemblies, just like C4. You can also attach X4 to creatures now.
tweak: C4 and X4 wires no longer need a screwdriver to access.
add: Added a few extra C4/X4 suicide lines for different antagonists.
remove: Removed generic plastic explosives, as they're not used anywhere ingame and overlap with chemical grenades.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
