### PR TITLE
Fixes converting a Ripley MK-I to MK-II breaking when the MK-I has no power cell.

### DIFF
--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -365,6 +365,9 @@
 	if(M.occupant) //We're actualy making a new mech and swapping things over, it might get weird if players are involved
 		to_chat(loc, "<span class='warning'>[M] must be unoccupied before this conversion kit can be applied.</span>")
 		return FALSE
+	if(!M.cell) //Turns out things break if the cell is missing
+		to_chat(loc, "<span class='warning'>The conversion process requires a cell installed.</span>")
+		return FALSE
 	return TRUE
 
 /obj/item/mecha_parts/mecha_equipment/ripleyupgrade/attach(obj/mecha/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a check preventing the MK-I to MK-II conversion when there's no cell installed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mech code is held together with duct tape and the tears of maintainers. If anything at all is set unexpectedly, it all breaks.

Mechs without cells can move due to how the mech tries to subtract charge. Normally this isn't an issue because you can't move a mech that's in maintenance mode. Mechs in maintenance mode cannot be removed from maintenance mode without finishing the steps of replacing a cell. Converting skips the process of finishing the cell replacement steps but the cell is gone, resulting in this mess.

The easiest solution is to just not allow the conversion when the cell is missing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed being able to Convert a Ripley MK-I to MK-II without a battery and breaking things.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
