### PR TITLE
Fixes some erroneous abductor text.

### DIFF
--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -26,7 +26,7 @@
 	sub_role = "Scientist"
 	outfit = /datum/outfit/abductor/scientist
 	landmark_type = /obj/effect/landmark/abductor/scientist
-	greet_text = "Use your stealth technology and equipment to incapacitate humans for your scientist to retrieve."
+	greet_text = "Use your experimental console and surgical equipment to monitor your agent and experiment upon abducted humans."
 	show_in_antagpanel = TRUE
 
 /datum/antagonist/abductor/create_team(datum/team/abductor_team/new_team)
@@ -40,8 +40,8 @@
 	return team
 
 /datum/antagonist/abductor/on_gain()
-	owner.special_role = "[name] [sub_role]"
-	owner.assigned_role = "[name] [sub_role]"
+	owner.special_role = "[name]"
+	owner.assigned_role = "[name]"
 	objectives += team.objectives
 	finalize_abductor()
 	ADD_TRAIT(owner, TRAIT_ABDUCTOR_TRAINING, ABDUCTOR_ANTAGONIST)


### PR DESCRIPTION
## About The Pull Request

* Fixes an issue where abductor names would appear as "Abductor Scientist Scientist" or the like. Fixes https://github.com/tgstation/tgstation/issues/44642.
* Fixes an issue where abductor scientists got the same greeting text as abductor agents.

## Why It's Good For The Game

Fixes bugs and/or erroneous text.