### PR TITLE
Fixes being unable to clone multiple empty clones simultaneously

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -41,7 +41,7 @@
 	if(pods)
 		for(var/P in pods)
 			var/obj/machinery/clonepod/pod = P
-			if(pod.occupant && pod.clonemind == mind)
+			if(pod.occupant && mind && pod.clonemind == mind)
 				return null
 			if(pod.is_operational() && !(pod.occupant || pod.mess))
 				return pod


### PR DESCRIPTION
:cl:
fix: Fixed being unable to clone multiple empty clones simultaneously
/:cl:

My bad, should have caught this in my last PR.

Fixes #45721