### PR TITLE
Fixes ayyylium runtime.

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -87,7 +87,7 @@
 	var/datum/gas_mixture/breath
 
 	if(!getorganslot(ORGAN_SLOT_BREATHING_TUBE))
-		if(health <= HEALTH_THRESHOLD_FULLCRIT || (pulledby && pulledby.grab_state >= GRAB_KILL) || HAS_TRAIT(src, TRAIT_MAGIC_CHOKE) || lungs.organ_flags & ORGAN_FAILING)
+		if(health <= HEALTH_THRESHOLD_FULLCRIT || (pulledby && pulledby.grab_state >= GRAB_KILL) || HAS_TRAIT(src, TRAIT_MAGIC_CHOKE) || (lungs && lungs.organ_flags & ORGAN_FAILING))
 			losebreath++  //You can't breath at all when in critical or when being choked, so you're going to miss a breath
 
 		else if(health <= crit_threshold)


### PR DESCRIPTION
## About The Pull Request

```
[15:34:48] Runtime in life.dm,90: Cannot read null.organ_flags
  proc name: breathe (/mob/living/carbon/proc/breathe)
  src: the alien drone (440) (/mob/living/carbon/alien/humanoid/drone)
  src.loc: the floor (220,91,8) (/turf/open/floor/plasteel/white)
  call stack:
  the alien drone (440) (/mob/living/carbon/alien/humanoid/drone): breathe()
  the alien drone (440) (/mob/living/carbon/alien/humanoid/drone): handle breathing(4)
  the alien drone (440) (/mob/living/carbon/alien/humanoid/drone): Life(2, 4)
  the alien drone (440) (/mob/living/carbon/alien/humanoid/drone): Life(2, 4)
  the alien drone (440) (/mob/living/carbon/alien/humanoid/drone): Life(2, 4)
  Mobs (/datum/controller/subsystem/mobs): fire(1)
  Mobs (/datum/controller/subsystem/mobs): ignite(1)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing(0)
```

## Why It's Good For The Game

Runtime every time when someone don't have lungs is silly.
