### PR TITLE
[WIP] Adds some fluff to the ghost dialog

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -16,6 +16,8 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/antag_moodlet //typepath of moodlet that the mob will gain with their status
 	var/can_hijack = HIJACK_NEUTRAL //If these antags are alone on shuttle hijack happens.
 
+	var/ghost_text // Will be shown if someone tries to ghost while cuffed or in prison
+
 	//Antag panel properties
 	var/show_in_antagpanel = TRUE	//This will hide adding this antag type in antag panel, use only for internal subtypes that shouldn't be added directly but still show if possessed by mind
 	var/antagpanel_category = "Uncategorized"	//Antagpanel will display these together, REQUIRED

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -6,6 +6,7 @@
 	var/datum/team/brother_team/team
 	antag_moodlet = /datum/mood_event/focused
 	can_hijack = HIJACK_HIJACKER
+	ghost_text = "I can't abandon my brother, not when we've come so far!"
 
 /datum/antagonist/brother/create_team(datum/team/brother_team/new_team)
 	if(!new_team)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -12,6 +12,7 @@
 	var/ignore_implant = FALSE
 	var/give_equipment = FALSE
 	var/datum/team/cult/cult_team
+	ghost_text = "You disappoint me mortal. Giving up so easily? I chose you for a reason."
 
 
 /datum/antagonist/cult/get_team()

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -9,6 +9,7 @@
 	antag_moodlet = /datum/mood_event/revolution
 	var/hud_type = "rev"
 	var/datum/team/revolution/rev_team
+	ghost_text = "I can't give up now, the heads must pay!"
 
 /datum/antagonist/rev/can_be_owned(datum/mind/new_owner)
 	. = ..()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -15,6 +15,7 @@
 	var/traitor_kind = TRAITOR_HUMAN //Set on initial assignment
 	var/datum/contractor_hub/contractor_hub
 	can_hijack = HIJACK_HIJACKER
+	ghost_text = "The syndicate does not take kindly to those who abandon their mission."
 
 /datum/antagonist/traitor/on_gain()
 	if(owner.current && isAI(owner.current))

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -13,6 +13,7 @@
 	var/outfit_type = /datum/outfit/wizard
 	var/wiz_age = WIZARD_AGE_MIN /* Wizards by nature cannot be too young. */
 	can_hijack = HIJACK_HIJACKER
+	ghost_text = "The old wizard in a prison trick? I did that when my beard only reached to my bellybutton!"
 
 /datum/antagonist/wizard/on_gain()
 	register()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -285,7 +285,22 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(stat == DEAD)
 		ghostize(1)
 	else
-		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
+		var/ghost_text = "Are you -sure- you want to ghost?"
+
+		// Check if we are an antag and either stuck in prison or cuffed
+		if(mind?.antag_datums && mind.antag_datums.len && (is_type_in_list(get_area(src), list(/area/security/brig, /area/security/prison)) || is_cuffed()))
+			var/list/possible_ghost_texts = list()
+
+			for(var/datum/antagonist/A in mind.antag_datums)
+				
+				if(A.ghost_text)
+					possible_ghost_texts += A.ghost_text		
+
+			// Still here? Time to make someone feel bad if possible
+			if(possible_ghost_texts.len)
+				ghost_text = pick(possible_ghost_texts)
+
+		var/response = alert(src, ghost_text + "\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)" ,"Are you sure you want to ghost?","Ghost","Stay in body")
 		if(response != "Ghost")
 			return	//didn't want to ghost after-all
 		ghostize(0)						//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1029,3 +1029,6 @@
 	if(mood)
 		if(mood.sanity < SANITY_UNSTABLE)
 			return TRUE
+
+/mob/living/carbon/is_cuffed()
+	return handcuffed ? TRUE : FALSE

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -591,3 +591,6 @@
 ///Can the mob see reagents inside of containers?
 /mob/proc/can_see_reagents()
 	return stat == DEAD || has_unlimited_silicon_privilege //Dead guys and silicons can always see reagents
+
+/mob/proc/is_cuffed()
+	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds the ability to specify a "ghost text" on antag datums. This will be shown when a player tries to ghost while in prison or cuffed. Inspired by doom exit quotes.

Example

![](https://i.imgur.com/1PgVyDV.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This tries to guilt people into not ghosting as soon as they are caught, if that fails it adds some neat fluff to the game which is always a good thing imo.

I am open to suggestions on what the ghost texts should be.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can't run from your responsibilities
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
