### PR TITLE
Fixes wooden floor runtime.

### DIFF
--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -25,7 +25,7 @@
 /turf/open/floor/wood/screwdriver_act(mob/living/user, obj/item/I)
 	if(..())
 		return TRUE
-	return pry_tile(I, user)
+	return pry_tile(I, user) ? TRUE : FALSE
 
 /turf/open/floor/wood/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	if(T.turf_type == type)


### PR DESCRIPTION
## About The Pull Request

pry_tile returns the new turf and not TRUE/FALSE.

```
[2019-08-26 21:48:02.379] runtime error: type mismatch: 0 |= the plating (124,154,2) (/turf/open/floor/plating)
 - proc name: tool act (/atom/proc/tool_act)
 -   source file: atoms.dm,989
 -   usr: Star Baxter (/mob/living/carbon/human)
 -   src: the plating (124,154,2) (/turf/open/floor/plating)
 -   usr.loc: the floor (123,155,2) (/turf/open/floor/wood)
 -   call stack:
 - the plating (124,154,2) (/turf/open/floor/plating): tool act(Star Baxter (/mob/living/carbon/human), the screwdriver (/obj/item/screwdriver), "screwdriver")
 - the screwdriver (/obj/item/screwdriver): tool attack chain(Star Baxter (/mob/living/carbon/human), the plating (124,154,2) (/turf/open/floor/plating))
 - the screwdriver (/obj/item/screwdriver): melee attack chain(Star Baxter (/mob/living/carbon/human), the plating (124,154,2) (/turf/open/floor/plating), "icon-x=26;icon-y=29;left=1;scr...")
 - Star Baxter (/mob/living/carbon/human): ClickOn(the plating (124,154,2) (/turf/open/floor/plating), "icon-x=26;icon-y=29;left=1;scr...")
 - the plating (124,154,2) (/turf/open/floor/plating): Click(the plating (124,154,2) (/turf/open/floor/plating), "mapwindow.map", "icon-x=26;icon-y=29;left=1;scr...")
 - Igotdild4u (/client): Click(the plating (124,154,2) (/turf/open/floor/plating), the plating (124,154,2) (/turf/open/floor/plating), "mapwindow.map", "icon-x=26;icon-y=29;left=1;scr...")
```
