### PR TITLE
You can rotate machines with alt-click again

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -608,6 +608,7 @@ Class Procs:
 		updateUsrDialog()
 
 /obj/machinery/AltClick(mob/user)
+	..()
 	if(!user.canUseTopic(src, !issilicon(user)) || !is_operational())
 		return
 	if(inserted_modify_id)


### PR DESCRIPTION
Call parent.
Fixes #45613

## Changelog
:cl:
fix: Alt-clicking certain machines, such as emitters, rotates them once more.
/:cl:
