### PR TITLE
syndicate shielded hardsuit now has a red shield by default

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -800,7 +800,6 @@
 		shield_state = "shield-old"
 		shield_on = "shield-old"
 		to_chat(user, "<span class='warning'>You roll back the hardsuit's software, changing the shield's color!</span>")
-		user.update_inv_wear_suit()
 
 	else
 		shield_state = "shield-red"

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -790,6 +790,22 @@
 	shield_state = "shield-red"
 	shield_on = "shield-red"
 
+/obj/item/clothing/suit/space/hardsuit/shielded/syndi/attackby(obj/item/W, mob/living/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(shield_state == "shield-red")
+			shield_state = "shield-old"
+			shield_on = "shield-old"
+			to_chat(user, "<span class='warning'>You roll back the hardsuit's software, changing the shield's color!</span>")
+			user.update_inv_wear_suit()
+
+		else
+			shield_state = "shield-red"
+			shield_on = "shield-red"
+			to_chat(user, "<span class='warning'>You update the hardsuit's hardware, changing back the shield's color to red.</span>")
+			user.update_inv_wear_suit()
+
+	else
+		return ..()
 
 /obj/item/clothing/suit/space/hardsuit/shielded/syndi/Initialize()
 	jetpack = new /obj/item/tank/jetpack/suit(src)

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -787,6 +787,8 @@
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/transforming/energy/sword/saber, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/shielded/syndi
 	slowdown = 0
+	shield_state = "shield-red"
+	shield_on = "shield-red"
 
 
 /obj/item/clothing/suit/space/hardsuit/shielded/syndi/Initialize()

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -790,22 +790,23 @@
 	shield_state = "shield-red"
 	shield_on = "shield-red"
 
-/obj/item/clothing/suit/space/hardsuit/shielded/syndi/attackby(obj/item/W, mob/living/user, params)
-	if(W.tool_behaviour == TOOL_MULTITOOL)
-		if(shield_state == "shield-red")
-			shield_state = "shield-old"
-			shield_on = "shield-old"
-			to_chat(user, "<span class='warning'>You roll back the hardsuit's software, changing the shield's color!</span>")
-			user.update_inv_wear_suit()
-
-		else
-			shield_state = "shield-red"
-			shield_on = "shield-red"
-			to_chat(user, "<span class='warning'>You update the hardsuit's hardware, changing back the shield's color to red.</span>")
-			user.update_inv_wear_suit()
+/obj/item/clothing/suit/space/hardsuit/shielded/syndi/multitool_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(shield_state == "broken")
+		to_chat(user, "<span class='warning'>You can't interface with the hardsuit's software if the shield's broken!</span>")
+		return
+	
+	if(shield_state == "shield-red")
+		shield_state = "shield-old"
+		shield_on = "shield-old"
+		to_chat(user, "<span class='warning'>You roll back the hardsuit's software, changing the shield's color!</span>")
+		user.update_inv_wear_suit()
 
 	else
-		return ..()
+		shield_state = "shield-red"
+		shield_on = "shield-red"
+		to_chat(user, "<span class='warning'>You update the hardsuit's hardware, changing back the shield's color to red.</span>")
+	user.update_inv_wear_suit()
 
 /obj/item/clothing/suit/space/hardsuit/shielded/syndi/Initialize()
 	jetpack = new /obj/item/tank/jetpack/suit(src)


### PR DESCRIPTION
## About The Pull Request

title
i'd have changed the color of the helmet light too if the shading wasn't a pain to work with
u can also now swap it to blue and back with a multitool

## Why It's Good For The Game

syndicates are red not blue!

## Changelog
:cl:
tweak: syndicate shielded hardsuit's blue shield has been replaced with a red one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
