### PR TITLE
cargo request console pings supply radio when someone makes a new request

### DIFF
--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -35,8 +35,8 @@
 		obj_flags &= ~EMAGGED
 
 /obj/machinery/computer/cargo/Destroy()
-	. = ..()
 	QDEL_NULL(radio)
+	..()
 
 /obj/machinery/computer/cargo/proc/get_export_categories()
 	var/cat = EXPORT_CARGO

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -24,19 +24,19 @@
 	circuit = /obj/item/circuitboard/computer/cargo/request
 	requestonly = TRUE
 
-/obj/machinery/computer/cargo/Destroy()
-	. = ..()
-	QDEL_NULL(radio)
-
 /obj/machinery/computer/cargo/Initialize()
 	. = ..()
-	radio = new /obj/item/radio/headset/silicon/ai(src)
+	radio = new /obj/item/radio/headset/headset_cargo(src)
 	var/obj/item/circuitboard/computer/cargo/board = circuit
 	contraband = board.contraband
 	if (board.obj_flags & EMAGGED)
 		obj_flags |= EMAGGED
 	else
 		obj_flags &= ~EMAGGED
+
+/obj/machinery/computer/cargo/Destroy()
+	. = ..()
+	QDEL_NULL(radio)
 
 /obj/machinery/computer/cargo/proc/get_export_categories()
 	var/cat = EXPORT_CARGO

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -10,6 +10,10 @@
 		cannot transport live organisms, human remains, classified nuclear weaponry, \
 		homing beacons or machinery housing any form of artificial intelligence."
 	var/blockade_warning = "Bluespace instability detected. Shuttle movement impossible."
+	/// radio used by the console to send messages on supply channel
+	var/obj/item/radio/headset/radio
+	/// var that tracks message cooldown
+	var/message_cooldown
 
 	light_color = "#E2853D"//orange
 
@@ -20,8 +24,13 @@
 	circuit = /obj/item/circuitboard/computer/cargo/request
 	requestonly = TRUE
 
+/obj/machinery/computer/cargo/Destroy()
+	. = ..()
+	QDEL_NULL(radio)
+
 /obj/machinery/computer/cargo/Initialize()
 	. = ..()
+	radio = new /obj/item/radio/headset/silicon/ai(src)
 	var/obj/item/circuitboard/computer/cargo/board = circuit
 	contraband = board.contraband
 	if (board.obj_flags & EMAGGED)
@@ -199,6 +208,9 @@
 				SSshuttle.shoppinglist += SO
 				if(self_paid)
 					say("Order processed. The price will be charged to [account.account_holder]'s bank account on delivery.")
+			if(requestonly && message_cooldown < world.time)
+				radio.talk_into(src, "A new order has been requested.", RADIO_CHANNEL_SUPPLY)
+				message_cooldown = world.time + 30 SECONDS
 			. = TRUE
 		if("remove")
 			var/id = text2num(params["id"])
@@ -228,7 +240,7 @@
 		if("denyall")
 			SSshuttle.requestlist.Cut()
 			. = TRUE
-		if("toggleprivate")	
+		if("toggleprivate")
 			self_paid = !self_paid
 	if(.)
 		post_signal("supply")

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -14,7 +14,6 @@ Format:
 endmap
 
 map boxstation
-	default
 	#voteweight 1.5
 	votable
 endmap
@@ -40,6 +39,7 @@ map donutstation
 endmap
 
 map runtimestation
+	default
 endmap
 
 map multiz_debug

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -14,6 +14,7 @@ Format:
 endmap
 
 map boxstation
+	default
 	#voteweight 1.5
 	votable
 endmap
@@ -39,7 +40,6 @@ map donutstation
 endmap
 
 map runtimestation
-	default
 endmap
 
 map multiz_debug


### PR DESCRIPTION
:cl:
tweak: cargo request console pings supply radio when someone makes a new request
/:cl:

its hard to notice new requests if you arent 24/7 near the supply console, better interactivity doesnt hurt