### PR TITLE
[HUGE INTERNET FIGHT] Adds botany chemicals to biogenerator

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -217,7 +217,7 @@
 		S += 5
 		if(I.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) < 0.1)
 			points += 1*productivity
-		else points += I.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment)*10*productivity
+		else points += I.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment)*1*productivity
 		qdel(I)
 	if(S)
 		processing = TRUE

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -113,6 +113,16 @@
 	desc = "A small bottle of diethylamine."
 	list_reagents = list(/datum/reagent/diethylamine = 30)
 
+/obj/item/reagent_containers/glass/bottle/ash
+	name = "ash bottle"
+	desc = "A small bottle of ash."
+	list_reagents = list(/datum/reagent/ash = 30)
+
+/obj/item/reagent_containers/glass/bottle/saltpetre
+	name = "saltpetre bottle"
+	desc = "A small bottle of saltpetre."
+	list_reagents = list(/datum/reagent/saltpetre = 30)
+
 /obj/item/reagent_containers/glass/bottle/facid
 	name = "Fluorosulfuric Acid Bottle"
 	desc = "A small bottle. Contains a small amount of fluorosulfuric acid."

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -123,6 +123,54 @@
 	build_path = /obj/item/reagent_containers/glass/bottle/nutrient/empty
 	category = list("initial", "Botany Chemicals")
 
+/datum/design/plantbgone_bottle
+	name = "Plant-B-Gone Bottle"
+	id = "plantbgone_bottle"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 50)
+	build_path = /obj/item/reagent_containers/spray/plantbgone
+	category = list("initial","Botany Chemicals")
+
+/datum/design/mutagen_bottle
+	name = "Unstable Mutagen Bottle"
+	id = "mutagen_bottle"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 400)
+	build_path = /obj/item/reagent_containers/glass/bottle/mutagen
+	category = list("initial","Botany Chemicals")
+
+/datum/design/ash_bottle
+	name = "Ash Bottle"
+	id = "ash_bottle"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 15)
+	build_path = /obj/item/reagent_containers/glass/bottle/ash
+	category = list("initial","Botany Chemicals")
+
+/datum/design/ammonia_bottle
+	name = "Ammonia Bottle"
+	id = "ammonia_bottle"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 25)
+	build_path = /obj/item/reagent_containers/glass/bottle/ammonia
+	category = list("initial","Botany Chemicals")
+
+/datum/design/saltpetre_bottle
+	name = "Saltpetre Bottle"
+	id = "saltpetre_bottle"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 50)
+	build_path = /obj/item/reagent_containers/glass/bottle/saltpetre
+	category = list("initial","Botany Chemicals")
+
+/datum/design/diethylamine_bottle
+	name = "Diethylamine Bottle"
+	id = "diethylamine_bottle"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 100)
+	build_path = /obj/item/reagent_containers/glass/bottle/diethylamine
+	category = list("initial","Botany Chemicals")
+
 /datum/design/cloth
 	name = "Roll of Cloth"
 	id = "cloth"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds mutagen, ash, ammonia, saltpetre, diethylamine and plant-b-gone to the biogenerator. Also nerfs biomass produced by plants with over 9 nutriment by 90% for balance.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Chemistry can't keep up with the botanists' demands. They never have. The blumpkin/glowshroom strategy for mutagen is valid but takes ages and doesn't account for the other chemicals botany needs. Botany already has access to a chem dispenser roundstart via tech storage. This seems like an amicable compromise between giving botany their own chem dispenser and leaving it as it is now.

Test this before you judge it because the nerf makes it a lot harder to get biomass than you might think.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
add: Adds mutagen, ash, ammonia, saltpetre, diethylamine and plant-b-gone to the hydroponics biogenerator
balance: Plants with over 9 nutriment (e.g. watermelons) now only produce 1/10th the biomass
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
