### PR TITLE
Earthsblood Healing Changed, Loses Brain Damage, Applies Pacifism on Ending Instead (Resilience Variable)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -936,18 +936,14 @@
 	var/mob/living/carbon/human/hippie = L
 	if(!istype(L))
 		return ..()
-	var/resi = NONE
+	var/resi = 0
 	switch(current_cycle + ODcycle)
-		if(0-20) //i'm a (benevolent) god sweet nerevar
-			resi = NONE
 		if(21 to 30)
 			resi = TRAUMA_RESILIENCE_BASIC //plant-friendly zone
 		if(31 to 55)
 			resi = TRAUMA_RESILIENCE_SURGERY
-		if(56 to 100)
+		if(56 to INFINITY)
 			resi = TRAUMA_RESILIENCE_LOBOTOMY
-		else
-			resi = TRAUMA_RESILIENCE_MAGIC
 	if(!resi)
 		return ..()
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -952,11 +952,13 @@
 		return ..()
 
 	var/datum/brain_trauma/severe/pacifism/PBT = hippiebrain.has_trauma_type(/datum/brain_trauma/severe/pacifism)
-	if(!PBT)
-		PBT = hippiebrain.gain_trauma(/datum/brain_trauma/severe/pacifism)
-	if(PBT.resilience >= resi)
-		return ..()
-	PBT.resilience = resi
+	if(PBT?.resilience >= resi)
+		return //they have same or better
+	if(PBT)
+		PBT.resilience = resi
+	else
+		hippiebrain.gain_trauma(/datum/brain_trauma/severe/pacifism, resi)
+	return ..()
 
 
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -905,6 +905,11 @@
 	taste_description = "shag carpeting and rock"
 	var/ODcycle = 0 //adds to current_cycle in calculation. 5 cycles while OD = 1 "normal" cycle (basically you're getting 1.2 instead of 2 cycles during OD)
 
+/datum/reagent/medicine/earthsblood/on_transfer(atom/A, method=INJECT, trans_volume)
+	if(method == INJECT && trans_volume < 5)
+		return
+	..()
+
 /datum/reagent/medicine/earthsblood/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-5 * REM, 0)
 	M.adjustFireLoss(-5 * REM, 0)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -899,28 +899,62 @@
 
 /datum/reagent/medicine/earthsblood //Created by ambrosia gaia plants
 	name = "Earthsblood"
-	description = "Ichor from an extremely powerful plant. Great for restoring wounds, but it's a little heavy on the brain."
+	description = "Ichor from an extremely powerful plant. Some conspiracy theorists INSISTS this plant was used by Centcom during Plasmastock to minimize any chance of rioting."
 	color = rgb(255, 175, 0)
 	overdose_threshold = 25
+	taste_description = "shag carpeting and rock"
+	var/ODcycle = 0 //adds to current_cycle in calculation. 5 cycles while OD = 1 "normal" cycle (basically you're getting 1.2 instead of 2 cycles during OD)
 
 /datum/reagent/medicine/earthsblood/on_mob_life(mob/living/carbon/M)
-	M.adjustBruteLoss(-3 * REM, 0)
-	M.adjustFireLoss(-3 * REM, 0)
-	M.adjustOxyLoss(-15 * REM, 0)
+	M.adjustBruteLoss(-5 * REM, 0)
+	M.adjustFireLoss(-5 * REM, 0)
+	M.adjustOxyLoss(-3 * REM, 0)
 	M.adjustToxLoss(-3 * REM, 0)
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2 * REM, 150) //This does, after all, come from ambrosia, and the most powerful ambrosia in existence, at that!
 	M.adjustCloneLoss(-1 * REM, 0)
-	M.adjustStaminaLoss(-30 * REM, 0)
+	M.adjustStaminaLoss(-3 * REM, 0)
 	M.jitteriness = min(max(0, M.jitteriness + 3), 30)
 	M.druggy = min(max(0, M.druggy + 10), 15) //See above
+	metabolization_rate += 0.2
 	..()
 	. = 1
 
 /datum/reagent/medicine/earthsblood/overdose_process(mob/living/M)
 	M.hallucination = min(max(0, M.hallucination + 5), 60)
 	M.adjustToxLoss(5 * REM, 0)
+	ODcycle += 0.2
 	..()
 	. = 1
+/datum/reagent/medicine/earthsblood/on_mob_end_metabolize(mob/living/L)
+	var/mob/living/carbon/human/hippie = L
+	if(!istype(L))
+		return ..()
+	var/resi = NONE
+	switch(current_cycle + ODcycle)
+		if(0)
+			resi = NONE //i'm a god sweet nerevar
+		if(1 to 10)
+			resi = TRAUMA_RESILIENCE_BASIC //plant-friendly zone
+		if(11 to 50)
+			resi = TRAUMA_RESILIENCE_SURGERY
+		if(51 to 100)
+			resi = TRAUMA_RESILIENCE_LOBOTOMY
+		else
+			resi = TRAUMA_RESILIENCE_MAGIC
+	if(!resi)
+		return ..()
+
+	var/obj/item/organ/brain/hippiebrain = hippie?.getorganslot(ORGAN_SLOT_BRAIN)
+	if(!hippiebrain)
+		return ..()
+
+	var/datum/brain_trauma/severe/pacifism/PBT = hippiebrain.has_trauma_type(/datum/brain_trauma/severe/pacifism)
+	if(!PBT)
+		PBT = hippiebrain.gain_trauma(/datum/brain_trauma/severe/pacifism)
+	if(PBT.resilience >= resi)
+		return ..()
+	PBT.resilience = resi
+
+
 
 /datum/reagent/medicine/haloperidol
 	name = "Haloperidol"
@@ -1197,7 +1231,7 @@
 	M.adjustFireLoss(3*REM, 0.)
 	M.adjust_bodytemperature(-35 * TEMPERATURE_DAMAGE_COEFFICIENT, 50)
 	..()
-  
+
 /datum/reagent/medicine/silibinin/on_mob_life(mob/living/carbon/M)
 	M.adjustOrganLoss(ORGAN_SLOT_LIVER, -2)//Add a chance to cure liver trauma once implemented.
 	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -903,10 +903,11 @@
 	color = rgb(255, 175, 0)
 	overdose_threshold = 25
 	taste_description = "shag carpeting and rock"
+	metabolization_rate = 0.5
 	var/ODcycle = 0 //adds to current_cycle in calculation. 5 cycles while OD = 1 "normal" cycle (basically you're getting 1.2 instead of 2 cycles during OD)
 
 /datum/reagent/medicine/earthsblood/on_mob_life(mob/living/carbon/M)
-	if(current_cycle <= 20) //5u has to be processed before u get into THE FUN ZONE
+	if(current_cycle <= 25) //5u has to be processed before u get into THE FUN ZONE
 		M.adjustBruteLoss(-1 * REM, 0)
 		M.adjustFireLoss(-1 * REM, 0)
 		M.adjustOxyLoss(-0.5 * REM, 0)
@@ -938,11 +939,11 @@
 		return ..()
 	var/resi = 0
 	switch(current_cycle + ODcycle)
-		if(21 to 30)
+		if(25 to 40)
 			resi = TRAUMA_RESILIENCE_BASIC //plant-friendly zone
-		if(31 to 55)
+		if(41 to 60)
 			resi = TRAUMA_RESILIENCE_SURGERY
-		if(56 to INFINITY)
+		if(61 to INFINITY)
 			resi = TRAUMA_RESILIENCE_LOBOTOMY
 	if(!resi)
 		return ..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -905,21 +905,24 @@
 	taste_description = "shag carpeting and rock"
 	var/ODcycle = 0 //adds to current_cycle in calculation. 5 cycles while OD = 1 "normal" cycle (basically you're getting 1.2 instead of 2 cycles during OD)
 
-/datum/reagent/medicine/earthsblood/on_transfer(atom/A, method=INJECT, trans_volume)
-	if(method == INJECT && trans_volume < 5)
-		return
-	..()
-
 /datum/reagent/medicine/earthsblood/on_mob_life(mob/living/carbon/M)
-	M.adjustBruteLoss(-5 * REM, 0)
-	M.adjustFireLoss(-5 * REM, 0)
-	M.adjustOxyLoss(-3 * REM, 0)
-	M.adjustToxLoss(-3 * REM, 0)
-	M.adjustCloneLoss(-1 * REM, 0)
-	M.adjustStaminaLoss(-3 * REM, 0)
-	M.jitteriness = min(max(0, M.jitteriness + 3), 30)
+	if(current_cycle <= 20) //5u has to be processed before u get into THE FUN ZONE
+		M.adjustBruteLoss(-1 * REM, 0)
+		M.adjustFireLoss(-1 * REM, 0)
+		M.adjustOxyLoss(-0.5 * REM, 0)
+		M.adjustToxLoss(-0.5 * REM, 0)
+		M.adjustCloneLoss(-0.1 * REM, 0)
+		M.adjustStaminaLoss(-0.5 * REM, 0)
+	else
+		M.adjustBruteLoss(-5 * REM, 0)
+		M.adjustFireLoss(-5 * REM, 0)
+		M.adjustOxyLoss(-3 * REM, 0)
+		M.adjustToxLoss(-3 * REM, 0)
+		M.adjustCloneLoss(-1 * REM, 0)
+		M.adjustStaminaLoss(-3 * REM, 0)
+		M.jitteriness = min(max(0, M.jitteriness + 3), 30)
+		metabolization_rate += 0.2
 	M.druggy = min(max(0, M.druggy + 10), 15) //See above
-	metabolization_rate += 0.2
 	..()
 	. = 1
 
@@ -935,13 +938,13 @@
 		return ..()
 	var/resi = NONE
 	switch(current_cycle + ODcycle)
-		if(0)
-			resi = NONE //i'm a god sweet nerevar
-		if(1 to 10)
+		if(0-20) //i'm a (benevolent) god sweet nerevar
+			resi = NONE
+		if(21 to 30)
 			resi = TRAUMA_RESILIENCE_BASIC //plant-friendly zone
-		if(11 to 50)
+		if(31 to 55)
 			resi = TRAUMA_RESILIENCE_SURGERY
-		if(51 to 100)
+		if(56 to 100)
 			resi = TRAUMA_RESILIENCE_LOBOTOMY
 		else
 			resi = TRAUMA_RESILIENCE_MAGIC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Earthsblood Metab Changes
Brute/Burn upped to 5
Oxy/Stam dropped to 3 (Matched with Tox)
Increases metabolization rate per cycle (less healing)

### Earthsblood Brain Damage Removal
Replaces with pacifism on end of metabolization, with resilience scaling with iterations. ODs add to the iteration calculation by 0.2 (5 iterations of OD will add 1 to the calculation)
No, you cannot cheese it. It will not replace a trauma with lower/equal resilience.

### Earthsblood Pacifism
Pacifism is based off of current_cycle. Do remember metabolization increases so unless you're ODing you will rarely reach lobotomy stage. If you reach magic stage you're doing an exploit.

### Not part of the Cobbduceus series since it was a nutty chem before rework.
prob should have changed the name tho

## Why It's Good For The Game

This chemical is major dumb healing and can be achieved reliably per round. Technically it will still do major dumb healing if you also use neurine OR you don't mind being a very lovely person for the rest of the round OR you don't mind getting noggin surgery OR you just keep eating it and outrunning the metab.

This plant/chem was made pre-gene machine anyways so it wasn't balanced around having mannitol plants and certainly not having mannitol in the same plant. It WAS balanced around trekchems which were removed for being too strong.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Hippieby
del: Removed Earthsblood's Brain Damage
add: Earthsblood now gives you pacifism on metabolization end with resilience scaling with current cycle
add: Earthsblood's healing has been changed: Up'd Brute/Burn, Lowered Oxy/Stam/Cloning
add: Earthsblood now metabs faster per cycle (less healing but less cycles means lower trauma resilience)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->


# UPDATE

### Earthsblood does MINOR healing, THEN ramps up and begins pacification.

CC/Iterations | MR | Reagent Needed
-- | -- | --
1 | 0.5 | 0.5
5 | 0.5 | 2.5
10 | 0.5 | 5
15 | 0.5 | 7.5
20 | 0.5 | 10
25 (AMP UP ZONE / NEURINE ZONE) | 0.5 | 12.5
30 | 1 | 16.5
35 | 1.5 | 23
40 | 2 | 32
41 (SURGERY ZONE) | 2.1 | 34.1
61 (LOBOTOMY ZONE) | 4.1 | 97.1
