### PR TITLE
Makes the Mutate spell less annoying to use

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -179,6 +179,7 @@
 /datum/spellbook_entry/mutate
 	name = "Mutate"
 	spell_type = /obj/effect/proc_holder/spell/targeted/genetic/mutate
+	cost = 1
 
 /datum/spellbook_entry/jaunt
 	name = "Ethereal Jaunt"

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -179,7 +179,6 @@
 /datum/spellbook_entry/mutate
 	name = "Mutate"
 	spell_type = /obj/effect/proc_holder/spell/targeted/genetic/mutate
-	cost = 1
 
 /datum/spellbook_entry/jaunt
 	name = "Ethereal Jaunt"

--- a/code/modules/spells/spell_types/genetic.dm
+++ b/code/modules/spells/spell_types/genetic.dm
@@ -28,7 +28,8 @@
 		for(var/A in traits)
 			ADD_TRAIT(target, A, GENETICS_SPELL)
 		active_on += target
-		addtimer(CALLBACK(src, .proc/remove, target), duration)
+		if(duration < charge_max)
+			addtimer(CALLBACK(src, .proc/remove, target), duration)
 
 /obj/effect/proc_holder/spell/targeted/genetic/Destroy()
 	. = ..()

--- a/code/modules/spells/spell_types/genetic.dm
+++ b/code/modules/spells/spell_types/genetic.dm
@@ -29,7 +29,7 @@
 			ADD_TRAIT(target, A, GENETICS_SPELL)
 		active_on += target
 		if(duration < charge_max)
-			addtimer(CALLBACK(src, .proc/remove, target), duration)
+			addtimer(CALLBACK(src, .proc/remove, target), duration, TIMER_OVERRIDE|TIMER_UNIQUE)
 
 /obj/effect/proc_holder/spell/targeted/genetic/Destroy()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This PR makes it so that if you cast the mutate spell (or another "genetic" spell (no, the ones that come from genetic powers don't fall into this category)) when the spell's charge_max value (its cooldown length) is less than or equal to the spell's duration, the effects of the spell will be permanent (until you lose/refund the mutate spell, of course). This means that you won't have to keep recasting it every 30 seconds to keep your buffs.

## Why It's Good For The Game

Less pointless clicking is good.

## Changelog
:cl: ATHATH
balance: The Mutate spell's effects are now permanent (until/unless you forget or otherwise lose the spell) if you purchase it five times.
/:cl: