### PR TITLE
Makes the Hivemind Link power not absolute garbage

### DIFF
--- a/code/modules/antagonists/changeling/powers/linglink.dm
+++ b/code/modules/antagonists/changeling/powers/linglink.dm
@@ -68,3 +68,7 @@
 				target.reagents.add_reagent(/datum/reagent/medicine/salbutamol, 40) // So they don't choke to death while you interrogate them
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]", "[i]"))
 	changeling.islinking = 0
+
+/datum/action/changeling/linglink/Remove(mob/user)
+	changeling.islinking = 0
+	..()

--- a/code/modules/antagonists/changeling/powers/linglink.dm
+++ b/code/modules/antagonists/changeling/powers/linglink.dm
@@ -1,10 +1,10 @@
 /datum/action/changeling/linglink
 	name = "Hivemind Link"
-	desc = "We link our victim's mind into the hivemind for personal interrogation."
+	desc = "We link our victim's mind into the hivemind for personal interrogation and/or remote communication."
 	helptext = "If we find a human mad enough to support our cause, this can be a helpful tool to stay in touch."
 	button_icon_state = "hivemind_link"
 	chemical_cost = 0
-	dna_cost = 0
+	dna_cost = 2
 	req_human = 1
 
 /datum/action/changeling/linglink/can_sting(mob/living/carbon/user)
@@ -12,7 +12,7 @@
 		return
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	if(changeling.islinking)
-		to_chat(user, "<span class='warning'>We have already formed a link with the victim!</span>")
+		to_chat(user, "<span class='warning'>We are already forming a link!</span>")
 		return
 	if(!user.pulling)
 		to_chat(user, "<span class='warning'>We must be tightly grabbing a creature to link with them!</span>")
@@ -44,9 +44,17 @@
 		switch(i)
 			if(1)
 				to_chat(user, "<span class='notice'>This creature is compatible. We must hold still...</span>")
+				if(!do_mob(user, target, 60))
+					to_chat(user, "<span class='warning'>Our linking with [target] has been interrupted!</span>")
+					changeling.islinking = 0
+					return
 			if(2)
 				to_chat(user, "<span class='notice'>We stealthily stab [target] with a minor proboscis...</span>")
 				to_chat(target, "<span class='userdanger'>You experience a stabbing sensation and your ears begin to ring...</span>")
+				if(!do_mob(user, target, 60))
+					to_chat(user, "<span class='warning'>Our linking with [target] has been interrupted!</span>")
+					changeling.islinking = 0
+					return
 			if(3)
 				to_chat(user, "<span class='notice'>We mold the [target]'s mind like clay, granting [target.p_them()] the ability to speak in the hivemind!</span>")
 				to_chat(target, "<span class='userdanger'>A migraine throbs behind your eyes, you hear yourself screaming - but your mouth has not opened!</span>")
@@ -58,15 +66,5 @@
 				target.say("[MODE_TOKEN_CHANGELING] AAAAARRRRGGGGGHHHHH!!")
 				to_chat(target, "<span class='changeling bold'>You can now communicate in the changeling hivemind, say \"[MODE_TOKEN_CHANGELING] message\" to communicate!</span>")
 				target.reagents.add_reagent(/datum/reagent/medicine/salbutamol, 40) // So they don't choke to death while you interrogate them
-				sleep(1800)
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]", "[i]"))
-		if(!do_mob(user, target, 20))
-			to_chat(user, "<span class='warning'>Our link with [target] has ended!</span>")
-			changeling.islinking = 0
-			target.mind.linglink = 0
-			return
-
 	changeling.islinking = 0
-	target.mind.linglink = 0
-	to_chat(user, "<span class='notice'>You cannot sustain the connection any longer, your victim fades from the hivemind</span>")
-	to_chat(target, "<span class='userdanger'>The link cannot be sustained any longer, your connection to the hivemind has faded!</span>")

--- a/code/modules/antagonists/changeling/powers/linglink.dm
+++ b/code/modules/antagonists/changeling/powers/linglink.dm
@@ -68,6 +68,7 @@
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]", "[i]"))
 	changeling.islinking = 0
 
+
 /datum/action/changeling/linglink/Remove(mob/user)
 	changeling.islinking = 0
 	..()

--- a/code/modules/antagonists/changeling/powers/linglink.dm
+++ b/code/modules/antagonists/changeling/powers/linglink.dm
@@ -68,7 +68,6 @@
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]", "[i]"))
 	changeling.islinking = 0
 
-
 /datum/action/changeling/linglink/Remove(mob/user)
 	changeling.islinking = 0
 	..()

--- a/code/modules/antagonists/changeling/powers/linglink.dm
+++ b/code/modules/antagonists/changeling/powers/linglink.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/linglink
 	name = "Hivemind Link"
-	desc = "We link our victim's mind into the hivemind for personal interrogation and/or remote communication."
-	helptext = "If we find a human mad enough to support our cause, this can be a helpful tool to stay in touch."
+	desc = "We permanently link our victim's mind into the hivemind, allowing them to hear messages sent through it and even send messages through it themselves."
+	helptext = "If we find a humanoid mad enough to support our cause, this can be a helpful tool to stay in touch."
 	button_icon_state = "hivemind_link"
 	chemical_cost = 0
 	dna_cost = 2

--- a/code/modules/antagonists/changeling/powers/linglink.dm
+++ b/code/modules/antagonists/changeling/powers/linglink.dm
@@ -65,7 +65,6 @@
 				target.mind.linglink = 1
 				target.say("[MODE_TOKEN_CHANGELING] AAAAARRRRGGGGGHHHHH!!")
 				to_chat(target, "<span class='changeling bold'>You can now communicate in the changeling hivemind, say \"[MODE_TOKEN_CHANGELING] message\" to communicate!</span>")
-				target.reagents.add_reagent(/datum/reagent/medicine/salbutamol, 40) // So they don't choke to death while you interrogate them
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]", "[i]"))
 	changeling.islinking = 0
 


### PR DESCRIPTION
## About The Pull Request

Hivemind Link is a default power that all changelings get. Did you even know it existed?

No, it's not the thing you use to communicate to other lings in lingchat.

Hivemind Link allows you to spend 8 seconds altering the flesh in the head of a target whom you've aggressively grabbed (while sending ominous/scary messages to them). Once you're done, your target will receive 40u of salbutamol and the ability to communicate in (and see/hear) hivemind chat... for only the next three minutes. Once those three minutes are up, they are kicked out of hivemind chat. Did I mention that every time you temporarily link someone to the hivemind with this ability, they automatically scream in hivemind chat? And did I also mention that you have to wait until this power expires on one target in order to use it on another?

This PR reworks Hivemind Link to make it actually useful to use as a power, but bumps up its price to 2 DNA points to compensate (meaning that it's no longer a default ling power).

Hivemind Link now permanently inducts people into the hivemind and can now add multiple people to the hivemind (although you still have to add them one at a time), but also now takes 12 seconds to fully perform, no longer gives your target 40u of salbutamol, and is no longer a free/default power (it now costs 2 DNA points, as mentioned above).

## Why It's Good For The Game

Hivemind Link SUCKED before. Now lings can use it to keep in touch with mortal collaborators and/or use it as a meme option in the place of something like transsting.

## Changelog
:cl: ATHATH
balance: The Hivemind Link changeling power now permanently inducts people into the hivemind and can now add multiple people to the hivemind (although you still have to add them one at a time), but also now takes 12 seconds to fully perform, no longer gives your target 40u of salbutamol, and is no longer a free/default power (it now costs 2 DNA points).
/:cl: