### PR TITLE
Fixes self-sustaining rainbow slime extracts, blue slime extracts' foam activation and refactors foam code into a helper proc

### DIFF
--- a/code/__HELPERS/reagents.dm
+++ b/code/__HELPERS/reagents.dm
@@ -72,3 +72,14 @@
 	if(!GLOB.chemical_reactions_list[primary_reagent])
 		GLOB.chemical_reactions_list[primary_reagent] = list()
 	GLOB.chemical_reactions_list[primary_reagent] += R
+
+/proc/create_foam(datum/effect_system/foam_spread/foam,datum/reagents/holder,foam_volume,metaltype = 0,notification="<span class='danger'>The solution spills out foam!</span>")
+	var/location = get_turf(holder.my_atom)
+	for(var/mob/M in viewers(5, location))
+		to_chat(M, notification)
+	if(metaltype == 0)
+		foam.set_up(foam_volume, location, holder)
+	else
+		foam.set_up(foam_volume, location, holder, metaltype)
+	foam.start()
+	holder.clear_reagents()

--- a/code/__HELPERS/reagents.dm
+++ b/code/__HELPERS/reagents.dm
@@ -73,12 +73,13 @@
 		GLOB.chemical_reactions_list[primary_reagent] = list()
 	GLOB.chemical_reactions_list[primary_reagent] += R
 
-/datum/reagents/proc/create_foam(foam_volume,metaltype = 0,notification = null)
+//Creates foam from the reagent. Metaltype is for metal foam, notification is what to show people in textbox
+/datum/reagents/proc/create_foam(datum/effect_system/foamtype,foam_volume,metaltype = 0,notification = null)
 	var/location = get_turf(my_atom)
-	var/datum/effect_system/foam_spread/foam = new()
+	var/datum/effect_system/foam_spread/foam = new(foamtype)
 	foam.set_up(foam_volume, location, src, metaltype)
 	foam.start()
-	src.clear_reagents()
+	clear_reagents()
 	if(!notification)
 		return
 	for(var/mob/M in viewers(5, location))

--- a/code/__HELPERS/reagents.dm
+++ b/code/__HELPERS/reagents.dm
@@ -73,13 +73,13 @@
 		GLOB.chemical_reactions_list[primary_reagent] = list()
 	GLOB.chemical_reactions_list[primary_reagent] += R
 
-/proc/create_foam(datum/effect_system/foam_spread/foam,datum/reagents/holder,foam_volume,metaltype = 0,notification="<span class='danger'>The solution spills out foam!</span>")
-	var/location = get_turf(holder.my_atom)
+/datum/reagents/proc/create_foam(foam_volume,metaltype = 0,notification = null)
+	var/location = get_turf(my_atom)
+	var/datum/effect_system/foam_spread/foam = new()
+	foam.set_up(foam_volume, location, src, metaltype)
+	foam.start()
+	src.clear_reagents()
+	if(!notification)
+		return
 	for(var/mob/M in viewers(5, location))
 		to_chat(M, notification)
-	if(metaltype == 0)
-		foam.set_up(foam_volume, location, holder)
-	else
-		foam.set_up(foam_volume, location, holder, metaltype)
-	foam.start()
-	holder.clear_reagents()

--- a/code/__HELPERS/reagents.dm
+++ b/code/__HELPERS/reagents.dm
@@ -74,9 +74,9 @@
 	GLOB.chemical_reactions_list[primary_reagent] += R
 
 //Creates foam from the reagent. Metaltype is for metal foam, notification is what to show people in textbox
-/datum/reagents/proc/create_foam(datum/effect_system/foamtype,foam_volume,metaltype = 0,notification = null)
+/datum/reagents/proc/create_foam(foamtype,foam_volume,metaltype = 0,notification = null)
 	var/location = get_turf(my_atom)
-	var/datum/effect_system/foam_spread/foam = new(foamtype)
+	var/datum/effect_system/foam_spread/foam = new foamtype()
 	foam.set_up(foam_volume, location, src, metaltype)
 	foam.start()
 	clear_reagents()

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -230,7 +230,7 @@
 	chemholder = null
 	return ..()
 
-/datum/effect_system/foam_spread/set_up(amt=5, loca, datum/reagents/carry = null)
+/datum/effect_system/foam_spread/set_up(amt=5, loca, datum/reagents/carry = null, metaltype = 0)
 	if(isturf(loca))
 		location = loca
 	else
@@ -238,10 +238,8 @@
 
 	amount = round(sqrt(amt / 2), 1)
 	carry.copy_to(chemholder, carry.total_volume)
-
-/datum/effect_system/foam_spread/metal/set_up(amt=5, loca, datum/reagents/carry = null, metaltype)
-	..()
-	metal = metaltype
+	if(metaltype != 0)
+		metal = metaltype
 
 /datum/effect_system/foam_spread/start()
 	var/obj/effect/particle_effect/foam/F = new effect_type(location)

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -40,7 +40,7 @@
 			else
 				R.add_reagent(pick(saferChems), reagentsAmount)
 
-			R.create_foam(200)
+			R.create_foam(/datum/effect_system/foam_spread,200)
 
 			var/cockroaches = prob(33) ? 3 : 0
 			while(cockroaches)

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -40,9 +40,7 @@
 			else
 				R.add_reagent(pick(saferChems), reagentsAmount)
 
-			var/datum/effect_system/foam_spread/foam = new
-			foam.set_up(200, get_turf(vent), R)
-			foam.start()
+			R.create_foam(200)
 
 			var/cockroaches = prob(33) ? 3 : 0
 			while(cockroaches)
@@ -97,9 +95,7 @@
 			R.my_atom = vent
 			R.add_reagent(/datum/reagent/consumable/ethanol/beer, reagentsAmount)
 
-			var/datum/effect_system/foam_spread/foam = new
-			foam.set_up(200, get_turf(vent), R)
-			foam.start()
+			R.create_foam(200)
 		CHECK_TICK
 
 /datum/round_event/vent_clog/plasma_decon/announce()

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -354,8 +354,7 @@
 	mob_react = FALSE
 
 /datum/chemical_reaction/foam/on_reaction(datum/reagents/holder, created_volume)
-	var/datum/effect_system/foam_spread/foam = new()
-	create_foam(foam,holder,2*created_volume)
+	holder.create_foam(2*created_volume,notification="<span class='danger'>The solution spews out foam!</span>")
 
 /datum/chemical_reaction/metalfoam
 	name = "Metal Foam"
@@ -364,8 +363,7 @@
 	mob_react = FALSE
 
 /datum/chemical_reaction/metalfoam/on_reaction(datum/reagents/holder, created_volume)
-	var/datum/effect_system/foam_spread/metal/foam = new()
-	create_foam(foam,holder,5*created_volume,1,"<span class='danger'>The solution spews out a metallic foam!</span>")
+	holder.create_foam(5*created_volume,1,"<span class='danger'>The solution spews out a metallic foam!</span>")
 
 /datum/chemical_reaction/smart_foam
 	name = "Smart Metal Foam"
@@ -374,8 +372,7 @@
 	mob_react = TRUE
 
 /datum/chemical_reaction/smart_foam/on_reaction(datum/reagents/holder, created_volume)
-	var/datum/effect_system/foam_spread/metal/smart/foam = new()
-	create_foam(foam,holder,5*created_volume,1,"<span class='danger'>The solution spews out metallic foam!</span>")
+	holder.create_foam(5*created_volume,1,"<span class='danger'>The solution spews out metallic foam!</span>")
 
 /datum/chemical_reaction/ironfoam
 	name = "Iron Foam"
@@ -384,8 +381,7 @@
 	mob_react = FALSE
 
 /datum/chemical_reaction/ironfoam/on_reaction(datum/reagents/holder, created_volume)
-	var/datum/effect_system/foam_spread/metal/foam = new()
-	create_foam(foam,holder,5*created_volume,2,"<span class='danger'>The solution spews out a metallic foam!</span>")
+	holder.create_foam(5*created_volume,2,"<span class='danger'>The solution spews out a metallic foam!</span>")
 
 /datum/chemical_reaction/foaming_agent
 	name = "Foaming Agent"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -354,15 +354,8 @@
 	mob_react = FALSE
 
 /datum/chemical_reaction/foam/on_reaction(datum/reagents/holder, created_volume)
-	var/location = get_turf(holder.my_atom)
-	for(var/mob/M in viewers(5, location))
-		to_chat(M, "<span class='danger'>The solution spews out foam!</span>")
-	var/datum/effect_system/foam_spread/s = new()
-	s.set_up(created_volume*2, location, holder)
-	s.start()
-	holder.clear_reagents()
-	return
-
+	var/datum/effect_system/foam_spread/foam = new()
+	create_foam(foam,holder,2*created_volume)
 
 /datum/chemical_reaction/metalfoam
 	name = "Metal Foam"
@@ -371,15 +364,8 @@
 	mob_react = FALSE
 
 /datum/chemical_reaction/metalfoam/on_reaction(datum/reagents/holder, created_volume)
-	var/location = get_turf(holder.my_atom)
-
-	for(var/mob/M in viewers(5, location))
-		to_chat(M, "<span class='danger'>The solution spews out a metallic foam!</span>")
-
-	var/datum/effect_system/foam_spread/metal/s = new()
-	s.set_up(created_volume*5, location, holder, 1)
-	s.start()
-	holder.clear_reagents()
+	var/datum/effect_system/foam_spread/metal/foam = new()
+	create_foam(foam,holder,5*created_volume,1,"<span class='danger'>The solution spews out a metallic foam!</span>")
 
 /datum/chemical_reaction/smart_foam
 	name = "Smart Metal Foam"
@@ -388,12 +374,8 @@
 	mob_react = TRUE
 
 /datum/chemical_reaction/smart_foam/on_reaction(datum/reagents/holder, created_volume)
-	var/turf/location = get_turf(holder.my_atom)
-	location.visible_message("<span class='danger'>The solution spews out metallic foam!</span>")
-	var/datum/effect_system/foam_spread/metal/smart/s = new()
-	s.set_up(created_volume * 5, location, holder, TRUE)
-	s.start()
-	holder.clear_reagents()
+	var/datum/effect_system/foam_spread/metal/smart/foam = new()
+	create_foam(foam,holder,5*created_volume,1,"<span class='danger'>The solution spews out metallic foam!</span>")
 
 /datum/chemical_reaction/ironfoam
 	name = "Iron Foam"
@@ -402,13 +384,8 @@
 	mob_react = FALSE
 
 /datum/chemical_reaction/ironfoam/on_reaction(datum/reagents/holder, created_volume)
-	var/location = get_turf(holder.my_atom)
-	for(var/mob/M in viewers(5, location))
-		to_chat(M, "<span class='danger'>The solution spews out a metallic foam!</span>")
-	var/datum/effect_system/foam_spread/metal/s = new()
-	s.set_up(created_volume*5, location, holder, 2)
-	s.start()
-	holder.clear_reagents()
+	var/datum/effect_system/foam_spread/metal/foam = new()
+	create_foam(foam,holder,5*created_volume,2,"<span class='danger'>The solution spews out a metallic foam!</span>")
 
 /datum/chemical_reaction/foaming_agent
 	name = "Foaming Agent"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -354,7 +354,7 @@
 	mob_react = FALSE
 
 /datum/chemical_reaction/foam/on_reaction(datum/reagents/holder, created_volume)
-	holder.create_foam(2*created_volume,notification="<span class='danger'>The solution spews out foam!</span>")
+	holder.create_foam(/datum/effect_system/foam_spread,2*created_volume,notification="<span class='danger'>The solution spews out foam!</span>")
 
 /datum/chemical_reaction/metalfoam
 	name = "Metal Foam"
@@ -363,7 +363,7 @@
 	mob_react = FALSE
 
 /datum/chemical_reaction/metalfoam/on_reaction(datum/reagents/holder, created_volume)
-	holder.create_foam(5*created_volume,1,"<span class='danger'>The solution spews out a metallic foam!</span>")
+	holder.create_foam(/datum/effect_system/foam_spread/metal,5*created_volume,1,"<span class='danger'>The solution spews out a metallic foam!</span>")
 
 /datum/chemical_reaction/smart_foam
 	name = "Smart Metal Foam"
@@ -372,7 +372,7 @@
 	mob_react = TRUE
 
 /datum/chemical_reaction/smart_foam/on_reaction(datum/reagents/holder, created_volume)
-	holder.create_foam(5*created_volume,1,"<span class='danger'>The solution spews out metallic foam!</span>")
+	holder.create_foam(/datum/effect_system/foam_spread/metal/smart,5*created_volume,1,"<span class='danger'>The solution spews out metallic foam!</span>")
 
 /datum/chemical_reaction/ironfoam
 	name = "Iron Foam"
@@ -381,7 +381,7 @@
 	mob_react = FALSE
 
 /datum/chemical_reaction/ironfoam/on_reaction(datum/reagents/holder, created_volume)
-	holder.create_foam(5*created_volume,2,"<span class='danger'>The solution spews out a metallic foam!</span>")
+	holder.create_foam(/datum/effect_system/foam_spread/metal,5*created_volume,2,"<span class='danger'>The solution spews out a metallic foam!</span>")
 
 /datum/chemical_reaction/foaming_agent
 	name = "Foaming Agent"

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -210,20 +210,13 @@
 /datum/chemical_reaction/slime/slimefoam
 	name = "Slime Foam"
 	id = "m_foam"
-	//results = list(/datum/reagent/fluorosurfactant = 20, /datum/reagent/water = 20)
 	required_reagents = list(/datum/reagent/water = 5)
 	required_container = /obj/item/slime_extract/blue
 	required_other = TRUE
 
 /datum/chemical_reaction/slime/slimefoam/on_reaction(datum/reagents/holder)
-	var/location = get_turf(holder.my_atom)
-	for(var/mob/M in viewers(5, location))
-		to_chat(M, "<span class='danger'>The solution spews out foam!</span>")
-	var/datum/effect_system/foam_spread/s = new()
-	s.set_up(80, location, holder)
-	s.start()
-	holder.clear_reagents()
-	return
+	var/datum/effect_system/foam_spread/foam = new()
+	create_foam(foam,holder,80)
 
 //Dark Blue
 /datum/chemical_reaction/slime/slimefreeze

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -215,8 +215,7 @@
 	required_other = TRUE
 
 /datum/chemical_reaction/slime/slimefoam/on_reaction(datum/reagents/holder)
-	var/datum/effect_system/foam_spread/foam = new()
-	create_foam(foam,holder,80)
+	holder.create_foam(80, "<span class='danger'>[src] spews out foam!</span>")
 
 //Dark Blue
 /datum/chemical_reaction/slime/slimefreeze

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -215,7 +215,7 @@
 	required_other = TRUE
 
 /datum/chemical_reaction/slime/slimefoam/on_reaction(datum/reagents/holder)
-	holder.create_foam(80, "<span class='danger'>[src] spews out foam!</span>")
+	holder.create_foam(/datum/effect_system/foam_spread,80, "<span class='danger'>[src] spews out foam!</span>")
 
 //Dark Blue
 /datum/chemical_reaction/slime/slimefreeze

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -210,10 +210,20 @@
 /datum/chemical_reaction/slime/slimefoam
 	name = "Slime Foam"
 	id = "m_foam"
-	results = list(/datum/reagent/fluorosurfactant = 20, /datum/reagent/water = 20)
+	//results = list(/datum/reagent/fluorosurfactant = 20, /datum/reagent/water = 20)
 	required_reagents = list(/datum/reagent/water = 5)
 	required_container = /obj/item/slime_extract/blue
 	required_other = TRUE
+
+/datum/chemical_reaction/slime/slimefoam/on_reaction(datum/reagents/holder)
+	var/location = get_turf(holder.my_atom)
+	for(var/mob/M in viewers(5, location))
+		to_chat(M, "<span class='danger'>The solution spews out foam!</span>")
+	var/datum/effect_system/foam_spread/s = new()
+	s.set_up(80, location, holder)
+	s.start()
+	holder.clear_reagents()
+	return
 
 //Dark Blue
 /datum/chemical_reaction/slime/slimefreeze

--- a/code/modules/research/xenobiology/crossbreeding/selfsustaining.dm
+++ b/code/modules/research/xenobiology/crossbreeding/selfsustaining.dm
@@ -42,10 +42,10 @@ Self-sustaining extracts:
 		return
 	if(reagentselect == "lesser plasma")
 		amount = 4
-		reagentselect = "plasma"
+		reagentselect = /datum/reagent/toxin/plasma
 	if(reagentselect == "holy water and uranium")
 		reagentselect = /datum/reagent/water/holywater
-		secondary = "uranium"
+		secondary = /datum/reagent/uranium
 	extract.forceMove(user.drop_location())
 	qdel(src)
 	user.put_in_active_hand(extract)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -298,11 +298,7 @@
 			return 250
 
 		if(SLIME_ACTIVATE_MAJOR)
-			var/location = get_turf(user)
-			var/datum/effect_system/foam_spread/s = new()
-			s.set_up(20, location, user.reagents)
-			s.start()
-			user.reagents.clear_reagents()
+			user.reagents.create_foam(20)
 			user.visible_message("<span class='danger'>Foam spews out from [user]'s skin!</span>", "<span class='warning'>You activate [src], and foam bursts out of your skin!</span>")
 			return 600
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -298,7 +298,7 @@
 			return 250
 
 		if(SLIME_ACTIVATE_MAJOR)
-			user.reagents.create_foam(20)
+			user.reagents.create_foam(/datum/effect_system/foam_spread,20)
 			user.visible_message("<span class='danger'>Foam spews out from [user]'s skin!</span>", "<span class='warning'>You activate [src], and foam bursts out of your skin!</span>")
 			return 600
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes uranium/holy water and small plasma activation of self-sustaining rainbow slime extracts. Also changes the blue slime extract water activation to call new foam helper proc, instead of filling it with water and fluorosurfactant that previously turned the water into more fluorosurfactant.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes uranium/holy water and small plasma activation of self-sustaining rainbow slime extracts
fix: injecting blue slime extracts with water now creates foam, not fluorosurfactant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
