### PR TITLE
Fixes defib paddles

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -215,6 +215,7 @@
 		var/M = get(paddles, /mob)
 		remove_paddles(M)
 	QDEL_NULL(paddles)
+	QDEL_NULL(cell)
 	return ..()
 
 /obj/item/defibrillator/proc/deductcharge(chrgdeductamt)
@@ -303,6 +304,10 @@
 	var/combat = FALSE //If it penetrates armor and gives additional functionality
 	var/grab_ghost = FALSE
 	var/tlimit = DEFIB_TIME_LIMIT * 10
+
+/obj/item/twohanded/shockpaddles/Destroy()
+	defib = null
+	return ..()
 
 /obj/item/twohanded/shockpaddles/equipped(mob/user, slot)
 	. = ..()

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -215,8 +215,7 @@
 		var/M = get(paddles, /mob)
 		remove_paddles(M)
 	QDEL_NULL(paddles)
-	. = ..()
-	update_icon()
+	return ..()
 
 /obj/item/defibrillator/proc/deductcharge(chrgdeductamt)
 	if(cell)
@@ -322,16 +321,15 @@
 		defib.fire_act(exposed_temperature, exposed_volume)
 
 /obj/item/twohanded/shockpaddles/proc/check_range()
-	if(!req_defib)
+	if(!req_defib || !defib)
 		return
 	if(!in_range(src,defib))
 		var/mob/living/L = loc
 		if(istype(L))
 			to_chat(L, "<span class='warning'>[defib]'s paddles overextend and come out of your hands!</span>")
-			L.temporarilyRemoveItemFromInventory(src,TRUE)
 		else
 			visible_message("<span class='notice'>[src] snap back into [defib].</span>")
-			snap_back()
+		snap_back()
 
 /obj/item/twohanded/shockpaddles/proc/recharge(var/time)
 	if(req_defib || !time)
@@ -377,8 +375,9 @@
 		var/obj/item/twohanded/offhand/O = user.get_inactive_held_item()
 		if(istype(O))
 			O.unwield()
-		to_chat(user, "<span class='notice'>The paddles snap back into the main unit.</span>")
-		snap_back()
+		if(user != loc)
+			to_chat(user, "<span class='notice'>The paddles snap back into the main unit.</span>")
+			snap_back()
 	return unwield(user)
 
 /obj/item/twohanded/shockpaddles/proc/snap_back()

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -35,7 +35,6 @@
 
 /obj/item/defibrillator/loaded/Initialize() //starts with hicap
 	. = ..()
-	paddles = make_paddles()
 	cell = new(src)
 	update_icon()
 	return
@@ -260,7 +259,6 @@
 
 /obj/item/defibrillator/compact/loaded/Initialize()
 	. = ..()
-	paddles = make_paddles()
 	cell = new(src)
 	update_icon()
 
@@ -272,7 +270,6 @@
 
 /obj/item/defibrillator/compact/combat/loaded/Initialize()
 	. = ..()
-	paddles = make_paddles()
 	cell = new /obj/item/stock_parts/cell/infinite(src)
 	update_icon()
 
@@ -308,16 +305,11 @@
 	var/grab_ghost = FALSE
 	var/tlimit = DEFIB_TIME_LIMIT * 10
 
-	var/mob/listeningTo
-
 /obj/item/twohanded/shockpaddles/equipped(mob/user, slot)
 	. = ..()
-	if(!req_defib || listeningTo == user)
+	if(!req_defib)
 		return
-	if(listeningTo)
-		UnregisterSignal(listeningTo, COMSIG_MOVABLE_MOVED)
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/check_range)
-	listeningTo = user
 
 /obj/item/twohanded/shockpaddles/Moved()
 	. = ..()
@@ -380,9 +372,8 @@
 /obj/item/twohanded/shockpaddles/dropped(mob/user)
 	if(!req_defib)
 		return ..()
-	if(listeningTo)
-		UnregisterSignal(listeningTo, COMSIG_MOVABLE_MOVED)
 	if(user)
+		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 		var/obj/item/twohanded/offhand/O = user.get_inactive_held_item()
 		if(istype(O))
 			O.unwield()


### PR DESCRIPTION
## About The Pull Request

Defibs now always properly snap back. Fixes #45794
Juggling defib paddles in your hands no longer tells you that they snap back to the defib unit.
Roundstart defibs now only have one pair of paddles.
Defibs no longer update_icon's at the end of destroy (wtf)
Defibs no longer call temporarilyRemoveFromInventory without doing forceMove afterwards. This resulted in the paddles sometimes getting stuck inside of mobs.
Nulls/Deletes some more stuff on Destroy.

## Why It's Good For The Game

Good god, these things are a mess. Whoever made these overthought it way too hard.

## Changelog
:cl:
fix: Various defib fixes.
/:cl:
