### PR TITLE
Nuitrition now checks that fatness is caused by nuitrition

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -999,7 +999,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		return //hunger is for BABIES
 
 	//The fucking TRAIT_FAT mutation is the dumbest shit ever. It makes the code so difficult to work with
-	if(HAS_TRAIT(H, TRAIT_FAT))//I share your pain, past coder.
+	if(HAS_TRAIT_FROM(H, TRAIT_FAT, OBESITY))//I share your pain, past coder.
 		if(H.overeatduration < 100)
 			to_chat(H, "<span class='notice'>You feel fit again!</span>")
 			REMOVE_TRAIT(H, TRAIT_FAT, OBESITY)


### PR DESCRIPTION
## About The Pull Request

Obesity checks on nutrition now only tries to remove fatness if it were caused by nutrition

## Why It's Good For The Game

It no longer spams chat with `you feel fit again!` when you become fat from ferveatium

## Changelog
:cl:
fix: you will no longer recieve "you feel fit again!" several times when you become fat from ferveatium
/:cl: