### PR TITLE
Allows you to swap seeds and disks in botany gene modifier with a click

### DIFF
--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -75,22 +75,22 @@
 		return
 
 	if(istype(I, /obj/item/seeds))
-		if(seed)
-			to_chat(user, "<span class='warning'>A sample is already loaded into the machine!</span>")
-		else
-			if(!user.temporarilyRemoveItemFromInventory(I))
-				return
-			insert_seed(I)
-			to_chat(user, "<span class='notice'>You add [I] to the machine.</span>")
-			interact(user)
-		return
+		if (operation)
+			to_chat(user, "<span class='notice'>Please complete current operation.</span>")
+			return
+		if(!user.transferItemToLoc(I, src))
+			return
+		eject_seed()
+		insert_seed(I)
+		to_chat(user, "<span class='notice'>You add [I] to the machine.</span>")
+		interact(user)
 	else if(istype(I, /obj/item/disk/plantgene))
 		if (operation)
 			to_chat(user, "<span class='notice'>Please complete current operation.</span>")
 			return
-		eject_disk()
 		if(!user.transferItemToLoc(I, src))
 			return
+		eject_disk()
 		disk = I
 		to_chat(user, "<span class='notice'>You add [I] to the machine.</span>")
 		interact(user)
@@ -252,28 +252,25 @@
 	usr.set_machine(src)
 
 	if(href_list["eject_seed"] && !operation)
-		if (seed)
-			seed.forceMove(drop_location())
-			seed.verb_pickup()
-			seed = null
-			update_genes()
-			update_icon()
+		var/obj/item/I = usr.get_active_held_item()
+		if(istype(I, /obj/item/seeds))
+			if(!usr.transferItemToLoc(I, src))
+				return
+			eject_seed()
+			insert_seed(I)
+			to_chat(usr, "<span class='notice'>You add [I] to the machine.</span>")
 		else
-			var/obj/item/I = usr.get_active_held_item()
-			if (istype(I, /obj/item/seeds))
-				if(!usr.temporarilyRemoveItemFromInventory(I))
-					return
-				insert_seed(I)
-				to_chat(usr, "<span class='notice'>You add [I] to the machine.</span>")
-		update_icon()
+			eject_seed()
 	else if(href_list["eject_disk"] && !operation)
 		var/obj/item/I = usr.get_active_held_item()
-		eject_disk()
 		if(istype(I, /obj/item/disk/plantgene))
 			if(!usr.transferItemToLoc(I, src))
 				return
+			eject_disk()
 			disk = I
 			to_chat(usr, "<span class='notice'>You add [I] to the machine.</span>")
+		else
+			eject_disk()
 	else if(href_list["op"] == "insert" && disk && disk.gene && seed)
 		if(!operation) // Wait for confirmation
 			operation = "insert"
@@ -363,12 +360,22 @@
 
 /obj/machinery/plantgenes/proc/eject_disk()
 	if (disk && !operation)
-		if(Adjacent(usr) && !issilicon(usr))
+		if(Adjacent(usr) && !issiliconoradminghost(usr))
 			if (!usr.put_in_hands(disk))
 				disk.forceMove(drop_location())
 		else
 			disk.forceMove(drop_location())
 		disk = null
+		update_genes()
+
+/obj/machinery/plantgenes/proc/eject_seed()
+	if (seed && !operation)
+		if(Adjacent(usr) && !issiliconoradminghost(usr))
+			if (!usr.put_in_hands(seed))
+				seed.forceMove(drop_location())
+		else
+			seed.forceMove(drop_location())
+		seed = null
 		update_genes()
 
 /obj/machinery/plantgenes/proc/update_genes()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so you can swap disks or seeds out of the plant DNA modifier by clicking it with them when there are already some inside. Also works when clicking the fields in the UI.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Just a small QoL improvement for hydroponics to make the plant DNA modifier less clunky to use.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
tweak: Clicking the plant DNA modifier or its UI fields with a disk or pack of seeds when it already has some inside will swap them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
