### PR TITLE
Wizard rounds properly generate the round end report if the wiz dies and the round ends.

### DIFF
--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -59,6 +59,11 @@
 
 	return TRUE
 
+/datum/game_mode/wizard/check_finished()
+	. = ..()
+	if(.)
+		finished = TRUE
+
 /datum/game_mode/wizard/set_round_result()
 	..()
 	if(finished)


### PR DESCRIPTION
## About The Pull Request

See title. Fixes https://github.com/tgstation/tgstation/issues/45294.

basically the finished var was never set anywhere; let me know if there is a better way to do this, I think this is the proper way that accounts for mulliganing

## Why It's Good For The Game

bug fix

## Changelog
:cl:
fix: Wizard rounds should properly generate messages when the wiz dies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
