### PR TITLE
Removes Cigars from Smoker Spawn Pool

### DIFF
--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -7,6 +7,11 @@
 	mood_change = 2
 	timeout = 6 MINUTES
 
+/datum/mood_event/wrong_brand
+	description = "<span class='warning'>I hate that brand of cigarettes.</span>\n"
+	mood_change = -2
+	timeout = 6 MINUTES
+	
 /datum/mood_event/overdose
 	mood_change = -8
 	timeout = 5 MINUTES

--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -7,11 +7,6 @@
 	mood_change = 2
 	timeout = 6 MINUTES
 
-/datum/mood_event/wrong_brand
-	description = "<span class='warning'>I hate that brand of cigarettes.</span>\n"
-	mood_change = -2
-	timeout = 6 MINUTES
-
 /datum/mood_event/overdose
 	mood_change = -8
 	timeout = 5 MINUTES

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -535,7 +535,7 @@
 		if(istype(I, C.spawn_type))
 			SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "wrong_cigs")
 			return
-			SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "wrong_cigs", /datum/mood_event/wrong_brand)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "wrong_cigs", /datum/mood_event/wrong_brand)
 
 /datum/quirk/unstable
 	name = "Unstable"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -523,7 +523,19 @@
 	. = ..()
 
 /datum/quirk/junkie/smoker/announce_drugs()
-	to_chat(quirk_holder, "<span class='boldnotice'>There is a [drug_instance.name] [where_drug], and a lighter [where_accessory].</span>")
+	to_chat(quirk_holder, "<span class='boldnotice'>There is a [drug_instance.name] [where_drug], and a lighter [where_accessory]. Make sure you get your favorite brand when you run out.</span>")
+
+
+/datum/quirk/junkie/smoker/on_process()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/I = H.get_item_by_slot(SLOT_WEAR_MASK)
+	if (istype(I, /obj/item/clothing/mask/cigarette))
+		var/obj/item/storage/fancy/cigarettes/C = drug_instance
+		if(istype(I, C.spawn_type))
+			SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "wrong_cigs")
+			return
+			SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "wrong_cigs", /datum/mood_event/wrong_brand)
 
 /datum/quirk/unstable
 	name = "Unstable"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -519,26 +519,11 @@
 		/obj/item/storage/fancy/cigarettes/cigpack_uplift,
 		/obj/item/storage/fancy/cigarettes/cigpack_robust,
 		/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
-		/obj/item/storage/fancy/cigarettes/cigpack_carp,
-		/obj/item/storage/fancy/cigarettes/cigars,
-		/obj/item/storage/fancy/cigarettes/cigars/cohiba,
-		/obj/item/storage/fancy/cigarettes/cigars/havana)
+		/obj/item/storage/fancy/cigarettes/cigpack_carp)
 	. = ..()
 
 /datum/quirk/junkie/smoker/announce_drugs()
-	to_chat(quirk_holder, "<span class='boldnotice'>There is a [drug_instance.name] [where_drug], and a lighter [where_accessory]. Make sure you get your favorite brand when you run out.</span>")
-
-
-/datum/quirk/junkie/smoker/on_process()
-	. = ..()
-	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/I = H.get_item_by_slot(SLOT_WEAR_MASK)
-	if (istype(I, /obj/item/clothing/mask/cigarette))
-		var/obj/item/storage/fancy/cigarettes/C = drug_instance
-		if(istype(I, C.spawn_type))
-			SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "wrong_cigs")
-			return
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "wrong_cigs", /datum/mood_event/wrong_brand)
+	to_chat(quirk_holder, "<span class='boldnotice'>There is a [drug_instance.name] [where_drug], and a lighter [where_accessory].</span>")
 
 /datum/quirk/unstable
 	name = "Unstable"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If you take smoker quirk, you no longer get cigars. There is also no punishment for smoking different brands now. 

## Why It's Good For The Game

Cigars are big and annoying, plus a premium item, you shouldn't be starting with them. I don't like the brand preference mechanic because I smoke different brands based off what job I have, I don't want to be forced to like a certain brand. I think this applies to others as well. 

## Changelog
:cl:
del: smoker trait no longer gives cigars
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
