### PR TITLE
Changes thermite

### DIFF
--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -1,7 +1,7 @@
 /datum/component/thermite
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 	var/amount
-	var/burn_coeff
+	var/burn_require
 	var/overlay
 
 	var/static/list/blacklist = typecacheof(list(
@@ -26,13 +26,15 @@
 		return COMPONENT_INCOMPATIBLE
 
 	if(immunelist[parent.type])
-		burn_coeff = 0 //Yeah the overlay can still go on it and be cleaned but you arent burning down a diamond wall
-	else if(resistlist[parent.type])
-		burn_coeff = 0.5
-	else
-		burn_coeff = 1
-
+		amount = 0 //Yeah the overlay can still go on it and be cleaned but you arent burning down a diamond wall
+		return
 	amount = _amount
+	if(resistlist[parent.type])
+		burn_require = 50
+		return
+	burn_require = 30
+
+
 
 	var/turf/master = parent
 	overlay = mutable_appearance('icons/effects/effects.dmi', "thermite")
@@ -74,7 +76,7 @@
 		qdel(fakefire)
 	if(user)
 		master.add_hiddenprint(user)
-	if(amount * burn_coeff >= 30)
+	if(amount >= burn_require)
 		master = master.Melt()
 		master.burn_tile()
 	qdel(src)

--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -28,11 +28,11 @@
 	if(immunelist[parent.type])
 		burn_coeff = 0 //Yeah the overlay can still go on it and be cleaned but you arent burning down a diamond wall
 	else if(resistlist[parent.type])
-		burn_coeff = 0.25
+		burn_coeff = 0.5
 	else
 		burn_coeff = 1
 
-	amount = _amount*10
+	amount = _amount
 
 	var/turf/master = parent
 	overlay = mutable_appearance('icons/effects/effects.dmi', "thermite")
@@ -41,6 +41,11 @@
 	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean_react)
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/attackby_react)
 	RegisterSignal(parent, COMSIG_ATOM_FIRE_ACT, .proc/flame_react)
+
+/datum/component/thermite/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT)
+	UnregisterSignal(parent, COMSIG_PARENT_ATTACKBY)
+	UnregisterSignal(parent, COMSIG_ATOM_FIRE_ACT)
 
 /datum/component/thermite/Destroy()
 	var/turf/master = parent
@@ -58,16 +63,20 @@
 /datum/component/thermite/proc/thermite_melt(mob/user)
 	var/turf/master = parent
 	master.cut_overlay(overlay)
-	var/obj/effect/overlay/thermite/fakefire = new(master)
-
 	playsound(master, 'sound/items/welder.ogg', 100, 1)
+	var/obj/effect/overlay/thermite/fakefire = new(master)
+	addtimer(CALLBACK(src, .proc/burn_parent, fakefire, user), min(amount * 0.25 SECONDS, 15 SECONDS))
+	UnregisterFromParent()
 
-	if(amount * burn_coeff >= 50)
+/datum/component/thermite/proc/burn_parent(var/datum/fakefire, mob/user)
+	var/turf/master = parent
+	if(!QDELETED(fakefire))
+		qdel(fakefire)
+	if(user)
+		master.add_hiddenprint(user)
+	if(amount * burn_coeff >= 30)
 		master = master.Melt()
 		master.burn_tile()
-		if(user)
-			master.add_hiddenprint(user)
-	QDEL_IN(fakefire, 10 SECONDS)
 	qdel(src)
 
 /datum/component/thermite/proc/clean_react(datum/source, strength)

--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -65,7 +65,7 @@
 	master.cut_overlay(overlay)
 	playsound(master, 'sound/items/welder.ogg', 100, 1)
 	var/obj/effect/overlay/thermite/fakefire = new(master)
-	addtimer(CALLBACK(src, .proc/burn_parent, fakefire, user), min(amount * 0.25 SECONDS, 15 SECONDS))
+	addtimer(CALLBACK(src, .proc/burn_parent, fakefire, user), min(amount * 0.35 SECONDS, 20 SECONDS))
 	UnregisterFromParent()
 
 /datum/component/thermite/proc/burn_parent(var/datum/fakefire, mob/user)


### PR DESCRIPTION
## About The Pull Request

This PR increases the amount of thermite you need to burn down a wall and also increases the time it needs.
Normal Wall: From 5 to 30 units
Reinforced Wall: From 20 to 50 units
It used to always be 10 seconds but it scales with the amount of thermite. One unit of thermite burns for 0.35 seconds and the maximum burn length is 20 seconds.

This also makes thermite not instantly destroy any walls.

## Why It's Good For The Game

This is part of the whole 'make walls mean something' package.

The numbers aren't chosen randomly, 30 units is exactly one bottle. 5 units is kinda hilariously low and most people already use way more thermite than they actually need to destroy walls.

The amount of time it takes for a normal wall to burn down is barely changed (from 10s to 10.5s) because having a specialized wall destruction tool destroy a wall in roughly that time is a good baseline.

Destroying r-walls in 10 seconds is a bit low though and mostly just abused to dab on AIs.

## Changelog
:cl:
balance: Thermite now burns longer and needs more units to burn down walls.
/:cl:
