### PR TITLE
Fixes some problems with some virology symptoms

### DIFF
--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -53,7 +53,7 @@ Bonus
 				to_chat(M, "<span class='warning'>[pick("Your head hurts.", "Your mind blanks for a moment.")]</span>")
 		else
 			to_chat(M, "<span class='userdanger'>You can't think straight!</span>")
-			M.confused = min(100, M.confused + (16 * power))
+			M.confused = CLAMP(M.confused, M.confused + (16 * power), 100)
 			if(brain_damage)
 				M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3 * power, 80)
 				M.updatehealth()

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -55,7 +55,7 @@ Bonus
 			to_chat(M, "<span class='userdanger'>You can't think straight!</span>")
 			M.confused = min(100, M.confused + (16 * power))
 			if(brain_damage)
-				M.adjustOrganLoss(ORGAN_SLOT_BRAIN,3 * power, 80)
+				M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3 * power, 80)
 				M.updatehealth()
 
 	return

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -57,5 +57,4 @@ Bonus
 			if(brain_damage)
 				M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3 * power, 80)
 				M.updatehealth()
-
 	return

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -30,7 +30,7 @@ Bonus
 	symptom_delay_max = 30
 	var/brain_damage = FALSE
 	threshold_desc = "<b>Resistance 6:</b> Causes brain damage over time.<br>\
-					  <b>Transmission 6:</b> Increases confusion duration.<br>\
+					  <b>Transmission 6:</b> Increases confusion duration and strength.<br>\
 					  <b>Stealth 4:</b> The symptom remains hidden until active."
 
 /datum/symptom/confusion/Start(datum/disease/advance/A)
@@ -53,7 +53,7 @@ Bonus
 				to_chat(M, "<span class='warning'>[pick("Your head hurts.", "Your mind blanks for a moment.")]</span>")
 		else
 			to_chat(M, "<span class='userdanger'>You can't think straight!</span>")
-			M.confused = min(100 * power, M.confused + 8)
+			M.confused = min(100, M.confused + (16 * power))
 			if(brain_damage)
 				M.adjustOrganLoss(ORGAN_SLOT_BRAIN,3 * power, 80)
 				M.updatehealth()

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -48,6 +48,6 @@ Bonus
 				to_chat(M, "<span class='warning'>[pick("You feel dizzy.", "Your head spins.")]</span>")
 		else
 			to_chat(M, "<span class='userdanger'>A wave of dizziness washes over you!</span>")
-			M.dizziness = min(M.dizziness + 30, 100)
+			M.dizziness = CLAMP(M.dizziness, M.dizziness + 30, 100)
 			if(power >= 2)
 				M.set_drugginess(40)

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -50,4 +50,4 @@ Bonus
 			to_chat(M, "<span class='userdanger'>A wave of dizziness washes over you!</span>")
 			M.dizziness = min(L.dizziness + 30, 100)
 			if(power >= 2)
-				M.set_drugginess(30)
+				M.set_drugginess(40)

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -26,7 +26,7 @@ Bonus
 	severity = 2
 	base_message_chance = 50
 	symptom_delay_min = 15
-	symptom_delay_max = 40
+	symptom_delay_max = 30
 	threshold_desc = "<b>Transmission 6:</b> Also causes druggy vision.<br>\
 					  <b>Stealth 4:</b> The symptom remains hidden until active."
 
@@ -48,6 +48,6 @@ Bonus
 				to_chat(M, "<span class='warning'>[pick("You feel dizzy.", "Your head spins.")]</span>")
 		else
 			to_chat(M, "<span class='userdanger'>A wave of dizziness washes over you!</span>")
-			M.Dizzy(5)
+			M.dizziness = min(L.dizziness + 30, 100)
 			if(power >= 2)
-				M.set_drugginess(5)
+				M.set_drugginess(30)

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -48,6 +48,6 @@ Bonus
 				to_chat(M, "<span class='warning'>[pick("You feel dizzy.", "Your head spins.")]</span>")
 		else
 			to_chat(M, "<span class='userdanger'>A wave of dizziness washes over you!</span>")
-			M.dizziness = min(L.dizziness + 30, 100)
+			M.dizziness = min(M.dizziness + 30, 100)
 			if(power >= 2)
 				M.set_drugginess(40)

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -29,7 +29,7 @@ Bonus
 	symptom_delay_max = 90
 	var/fake_healthy = FALSE
 	threshold_desc = "<b>Stage Speed 7:</b> Increases the amount of hallucinations.<br>\
-					  <b>Stealth 4:</b> The virus mimics positive symptoms.."
+					  <b>Stealth 4:</b> The virus mimics positive symptoms."
 
 /datum/symptom/hallucigen/Start(datum/disease/advance/A)
 	if(!..())
@@ -61,5 +61,8 @@ Bonus
 					to_chat(M, "<span class='notice'>[pick(healthy_messages)]</span>")
 		else
 			if(prob(base_message_chance))
-				to_chat(M, "<span class='userdanger'>[pick("Oh, your head...", "Your head pounds.", "They're everywhere! Run!", "Something in the shadows...")]</span>")
+				if(!fake_healthy)
+					to_chat(M, "<span class='userdanger'>[pick("Oh, your head...", "Your head pounds.", "They're everywhere! Run!", "Something in the shadows...")]</span>")
+				else
+					to_chat(M, "<span class='notice'>[pick(healthy_messages)]</span>")
 			M.hallucination += (45 * power)

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -60,7 +60,7 @@ Bonus
 		if(5)
 			if(prob(50))
 				to_chat(M, "<span class='warning'>[pick("So tired...","You feel very sleepy.","You have a hard time keeping your eyes open.","You try to stay awake.")]</span>")
-			M.drowsyness = min(M.drowsyness + 40, 70)
+			M.drowsyness = CLAMP(M.drowsyness, M.drowsyness + 40, 70)
 			if(yawning)
 				M.emote("yawn")
 				if(M.CanSpreadAirborneDisease())

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -24,15 +24,15 @@ Bonus
 	symptom_delay_max = 70
 	severity = 4
 	var/yawning = FALSE
-	threshold_desc = "<b>Transmission 7:</b> Causes the host to periodically emit a yawn that spreads the virus in a manner similar to that of a sneeze.<br>\
-					  <b>Resistance 10:</b> Causes narcolepsy more often, increasing the chance of the host falling asleep."
+	threshold_desc = "<b>Transmission 4:</b> Causes the host to periodically emit a yawn that spreads the virus in a manner similar to that of a sneeze.<br>\
+					  <b>Stage Speed 7:</b> Causes narcolepsy more often, increasing the chance of the host falling asleep."
 
 /datum/symptom/narcolepsy/Start(datum/disease/advance/A)
 	if(!..())
 		return
-	if(A.properties["transmittable"] >= 7) //yawning (mostly just some copy+pasted code from sneezing, with a few tweaks)
+	if(A.properties["transmittable"] >= 4) //yawning (mostly just some copy+pasted code from sneezing, with a few tweaks)
 		yawning = TRUE
-	if(A.properties["resistance"] >= 10) //act more often
+	if(A.properties["stage_speed"] >= 7) //act more often
 		symptom_delay_min = 20
 		symptom_delay_max = 45
 

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -24,7 +24,7 @@ Bonus
 	symptom_delay_max = 70
 	severity = 4
 	var/yawning = FALSE
-	threshold_desc = "<b>Transmission 7:</b> Causes the host to yawn, spreading the virus in a manner similar to that of a sneeze.<br>\
+	threshold_desc = "<b>Transmission 7:</b> Causes the host to occasionally emit a yawn that spreads the virus in a manner similar to that of a sneeze.<br>\
 					  <b>Resistance 10:</b> Causes narcolepsy more often, increasing the chance of the host falling asleep."
 
 /datum/symptom/narcolepsy/Start(datum/disease/advance/A)
@@ -54,14 +54,14 @@ Bonus
 				to_chat(M, "<span class='warning'>You nod off for a moment.</span>")
 			M.drowsyness += 10
 			if(yawning)
-				M.emote("sneeze")
+				M.emote("yawn")
 				if(M.CanSpreadAirborneDisease())
-					A.spread(4)
+					A.spread(6)
 		if(5)
 			if(prob(50))
 				to_chat(M, "<span class='warning'>[pick("So tired...","You feel very sleepy.","You have a hard time keeping your eyes open.","You try to stay awake.")]</span>")
 			M.drowsyness = min(M.drowsyness + 40, 200)
 			if(yawning)
-				M.emote("sneeze")
+				M.emote("yawn")
 				if(M.CanSpreadAirborneDisease())
-					A.spread(4)
+					A.spread(6)

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -24,7 +24,7 @@ Bonus
 	symptom_delay_max = 70
 	severity = 4
 	var/yawning = FALSE
-	threshold_desc = "<b>Transmission 7:</b> Causes the host to occasionally emit a yawn that spreads the virus in a manner similar to that of a sneeze.<br>\
+	threshold_desc = "<b>Transmission 7:</b> Causes the host to periodically emit a yawn that spreads the virus in a manner similar to that of a sneeze.<br>\
 					  <b>Resistance 10:</b> Causes narcolepsy more often, increasing the chance of the host falling asleep."
 
 /datum/symptom/narcolepsy/Start(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -18,20 +18,20 @@ Bonus
 	stealth = -1
 	resistance = -2
 	stage_speed = -3
-	transmittable = -4
+	transmittable = 0
 	level = 6
 	symptom_delay_min = 25
 	symptom_delay_max = 70
 	severity = 4
-	var/stamina = FALSE
-	threshold_desc = "<b>Transmission 7:</b> Also relaxes the muscles, weakening and slowing the host.<br>\
+	var/yawning = FALSE
+	threshold_desc = "<b>Transmission 7:</b> Causes the host to yawn, spreading the virus in a manner similar to that of a sneeze.<br>\
 					  <b>Resistance 10:</b> Causes narcolepsy more often, increasing the chance of the host falling asleep."
 
 /datum/symptom/narcolepsy/Start(datum/disease/advance/A)
 	if(!..())
 		return
-	if(A.properties["transmittable"] >= 7) //stamina damage
-		stamina = TRUE
+	if(A.properties["transmittable"] >= 7) //yawning (mostly just some copy+pasted code from sneezing, with a few tweaks)
+		yawning = TRUE
 	if(A.properties["resistance"] >= 10) //act more often
 		symptom_delay_min = 20
 		symptom_delay_max = 45
@@ -53,11 +53,15 @@ Bonus
 			if(prob(50))
 				to_chat(M, "<span class='warning'>You nod off for a moment.</span>")
 			M.drowsyness += 10
-			if(stamina)
-				M.adjustStaminaLoss(20)
+			if(yawning)
+				M.emote("sneeze")
+				if(M.CanSpreadAirborneDisease())
+					A.spread(4)
 		if(5)
 			if(prob(50))
 				to_chat(M, "<span class='warning'>[pick("So tired...","You feel very sleepy.","You have a hard time keeping your eyes open.","You try to stay awake.")]</span>")
 			M.drowsyness = min(M.drowsyness + 40, 200)
-			if(stamina)
-				M.adjustStaminaLoss(30)
+			if(yawning)
+				M.emote("sneeze")
+				if(M.CanSpreadAirborneDisease())
+					A.spread(4)

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -20,19 +20,19 @@ Bonus
 	stage_speed = -3
 	transmittable = 0
 	level = 6
-	symptom_delay_min = 25
-	symptom_delay_max = 70
+	symptom_delay_min = 30
+	symptom_delay_max = 85
 	severity = 4
 	var/yawning = FALSE
 	threshold_desc = "<b>Transmission 4:</b> Causes the host to periodically emit a yawn that spreads the virus in a manner similar to that of a sneeze.<br>\
-					  <b>Stage Speed 7:</b> Causes narcolepsy more often, increasing the chance of the host falling asleep."
+					  <b>Stage Speed 10:</b> Causes narcolepsy more often, increasing the chance of the host falling asleep."
 
 /datum/symptom/narcolepsy/Start(datum/disease/advance/A)
 	if(!..())
 		return
 	if(A.properties["transmittable"] >= 4) //yawning (mostly just some copy+pasted code from sneezing, with a few tweaks)
 		yawning = TRUE
-	if(A.properties["stage_speed"] >= 7) //act more often
+	if(A.properties["stage_speed"] >= 10) //act more often
 		symptom_delay_min = 20
 		symptom_delay_max = 45
 

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -20,11 +20,9 @@ Bonus
 	stage_speed = -3
 	transmittable = -4
 	level = 6
-	symptom_delay_min = 15
-	symptom_delay_max = 80
+	symptom_delay_min = 25
+	symptom_delay_max = 70
 	severity = 4
-	var/sleep_level = 0
-	var/sleepy_ticks = 0
 	var/stamina = FALSE
 	threshold_desc = "<b>Transmission 7:</b> Also relaxes the muscles, weakening and slowing the host.<br>\
 					  <b>Resistance 10:</b> Causes narcolepsy more often, increasing the chance of the host falling asleep."
@@ -35,59 +33,31 @@ Bonus
 	if(A.properties["transmittable"] >= 7) //stamina damage
 		stamina = TRUE
 	if(A.properties["resistance"] >= 10) //act more often
-		symptom_delay_min = 10
-		symptom_delay_max = 60
+		symptom_delay_min = 20
+		symptom_delay_max = 45
 
 /datum/symptom/narcolepsy/Activate(var/datum/disease/advance/A)
 	var/mob/living/M = A.affected_mob
-	//this ticks even when on cooldown
-	switch(sleep_level) //Works sorta like morphine
-		if(10 to 19)
-			M.drowsyness += 1
-		if(20 to INFINITY)
-			M.Sleeping(30, 0)
-			sleep_level = 0
-			sleepy_ticks = 0
-
-	if(sleepy_ticks && A.stage>=5)
-		sleep_level++
-		sleepy_ticks--
-	else
-		sleep_level = 0
-
-	if(!..())
-		return
-
 	switch(A.stage)
 		if(1)
-			if(prob(10))
+			if(prob(50))
 				to_chat(M, "<span class='warning'>You feel tired.</span>")
 		if(2)
-			if(prob(10))
+			if(prob(50))
 				to_chat(M, "<span class='warning'>You feel very tired.</span>")
-				sleepy_ticks += rand(10,14)
-				if(stamina)
-					M.adjustStaminaLoss(10)
 		if(3)
-			if(prob(15))
+			if(prob(50))
 				to_chat(M, "<span class='warning'>You try to focus on staying awake.</span>")
-				sleepy_ticks += rand(10,14)
-				if(stamina)
-					M.adjustStaminaLoss(15)
+			M.drowsyness += 5
 		if(4)
-			if(prob(20))
+			if(prob(50))
 				to_chat(M, "<span class='warning'>You nod off for a moment.</span>")
-				sleepy_ticks += rand(10,14)
-				if(stamina)
-					M.adjustStaminaLoss(20)
+			M.drowsyness += 10
+			if(stamina)
+				M.adjustStaminaLoss(20)
 		if(5)
-			if(prob(25))
+			if(prob(50))
 				to_chat(M, "<span class='warning'>[pick("So tired...","You feel very sleepy.","You have a hard time keeping your eyes open.","You try to stay awake.")]</span>")
-				M.drowsyness = max(M.drowsyness, 2)
-				sleepy_ticks += rand(10,14)
-				if(stamina)
-					M.adjustStaminaLoss(30)
-
-
-
-
+			M.drowsyness = min(M.drowsyness + 40, 200)
+			if(stamina)
+				M.adjustStaminaLoss(30)

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -60,7 +60,7 @@ Bonus
 		if(5)
 			if(prob(50))
 				to_chat(M, "<span class='warning'>[pick("So tired...","You feel very sleepy.","You have a hard time keeping your eyes open.","You try to stay awake.")]</span>")
-			M.drowsyness = min(M.drowsyness + 40, 200)
+			M.drowsyness = min(M.drowsyness + 40, 70)
 			if(yawning)
 				M.emote("yawn")
 				if(M.CanSpreadAirborneDisease())

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -312,12 +312,6 @@
 	message = "sneezes."
 	emote_type = EMOTE_AUDIBLE
 
-/datum/emote/living/yawn
-	key = "yawn"
-	key_third_person = "yawns"
-	message = "yawns."
-	emote_type = EMOTE_AUDIBLE
-
 /datum/emote/living/smug
 	key = "smug"
 	key_third_person = "smugs"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -312,6 +312,12 @@
 	message = "sneezes."
 	emote_type = EMOTE_AUDIBLE
 
+/datum/emote/living/yawn
+	key = "yawn"
+	key_third_person = "yawns"
+	message = "yawns."
+	emote_type = EMOTE_AUDIBLE
+
 /datum/emote/living/smug
 	key = "smug"
 	key_third_person = "smugs"


### PR DESCRIPTION
## About The Pull Request

17 days ago, I made this PR: https://github.com/tgstation/tgstation/pull/45741.

15 days ago, I made my last comment in that PR (before cobby posted in it, at least).

3 days ago, cobby reviewed my PR, suggesting that I make sure that the symptoms won't make people who are EXTREMELY confused, dizzy, etc. LESS confused, dizzy, etc. I received no pings or other notifications that he had reviewed my PR.

2 days ago, oranges closed my PR for being "stale", which prevented any of my future changes to the virologypatch branch that I had made from showing up in my PR's "Files changed" section.

This PR is literally just my previous PR, but with CLAMPs used instead of mins (which should fix the issue that cobby asked me to fix/deal with).

If you want to see a proper "About The Pull Request" section about/for this PR, go see the one in https://github.com/tgstation/tgstation/pull/45741.

## Why It's Good For The Game

If you want to see a proper "Why It's Good For The Game" section about/for this PR, go see the one in https://github.com/tgstation/tgstation/pull/45741.


## Changelog
:cl: ATHATH
tweak: The confusion symptom now noticeably confuses you.
tweak: The confusion symptom's transmission 6 threshold effect now actually affects how much the symptom increases your confused value by (instead of affecting the cap that the symptom can bring it to, which is plenty high enough by default).
tweak: The dizziness symptom now actually makes you noticeably dizzy (and has a cap for how dizzy it can make you).
tweak: The dizziness symptom's transmission 6 threshold effect now makes your screen look "druggy" all of the time (only once its virus reaches a high enough stage, of course), instead of only occasionally.
tweak: The hallucigen symptom's stealth 4 threshold effect now continues to give you positive messages instead of bad ones at stage 5. Before this tweak, meeting that stealth threshold would actually cause bad messages to appear MORE often at stage 5 than if you hadn't met it.
tweak: Pretty much completely reworked the narcolepsy symptom so that it now uses the "drowsyness" (yes, that's how it's spelled in the code; no, I don't know why it's misspelled like that in the code) status effect instead of a confusing mess of ticking counters that rarely actually put you to sleep.
tweak: The narcolepsy symptom's transmission 7 threshold effect now only requires transmission 4 no longer causes its virus to occasionally deal negligible amounts of stamina damage. Instead, it now causes the host to periodically yawn, spreading its virus whenever they do so.
tweak: The narcolepsy symptom's resistance 10 threshold effect is now a stage speed 10 threshold effect.
tweak: The narcolepsy symptom's activation frequencies have been tweaked a bit to make the symptom less threatening (albeit still quite potent) without its stage speed 10 (formerly a resistance 10) threshold effect.
balance: The nacrolepsy symptom now adds 0 to its virus's transmission stat (upped from -4).
fix: Fixed a bug that could cause the confusion symptom to lower your confusion value if you had a high confusion value when it activated.
/:cl: