### PR TITLE
Buffs stamcrit

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -531,7 +531,7 @@
 	var/stam = getStaminaLoss()
 	if(stam > DAMAGE_PRECISION && (maxHealth - stam) <= crit_threshold && !stat)
 		enter_stamcrit()
-	else if(stam_paralyzed)
+	else if(stam_paralyzed && stam < 70)
 		stam_paralyzed = FALSE
 	else
 		return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -531,7 +531,7 @@
 	var/stam = getStaminaLoss()
 	if(stam > DAMAGE_PRECISION && (maxHealth - stam) <= crit_threshold && !stat)
 		enter_stamcrit()
-	else if(stam_paralyzed && stam < 70)
+	else if(stam_paralyzed)
 		stam_paralyzed = FALSE
 	else
 		return

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -13,7 +13,10 @@
 		return
 	if(!IsParalyzed())
 		to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")
+	var/prev = stam_paralyzed
 	stam_paralyzed = TRUE
+	if(!prev) // Puts you a little further into the initial stamcrit, makes stamcrit harder to outright counter with chems.
+		adjustStaminaLoss(30, FALSE)
 
 /mob/living/carbon/adjust_drugginess(amount)
 	druggy = max(druggy+amount, 0)

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -15,7 +15,7 @@
 		to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")
 	var/prev = stam_paralyzed
 	stam_paralyzed = TRUE
-	if(!prev) // Puts you a little further into the initial stamcrit, makes stamcrit harder to outright counter with chems.
+	if(!prev && getStaminaLoss() < 120) // Puts you a little further into the initial stamcrit, makes stamcrit harder to outright counter with chems.
 		adjustStaminaLoss(30, FALSE)
 
 /mob/living/carbon/adjust_drugginess(amount)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Overall makes stam crit slightly more reliable, by applying some extra stamina damage upon first entering stam crit. This prevents hovering around 100 stam damage and potentially getting out of stam crit near instantly with stam healing chems. Overall, it makes stam crit a bit more reliable.
If you don't use stamina regen chems, nothing has changed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes stam crit (slightly) more reliable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
balance: Stam crit made more reliable against stamina regen drugs. Upon first entering stam crit, some extra stamina damage will be applied. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
