### PR TITLE
Fixes piping sprite/layers

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -18,6 +18,7 @@
 	var/mutable_appearance/center
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/New()
+	icon_state = ""
 	center = mutable_appearance(icon, "manifold_center")
 	return ..()
 

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
@@ -17,6 +17,7 @@
 	var/mutable_appearance/center
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/New()
+	icon_state = ""
 	center = mutable_appearance(icon, "manifold4w_center")
 	return ..()
 

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -2,7 +2,7 @@
 
 /obj/machinery/atmospherics/pipe/manifold
 	icon = 'icons/obj/atmospherics/pipes/manifold.dmi'
-	icon_state = "manifold-2"
+	icon_state = ""
 
 	name = "pipe manifold"
 	desc = "A manifold composed of regular pipes."

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -2,7 +2,7 @@
 
 /obj/machinery/atmospherics/pipe/manifold
 	icon = 'icons/obj/atmospherics/pipes/manifold.dmi'
-	icon_state = ""
+	icon_state = "manifold-2"
 
 	name = "pipe manifold"
 	desc = "A manifold composed of regular pipes."
@@ -22,6 +22,7 @@
  * This is true for the other manifolds (the 4 ways and the heat exchanges) too.
  */
 /obj/machinery/atmospherics/pipe/manifold/New()
+	icon_state = ""
 	center = mutable_appearance(icon, "manifold_center")
 	return ..()
 

--- a/code/modules/atmospherics/machinery/pipes/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold4w.dm
@@ -2,7 +2,7 @@
 
 /obj/machinery/atmospherics/pipe/manifold4w
 	icon = 'icons/obj/atmospherics/pipes/manifold.dmi'
-	icon_state = "manifold4w-2"
+	icon_state = ""
 
 	name = "4-way pipe manifold"
 	desc = "A manifold composed of regular pipes."

--- a/code/modules/atmospherics/machinery/pipes/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold4w.dm
@@ -2,7 +2,7 @@
 
 /obj/machinery/atmospherics/pipe/manifold4w
 	icon = 'icons/obj/atmospherics/pipes/manifold.dmi'
-	icon_state = ""
+	icon_state = "manifold4w-2"
 
 	name = "4-way pipe manifold"
 	desc = "A manifold composed of regular pipes."
@@ -17,6 +17,7 @@
 	var/mutable_appearance/center
 
 /obj/machinery/atmospherics/pipe/manifold4w/New()
+	icon_state = ""
 	center = mutable_appearance(icon, "manifold4w_center")
 	return ..()
 

--- a/code/modules/atmospherics/machinery/pipes/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple.dm
@@ -3,7 +3,7 @@
 
 /obj/machinery/atmospherics/pipe/simple
 	icon = 'icons/obj/atmospherics/pipes/simple.dmi'
-	icon_state = ""
+	icon_state = "pipe11-2"
 
 	name = "pipe"
 	desc = "A one meter section of regular pipe."

--- a/code/modules/atmospherics/machinery/pipes/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple.dm
@@ -3,7 +3,7 @@
 
 /obj/machinery/atmospherics/pipe/simple
 	icon = 'icons/obj/atmospherics/pipes/simple.dmi'
-	icon_state = "pipe11-2"
+	icon_state = ""
 
 	name = "pipe"
 	desc = "A one meter section of regular pipe."


### PR DESCRIPTION
### About The Pull Request

Fixes the spriting bug where _someone_ added icon states not knowing they're assigned afterwards
This was caused by #45390 

## Why It's Good For The Game

when piping the pipes no longer look like they're connected or different layers don't show another fake pipe.

## Changelog
:cl:
fix: Fixes pipe sprite issues with layering
/:cl:
