### PR TITLE
Gives some upsides to the toxolysis symptom

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -108,7 +108,7 @@
 	desc = "The virus heals the host's toxin damage and rapidly breaks down any foreign chemicals in their bloodstream."
 	threshold_desc = "<b>Resistance 7:</b> Consumed chemicals nourish the host.<br>\
 					  <b>Stage Speed 6:</b> Increases chemical removal speed and toxin damage healing rate.<br>\
-					  <b>Stealth 3:</b> Only removes toxins from the host's bloodstream (instead of all foreign chemicals)."
+					  <b>Stealth 3:</b> Only removes toxins (instead of all foreign chemicals) from the host's bloodstream."
 
 /datum/symptom/heal/chem/Start(datum/disease/advance/A)
 	if(!..())

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -108,7 +108,7 @@
 	desc = "The virus heals the host's toxin damage and rapidly breaks down any foreign chemicals in their bloodstream."
 	threshold_desc = "<b>Resistance 7:</b> Consumed chemicals nourish the host.<br>\
 					  <b>Stage Speed 6:</b> Increases chemical removal speed and toxin damage healing rate.<br>\
-					  <b>Stealth 3:</b> Only removes toxins (instead of all foreign chemicals) from the bloodstream."
+					  <b>Stealth 3:</b> Only removes toxins from the host's bloodstream (instead of all foreign chemicals)."
 
 /datum/symptom/heal/chem/Start(datum/disease/advance/A)
 	if(!..())

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -126,14 +126,14 @@
 		for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
 			M.reagents.remove_reagent(R.type, actual_power)
 			if(food_conversion && M.nutrition < NUTRITION_LEVEL_ALMOST_FULL)
-				M.adjust_nutrition(0.3)
+				M.adjust_nutrition(10)
 			if(prob(2))
 				to_chat(M, "<span class='notice'>You feel a mild warmth as your blood purifies itself.</span>")
 	else
 		for(var/datum/reagent/R in M.reagents.reagent_list) //Not just toxins!
 			M.reagents.remove_reagent(R.type, actual_power)
 			if(food_conversion && M.nutrition < NUTRITION_LEVEL_ALMOST_FULL) //Perhaps I should remove the NUTRITION_LEVEL_ALMOST_FULL check here but leave the one up above to give this symptom the ability to make you fat (again) if you don't meet its resistance threshold? Nah, this is fine.
-				M.adjust_nutrition(0.3)
+				M.adjust_nutrition(10)
 			if(prob(2))
 				to_chat(M, "<span class='notice'>You feel a mild warmth as your blood purifies itself.</span>")
 	return 1

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -103,18 +103,22 @@
 	stage_speed = 2
 	transmittable = -2
 	level = 7
+	var/food_conversion = FALSE
 	var/tox_only = FALSE
 	desc = "The virus heals the host's toxin damage and rapidly breaks down any foreign chemicals in their bloodstream."
-	threshold_desc = "<b>Resistance 7:</b> Only removes toxins (instead of all foreign chemicals) from the bloodstream.<br>\
-					  <b>Stage Speed 6:</b> Increases chem removal speed and toxin damage healing rate."
+	threshold_desc = "<b>Resistance 7:</b> Consumed chemicals nourish the host.<br>\
+					  <b>Stage Speed 6:</b> Increases chemical removal speed and toxin damage healing rate.<br>\
+					  <b>Stealth 3:</b> Only removes toxins (instead of all foreign chemicals) from the bloodstream."
 
 /datum/symptom/heal/chem/Start(datum/disease/advance/A)
 	if(!..())
 		return
 	if(A.properties["resistance"] >= 7)
-		tox_only = TRUE
+		food_conversion = TRUE
 	if(A.properties["stage_rate"] >= 6)
 		power = 2
+	if(A.properties["stealth"] >= 3)
+		tox_only = TRUE
 
 /datum/symptom/heal/chem/Heal(mob/living/M, datum/disease/advance/A, actual_power)
 	M.adjustToxLoss(-(0.5 * actual_power))


### PR DESCRIPTION
## About The Pull Request

See the changelog.

## Why It's Good For The Game

Currently, toxolysis is pretty much just a grief/meme symptom that's used either to make the lives of Medbay's staff more difficult or to purge your virus's cure from its hosts' bloodstreams (although the toxolysis symptom has bad enough stats that it isn't really worth being used for either of those purposes). This PR gives it ways to be helpful instead of annoying/negative.

## Changelog
:cl: ATHATH
balance: The toxolysis symptom now slowly heals toxin damage.
balance: The toxolysis symptom's resistance 7 threshold effect now is the threshold effect that causes the toxolysis symptom to feed its virus's host while it purges chems. Said feeding has been massively buffed in potency, but can no longer make a host fat (on its own).
balance: The toxolysis symptom's stage speed 6 threshold effect now increases the speed at which the toxolysis symptom purges chems (this used to be what the resistance 7 threshold did) and the speed at which the toxolysis symptom heals toxin damage.
add: Adds a new stealth 3 threshold to the toxolysis symptom that causes it to only purge toxins (instead of all kinds of chems). You might want to avoid meeting this threshold if your virus's cure isn't a toxin!
/:cl: