### PR TITLE
One HoP ticket per person, old tickets delete

### DIFF
--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -15,7 +15,7 @@
 	var/ticket_number = 0 //Increment the ticket number whenever the HOP presses his button
 	var/current_number = 0 //What ticket number are we currently serving?
 	var/max_number = 100 //At this point, you need to refill it.
-	var/cooldown = 50 //Small cooldown, used when emagged to prevent flaming ticket spam
+	var/cooldown = 50
 	var/ready = TRUE
 	var/id = "ticket_machine_default" //For buttons
 	var/list/ticket_holders = list()
@@ -161,7 +161,7 @@
 
 /obj/machinery/ticket_machine/attack_hand(mob/living/carbon/user)
 	. = ..()
-	if(!ready && (obj_flags & EMAGGED))
+	if(!ready)
 		to_chat(user,"You press the button, but nothing happens...")
 		return
 	if(ticket_number >= max_number)
@@ -170,9 +170,7 @@
 	if((user in ticket_holders) && !(obj_flags & EMAGGED))
 		to_chat(user, "You already have a ticket!")
 		return
-	ready = FALSE
 	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 100, 0)
-	addtimer(CALLBACK(src, .proc/reset_cooldown), cooldown)//Small cooldown to prevent the clown from ripping out every ticket
 	ticket_number ++
 	to_chat(user, "<span class='notice'>You take a ticket from [src], looks like you're ticket number #[ticket_number]...</span>")
 	var/obj/item/ticket_machine_ticket/theirticket = new /obj/item/ticket_machine_ticket(get_turf(src))
@@ -186,6 +184,8 @@
 	ticket_holders += user
 	tickets += theirticket
 	if(obj_flags & EMAGGED) //Emag the machine to destroy the HOP's life.
+		ready = FALSE
+		addtimer(CALLBACK(src, .proc/reset_cooldown), cooldown)//Small cooldown to prevent piles of flaming tickets
 		theirticket.fire_act()
 		user.dropItemToGround(theirticket)
 		user.adjust_fire_stacks(1)

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -51,12 +51,12 @@
 	if(current_number >= ticket_number)
 		return
 	playsound(src, 'sound/misc/announce_dig.ogg', 50, 0)
-	if(current_number && !(obj_flags & EMAGGED))
+	if(current_number && !(obj_flags & EMAGGED) && tickets[current_number])
 		tickets[current_number].visible_message("<span class='notice'>\the [tickets[current_number]] disperses!</span>")
-		QDEL_NULL(tickets[current_number])
+		qdel(tickets[current_number])
 	current_number ++ //Increment the one we're serving.
 	say("Now serving ticket #[current_number]!")
-	if(!(obj_flags & EMAGGED))
+	if(!(obj_flags & EMAGGED) && tickets[current_number])
 		tickets[current_number].visible_message("<span class='notice'>\the [tickets[current_number]] vibrates!</span>")
 	update_icon() //Update our icon here rather than when they take a ticket to show the current ticket number being served
 
@@ -179,6 +179,7 @@
 	theirticket.name = "Ticket #[ticket_number]"
 	theirticket.maptext = "<font color='#000000'>[ticket_number]</font>"
 	theirticket.saved_maptext = "<font color='#000000'>[ticket_number]</font>"
+	theirticket.ticket_number = ticket_number
 	theirticket.source = src
 	theirticket.owner = user
 	user.put_in_hands(theirticket)
@@ -204,6 +205,7 @@
 	var/saved_maptext = null
 	var/mob/living/carbon/owner
 	var/obj/machinery/ticket_machine/source
+	var/ticket_number
 
 /obj/item/ticket_machine_ticket/attack_hand(mob/user)
 	. = ..()
@@ -229,4 +231,7 @@
 /obj/item/ticket_machine_ticket/Destroy()
 	if(owner && source)
 		source.ticket_holders -= owner
-	..()
+		source.tickets[ticket_number] = null
+		owner = null
+		source = null
+	return ..()

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -19,7 +19,7 @@
 	var/ready = TRUE
 	var/id = "ticket_machine_default" //For buttons
 	var/list/ticket_holders = list()
-	var/list/tickets = list()
+	var/list/obj/item/ticket_machine_ticket/tickets = list()
 
 /obj/machinery/ticket_machine/multitool_act(mob/living/user, obj/item/I)
 	if(!multitool_check_buffer(user, I)) //make sure it has a data buffer
@@ -56,7 +56,8 @@
 		QDEL_NULL(tickets[current_number])
 	current_number ++ //Increment the one we're serving.
 	say("Now serving ticket #[current_number]!")
-	tickets[current_number].visible_message("<span class='notice'>\the [tickets[current_number]] vibrates!</span>")
+	if(!(obj_flags & EMAGGED))
+		tickets[current_number].visible_message("<span class='notice'>\the [tickets[current_number]] vibrates!</span>")
 	update_icon() //Update our icon here rather than when they take a ticket to show the current ticket number being served
 
 /obj/machinery/button/ticket_machine
@@ -175,7 +176,7 @@
 	ticket_number ++
 	to_chat(user, "<span class='notice'>You take a ticket from [src], looks like you're ticket number #[ticket_number]...</span>")
 	var/obj/item/ticket_machine_ticket/theirticket = new /obj/item/ticket_machine_ticket(get_turf(src))
-	theirticket.name = "NanoPaper Ticket #[ticket_number]"
+	theirticket.name = "Ticket #[ticket_number]"
 	theirticket.maptext = "<font color='#000000'>[ticket_number]</font>"
 	theirticket.saved_maptext = "<font color='#000000'>[ticket_number]</font>"
 	theirticket.source = src
@@ -191,8 +192,8 @@
 		return
 
 /obj/item/ticket_machine_ticket
-	name = "NanoPaper Ticket"
-	desc = "A ticket which shows your place in the Head of Personnel line. Made from Nanotrasen patented NanoPaper®. Feels (and burns) just like the real thing. Its form seems to shimmer and shift in your hand."
+	name = "Ticket"
+	desc = "A ticket which shows your place in the Head of Personnel's line. Made from Nanotrasen patented NanoPaper®. Though solid, its form seems to shimmer slightly. Feels (and burns) just like the real thing."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "ticket"
 	maptext_x = 7

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -33,7 +33,7 @@
 	if(obj_flags & EMAGGED)
 		return
 	to_chat(user, "<span class='warning'>You overload [src]'s bureaucratic logic circuitry to its MAXIMUM setting.</span>")
-	ticket_number = rand(0,100)
+	ticket_number = rand(0,max_number)
 	current_number = ticket_number
 	obj_flags |= EMAGGED
 	if(tickets.len)
@@ -193,7 +193,7 @@
 
 /obj/item/ticket_machine_ticket
 	name = "Ticket"
-	desc = "A ticket which shows your place in the Head of Personnel's line. Made from Nanotrasen patented NanoPaper®. Though solid, its form seems to shimmer slightly. Feels (and burns) just like the real thing."
+	desc = "A ticket which shows your place in the Head of Personnel's line. Made from Nanotrasen patented NanoPaperÂ®. Though solid, its form seems to shimmer slightly. Feels (and burns) just like the real thing."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "ticket"
 	maptext_x = 7


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right now it's too easy for people to print off a bunch of tickets, litter the hall with them and leave the HoP unable to keep up with the amount of tickets, rendering the machine useless.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No ticket spam, means the ticket machine will see more use
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
tweak: Can only get one HoP ticket per person unless it's emagged
tweak: Previous ticket deletes ("disperses", it's "nanite paper") when HoP calls the next customer
tweak: Reduces maximum number of tickets to 100 because the refill mechanic would never be used otherwise
del: Can no longer recycle tickets using the machine, because it allows you to artificially inflate the amount of tickets the HoP has to get through
add: Tickets vibrate (nanomachines, son) when it's your turn, so you can step away from the line if it's taking too long
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
