### PR TITLE
Laserpointer scaling fix

### DIFF
--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -13,7 +13,7 @@
 	var/turf/pointer_loc
 	var/energy = 5
 	var/max_energy = 5
-	var/effectchance = 33
+	var/effectchance = 25
 	var/recharging = 0
 	var/recharge_locked = FALSE
 	var/obj/item/stock_parts/micro_laser/diode //used for upgrading!
@@ -137,7 +137,7 @@
 			continue
 		if(user.mobility_flags & MOBILITY_STAND)
 			H.setDir(get_dir(H,targloc)) // kitty always looks at the light
-			if(prob(effectchance))
+			if(prob(effectchance * diode.rating))
 				H.visible_message("<span class='warning'>[H] makes a grab for the light!</span>","<span class='userdanger'>LIGHT!</span>")
 				H.Move(targloc)
 				log_combat(user, H, "moved with a laser pointer",src)
@@ -148,7 +148,7 @@
 
 	//cats!
 	for(var/mob/living/simple_animal/pet/cat/C in view(1,targloc))
-		if(prob(50))
+		if(prob(effectchance * diode.rating))
 			C.visible_message("<span class='notice'>[C] pounces on the light!</span>","<span class='warning'>LIGHT!</span>")
 			C.Move(targloc)
 			C.set_resting(TRUE, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Laserpointers often use `if(prob(effectchance * diode.rating))` - stock part ratings go from 1 to 4; I lowered `effectchance` to 25 so that tier 4 micro lasers no longer result in an ugly prob(132) check that just gets rounded to prob(100).
I also changed cat related prob() checks to scale off the laserpointer diode's rating, making them less random.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I didn't notice the prob() check cause any issues above prob(100), but I'd rather not take any chances. As a side effect, laser pointers with non T4 diodes are slightly weaker.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
code: Changed a laser pointer var so that T4 micro lasers no longer give a success percentage above 100%.
tweak: Made cat related laserpointer acts scale off the pointer's micro laser tier.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
