### PR TITLE
Removes bolt of death from xenobiology magicarps.

### DIFF
--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -58,40 +58,22 @@
 	projectiletype = pick(allowed_projectile_types)
 	..()
 
-	// these are for the xenobio gold slime pool
-
-/mob/living/simple_animal/hostile/carp/xenobiology/ranged
-	name = "magicarp"
-	desc = "50% magic, 50% carp, 100% horrible."
-	icon_state = "magicarp"
-	icon_living = "magicarp"
-	icon_dead = "magicarp_dead"
-	icon_gib = "magicarp_gib"
-	ranged = 1
-	retreat_distance = 2
-	minimum_distance = 0 //Between shots they can and will close in to nash
-	projectiletype = /obj/item/projectile/magic
-	projectilesound = 'sound/weapons/emitter.ogg'
-	maxHealth = 50
-	health = 50
+/mob/living/simple_animal/hostile/carp/ranged/xenobiology // these are for the xenobio gold slime pool
 	gold_core_spawnable = HOSTILE_SPAWN
-	random_color = FALSE
-	var/xeno_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
+	allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
 	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball, /obj/item/projectile/magic/spellblade,
-	/obj/item/projectile/magic/arcane_barrage) //and all this code just to remove a single bolt
+	/obj/item/projectile/magic/arcane_barrage) //thanks Lett1
 
-/mob/living/simple_animal/hostile/carp/xenobiology/ranged/Initialize()
-	projectiletype = pick(xeno_projectile_types)
+/mob/living/simple_animal/hostile/carp/ranged/xenobiology/Initialize()
+	projectiletype = pick(allowed_projectile_types)
 	..()
 
-/mob/living/simple_animal/hostile/carp/xenobiology/ranged/chaos/Shoot()
-	projectiletype = pick(xeno_projectile_types)
+/mob/living/simple_animal/hostile/carp/ranged/chaos/xenobiology/Shoot()
+	projectiletype = pick(allowed_projectile_types)
 	..()
 
-/mob/living/simple_animal/hostile/carp/xenobiology/ranged/chaos
-	name = "chaos magicarp"
-	desc = "50% carp, 100% magic, 150% horrible."
-	color = "#00FFFF"
-	maxHealth = 75
-	health = 75
+/mob/living/simple_animal/hostile/carp/ranged/chaos/xenobiology
 	gold_core_spawnable = HOSTILE_SPAWN
+	allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
+	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball, /obj/item/projectile/magic/spellblade,
+	/obj/item/projectile/magic/arcane_barrage)

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -79,7 +79,7 @@
 	var/xeno_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
 	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball, /obj/item/projectile/magic/spellblade,
 	/obj/item/projectile/magic/arcane_barrage) //and all this code just to remove a single bolt
-	
+
 /mob/living/simple_animal/hostile/carp/xenobiology/ranged/Initialize()
 	projectiletype = pick(xeno_projectile_types)
 	..()

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -38,9 +38,9 @@
 	health = 50
 	gold_core_spawnable = NO_SPAWN
 	random_color = FALSE
-	var/allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
+	var/allowed_projectile_types = list(/obj/item/projectile/magic/death, /obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
 	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball, /obj/item/projectile/magic/spellblade,
-	/obj/item/projectile/magic/arcane_barrage, /obj/item/projectile/magic/death)
+	/obj/item/projectile/magic/arcane_barrage)
 
 /mob/living/simple_animal/hostile/carp/ranged/Initialize()
 	projectiletype = pick(allowed_projectile_types)
@@ -64,16 +64,9 @@
 	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball, /obj/item/projectile/magic/spellblade,
 	/obj/item/projectile/magic/arcane_barrage) //thanks Lett1
 
-/mob/living/simple_animal/hostile/carp/ranged/xenobiology/Initialize()
-	projectiletype = pick(allowed_projectile_types)
-	..()
-
-/mob/living/simple_animal/hostile/carp/ranged/chaos/xenobiology/Shoot()
-	projectiletype = pick(allowed_projectile_types)
-	..()
-
 /mob/living/simple_animal/hostile/carp/ranged/chaos/xenobiology
 	gold_core_spawnable = HOSTILE_SPAWN
 	allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
 	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball, /obj/item/projectile/magic/spellblade,
 	/obj/item/projectile/magic/arcane_barrage)
+

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -36,11 +36,12 @@
 	projectilesound = 'sound/weapons/emitter.ogg'
 	maxHealth = 50
 	health = 50
+	gold_core_spawnable = NO_SPAWN
 	random_color = FALSE
 	var/allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
 	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball, /obj/item/projectile/magic/spellblade,
-	/obj/item/projectile/magic/arcane_barrage)
-	
+	/obj/item/projectile/magic/arcane_barrage, /obj/item/projectile/magic/death)
+
 /mob/living/simple_animal/hostile/carp/ranged/Initialize()
 	projectiletype = pick(allowed_projectile_types)
 	. = ..()
@@ -51,7 +52,47 @@
 	color = "#00FFFF"
 	maxHealth = 75
 	health = 75
+	gold_core_spawnable = NO_SPAWN
 
 /mob/living/simple_animal/hostile/carp/ranged/chaos/Shoot()
 	projectiletype = pick(allowed_projectile_types)
+	..()
+
+	// these are for the xenobio gold slime pool
+
+/mob/living/simple_animal/hostile/carp/xenobiology/ranged
+	name = "magicarp"
+	desc = "50% magic, 50% carp, 100% horrible."
+	icon_state = "magicarp"
+	icon_living = "magicarp"
+	icon_dead = "magicarp_dead"
+	icon_gib = "magicarp_gib"
+	ranged = 1
+	retreat_distance = 2
+	minimum_distance = 0 //Between shots they can and will close in to nash
+	projectiletype = /obj/item/projectile/magic
+	projectilesound = 'sound/weapons/emitter.ogg'
+	maxHealth = 50
+	health = 50
+	gold_core_spawnable = HOSTILE_SPAWN
+	var/xeno_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
+	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball, /obj/item/projectile/magic/spellblade,
+	/obj/item/projectile/magic/arcane_barrage) //and all this code just to remove a single bolt
+	..()
+	
+/mob/living/simple_animal/hostile/carp/xenobiology/ranged/Initialize()
+	projectiletype = pick(xeno_projectile_types)
+	..()
+
+/mob/living/simple_animal/hostile/carp/xenobiology/ranged/chaos/Shoot()
+	projectiletype = pick(xeno_projectile_types)
+	..()
+
+/mob/living/simple_animal/hostile/carp/xenobiology/ranged/chaos
+	name = "chaos magicarp"
+	desc = "50% carp, 100% magic, 150% horrible."
+	color = "#00FFFF"
+	maxHealth = 75
+	health = 75
+	gold_core_spawnable = HOSTILE_SPAWN
 	..()

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -79,7 +79,6 @@
 	var/xeno_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
 	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball, /obj/item/projectile/magic/spellblade,
 	/obj/item/projectile/magic/arcane_barrage) //and all this code just to remove a single bolt
-	..()
 	
 /mob/living/simple_animal/hostile/carp/xenobiology/ranged/Initialize()
 	projectiletype = pick(xeno_projectile_types)

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -38,8 +38,8 @@
 	health = 50
 	random_color = FALSE
 	var/allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
-	/obj/item/projectile/magic/death, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball,
-	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
+	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball, /obj/item/projectile/magic/spellblade,
+	/obj/item/projectile/magic/arcane_barrage)
 	
 /mob/living/simple_animal/hostile/carp/ranged/Initialize()
 	projectiletype = pick(allowed_projectile_types)

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -95,4 +95,3 @@
 	maxHealth = 75
 	health = 75
 	gold_core_spawnable = HOSTILE_SPAWN
-	..()

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -75,6 +75,7 @@
 	maxHealth = 50
 	health = 50
 	gold_core_spawnable = HOSTILE_SPAWN
+	random_color = FALSE
 	var/xeno_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
 	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball, /obj/item/projectile/magic/spellblade,
 	/obj/item/projectile/magic/arcane_barrage) //and all this code just to remove a single bolt

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -38,9 +38,9 @@
 	health = 50
 	gold_core_spawnable = NO_SPAWN
 	random_color = FALSE
-	var/allowed_projectile_types = list(/obj/item/projectile/magic/death, /obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
-	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball, /obj/item/projectile/magic/spellblade,
-	/obj/item/projectile/magic/arcane_barrage)
+	var/allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
+	/obj/item/projectile/magic/death, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball,
+	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
 
 /mob/living/simple_animal/hostile/carp/ranged/Initialize()
 	projectiletype = pick(allowed_projectile_types)


### PR DESCRIPTION
The bolt of death has been removed from the xenobiology Magicarp and Chaos Magicarp.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes bolt of death on the xenobiology Magicarp and Chaos Magicarp. Can't be more to-the-point than that.

I've decided to keep the other bolts in for magicarps, because those can be fun in the right hands, but bolts of death are simply unfun and unbalanced no matter what, often on both ends.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The bolt of death is what it says on the tin: A bolt of death.

We removed tasers, SRM-8 missile racks, nerfed rubbershot and tried to get rid of so many other oneshots for a reason: They're unfun to play against and count as an instant win in combat. It would also be one less reason for powergamers to go into xenobiology.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: In a freak magic accident, all xenobio-made magicarps have lost their bolt of death. This is a great tragedy for xenobiologists all around the galaxy.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
