### PR TITLE
[s]Wizards no longer get a free use of a touch spell by refunding the spell.

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -90,7 +90,6 @@
 			qdel(S)
 			return cost * (spell_levels+1)
 	return -1
-
 /datum/spellbook_entry/proc/GetInfo()
 	if(!S)
 		S = new spell_type()

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -86,20 +86,10 @@
 	for(var/obj/effect/proc_holder/spell/aspell in user.mind.spell_list)
 		if(initial(S.name) == initial(aspell.name))
 			spell_levels = aspell.spell_level
-			CheckTouchSpells(user, aspell)
 			user.mind.spell_list.Remove(aspell)
 			qdel(S)
 			return cost * (spell_levels+1)
 	return -1
-
-// Removes hand attacks for touch spells (ei nath, etc.) so the wiz doesn't get a free use if they refund the spell.
-/datum/spellbook_entry/proc/CheckTouchSpells(mob/living/carbon/human/user, obj/effect/proc_holder/spell/aspell)
-	if (istype(aspell, /obj/effect/proc_holder/spell/targeted/touch))
-		var/obj/effect/proc_holder/spell/targeted/touch/touchspell = aspell
-		for(var/obj/item/melee/touch_attack/T in user.contents)
-			if (istype(T, touchspell.hand_path))
-				qdel(T)
-				to_chat(user, "<span class='notice'>Your hand loses its charge.</span>")
 
 /datum/spellbook_entry/proc/GetInfo()
 	if(!S)

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -86,10 +86,21 @@
 	for(var/obj/effect/proc_holder/spell/aspell in user.mind.spell_list)
 		if(initial(S.name) == initial(aspell.name))
 			spell_levels = aspell.spell_level
+			CheckTouchSpells(user, aspell)
 			user.mind.spell_list.Remove(aspell)
 			qdel(S)
 			return cost * (spell_levels+1)
 	return -1
+
+// Removes hand attacks for touch spells (ei nath, etc.) so the wiz doesn't get a free use if they refund the spell.
+/datum/spellbook_entry/proc/CheckTouchSpells(mob/living/carbon/human/user, obj/effect/proc_holder/spell/aspell)
+	if (istype(aspell, /obj/effect/proc_holder/spell/targeted/touch))
+		var/obj/effect/proc_holder/spell/targeted/touch/touchspell = aspell
+		for(var/obj/item/melee/touch_attack/T in user.contents)
+			if (istype(T, touchspell.hand_path))
+				qdel(T)
+				to_chat(user, "<span class='notice'>Your hand loses its charge.</span>")
+
 /datum/spellbook_entry/proc/GetInfo()
 	if(!S)
 		S = new spell_type()

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -7,6 +7,12 @@
 	include_user = TRUE
 	range = -1
 
+/obj/effect/proc_holder/spell/targeted/touch/Destroy()
+	for(var/obj/item/melee/touch_attack/T in usr.contents)
+		if (istype(T, hand_path))
+			qdel(T)
+			to_chat(usr, "<span class='notice'>The power of the spell dissipates from your hand.</span>")
+
 /obj/effect/proc_holder/spell/targeted/touch/proc/remove_hand(recharge = FALSE)
 	QDEL_NULL(attached_hand)
 	if(recharge)

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -8,10 +8,8 @@
 	range = -1
 
 /obj/effect/proc_holder/spell/targeted/touch/Destroy()
-	for(var/obj/item/melee/touch_attack/T in usr.contents)
-		if (istype(T, hand_path))
-			qdel(T)
-			to_chat(usr, "<span class='notice'>The power of the spell dissipates from your hand.</span>")
+	remove_hand()
+	..()
 
 /obj/effect/proc_holder/spell/targeted/touch/proc/remove_hand(recharge = FALSE)
 	QDEL_NULL(attached_hand)

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -9,6 +9,7 @@
 
 /obj/effect/proc_holder/spell/targeted/touch/Destroy()
 	remove_hand()
+	to_chat(usr, "<span class='notice'>The power of the spell dissipates from your hand.</span>")
 	..()
 
 /obj/effect/proc_holder/spell/targeted/touch/proc/remove_hand(recharge = FALSE)


### PR DESCRIPTION
## About The Pull Request

If a wiz refunds a touch spell (ei nath, etc.), if there is an active touch attack, that attack is deleted. EDIT: Now with new and improved coding

Fixes https://github.com/tgstation/tgstation/issues/46202.

## Why It's Good For The Game

Fixes an exploit.