### PR TITLE
Adds orange hardhats to the engidrobe

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -84,7 +84,9 @@
 					/obj/item/clothing/suit/hazardvest = 3,
 					/obj/item/clothing/shoes/workboots = 3,
 					/obj/item/clothing/head/hardhat = 3,
-					/obj/item/clothing/head/hardhat/weldhat = 3)
+					/obj/item/clothing/head/hardhat/weldhat = 3,
+					/obj/item/clothing/head/hardhat/orange = 3,
+					/obj/item/clothing/head/hardhat/weldhat/orange = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/engi_wardrobe
 	payment_department = ACCOUNT_ENG
 /obj/item/vending_refill/wardrobe/engi_wardrobe


### PR DESCRIPTION
## About The Pull Request

This PR adds 3 orange hardhats and 3 orange welding hardhats to the EngiDrobe.

(This is my first PR so let me know if I fucked something up.)

## Why It's Good For The Game

Engineers already have an orange outfit, but no matching hardhat. The orange hats already exist in the game, so why not give them to engineers?

## Changelog
:cl: Bumtickley00
add: The engidrobe now has orange hardhats.
/:cl: