### PR TITLE
Purifying a soulstone removes blood cult status from its shades

### DIFF
--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -219,6 +219,8 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			for(var/mob/M in SS.contents)
 				if(M.mind)
 					SS.icon_state = "purified_soulstone2"
+					if(iscultist(M))
+						SSticker.mode.remove_cultist(M.mind, FALSE, FALSE)
 			for(var/mob/living/simple_animal/shade/EX in SS)
 				EX.icon_state = "ghost1"
 				EX.name = "Purified [initial(EX.name)]"

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -198,6 +198,8 @@
 				T.health = T.maxHealth
 				if(purified)
 					icon_state = "purified_soulstone2"
+					if(iscultist(T))
+						SSticker.mode.remove_cultist(T.mind, FALSE, FALSE)
 				else
 					icon_state = "soulstone2"
 				name = "soulstone: Shade of [T.real_name]"


### PR DESCRIPTION
## About The Pull Request

Purifying a soulstone now removes cult status from the shade inside.

## Why It's Good For The Game

Players are pretty frequently confused about their cult status after their shade being purified, as they still have the antag status, UI elements, and communion ability despite the different sprites and flavortext.  Removing cult status will fix this confusion.

## Changelog
:cl:
tweak: Purifying a soul stone now deconverts cultists inside of it.
/:cl: