### PR TITLE
Fixes tray runtime

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -294,8 +294,7 @@
 	. = ..()
 	// Drop all the things. All of them.
 	var/list/obj/item/oldContents = contents.Copy()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.quick_empty()
+	SEND_SIGNAL(src, COMSIG_TRY_STORAGE_QUICK_EMPTY)
 	// Make each item scatter a bit
 	for(var/obj/item/I in oldContents)
 		INVOKE_ASYNC(src, .proc/do_scatter, I)


### PR DESCRIPTION
## About The Pull Request

Interaction now works properly.
It gets rid of a getComponent
What's not to like about this.
Fixes https://github.com/tgstation/tgstation/issues/46176

## Changelog
:cl:
fix: Trays now scatter their contents when used for attacks, like they are supposed to.
/:cl:
