### PR TITLE
Organic Slurry won't work if not ingested

### DIFF
--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -68,7 +68,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	holder.remove_reagent(type, metabolization_rate * M.metabolism_efficiency) //By default it slowly disappears.
 	return
 
-datum/reagent/proc/on_transfer(atom/A, method=TOUCH, volume) //Called after a reagent is transfered
+/datum/reagent/proc/on_transfer(atom/A, method=TOUCH, trans_volume) //Called after a reagent is transfered
 	return
 
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1782,3 +1782,13 @@
 /datum/reagent/yuck/on_mob_end_metabolize(mob/living/L)
 	yuck_cycle = 0 // reset vomiting
 	return ..()
+
+/datum/reagent/yuck/on_transfer(atom/A, method=TOUCH, trans_volume)
+	if(method == INGEST || !iscarbon(A))
+		return ..()
+
+	A.reagents.remove_reagent(type, trans_volume)
+	A.reagents.add_reagent(/datum/reagent/fuel, trans_volume * 0.75)
+	A.reagents.add_reagent(/datum/reagent/water, trans_volume * 0.25)
+
+	return ..()


### PR DESCRIPTION
## About The Pull Request

This causes Organic Slurry to convert to 3 parts welding fuel and 1 part water when injected, splashed, or otherwise not ingested. This causes the toxic effects of welding fuel to damage the mob.

I also made a small correction to the definition of the on_transfer proc, and corrected the `volume` argument to `trans_volume` as used by Syriniver and Trophazole.


## Why It's Good For The Game

Organic Slurry was not intended to work when injected and is only meant to be ingested. It doesn't make you want to puke when it's injected into your bloodstream, since you don't get a gag reflex.

I was considering whether to make this work with VAPOR too, but decided against it. If it's a good idea to allow with VAPOR then let me know.

## Changelog
:cl:
tweak: Organic Slurry reduces back to welder fuel if not consumed by the affected mob.
/:cl: