### PR TITLE
Thermite can burn reinforced again.

### DIFF
--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -27,14 +27,12 @@
 
 	if(immunelist[parent.type])
 		amount = 0 //Yeah the overlay can still go on it and be cleaned but you arent burning down a diamond wall
-		return
-	amount = _amount
-	if(resistlist[parent.type])
-		burn_require = 50
-		return
-	burn_require = 30
-
-
+	else
+		amount = _amount
+		if(resistlist[parent.type])
+			burn_require = 50
+		else
+			burn_require = 30
 
 	var/turf/master = parent
 	overlay = mutable_appearance('icons/effects/effects.dmi', "thermite")


### PR DESCRIPTION
## About The Pull Request

Thermite can burn reinforced walls again. Immune walls get the overlay once more.

## Why It's Good For The Game

Actually properly testing and proof reading code has its advantages.

## Changelog
:cl:
fix: Fixes thermite on reinforced and immune wall types.
/:cl:
