### PR TITLE
makes tank suicides leak the gas out

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -138,6 +138,10 @@
 		H.spawn_gibs()
 		H.spill_organs()
 		H.spread_bodyparts()
+		var/turf/T = get_turf(src)
+		if(T)
+			T.assume_air(air_contents)
+			air_update_turf()
 
 	return (BRUTELOSS)
 

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -142,6 +142,7 @@
 		if(T)
 			T.assume_air(air_contents)
 			air_update_turf()
+			qdel(air_contents)
 
 	return (BRUTELOSS)
 


### PR DESCRIPTION
## About The Pull Request

when you suicide with a full tank the gas now leaks when you explode

## Why It's Good For The Game

fun interaction, allows you to make your death quite spectacular with gas combinations

## Changelog
:cl:
add: The gas tank suicide is now more spectacular!
/:cl:
