### PR TITLE
Failing Tend Wounds now Give 80% damage (based off normal healing) instead of Flat 5 Brute

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -71,7 +71,7 @@
 	display_results(user, target, "<span class='warning'>You screwed up!</span>",
 		"<span class='warning'>[user] screws up!</span>",
 		"<span class='notice'>[user] fixes some of [target]'s wounds.</span>", TRUE)
-	target.take_bodypart_damage(5,0)
+	target.take_bodypart_damage(brutehealing*0.8,burnhealing*0.8)
 	return FALSE
 
 /***************************BRUTE***************************/


### PR DESCRIPTION
Burn Tending should not give brute damage.

This is a buff to base TW since less damage on fail but a nerf to higher TW since it's more damage a fail (implying you're failing when you're able to do advanced surgeries aka on optable/stasis bed)