### PR TITLE
adds sleep healing

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -70,15 +70,14 @@
 	if(owner.health > owner.crit_threshold)
 		var/healing = 15
 		if((locate(/obj/structure/bed) in owner.loc))
-			healing +=10
+			healing += 10
 		else
 			if((locate(/obj/structure/table) in owner.loc))
-				healing +=5
+				healing += 5
 		owner.adjustBruteLoss((-healing/50), 0)
 		owner.adjustFireLoss((-healing/50), 0)
 		owner.adjustToxLoss((-healing/50), 0)
 		owner.adjustStaminaLoss((-healing/50), 0)
-	..()
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -76,7 +76,7 @@
 				healing -= 0.1
 		owner.adjustBruteLoss(healing)
 		owner.adjustFireLoss(healing)
-		owner.adjustToxLoss(healing, 1, 1)
+		owner.adjustToxLoss(healing, TRUE, TRUE)
 		owner.adjustStaminaLoss(healing)
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -68,16 +68,16 @@
 
 /datum/status_effect/incapacitating/sleeping/tick()
 	if(owner.health > owner.crit_threshold)
-		var/healing = 0.3
+		var/healing = -0.2
 		if((locate(/obj/structure/bed) in owner.loc))
-			healing += 0.2
+			healing -= 0.3
 		else
 			if((locate(/obj/structure/table) in owner.loc))
-				healing += 0.1
-		owner.adjustBruteLoss((-healing), 0)
-		owner.adjustFireLoss((-healing), 0)
-		owner.adjustToxLoss((-healing), 0)
-		owner.adjustStaminaLoss((-healing), 0)
+				healing -= 0.1
+		owner.adjustBruteLoss(healing)
+		owner.adjustFireLoss(healing)
+		owner.adjustToxLoss(healing)
+		owner.adjustStaminaLoss(healing)
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -67,7 +67,7 @@
 	return ..()
 
 /datum/status_effect/incapacitating/sleeping/tick()
-	if(owner.health > owner.crit_threshold)
+	if(owner.health < 85 && owner.health > 0)
 		var/healing = -0.2
 		if((locate(/obj/structure/bed) in owner.loc))
 			healing -= 0.3

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -76,8 +76,8 @@
 				healing -= 0.1
 		owner.adjustBruteLoss(healing)
 		owner.adjustFireLoss(healing)
-		owner.adjustToxLoss(healing)
-		owner.adjustStaminaLoss(healing, 1, 1)
+		owner.adjustToxLoss(healing, 1, 1)
+		owner.adjustStaminaLoss(healing)
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -68,7 +68,7 @@
 
 /datum/status_effect/incapacitating/sleeping/tick()
 	if(owner.maxHealth != 0)
-		var/health_ratio = owner.health / owner.maxhealth
+		var/health_ratio = owner.health / owner.maxHealth
 		if(health_ratio > 0.8)
 			var/healing = -0.2
 			if((locate(/obj/structure/bed) in owner.loc))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -67,7 +67,7 @@
 	return ..()
 
 /datum/status_effect/incapacitating/sleeping/tick()
-	if(owner.maxHealth != 0)
+	if(owner.maxHealth)
 		var/health_ratio = owner.health / owner.maxHealth
 		if(health_ratio > 0.8)
 			var/healing = -0.2

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -68,16 +68,16 @@
 
 /datum/status_effect/incapacitating/sleeping/tick()
 	if(owner.health > owner.crit_threshold)
-		var/healing = 15
+		var/healing = 0.3
 		if((locate(/obj/structure/bed) in owner.loc))
-			healing += 10
+			healing += 0.2
 		else
 			if((locate(/obj/structure/table) in owner.loc))
-				healing += 5
-		owner.adjustBruteLoss((-healing/50), 0)
-		owner.adjustFireLoss((-healing/50), 0)
-		owner.adjustToxLoss((-healing/50), 0)
-		owner.adjustStaminaLoss((-healing/50), 0)
+				healing += 0.1
+		owner.adjustBruteLoss((-healing), 0)
+		owner.adjustFireLoss((-healing), 0)
+		owner.adjustToxLoss((-healing), 0)
+		owner.adjustStaminaLoss((-healing), 0)
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -67,17 +67,19 @@
 	return ..()
 
 /datum/status_effect/incapacitating/sleeping/tick()
-	if(owner.health < 85 && owner.health > 0)
-		var/healing = -0.2
-		if((locate(/obj/structure/bed) in owner.loc))
-			healing -= 0.3
-		else
-			if((locate(/obj/structure/table) in owner.loc))
-				healing -= 0.1
-		owner.adjustBruteLoss(healing)
-		owner.adjustFireLoss(healing)
-		owner.adjustToxLoss(healing, TRUE, TRUE)
-		owner.adjustStaminaLoss(healing)
+	if(owner.maxHealth != 0)
+		var/health_ratio = owner.health / owner.maxhealth
+		if(health_ratio > 0.8)
+			var/healing = -0.2
+			if((locate(/obj/structure/bed) in owner.loc))
+				healing -= 0.3
+			else
+				if((locate(/obj/structure/table) in owner.loc))
+					healing -= 0.1
+			owner.adjustBruteLoss(healing)
+			owner.adjustFireLoss(healing)
+			owner.adjustToxLoss(healing, TRUE, TRUE)
+			owner.adjustStaminaLoss(healing)
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -67,8 +67,18 @@
 	return ..()
 
 /datum/status_effect/incapacitating/sleeping/tick()
-	if(owner.getStaminaLoss())
-		owner.adjustStaminaLoss(-0.5) //reduce stamina loss by 0.5 per tick, 10 per 2 seconds
+	if(owner.health > owner.crit_threshold)
+		var/healing = 15
+		if((locate(/obj/structure/bed) in owner.loc))
+			healing +=10
+		else
+			if((locate(/obj/structure/table) in owner.loc))
+				healing +=5
+		owner.adjustBruteLoss((-healing/50), 0)
+		owner.adjustFireLoss((-healing/50), 0)
+		owner.adjustToxLoss((-healing/50), 0)
+		owner.adjustStaminaLoss((-healing/50), 0)
+	..()
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -77,7 +77,7 @@
 		owner.adjustBruteLoss(healing)
 		owner.adjustFireLoss(healing)
 		owner.adjustToxLoss(healing)
-		owner.adjustStaminaLoss(healing)
+		owner.adjustStaminaLoss(healing, 1, 1)
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -78,7 +78,7 @@
 					healing -= 0.1
 			owner.adjustBruteLoss(healing)
 			owner.adjustFireLoss(healing)
-			owner.adjustToxLoss(healing, TRUE, TRUE)
+			owner.adjustToxLoss(healing * 0.5, TRUE, TRUE)
 			owner.adjustStaminaLoss(healing)
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -136,3 +136,4 @@ MrDoomBringer = Game Master
 shizcalev = Game Master
 NicBR = Game Master
 LoserWasTaken = Game Master
+Fikou = Game Master


### PR DESCRIPTION
## About The Pull Request

this adds sleep healing, while in sleep you heal a certain amount of brute, burn, tox and stamina (0.2 laying on ground, 0.3 on a table and 0.5 on a bed) per tick as long as you are not in critical condition

## Why It's Good For The Game

gives an ingame reason to go to dorms, allows a heal for small booboos that you get from a punches and stuff, adds a new "dynamic" of having to deal with your target regaining their health if you put them to sleep
also makes morphine, a chemical in the medical bay, an actual thing that should be in the medical bay

## Changelog
:cl: Fikou, hippie guys that i stole and modified code from
add: you can now sleep to restore some health
/:cl: