### PR TITLE
Fix null brain in death query and typo correction

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -296,7 +296,7 @@ Versioning
 	var/lakey = L.lastattackerckey
 	var/sqlbrute = L.getBruteLoss()
 	var/sqlfire = L.getFireLoss()
-	var/sqlbrain = L.getOrganLoss(ORGAN_SLOT_BRAIN)
+	var/sqlbrain = L.getOrganLoss(ORGAN_SLOT_BRAIN) || BRAIN_DAMAGE_DEATH //getOrganLoss returns null without a brain but a value is required for this column
 	var/sqloxy = L.getOxyLoss()
 	var/sqltox = L.getToxLoss()
 	var/sqlclone = L.getCloneLoss()

--- a/code/modules/admin/verbs/reestablish_db_connection.dm
+++ b/code/modules/admin/verbs/reestablish_db_connection.dm
@@ -19,8 +19,8 @@
 		message_admins("[key_name_admin(usr)] has <b>forced</b> the database to disconnect!")
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Force Reestablished Database Connection") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-	log_admin("[key_name(usr)] is attempting to re-established the DB Connection")
-	message_admins("[key_name_admin(usr)] is attempting to re-established the DB Connection")
+	log_admin("[key_name(usr)] is attempting to re-establish the DB Connection")
+	message_admins("[key_name_admin(usr)] is attempting to re-establish the DB Connection")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Reestablished Database Connection") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 	SSdbcore.failed_connections = 0


### PR DESCRIPTION
A mob without a brain would return `null` for `L.getOrganLoss(ORGAN_SLOT_BRAIN)` causing death queries to fail since brainloss is a required field. In this case the var will default to `BRAIN_DAMAGE_DEATH` since I figure not having a brain is basically the same as it being melted from brainrot. After all, having your brain removed is literal brainloss.

Also fixed a typo in the reconnect database verb log.