### PR TITLE
Fixes camera mobs being launchpadded, allows ghosts to click to use the launchpad (Revived edition)

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -71,6 +71,15 @@
 
 	return ..()
 
+/obj/machinery/launchpad/attack_ghost(mob/dead/observer/ghost)
+	. = ..()
+	if(.)
+		return
+	var/target_x = x + x_offset
+	var/target_y = y + y_offset
+	var/turf/target = locate(target_x, target_y, z)
+	ghost.forceMove(target)
+
 /obj/machinery/launchpad/proc/isAvailable()
 	if(stat & NOPOWER)
 		return FALSE
@@ -145,6 +154,7 @@
 	for(var/atom/movable/ROI in source)
 		if(ROI == src)
 			continue
+		if(!istype(ROI) || isdead(ROI) || iscameramob(ROI) || istype(ROI, /obj/effect/dummy/phased_mob))
 		// if it's anchored, don't teleport
 		var/on_chair = ""
 		if(ROI.anchored)
@@ -154,12 +164,9 @@
 					// TP people on office chairs
 					if(L.buckled.anchored)
 						continue
-
 					on_chair = " (on a chair)"
 				else
 					continue
-			else if(!isobserver(ROI))
-				continue
 		if(!first)
 			log_msg += ", "
 		if(ismob(ROI))

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -155,9 +155,9 @@
 		if(ROI == src)
 			continue
 		if(!istype(ROI) || isdead(ROI) || iscameramob(ROI) || istype(ROI, /obj/effect/dummy/phased_mob))
-		// if it's anchored, don't teleport
+			continue//don't teleport these
 		var/on_chair = ""
-		if(ROI.anchored)
+		if(ROI.anchored)// if it's anchored, don't teleport
 			if(isliving(ROI))
 				var/mob/living/L = ROI
 				if(L.buckled)


### PR DESCRIPTION
fixes #45384

## Changelog
:cl:
add: Ghosts can now click launchpads to teleport to their current offset configuration.
fix: Launchpads no longer teleport camera eyes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
