### PR TITLE
Fix multi surgery. Add operating computer surgery target.

### DIFF
--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -104,7 +104,7 @@
 						else
 							alternative_step = "Finish operation"
 					data["procedures"] += list(list(
-						"name" = capitalize(procedure.name),
+						"name" = capitalize("[parse_zone(procedure.location)] [procedure.name]"),
 						"next_step" = capitalize(surgery_step.name),
 						"chems_needed" = chems_needed,
 						"alternative_step" = alternative_step,

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -49,7 +49,7 @@
 			var/datum/surgery/S = available_surgeries[P]
 
 			for(var/datum/surgery/other in M.surgeries)
-				if(other.location == S.location)
+				if(other.location == selected_zone)
 					return //during the input() another surgery was started at the same location.
 
 			//we check that the surgery is still doable after the input() wait.
@@ -79,7 +79,7 @@
 	else if(!current_surgery.step_in_progress)
 		attempt_cancel_surgery(current_surgery, I, M, user)
 
-	return 1
+	return TRUE
 
 /proc/attempt_cancel_surgery(datum/surgery/S, obj/item/I, mob/living/M, mob/user)
 	var/selected_zone = user.zone_selected

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -76,6 +76,8 @@
 
 
 /datum/surgery/proc/next_step(mob/user, intent)
+	if(location != user.zone_selected)
+		return FALSE
 	if(step_in_progress)
 		return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Fixes #45858
Fix multi surgery
Add operating computer surgery target.

![image](https://user-images.githubusercontent.com/7734424/62971193-e2cc2400-be19-11e9-92ad-0d05452bfce3.png)

## Why It's Good For The Game
You can perform many surgeries at one time again.
Started surgery on one body part don't block it on another.
You can see target of started surgery on operating computer.
## Changelog
:cl:
fix: You can perform many surgeries at one time again.
add: You can see target of started surgery on operating computer.
/:cl:
