### PR TITLE
Cobbduceus Part 4/X: Operating Computers Sync to Stasis Beds

### DIFF
--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -27,6 +27,7 @@
 	for(var/i in linked_stasisbeds)
 		var/obj/machinery/stasis/SB = i
 		SB.op_computer = null
+	..()
 
 /obj/machinery/computer/operating/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/disk/surgery))

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -3,7 +3,7 @@
 
 /obj/machinery/computer/operating
 	name = "operating computer"
-	desc = "Monitors patient vitals and displays surgery steps. Can be loaded with surgery disks to perform experimental procedures."
+	desc = "Monitors patient vitals and displays surgery steps. Can be loaded with surgery disks to perform experimental procedures. Automatically syncs to stasis beds within its line of sight for surgical tech advancement."
 	icon_screen = "crew"
 	icon_keyboard = "med_key"
 	circuit = /obj/item/circuitboard/computer/operating
@@ -16,11 +16,17 @@
 	var/datum/techweb/linked_techweb
 	var/menu = MENU_OPERATION
 	light_color = LIGHT_COLOR_BLUE
+	var/list/linked_stasisbeds
 
 /obj/machinery/computer/operating/Initialize()
 	. = ..()
 	linked_techweb = SSresearch.science_tech
 	find_table()
+
+/obj/machinery/computer/operating/Destroy()
+	for(var/i in linked_stasisbeds)
+		var/obj/machinery/stasis/SB = i
+		SB.op_computer = null
 
 /obj/machinery/computer/operating/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/disk/surgery))
@@ -46,6 +52,14 @@
 		if(table)
 			table.computer = src
 			break
+	if(!linked_stasisbeds)
+		linked_stasisbeds = list()
+
+	for(var/obj/machinery/stasis/SB in view(7,src))
+		if(SB.op_computer)
+			continue
+		linked_stasisbeds |= SB
+		SB.op_computer = src
 
 /obj/machinery/computer/operating/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.not_incapacitated_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
@@ -56,18 +70,17 @@
 /obj/machinery/computer/operating/ui_data(mob/user)
 	var/list/data = list()
 	data["table"] = table
+	data["menu"] = menu
+
+	var/list/surgeries = list()
+	for(var/X in advanced_surgeries)
+		var/datum/surgery/S = X
+		var/list/surgery = list()
+		surgery["name"] = initial(S.name)
+		surgery["desc"] = initial(S.desc)
+		surgeries += list(surgery)
+	data["surgeries"] = surgeries
 	if(table)
-		data["menu"] = menu
-
-		var/list/surgeries = list()
-		for(var/X in advanced_surgeries)
-			var/datum/surgery/S = X
-			var/list/surgery = list()
-			surgery["name"] = initial(S.name)
-			surgery["desc"] = initial(S.desc)
-			surgeries += list(surgery)
-		data["surgeries"] = surgeries
-
 		data["patient"] = list()
 		if(table.check_patient())
 			patient = table.patient

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -17,10 +17,12 @@
 	var/stasis_can_toggle = 0
 	var/mattress_state = "stasis_on"
 	var/obj/effect/overlay/vis/mattress_on
+	var/obj/machinery/computer/operating/op_computer
 
 /obj/machinery/stasis/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>Alt-click to [stasis_enabled ? "turn off" : "turn on"] the machine.</span>"
+	. += "<span class='notice'>[src] is [op_computer ? "linked" : "<b>NOT</b> linked"] to an operating computer.</span>"
 
 /obj/machinery/stasis/proc/play_power_sound()
 	var/_running = stasis_running()

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -75,6 +75,14 @@
 		if(type in table.computer.advanced_surgeries)
 			return TRUE
 
+	var/obj/machinery/stasis/the_stasis_bed = locate(/obj/machinery/stasis, T)
+	if(the_stasis_bed?.op_computer)
+		if(the_stasis_bed.op_computer.stat & (NOPOWER|BROKEN))
+			return .
+		if(replaced_by in the_stasis_bed.op_computer.advanced_surgeries)
+			return FALSE
+		if(type in the_stasis_bed.op_computer.advanced_surgeries)
+			return TRUE
 
 /datum/surgery/proc/next_step(mob/user, intent)
 	if(location != user.zone_selected)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Operating Computers can now be built to support advanced surgeries to stasis beds. Unlike a table, these can be within LoS of the computer.

Do note it links them the same way it does a table (once when THE COMPUTER  is built).

A minor change is now the surgery tab of the computer can be accessed to sync surgeries even if a table isn't linked.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Stasis beds should be surgery hotspots, and this allows doctors to explore some of the unique pathways/surgeries without relying on a table.

Do note that some surgeries will still be better performed on the optable since the beds have a small penalty.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Cobby
add: Operating computers can now be built to sync with all nearby stasis beds within it's LoS and provide them with advanced surgeries.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
