### PR TITLE
Changes the Disintegrate spell's name to "Smite"

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -120,7 +120,7 @@
 	category = "Defensive"
 
 /datum/spellbook_entry/disintegrate
-	name = "Disintegrate"
+	name = "Gib"
 	spell_type = /obj/effect/proc_holder/spell/targeted/touch/disintegrate
 
 /datum/spellbook_entry/disabletech

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -120,7 +120,7 @@
 	category = "Defensive"
 
 /datum/spellbook_entry/disintegrate
-	name = "Gib"
+	name = "Smite"
 	spell_type = /obj/effect/proc_holder/spell/targeted/touch/disintegrate
 
 /datum/spellbook_entry/disabletech

--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -43,7 +43,7 @@
 	return ..()
 
 /obj/item/melee/touch_attack/disintegrate
-	name = "\improper gibbing touch"
+	name = "\improper smiting touch"
 	desc = "This hand of mine glows with an awesome power!"
 	catchphrase = "EI NATH!!"
 	on_use_sound = 'sound/magic/disintegrate.ogg'

--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -43,7 +43,7 @@
 	return ..()
 
 /obj/item/melee/touch_attack/disintegrate
-	name = "\improper disintegrating touch"
+	name = "\improper gibbing touch"
 	desc = "This hand of mine glows with an awesome power!"
 	catchphrase = "EI NATH!!"
 	on_use_sound = 'sound/magic/disintegrate.ogg'

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -53,8 +53,8 @@
 
 
 /obj/effect/proc_holder/spell/targeted/touch/disintegrate
-	name = "Disintegrate"
-	desc = "This spell charges your hand with vile energy that can be used to violently explode victims."
+	name = "Gib"
+	desc = "This spell charges your hand with vile energy that can be used to cause a touched victim to violently explode."
 	hand_path = /obj/item/melee/touch_attack/disintegrate
 
 	school = "evocation"

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -53,8 +53,8 @@
 
 
 /obj/effect/proc_holder/spell/targeted/touch/disintegrate
-	name = "Gib"
-	desc = "This spell charges your hand with vile energy that can be used to cause a touched victim to violently explode."
+	name = "Smite"
+	desc = "This spell charges your hand with an unholy energy that can be used to cause a touched victim to violently explode."
 	hand_path = /obj/item/melee/touch_attack/disintegrate
 
 	school = "evocation"


### PR DESCRIPTION
## About The Pull Request

This PR has been made as an alternative to another one of my PRs: https://github.com/tgstation/tgstation/pull/45782

It simply changes the name of the "Disintegrate" spell (and some references to it) to "Smite" (and slightly edits the description of the Disintegrate spell).

## Why It's Good For The Game

The new name more accurately reflects what the spell does.

## Changelog
:cl: ATHATH
tweak: Changed the name of the "Disintegrate" spell (and some references to it) to "Smite" (and slightly edits the description of the Disintegrate spell).
/:cl:

On a side note, are we supposed to capitalize spell names in our changelogs/normal use of them, or are we suppose to leave them uncapitalized? In other words, are spell names proper nouns?