### PR TITLE
Adds support for admin-bused pneumatic cannons that fire non /items again

### DIFF
--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -128,6 +128,8 @@
 	loadedItems += I
 	if(isitem(I))
 		loadedWeightClass += I.w_class
+	else
+		loadedWeightClass++
 	return TRUE
 
 /obj/item/pneumatic_cannon/afterattack(atom/target, mob/living/user, flag, params)
@@ -184,7 +186,7 @@
 		for(var/i in 1 to throw_amount)
 			if(!loadedItems.len)
 				break
-			var/obj/item/I
+			var/atom/movable/I
 			if(fire_mode == PCANNON_FILO)
 				I = loadedItems[loadedItems.len]
 			else
@@ -192,13 +194,17 @@
 			if(!throw_item(target, I, user))
 				break
 
-/obj/item/pneumatic_cannon/proc/throw_item(turf/target, obj/item/I, mob/user)
-	if(!istype(I))
+/obj/item/pneumatic_cannon/proc/throw_item(turf/target, atom/movable/AM, mob/user)
+	if(!istype(AM))
 		return FALSE
-	loadedItems -= I
-	loadedWeightClass -= I.w_class
-	I.forceMove(get_turf(src))
-	I.throw_at(target, pressureSetting * 10 * range_multiplier, pressureSetting * 2, user, spin_item)
+	loadedItems -= AM
+	if(isitem(AM))
+		var/obj/item/I = AM
+		loadedWeightClass -= I.w_class
+	else
+		loadedWeightClass--
+	AM.forceMove(get_turf(src))
+	AM.throw_at(target, pressureSetting * 10 * range_multiplier, pressureSetting * 2, user, spin_item)
 	return TRUE
 
 /obj/item/pneumatic_cannon/proc/get_target(turf/target, turf/starting)
@@ -215,7 +221,10 @@
 	. = ..()
 	if (loadedItems.Remove(A))
 		var/obj/item/I = A
-		loadedWeightClass -= I.w_class
+		if(istype(I))
+			loadedWeightClass -= I.w_class
+		else
+			loadedWeightClass--
 	else if (A == tank)
 		tank = null
 		update_icon()

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -126,7 +126,8 @@
 	else
 		I.forceMove(src)
 	loadedItems += I
-	loadedWeightClass += I.w_class
+	if(isitem(I))
+		loadedWeightClass += I.w_class
 	return TRUE
 
 /obj/item/pneumatic_cannon/afterattack(atom/target, mob/living/user, flag, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds an isitem check so load_item doesn't runtime when it adds a non /item into the cannon which admins can trigger using fill_with_type

## Why It's Good For The Game

It probably isn't but let's pretend it lets us do something fun other than making a singularity cannon.

## Changelog
:cl:
tweak: Pneumatic cannons can be used with non /items again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
