### PR TITLE
Footprints no longer always face south and can rotate properly

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -121,7 +121,6 @@
 
 //Converts an angle (degrees) into an ss13 direction
 /proc/angle2dir(degree)
-
 	degree = SIMPLIFY_DEGREES(degree)
 	switch(degree)
 		if(0 to 22.5) //north requires two angle ranges
@@ -143,8 +142,9 @@
 		if(337.5 to 360)
 			return NORTH
 
-/proc/angle2dir_cardinal(angle)
-	switch(round(angle, 0.1))
+/proc/angle2dir_cardinal(degree)
+	degree = SIMPLIFY_DEGREES(degree)
+	switch(round(degree, 0.1))
 		if(315.5 to 360, 0 to 45.5)
 			return NORTH
 		if(45.6 to 135.5)

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -140,15 +140,21 @@
 //BLOODY FOOTPRINTS
 /obj/effect/decal/cleanable/blood/footprints
 	name = "footprints"
-	icon = 'icons/effects/footprints.dmi'
-	icon_state = "nothingwhatsoever"
 	desc = "WHOSE FOOTPRINTS ARE THESE?"
+	icon = 'icons/effects/footprints.dmi'
 	icon_state = "blood1"
 	random_icon_states = null
 	blood_state = BLOOD_STATE_HUMAN //the icon state to load images from
 	var/entered_dirs = 0
 	var/exited_dirs = 0
 	var/list/shoe_types = list()
+
+/obj/effect/decal/cleanable/blood/footprints/Initialize(mapload)
+	. = ..()
+	icon_state = "" //All of the footprint visuals come from overlays
+	if(mapload)
+		entered_dirs |= dir //Keep the same appearance as in the map editor
+		update_icon()
 
 /obj/effect/decal/cleanable/blood/footprints/Crossed(atom/movable/O)
 	..()

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -174,7 +174,7 @@
 			exited_dirs |= angle2dir_cardinal(dir2angle(Ddir) + ang_change)
 
 	update_icon()
-	..()
+	return ..()
 
 /obj/effect/decal/cleanable/blood/footprints/Crossed(atom/movable/O)
 	..()

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -156,6 +156,26 @@
 		entered_dirs |= dir //Keep the same appearance as in the map editor
 		update_icon()
 
+//Rotate all of the footprint directions too
+/obj/effect/decal/cleanable/blood/footprints/setDir(newdir)
+	if(dir == newdir)
+		return ..()
+
+	var/ang_change = dir2angle(newdir) - dir2angle(dir)
+	var/old_entered_dirs = entered_dirs
+	var/old_exited_dirs = exited_dirs
+	entered_dirs = 0
+	exited_dirs = 0
+
+	for(var/Ddir in GLOB.cardinals)
+		if(old_entered_dirs & Ddir)
+			entered_dirs |= angle2dir_cardinal(dir2angle(Ddir) + ang_change)
+		if(old_exited_dirs & Ddir)
+			exited_dirs |= angle2dir_cardinal(dir2angle(Ddir) + ang_change)
+
+	update_icon()
+	..()
+
 /obj/effect/decal/cleanable/blood/footprints/Crossed(atom/movable/O)
 	..()
 	if(ishuman(O))


### PR DESCRIPTION
## About The Pull Request
Footprints now remove their icon_state in Initialize (the icon_state still has a valid default so that it can be seen in the map editor, as intended by https://github.com/tgstation/tgstation/pull/41573.)

Footprints now also handle rotation properly. If you've got a trail of footprints on a shuttle and the shuttle rotates, they'll all be facing the correct direction.

Maploaded footprints should still look the same as they do now. They're only used in a couple of lavaland ruins.

I also modified `/proc/angle2dir_cardinal` to normalize its input (the same way `/proc/angle2dir` does.

## Why It's Good For The Game
Before:
![image](https://user-images.githubusercontent.com/1499676/62546572-9c942500-b85b-11e9-8390-224e979592df.png)
After:
![image](https://user-images.githubusercontent.com/1499676/62546677-d5cc9500-b85b-11e9-87ee-11a52e4c57f9.png)

## Changelog
:cl:
fix: bloody footprints no longer spawn with incorrect steps and don't break when rotated on shuttles
/:cl:
