### PR TITLE
forgotten no longer, chap and geneticist now have family heirlooms

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -116,6 +116,8 @@
 				heirloom_type = pick(/obj/item/reagent_containers/glass/rag, /obj/item/clothing/head/that, /obj/item/reagent_containers/food/drinks/shaker)
 			if("Curator")
 				heirloom_type = pick(/obj/item/pen/fountain, /obj/item/storage/pill_bottle/dice)
+			if("Chaplain")
+				heirloom_type = pick(/obj/item/toy/windupToolbox, /obj/item/reagent_containers/food/drinks/bottle/holywater)
 			if("Assistant")
 				heirloom_type = /obj/item/storage/toolbox/mechanical/old/heirloom
 			//Security/Command
@@ -147,6 +149,8 @@
 				heirloom_type = /obj/item/book/manual/wiki/chemistry
 			if("Virologist")
 				heirloom_type = /obj/item/reagent_containers/syringe
+			if("Geneticist")
+				heirloom_type = /obj/item/clothing/under/shorts/purple
 			//Engineering
 			if("Chief Engineer")
 				heirloom_type = pick(/obj/item/clothing/head/hardhat/white, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters)


### PR DESCRIPTION
## About The Pull Request

chap now has a wind up toolbox or flask of holy water as family heirloom
gene now has purple shorts as a family heirloom

## Why It's Good For The Game

these 2 jobs were the only ones without any heirloom, makes sense that every job would have one

## Changelog
:cl:
tweak: The Chaplain and Geneticst now have family heirlooms, forgotten no longer!
/:cl: