### PR TITLE
Replaces Sanguibital's bleed rate increases with bleed damage

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -18,14 +18,14 @@
 		var/mob/living/carbon/human/H = M
 		if(H.bleed_rate)
 			H.adjustBruteLoss(-0.5*H.bleed_rate*REM)
-			H.bleed_rate += 2
+			H.bleed_rate += 0.5
 	..()
 	return TRUE
 
 /datum/reagent/medicine/C2/sanguibital/overdose_process(mob/living/carbon/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.bleed_rate += 2
+		H.bleed_rate += 0.5
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -17,8 +17,8 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.bleed_rate)
-			H.adjustBruteLoss(-0.5*H.bleed_rate*REM)
-			H.bleed_rate += 0.5
+             H.bleed(2)
+             H.apply_damage(round(-5*(1-(H.blood_volume/BLOOD_VOLUME_NORMAL)),0.1),BRUTE,forced = TRUE) //More Blood Loss = More Healing upto <5 brute per tick
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -18,7 +18,7 @@
 		var/mob/living/carbon/human/H = M
 		if(H.bleed_rate)
 			H.bleed(2)
-			H.adjustBruteLoss(round(5*((H.blood_volume/BLOOD_VOLUME_NORMAL)-1),0.1),TRUE) //More Blood Loss = More Healing upto <5 brute per tick
+			H.adjustBruteLoss(round(10*((H.blood_volume/BLOOD_VOLUME_NORMAL)-1),0.1),TRUE) //More Blood Loss = More Healing upto <5 brute per tick
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -17,8 +17,8 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.bleed_rate)
-             H.bleed(2)
-             H.apply_damage(round(-5*(1-(H.blood_volume/BLOOD_VOLUME_NORMAL)),0.1),BRUTE,forced = TRUE) //More Blood Loss = More Healing upto <5 brute per tick
+        	H.bleed(2)
+        	H.apply_damage(round(-5*(1-(H.blood_volume/BLOOD_VOLUME_NORMAL)),0.1),BRUTE,forced = TRUE) //More Blood Loss = More Healing upto <5 brute per tick
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -25,7 +25,7 @@
 /datum/reagent/medicine/C2/sanguibital/overdose_process(mob/living/carbon/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.bleed_rate += 0.5
+		H.bleed(2)
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -18,7 +18,7 @@
 		var/mob/living/carbon/human/H = M
 		if(H.bleed_rate)
 			H.bleed(2)
-			H.apply_damage(round(-5*(1-(H.blood_volume/BLOOD_VOLUME_NORMAL)),0.1),BRUTE,forced = TRUE) //More Blood Loss = More Healing upto <5 brute per tick
+			H.adjustBruteLoss(round(5*((H.blood_volume/BLOOD_VOLUME_NORMAL)-1),0.1),TRUE) //More Blood Loss = More Healing upto <5 brute per tick
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -17,8 +17,8 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.bleed_rate)
-        	H.bleed(2)
-        	H.apply_damage(round(-5*(1-(H.blood_volume/BLOOD_VOLUME_NORMAL)),0.1),BRUTE,forced = TRUE) //More Blood Loss = More Healing upto <5 brute per tick
+			H.bleed(2)
+			H.apply_damage(round(-5*(1-(H.blood_volume/BLOOD_VOLUME_NORMAL)),0.1),BRUTE,forced = TRUE) //More Blood Loss = More Healing upto <5 brute per tick
 	..()
 	return TRUE
 


### PR DESCRIPTION
##About The Pull Request

Sanguibital has its bleed rate effect reduced to 0.5 if not overdosed, and an additional 0.5 if overdosed.


##Why It's Good For The Game

Sanguibital, a category two healing chemical, currently sees too much use as a poisonous chemical, used to bleed crewmembers dry with shotgun darts, and syringes, rather than to heal them.

 A category two HEALING CHEMICAL should not be nearly so viable as a poison on near healthy targets as heparin, adding two to your bleed RATE per tick. When overdosed, it also adds two to your bleed RATE per tick.

Shotgun darts carry 30 units per dart. 30 units of sanguibital on a bleeding target WILL kill them in 30 seconds or less. If defibbed, you will die within the second. And this is before the overdose threshold.

This is in an AWFUL state as a healing chemical, or even as a poison.

It takes only 3 reagents to make sanguibital, meaning it is easier to acquire than most other toxins. It deals bleed damage nigh exponentially, as it increases BLEED RATE, rather than actual blood loss, PER TICK. 

## Changelog
:cl: Shirbu
balance: replaces Sanguibital's bleed rate stacks with bleed damage instead
/:cl:
