### PR TITLE
Simple Animals Can Now Use Held IDs

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -472,8 +472,28 @@
 			return
 	sync_lighting_plane_alpha()
 
-/mob/living/simple_animal/get_idcard(hand_first)
-	return access_card
+//Gets ID card. If hand_first is false the one in the id slot is prioritized, otherwise innate access goes first.
+/mob/living/simple_animal/get_idcard(hand_first = TRUE)
+	var/obj/item/card/id/id_card
+	
+	// Check hands if relevant
+	if (can_hold_items())
+		var/obj/item/held_item = get_active_held_item()
+		if(held_item) // Check active hand
+			id_card = held_item.GetID()
+		if(!id_card) // If there is no ID, check the other hand
+			held_item = get_inactive_held_item()
+			if(held_item)
+				id_card = held_item.GetID()
+		if(id_card && hand_first)
+			return id_card
+		else
+			. = id_card
+
+	// Check innate access
+	if(access_card)
+		return access_card
+
 
 /mob/living/simple_animal/can_hold_items()
 	return dextrous


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previously simple animals could longingly hold IDs without being able to use them. Now dexterous simple animals can use those held IDs!

Closes https://github.com/tgstation/tgstation/issues/45728.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
more access is better for open source
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
add: Simple animals can now use held IDs for machines and possibly more! Gorillas will no longer be discriminated against.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->