### PR TITLE
Powersink now wrenchs into the grid instead of being screwdrivered into it.

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -53,26 +53,30 @@
 	if(anchored)
 		return active ? Deactivate(user) : Activate(user)
 	else
-		to_chat(user, "<span class='warning'>You need to screw the beacon to the floor first!</span>")
+		to_chat(user, "<span class='warning'>You need to screw \the [src] to the floor first!</span>")
 
 /obj/machinery/power/singularity_beacon/attackby(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_SCREWDRIVER)
+	if(W.tool_behaviour == TOOL_WRENCH)
 		if(active)
-			to_chat(user, "<span class='warning'>You need to deactivate the beacon first!</span>")
+			to_chat(user, "<span class='warning'>You need to deactivate \the [src] first!</span>")
 			return
 
 		if(anchored)
 			setAnchored(FALSE)
-			to_chat(user, "<span class='notice'>You unscrew the beacon from the floor.</span>")
+			to_chat(user, "<span class='notice'>You unbolt \the [src] from the floor and detach it from the cable.</span>")
 			disconnect_from_network()
 			return
 		else
 			if(!connect_to_network())
-				to_chat(user, "<span class='warning'>This device must be placed over an exposed, powered cable node!</span>")
+				to_chat(user, "<span class='warning'>\the [src] must be placed over an exposed, powered cable node!</span>")
 				return
 			setAnchored(TRUE)
-			to_chat(user, "<span class='notice'>You screw the beacon to the floor and attach the cable.</span>")
+			to_chat(user, "<span class='notice'>You bolt \the [src] to the floor and attach it to the cable.</span>")
 			return
+	else if(W.tool_behaviour == TOOL_SCREWDRIVER)
+		user.visible_message( \
+			"[user] messes with \the [src] for a bit.", \
+			"<span class='notice'>You can't fit the screwdriver into \the [src]'s bolts! Try using a wrench.</span>")
 	else
 		return ..()
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -1,8 +1,8 @@
 // Powersink - used to drain station power
 
 /obj/item/powersink
-	desc = "A nulling power sink which drains energy from electrical systems."
 	name = "power sink"
+	desc = "A nulling power sink which drains energy from electrical systems."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "powersink0"
 	item_state = "electronic"
@@ -60,7 +60,7 @@
 	set_light(0)
 
 /obj/item/powersink/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_SCREWDRIVER)
+	if(I.tool_behaviour == TOOL_WRENCH)
 		if(mode == DISCONNECTED)
 			var/turf/T = loc
 			if(isturf(T) && !T.intact)
@@ -71,7 +71,7 @@
 					set_mode(CLAMPED_OFF)
 					user.visible_message( \
 						"[user] attaches \the [src] to the cable.", \
-						"<span class='notice'>You attach \the [src] to the cable.</span>",
+						"<span class='notice'>You wrench \the [src] into the cable.</span>",
 						"<span class='italics'>You hear some wires being connected to something.</span>")
 			else
 				to_chat(user, "<span class='warning'>This device must be placed over an exposed, powered cable node!</span>")
@@ -79,8 +79,13 @@
 			set_mode(DISCONNECTED)
 			user.visible_message( \
 				"[user] detaches \the [src] from the cable.", \
-				"<span class='notice'>You detach \the [src] from the cable.</span>",
+				"<span class='notice'>You unwrench \the [src] from the cable.</span>",
 				"<span class='italics'>You hear some wires being disconnected from something.</span>")
+
+	else if(I.tool_behaviour == TOOL_SCREWDRIVER)
+		user.visible_message( \
+			"[user] messes with \the [src] for a bit.", \
+			"<span class='notice'>You can't fit the screwdriver into \the [src]'s bolts! Try using a wrench.</span>")
 	else
 		return ..()
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -71,7 +71,7 @@
 					set_mode(CLAMPED_OFF)
 					user.visible_message( \
 						"[user] attaches \the [src] to the cable.", \
-						"<span class='notice'>You wrench \the [src] into the cable.</span>",
+						"<span class='notice'>You bolt \the [src] into the floor and connect it to the cable.</span>",
 						"<span class='italics'>You hear some wires being connected to something.</span>")
 			else
 				to_chat(user, "<span class='warning'>This device must be placed over an exposed, powered cable node!</span>")
@@ -79,7 +79,7 @@
 			set_mode(DISCONNECTED)
 			user.visible_message( \
 				"[user] detaches \the [src] from the cable.", \
-				"<span class='notice'>You unwrench \the [src] from the cable.</span>",
+				"<span class='notice'>You unbolt \the [src] from the floor and detach it from the cable.</span>",
 				"<span class='italics'>You hear some wires being disconnected from something.</span>")
 
 	else if(I.tool_behaviour == TOOL_SCREWDRIVER)


### PR DESCRIPTION
## About The Pull Request

see title
also it gives a message when trying to screwdriver it
update: ominous beacons too

## Why It's Good For The Game

Unsnowflakes the power sink from basically every other thing that can be affixed to the ground. Bolting it down makes more sense than screwing it in.

## Changelog
:cl:
tweak: power sink and ominous beacon now wrenchable, not screwdriverable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
