### PR TITLE
You can no longer pick up sofas

### DIFF
--- a/code/game/objects/structures/beds_chairs/sofa.dm
+++ b/code/game/objects/structures/beds_chairs/sofa.dm
@@ -3,6 +3,7 @@
 	icon_state = "sofamiddle"
 	icon = 'icons/obj/sofa.dmi'
 	buildstackamount = 1
+	item_chair = null
 
 /obj/structure/chair/sofa/left
 	icon_state = "sofaend_left"


### PR DESCRIPTION
## About The Pull Request

Fixes #45712

## Changelog
:cl:
fix: You can no longer pick up sofas to get regular chairs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
