### PR TITLE
Lessened the pain of players and medical doctors by buffing some of the worst c2 chemicals to a slightly better state

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -76,6 +76,7 @@
 
 /datum/reagent/medicine/C2/aiuri/on_mob_life(mob/living/carbon/M)
 	M.adjustFireLoss(-0.5*REM)
+	M.adjustOrganLoss(ORGAN_SLOT_EYES,0.25*REM)
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -75,8 +75,7 @@
 	var/message_cd = 0
 
 /datum/reagent/medicine/C2/aiuri/on_mob_life(mob/living/carbon/M)
-	M.adjustFireLoss(-2.0*REM)
-	M.adjustOrganLoss(ORGAN_SLOT_EYES,1*REM)
+	M.adjustFireLoss(-0.5*REM)
 	..()
 	return TRUE
 
@@ -275,7 +274,7 @@
 		if(method in list(PATCH, TOUCH))
 			var/harmies = min(Carbies.getBruteLoss(),Carbies.adjustBruteLoss(-1.25 * reac_volume)*-1)
 			var/burnies = min(Carbies.getFireLoss(),Carbies.adjustFireLoss(-1.25 * reac_volume)*-1)
-			Carbies.adjustToxLoss((harmies+burnies)*0.50)
+			Carbies.adjustToxLoss((harmies+burnies)*0.66)
 			if(show_message)
 				to_chat(Carbies, "<span class='danger'>You feel your burns and bruises healing! It stings like hell!</span>")
 			SEND_SIGNAL(Carbies, COMSIG_ADD_MOOD_EVENT, "painful_medicine", /datum/mood_event/painful_medicine)

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -75,7 +75,7 @@
 	var/message_cd = 0
 
 /datum/reagent/medicine/C2/aiuri/on_mob_life(mob/living/carbon/M)
-	M.adjustFireLoss(-0.5*REM)
+	M.adjustFireLoss(-2.0*REM)
 	M.adjustOrganLoss(ORGAN_SLOT_EYES,1*REM)
 	..()
 	return TRUE
@@ -275,7 +275,7 @@
 		if(method in list(PATCH, TOUCH))
 			var/harmies = min(Carbies.getBruteLoss(),Carbies.adjustBruteLoss(-1.25 * reac_volume)*-1)
 			var/burnies = min(Carbies.getFireLoss(),Carbies.adjustFireLoss(-1.25 * reac_volume)*-1)
-			Carbies.adjustToxLoss((harmies+burnies)*0.75)
+			Carbies.adjustToxLoss((harmies+burnies)*0.50)
 			if(show_message)
 				to_chat(Carbies, "<span class='danger'>You feel your burns and bruises healing! It stings like hell!</span>")
 			SEND_SIGNAL(Carbies, COMSIG_ADD_MOOD_EVENT, "painful_medicine", /datum/mood_event/painful_medicine)


### PR DESCRIPTION
## About The Pull Request

PR Theme: https://www.youtube.com/watch?v=g8Adf53SkTY

Changes Aiuri to have decreased eye damage because these are still supposed to be shit chems and C2 ones. 
Changes instabitaluri to be have a lessened toxin conversion rate to make it also more viable to be used by doctors in ghetto chem.

## Why It's Good For The Game

I have spoken to numerous people who believe C2 chems are very very bad, worse than they should be infact. I am not here to fix that today. I am here to ease the pain of these chems and breathe a little life into them by making them better while keeping the downsides they have. These are not supposed to be amazing chems, and they arent. But right now these chems are not very good, and should be improved just a bit so 1/10 players might use them. Seeing as how widespread these are, and how they have replaced the other chems in medkits, sleepers, actual purpose, there should be some incentive to use them.

## Changelog

:cl:
tweak: Changed the eye damage of aiuri to .25 from 1, does not change healing.
tweak: Changed toxin conversion of instabitaluri to 66% from 75%, does not buff healing.
balance: Changed eye damage giving rate of aiuri and toxin conversion of  instabitaluri 
/:cl:



