### PR TITLE
Tweaks the yuck chem

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -180,10 +180,10 @@
 		var/datum/reagent/the_reagent = r
 		if(istype(the_reagent, /datum/reagent/medicine))
 			medibonus += 1
-	M.adjustToxLoss(0.5 * medibonus)
-	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, sqrt(medibonus))
+	M.adjustToxLoss(0.5 * sqrt(medibonus))
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, 1)
 	for(var/datum/reagent/R in M.reagents.reagent_list)
-		M.reagents.remove_reagent(R.type, medibonus*0.5)
+		M.reagents.remove_reagent(R.type, 0.5)
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -180,7 +180,7 @@
 		var/datum/reagent/the_reagent = r
 		if(istype(the_reagent, /datum/reagent/medicine))
 			medibonus += 1
-	M.adjustToxLoss(0.5 * sqrt(medibonus))
+	M.adjustToxLoss(0.5 * FLOOR(sqrt(medibonus*2),1))
 	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, 1)
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		M.reagents.remove_reagent(R.type, 0.5)

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -180,7 +180,7 @@
 		var/datum/reagent/the_reagent = r
 		if(istype(the_reagent, /datum/reagent/medicine))
 			medibonus += 1
-	M.adjustToxLoss(0.5 * FLOOR(sqrt(medibonus*2),1))
+	M.adjustToxLoss(-0.5 * FLOOR(sqrt(medibonus*2),1))
 	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, 1)
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		M.reagents.remove_reagent(R.type, 0.5)

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -180,10 +180,10 @@
 		var/datum/reagent/the_reagent = r
 		if(istype(the_reagent, /datum/reagent/medicine))
 			medibonus += 1
-	M.adjustToxLoss(-0.5 * FLOOR(sqrt(medibonus*2),1))
-	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, 1)
+	M.adjustToxLoss(-0.5 * medibonus)
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, medibonus)
 	for(var/datum/reagent/R in M.reagents.reagent_list)
-		M.reagents.remove_reagent(R.type, 0.5)
+		M.reagents.remove_reagent(R.type, medibonus*0.5)
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -181,7 +181,7 @@
 		if(istype(the_reagent, /datum/reagent/medicine))
 			medibonus += 1
 	M.adjustToxLoss(0.5 * medibonus)
-	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, medibonus)
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, sqrt(medibonus))
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		M.reagents.remove_reagent(R.type, medibonus*0.5)
 	..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1772,7 +1772,8 @@
 	else
 		var/yuck_cycles = current_cycle - yuck_cycle
 		if(yuck_cycles % YUCK_PUKE_CYCLES == 0)
-			holder.remove_reagent(type, 5)
+			if(yuck_cycles >= YUCK_PUKE_CYCLES * YUCK_PUKES_TO_STUN)
+				holder.remove_reagent(type, 5)
 			C.vomit(rand(14, 26), stun = yuck_cycles >= YUCK_PUKE_CYCLES * YUCK_PUKES_TO_STUN)
 	if(holder)
 		return ..()


### PR DESCRIPTION
## About The Pull Request

This PR makes the following alteration to the yuck chem:
The yuck chem (that one that you make by dipping a dead mouse in welding fuel) no longer purges itself when it makes you vomit until your vomiting starts to stun you. This should make the chem much more viable to actually be used, since it'd normally make you vomit maybe once or twice before purging itself from your system completely unless you used really large doses of it. Now, you should usually get at least to the stun vomiting stage before the chem begins to purge itself (which may be a buff or a nerf to the chem, depending on how you look at it).


## Why It's Good For The Game

The yuck chem alteration makes it more viable to use in non-massive, non-tiny doses, which I think is appropriate for a "ghetto chem".

## Changelog
:cl: ATHATH
balance: The "yuck" chem now only starts to purge itself once you start stun-vomiting.
/:cl: