### PR TITLE
Adds robotic voiceboxes as contraband in the Robotech Deluxe

### DIFF
--- a/code/modules/vending/robotics.dm
+++ b/code/modules/vending/robotics.dm
@@ -19,6 +19,7 @@
 					/obj/item/clothing/mask/breath/medical = 5,
 					/obj/item/screwdriver = 5,
 					/obj/item/crowbar = 5)
+	contraband = list(/obj/item/organ/tongue/robot = 2)
 	refill_canister = /obj/item/vending_refill/robotics
 	default_price = 50
 	extra_price = 75

--- a/code/modules/vending/robotics.dm
+++ b/code/modules/vending/robotics.dm
@@ -22,7 +22,7 @@
 	contraband = list(/obj/item/organ/tongue/robot = 2)
 	refill_canister = /obj/item/vending_refill/robotics
 	default_price = 50
-	extra_price = 75
+	extra_price = 300
 	payment_department = ACCOUNT_SCI
 
 /obj/item/vending_refill/robotics


### PR DESCRIPTION
## About The Pull Request

The title explains most of it, really.

## Why It's Good For The Game

It's a bit sad that in order to let your fully augged patient speak like a robot, you have to wait for a meat-eor shower or use other esoteric means to give them the SPAN_ROBOT span. Now you can hack your vendor and make your patient an even better imitation of an android and/or add an extra element to your cardborg costume.

## Changelog
:cl: ATHATH
add: Added two robotic voiceboxes to the contraband section of the Robotech Deluxe.
/:cl:
