### PR TITLE
Reworks Cult Summon Rune and Cult Communion

### DIFF
--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -4,10 +4,10 @@
 	icon_icon = 'icons/mob/actions/actions_cult.dmi'
 	background_icon_state = "bg_demon"
 	buttontooltipstyle = "cult"
-	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUN|AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_STUN|AB_CHECK_CONSCIOUS
 
 /datum/action/innate/cult/IsAvailable()
-	if(!iscultist(owner))
+	if((!iscultist(owner)) || (owner.reagents.has_reagent(/datum/reagent/water/holywater)))
 		return FALSE
 	return ..()
 

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -719,10 +719,10 @@ structure_check() searches for nearby cultist structures required for the invoca
 		fail_invoke()
 		log_game("Summon Cultist rune failed - target died")
 		return
-	if(cultist_to_summon.pulledby || cultist_to_summon.buckled)
-		to_chat(user, "<span class='cult italic'>[cultist_to_summon] is being held in place!</span>")
+	if(cultist_to_summon.reagents.has_reagent(/datum/reagent/water/holywater))
+		to_chat(user, "<span class='cult italic'>The holy energy in [cultist_to_summon]'s body blocks the summon!</span>")
 		fail_invoke()
-		log_game("Summon Cultist rune failed - target restrained")
+		log_game("Summon Cultist rune failed - target contains holy water")
 		return
 	if(!iscultist(cultist_to_summon))
 		to_chat(user, "<span class='cult italic'>[cultist_to_summon] is not a follower of the Geometer!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

**Cult Communion Changes**
You can now use cult speech if restrained, but not if holy water is in your body
**Summon Rune Changes**
Restrained/Stunned cultists can now be summoned, but not cultists with holy water in them

## Why It's Good For The Game

Restricting speech when restrained never really made sense, I don't see how a pair of metal cuffs blocks you from speaking to other cultists. It made summon(ing you) hard, since no one knew you were captured. Gives holywater more practical use. 

Summon Rune was basically pointless since you had nearly no opportunity to act in order to save a cultist. This allows it to be used in the span of a cultist being dragged to brig, but make sure to act before they're watered up, as it'll be too late then. 

## Changelog
:cl:
balance: You can now use cult communion (cult speak) if restrained, but not if holy water is in your system.
balance: Summon Rune now works on restrained/stunned cultists, but not on cultists with holy water in them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
