### PR TITLE
Highly increasing Timelock on all Security Department Jobs (Besides the lawyer)

### DIFF
--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -10,7 +10,7 @@
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 300
+	exp_requirements = 600
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/detective

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -12,7 +12,7 @@
 	selection_color = "#ffdddd"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 300
+	exp_requirements = 960
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
 

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -10,7 +10,7 @@
 	supervisors = "the head of security, and the head of your assigned department (if applicable)"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 300
+	exp_requirements = 480
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/security

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -10,7 +10,7 @@
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 300
+	exp_requirements = 720
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/warden


### PR DESCRIPTION
## About The Pull Request

Changes the `exp_requirements` for the following jobs in the list:

Security Officer from `300` to `480` (5h to 8h)
Detective from `300` to `600` (5h to 10h)
Warden from `300` to `720` (5h to 12h)
And the HoS from `300` to `960` (5h to 16h)

## Why It's Good For The Game

As-is the current Time-lock (which is set to 5 hours for all of the security Department jobs) is, as i believe, not enough time of playing crew to properly understand how big Security can have an effect on the round and how easily Security can change any person on the stations plans for anything, here’s a few examples of this:

You wanna do surgery as a roboticist on a Security Officer to turn him into a robo-cop with the Sec-Officers permission?: Security can come in and arrest you, sometimes in a manner that can only be described as “Shitcurity”.

You feel like carving up some human bodies for food as chef?: Security can comes in and arrests you despite the fact that the bodies were un-recoverable beyond all means.

Do you want to just do some good ‘ol toxins as a scientist?: You get shot on the spot for holding a bomb while in toxins.

All of these are examples where Security can completely change someones plans, sometimes this is completely justified, other times it’s about as justified as the existence of mosquitos, hence why this PR is ment to fix this issue by increasing the Security Officers to 8 hours, the Detectives timelock to 10 hours, the Warden gets theirs increased to 12 hours, & the HoS gets theirs increased to 16 hours hours so that Security Officers would take (if a round was, on average, around 2 hours long) around 4 rounds to properly understand the impact of the job and become able to play it, while Warden has 12 hours which would give 4 hours in-between the Warden and the HoS so atleast 2 rounds could be fit in-between so the Warden can atleast get some experience with Sec-Wrangling, and the HoS would require 16 hours so they can fully understand their job of both wrangling the Greytiders and the Security who has no clue on what to do with their job at the same time.

## Changelog
:cl:Mrhugo13
tweak: Security Officer now require 8 hours of playing any department to play.
tweak: Detective now require 10 hours of playing any department to play.
tweak: Warden now require 12 hours of playing any department to play.
tweak: Head of Security now require 16 hours of playing any department to play.
/:cl:
