### PR TITLE
Clicking a display case on help intent examines it.

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -172,6 +172,9 @@
 	    //prevents remote "kicks" with TK
 		if (!Adjacent(user))
 			return
+		if (user.a_intent == INTENT_HELP)
+			user.examinate(src)
+			return
 		user.visible_message("<span class='danger'>[user] kicks the display case.</span>", null, null, COMBAT_MESSAGE_RANGE)
 		log_combat(user, src, "kicks")
 		user.do_attack_animation(src, ATTACK_EFFECT_KICK)


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

QoL for the curator: Because clicking a display case is intuitive behavior to examine it, and it's weird to attack it when you are explicitly on a non-attacking intent. 

## Changelog
:cl: bandit
tweak: Clicking a display case on help intent examines it.
/:cl:
