### PR TITLE
Makes organ decay a lot nicer.

### DIFF
--- a/code/game/objects/items/body_egg.dm
+++ b/code/game/objects/items/body_egg.dm
@@ -17,25 +17,25 @@
 /obj/item/organ/body_egg/Insert(var/mob/living/carbon/M, special = 0)
 	..()
 	ADD_TRAIT(owner, TRAIT_XENO_HOST, TRAIT_GENERIC)
-	START_PROCESSING(SSobj, src)
 	owner.med_hud_set_status()
 	INVOKE_ASYNC(src, .proc/AddInfectionImages, owner)
 
 /obj/item/organ/body_egg/Remove(var/mob/living/carbon/M, special = 0)
-	STOP_PROCESSING(SSobj, src)
 	if(owner)
 		REMOVE_TRAIT(owner, TRAIT_XENO_HOST, TRAIT_GENERIC)
 		owner.med_hud_set_status()
 		INVOKE_ASYNC(src, .proc/RemoveInfectionImages, owner)
 	..()
 
-/obj/item/organ/body_egg/process()
+/obj/item/organ/body_egg/on_death()
+	. = ..()
 	if(!owner)
 		return
-	if(!(src in owner.internal_organs))
-		Remove(owner)
-		return
 	egg_process()
+
+/obj/item/organ/body_egg/on_life()
+	. = ..()
+	egg_process
 
 /obj/item/organ/body_egg/proc/egg_process()
 	return

--- a/code/game/objects/items/body_egg.dm
+++ b/code/game/objects/items/body_egg.dm
@@ -35,7 +35,7 @@
 
 /obj/item/organ/body_egg/on_life()
 	. = ..()
-	egg_process
+	egg_process()
 
 /obj/item/organ/body_egg/proc/egg_process()
 	return

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -406,39 +406,28 @@
 	return FALSE
 
 /obj/machinery/smartfridge/organ/load(obj/item/O)
-	if(..())	//if the item loads, clear can_decompose
-		var/obj/item/organ/organ = O
-		organ.organ_flags |= ORGAN_FROZEN
-
-/obj/machinery/smartfridge/organ/dispense(obj/item/O, var/mob/M)
+	. = ..()
+	if(!.)	//if the item loads, clear can_decompose
+		return
 	var/obj/item/organ/organ = O
-	organ.organ_flags &= ~ORGAN_FROZEN
-	..()
+	organ.organ_flags |= ORGAN_FROZEN
 
 /obj/machinery/smartfridge/organ/RefreshParts()
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		max_n_of_items = 20 * B.rating
 		repair_rate = max(0, STANDARD_ORGAN_HEALING * (B.rating - 1))
 
-/obj/machinery/smartfridge/organ/Destroy()
-	for(var/organ in src)
-		var/obj/item/organ/O = organ
-		if(O)
-			O.organ_flags &= ~ORGAN_FROZEN
-	..()
-
 /obj/machinery/smartfridge/organ/process()
-	for(var/organ in src)
+	for(var/organ in contents)
 		var/obj/item/organ/O = organ
-		if(O)
-			O.damage = max(0, O.damage - repair_rate)
+		if(!istype(O))
+			return
+		O.applyOrganDamage(-repair_rate)
 
-/obj/machinery/smartfridge/organ/deconstruct()
-	for(var/organ in src)
-		var/obj/item/organ/O = organ
-		if(O)
-			O.organ_flags &= ~ORGAN_FROZEN
-	..()
+/obj/machinery/smartfridge/organ/Exited(obj/item/organ/AM, atom/newLoc)
+	. = ..()
+	if(istype(AM))
+		AM.organ_flags &= ~ORGAN_FROZEN
 
 // -----------------------------
 // Chemistry Medical Smartfridge

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -71,6 +71,7 @@
 
 		brainmob.reset_perspective()
 		brain = newbrain
+		brain.organ_flags |= ORGAN_FROZEN
 
 		name = "[initial(name)]: [brainmob.real_name]"
 		update_icon()
@@ -107,6 +108,7 @@
 		user.put_in_hands(brain) //puts brain in the user's hand or otherwise drops it on the user's turf
 	else
 		brain.forceMove(get_turf(src))
+	brain.organ_flags &= ~ORGAN_FROZEN
 	brain = null //No more brain in here
 
 

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -22,6 +22,7 @@
 	return S
 
 /obj/item/organ/body_egg/alien_embryo/on_life()
+	. = ..()
 	switch(stage)
 		if(2, 3)
 			if(prob(2))

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -118,7 +118,7 @@
   * outputs:
   * description: If an organ exists in the slot requested, and we are capable of taking damage (we don't have GODMODE on), call the damage proc on that organ.
   */
-/mob/living/carbon/adjustOrganLoss(slot, amount, maximum = 500)
+/mob/living/carbon/adjustOrganLoss(slot, amount, maximum)
 	var/obj/item/organ/O = getorganslot(slot)
 	if(O && !(status_flags & GODMODE))
 		O.applyOrganDamage(amount, maximum)

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -117,10 +117,8 @@
 	if(special != HEART_SPECIAL_SHADOWIFY)
 		blade = new/obj/item/light_eater
 		M.put_in_hands(blade)
-	START_PROCESSING(SSobj, src)
 
 /obj/item/organ/heart/nightmare/Remove(mob/living/carbon/M, special = 0)
-	STOP_PROCESSING(SSobj, src)
 	respawn_progress = 0
 	if(blade && special != HEART_SPECIAL_SHADOWIFY)
 		M.visible_message("<span class='warning'>\The [blade] disintegrates!</span>")
@@ -133,12 +131,10 @@
 /obj/item/organ/heart/nightmare/update_icon()
 	return //always beating visually
 
-/obj/item/organ/heart/nightmare/process()
-	if(QDELETED(owner) || owner.stat != DEAD)
-		respawn_progress = 0
+/obj/item/organ/heart/nightmare/on_death()
+	if(!owner)
 		return
 	var/turf/T = get_turf(owner)
-
 	if(istype(T))
 		var/light_amount = T.get_lumcount()
 		if(light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -10,8 +10,8 @@
 
 	if(!IS_IN_STASIS(src))
 
-		if(stat != DEAD) //Reagent processing needs to come before breathing, to prevent edge cases.
-			handle_organs()
+		//Reagent processing needs to come before breathing, to prevent edge cases.
+		handle_organs()
 
 		. = ..()
 
@@ -333,9 +333,14 @@
 			. |= BP.on_life(stam_regen)
 
 /mob/living/carbon/proc/handle_organs()
-	for(var/V in internal_organs)
-		var/obj/item/organ/O = V
-		O.on_life()
+	if(stat != DEAD)
+		for(var/V in internal_organs)
+			var/obj/item/organ/O = V
+			O.on_life()
+	else
+		for(var/V in internal_organs)
+			var/obj/item/organ/O = V
+			O.on_death() //Needed so organs decay while inside the body.
 
 /mob/living/carbon/handle_diseases()
 	for(var/thing in diseases)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -69,7 +69,7 @@
 	on_death() //Kinda hate doing it like this, but I really don't want to call process directly.
 
 /obj/item/organ/proc/on_death()	//runs decay when outside of a person
-	if((organ_flags & (ORGAN_SYNTHETIC | ORGAN_FROZEN)) || istype(loc, /obj/item/mmi))
+	if(organ_flags & (ORGAN_SYNTHETIC | ORGAN_FROZEN))
 		return
 	applyOrganDamage(maxHealth * decay_factor)
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -77,10 +77,10 @@
 	if(organ_flags & ORGAN_FAILING)
 		return
 	///Damage decrements by a percent of its maxhealth
-	applyOrganDamage(-(maxHealth * healing_factor))
-	if(owner.satiety > 0)
-		///Damage decrements again by a percent of its maxhealth, up to a total of 4 extra times depending on the owner's health
-		applyOrganDamage(4 * healing_factor * owner.satiety / MAX_SATIETY)
+	var/healing_amount = -(maxHealth * healing_factor)
+	///Damage decrements again by a percent of its maxhealth, up to a total of 4 extra times depending on the owner's health
+	healing_amount -= owner.satiety > 0 ? 4 * healing_factor * owner.satiety / MAX_SATIETY : 0
+	applyOrganDamage(healing_amount)
 
 /obj/item/organ/examine(mob/user)
 	. = ..()

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -141,6 +141,8 @@
 
 ///Adjusts an organ's damage by the amount "d", up to a maximum amount, which is by default max damage
 /obj/item/organ/proc/applyOrganDamage(var/d, var/maximum = maxHealth)	//use for damaging effects
+	if(!d) //Micro-optimization.
+		return
 	if(maximum < damage)
 		return
 	damage = CLAMP(damage + d, 0, maximum)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Here we go again.
This gets rid of double processing memes and the weird reluctance to use the getters and setters and instead check stuff... every... single... tick... TWICE!

Also cleaned up the organ freezer code. The dropping stuff functionality is already handled by machines in general. No need to reimplement it.

EDIT: Body eggs no longer process twice on SSobj.

## Why It's Good For The Game

Organ decay code was well... less than stellar. Sad really since organ damage could be an interesting part of the game.

## Changelog
:cl:
code: Cleaned up organ decay code.
balance: Stasis now stops body eggs from processing.
/:cl:
