### PR TITLE
Air Injectors no longer use power

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -4,7 +4,7 @@
 	name = "air injector"
 	desc = "Has a valve and pump attached to it."
 
-	use_power = IDLE_POWER_USE
+	use_power = NO_POWER_USE
 	can_unwrench = TRUE
 	shift_underlay_only = FALSE
 


### PR DESCRIPTION
There are WAY too many situations where this is unreasonable, one example being every case where you have to eject it out to space.

I need to look through this to actually remove power interactions, probably.

fixes #45942 