### PR TITLE
Tries to salvage the mech wreckage

### DIFF
--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -123,7 +123,6 @@
 /obj/structure/mecha_wreckage/gygax/dark
 	name = "\improper Dark Gygax wreckage"
 	icon_state = "darkgygax-broken"
-	parts = null
 
 /obj/structure/mecha_wreckage/marauder
 	name = "\improper Marauder wreckage"

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -85,6 +85,7 @@
 		var/obj/S = pick(crowbar_salvage)
 		S.forceMove(user.drop_location())
 		user.visible_message("[user] pries [S] from [src].", "<span class='notice'>You pry [S] from [src].</span>")
+		crowbar_salvage -= S
 		return
 	to_chat(user, "<span class='notice'>You don't see anything that can be cut with [I]!</span>")
 

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -11,16 +11,25 @@
 	anchored = FALSE
 	opacity = 0
 	var/list/welder_salvage = list(/obj/item/stack/sheet/plasteel, /obj/item/stack/sheet/metal, /obj/item/stack/rods)
-	var/list/wirecutters_salvage = list(/obj/item/stack/cable_coil)
-	var/list/crowbar_salvage = list()
 	var/salvage_num = 5
+	var/list/crowbar_salvage = list()
+	var/wires_removed = FALSE
 	var/mob/living/silicon/ai/AI //AIs to be salvaged
+	var/list/parts
 
 /obj/structure/mecha_wreckage/Initialize(mapload, mob/living/silicon/ai/AI_pilot)
 	. = ..()
+	if(parts)
+		for(var/i in 1 to 2)
+			if(!parts.len)
+				break
+			if(prob(60))
+				continue
+			var/part = pick(parts)
+			welder_salvage += part
+		parts = null
 	if(!AI_pilot) //Type-checking for this is already done in mecha/Destroy()
 		return
-
 	AI = AI_pilot
 	AI.apply_damage(150, BURN) //Give the AI a bit of damage from the "shock" of being suddenly shut down
 	AI.death() //The damage is not enough to kill the AI, but to be 'corrupted files' in need of repair.
@@ -29,101 +38,92 @@
 	AI.controlled_mech = null
 	AI.remote_control = null
 
+/obj/structure/mecha_wreckage/Destroy()
+	if(AI)
+		QDEL_NULL(AI)
+	QDEL_LIST(crowbar_salvage)
+	return ..()
+
 /obj/structure/mecha_wreckage/examine(mob/user)
 	. = ..()
-	if(AI)
-		. += "<span class='notice'>The AI recovery beacon is active.</span>"
-
-/obj/structure/mecha_wreckage/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_WELDER)
-		if(salvage_num <= 0 || !length(welder_salvage))
-			to_chat(user, "<span class='warning'>You don't see anything that can be cut with [I]!</span>")
-			return
-
-		if(!I.use_tool(src, user, 0, volume=50))
-			return
-
-		var/type = prob(70) ? pick(welder_salvage) : null
-		if(type)
-			var/N = new type(get_turf(user))
-			user.visible_message("[user] cuts [N] from [src].", "<span class='notice'>You cut [N] from [src].</span>")
-			if(istype(N, /obj/item/mecha_parts/part))
-				welder_salvage -= type
-			salvage_num--
-		else
-			to_chat(user, "<span class='warning'>You fail to salvage anything valuable from [src]!</span>")
+	if(!AI)
 		return
+	. += "<span class='notice'>The AI recovery beacon is active.</span>"
 
-	else if(I.tool_behaviour == TOOL_WIRECUTTER)
-		if(salvage_num <= 0)
-			to_chat(user, "<span class='warning'>You don't see anything that can be cut with [I]!</span>")
-			return
-		else if(wirecutters_salvage && wirecutters_salvage.len)
-			var/type = prob(70) ? pick(wirecutters_salvage) : null
-			if(type)
-				var/N = new type(get_turf(user))
-				user.visible_message("[user] cuts [N] from [src].", "<span class='notice'>You cut [N] from [src].</span>")
-				salvage_num--
-			else
-				to_chat(user, "<span class='warning'>You fail to salvage anything valuable from [src]!</span>")
+/obj/structure/mecha_wreckage/welder_act(mob/living/user, obj/item/I)
+	..()
+	. = TRUE
+	if(salvage_num <= 0 || !length(welder_salvage))
+		to_chat(user, "<span class='notice'>You don't see anything that can be cut with [I]!</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume=50))
+		return
+	if(prob(30))
+		to_chat(user, "<span class='notice'>You fail to salvage anything valuable from [src]!</span>")
+		return
+	var/type = pick(welder_salvage)
+	var/N = new type(get_turf(user))
+	user.visible_message("[user] cuts [N] from [src].", "<span class='notice'>You cut [N] from [src].</span>")
+	if(!istype(N, /obj/item/stack))
+		welder_salvage -= type
+	salvage_num--
 
-	else if(I.tool_behaviour == TOOL_CROWBAR)
-		if(crowbar_salvage && crowbar_salvage.len)
-			var/obj/S = pick(crowbar_salvage)
-			if(S)
-				S.forceMove(user.drop_location())
-				crowbar_salvage -= S
-				user.visible_message("[user] pries [S] from [src].", "<span class='notice'>You pry [S] from [src].</span>")
-			return
-		else
-			to_chat(user, "<span class='warning'>You don't see anything that can be pried with [I]!</span>")
+/obj/structure/mecha_wreckage/wirecutter_act(mob/living/user, obj/item/I)
+	..()
+	. = TRUE
+	if(wires_removed)
+		to_chat(user, "<span class='notice'>You don't see anything that can be cut with [I]!</span>")
+		return
+	var/N = new /obj/item/stack/cable_coil(get_turf(user), rand(1,3))
+	user.visible_message("[user] cuts [N] from [src].", "<span class='notice'>You cut [N] from [src].</span>")
+	wires_removed = TRUE
 
+/obj/structure/mecha_wreckage/crowbar_act(mob/living/user, obj/item/I)
+	..()
+	. = TRUE
+	if(crowbar_salvage.len)
+		var/obj/S = pick(crowbar_salvage)
+		S.forceMove(user.drop_location())
+		user.visible_message("[user] pries [S] from [src].", "<span class='notice'>You pry [S] from [src].</span>")
+		return
+	to_chat(user, "<span class='notice'>You don't see anything that can be cut with [I]!</span>")
 
 /obj/structure/mecha_wreckage/transfer_ai(interaction, mob/user, null, obj/item/aicard/card)
 	if(!..())
 		return
 
  //Proc called on the wreck by the AI card.
-	if(interaction == AI_TRANS_TO_CARD) //AIs can only be transferred in one direction, from the wreck to the card.
-		if(!AI) //No AI in the wreck
-			to_chat(user, "<span class='warning'>No AI backups found.</span>")
-			return
-		cut_overlays() //Remove the recovery beacon overlay
-		AI.forceMove(card) //Move the dead AI to the card.
-		card.AI = AI
-		if(AI.client) //AI player is still in the dead AI and is connected
-			to_chat(AI, "The remains of your file system have been recovered on a mobile storage device.")
-		else //Give the AI a heads-up that it is probably going to get fixed.
-			AI.notify_ghost_cloning("You have been recovered from the wreckage!", source = card)
-		to_chat(user, "<span class='boldnotice'>Backup files recovered</span>: [AI.name] ([rand(1000,9999)].exe) salvaged from [name] and stored within local memory.")
-
-	else
-		return ..()
-
+	if(interaction != AI_TRANS_TO_CARD) //AIs can only be transferred in one direction, from the wreck to the card.
+		return
+	if(!AI) //No AI in the wreck
+		to_chat(user, "<span class='warning'>No AI backups found.</span>")
+		return
+	cut_overlays() //Remove the recovery beacon overlay
+	AI.forceMove(card) //Move the dead AI to the card.
+	card.AI = AI
+	if(AI.client) //AI player is still in the dead AI and is connected
+		to_chat(AI, "The remains of your file system have been recovered on a mobile storage device.")
+	else //Give the AI a heads-up that it is probably going to get fixed.
+		AI.notify_ghost_cloning("You have been recovered from the wreckage!", source = card)
+	to_chat(user, "<span class='boldnotice'>Backup files recovered</span>: [AI.name] ([rand(1000,9999)].exe) salvaged from [name] and stored within local memory.")
+	AI = null
 
 /obj/structure/mecha_wreckage/gygax
 	name = "\improper Gygax wreckage"
 	icon_state = "gygax-broken"
-
-/obj/structure/mecha_wreckage/gygax/Initialize()
-	. = ..()
-	var/list/parts = list(/obj/item/mecha_parts/part/gygax_torso,
-								/obj/item/mecha_parts/part/gygax_head,
-								/obj/item/mecha_parts/part/gygax_left_arm,
-								/obj/item/mecha_parts/part/gygax_right_arm,
-								/obj/item/mecha_parts/part/gygax_left_leg,
-								/obj/item/mecha_parts/part/gygax_right_leg)
-	for(var/i = 0; i < 2; i++)
-		if(parts.len && prob(40))
-			var/part = pick(parts)
-			welder_salvage += part
-			parts -= part
-
-
+	parts = list(
+				/obj/item/mecha_parts/part/gygax_torso,
+				/obj/item/mecha_parts/part/gygax_head,
+				/obj/item/mecha_parts/part/gygax_left_arm,
+				/obj/item/mecha_parts/part/gygax_right_arm,
+				/obj/item/mecha_parts/part/gygax_left_leg,
+				/obj/item/mecha_parts/part/gygax_right_leg
+				)
 
 /obj/structure/mecha_wreckage/gygax/dark
 	name = "\improper Dark Gygax wreckage"
 	icon_state = "darkgygax-broken"
+	parts = null
 
 /obj/structure/mecha_wreckage/marauder
 	name = "\improper Marauder wreckage"
@@ -147,103 +147,54 @@
 /obj/structure/mecha_wreckage/ripley
 	name = "\improper Ripley wreckage"
 	icon_state = "ripley-broken"
-
-/obj/structure/mecha_wreckage/ripley/Initialize()
-	. = ..()
-	var/list/parts = list(/obj/item/mecha_parts/part/ripley_torso,
-								/obj/item/mecha_parts/part/ripley_left_arm,
-								/obj/item/mecha_parts/part/ripley_right_arm,
-								/obj/item/mecha_parts/part/ripley_left_leg,
-								/obj/item/mecha_parts/part/ripley_right_leg)
-	for(var/i = 0; i < 2; i++)
-		if(parts.len && prob(40))
-			var/part = pick(parts)
-			welder_salvage += part
-			parts -= part
+	parts = list(/obj/item/mecha_parts/part/ripley_torso,
+				/obj/item/mecha_parts/part/ripley_left_arm,
+				/obj/item/mecha_parts/part/ripley_right_arm,
+				/obj/item/mecha_parts/part/ripley_left_leg,
+				/obj/item/mecha_parts/part/ripley_right_leg)
 
 /obj/structure/mecha_wreckage/ripley/mkii
 	name = "\improper Ripley MK-II wreckage"
 	icon_state = "ripleymkii-broken"
 
-/obj/structure/mecha_wreckage/ripley/mkii/Initialize()
-	. = ..()
-	var/list/parts = list(/obj/item/mecha_parts/part/ripley_torso,
-								/obj/item/mecha_parts/part/ripley_left_arm,
-								/obj/item/mecha_parts/part/ripley_right_arm,
-								/obj/item/mecha_parts/part/ripley_left_leg,
-								/obj/item/mecha_parts/part/ripley_right_leg)
-	for(var/i = 0; i < 2; i++)
-		if(parts.len && prob(40))
-			var/part = pick(parts)
-			welder_salvage += part
-			parts -= part
-
-
 /obj/structure/mecha_wreckage/ripley/firefighter
 	name = "\improper Firefighter wreckage"
 	icon_state = "firefighter-broken"
-
-/obj/structure/mecha_wreckage/ripley/firefighter/Initialize()
-	. = ..()
-	var/list/parts = list(/obj/item/mecha_parts/part/ripley_torso,
-								/obj/item/mecha_parts/part/ripley_left_arm,
-								/obj/item/mecha_parts/part/ripley_right_arm,
-								/obj/item/mecha_parts/part/ripley_left_leg,
-								/obj/item/mecha_parts/part/ripley_right_leg,
-								/obj/item/clothing/suit/fire)
-	for(var/i = 0; i < 2; i++)
-		if(parts.len && prob(40))
-			var/part = pick(parts)
-			welder_salvage += part
-			parts -= part
-
+	parts = list(/obj/item/mecha_parts/part/ripley_torso,
+				/obj/item/mecha_parts/part/ripley_left_arm,
+				/obj/item/mecha_parts/part/ripley_right_arm,
+				/obj/item/mecha_parts/part/ripley_left_leg,
+				/obj/item/mecha_parts/part/ripley_right_leg,
+				/obj/item/clothing/suit/fire)
 
 /obj/structure/mecha_wreckage/ripley/deathripley
 	name = "\improper Death-Ripley wreckage"
 	icon_state = "deathripley-broken"
-
+	parts = null
 
 /obj/structure/mecha_wreckage/honker
 	name = "\improper H.O.N.K wreckage"
 	icon_state = "honker-broken"
 	desc = "All is right in the universe."
-
-/obj/structure/mecha_wreckage/honker/Initialize()
-	. = ..()
-	var/list/parts = list(
-							/obj/item/mecha_parts/chassis/honker,
-							/obj/item/mecha_parts/part/honker_torso,
-							/obj/item/mecha_parts/part/honker_head,
-							/obj/item/mecha_parts/part/honker_left_arm,
-							/obj/item/mecha_parts/part/honker_right_arm,
-							/obj/item/mecha_parts/part/honker_left_leg,
-							/obj/item/mecha_parts/part/honker_right_leg)
-	for(var/i = 0; i < 2; i++)
-		if(parts.len && prob(40))
-			var/part = pick(parts)
-			welder_salvage += part
-			parts -= part
-
+	parts = list(
+				/obj/item/mecha_parts/chassis/honker,
+				/obj/item/mecha_parts/part/honker_torso,
+				/obj/item/mecha_parts/part/honker_head,
+				/obj/item/mecha_parts/part/honker_left_arm,
+				/obj/item/mecha_parts/part/honker_right_arm,
+				/obj/item/mecha_parts/part/honker_left_leg,
+				/obj/item/mecha_parts/part/honker_right_leg)
 
 /obj/structure/mecha_wreckage/durand
 	name = "\improper Durand wreckage"
 	icon_state = "durand-broken"
-
-/obj/structure/mecha_wreckage/durand/Initialize()
-	. = ..()
-	var/list/parts = list(
-								/obj/item/mecha_parts/part/durand_torso,
-								/obj/item/mecha_parts/part/durand_head,
-								/obj/item/mecha_parts/part/durand_left_arm,
-								/obj/item/mecha_parts/part/durand_right_arm,
-								/obj/item/mecha_parts/part/durand_left_leg,
-								/obj/item/mecha_parts/part/durand_right_leg)
-	for(var/i = 0; i < 2; i++)
-		if(parts.len && prob(40))
-			var/part = pick(parts)
-			welder_salvage += part
-			parts -= part
-
+	parts = list(
+			/obj/item/mecha_parts/part/durand_torso,
+			/obj/item/mecha_parts/part/durand_head,
+			/obj/item/mecha_parts/part/durand_left_arm,
+			/obj/item/mecha_parts/part/durand_right_arm,
+			/obj/item/mecha_parts/part/durand_left_leg,
+			/obj/item/mecha_parts/part/durand_right_leg)
 
 /obj/structure/mecha_wreckage/phazon
 	name = "\improper Phazon wreckage"
@@ -253,18 +204,10 @@
 /obj/structure/mecha_wreckage/odysseus
 	name = "\improper Odysseus wreckage"
 	icon_state = "odysseus-broken"
-
-/obj/structure/mecha_wreckage/odysseus/Initialize()
-	. = ..()
-	var/list/parts = list(
-								/obj/item/mecha_parts/part/odysseus_torso,
-								/obj/item/mecha_parts/part/odysseus_head,
-								/obj/item/mecha_parts/part/odysseus_left_arm,
-								/obj/item/mecha_parts/part/odysseus_right_arm,
-								/obj/item/mecha_parts/part/odysseus_left_leg,
-								/obj/item/mecha_parts/part/odysseus_right_leg)
-	for(var/i = 0; i < 2; i++)
-		if(parts.len && prob(40))
-			var/part = pick(parts)
-			welder_salvage += part
-			parts -= part
+	parts = list(
+			/obj/item/mecha_parts/part/odysseus_torso,
+			/obj/item/mecha_parts/part/odysseus_head,
+			/obj/item/mecha_parts/part/odysseus_left_arm,
+			/obj/item/mecha_parts/part/odysseus_right_arm,
+			/obj/item/mecha_parts/part/odysseus_left_leg,
+			/obj/item/mecha_parts/part/odysseus_right_leg)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Amount of cable salvaged no longer directly relates to the amount of metal you can salvage.
AIs now get deleted slightly more properly if a mech wreckage gets destroyed.
Gets rid of a bunch of duplicate code for parts.
You can now attack mech wrecks.

## Why It's Good For The Game

Mech wreckage was absolute shitcode like everything related to mechs.

Cable tweak makes sense imo.

## Changelog
:cl:
tweak: The amount of cable and metal you can harvest from a mech wreck are no longer directly related.
fix: You can now attack mech wrecks.
/:cl: