### PR TITLE
Moves away from using GetComponent to delete components.

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -346,3 +346,6 @@
 #define COMSIG_XENO_TURF_CLICK_SHIFT "xeno_turf_click_shift"				//from turf ShiftClickOn(): (/mob)
 #define COMSIG_XENO_TURF_CLICK_CTRL "xeno_turf_click_alt"					//from turf AltClickOn(): (/mob)
 #define COMSIG_XENO_MONKEY_CLICK_CTRL "xeno_monkey_click_ctrl"				//from monkey CtrlClickOn(): (/mob)
+
+#define COMSIG_DELETE_COMPONENT(A)	"component_delete_[A]"
+	#define COMPONENT_DELETED_SUCCESSFULLY	(1 << 0)

--- a/code/datums/components/decals/blood.dm
+++ b/code/datums/components/decals/blood.dm
@@ -1,5 +1,6 @@
 /datum/component/decal/blood
 	dupe_mode = COMPONENT_DUPE_UNIQUE
+	delete_on_signal = TRUE
 
 /datum/component/decal/blood/Initialize(_icon, _icon_state, _dir, _cleanable=CLEAN_STRENGTH_BLOOD, _color, _layer=ABOVE_OBJ_LAYER)
 	if(!isitem(parent))

--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -1,11 +1,12 @@
 ///Component specifically for explosion sensetive things, currently only applies to heat based explosions but can later perhaps be used for things that are dangerous to handle carelessly like nitroglycerin.
 /datum/component/explodable
+	delete_on_signal = TRUE
 	var/devastation_range = 0
 	var/heavy_impact_range = 0
 	var/light_impact_range = 2
 	var/flash_range = 3
 	var/equipped_slot //For items, lets us determine where things should be hit.
-	
+
 /datum/component/explodable/Initialize(devastation_range_override, heavy_impact_range_override, light_impact_range_override, flash_range_override)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -20,8 +21,8 @@
 			RegisterSignal(parent, list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_HIT_REACT), .proc/explodable_attack)
 			RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 			RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/on_drop)
-				
-			
+
+
 
 	if(devastation_range_override)
 		devastation_range = devastation_range_override
@@ -45,14 +46,14 @@
 /datum/component/explodable/proc/explodable_attack(datum/source, atom/movable/target, mob/living/user)
 	check_if_detonate(target)
 
-///Called when you attack a specific body part of the thing this is equipped on. Useful for exploding pants. 
+///Called when you attack a specific body part of the thing this is equipped on. Useful for exploding pants.
 /datum/component/explodable/proc/explodable_attack_zone(datum/source, damage, damagetype, def_zone)
 	if(!def_zone)
 		return
 	if(damagetype != BURN) //Don't bother if it's not fire.
 		return
 	if(!is_hitting_zone(def_zone)) //You didn't hit us! ha!
-		return	
+		return
 	detonate()
 
 /datum/component/explodable/proc/on_equip(datum/source, mob/equipper, slot)
@@ -87,7 +88,7 @@
 		if(I.body_parts_covered & bodypart.body_part)
 			return TRUE
 	return FALSE
-	
+
 
 /datum/component/explodable/proc/check_if_detonate(target)
 	if(!isitem(target))

--- a/code/datums/components/forensics.dm
+++ b/code/datums/components/forensics.dm
@@ -43,8 +43,7 @@
 
 /datum/component/forensics/proc/wipe_blood_DNA()
 	blood_DNA = null
-	if(isitem(parent))
-		qdel(parent.GetComponent(/datum/component/decal/blood))
+	SEND_SIGNAL(parent, COMSIG_DELETE_COMPONENT(/datum/component/decal/blood))
 	return TRUE
 
 /datum/component/forensics/proc/wipe_fibers()

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -5,7 +5,7 @@
 
 /datum/component/radioactive
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
-
+	delete_on_signal = TRUE
 	var/source
 
 	var/hl3_release_date //the half-life measured in ticks
@@ -18,7 +18,7 @@
 	hl3_release_date = _half_life
 	can_contaminate = _can_contaminate
 
-	if(istype(parent, /atom)) 
+	if(istype(parent, /atom))
 		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/rad_examine)
 		if(istype(parent, /obj/item))
 			RegisterSignal(parent, COMSIG_ITEM_ATTACK, .proc/rad_attack)

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -1,4 +1,5 @@
 /datum/component/slippery
+	delete_on_signal = TRUE
 	var/force_drop_items = FALSE
 	var/knockdown_time = 0
 	var/paralyze_time = 0

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -1,4 +1,5 @@
 /datum/component/squeak
+	delete_on_signal = TRUE
 	var/static/list/default_squeak_sounds = list('sound/items/toysqueak1.ogg'=1, 'sound/items/toysqueak2.ogg'=1, 'sound/items/toysqueak3.ogg'=1)
 	var/list/override_squeak_sounds
 

--- a/code/datums/components/wet_floor.dm
+++ b/code/datums/components/wet_floor.dm
@@ -43,7 +43,7 @@
 /datum/component/wet_floor/Destroy()
 	STOP_PROCESSING(SSwet_floors, src)
 	var/turf/T = parent
-	qdel(T.GetComponent(/datum/component/slippery))
+	SEND_SIGNAL(T, COMSIG_DELETE_COMPONENT(/datum/component/slippery))
 	if(istype(T))		//If this is false there is so many things wrong with it.
 		T.cut_overlay(current_overlay)
 	else
@@ -92,7 +92,7 @@
 			intensity = 120
 			lube_flags = SLIDE | GALOSHES_DONT_HELP | SLIP_WHEN_CRAWLING
 		else
-			qdel(parent.GetComponent(/datum/component/slippery))
+			SEND_SIGNAL(parent, COMSIG_DELETE_COMPONENT(/datum/component/slippery))
 			return
 
 	parent.LoadComponent(/datum/component/slippery, intensity, lube_flags, CALLBACK(src, .proc/AfterSlip))
@@ -147,7 +147,7 @@
 	O.cut_overlay(current_overlay)
 	//That turf is no longer slippery, we're out of here
 	//Slippery components don't transfer due to callbacks
-	qdel(O.GetComponent(/datum/component/slippery))
+	SEND_SIGNAL(O, COMSIG_DELETE_COMPONENT(/datum/component/slippery))
 
 /datum/component/wet_floor/PostTransfer()
 	if(!isopenturf(parent))

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -67,8 +67,7 @@
 
 /datum/material/uranium/on_removed(atom/source, material_flags)
 	. = ..()
-	qdel(source.GetComponent(/datum/component/radioactive))
-
+	SEND_SIGNAL(source, COMSIG_DELETE_COMPONENT(/datum/component/radioactive))
 
 ///Adds firestacks on hit (Still needs support to turn into gas on destruction)
 /datum/material/plasma
@@ -89,7 +88,7 @@
 /datum/material/plasma/on_removed(atom/source, material_flags)
 	. = ..()
 	source.RemoveElement(/datum/element/firestacker)
-	qdel(source.GetComponent(/datum/component/explodable))
+	SEND_SIGNAL(source, COMSIG_DELETE_COMPONENT(/datum/component/explodable))
 
 ///Can cause bluespace effects on use. (Teleportation) (Not yet implemented)
 /datum/material/bluespace
@@ -117,8 +116,8 @@
 
 /datum/material/bananium/on_removed(atom/source, amount, material_flags)
 	. = ..()
-	qdel(source.GetComponent(/datum/component/slippery))
-	qdel(source.GetComponent(/datum/component/squeak))
+	SEND_SIGNAL(source, COMSIG_DELETE_COMPONENT(/datum/component/slippery))
+	SEND_SIGNAL(source, COMSIG_DELETE_COMPONENT(/datum/component/squeak))
 
 
 ///Mediocre force increase

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -296,9 +296,7 @@
 				things_to_clear += occupant.GetAllContents()
 			for(var/atom/movable/AM in things_to_clear) //Scorches away blood and forensic evidence, although the SSU itself is unaffected
 				SEND_SIGNAL(AM, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_STRONG)
-				var/datum/component/radioactive/contamination = AM.GetComponent(/datum/component/radioactive)
-				if(contamination)
-					qdel(contamination)
+				SEND_SIGNAL(AM, COMSIG_DELETE_COMPONENT(/datum/component/radioactive))
 		open_machine(FALSE)
 		if(occupant)
 			dump_contents()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This tries to replace the good ol qdel(GetComponent()) with a signal based approach.

## Why It's Good For The Game

This system is better in the way that we no longer delete the component directly and instead tell it to go ~fuck~ delete itself with a signal. This allows for easier deletion of components that can be applied multiple times and could even be used to a system for targeted deletion if you have multiple sources for a component.