### PR TITLE
Spray cans can't be set to extremely dark colours

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -234,8 +234,8 @@
 		if("select_colour")
 			if(can_change_colour)
 				var/chosen_colour = input(usr,"","Choose Color",paint_color) as color|null
-				
-				if(color_hex2num(chosen_colour) < 200) //Colors too dark are rejected
+
+				if(color_hex2num(chosen_colour) < 350) //Colors too dark are rejected
 					to_chat(usr, "<span class='warning'>That color is too dark! Choose a lighter one.</span>")
 					. = FALSE
 				else

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -233,8 +233,14 @@
 				paint_mode = PAINT_NORMAL
 		if("select_colour")
 			if(can_change_colour)
-				paint_color = input(usr,"","Choose Color",paint_color) as color|null
-				. = TRUE
+				var/chosen_colour = input(usr,"","Choose Color",paint_color) as color|null
+				
+				if(color_hex2num(chosen_colour) < 200) //Colors too dark are rejected
+					to_chat(usr, "<span class='warning'>That color is too dark! Choose a lighter one.</span>")
+					. = FALSE
+				else
+					paint_color = chosen_colour
+					. = TRUE
 		if("enter_text")
 			var/txt = stripped_input(usr,"Choose what to write.",
 				"Scribbles",default = text_buffer)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -664,8 +664,7 @@
 
 	if(isobj(target))
 		if(actually_paints)
-
-			if(color_hex2num(chosen_colour) < 350 && !istype(target, /obj/structure/window)) //Colors too dark are rejected
+			if(color_hex2num(paint_color) < 350 && !istype(target, /obj/structure/window)) //Colors too dark are rejected
 				to_chat(usr, "<span class='warning'>A colour that dark on an object like this? Surely not...</span>")
 				return FALSE
 				

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -235,12 +235,11 @@
 			if(can_change_colour)
 				var/chosen_colour = input(usr,"","Choose Color",paint_color) as color|null
 
-				if(color_hex2num(chosen_colour) < 350) //Colors too dark are rejected
-					to_chat(usr, "<span class='warning'>That color is too dark! Choose a lighter one.</span>")
-					. = FALSE
-				else
+				if (!isnull(chosen_colour))
 					paint_color = chosen_colour
 					. = TRUE
+				else 
+					. = FALSE
 		if("enter_text")
 			var/txt = stripped_input(usr,"Choose what to write.",
 				"Scribbles",default = text_buffer)
@@ -665,12 +664,19 @@
 
 	if(isobj(target))
 		if(actually_paints)
+
+			if(color_hex2num(chosen_colour) < 350 && !istype(target, /obj/structure/window)) //Colors too dark are rejected
+				to_chat(usr, "<span class='warning'>A colour that dark on an object like this? Surely not...</span>")
+				return FALSE
+				
 			target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
+
 			if(istype(target, /obj/structure/window))
 				if(color_hex2num(paint_color) < 255)
 					target.set_opacity(255)
 				else
 					target.set_opacity(initial(target.opacity))
+
 		. = use_charges(user, 2)
 		var/fraction = min(1, . / reagents.maximum_volume)
 		reagents.reaction(target, TOUCH, fraction * volume_multiplier)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Places a cap on the darkness of custom colours you can choose from the spray can in the same way tablet computers do.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Prevents being able to repaint objects into black blobs.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Sprays cans have a cap on how dark you can make objects. Art is uneffected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
