### PR TITLE
Adds new event to the Orion Trail Game - Old Ship

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -372,7 +372,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 						   ORION_TRAIL_MALFUNCTION	= 2,
 						   ORION_TRAIL_COLLISION	= 1,
 						   ORION_TRAIL_SPACEPORT	= 2,
-						   ORION_TRAIL_OLDSHIP		= 3
+						   ORION_TRAIL_OLDSHIP		= 2
 						   )
 	var/list/stops = list()
 	var/list/stopblurbs = list()
@@ -812,27 +812,28 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];search=1'>Search it</a><a href='byond://?src=[REF(src)];eventclose=1'>Leave it</a></P><P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
 
 		if(ORION_TRAIL_SEARCH)
-			if(prob(20))
-				var/rescued = add_crewmember()
-				var/oldfood = rand(1,7)
-				var/oldfuel = rand(4,10)
-				food += oldfood
-				fuel += oldfuel
-				eventdat += "<br>As you look through it you find some supplies and a living person!"
-				eventdat += "<br>[rescued] was rescued from the abandoned ship!"
-				eventdat += "<br>You found [oldfood] <b>Food</b> and [oldfuel] <b>Fuel</b>."
-			else if(prob(20))
-				var/lfuel = rand(4,7)
-				var/deadname = remove_crewmember()
-				fuel -= lfuel
-				eventdat += "<br>[deadname] was lost deep in the wreckage, and your own vessel lost [lfuel] <b>Fuel</b> maneuvering to the the abandoned ship."
-			else if(prob(40))
-				var/oldfood = rand(5,11)
-				food += oldfood
-				engine++
-				eventdat += "<br>You found [oldfood] <b>Food</b> and some parts amongst the wreck."
-			else
-				eventdat += "<br>As you look through the wreck you cannot find much of use."
+			switch(rand(100))
+				if(0 to 15)
+					var/rescued = add_crewmember()
+					var/oldfood = rand(1,7)
+					var/oldfuel = rand(4,10)
+					food += oldfood
+					fuel += oldfuel
+					eventdat += "<br>As you look through it you find some supplies and a living person!"
+					eventdat += "<br>[rescued] was rescued from the abandoned ship!"
+					eventdat += "<br>You found [oldfood] <b>Food</b> and [oldfuel] <b>Fuel</b>."
+				if(15 to 35)
+					var/lfuel = rand(4,7)
+					var/deadname = remove_crewmember()
+					fuel -= lfuel
+					eventdat += "<br>[deadname] was lost deep in the wreckage, and your own vessel lost [lfuel] <b>Fuel</b> maneuvering to the the abandoned ship."
+				if(35 to 65)
+					var/oldfood = rand(5,11)
+					food += oldfood
+					engine++
+					eventdat += "<br>You found [oldfood] <b>Food</b> and some parts amongst the wreck."
+				else
+					eventdat += "<br>As you look through the wreck you cannot find much of use."
 			eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];eventclose=1'>Continue</a></P>"
 			eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
 			canContinueEvent = 1

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -372,7 +372,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 						   ORION_TRAIL_MALFUNCTION	= 2,
 						   ORION_TRAIL_COLLISION	= 1,
 						   ORION_TRAIL_SPACEPORT	= 2,
-						   ORION_TRAIL_OLDSHIP		= 3
+						   ORION_TRAIL_OLDSHIP		= 2
 						   )
 	var/list/stops = list()
 	var/list/stopblurbs = list()

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -340,6 +340,8 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 #define ORION_TRAIL_COLLISION	"Collision"
 #define ORION_TRAIL_SPACEPORT	"Spaceport"
 #define ORION_TRAIL_BLACKHOLE	"BlackHole"
+#define ORION_TRAIL_OLDSHIP		"Old Ship"
+#define ORION_TRAIL_SEARCH		"Old Ship Search"
 
 #define ORION_STATUS_START		1
 #define ORION_STATUS_NORMAL		2
@@ -369,7 +371,8 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 						   ORION_TRAIL_LING			= 3,
 						   ORION_TRAIL_MALFUNCTION	= 2,
 						   ORION_TRAIL_COLLISION	= 1,
-						   ORION_TRAIL_SPACEPORT	= 2
+						   ORION_TRAIL_SPACEPORT	= 2,
+						   ORION_TRAIL_OLDSHIP		= 2
 						   )
 	var/list/stops = list()
 	var/list/stopblurbs = list()
@@ -592,6 +595,10 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			food = 80
 			fuel = 60
 			settlers = list("Harry","Larry","Bob")
+	else if(href_list["search"]) //search old ship
+		if(event == ORION_TRAIL_OLDSHIP)
+			event = "Old Ship Search"
+			event()
 	else if(href_list["slow"]) //slow down
 		if(event == ORION_TRAIL_FLUX)
 			food -= (alive+lings_aboard)*2
@@ -799,6 +806,45 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			eventdat += "<br>What will you do?"
 			eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];slow=1'>Slow Down</a> <a href='byond://?src=[REF(src)];keepspeed=1'>Continue</a></P>"
 			eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
+
+		if(ORION_TRAIL_OLDSHIP)
+			eventdat += "<br>Your crew spots an old ship floating through space. It might have some supplies, but then again it looks rather unsafe."
+			eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];search=1'>Search it</a><a href='byond://?src=[REF(src)];eventclose=1'>Leave it</a></P><P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
+
+		if(ORION_TRAIL_SEARCH)
+			if(prob(20))
+				var/rescued = add_crewmember()
+				var/oldfood = rand(1,7)
+				var/oldfuel = rand(4,10)
+				food += oldfood
+				fuel += oldfuel
+				eventdat += "<br>As you look through it you find some supplies and a living person!"
+				eventdat += "<br>[rescued] was rescued from the abandoned ship!"
+				eventdat += "<br>You found [oldfood] <b>Food</b> and [oldfuel] <b>Fuel</b>."
+				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];eventclose=1'>Continue</a></P>"
+				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
+				canContinueEvent = 1
+			else if(prob(20))
+				var/lfuel = rand(4,7)
+				var/deadname = remove_crewmember()
+				fuel -= lfuel
+				eventdat += "<br>[deadname] was lost deep in the wreckage, and your own vessel lost [lfuel] <b>Fuel</b> maneuvering to the the abandoned ship."
+				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];eventclose=1'>Continue</a></P>"
+				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
+				canContinueEvent = 1
+			else if(prob(40))
+				var/oldfood = rand(5,11)
+				food += oldfood
+				engine++
+				eventdat += "<br>You found [oldfood] <b>Food</b> and some parts amongst the wreck."
+				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];eventclose=1'>Continue</a></P>"
+				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
+				canContinueEvent = 1
+			else
+				eventdat += "<br>As you look through the wreck you cannot find much of use."
+				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];eventclose=1'>Continue</a></P>"
+				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
+				canContinueEvent = 1
 
 		if(ORION_TRAIL_ILLNESS)
 			eventdat += "A deadly illness has been contracted!"
@@ -1156,6 +1202,8 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 #undef ORION_TRAIL_COLLISION
 #undef ORION_TRAIL_SPACEPORT
 #undef ORION_TRAIL_BLACKHOLE
+#undef ORION_TRAIL_OLDSHIP
+#undef ORION_TRAIL_SEARCH
 
 #undef ORION_STATUS_START
 #undef ORION_STATUS_NORMAL

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -372,7 +372,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 						   ORION_TRAIL_MALFUNCTION	= 2,
 						   ORION_TRAIL_COLLISION	= 1,
 						   ORION_TRAIL_SPACEPORT	= 2,
-						   ORION_TRAIL_OLDSHIP		= 2
+						   ORION_TRAIL_OLDSHIP		= 3
 						   )
 	var/list/stops = list()
 	var/list/stopblurbs = list()
@@ -597,7 +597,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			settlers = list("Harry","Larry","Bob")
 	else if(href_list["search"]) //search old ship
 		if(event == ORION_TRAIL_OLDSHIP)
-			event = "Old Ship Search"
+			event = ORION_TRAIL_SEARCH
 			event()
 	else if(href_list["slow"]) //slow down
 		if(event == ORION_TRAIL_FLUX)
@@ -821,30 +821,21 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 				eventdat += "<br>As you look through it you find some supplies and a living person!"
 				eventdat += "<br>[rescued] was rescued from the abandoned ship!"
 				eventdat += "<br>You found [oldfood] <b>Food</b> and [oldfuel] <b>Fuel</b>."
-				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];eventclose=1'>Continue</a></P>"
-				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
-				canContinueEvent = 1
 			else if(prob(20))
 				var/lfuel = rand(4,7)
 				var/deadname = remove_crewmember()
 				fuel -= lfuel
 				eventdat += "<br>[deadname] was lost deep in the wreckage, and your own vessel lost [lfuel] <b>Fuel</b> maneuvering to the the abandoned ship."
-				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];eventclose=1'>Continue</a></P>"
-				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
-				canContinueEvent = 1
 			else if(prob(40))
 				var/oldfood = rand(5,11)
 				food += oldfood
 				engine++
 				eventdat += "<br>You found [oldfood] <b>Food</b> and some parts amongst the wreck."
-				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];eventclose=1'>Continue</a></P>"
-				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
-				canContinueEvent = 1
 			else
 				eventdat += "<br>As you look through the wreck you cannot find much of use."
-				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];eventclose=1'>Continue</a></P>"
-				eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
-				canContinueEvent = 1
+			eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];eventclose=1'>Continue</a></P>"
+			eventdat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
+			canContinueEvent = 1
 
 		if(ORION_TRAIL_ILLNESS)
 			eventdat += "A deadly illness has been contracted!"

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -597,7 +597,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			settlers = list("Harry","Larry","Bob")
 	else if(href_list["search"]) //search old ship
 		if(event == ORION_TRAIL_OLDSHIP)
-			event = "Old Ship Search"
+			event = ORION_TRAIL_SEARCH
 			event()
 	else if(href_list["slow"]) //slow down
 		if(event == ORION_TRAIL_FLUX)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new event to the Orion trail arcade game - Old ship. The old ship is a medium rarity event where the player has an option to search the ship, or leave it. Searching the ship can take or give resources and crew members.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It updates content where there hasn't been any content additions in a long time. It makes an option to the player to gamble, which the other events do less so.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Quartich
add: Adds a new event to the Orion Trail - Old Ship
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
