### PR TITLE
Failing healing surgery only gives one error message now

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -60,7 +60,6 @@
 	return TRUE
 
 /datum/surgery_step/heal/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] screws up!", "<span class='warning'>You screwed up!</span>")
 	display_results(user, target, "<span class='warning'>You screwed up!</span>",
 		"[user] screws up!",
 		"[user] fixes some of [target]'s wounds.", TRUE)


### PR DESCRIPTION
## About The Pull Request

Fixes #45772

## Changelog
:cl:
spellcheck: Tend wounds only generates one failure message now.
/:cl:
