### PR TITLE
[s]Wizards can no longer go into rod form in the wizard's den to break out of it.

### DIFF
--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -12,6 +12,10 @@
 	action_icon_state = "immrod"
 
 /obj/effect/proc_holder/spell/targeted/rod_form/cast(list/targets,mob/user = usr)
+	var/area/A = get_area(user)
+	if(istype(A, /area/wizard_station))
+		to_chat(user, "<span class='warning'>You know better than to trash Wizard Federation property. Best wait until you leave to use [src].</span>")
+		return
 	for(var/mob/living/M in targets)
 		var/turf/start = get_turf(M)
 		var/obj/effect/immovablerod/wizard/W = new(start, get_ranged_target_turf(start, M.dir, (15 + spell_level * 3)))


### PR DESCRIPTION
## About The Pull Request

No more rod form in the wizard's den. This applies whether you are a wizard or whether you somehow ended up in the den and are not a wizard, which I don't know how that would happen, but if you did.

Fixes https://github.com/tgstation/tgstation/issues/46201.

## Why It's Good For The Game

Patches an exploit. We have precedent for magic not usable in the wizard den.
