### PR TITLE
Fix placement issue with APC frames

### DIFF
--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -92,7 +92,7 @@
 	if(!..())
 		return
 	var/turf/T = get_turf(on_wall) //the user is not where it needs to be.
-	var/area/A = get_area(T)
+	var/area/A = get_area(user)
 	if(A.get_apc())
 		to_chat(user, "<span class='warning'>This area already has an APC!</span>")
 		return //only one APC per area


### PR DESCRIPTION
Placing an APC on a wall currently evaluates the area that the wall is in ; as walls often border two areas this may not be the area the user expects.  Instead if we evaluate the area of the user we'll be "inside" the target area.

Fixes surpious and inexplicable "This area already has an APC!" errors.

The fact that diagonal placement of frames is prohibited is assumed in this fix.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Get APC's intended area based on the User's location rather than the target turf, which will be a wall possibly in a different area (on a boundary between two areas).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The error "This area already contains an APC!" is confusing and misleading, while the wall's area does, the user trying to place it won't realise this distinction, nor is it a desirable distinction.  Multiple existing APCs can not be placed back on the wall if removed from it.  See bug report for examples and debugging.

## Changelog
:cl:iain0
fix: Occasional 'Already contains an APC!' error incorrectly generated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

----

ed. Fixes #46021 