### PR TITLE
buffs the cybernetic heart

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -173,13 +173,9 @@
 
 /obj/item/organ/heart/cybernetic
 	name = "cybernetic heart"
-	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of epinephrine, used automatically after facing severe trauma."
+	desc = "An electronic device designed to mimic the functions of an organic human heart."
 	icon_state = "heart-c"
 	organ_flags = ORGAN_SYNTHETIC
-
-	var/dose_available = TRUE
-	var/rid = /datum/reagent/medicine/epinephrine
-	var/ramount = 10
 
 /obj/item/organ/heart/cybernetic/emp_act()
 	. = ..()
@@ -189,21 +185,26 @@
 
 /obj/item/organ/heart/cybernetic/on_life()
 	. = ..()
-	if(dose_available && owner.stat == UNCONSCIOUS && !owner.reagents.has_reagent(rid))
-		owner.reagents.add_reagent(rid, ramount)
-		used_dose()
-
-/obj/item/organ/heart/cybernetic/proc/used_dose()
-	dose_available = FALSE
 
 /obj/item/organ/heart/cybernetic/upgraded
 	name = "upgraded cybernetic heart"
-	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of epinephrine, used automatically after facing severe trauma. This upgraded model can regenerate its dose after use."
+	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of medicine, used automatically after facing severe trauma. It can regenerate its dose in 10 minutes."
 	icon_state = "heart-c-u"
 
-/obj/item/organ/heart/cybernetic/upgraded/used_dose()
+	var/dose_available = TRUE
+	var/list/cybernetic_reagents = list(/datum/reagent/medicine/salbutamol = 15, /datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/ephedrine = 5)
+
+/obj/item/organ/heart/cybernetic/upgraded/on_life()
 	. = ..()
-	addtimer(VARSET_CALLBACK(src, dose_available, TRUE), 5 MINUTES)
+	if(dose_available && owner.health <= owner.crit_threshold)
+		var/reagent
+		for(reagent in cybernetic_reagents)
+			owner.reagents.add_reagent(reagent, cybernetic_reagents[reagent]) // add every reagent to the owner of the heart
+	used_dose()
+
+/obj/item/organ/heart/cybernetic/upgraded/proc/used_dose()
+	dose_available = FALSE
+	addtimer(VARSET_CALLBACK(src, dose_available, TRUE), 10 MINUTES)
 
 /obj/item/organ/heart/freedom
 	name = "heart of freedom"

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -182,6 +182,7 @@
 	if(. & EMP_PROTECT_SELF)
 		return
 	Stop()
+	addtimer(CALLBACK(src, .proc/Restart), 20 SECONDS)
 
 /obj/item/organ/heart/cybernetic/on_life()
 	. = ..()

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -192,15 +192,15 @@
 	icon_state = "heart-c-u"
 
 	var/dose_available = TRUE
-	var/list/cybernetic_reagents = list(/datum/reagent/medicine/salbutamol = 15, /datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/ephedrine = 5)
+	var/list/cybernetic_reagents = list( /datum/reagent/medicine/atropine = 15, /datum/reagent/medicine/omnizine = 10, /datum/reagent/medicine/salbutamol = 10, /datum/reagent/medicine/ephedrine = 10) // associative list
 
 /obj/item/organ/heart/cybernetic/upgraded/on_life()
 	. = ..()
 	if(dose_available && owner.health <= owner.crit_threshold)
-		var/reagent
-		for(reagent in cybernetic_reagents)
-			owner.reagents.add_reagent(reagent, cybernetic_reagents[reagent]) // add every reagent to the owner of the heart
-	used_dose()
+		var/cybernetic_reagent
+		for(cybernetic_reagent in cybernetic_reagents)
+			owner.reagents.add_reagent(cybernetic_reagent, cybernetic_reagents[cybernetic_reagent]) // add every reagent to the owner of the heart
+		used_dose()
 
 /obj/item/organ/heart/cybernetic/upgraded/proc/used_dose()
 	dose_available = FALSE

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -188,7 +188,7 @@
 
 /obj/item/organ/heart/cybernetic/upgraded
 	name = "upgraded cybernetic heart"
-	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of medicine, used automatically after facing severe trauma. It can regenerate its dose in 10 minutes."
+	desc = "An electronic device designed to mimic the functions of an organic human heart. Also holds an emergency dose of medicine, used automatically after facing severe trauma. It can regenerate its dose in 5 minutes."
 	icon_state = "heart-c-u"
 
 	var/dose_available = TRUE

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -204,7 +204,7 @@
 
 /obj/item/organ/heart/cybernetic/upgraded/proc/used_dose()
 	dose_available = FALSE
-	addtimer(VARSET_CALLBACK(src, dose_available, TRUE), 10 MINUTES)
+	addtimer(VARSET_CALLBACK(src, dose_available, TRUE), 5 MINUTES)
 
 /obj/item/organ/heart/freedom
 	name = "heart of freedom"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Injects reagents on crit instead of unconsciousness, because for some reason it didn't do that.
The heart will restart after being EMP'ed in at least 20 seconds based on emp severity instead of stopping forever.
The heart will take damage based on emp severity, like all other cybernetics.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cybernetic hearts are pretty useless right now and I don't think anyone actually uses them due to the fact that if you get EMP'ed you are dead. Making the cybernetic heart not instantly kill you would be good. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: cybernetic heart will restart after 20 seconds instead of stopping forever
tweak: cybernetic heart takes damage from emp like other cybernetics
tweak: heart injects epinephrine on crit instead of unconsciousness
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
