### PR TITLE
Adds proper logging for nuke code request messages

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -320,7 +320,7 @@
 					return
 				Nuke_request(input, usr)
 				to_chat(usr, "<span class='notice'>Request sent.</span>")
-				usr.log_message("has requested the nuclear codes from CentCom", LOG_SAY)
+				usr.log_message("has requested the nuclear codes from CentCom with reason \"[input]\"", LOG_SAY)
 				priority_announce("The codes for the on-station nuclear self-destruct have been requested by [usr]. Confirmation or denial of this request will be sent shortly.", "Nuclear Self Destruct Codes Requested",'sound/ai/commandreport.ogg')
 				CM.lastTimeUsed = world.time
 


### PR DESCRIPTION
## About The Pull Request

Adds logging for CentComm nuke code requests.

## Why It's Good For The Game

The actual text of nuke code request messages is not currently logged anywhere.  This PR removes ambiguity/guesswork when investigating them.

## Changelog
:cl: Penterwast
admin: Added logging for CentComm nuke request messages.
/:cl:
