### PR TITLE
Makes felinids die from chocolate.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -89,6 +89,22 @@
 			NT.Insert(H, drop_if_replaced = FALSE)
 		else
 			tail.Remove(H)
+			
+/datum/species/human/felinid/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/M)
+	.=..()
+	if(chem.type == /datum/reagent/consumable/coco)
+		if(prob(40))
+			M.adjust_disgust(20)
+		if(prob(5))
+			M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>")
+		if(prob(10))
+			var/sick_message = pick("You feel nauseous.", "You're nya't feeling so good.","You feel like your insides are melting.","You feel illsies.")
+			to_chat(M, "<span class='notice'>[sick_message]</span>")
+		if(prob(15))
+			var/obj/item/organ/guts = pick(M.internal_organs)
+			guts.applyOrganDamage(15)
+		return TRUE
+
 
 /proc/mass_purrbation()
 	for(var/M in GLOB.mob_list)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -351,6 +351,26 @@
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#302000" // rgb: 48, 32, 0
 	taste_description = "bitterness"
+	
+/datum/reagent/consumable/coco/on_mob_life(mob/living/carbon/M)
+	if(iscatperson(M))
+		if(prob(40))
+			M.adjust_disgust(20)
+		if(prob(5))
+			M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>")
+		if(prob(10))
+			var/sick_message = pick("You feel nauseous.", "You're nya't feeling so good.","You feel like your insides are melting.","You feel illsies.")
+			to_chat(M, "<span class='notice'>[sick_message]</span>")
+		if(prob(15))
+			var/obj/item/organ/guts = pick(M.internal_organs)
+			guts.applyOrganDamage(15)
+	..()
+
+/datum/reagent/consumable/coco/on_mob_add(mob/living/carbon/M)
+	if(iscatperson(M))
+			to_chat(M, "<span class='warning'>Your insides revolt at the presence of lethal chocolate!</span>")
+			M.vomit(20)
+	..()
 
 /datum/reagent/consumable/hot_coco
 	name = "Hot Chocolate"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -351,20 +351,6 @@
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#302000" // rgb: 48, 32, 0
 	taste_description = "bitterness"
-	
-/datum/reagent/consumable/coco/on_mob_life(mob/living/carbon/M)
-	if(iscatperson(M))
-		if(prob(40))
-			M.adjust_disgust(20)
-		if(prob(5))
-			M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>")
-		if(prob(10))
-			var/sick_message = pick("You feel nauseous.", "You're nya't feeling so good.","You feel like your insides are melting.","You feel illsies.")
-			to_chat(M, "<span class='notice'>[sick_message]</span>")
-		if(prob(15))
-			var/obj/item/organ/guts = pick(M.internal_organs)
-			guts.applyOrganDamage(15)
-	..()
 
 /datum/reagent/consumable/coco/on_mob_add(mob/living/carbon/M)
 	.=..()

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -367,10 +367,11 @@
 	..()
 
 /datum/reagent/consumable/coco/on_mob_add(mob/living/carbon/M)
+	.=..()
 	if(iscatperson(M))
 		to_chat(M, "<span class='warning'>Your insides revolt at the presence of lethal chocolate!</span>")
 		M.vomit(20)
-	..()
+
 
 /datum/reagent/consumable/hot_coco
 	name = "Hot Chocolate"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -368,8 +368,8 @@
 
 /datum/reagent/consumable/coco/on_mob_add(mob/living/carbon/M)
 	if(iscatperson(M))
-			to_chat(M, "<span class='warning'>Your insides revolt at the presence of lethal chocolate!</span>")
-			M.vomit(20)
+		to_chat(M, "<span class='warning'>Your insides revolt at the presence of lethal chocolate!</span>")
+		M.vomit(20)
 	..()
 
 /datum/reagent/consumable/hot_coco


### PR DESCRIPTION
This pr is held up by: https://github.com/tgstation/tgstation/issues/46236

I know felinids are a deprecated feature and we probably should not be supporting them but..

:cl: GuyonBroadway
balance: Felinids now have a very adverse reaction to chocolate products.
/:cl:

![image](https://user-images.githubusercontent.com/22083966/63973336-7a7c7400-caa2-11e9-8b2e-30505b4e9cc5.png)

The people have spoken. 

Felinids now vomit, become nauseated and suffer major organ damage from consuming chocolate. 