### PR TITLE
Fixes emergency pod storage

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -286,8 +286,8 @@ All ShuttleMove procs go here
 
 /obj/item/storage/pod/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
 	. = ..()
-	// If the pod was launched, the storage will always open. The CentCom check
-	// ignores the movement of the shuttle from the staging area on CentCom to
+	// If the pod was launched, the storage will always open. The reserved_level check
+	// ignores the movement of the shuttle from the transit level to
 	// the station as it is loaded in.
 	if (oldT && !is_reserved_level(oldT.z))
 		unlocked = TRUE

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -289,7 +289,7 @@ All ShuttleMove procs go here
 	// If the pod was launched, the storage will always open. The CentCom check
 	// ignores the movement of the shuttle from the staging area on CentCom to
 	// the station as it is loaded in.
-	if (oldT && !is_centcom_level(oldT.z))
+	if (oldT && !is_reserved_level(oldT.z))
 		unlocked = TRUE
 
 /************************************Mob move procs************************************/


### PR DESCRIPTION
## About The Pull Request

Fixes the emergency pod suit storage being open while on non-red/delta alert and the shuttle was on the station

## Changelog
:cl:
fix: fixed pod suit storage not working as intended
/:cl:
