### PR TITLE
Walking now makes no footstep sound, and xeno footsteps are louder

### DIFF
--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -14,7 +14,7 @@
 	var/turf/open/T = get_turf(parent)
 	if(!istype(T))
 		return
-	
+
 	var/mob/living/LM = parent
 	var/v = volume
 	var/e = e_range
@@ -22,27 +22,26 @@
 		if (LM.lying && !LM.buckled && !(!T.footstep || LM.movement_type & (VENTCRAWLING | FLYING))) //play crawling sound if we're lying
 			playsound(T, 'sound/effects/footstep/crawl1.ogg', 15 * v)
 		return
-	
+
 	if(iscarbon(LM))
 		var/mob/living/carbon/C = LM
 		if(!C.get_bodypart(BODY_ZONE_L_LEG) && !C.get_bodypart(BODY_ZONE_R_LEG))
 			return
 		if(ishuman(C) && C.m_intent == MOVE_INTENT_WALK)
-			v /= 2
-			e -= 5
+			return // stealth
 	steps++
-	
+
 	if(steps >= 6)
 		steps = 0
-	
+
 	if(steps % 2)
 		return
-	
+
 	if(!LM.has_gravity(T) && steps != 0) // don't need to step as often when you hop around
 		return
-		
+
 	//begin playsound shenanigans//
-	
+
 	//for barefooted non-clawed mobs like monkeys
 	if(isbarefoot(LM))
 		playsound(T, pick(GLOB.barefootstep[T.barefootstep][1]),
@@ -50,19 +49,19 @@
 			TRUE,
 			GLOB.barefootstep[T.barefootstep][3] + e)
 		return
-	
+
 	//for xenomorphs, dogs, and other clawed mobs
 	if(isclawfoot(LM))
 		if(isalienadult(LM)) //xenos are stealthy and get quieter footsteps
-			v /= 3
+			v /= 2
 			e -= 5
-		
+
 		playsound(T, pick(GLOB.clawfootstep[T.clawfootstep][1]),
 				GLOB.clawfootstep[T.clawfootstep][2] * v,
 				TRUE,
 				GLOB.clawfootstep[T.clawfootstep][3] + e)
 		return
-	
+
 	//for megafauna and other large and imtimidating mobs such as the bloodminer
 	if(isheavyfoot(LM))
 		playsound(T, pick(GLOB.heavyfootstep[T.heavyfootstep][1]),
@@ -70,12 +69,12 @@
 				TRUE,
 				GLOB.heavyfootstep[T.heavyfootstep][3] + e)
 		return
-	
+
 	//for slimes
-	if(isslime(LM)) 
+	if(isslime(LM))
 		playsound(T, 'sound/effects/footstep/slime1.ogg', 15 * v)
 		return
-		
+
 	//for (simple) humanoid mobs (clowns, russians, pirates, etc.)
 	if(isshoefoot(LM))
 		if(!ishuman(LM))
@@ -87,13 +86,13 @@
 		if(ishuman(LM)) //for proper humans, they're special
 			var/mob/living/carbon/human/H = LM
 			var/feetCover = (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))
-			
+
 			if(H.shoes || feetCover) //are we wearing shoes
 				playsound(T, pick(GLOB.footstep[T.footstep][1]),
 					GLOB.footstep[T.footstep][2] * v,
 					TRUE,
 					GLOB.footstep[T.footstep][3] + e)
-			
+
 			if((!H.shoes && !feetCover)) //are we NOT wearing shoes
 				if(H.dna.species.special_step_sounds)
 					playsound(T, pick(H.dna.species.special_step_sounds), 50, TRUE)


### PR DESCRIPTION
This intends to further encourage the use of walking mode as a stealth measure.
Xenos footsteps now play at 50% instead of 33% (which is still low), so that they are encouraged to walk as well.

~A possible next change would be to remove plasteel footsteps as people get so used to the sound that they basically start ignoring it, taking away the purpose of having the sounds on the first place.
But that's for another PR.~

## Changelog
:cl:
balance: Walking now makes your footsteps completely unnoticeable.
balance: Xenos now make more noise if running.
/:cl:
