### PR TITLE
Increases the slice time of walls from 10 to 20 seconds

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -13,7 +13,7 @@
 	baseturfs = /turf/open/floor/plating
 
 	var/hardness = 40 //lower numbers are harder. Used to determine the probability of a hulk smashing through.
-	var/slicing_duration = 100  //default time taken to slice the wall
+	var/slicing_duration = 20 SECONDS  //default time taken to slice the wall
 	var/sheet_type = /obj/item/stack/sheet/metal
 	var/sheet_amount = 2
 	var/girder_type = /obj/structure/girder

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -11,9 +11,10 @@
 	heat_capacity = 312500 //a little over 5 cm thick , 312500 for 1 m by 2.5 m by 0.25 m plasteel wall
 
 	baseturfs = /turf/open/floor/plating
-
-	var/hardness = 40 //lower numbers are harder. Used to determine the probability of a hulk smashing through.
-	var/slicing_duration = 20 SECONDS  //default time taken to slice the wall
+	///lower numbers are harder. Used to determine the probability of a hulk smashing through.
+	var/hardness = 40 
+	///default time taken to slice the wall
+	var/slicing_duration = 20 SECONDS
 	var/sheet_type = /obj/item/stack/sheet/metal
 	var/sheet_amount = 2
 	var/girder_type = /obj/structure/girder


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Walls now take 20 seconds to slice open instead of 10

## Why It's Good For The Game

Walls are a bit too easy to get through with basic tools. This isn't a crippling change but one that will make you think twice about trying to cut open walls in public areas.

## Changelog
:cl:
balance: Walls take 20 seconds to cut with a welder instead of 10
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
