### PR TITLE
Moves ling code out of click code.

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -149,8 +149,12 @@
 
 // /mob signals
 #define COMSIG_MOB_DEATH "mob_death"							//from base of mob/death(): (gibbed)
+
 #define COMSIG_MOB_CLICKON "mob_clickon"						//from base of mob/clickon(): (atom/A, params)
+#define COMSIG_MOB_MIDDLECLICKON "mob_middleclickon"			//from base of mob/MiddleClickOn(): (atom/A)
+#define COMSIG_MOB_ALTCLICKON "mob_altclickon"				//from base of mob/AltClickOn(): (atom/A)
 	#define COMSIG_MOB_CANCEL_CLICKON 1
+
 #define COMSIG_MOB_ALLOWED "mob_allowed"						//from base of obj/allowed(mob/M): (/obj) returns bool, if TRUE the mob has id access to the obj
 #define COMSIG_MOB_RECEIVE_MAGIC "mob_receive_magic"			//from base of mob/anti_magic_check(): (mob/user, magic, holy, tinfoil, chargecost, self, protection_sources)
 	#define COMPONENT_BLOCK_MAGIC 1

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -281,30 +281,15 @@
 /mob/proc/RestrainedClickOn(atom/A)
 	return
 
-/*
-	Middle click
-	Only used for swapping hands
-*/
+/**
+  *Middle click
+  *Mainly used for swapping hands
+  */
 /mob/proc/MiddleClickOn(atom/A)
-	return
-
-/mob/living/carbon/MiddleClickOn(atom/A)
-	if(!stat && mind && iscarbon(A) && A != src)
-		var/datum/antagonist/changeling/C = mind.has_antag_datum(/datum/antagonist/changeling)
-		if(C && C.chosen_sting)
-			C.chosen_sting.try_to_sting(src,A)
-			next_click = world.time + 5
-			return
+	. = SEND_SIGNAL(src, COMSIG_MOB_MIDDLECLICKON, A)
+	if(. & COMSIG_MOB_CANCEL_CLICKON)
+		return
 	swap_hand()
-
-/mob/living/simple_animal/drone/MiddleClickOn(atom/A)
-	swap_hand()
-
-// In case of use break glass
-/*
-/atom/proc/MiddleClick(mob/M as mob)
-	return
-*/
 
 /*
 	Shift click
@@ -349,17 +334,10 @@
 	Unused except for AI
 */
 /mob/proc/AltClickOn(atom/A)
+	. = SEND_SIGNAL(src, COMSIG_MOB_ALTCLICKON, A)
+	if(. & COMSIG_MOB_CANCEL_CLICKON)
+		return
 	A.AltClick(src)
-	return
-
-/mob/living/carbon/AltClickOn(atom/A)
-	if(!stat && mind && iscarbon(A) && A != src)
-		var/datum/antagonist/changeling/C = mind.has_antag_datum(/datum/antagonist/changeling)
-		if(C && C.chosen_sting)
-			C.chosen_sting.try_to_sting(src,A)
-			next_click = world.time + 5
-			return
-	..()
 
 /atom/proc/AltClick(mob/user)
 	SEND_SIGNAL(src, COMSIG_CLICK_ALT, user)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -87,8 +87,8 @@
 
 //Middle click cycles through selected modules.
 /mob/living/silicon/robot/MiddleClickOn(atom/A)
+	..()
 	cycle_modules()
-	return
 
 //Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks
 // for non-doors/apcs

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -87,7 +87,7 @@
 
 //Middle click cycles through selected modules.
 /mob/living/silicon/robot/MiddleClickOn(atom/A)
-	..()
+	. = ..()
 	cycle_modules()
 
 //Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks

--- a/code/_onclick/overmind.dm
+++ b/code/_onclick/overmind.dm
@@ -20,7 +20,7 @@
 		expand_blob(T)
 
 /mob/camera/blob/MiddleClickOn(atom/A) //Rally spores
-	..()
+	. = ..()
 	var/turf/T = get_turf(A)
 	if(T)
 		rally_spores(T)

--- a/code/_onclick/overmind.dm
+++ b/code/_onclick/overmind.dm
@@ -20,6 +20,7 @@
 		expand_blob(T)
 
 /mob/camera/blob/MiddleClickOn(atom/A) //Rally spores
+	..()
 	var/turf/T = get_turf(A)
 	if(T)
 		rally_spores(T)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -102,6 +102,9 @@
 	remove_changeling_powers()
 	. = ..()
 
+/datum/antagonist/changeling/on_body_transfer(mob/living/old_body, mob/living/new_body)
+	..()
+
 /datum/antagonist/changeling/proc/remove_clownmut()
 	if (owner)
 		var/mob/living/carbon/human/H = owner.current
@@ -149,6 +152,14 @@
 		var/datum/action/changeling/S = power
 		if(istype(S) && S.needs_button)
 			S.Grant(owner.current)
+
+///Handles stinging without verbs.
+/datum/antagonist/changeling/proc/stingAtom(mob/living/carbon/ling, atom/A)
+	if(!chosen_sting || A == ling || !istype(ling) || ling.stat)
+		return
+	chosen_sting.try_to_sting(ling, A)
+	ling.changeNext_move(CLICK_CD_MELEE)
+	return COMSIG_MOB_CANCEL_CLICKON
 
 /datum/antagonist/changeling/proc/has_sting(datum/action/changeling/power)
 	for(var/P in purchasedpowers)
@@ -352,12 +363,12 @@
 		if(B)
 			B.organ_flags &= ~ORGAN_VITAL
 			B.decoy_override = TRUE
+		RegisterSignal(C, list(COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON), .proc/stingAtom)
 	update_changeling_icons_added()
-	return
 
 /datum/antagonist/changeling/remove_innate_effects()
 	update_changeling_icons_removed()
-	return
+	UnregisterSignal(owner.current, list(COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON))
 
 
 /datum/antagonist/changeling/greet()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -102,9 +102,6 @@
 	remove_changeling_powers()
 	. = ..()
 
-/datum/antagonist/changeling/on_body_transfer(mob/living/old_body, mob/living/new_body)
-	..()
-
 /datum/antagonist/changeling/proc/remove_clownmut()
 	if (owner)
 		var/mob/living/carbon/human/H = owner.current


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Every mob with hands can now swap hands with middle click. (huzzah!)
Carbons no longer have a check if they are a ling every time they alt or middle click.

## Why It's Good For The Game

Ling code is just like lings ingame. Complete abominations that make everyone them cry due to their idiotic design.

## Changelog
:cl:
add: All mobs can now switch hands with middle click. This mostly affects gorillas, dexterous stands and monky.
code: Ling sting code has been migrated over to signals.
/:cl:
