### PR TITLE
All windows now have consistant spans

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -554,15 +554,15 @@
 	. = ..()
 	switch(state)
 		if(RWINDOW_SECURE)
-			. += "It's been screwed in with one way screws, you'd need to <b>heat them</b> to have any chance of backing them out."
+			. += "<span class='notice'>It's been screwed in with one way screws, you'd need to <b>heat them</b> to have any chance of backing them out.</span>"
 		if(RWINDOW_BOLTS_HEATED)
-			. += "The screws are glowing white hot, and you'll likely be able to <b>unscrew them</b> now."
+			. += "<span class='notice'>The screws are glowing white hot, and you'll likely be able to <b>unscrew them</b> now.</span>"
 		if(RWINDOW_BOLTS_OUT)
-			. += "The screws have been removed, revealing a small gap you could fit a <b>prying tool</b> in."
+			. += "<span class='notice'>The screws have been removed, revealing a small gap you could fit a <b>prying tool</b> in.</span>"
 		if(RWINDOW_POPPED)
-			. += "The main plate of the window has popped out of the frame, exposing some bars that look like they can be <b>cut</b>."
+			. += "<span class='notice'>The main plate of the window has popped out of the frame, exposing some bars that look like they can be <b>cut</b>.</span>"
 		if(RWINDOW_BARS_CUT)
-			. += "The main pane can be easily moved out of the way to reveal some <b>bolts</b> holding the frame in."
+			. += "<span class='notice'>The main pane can be easily moved out of the way to reveal some <b>bolts</b> holding the frame in.</span>"
 
 /obj/structure/window/plasma/reinforced/spawner/east
 	dir = EAST

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -435,15 +435,15 @@
 	. = ..()
 	switch(state)
 		if(RWINDOW_SECURE)
-			. += "It's been screwed in with one way screws, you'd need to <b>heat them</b> to have any chance of backing them out."
+			. += "<span class='notice'>It's been screwed in with one way screws, you'd need to <b>heat them</b> to have any chance of backing them out.</span>"
 		if(RWINDOW_BOLTS_HEATED)
-			. += "The screws are glowing white hot, and you'll likely be able to <b>unscrew them</b> now."
+			. += "<span class='notice'>The screws are glowing white hot, and you'll likely be able to <b>unscrew them</b> now.</span>"
 		if(RWINDOW_BOLTS_OUT)
-			. += "The screws have been removed, revealing a small gap you could fit a <b>prying tool</b> in."
+			. += "<span class='notice'>The screws have been removed, revealing a small gap you could fit a <b>prying tool</b> in.</span>"
 		if(RWINDOW_POPPED)
-			. += "The main plate of the window has popped out of the frame, exposing some bars that look like they can be <b>cut</b>."
+			. += "<span class='notice'>The main plate of the window has popped out of the frame, exposing some bars that look like they can be <b>cut</b>.</span>"
 		if(RWINDOW_BARS_CUT)
-			. += "The main pane can be easily moved out of the way to reveal some <b>bolts</b> holding the frame in."
+			. += "<span class='notice'>The main pane can be easily moved out of the way to reveal some <b>bolts</b> holding the frame in.</span>"
 
 /obj/structure/window/reinforced/spawner/east
 	dir = EAST


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The examine messages for reinforced and plasma windows were missing notice spans and were not consistent with regular windows. This fixes it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![window_spans](https://user-images.githubusercontent.com/11001588/62751814-71eadc00-baa8-11e9-8dd3-4b339806a7cf.PNG)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: All windows now have consistent examine messages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
