### PR TITLE
Fixes become_husk's update_body placement

### DIFF
--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -430,9 +430,9 @@
 /mob/living/proc/become_husk(source)
 	if(!HAS_TRAIT(src, TRAIT_HUSK))
 		ADD_TRAIT(src, TRAIT_DISFIGURED, "husk")
-		update_body()
 		. = TRUE
 	ADD_TRAIT(src, TRAIT_HUSK, source)
+	update_body()
 
 /mob/living/proc/cure_fakedeath(source)
 	REMOVE_TRAIT(src, TRAIT_FAKEDEATH, source)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -431,8 +431,10 @@
 	if(!HAS_TRAIT(src, TRAIT_HUSK))
 		ADD_TRAIT(src, TRAIT_DISFIGURED, "husk")
 		. = TRUE
-	ADD_TRAIT(src, TRAIT_HUSK, source)
-	update_body()
+		ADD_TRAIT(src, TRAIT_HUSK, source)
+		update_body()
+	else
+		ADD_TRAIT(src, TRAIT_HUSK, source)	//I have no idea why the original code applied this unconditionally, but here it is
 
 /mob/living/proc/cure_fakedeath(source)
 	REMOVE_TRAIT(src, TRAIT_FAKEDEATH, source)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So the original become_husk called update_body only when the body became a husk, and it did so before it assigned the husk trait to the body. Whoops! Fixes #45647 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People won't spend half an hour on a corpse that's actually just an overcooked sausage

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Husking now properly makes the body look like a husk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
