### PR TITLE
fixes VV runtiming when VVing something without a sprite

### DIFF
--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -21,18 +21,22 @@
 	var/hash
 
 	var/type = islist? /list : D.type
+	var/no_icon = FALSE
 
 	if(istype(D, /atom))
 		sprite = getFlatIcon(D)
-		hash = md5(sprite)
-		src << browse_rsc(sprite, "vv[hash].png")
+		if(sprite)
+			hash = md5(sprite)
+			src << browse_rsc(sprite, "vv[hash].png")
+		else
+			no_icon = TRUE
 
 	title = "[D] ([REF(D)]) = [type]"
 	var/formatted_type = replacetext("[type]", "/", "<wbr>/")
 
 	var/sprite_text
 	if(sprite)
-		sprite_text = "<img src='vv[hash].png'></td><td>"
+		sprite_text = no_icon? "\[NO ICON\]" : "<img src='vv[hash].png'></td><td>"
 	var/list/header = islist(D)? list("<b>/list</b>") : D.vv_get_header()
 
 	var/marked_line


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #45851
 [2019-08-11 02:28:26.469] runtime error: bad resource file
 - proc name: View Variables (/client/proc/debug_variables)
 -   source file: view_variables.dm,28
 -   usr: Verbs-The-Noun (/mob/living/carbon/human)
 -   src: Peoplearestrange (/client)
 -   usr.loc: the floor (170,51,1) (/turf/open/floor/plasteel)
 -   call stack:
 - Peoplearestrange (/client): View Variables(the gondola (/mob/living/simple_animal/pet/gondola))
 
adds a null check so it doesn't send the icon which would result in a runtime if it's null.

## Why It's Good For The Game

something something adminbus

## Changelog
:cl:
fix: VV no longer runtimes with bad resource file when you try to VV something with a blank icon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
