### PR TITLE
Remove verbs "cmd_toggle_pda_receiver" and "cmd_toggle_pda_silent" from cyborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -125,6 +125,9 @@
 	module = new /obj/item/robot_module(src)
 	module.rebuild_modules()
 	update_icons()
+	//Remove the two verbs cmd_toggle_pda_receiver and cmd_toggle_pda_silent since cyborgs to do not have PDAs
+	src.verbs -= /mob/living/silicon/verb/cmd_toggle_pda_receiver
+	src.verbs -= /mob/living/silicon/verb/cmd_toggle_pda_silent
 	. = ..()
 
 	//If this body is meant to be a borg controlled by the AI player


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This fixes #45482
Adds code to robot.dm that removes the two verbs "cmd_toggle_pda_receiver" and "cmd_toggle_pda_silent" from cyborg players, because they don't have PDAs which causes error check to trip.

In https://github.com/tgstation/tgstation/blob/02251be5ac7015cf17d32ba2a9248ef86f1adf8b/code/game/objects/items/devices/PDA/PDA.dm#L963-L984
all silicon mobs receive these two verbs while needed for PAIs and AIs the cyborgs don't need this command and trip an error when trying to use the verbs:
![image](https://user-images.githubusercontent.com/33846895/63061646-24320180-bef6-11e9-86fe-bb71c2e5fc46.png)

These two verbs are normally for toggling PDA ringer and sender:
![image](https://user-images.githubusercontent.com/33846895/63061905-28125380-bef7-11e9-9da1-636e9dc82c1c.png)
![image](https://user-images.githubusercontent.com/33846895/63061673-3e6bdf80-bef6-11e9-8849-63867f76de7a.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Good for the game because players don't get an error message and cyborg player now don't have the useless "AI Commands" tab
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cyborgs no longer receive the useless commands "PDA - Toggle Ringer" and "PDA - Toggle Sender/Receiver" which only showed an error for them in chat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
