### PR TITLE
Fixes turrets shooting silicons and loyalty check not ignoring heads.

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -59,7 +59,7 @@
 	var/stun_all = 0		//if this is active, the turret shoots everything that isn't security or head of staff
 	var/check_anomalies = 1	//checks if it can shoot at unidentified lifeforms (ie xenos)
 	var/shoot_unloyal = 0	//checks if it can shoot people that aren't loyalty implanted and who arent heads
-	var/shoot_borgs = 0 // checks if it can shoot people that are cyborgs
+	var/shoot_cyborgs = 0 // checks if it can shoot people that are cyborgs
 	var/attacked = 0		//if set to 1, the turret gets pissed off and shoots at people nearby (unless they have sec access!)
 
 	var/on = TRUE				//determines if the turret is on

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -64,7 +64,7 @@
 
 	var/on = TRUE				//determines if the turret is on
 
-	var/list/faction = list("turret") // Same faction mobs will never be shot at, no matter the other settings
+	var/list/faction = list("turret", "silicon") // Same faction mobs will never be shot at, no matter the other settings
 
 	var/datum/effect_system/spark_spread/spark_system	//the spark system, used for generating... sparks?
 
@@ -470,7 +470,7 @@
 
 /obj/machinery/porta_turret/proc/assess_perp(mob/living/carbon/human/perp)
 	var/threatcount = 0	//the integer returned
-
+	
 	if(obj_flags & EMAGGED)
 		return 10	//if emagged, always return 10.
 
@@ -498,7 +498,7 @@
 			threatcount += 4
 
 	if(shoot_unloyal)
-		if (!HAS_TRAIT(perp, TRAIT_MINDSHIELD))
+		if (!HAS_TRAIT(perp, TRAIT_MINDSHIELD) || !(perp.get_id_name() in list("Research Director", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel")))
 			threatcount += 4
 
 	return threatcount

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -414,9 +414,13 @@
 				if(assess_perp(C) >= 4)
 					if(shoot_heads_of_staff)
 						targets += C
+						continue
 					else 
-						if (C.get_id_name!( in list("Captain", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel")))
+						if (C.get_id_name( in list("Captain", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel")))
 							continue
+						else 
+							targets += C
+							continue 
 			else if(check_anomalies) //non humans who are not simple animals (xenos etc)
 				if(!in_faction(C))
 					targets += C
@@ -510,7 +514,9 @@
 	if(shoot_unloyal)
 		if (!HAS_TRAIT(perp, TRAIT_MINDSHIELD))
 			if (!shoot_heads_of_staff)
-				if (!(perp.get_id_name() in list("Captain", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel")))
+				if ((perp.get_id_name() in list("Captain", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel")))
+					return 0
+				else 
 					threatcount += 4
 			else
 				threatcount += 4

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -418,7 +418,7 @@
 						continue
 					else 
 						var/obj/item/card/id/I = C.get_idcard(TRUE)
-						if (I.assignment in GLOB.command_positions)
+						if (I.assignment != null & I.assignment in GLOB.command_positions)
 							continue
 						else 
 							targets += C

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -418,7 +418,7 @@
 						continue
 					else 
 						var/obj/item/card/id/I = C.get_idcard(TRUE)
-						if (I.assignment != null & I.assignment in GLOB.command_positions)
+						if (I?.assignment in GLOB.command_positions)
 							continue
 						else 
 							targets += C

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -515,7 +515,9 @@
 
 	if(shoot_unloyal)
 		if (!HAS_TRAIT(perp, TRAIT_MINDSHIELD))
+
 			if (!shoot_heads_of_staff)
+			
 				if ((perp.get_id_name() in list("Captain", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel")))
 					return 0
 				else 

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -416,7 +416,7 @@
 						targets += C
 						continue
 					else 
-						if (C.get_id_name( in list("Captain", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel")))
+						if (C.get_id_name in list("Captain", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel"))
 							continue
 						else 
 							targets += C

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -411,12 +411,13 @@
 
 			//if the target is a human and not in our faction, analyze threat level
 			if(ishuman(C) && !in_faction(C))
+				var/obj/item/card/id/I = C.get_idcard(TRUE)
 				if(assess_perp(C) >= 4)
 					if(shoot_heads_of_staff)
 						targets += C
 						continue
 					else 
-						if (C.get_id_name in list("Captain", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel"))
+						if (I.assignment in list("Captain", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel"))
 							continue
 						else 
 							targets += C

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -171,7 +171,7 @@
 		dat += "Neutralize All Non-Security and Non-Command Personnel: <A href='?src=[REF(src)];operation=shootall'>[stun_all ? "Yes" : "No"]</A><BR>"
 		dat += "Neutralize All Unidentified Life Signs: <A href='?src=[REF(src)];operation=checkxenos'>[check_anomalies ? "Yes" : "No"]</A><BR>"
 		dat += "Neutralize All Non-Loyalty Implanted Personnel: <A href='?src=[REF(src)];operation=checkloyal'>[shoot_unloyal ? "Yes" : "No"]</A><BR>"
-		dat += "Neutralize All Cyborgs: <A href = '?src=[REF(src)];operation=shootborgs'>[shoot_cyborgs ? "Yes" : "No" :]</A><BR>"
+		dat += "Neutralize All Cyborgs: <A href='?src=[REF(src)];operation=shootborgs'>[shoot_cyborgs ? "Yes" : "No"]</A><BR>"
 	if(issilicon(user))
 		if(!manual_control)
 			var/mob/living/silicon/S = user

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -418,7 +418,7 @@
 						continue
 					else 
 						var/obj/item/card/id/I = C.get_idcard(TRUE)
-						if (I.assignment in list("Captain", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel"))
+						if (I.assignment in GLOB.command_positions)
 							continue
 						else 
 							targets += C
@@ -518,7 +518,7 @@
 
 			if (!shoot_heads_of_staff)
 			
-				if ((perp.get_id_name() in list("Captain", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel")))
+				if (perp.get_id_name() in GLOB.command_positions)
 					return 0
 				else 
 					threatcount += 4

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -58,13 +58,13 @@
 	var/auth_weapons = 0	//checks if it can shoot people that have a weapon they aren't authorized to have
 	var/stun_all = 0		//if this is active, the turret shoots everything that isn't security or head of staff
 	var/check_anomalies = 1	//checks if it can shoot at unidentified lifeforms (ie xenos)
-	var/shoot_unloyal = 0	//checks if it can shoot people that aren't loyalty implantd
-
+	var/shoot_unloyal = 0	//checks if it can shoot people that aren't loyalty implanted and who arent heads
+	var/shoot_borgs = 0 // checks if it can shoot people that are cyborgs
 	var/attacked = 0		//if set to 1, the turret gets pissed off and shoots at people nearby (unless they have sec access!)
 
 	var/on = TRUE				//determines if the turret is on
 
-	var/list/faction = list("turret", "silicon") // Same faction mobs will never be shot at, no matter the other settings
+	var/list/faction = list("turret", ) // Same faction mobs will never be shot at, no matter the other settings
 
 	var/datum/effect_system/spark_spread/spark_system	//the spark system, used for generating... sparks?
 
@@ -171,6 +171,7 @@
 		dat += "Neutralize All Non-Security and Non-Command Personnel: <A href='?src=[REF(src)];operation=shootall'>[stun_all ? "Yes" : "No"]</A><BR>"
 		dat += "Neutralize All Unidentified Life Signs: <A href='?src=[REF(src)];operation=checkxenos'>[check_anomalies ? "Yes" : "No"]</A><BR>"
 		dat += "Neutralize All Non-Loyalty Implanted Personnel: <A href='?src=[REF(src)];operation=checkloyal'>[shoot_unloyal ? "Yes" : "No"]</A><BR>"
+		dat += "Neutralize All Cyborgs: <A href = '?src=[REF(src)];operation=shootborgs'>[shoot_cyborgs ? "Yes" : "No" :]</A><BR>"
 	if(issilicon(user))
 		if(!manual_control)
 			var/mob/living/silicon/S = user
@@ -212,9 +213,12 @@
 				check_anomalies = !check_anomalies
 			if("checkloyal")
 				shoot_unloyal = !shoot_unloyal
+			if ("shootborgs")
+				shoot_cyborgs = !shoot_cyborgs
 			if("manual")
 				if(issilicon(usr) && !manual_control)
 					give_control(usr)
+			
 		interact(usr)
 
 /obj/machinery/porta_turret/power_change()
@@ -500,7 +504,9 @@
 	if(shoot_unloyal)
 		if (!HAS_TRAIT(perp, TRAIT_MINDSHIELD) || !(perp.get_id_name() in list("Research Director", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel")))
 			threatcount += 4
-
+	if (shoot_cyborgs)
+		if (iscyborg(perp))
+			threatcount +=4
 	return threatcount
 
 

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -411,12 +411,13 @@
 
 			//if the target is a human and not in our faction, analyze threat level
 			if(ishuman(C) && !in_faction(C))
-				var/obj/item/card/id/I = C.get_idcard(TRUE)
+				
 				if(assess_perp(C) >= 4)
 					if(shoot_heads_of_staff)
 						targets += C
 						continue
 					else 
+						var/obj/item/card/id/I = C.get_idcard(TRUE)
 						if (I.assignment in list("Captain", "Head of Security", "Research Director", "Chief Engineer", "Chief Medical Officer", "Head of Personnel"))
 							continue
 						else 


### PR DESCRIPTION
Makes it so turrets wont constantly shoot silicons and that the loyalty implant check option ignores heads.


## About The Pull Request

This PR adds several turret fixes to make them much better for everyday use.

## Why It's Good For The Game

Quality of life improvements to turrets that make them much better than unga me shoot silicon and me shoot heads who are never going to be disloyal in revs. 

## Changelog
:cl:
fix: fixed turrets firing at silicons constantly
fix: fixed turrets shooting at heads when on loyalty check
/:cl:


