### PR TITLE
Antiglow 2, electric boogaloo.

### DIFF
--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -30,5 +30,5 @@
 	result = SHOCKTOUCH
 
 /datum/generecipe/antiglow
-	required = "/datum/mutatin/human/glow; /datum/mutation/human/void"
+	required = "/datum/mutation/human/glow; /datum/mutation/human/void"
 	result = ANTIGLOWY

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -204,7 +204,7 @@
 	if(!glowth)
 		return
 	var/power = GET_MUTATION_POWER(src)
-	glowth.set_light(range * power, glow * power, dna.features["mcolor"])
+	glowth.set_light(range * power, glow * power, "#[dna.features["mcolor"]]")
 
 /datum/mutation/human/glow/on_losing(mob/living/carbon/human/owner)
 	. = ..()


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/46294

## About The Pull Request

Please end me.

## Changelog
:cl:
fix: Antiglow now properly antiglows.
fix: You can now mix antiglow
fix: Glowy now glowies correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
