### PR TITLE
2 Initialization hints

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -7,7 +7,7 @@
 	..()
 
 /obj/structure/closet/secure_closet/freezer/Initialize()
-	..()
+	. = ..()
 	recursive_organ_check(src)
 
 /obj/structure/closet/secure_closet/freezer/open(mob/living/user)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -109,7 +109,7 @@
 	..()
 
 /obj/structure/closet/crate/freezer/Initialize()
-	..()
+	. = ..()
 	recursive_organ_check(src)
 
 


### PR DESCRIPTION
Very tiny code improvement, adds initialization hint to 2 objects that missed them, due to which they showed up in the init() debug log as errors.