### PR TITLE
Cultists can now snuff out blood magic by dropping it

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -360,7 +360,7 @@
 
 /obj/item/melee/blood_magic/Initialize()
 	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CULT_TRAIT)
+	ADD_TRAIT(src, CULT_TRAIT)
 
 /obj/item/melee/blood_magic/Destroy()
 	if(!QDELETED(source))

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -358,10 +358,6 @@
 	health_cost = source.health_cost
 	..()
 
-/obj/item/melee/blood_magic/Initialize()
-	. = ..()
-	ADD_TRAIT(src, CULT_TRAIT)
-
 /obj/item/melee/blood_magic/Destroy()
 	if(!QDELETED(source))
 		if(uses <= 0)


### PR DESCRIPTION
## About The Pull Request

This PR removes three lines that make cultists unable to simply drop their blood magic
I don't know how to add a line when an item is dropped so it's just unnanounced

## Why It's Good For The Game

It's just quality of life. Makes a cultist's life easier. Hopefully it's not too much **powercreep**

:cl:
tweak: cultists can now easily snuff out blood spells by dropping them. they will also drop the spell when stunned, but can easily activate it again
/:cl: