### PR TITLE
inorganics can no longer become zombified

### DIFF
--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -45,6 +45,8 @@
 		return
 	if(!(src in owner.internal_organs))
 		Remove(owner)
+	if(MOB_INORGANIC in mob_biotypes)//does not process in inorganic things
+		return
 	if (causes_damage && !iszombie(owner) && owner.stat != DEAD)
 		owner.adjustToxLoss(1)
 		if (prob(10))

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -45,7 +45,7 @@
 		return
 	if(!(src in owner.internal_organs))
 		Remove(owner)
-	if(MOB_INORGANIC in mob_biotypes)//does not process in inorganic things
+	if(MOB_INORGANIC in owner.mob_biotypes)//does not process in inorganic things
 		return
 	if (causes_damage && !iszombie(owner) && owner.stat != DEAD)
 		owner.adjustToxLoss(1)


### PR DESCRIPTION
We're getting to 1,200 issues, whether you like it or not.

## About The Pull Request

Nonorganics can no longer become zombies

## Why It's Good For The Game

It didn't make sense, and some golem abilities break with the zombie organ.
(fixes #45881)
