### PR TITLE
[s]You can no longer send cult messages undetectably by including an IC filtered word.

### DIFF
--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -20,7 +20,9 @@
 	var/input = stripped_input(usr, "Please choose a message to tell to the other acolytes.", "Voice of Blood", "")
 	if(!input || !IsAvailable())
 		return
-
+	if(CHAT_FILTER_CHECK(input))
+		alert("You cannot send a message that contains a word prohibited in IC chat!")
+		return
 	cultist_commune(usr, input)
 
 /datum/action/innate/cult/comm/proc/cultist_commune(mob/living/user, message)

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -21,7 +21,7 @@
 	if(!input || !IsAvailable())
 		return
 	if(CHAT_FILTER_CHECK(input))
-		alert("You cannot send a message that contains a word prohibited in IC chat!")
+		to_chat(owner, "<span class='warning'>You cannot send a message that contains a word prohibited in IC chat!</span>")
 		return
 	cultist_commune(usr, input)
 

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -21,7 +21,7 @@
 	if(!input || !IsAvailable())
 		return
 	if(CHAT_FILTER_CHECK(input))
-		to_chat(owner, "<span class='warning'>You cannot send a message that contains a word prohibited in IC chat!</span>")
+		to_chat(usr, "<span class='warning'>You cannot send a message that contains a word prohibited in IC chat!</span>")
 		return
 	cultist_commune(usr, input)
 


### PR DESCRIPTION
## About The Pull Request

Cult messaging checks for the IC filter, which it previously did not, resulting in an exploit where you can put an IC-filtered word into a cult message, and have it still go through to cultists while being blocked from whisper.

Fixes https://github.com/tgstation/tgstation/issues/46085.

## Why It's Good For The Game

Fixes another exploit. Please let me know if there are any other instances of exploits and/or oversights with the IC filter.
