### PR TITLE
ignoring OOC players should display the correct name.

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -300,7 +300,8 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	var/selection = input("Please, select a player!", "Ignore", null, null) as null|anything in choices
 	if(!selection || !(selection in choices))
 		return
-	selection = choices[selection]
+	displayed_choicename = selection // ckey string
+	selection = choices[selection] // client
 	if(selection == src)
 		to_chat(src, "You can't ignore yourself.")
 		return


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/46039. Or should at least I haven't tested it.

please note I did not write the ignoring code

## Why It's Good For The Game

bug, fix, etc

## Changelog
:cl: bandit
fix: Fixed an erroneous message with ignoring a player's OOC messages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
