### PR TITLE
pepperspray buff

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -297,10 +297,14 @@
 			victim.confused = max(M.confused, 3)
 			victim.damageoverlaytemp = 60
 			victim.Paralyze(60)
+			victim.adjustStaminaLoss(40)
 			return
 		else if ( eyes_covered ) // Eye cover is better than mouth cover
 			victim.blur_eyes(3)
+			victim.confused = max(M.confused, 1)
 			victim.damageoverlaytemp = 30
+			victim.Paralyze(10)
+			victim.adjustStaminaLoss(20)
 			return
 		else // Oh dear :D
 			if(prob(5))
@@ -310,6 +314,7 @@
 			victim.confused = max(M.confused, 6)
 			victim.damageoverlaytemp = 75
 			victim.Paralyze(100)
+			victim.adjustStaminaLoss(60)
 		victim.update_damage_hud()
 
 /datum/reagent/consumable/condensedcapsaicin/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -197,7 +197,7 @@
 	item_state = "pepperspray"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
-	volume = 40
+	volume = 50
 	stream_range = 4
 	amount_per_transfer_from_this = 5
 	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 40)


### PR DESCRIPTION
closes #46272
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Peppersprays now deal an amount of stamina damage that changes with the amount of protection you have.
Mouth covering gives you 40 stamina damage.
Eye covering gives you 20. (It also now paralyzes for 10 and slightly confuses you)
No covering gives you 60.
Peppersprays now store 50 units, from 40.
## Why It's Good For The Game

peppersprays are a joke, you can completely ignore them if you wear a breath mask and a pair of prescription glasses. this PR aims to make it slightly less useless
i also thought of making pepper still give some stamina damage even with mouth + eye covering, but i'm not so sure about that

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: pepperspray now deals stamina damage and paralyzes you even with glasses on
tweak: it also stores 50u
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
