### PR TITLE
Imaginary Friend/Split Personality Trauma Fixes

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -8,6 +8,10 @@
 	var/friend_initialized = FALSE
 
 /datum/brain_trauma/special/imaginary_friend/on_gain()
+	var/mob/living/M = owner
+	if(M.stat == DEAD || !M.client)
+		qdel(src)
+		return
 	..()
 	make_friend()
 	get_ghost()

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -13,6 +13,10 @@
 	var/mob/living/split_personality/owner_backseat
 
 /datum/brain_trauma/severe/split_personality/on_gain()
+	var/mob/living/M = owner
+	if(M.stat == DEAD || !M.client)	//No use assigning people to a corpse
+		qdel(src)
+		return
 	..()
 	make_backseats()
 	get_ghost()

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -14,7 +14,7 @@
 
 /datum/brain_trauma/severe/split_personality/on_gain()
 	var/mob/living/M = owner
-	if(M.stat == DEAD || !M.client)	//No use assigning people to a corpse
+	if(M.stat == DEAD)	//No use assigning people to a corpse
 		qdel(src)
 		return
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Two traumas, imaginary friend and split personality, had no check for when an individual was dead, and so after organ decay was added, this become significantly more noticeable. You should still roll for traumas while dead, as that was the intended behavior, but these two shouldn't be in that rolled list. Fixes #45598 and fixes #45628. It also checks for if the owner has a client in imaginary friend's case.

Again, to reiterate, being dead does not exempt you from traumas, as previous pseudo-organ decay mechanics had you get brain damage and trauma upon revival, this just cuts down on ghost roles spam from two traumas that delete themselves when the owner's dead.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I, for one, would like to never be the imaginary friend of monkey(542)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Split Personality is only rolled if the brain's owner is not dead, and Imaginary Friend is rolled only if they're both not dead and also a player.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
