### PR TITLE
Limits camera pictures to 3x3 Max

### DIFF
--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -31,8 +31,8 @@
 	var/picture_size_y = 2
 	var/picture_size_x_min = 1
 	var/picture_size_y_min = 1
-	var/picture_size_x_max = 4
-	var/picture_size_y_max = 4
+	var/picture_size_x_max = 3
+	var/picture_size_y_max = 3
 	var/can_customise = TRUE
 	var/default_picture_name
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
mitigates #45718 

Limits camera pictures to 3x3 as a temporary mitigation for 45718
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents potential issues

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Limited camera pictures to 3x3 max
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
