### PR TITLE
Backend for species specific iconbases

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
             for species_x that draws from icons/mob/iconbase1, it will instead draw from icons/mob/species_x/iconbase1
             any valid filepath can be used, but please keep the filestructure sensible
 	this list is currently used by the following procs
-	* get_species_iconbase()
+	* build_worn_icon()
 		> currently this only works with clothing, and directly checks for species id
 	*/
 	var/list/alternate_iconbases = list()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -15,9 +15,20 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/hair_color	// this allows races to have specific hair colors... if null, it uses the H's hair/facial hair colors. if "mutcolor", it uses the H's mutant_color
 	var/hair_alpha = 255	// the alpha used by the hair. 255 is completely solid, 0 is transparent.
 
-	var/list/alternate_spritesheets = list() // this is an association list, put in a spritesheet path matched with an alternate sheet to swap out the spritesheet for this species for an alternative one
-											 // currently works with clothing only.
-
+	/*!
+	alternate_iconbases takes the following format to switch between source iconbases on a species by species basis
+	\`\`\`example format for the alternate spritesheet list:
+			list('icons/mob/iconbase1' = 'icon/mob/species_x/iconbase1',
+                'icons/mob/iconbase2' = 'icons/mob/species_x/iconbase2')
+	\`\`\`
+        > in this example, wheen update_icons() loads a clothing sprite
+            for species_x that draws from icons/mob/iconbase1, it will instead draw from icons/mob/species_x/iconbase1
+            any valid filepath can be used, but please keep the filestructure sensible
+	this list is currently used by the following procs
+	* get_species_iconbase()
+		> currently this only works with clothing, and directly checks for species id
+	*/
+	var/list/alternate_iconbases = list()
 	var/use_skintones = 0	// does it use skintones or not? (spoiler alert this is only used by humans)
 	var/exotic_blood = ""	// If your race wants to bleed something other than bog standard blood, change this to reagent id.
 	var/exotic_bloodtype = "" //If your race uses a non standard bloodtype (A+, O-, AB-, etc)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -15,6 +15,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/hair_color	// this allows races to have specific hair colors... if null, it uses the H's hair/facial hair colors. if "mutcolor", it uses the H's mutant_color
 	var/hair_alpha = 255	// the alpha used by the hair. 255 is completely solid, 0 is transparent.
 
+	var/list/alternate_spritesheets = list() // this is an association list, put in a spritesheet path matched with an alternate sheet to swap out the spritesheet for this species for an alternative one
+											 // currently works with clothing only.
+
 	var/use_skintones = 0	// does it use skintones or not? (spoiler alert this is only used by humans)
 	var/exotic_blood = ""	// If your race wants to bleed something other than bog standard blood, change this to reagent id.
 	var/exotic_bloodtype = "" //If your race uses a non standard bloodtype (A+, O-, AB-, etc)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -475,6 +475,7 @@ covers:
  centering large appearances
  layering appearances on custom layers
  building appearances from custom icon files
+ custom icon files from species/datum
 
 By Remie Richards (yes I'm taking credit because this just removed 90% of the copypaste in update_icons())
 
@@ -507,17 +508,15 @@ generate/load female uniform sprites matching all previously decided variables
 	if(!t_icon)
 		t_icon = default_icon_file
 
-	//Find a valid icon file from variables+arguments
+	//Find a valid icon file from variables+arguments and datum/species
 	var/file2use
-	if(!isinhands && mob_overlay_icon)
-		file2use = mob_overlay_icon
-	if(!file2use)
+	if(!isinhands)
+		file2use = mob_overlay_icon ? mob_overlay_icon : default_icon_file
+    	var/mob/living/carbon/human/H = loc
+   		if(istype(H) && H.dna.species.alternate_iconbases.len)
+	    	file2use = H.dna.species.alternate_iconbases[file2use] ? H.dna.species.alternate_iconbases[file2use] : file2use
+	else
 		file2use = default_icon_file
-
-	//Check for an alternate spritesheet path in the species datum
-    var/mob/living/carbon/human/H = loc
-    if(istype(H))
-	    file2use = get_species_iconbase(file2use, isinhands)
 
 	//Find a valid layer from variables+arguments
 	var/layer2use
@@ -672,26 +671,3 @@ generate/load female uniform sprites matching all previously decided variables
 
 	update_inv_head()
 	update_inv_wear_mask()
-
-/*! Explanation of alternate species iconbase system
-This proc checks for alternate iconbases defined in alternate_iconbases, found in datum/species
-This gives us the ability to swap out sprites for a species via a simple edit to their species datum.
-I've only added this to the proc responsible for building clothing icons, but this could be used virtually anywhere
-in species level spriting; ie you could change what the mob effects in icons/mob/human look like
-in order to for example make it so gibing for a lizard shows a lizard sprite instead of a human during the gibbing animation
-	> Added proc
-* get_species_iconbase
-	> arguments for get_species_iconbase
-* spritesheet : the original iconbase's file path
-* isinhands : whether the object is held in the mob's hands, we don't want species specific sprite paths for held items
-	> output of get_species_iconbase
-returns the original iconbase's file path, or an alternate path if one was found in species datum and the item isn't currently being held
-	> usage of get_species_iconbase
-currently used in the following procs: build_worn_icon
-*/
-/mob/living/carbon/human/proc/get_species_iconbase(iconbase, isinhands = FALSE)
-	if(dna && dna.species.alternate_iconbases.len && dna.species.alternate_iconbases[iconbase])
-		return isinhands? iconbase : dna.species.alternate_iconbases[iconbase]
-	else
-		return iconbase
-	

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -515,9 +515,9 @@ generate/load female uniform sprites matching all previously decided variables
 		file2use = default_icon_file
 
 	//Check for an alternate spritesheet path in the species datum
-	var/mob/living/carbon/human/H = loc
-	if(!isinhands && H.dna && H.dna.species.alternate_spritesheets[file2use])
-		file2use = H.dna.species.alternate_spritesheets[file2use]
+    var/mob/living/carbon/human/H = loc
+    if(istype(H))
+	    file2use = get_species_iconbase(file2use, isinhands)
 
 	//Find a valid layer from variables+arguments
 	var/layer2use
@@ -672,3 +672,26 @@ generate/load female uniform sprites matching all previously decided variables
 
 	update_inv_head()
 	update_inv_wear_mask()
+
+/*! Explanation of alternate species iconbase system
+This proc checks for alternate iconbases defined in alternate_iconbases, found in datum/species
+This gives us the ability to swap out sprites for a species via a simple edit to their species datum.
+I've only added this to the proc responsible for building clothing icons, but this could be used virtually anywhere
+in species level spriting; ie you could change what the mob effects in icons/mob/human look like
+in order to for example make it so gibing for a lizard shows a lizard sprite instead of a human during the gibbing animation
+	> Added proc
+* get_species_iconbase
+	> arguments for get_species_iconbase
+* spritesheet : the original iconbase's file path
+* isinhands : whether the object is held in the mob's hands, we don't want species specific sprite paths for held items
+	> output of get_species_iconbase
+returns the original iconbase's file path, or an alternate path if one was found in species datum and the item isn't currently being held
+	> usage of get_species_iconbase
+currently used in the following procs: build_worn_icon
+*/
+/mob/living/carbon/human/proc/get_species_iconbase(iconbase, isinhands = FALSE)
+	if(dna && dna.species.alternate_iconbases.len && dna.species.alternate_iconbases[iconbase])
+		return isinhands? iconbase : dna.species.alternate_iconbases[iconbase]
+	else
+		return iconbase
+	

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -514,6 +514,11 @@ generate/load female uniform sprites matching all previously decided variables
 	if(!file2use)
 		file2use = default_icon_file
 
+	//Check for an alternate spritesheet path in the species datum
+	var/mob/living/carbon/human/H = loc
+	if(!isinhands && H.dna && H.dna.species.alternate_spritesheets[file2use])
+		file2use = H.dna.species.alternate_spritesheets[file2use]
+
 	//Find a valid layer from variables+arguments
 	var/layer2use
 	if(alternate_worn_layer)


### PR DESCRIPTION
this change makes it possible to define species specific iconbases (.dmi filepaths). Alternate iconbase file paths must be added into an ordered list (alternate_iconbases) in the datum/species. For now this only works with clothing.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

These minor change makes it possible to define species specific iconbases. Alternate iconbases must be added into an ordered list in the species datum. For now this only works with clothing, since the only check for alternate iconbases I added was to build_worn_icon()

an example that can be used to validate this PR is to add 

alternate_iconbases = list('icons/mob/clothing/under/captain.dmi' = 'icons/mob/clothing/head')

to a species datum, which will result in the captain's hat being displayed on the icon when wearing the captain's uniform as the race you chose for this test.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Currently /tg/'s .dmi files are kind of cluttered, to put things mildly. There's been some progress in that regards with the recent breakup of the uniform sprites, and this will make it possible to do for species bodyparts, as well as basically anything else that's being applied to human type mobs. It also makes it possible to have a species with a body shape that doesn't fit into the normal clothing boundaries (ie Vox from the paradise codebaes), if the creator is willing to put the work in to make all the necessary conversions for every state on the sheet, and the huge number of extra icon states involved won't end up cluttering the main ones.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the ability to give species their own iconbases
add: added the variable list/alternate_iconbases ( initial state of list() ) to datum/species where you associate current iconbases with their alternate versions. 
add: Added about 5 lines of code into build_worn_icon() to check for alternate iconbases, plus a bunch of documentation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
