### PR TITLE
Makes Traps of The Wizard Variety Cost More

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -263,7 +263,6 @@
 	name = "The Traps!"
 	spell_type = /obj/effect/proc_holder/spell/aoe_turf/conjure/the_traps
 	category = "Defensive"
-	cost = 1
 
 
 /datum/spellbook_entry/item


### PR DESCRIPTION
## About The Pull Request

Increases price of the traps from 1 to 2

## Why It's Good For The Game

traps is an unfun spell, made even worse by the fact you can buy 5 of them and still have enough points to buy another spell, or summon events to literally get instant traps, also really popular and good
tldr traps are gay

## Changelog
:cl:
balance: The Traps! now costs 2 wizardbux.
/:cl: