### PR TITLE
Repeatable brain shock step for revival surgery.

### DIFF
--- a/code/modules/surgery/advanced/revival.dm
+++ b/code/modules/surgery/advanced/revival.dm
@@ -28,6 +28,7 @@
 /datum/surgery_step/revive
 	name = "shock body"
 	implements = list(/obj/item/twohanded/shockpaddles = 100, /obj/item/melee/baton = 75, /obj/item/gun/energy = 60)
+	repeatable = TRUE
 	time = 120
 
 /datum/surgery_step/revive/tool_check(mob/user, obj/item/tool)


### PR DESCRIPTION
## About The Pull Request
Revival brain shock stem now repeatable.
## Why It's Good For The Game
Someone (like me) sometimes forgot to fix something i body, and for repeat revival it need start operation from start.
This allow you perforn next try if your patient dont propertly revived vith no need to start operation from null.
## Changelog
:cl:
add: Revival brain shock stem now repeatable.
/:cl:
