### PR TITLE
ANTAG FREEZE, ANTAG FREEZE ABOVE THIS LINE

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # CONTRIBUTING
-
+ANTAG FREEZE
 ## Reporting Issues
 
 See [this page](http://tgstation13.org/wiki/Reporting_Issues) for a guide and format to issue reports.


### PR DESCRIPTION
After some discussion, I have enacted a gamemode and antag items/roles freeze

This should not come as a surprise, given that I have been talking publicly about the issue with the lack of crew content for some time, use this time to focus on crew content, job content and if you're very bold, perhaps a new job.

If you need inspiration, see this thread: https://tgstation13.org/phpBB/viewtopic.php?f=9&t=23614

Key info

WHEN: NOW

HOW LONG: a minimum of 1 month, this will almost certainly be extended.

WHY: we want to encourage a focus on crew content and job content for standard crew

Note that maintainers can still greenlight an antag rebalance or change if they feel it's necessary at any time to protect the server or health of the community.