### PR TITLE
Makes nanites be passed down when jellypeople and slimes split

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -292,6 +292,7 @@
 //Nanites
 #define COMSIG_HAS_NANITES "has_nanites"						//() returns TRUE if nanites are found
 #define COMSIG_NANITE_GET_PROGRAMS	"nanite_get_programs"		//(list/nanite_programs) - makes the input list a copy the nanites' program list
+#define COMSIG_NANITE_GET_VOLUME "nanite_get_volume"			//(amount) Returns nanite amount
 #define COMSIG_NANITE_SET_VOLUME "nanite_set_volume"			//(amount) Sets current nanite volume to the given amount
 #define COMSIG_NANITE_ADJUST_VOLUME "nanite_adjust"				//(amount) Adjusts nanite volume by the given amount
 #define COMSIG_NANITE_SET_MAX_VOLUME "nanite_set_max_volume"	//(amount) Sets maximum nanite volume to the given amount

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -37,7 +37,6 @@
 	RegisterSignal(parent, COMSIG_HAS_NANITES, .proc/confirm_nanites)
 	RegisterSignal(parent, COMSIG_NANITE_UI_DATA, .proc/nanite_ui_data)
 	RegisterSignal(parent, COMSIG_NANITE_GET_PROGRAMS, .proc/get_programs)
-	RegisterSignal(parent, COMSIG_NANITE_GET_VOLUME, .proc/get_volume)
 	RegisterSignal(parent, COMSIG_NANITE_SET_VOLUME, .proc/set_volume)
 	RegisterSignal(parent, COMSIG_NANITE_ADJUST_VOLUME, .proc/adjust_nanites)
 	RegisterSignal(parent, COMSIG_NANITE_SET_MAX_VOLUME, .proc/set_max_volume)
@@ -62,7 +61,6 @@
 	UnregisterSignal(parent, list(COMSIG_HAS_NANITES,
 								COMSIG_NANITE_UI_DATA,
 								COMSIG_NANITE_GET_PROGRAMS,
-								COMSIG_NANITE_GET_VOLUME,
 								COMSIG_NANITE_SET_VOLUME,
 								COMSIG_NANITE_ADJUST_VOLUME,
 								COMSIG_NANITE_SET_MAX_VOLUME,
@@ -220,9 +218,6 @@
 		else
 			return FALSE
 	return FALSE
-
-/datum/component/nanites/proc/get_volume(datum/source, list/L)
-	L[1] += nanite_volume
 
 /datum/component/nanites/proc/set_volume(datum/source, amount)
 	nanite_volume = CLAMP(amount, 0, max_nanites)

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -37,6 +37,7 @@
 	RegisterSignal(parent, COMSIG_HAS_NANITES, .proc/confirm_nanites)
 	RegisterSignal(parent, COMSIG_NANITE_UI_DATA, .proc/nanite_ui_data)
 	RegisterSignal(parent, COMSIG_NANITE_GET_PROGRAMS, .proc/get_programs)
+	RegisterSignal(parent, COMSIG_NANITE_GET_VOLUME, .proc/get_volume)
 	RegisterSignal(parent, COMSIG_NANITE_SET_VOLUME, .proc/set_volume)
 	RegisterSignal(parent, COMSIG_NANITE_ADJUST_VOLUME, .proc/adjust_nanites)
 	RegisterSignal(parent, COMSIG_NANITE_SET_MAX_VOLUME, .proc/set_max_volume)
@@ -61,6 +62,7 @@
 	UnregisterSignal(parent, list(COMSIG_HAS_NANITES,
 								COMSIG_NANITE_UI_DATA,
 								COMSIG_NANITE_GET_PROGRAMS,
+								COMSIG_NANITE_GET_VOLUME,
 								COMSIG_NANITE_SET_VOLUME,
 								COMSIG_NANITE_ADJUST_VOLUME,
 								COMSIG_NANITE_SET_MAX_VOLUME,
@@ -218,6 +220,9 @@
 		else
 			return FALSE
 	return FALSE
+
+/datum/component/nanites/proc/get_volume(datum/source, list/L)
+	L[1] += nanite_volume
 
 /datum/component/nanites/proc/set_volume(datum/source, amount)
 	nanite_volume = CLAMP(amount, 0, max_nanites)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -224,8 +224,9 @@
 	spare.domutcheck()
 	spare.Move(get_step(H.loc, pick(NORTH,SOUTH,EAST,WEST)))
 
-	if(H.GetComponent(/datum/component/nanites))
-		var/datum/component/nanites/owner_nanites = H.GetComponent(/datum/component/nanites)
+
+	var/datum/component/nanites/owner_nanites = H.GetComponent(/datum/component/nanites)
+	if(owner_nanites)
 		//copying over nanite programs/cloud sync with 50% saturation in host and spare
 		owner_nanites.nanite_volume *= 0.5
 		spare.AddComponent(/datum/component/nanites, owner_nanites.nanite_volume)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -224,24 +224,15 @@
 	spare.domutcheck()
 	spare.Move(get_step(H.loc, pick(NORTH,SOUTH,EAST,WEST)))
 
-	var/list/L = list()
-	to_chat(owner, "<span class='warning'>list definition worked</span>")
+	var/list/L[1]
 	var/nanite_volume_new = 0
-	to_chat(owner, "<span class='warning'>nanvol worked</span>")
 	SEND_SIGNAL(owner, COMSIG_NANITE_GET_VOLUME, L)
-	to_chat(owner, "<span class='warning'>get volume sig worked worked</span>")
 	if(L[1] > 0)
-		to_chat(owner, "<span class='warning'>L check true</span>")
 		nanite_volume_new = L[1] * 0.5 //Copying over nanites with 50% of volume to each party
-		to_chat(owner, "<span class='warning'>change nan vol worked</span>")
 	if(nanite_volume_new > 0)
-		to_chat(owner, "<span class='warning'>nan vol check true</span>")
 		SEND_SIGNAL(owner, COMSIG_NANITE_SET_VOLUME, nanite_volume_new)
-		to_chat(owner, "<span class='warning'>owner set volume worked worked</span>")
 		spare.AddComponent(/datum/component/nanites, nanite_volume_new)
-		to_chat(owner, "<span class='warning'>add component worked</span>")
 		SEND_SIGNAL(spare, COMSIG_NANITE_SYNC, owner)
-		to_chat(owner, "<span class='warning'>sync worked</span>")
 
 	H.blood_volume *= 0.45
 	H.notransform = 0

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -225,12 +225,23 @@
 	spare.Move(get_step(H.loc, pick(NORTH,SOUTH,EAST,WEST)))
 
 	var/list/L = list()
+	to_chat(owner, "<span class='warning'>list definition worked</span>")
+	var/nanite_volume_new = 0
+	to_chat(owner, "<span class='warning'>nanvol worked</span>")
 	SEND_SIGNAL(owner, COMSIG_NANITE_GET_VOLUME, L)
-	var/nanite_volume_new = L[1] * 0.5 //Copying over nanites with 50% of volume to each party
-	if(nanite_volume_new)
+	to_chat(owner, "<span class='warning'>get volume sig worked worked</span>")
+	if(L[1] > 0)
+		to_chat(owner, "<span class='warning'>L check true</span>")
+		nanite_volume_new = L[1] * 0.5 //Copying over nanites with 50% of volume to each party
+		to_chat(owner, "<span class='warning'>change nan vol worked</span>")
+	if(nanite_volume_new > 0)
+		to_chat(owner, "<span class='warning'>nan vol check true</span>")
 		SEND_SIGNAL(owner, COMSIG_NANITE_SET_VOLUME, nanite_volume_new)
+		to_chat(owner, "<span class='warning'>owner set volume worked worked</span>")
 		spare.AddComponent(/datum/component/nanites, nanite_volume_new)
+		to_chat(owner, "<span class='warning'>add component worked</span>")
 		SEND_SIGNAL(spare, COMSIG_NANITE_SYNC, owner)
+		to_chat(owner, "<span class='warning'>sync worked</span>")
 
 	H.blood_volume *= 0.45
 	H.notransform = 0

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -225,6 +225,7 @@
 	spare.Move(get_step(H.loc, pick(NORTH,SOUTH,EAST,WEST)))
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 	var/list/L[1]
 	var/nanite_volume_new = 0
 	SEND_SIGNAL(owner, COMSIG_NANITE_GET_VOLUME, L)
@@ -235,6 +236,8 @@
 		spare.AddComponent(/datum/component/nanites, nanite_volume_new)
 		SEND_SIGNAL(spare, COMSIG_NANITE_SYNC, owner)
 
+=======
+>>>>>>> parent of 54d7285416... Makes nanites be passed down when jellypeople and slimes split
 =======
 >>>>>>> parent of 54d7285416... Makes nanites be passed down when jellypeople and slimes split
 	H.blood_volume *= 0.45

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -224,6 +224,13 @@
 	spare.domutcheck()
 	spare.Move(get_step(H.loc, pick(NORTH,SOUTH,EAST,WEST)))
 
+	if(owner.GetComponent(/datum/component/nanites))
+		var/datum/component/nanites/owner_nanites = owner.GetComponent(/datum/component/nanites)
+		//copying over nanite programs/cloud sync with 50% saturation in host and spare
+		owner_nanites.nanite_volume *= 0.5
+		spare.AddComponent(/datum/component/nanites, owner_nanites.nanite_volume)
+		SEND_SIGNAL(spare, COMSIG_NANITE_SYNC, owner_nanites)
+
 	H.blood_volume *= 0.45
 	H.notransform = 0
 

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -224,22 +224,13 @@
 	spare.domutcheck()
 	spare.Move(get_step(H.loc, pick(NORTH,SOUTH,EAST,WEST)))
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-	var/list/L[1]
-	var/nanite_volume_new = 0
-	SEND_SIGNAL(owner, COMSIG_NANITE_GET_VOLUME, L)
-	if(L[1] > 0)
-		nanite_volume_new = L[1] * 0.5 //Copying over nanites with 50% of volume to each party
-	if(nanite_volume_new > 0)
-		SEND_SIGNAL(owner, COMSIG_NANITE_SET_VOLUME, nanite_volume_new)
-		spare.AddComponent(/datum/component/nanites, nanite_volume_new)
-		SEND_SIGNAL(spare, COMSIG_NANITE_SYNC, owner)
+	if(H.GetComponent(/datum/component/nanites))
+		var/datum/component/nanites/owner_nanites = H.GetComponent(/datum/component/nanites)
+		//copying over nanite programs/cloud sync with 50% saturation in host and spare
+		owner_nanites.nanite_volume *= 0.5
+		spare.AddComponent(/datum/component/nanites, owner_nanites.nanite_volume)
+		SEND_SIGNAL(spare, COMSIG_NANITE_SYNC, owner_nanites, TRUE, TRUE) //The trues are to copy activation as well
 
-=======
->>>>>>> parent of 54d7285416... Makes nanites be passed down when jellypeople and slimes split
-=======
->>>>>>> parent of 54d7285416... Makes nanites be passed down when jellypeople and slimes split
 	H.blood_volume *= 0.45
 	H.notransform = 0
 

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -224,12 +224,13 @@
 	spare.domutcheck()
 	spare.Move(get_step(H.loc, pick(NORTH,SOUTH,EAST,WEST)))
 
-	if(owner.GetComponent(/datum/component/nanites))
-		var/datum/component/nanites/owner_nanites = owner.GetComponent(/datum/component/nanites)
-		//copying over nanite programs/cloud sync with 50% saturation in host and spare
-		owner_nanites.nanite_volume *= 0.5
-		spare.AddComponent(/datum/component/nanites, owner_nanites.nanite_volume)
-		SEND_SIGNAL(spare, COMSIG_NANITE_SYNC, owner_nanites)
+	var/list/L = list()
+	SEND_SIGNAL(owner, COMSIG_NANITE_GET_VOLUME, L)
+	var/nanite_volume_new = L[1] * 0.5 //Copying over nanites with 50% of volume to each party
+	if(nanite_volume_new)
+		SEND_SIGNAL(owner, COMSIG_NANITE_SET_VOLUME, nanite_volume_new)
+		spare.AddComponent(/datum/component/nanites, nanite_volume_new)
+		SEND_SIGNAL(spare, COMSIG_NANITE_SYNC, owner)
 
 	H.blood_volume *= 0.45
 	H.notransform = 0

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -224,6 +224,7 @@
 	spare.domutcheck()
 	spare.Move(get_step(H.loc, pick(NORTH,SOUTH,EAST,WEST)))
 
+<<<<<<< HEAD
 	var/list/L[1]
 	var/nanite_volume_new = 0
 	SEND_SIGNAL(owner, COMSIG_NANITE_GET_VOLUME, L)
@@ -234,6 +235,8 @@
 		spare.AddComponent(/datum/component/nanites, nanite_volume_new)
 		SEND_SIGNAL(spare, COMSIG_NANITE_SYNC, owner)
 
+=======
+>>>>>>> parent of 54d7285416... Makes nanites be passed down when jellypeople and slimes split
 	H.blood_volume *= 0.45
 	H.notransform = 0
 

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -173,6 +173,10 @@
 			var/list/babies = list()
 			var/new_nutrition = round(nutrition * 0.9)
 			var/new_powerlevel = round(powerlevel / 4)
+			var/list/L = list()
+			SEND_SIGNAL(src, COMSIG_NANITE_GET_VOLUME, L) //Getting nanite volume before loop to only do it once
+			var/new_nanite_volume = L[1] * 0.5
+
 			for(var/i=1,i<=4,i++)
 				var/child_colour
 				if(mutation_chance >= 100)
@@ -192,11 +196,11 @@
 				babies += M
 				M.mutation_chance = CLAMP(mutation_chance+(rand(5,-5)),0,100)
 				SSblackbox.record_feedback("tally", "slime_babies_born", 1, M.colour)
-				if(src.GetComponent(/datum/component/nanites))
-					var/datum/component/nanites/original_nanites = src.GetComponent(/datum/component/nanites)
-					//copying over nanite programs/cloud sync with 25% of the original slime's saturation in each slime
-					M.AddComponent(/datum/component/nanites, original_nanites.nanite_volume*0.25)
-					SEND_SIGNAL(M, COMSIG_NANITE_SYNC, original_nanites)
+
+				if(new_nanite_volume) //If original slime had nanites, copy over and sync with 25% of the original volume
+					M.AddComponent(/datum/component/nanites, new_nanite_volume)
+					SEND_SIGNAL(M, COMSIG_NANITE_SYNC, src)
+
 			var/mob/living/simple_animal/slime/new_slime = pick(babies)
 			new_slime.a_intent = INTENT_HARM
 			if(src.mind)

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -192,7 +192,11 @@
 				babies += M
 				M.mutation_chance = CLAMP(mutation_chance+(rand(5,-5)),0,100)
 				SSblackbox.record_feedback("tally", "slime_babies_born", 1, M.colour)
-
+				if(src.GetComponent(/datum/component/nanites))
+					var/datum/component/nanites/original_nanites = src.GetComponent(/datum/component/nanites)
+					//copying over nanite programs/cloud sync with 25% of the original slime's saturation in each slime
+					M.AddComponent(/datum/component/nanites, original_nanites.nanite_volume*0.25)
+					SEND_SIGNAL(M, COMSIG_NANITE_SYNC, original_nanites)
 			var/mob/living/simple_animal/slime/new_slime = pick(babies)
 			new_slime.a_intent = INTENT_HARM
 			if(src.mind)

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -173,9 +173,9 @@
 			var/list/babies = list()
 			var/new_nutrition = round(nutrition * 0.9)
 			var/new_powerlevel = round(powerlevel / 4)
-			var/list/L[1]
-			SEND_SIGNAL(src, COMSIG_NANITE_GET_VOLUME, L) //Getting nanite volume before loop to only do it once
-			var/new_nanite_volume = L[1] * 0.25
+			var/datum/component/nanites/original_nanites
+			if(GetComponent(/datum/component/nanites))
+				original_nanites = GetComponent(/datum/component/nanites)
 
 			for(var/i=1,i<=4,i++)
 				var/child_colour
@@ -197,16 +197,10 @@
 				M.mutation_chance = CLAMP(mutation_chance+(rand(5,-5)),0,100)
 				SSblackbox.record_feedback("tally", "slime_babies_born", 1, M.colour)
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-				if(new_nanite_volume) //If original slime had nanites, copy over and sync with 25% of the original volume
-					M.AddComponent(/datum/component/nanites, new_nanite_volume)
-					SEND_SIGNAL(M, COMSIG_NANITE_SYNC, src)
+				if(original_nanites)
+					M.AddComponent(/datum/component/nanites, original_nanites.nanite_volume*0.25)
+					SEND_SIGNAL(M, COMSIG_NANITE_SYNC, original_nanites, TRUE, TRUE) //The trues are to copy activation as well
 
-=======
->>>>>>> parent of 54d7285416... Makes nanites be passed down when jellypeople and slimes split
-=======
->>>>>>> parent of 54d7285416... Makes nanites be passed down when jellypeople and slimes split
 			var/mob/living/simple_animal/slime/new_slime = pick(babies)
 			new_slime.a_intent = INTENT_HARM
 			if(src.mind)

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -173,9 +173,7 @@
 			var/list/babies = list()
 			var/new_nutrition = round(nutrition * 0.9)
 			var/new_powerlevel = round(powerlevel / 4)
-			var/datum/component/nanites/original_nanites
-			if(GetComponent(/datum/component/nanites))
-				original_nanites = GetComponent(/datum/component/nanites)
+			var/datum/component/nanites/original_nanites = GetComponent(/datum/component/nanites)
 
 			for(var/i=1,i<=4,i++)
 				var/child_colour

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -198,10 +198,13 @@
 				SSblackbox.record_feedback("tally", "slime_babies_born", 1, M.colour)
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 				if(new_nanite_volume) //If original slime had nanites, copy over and sync with 25% of the original volume
 					M.AddComponent(/datum/component/nanites, new_nanite_volume)
 					SEND_SIGNAL(M, COMSIG_NANITE_SYNC, src)
 
+=======
+>>>>>>> parent of 54d7285416... Makes nanites be passed down when jellypeople and slimes split
 =======
 >>>>>>> parent of 54d7285416... Makes nanites be passed down when jellypeople and slimes split
 			var/mob/living/simple_animal/slime/new_slime = pick(babies)

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -197,10 +197,13 @@
 				M.mutation_chance = CLAMP(mutation_chance+(rand(5,-5)),0,100)
 				SSblackbox.record_feedback("tally", "slime_babies_born", 1, M.colour)
 
+<<<<<<< HEAD
 				if(new_nanite_volume) //If original slime had nanites, copy over and sync with 25% of the original volume
 					M.AddComponent(/datum/component/nanites, new_nanite_volume)
 					SEND_SIGNAL(M, COMSIG_NANITE_SYNC, src)
 
+=======
+>>>>>>> parent of 54d7285416... Makes nanites be passed down when jellypeople and slimes split
 			var/mob/living/simple_animal/slime/new_slime = pick(babies)
 			new_slime.a_intent = INTENT_HARM
 			if(src.mind)

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -173,9 +173,9 @@
 			var/list/babies = list()
 			var/new_nutrition = round(nutrition * 0.9)
 			var/new_powerlevel = round(powerlevel / 4)
-			var/list/L = list()
+			var/list/L[1]
 			SEND_SIGNAL(src, COMSIG_NANITE_GET_VOLUME, L) //Getting nanite volume before loop to only do it once
-			var/new_nanite_volume = L[1] * 0.5
+			var/new_nanite_volume = L[1] * 0.25
 
 			for(var/i=1,i<=4,i++)
 				var/child_colour


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Splitting jellypeople and slimes will pass their nanites to their offspring, nanite volume being split evenly among the jellyperson's host/spare and the slime's children.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows for neat, cool (niche) interaction between xenobio and nanites. Also this just makes sense.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Slimes and jellypeople pass nanites to their offspring.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
