### PR TITLE
Adds a tuberculosis vaccine.

### DIFF
--- a/code/datums/diseases/tuberculosis.dm
+++ b/code/datums/diseases/tuberculosis.dm
@@ -3,7 +3,7 @@
 	name = "Fungal tuberculosis"
 	max_stages = 5
 	spread_text = "Airborne"
-	cure_text = "Spaceacillin & Perfluorodecalin"
+	cure_text = "Spaceacillin & Convermol"
 	cures = list(/datum/reagent/medicine/spaceacillin, /datum/reagent/medicine/C2/convermol)
 	agent = "Fungal Tubercle bacillus Cosmosis"
 	viable_mobtypes = list(/mob/living/carbon/human)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -106,6 +106,18 @@
 	if(istype(data))
 		src.data |= data.Copy()
 
+/datum/reagent/vaccine/fungal_tb
+
+/datum/reagent/vaccine/fungal_tb/New(data)
+	. = ..()
+	var/list/cached_data
+	if(!data)
+		cached_data = list()
+	else
+		cached_data = data
+	cached_data |= "[/datum/disease/tuberculosis]"
+	src.data = cached_data
+
 /datum/reagent/water
 	name = "Water"
 	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen."

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -307,7 +307,7 @@
 /obj/item/reagent_containers/glass/bottle/tuberculosiscure
 	name = "BVAK bottle"
 	desc = "A small bottle containing Bio Virus Antidote Kit."
-	list_reagents = list(/datum/reagent/medicine/atropine = 5, /datum/reagent/medicine/epinephrine = 5, /datum/reagent/medicine/C2/convermol = 10, /datum/reagent/medicine/spaceacillin = 10)
+	list_reagents = list(/datum/reagent/vaccine/fungal_tb = 30)
 
 //Oldstation.dmm chemical storage bottles
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -200,8 +200,8 @@
 	desc = "Bio Virus Antidote Kit autoinjector. Has a two use system for yourself, and someone else. Inject when infected."
 	icon_state = "tbpen"
 	item_state = "tbpen"
-	volume = 60
-	amount_per_transfer_from_this = 30
+	volume = 20
+	amount_per_transfer_from_this = 10
 	list_reagents = list(/datum/reagent/vaccine/fungal_tb = 20)
 
 /obj/item/reagent_containers/hypospray/medipen/tuberculosiscure/update_icon()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -185,14 +185,14 @@
 	name = "salicyclic acid medipen"
 	desc = "A autoinjector containing salicyclic acid, used to treat severe brute damage."
 	icon_state = "salacid"
-	item_state = "salacid"	
+	item_state = "salacid"
 	list_reagents = list(/datum/reagent/medicine/sal_acid = 10)
 
 /obj/item/reagent_containers/hypospray/medipen/salbutamol
 	name = "salbutamol medipen"
 	desc = "A autoinjector containing salbutamol, used to heal oxygen damage quickly."
 	icon_state = "salpen"
-	item_state = "salpen"	
+	item_state = "salpen"
 	list_reagents = list(/datum/reagent/medicine/salbutamol = 10)
 
 /obj/item/reagent_containers/hypospray/medipen/tuberculosiscure
@@ -202,7 +202,7 @@
 	item_state = "tbpen"
 	volume = 60
 	amount_per_transfer_from_this = 30
-	list_reagents = list(/datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/omnizine = 20, /datum/reagent/medicine/C2/convermol = 15, /datum/reagent/medicine/spaceacillin = 20)
+	list_reagents = list(/datum/reagent/vaccine/fungal_tb = 20)
 
 /obj/item/reagent_containers/hypospray/medipen/tuberculosiscure/update_icon()
 	if(reagents.total_volume > 30)


### PR DESCRIPTION
## About The Pull Request

Replaces the reagents in the TB cures with a proper TB vaccine.

Also updates the fungal TB description.

## Why It's Good For The Game

I think with chems that are pretty dangerous to the user, it is time that this item finally gets this overhaul instead of just injecting more and more omnizine every time someone decides that chems need to murder people.  Fixes #46125

Sure, the code is slightly hacky but as far as I can tell, the current structure for reagent code practically demands this as the solution.

## Changelog
:cl:
balance: Replaced the agent in the BVAK injector with a fungal TB vaccine.
/:cl:
