### PR TITLE
Money bag deposits straight into ID

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -201,7 +201,8 @@
 		total += cash_money
 		
 		registered_account.adjust_money(cash_money)
-		qdel(money)
+
+	QDEL_LIST(money)	
 
 	return total
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -201,6 +201,7 @@
 		total += cash_money
 		
 		registered_account.adjust_money(cash_money)
+		qdel(money)
 
 	return total
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -158,6 +158,15 @@
 	else if(istype(W, /obj/item/coin))
 		insert_money(W, user, TRUE)
 		return
+	else if(istype(W, /obj/item/storage/bag/money))
+		var/obj/item/storage/bag/money/money_bag = W
+		var/list/money_contained = money_bag.contents
+
+		var/money_added = mass_insert_money(money_contained, user)
+
+		if (money_added)
+			to_chat(user, "<span class='notice'>You stuff the contents into the card! They disappear in a puff of bluespace smoke, adding [money_added] worth of credits to the linked account.</span>")
+		return
 	else
 		return ..()
 
@@ -180,6 +189,20 @@
 	to_chat(user, "<span class='notice'>The linked account now reports a balance of $[registered_account.account_balance].</span>")
 	qdel(I)
 
+/obj/item/card/id/proc/mass_insert_money(list/money, mob/user)
+	if (!money || !money.len)
+		return FALSE
+
+	var/total = 0
+
+	for (var/obj/item/physical_money in money)
+		var/cash_money = physical_money.get_item_credit_value()
+
+		total += cash_money
+		
+		registered_account.adjust_money(cash_money)
+
+	return total
 
 /obj/item/card/id/proc/alt_click_can_use_id(mob/living/user)
 	if(!isliving(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Credits inside money bags can be unloaded straight into ID cards.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

With public mining, the only way for someone to make money is to use the coin press, which outputs coins inside money bags. To then deposit, you'd need to take each individual coin and then click the ID card, which is incredibly tedious. QoL change that just allows coins to be unloaded without a thousand mouse clicks.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Money bags can be unloaded straight into ID cards.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
