### PR TITLE
correct black suit

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -77,6 +77,7 @@
 
 /obj/structure/closet/lawcloset/PopulateContents()
 	..()
+	new /obj/item/clothing/under/suit/blacktwopiece(src)
 	new /obj/item/clothing/under/rank/civilian/lawyer/female(src)
 	new /obj/item/clothing/under/rank/civilian/lawyer/black(src)
 	new /obj/item/clothing/under/rank/civilian/lawyer/red(src)

--- a/code/modules/clothing/under/suits.dm
+++ b/code/modules/clothing/under/suits.dm
@@ -31,12 +31,20 @@
 	item_color = "waiter"
 	can_adjust = FALSE
 
-/obj/item/clothing/under/suit/black
-	name = "black suit"
+/obj/item/clothing/under/suit/blacktwopiece
+	name = "black two piece suit"
 	desc = "A black suit and red tie. Very formal."
 	icon_state = "black_suit"
 	item_state = "bl_suit"
 	item_color = "black_suit"
+	can_adjust = FALSE
+
+/obj/item/clothing/under/suit/black
+	name = "black suit"
+	desc = "A professional looking black suit. Ready for some serious law."
+	icon_state = "blacksuit"
+	item_state = "blacksuit"
+	item_color = "blacksuit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/suit/black/skirt


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes an issue where the incorrect black suit was being used in most places.

## Changelog
:cl:
fix: the correct black suit is now spawning in places it should be, the other sprite spawns in law wardrobe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
