### PR TITLE
Make ChangeTurf to keep air by default V2. Now properly tested.

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -135,19 +135,18 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 	return W
 
-/turf/open/ChangeTurf(path, list/new_baseturfs, flags) //Resist the temptation to make this default to keeping air.
+/turf/open/ChangeTurf(path, list/new_baseturfs, flags = CHANGETURF_INHERIT_AIR)
 	if ((flags & CHANGETURF_INHERIT_AIR) && ispath(path, /turf/open))
 		SSair.remove_from_active(src)
-		var/stashed_air = air
-		air = null // so that it doesn't get deleted
+		var/datum/gas_mixture/stashed_air = new()
+		stashed_air.copy_from(air)
 		. = ..()
-		if (!. || . == src) // changeturf failed or didn't do anything
-			air = stashed_air
+		if (!.) // changeturf failed or didn't do anything
+			QDEL_NULL(stashed_air)
 			return
 		var/turf/open/newTurf = .
-		if (!istype(newTurf.air, /datum/gas_mixture/immutable/space))
-			newTurf.air.copy_from(stashed_air)
-			QDEL_NULL(stashed_air)
+		newTurf.air.copy_from(stashed_air)
+		QDEL_NULL(stashed_air)
 		SSair.add_to_active(newTurf)
 	else
 		if(ispath(path,/turf/closed))


### PR DESCRIPTION
## About The Pull Request
ChangeTurf keep air by default if no flags sended on ChangeTurf().
fix#44623 #45209
Now propertly tested.
And complytely fixed CHANGETURF_INHERIT_AIR flag. 
## Why It's Good For The Game
Air dupers must cry.
No more the Drake "floor is lava" attack causes some annoying space wind.
## Changelog
:cl:
fix: CHANGETURF_INHERIT_AIR proreply replace, or not replace air.
fix: No more unintended air creation.
/:cl:
