### PR TITLE
Marks silicon binary chat as such in log files

### DIFF
--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -1,5 +1,5 @@
 /mob/living/proc/robot_talk(message)
-	log_talk(message, LOG_SAY)
+	log_talk(message, LOG_SAY, tag="binary")
 	var/desig = "Default Cyborg" //ezmode for taters
 	if(issilicon(src))
 		var/mob/living/silicon/S = src


### PR DESCRIPTION
## About The Pull Request

It is currently impossible to tell from logs whether a silicon said a message over binary chat or said it out loud.  This PR marks binary chat messages with (binary) in say logs.

## Why It's Good For The Game

Removes ambiguity from log files, makes investigating easier.

## Changelog
:cl: Penterwast
admin: Binary chat messages are now marked as such in logs.
/:cl: