### PR TITLE
Allows some snacks to be dunked in liquids

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -334,20 +334,19 @@ All foods are distributed among various categories. Use common sense.
 
 /obj/item/reagent_containers/food/snacks/afterattack(obj/item/reagent_containers/M, mob/user, proximity)
 	. = ..()
-	if(!dunkable)
+	if(!dunkable || !proximity)
 		return
 	if(istype(M, /obj/item/reagent_containers/glass) || istype(M, /obj/item/reagent_containers/food/drinks))	//you can dunk dunkable snacks into beakers or drinks
-		if(istype(M, /obj/item/reagent_containers/food/drinks/soda_cans)) //to prevent dunkage through soda can lids
-			if(!M.spillable)
-				to_chat(user, "<spane class='warning'>[M] is unopened!</span>")
-				return
+		if(!M.is_drainable())
+			to_chat(user, "<span class='warning'>[M] is unable to be dunked in!</span>")
+			return
 		if(M.reagents.trans_to(src, dunk_amount, transfered_by = user))	//if reagents were transfered, show the message
 			to_chat(user, "<span class='notice'>You dunk \the [src] into \the [M].</span>")
-		else			//if not, either the beaker was empty, or the snack was full
-			if(!M.reagents.total_volume)
-				to_chat(user, "<span class='warning'>[M] is empty!</span>")
-			else
-				to_chat(user, "<span class='warning'>[src] is full!</span>")
+			return
+		if(!M.reagents.total_volume)
+			to_chat(user, "<span class='warning'>[M] is empty!</span>")
+		else
+			to_chat(user, "<span class='warning'>[src] is full!</span>")
 
 // //////////////////////////////////////////////Store////////////////////////////////////////
 /// All the food items that can store an item inside itself, like bread or cake.

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -45,6 +45,8 @@ All foods are distributed among various categories. Use common sense.
 	var/eatverb
 	var/dried_type = null
 	var/dry = 0
+	var/dunkable = FALSE // for dunkable food, make true
+	var/dunk_amount = 10 // how much reagent is transferred per dunk
 	var/cooked_type = null  //for microwave cooking. path of the resulting item after microwaving
 	var/filling_color = "#FFFFFF" //color to use when added to custom food.
 	var/custom_food_type = null  //for food customizing. path of the custom food to create
@@ -330,6 +332,19 @@ All foods are distributed among various categories. Use common sense.
 					M.emote("me", 1, "[sattisfaction_text]")
 				qdel(src)
 
+/obj/item/reagent_containers/food/snacks/afterattack(obj/item/reagent_containers/glass/glass, mob/user, proximity)
+	. = ..()
+	if(!dunkable)
+		return
+	if(istype(glass))	//you can dunk dunkable snacks into beakers
+		if(glass.reagents.trans_to(src, dunk_amount, transfered_by = user))	//if reagents were transfered, show the message
+			to_chat(user, "<span class='notice'>You dunk \the [src] into \the [glass].</span>")
+		else			//if not, either the beaker was empty, or the snack was full
+			if(!glass.reagents.total_volume)
+				to_chat(user, "<span class='warning'>[glass] is empty!</span>")
+			else
+				to_chat(user, "<span class='warning'>[src] is full!</span>")
+
 // //////////////////////////////////////////////Store////////////////////////////////////////
 /// All the food items that can store an item inside itself, like bread or cake.
 /obj/item/reagent_containers/food/snacks/store
@@ -362,3 +377,4 @@ All foods are distributed among various categories. Use common sense.
 		TB.MouseDrop(over)
 	else
 		return ..()
+

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -332,16 +332,20 @@ All foods are distributed among various categories. Use common sense.
 					M.emote("me", 1, "[sattisfaction_text]")
 				qdel(src)
 
-/obj/item/reagent_containers/food/snacks/afterattack(obj/item/reagent_containers/glass/glass, mob/user, proximity)
+/obj/item/reagent_containers/food/snacks/afterattack(obj/item/reagent_containers/M, mob/user, proximity)
 	. = ..()
 	if(!dunkable)
 		return
-	if(istype(glass))	//you can dunk dunkable snacks into beakers
-		if(glass.reagents.trans_to(src, dunk_amount, transfered_by = user))	//if reagents were transfered, show the message
-			to_chat(user, "<span class='notice'>You dunk \the [src] into \the [glass].</span>")
+	if(istype(M, /obj/item/reagent_containers/glass) || istype(M, /obj/item/reagent_containers/food/drinks))	//you can dunk dunkable snacks into beakers or drinks
+		if(istype(M, /obj/item/reagent_containers/food/drinks/soda_cans)) //to prevent dunkage through soda can lids
+			if(!M.spillable)
+				to_chat(user, "<spane class='warning'>[M] is unopened!</span>")
+				return
+		if(M.reagents.trans_to(src, dunk_amount, transfered_by = user))	//if reagents were transfered, show the message
+			to_chat(user, "<span class='notice'>You dunk \the [src] into \the [M].</span>")
 		else			//if not, either the beaker was empty, or the snack was full
-			if(!glass.reagents.total_volume)
-				to_chat(user, "<span class='warning'>[glass] is empty!</span>")
+			if(!M.reagents.total_volume)
+				to_chat(user, "<span class='warning'>[M] is empty!</span>")
 			else
 				to_chat(user, "<span class='warning'>[src] is full!</span>")
 

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -5,7 +5,7 @@
 	slices_num = 5
 	tastes = list("bread" = 10)
 	foodtype = GRAIN
-
+	dunkable = TRUE
 
 /obj/item/reagent_containers/food/snacks/breadslice
 	icon = 'icons/obj/food/burgerbread.dmi'
@@ -16,6 +16,7 @@
 	slot_flags = ITEM_SLOT_HEAD
 	customfoodfilling = 0 //to avoid infinite bread-ception
 	foodtype = GRAIN
+	dunkable = TRUE
 
 /obj/item/reagent_containers/food/snacks/store/bread/plain
 	name = "bread"
@@ -34,7 +35,6 @@
 	icon_state = "breadslice"
 	customfoodfilling = 1
 	foodtype = GRAIN
-	dunkable = TRUE
 
 /obj/item/reagent_containers/food/snacks/store/bread/meat
 	name = "meatbread loaf"

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -34,6 +34,7 @@
 	icon_state = "breadslice"
 	customfoodfilling = 1
 	foodtype = GRAIN
+	dunkable = TRUE
 
 /obj/item/reagent_containers/food/snacks/store/bread/meat
 	name = "meatbread loaf"

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -98,6 +98,7 @@
 	filling_color = "#FFD700"
 	tastes = list("fries" = 3, "salt" = 1)
 	foodtype = VEGETABLES | GRAIN | FRIED
+	dunkable = TRUE
 
 /obj/item/reagent_containers/food/snacks/tatortot
 	name = "tator tot"
@@ -107,6 +108,7 @@
 	filling_color = "FFD700"
 	tastes = list("potato" = 3, "valids" = 1)
 	foodtype = FRIED | VEGETABLES
+	dunkable = TRUE
 
 /obj/item/reagent_containers/food/snacks/soydope
 	name = "soy dope"
@@ -128,6 +130,7 @@
 	filling_color = "#FFD700"
 	tastes = list("fries" = 3, "cheese" = 1)
 	foodtype = VEGETABLES | GRAIN
+	dunkable = TRUE
 
 /obj/item/reagent_containers/food/snacks/badrecipe
 	name = "burned mess"
@@ -146,6 +149,7 @@
 	filling_color = "#FFA500"
 	tastes = list("carrots" = 3, "salt" = 1)
 	foodtype = VEGETABLES
+	dunkable = TRUE
 
 /obj/item/reagent_containers/food/snacks/candiedapple
 	name = "candied apple"

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -12,10 +12,10 @@
 	filling_color = "#D2691E"
 	tastes = list("donut" = 1)
 	foodtype = JUNKFOOD | GRAIN | FRIED | SUGAR | BREAKFAST
+	dunkable = TRUE
 	var/frosted_icon = "donut2"
 	var/is_frosted = FALSE
 	var/extra_reagent = null
-	var/chem_volume = 15
 
 /obj/item/reagent_containers/food/snacks/donut/Initialize()
 	. = ..()
@@ -43,18 +43,6 @@
 				last_check_time = world.time
 				return
 	..()
-
-/obj/item/reagent_containers/food/snacks/donut/afterattack(obj/item/reagent_containers/glass/glass, mob/user, proximity)
-	. = ..()
-	if(istype(glass))	//you can dunk donuts into beakers
-		if(glass.reagents.trans_to(src, chem_volume, transfered_by = user))	//if reagents were transfered, show the message
-			to_chat(user, "<span class='notice'>You dunk \the [src] into \the [glass].</span>")
-		else			//if not, either the beaker was empty, or the donut was full
-			if(!glass.reagents.total_volume)
-				to_chat(user, "<span class='warning'>[glass] is empty!</span>")
-			else
-				to_chat(user, "<span class='warning'>[src] is full!</span>")
-
 
 /obj/item/reagent_containers/food/snacks/donut/chaos
 	name = "chaos donut"

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -190,6 +190,7 @@
 	filling_color = "#F0E68C"
 	tastes = list("cookie" = 1)
 	foodtype = GRAIN | SUGAR
+	dunkable = TRUE
 
 /obj/item/reagent_containers/food/snacks/donkpocket
 	name = "\improper Donk-pocket"
@@ -310,6 +311,7 @@
 	filling_color = "#CD853F"
 	tastes = list("sweetness" = 1)
 	foodtype = GRAIN | JUNKFOOD | SUGAR
+	dunkable = TRUE
 
 /obj/item/reagent_containers/food/snacks/chococornet
 	name = "chocolate cornet"
@@ -330,6 +332,7 @@
 	filling_color = "#D2691E"
 	tastes = list("cookie" = 2, "oat" = 1)
 	foodtype = GRAIN
+	dunkable = TRUE
 
 /obj/item/reagent_containers/food/snacks/raisincookie
 	name = "raisin cookie"
@@ -340,6 +343,7 @@
 	filling_color = "#F0E68C"
 	tastes = list("cookie" = 1, "raisins" = 1)
 	foodtype = GRAIN | FRUIT
+	dunkable = TRUE
 
 /obj/item/reagent_containers/food/snacks/cherrycupcake
 	name = "cherry cupcake"

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -15,6 +15,7 @@
 	var/frosted_icon = "donut2"
 	var/is_frosted = FALSE
 	var/extra_reagent = null
+	var/chem_volume = 15
 
 /obj/item/reagent_containers/food/snacks/donut/Initialize()
 	. = ..()
@@ -42,6 +43,18 @@
 				last_check_time = world.time
 				return
 	..()
+
+/obj/item/reagent_containers/food/snacks/donut/afterattack(obj/item/reagent_containers/glass/glass, mob/user, proximity)
+	. = ..()
+	if(istype(glass))	//you can dunk donuts into beakers
+		if(glass.reagents.trans_to(src, chem_volume, transfered_by = user))	//if reagents were transfered, show the message
+			to_chat(user, "<span class='notice'>You dunk \the [src] into \the [glass].</span>")
+		else			//if not, either the beaker was empty, or the donut was full
+			if(!glass.reagents.total_volume)
+				to_chat(user, "<span class='warning'>[glass] is empty!</span>")
+			else
+				to_chat(user, "<span class='warning'>[src] is full!</span>")
+
 
 /obj/item/reagent_containers/food/snacks/donut/chaos
 	name = "chaos donut"
@@ -92,7 +105,6 @@
 	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/ketchup = 2)
 	tastes = list("meat" = 1)
 	foodtype = JUNKFOOD | MEAT | GROSS | FRIED | BREAKFAST
-
 
 ////////////////////////////////////////////MUFFINS////////////////////////////////////////////
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds an afterattack method to snacks to allow snacks with the dunkable trait to be dunked in glasses or open drinks to transfer reagents. Currently this applies to donuts, bread/slices and misc food like cookies. If you feel something should be dunkable probably add it in here.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It simply adds an extra thing to do at lunchtime to get a little cozier. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Some foods can now be dunked in drinks. Dip your breakfast donut in some robust coffee today!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
