### PR TITLE
Makes itching deal damage through clothing

### DIFF
--- a/code/datums/diseases/advance/symptoms/itching.dm
+++ b/code/datums/diseases/advance/symptoms/itching.dm
@@ -47,8 +47,8 @@ BONUS
 	var/mob/living/carbon/M = A.affected_mob
 	var/picked_bodypart = pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG)
 	var/obj/item/bodypart/bodypart = M.get_bodypart(picked_bodypart)
-	if(bodypart && bodypart.status == BODYPART_ORGANIC && !bodypart.is_pseudopart)	 //robotic limbs will mean less scratching overall
-		var/can_scratch = scratch && !M.incapacitated() && get_location_accessible(M, picked_bodypart)
+	if(bodypart && bodypart.status == BODYPART_ORGANIC && !bodypart.is_pseudopart)	 //robotic limbs will mean less scratching overall (why are golems able to damage themselves with self-scratching, but not androids? the world may never know)
+		var/can_scratch = scratch && !M.incapacitated()
 		M.visible_message("[can_scratch ? "<span class='warning'>[M] scratches [M.p_their()] [bodypart.name].</span>" : ""]", "<span class='warning'>Your [bodypart.name] itches. [can_scratch ? " You scratch it." : ""]</span>")
 		if(can_scratch)
 			bodypart.receive_damage(0.5)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/44987.

tldr;
Damage from the itching symptom's stage speed 7 threshold effect is currently blocked by anything that would block surgery on the body part that itching targets, including jumpsuits. This effectively makes said threshold nigh-pointless, so I've decided to remove its blocking clothing check. While I was initially going to make it check for the THICKMATERIAL flag instead, nemvar suggested just letting it pierce through any clothing, as you can scratch an itch IRL by rubbing up against the inside(s) of hard clothing.

## Why It's Good For The Game

Almost everyone wears a jumpsuit, which blocks 5/6 of the damage from itching even if you're not wearing a mask or a hat. This is pretty lame, and makes the threshold effect that makes the itching symptom deal damage nigh-pointless.

## Changelog
:cl: ATHATH
tweak: The itching symptom's stage speed 7 threshold effect's damage is now no longer blocked by clothing.
/:cl: