### PR TITLE
Reinforced walls now get pulled correctly by singularities

### DIFF
--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -214,7 +214,7 @@
 		icon_state = "r_wall"
 
 /turf/closed/wall/r_wall/singularity_pull(S, current_size)
-	..()
+	.....() //dab
 	if(current_size >= STAGE_FIVE)
 		if(prob(30))
 			dismantle_wall()

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -213,8 +213,7 @@
 		queue_smooth(src)
 		icon_state = "r_wall"
 
-/turf/closed/wall/r_wall/singularity_pull(S, current_size)
-	.....() //dab
+/turf/closed/wall/r_wall/wall_singularity_pull(current_size)
 	if(current_size >= STAGE_FIVE)
 		if(prob(30))
 			dismantle_wall()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -241,6 +241,9 @@
 
 /turf/closed/wall/singularity_pull(S, current_size)
 	..()
+	wall_singularity_pull(current_size)
+
+/turf/closed/wall/proc/wall_singularity_pull(current_size)
 	if(current_size >= STAGE_FIVE)
 		if(prob(50))
 			dismantle_wall()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This got messed up in #30220
Basically, reinforced walls also had the functionality of normal walls when getting pulled, meaning they broke easier than normal walls and also runtime sometimes.

## Why It's Good For The Game

Bugs bad.

## Changelog
:cl:
fix: fixed reinforced wall singularity pull behaviour.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
