### PR TITLE
Fixes chameleon ID card job overlays not showing up after selecting a cardtype that doesn't use them

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -199,10 +199,10 @@
 		var/cash_money = physical_money.get_item_credit_value()
 
 		total += cash_money
-		
+
 		registered_account.adjust_money(cash_money)
 
-	QDEL_LIST(money)	
+	QDEL_LIST(money)
 
 	return total
 
@@ -223,7 +223,7 @@
 
 	if (isnull(new_bank_id))
 		return
-	
+
 	if(!alt_click_can_use_id(user))
 		return
 	if(!new_bank_id || new_bank_id < 111111 || new_bank_id > 999999)
@@ -367,6 +367,7 @@ update_label()
 	name = "agent card"
 	access = list(ACCESS_MAINT_TUNNELS, ACCESS_SYNDICATE)
 	var/anyone = FALSE //Can anyone forge the ID or just syndicate?
+	var/forged = FALSE //have we set a custom name and job assignment, or will we use what we're given when we chameleon change?
 
 /obj/item/card/id/syndicate/Initialize()
 	. = ..()
@@ -394,15 +395,15 @@ update_label()
 			else
 				return ..()
 
-		var/popup_input = alert(user, "Action", "Agent ID", "Show", "Forge", "Change Account ID")
+		var/popup_input = alert(user, "Choose Action", "Agent ID", "Show", "Forge/Reset", "Change Account ID")
 		if(user.incapacitated())
 			return
-		if(popup_input == "Forge")
+		if(popup_input == "Forge/Reset" && !forged)
 			var/input_text = input(user, "What name would you like to put on this card? Leave blank to randomise.", "Agent card name", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name))as text | null
-			
+
 			if (isnull(input_text))
 				return
-			
+
 			var/t = copytext(sanitize(input_text), 1, 26)
 			if(!t || t == "Unknown" || t == "floor" || t == "wall" || t == "r-wall") //Same as mob/dead/new_player/prefrences.dm
 				if (ishuman(user))
@@ -410,24 +411,26 @@ update_label()
 
 					// Invalid/blank names give a randomly generated one.
 					if (human_agent.gender == "male")
-						registered_name = "[pick(GLOB.first_names_male)] [pick(GLOB.last_names)]" 
+						registered_name = "[pick(GLOB.first_names_male)] [pick(GLOB.last_names)]"
 					else if (human_agent.gender == "female")
-						registered_name = "[pick(GLOB.first_names_female)] [pick(GLOB.last_names)]" 
+						registered_name = "[pick(GLOB.first_names_female)] [pick(GLOB.last_names)]"
 					else
 						registered_name = "[pick(GLOB.first_names)] [pick(GLOB.last_names)]"
 				else
 					alert ("Invalid name.")
-					return	
+					return
 			else
 				registered_name = t
 
-			var/u = copytext(sanitize(input(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels other than Maintenance.", "Agent card job assignment", "Assistant")as text | null),1,MAX_MESSAGE_LEN)
+			var/u = copytext(sanitize(input(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels other than Maintenance.", "Agent card job assignment", assignment ? assignment : "Assistant") as text | null),1,MAX_MESSAGE_LEN)
 			if(!u)
 				registered_name = ""
 				return
 			assignment = u
 			update_label()
+			forged = TRUE
 			to_chat(user, "<span class='notice'>You successfully forge the ID card.</span>")
+
 
 			// First time use automatically sets the account id to the user.
 			if (first_use && !registered_account)
@@ -440,6 +443,13 @@ update_label()
 							account.bank_cards += src
 							registered_account = account
 							to_chat(user, "<span class='notice'>Your account number has been automatically assigned.</span>")
+			return
+		else if (popup_input == "Forge/Reset" && forged)
+			registered_name = initial(registered_name)
+			assignment = initial(assignment)
+			update_label()
+			forged = FALSE
+			to_chat(user, "<span class='notice'>You successfully reset the ID card.</span>")
 			return
 		else if (popup_input == "Change Account ID")
 			set_new_account(user)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -255,21 +255,23 @@
 
 /datum/action/item_action/chameleon/change/id/update_item(obj/item/picked_item)
 	..()
-	var/obj/item/card/id/agent_card = target
+	var/obj/item/card/id/syndicate/agent_card = target
 	if(istype(agent_card))
 		var/obj/item/card/id/copied_card = picked_item
-		if(istype(copied_card))
-			agent_card.uses_overlays = copied_card.uses_overlays
-			agent_card.id_type_name = copied_card.id_type_name
-		else
-			agent_card.uses_overlays = FALSE
-			agent_card.id_type_name = copied_card.name
+		agent_card.uses_overlays = initial(copied_card.uses_overlays)
+		agent_card.id_type_name = initial(copied_card.id_type_name)
+		if(!agent_card.forged)
+			agent_card.registered_name = initial(copied_card.registered_name)
+			agent_card.assignment = initial(copied_card.assignment)
 		agent_card.update_label()
+		if(!agent_card.forged)
+			agent_card.name = initial(copied_card.name) //e.g. captain's spare ID, not Captain's ID Card (Captain)
 
 /datum/action/item_action/chameleon/change/id/apply_job_data(datum/job/job_datum)
 	..()
-	var/obj/item/card/id/agent_card = target
+	var/obj/item/card/id/syndicate/agent_card = target
 	if(istype(agent_card) && istype(job_datum))
+		agent_card.forged = TRUE
 		agent_card.assignment = job_datum.title
 
 /datum/action/item_action/chameleon/change/pda/update_item(obj/item/picked_item)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Certain IDs don't use the new ID card job overlays (e.g. Centcom IDs). The bug is that selecting these IDs permanently turns off uses_overlays, which means then trying to impersonate a job that uses them (such as any job on the station) won't work because even if the job title is correct the ID will show a question mark with a black background.

Also adds the ability to reset the forgery of an ID, so you can select IDs that have names that don't fit the Name - Assignment format (e.g. captain's spare ID).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
fix: Fixes chameleon ID card job overlays not showing up after selecting an ID that doesn't use them
tweak: You can reset (delete) the forged name/assignment on an ID so you can chameleon change to IDs with a generic name instead (e.g. captain's spare ID).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
