### PR TITLE
Adds chem descriptions to the borg hypo examine text

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -136,7 +136,6 @@ Borg Hypospray
 /obj/item/reagent_containers/borghypo/examine(mob/user)
 	. = ..()
 	. += DescribeContents()	//Because using the standardized reagents datum was just too cool for whatever fuckwit wrote this
-	//if(type == /obj/item/reagent_containers/borghypo) //So that nonstandard hypos (hacked, clown, etc) don't get this.
 	var/datum/reagent/loaded = modes[mode]
 	. += "Currently loaded: [initial(loaded.name)]. [initial(loaded.description)]"
 

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -136,40 +136,9 @@ Borg Hypospray
 /obj/item/reagent_containers/borghypo/examine(mob/user)
 	. = ..()
 	. += DescribeContents()	//Because using the standardized reagents datum was just too cool for whatever fuckwit wrote this
-	if(type == /obj/item/reagent_containers/borghypo) //So that nonstandard hypos (hacked, clown, etc) don't get this.
-		switch(mode)
-			if(1)
-				. += "Currently loaded: Convermol. Treats suffocation but is toxic, with both effects scaling based on oxygen deprivation and amount of the drug administered. Overdose threshold is 35u."
-			if(2)
-				. += "Currently loaded: Libital. Treats brute, but also inflicts damage on the patient's liver. Intended for minor injuries. No overdose effects."
-			if(3)
-				. += "Currently loaded: Multiver. Heals toxin effects and purges chemicals from the patient, including itself. Deals damage to the lungs, scailing with the number of medical chemicals in the patient. No overdose effects."
-			if(4)
-				. += "Currently loaded: Aiuri. Heals burn injuries, but also inflicts damage on the patient's eyes. Indended for minor injuries. No overdose effects."
-			if(5)
-				. += "Currently loaded: Epinephrine. For patients in critical condition, prevents suffocation effects and slightly heals all injury types. Overdose threshold is 30u."
-			if(6)
-				. += "Currently loaded: Spaceacillin. All-purpose antiviral agent, prevents spreading viruses from the patient to others. No overdose effects."
-			if(7)
-				. += "Currently loaded: Saline-Glucose Solution. Has a low chance to heal brute and burn injuries. Can function as a temporary substute for blood. Overdose threshold is 60u."
-			if(8)
-				. += "Currently loaded: Mannitol. Heals brain damage, but not traumas. No overdose effects."
-			if(9)
-				. += "Currently loaded: Oculine. Heals eye damage and has a chance to cure blindness not caused by genetics or brain damage. No overdose effects."
-			if(10)
-				. += "Currently loaded: Inacusiate. Rapidly heals ear damage. Non-effective against genetic deafness. No overdose effects."
-			if(11)
-				. += "Currently loaded: Mutadone. Removes genetic mutations. No overdose effects."
-			if(12)
-				. += "Currently loaded: Haloperidol. Dampens the effects of most drugs while purging them. Has as chance of dealing brain damage. No overdose effects."
-			if(13)
-				. += "Currently loaded: Oxandrolone. Heals burn injuries. Effect is greater for more severe injuries. Overdose threshold is 25u."
-			if(14)
-				. += "Currently loaded: Salicyclic Acid. Heals brute injuries. Effect is greater for more severe injuries. Overdose threshold is 25u."
-			if(15)
-				. += "Currently loaded: Rezadone. Heals all cellular damage, while also slowly healing brute and burn injuries. Overdose threshold is 30u."
-			if(16)
-				. += "Currently loaded: Pentetic Acid. Reduces high levels of radiation and slowly heals injuries from toxins. Purges all other chemicals. No overdose effects."
+	//if(type == /obj/item/reagent_containers/borghypo) //So that nonstandard hypos (hacked, clown, etc) don't get this.
+	var/datum/reagent/loaded = modes[mode]
+	. += "Currently loaded: [initial(loaded.name)]. [initial(loaded.description)]"
 
 /obj/item/reagent_containers/borghypo/proc/DescribeContents()
 	. = list()

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -136,6 +136,40 @@ Borg Hypospray
 /obj/item/reagent_containers/borghypo/examine(mob/user)
 	. = ..()
 	. += DescribeContents()	//Because using the standardized reagents datum was just too cool for whatever fuckwit wrote this
+	if(type == /obj/item/reagent_containers/borghypo) //So that nonstandard hypos (hacked, clown, etc) don't get this.
+		switch(mode)
+			if(1)
+				. += "Currently loaded: Convermol. Treats suffocation but is toxic, with both effects scaling based on oxygen deprivation and amount of the drug administered. Overdose threshold is 35u."
+			if(2)
+				. += "Currently loaded: Libital. Treats brute, but also inflicts damage on the patient's liver. Intended for minor injuries. No overdose effects."
+			if(3)
+				. += "Currently loaded: Multiver. Heals toxin effects and purges chemicals from the patient, including itself. Deals damage to the lungs, scailing with the number of medical chemicals in the patient. No overdose effects."
+			if(4)
+				. += "Currently loaded: Aiuri. Heals burn injuries, but also inflicts damage on the patient's eyes. Indended for minor injuries. No overdose effects."
+			if(5)
+				. += "Currently loaded: Epinephrine. For patients in critical condition, prevents suffocation effects and slightly heals all injury types. Overdose threshold is 30u."
+			if(6)
+				. += "Currently loaded: Spaceacillin. All-purpose antiviral agent, prevents spreading viruses from the patient to others. No overdose effects."
+			if(7)
+				. += "Currently loaded: Saline-Glucose Solution. Has a low chance to heal brute and burn injuries. Can function as a temporary substute for blood. Overdose threshold is 60u."
+			if(8)
+				. += "Currently loaded: Mannitol. Heals brain damage, but not traumas. No overdose effects."
+			if(9)
+				. += "Currently loaded: Oculine. Heals eye damage and has a chance to cure blindness not caused by genetics or brain damage. No overdose effects."
+			if(10)
+				. += "Currently loaded: Inacusiate. Rapidly heals ear damage. Non-effective against genetic deafness. No overdose effects."
+			if(11)
+				. += "Currently loaded: Mutadone. Removes genetic mutations. No overdose effects."
+			if(12)
+				. += "Currently loaded: Haloperidol. Dampens the effects of most drugs while purging them. Has as chance of dealing brain damage. No overdose effects."
+			if(13)
+				. += "Currently loaded: Oxandrolone. Heals burn injuries. Effect is greater for more severe injuries. Overdose threshold is 25u."
+			if(14)
+				. += "Currently loaded: Salicyclic Acid. Heals brute injuries. Effect is greater for more severe injuries. Overdose threshold is 25u."
+			if(15)
+				. += "Currently loaded: Rezadone. Heals all cellular damage, while also slowly healing brute and burn injuries. Overdose threshold is 30u."
+			if(16)
+				. += "Currently loaded: Pentetic Acid. Reduces high levels of radiation and slowly heals injuries from toxins. Purges all other chemicals. No overdose effects."
 
 /obj/item/reagent_containers/borghypo/proc/DescribeContents()
 	. = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a line of text to the mediborg hypo examine text depending on what chem is currently loaded.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Helps borg players that have to play around that pesky law 1 to know how the new chems work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Borgs can now examine their hypospray tool to get a summery of the currently loaded chem's effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

![image](https://user-images.githubusercontent.com/37497534/63660140-ed67b100-c769-11e9-9627-8a0a199c0d29.png)
