### PR TITLE
Safety Doors

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -10184,7 +10184,8 @@
 "azy" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
+	name = "Port Docking Bay 1";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -16634,7 +16635,8 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock";
-	req_access_txt = "2"
+	req_access_txt = "2";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
@@ -17620,7 +17622,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
+	name = "Escape Airlock";
+	safety_mode = 1
 	},
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -17632,7 +17635,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
+	name = "Escape Airlock";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
@@ -21424,7 +21428,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "Cargo Escape Airlock"
+	name = "Cargo Escape Airlock";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
@@ -46505,7 +46510,8 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock";
-	req_access_txt = "2"
+	req_access_txt = "2";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
@@ -46523,7 +46529,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
+	name = "Escape Airlock";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
@@ -46532,7 +46539,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "Cargo Escape Airlock"
+	name = "Cargo Escape Airlock";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
@@ -48774,7 +48782,8 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
+	name = "Port Docking Bay 1";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -49854,6 +49863,14 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hFg" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1";
+	safety_mode = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "hQK" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -49861,6 +49878,16 @@
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"hRW" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "hSc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -50632,6 +50659,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"nfJ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "noK" = (
 /obj/structure/girder,
 /turf/open/floor/plasteel/dark,
@@ -51403,6 +51440,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/maintenance/port)
+"rUe" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "rYJ" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
@@ -51911,6 +51958,14 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"uTg" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "uTi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52355,9 +52410,27 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/vacant_room/commissary)
+"xvG" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "xwN" = (
 /turf/open/floor/plating,
 /area/engine/engine_smes)
+"xxB" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "xEu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -62072,9 +62145,9 @@ apN
 apJ
 awZ
 ayl
-azy
+uTg
 auP
-cIh
+xvG
 aaa
 aaa
 aaa
@@ -62082,9 +62155,9 @@ aaa
 aaa
 aaa
 aaa
-azy
+hFg
 auP
-cIh
+xvG
 ayl
 aRY
 awW
@@ -63871,9 +63944,9 @@ asF
 apJ
 axh
 aIK
-azy
+uTg
 auP
-cIh
+xvG
 aaa
 aaa
 aaa
@@ -63881,9 +63954,9 @@ aaa
 aaa
 aaa
 aaa
-azy
+uTg
 auP
-cIh
+xvG
 ayl
 aRY
 awW
@@ -103463,13 +103536,13 @@ aaa
 aNa
 cyh
 aRW
-aTo
+rUe
 aNa
 aaa
 aaf
 aaa
 aNa
-aTo
+rUe
 aRW
 cyr
 aNa

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -353,19 +353,21 @@
 /area/construction/mining/aux_base)
 "abP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod 1"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod 1";
+	safety_mode = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "abQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
-	name = "Escape Pod 2"
+	name = "Escape Pod 2";
+	safety_mode = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -990,14 +992,15 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	name = "External Docking Port"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -2036,14 +2039,15 @@
 /area/hallway/secondary/entry)
 "aiA" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "External Docking Port"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -2289,9 +2293,6 @@
 "ajf" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Docking Port"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -26403,14 +26404,14 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "bbu" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod 3"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod 3"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -114050,6 +114051,23 @@
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"eAM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eCM" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -114062,6 +114080,22 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"eJt" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "eMD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -114264,6 +114298,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"gmr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gCK" = (
 /turf/closed/wall,
 /area/maintenance/department/science)
@@ -114828,6 +114879,22 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jMX" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "jRy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -114909,6 +114976,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"ksz" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "kuT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -114967,6 +115050,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/misc_lab/range)
+"lcU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ldk" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -115103,6 +115203,23 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"lJV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lKR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -115250,6 +115367,23 @@
 "mCL" = (
 /turf/closed/wall,
 /area/engine/storage_shared)
+"mGU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mHL" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -115291,6 +115425,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"mLP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mMY" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/snack/random,
@@ -115852,14 +116003,62 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"qkG" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qnx" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"qon" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qpq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"qtG" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qwX" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -116047,6 +116246,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"rKN" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "rLD" = (
 /obj/machinery/camera{
 	c_tag = "Medbay - Recovery Room";
@@ -116615,6 +116830,22 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/fore)
+"wcS" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wei" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -116892,6 +117123,22 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"xRT" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xXn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/engine/vacuum,
@@ -152448,14 +152695,14 @@ aad
 aad
 aad
 aaO
-aea
+lcU
 aaO
 aad
 aad
 aad
 aad
 aaO
-aee
+qtG
 aaO
 aad
 aad
@@ -152962,14 +153209,14 @@ aaO
 abf
 ads
 aaO
-aec
+qon
 aaO
 aeV
 afw
 afT
 agk
 aaO
-aej
+mGU
 aaO
 adq
 abf
@@ -153990,14 +154237,14 @@ aaO
 abf
 adq
 aaO
-aee
+qtG
 aaO
 aeX
 afx
 afx
 agl
 aaO
-aee
+qtG
 aaO
 ads
 abf
@@ -154504,14 +154751,14 @@ aad
 aad
 aad
 aaO
-aec
+qon
 aaO
 aad
 aaa
 aaa
 aad
 aaO
-aej
+mGU
 aaO
 aad
 aad
@@ -156970,9 +157217,9 @@ dSU
 dSU
 dSU
 dSU
-dYI
+eJt
 dZr
-dYI
+rKN
 dSU
 dSU
 ecc
@@ -157074,14 +157321,14 @@ aad
 aad
 aad
 aaO
-aea
+lcU
 aaO
 aad
 aaa
 aaa
 aad
 aaO
-aea
+lcU
 aaO
 aad
 aad
@@ -157484,9 +157731,9 @@ aaa
 aaa
 aaa
 dSU
-dYJ
+jMX
 dSU
-dYJ
+jMX
 dSU
 aaa
 aaa
@@ -157588,14 +157835,14 @@ aaO
 abf
 ads
 aaO
-aej
+mGU
 aaO
 afb
 afz
 afV
 agk
 aaO
-aec
+qon
 aaO
 adq
 abf

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -240,7 +240,6 @@
 /area/teleporter)
 "aaQ" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -279,7 +278,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aaX" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -323,7 +321,6 @@
 /area/space)
 "abd" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -410,21 +407,18 @@
 /area/quartermaster/storage)
 "abk" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "abl" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "abm" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -439,14 +433,12 @@
 /area/quartermaster/miningdock)
 "abo" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "abp" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -457,7 +449,6 @@
 /area/hallway/secondary/entry)
 "abr" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -733,7 +724,6 @@
 /area/science/storage)
 "aci" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -886,7 +876,6 @@
 /area/medical/storage)
 "acO" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -1014,14 +1003,12 @@
 /area/science/storage)
 "adk" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/science/explab)
 "adl" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -1137,7 +1124,6 @@
 /area/science/lab)
 "adz" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -1395,6 +1381,15 @@
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/science/test_area)
+"aei" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "aej" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -1577,7 +1572,6 @@
 /area/science/server)
 "aeQ" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -1980,7 +1974,6 @@
 /area/maintenance/solars/starboard/fore)
 "afR" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -2182,7 +2175,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "agq" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -2195,7 +2187,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "ags" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -2234,7 +2225,6 @@
 /area/quartermaster/storage)
 "agw" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -2254,7 +2244,6 @@
 /area/chapel/office)
 "agy" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -2363,14 +2352,12 @@
 "agJ" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "agK" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -2409,7 +2396,6 @@
 /area/science/test_area)
 "agQ" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -2607,7 +2593,6 @@
 "aht" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -2753,7 +2738,6 @@
 /area/crew_quarters/heads/hor)
 "ahO" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -2848,7 +2832,6 @@
 /area/crew_quarters/heads/captain/private)
 "aie" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -3030,7 +3013,6 @@
 /area/quartermaster/storage)
 "aiG" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -3050,14 +3032,12 @@
 /area/quartermaster/storage)
 "aiJ" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 10
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aiK" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -3096,7 +3076,6 @@
 "aiS" = (
 /obj/machinery/conveyor/inverted{
 	dir = 8;
-	icon_state = "conveyor_map_inverted";
 	id = "QMLoad"
 	},
 /turf/open/floor/plating,
@@ -3246,7 +3225,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -3345,7 +3323,6 @@
 /area/crew_quarters/heads/hop)
 "ajy" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -3401,7 +3378,6 @@
 "ajI" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -3409,7 +3385,6 @@
 "ajJ" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -3430,7 +3405,6 @@
 /area/bridge)
 "ajM" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -3457,6 +3431,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"ajQ" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	name = "Privacy Shutters"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "ajR" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -3488,7 +3473,6 @@
 /area/science/mixing)
 "ajW" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -4256,7 +4240,6 @@
 /area/science/robotics/lab)
 "amf" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -4281,7 +4264,6 @@
 /area/hallway/primary/central)
 "amk" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -4307,7 +4289,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -4826,7 +4807,6 @@
 "aof" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 1
 	},
 /obj/structure/cable,
@@ -5005,7 +4985,6 @@
 /area/hydroponics)
 "aoA" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -5030,14 +5009,12 @@
 /area/hydroponics)
 "aoE" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 10
 	},
 /turf/open/floor/plating,
 /area/hydroponics)
 "aoF" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -5104,7 +5081,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -5267,7 +5243,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -5593,7 +5568,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -5713,7 +5687,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -5721,7 +5694,6 @@
 "aqw" = (
 /obj/machinery/conveyor/inverted{
 	dir = 9;
-	icon_state = "conveyor_map_inverted";
 	id = "QMLoad2"
 	},
 /turf/open/floor/plating,
@@ -5989,7 +5961,6 @@
 /area/maintenance/department/security)
 "ard" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -6038,14 +6009,12 @@
 /area/storage/tools)
 "ari" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/storage/tools)
 "arj" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -6079,7 +6048,6 @@
 /area/vacant_room/commissary)
 "aro" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -6322,7 +6290,6 @@
 /area/hallway/secondary/entry)
 "arY" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -6408,7 +6375,6 @@
 /area/crew_quarters/fitness/recreation)
 "ash" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -6451,7 +6417,6 @@
 /area/science/lab)
 "asl" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -6506,7 +6471,6 @@
 "asq" = (
 /obj/machinery/conveyor/inverted{
 	dir = 8;
-	icon_state = "conveyor_map_inverted";
 	id = "QMLoad2"
 	},
 /turf/open/floor/plating,
@@ -6565,7 +6529,6 @@
 /area/storage/tools)
 "asv" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -6627,7 +6590,6 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "asD" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -6702,7 +6664,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -6754,7 +6715,6 @@
 /area/security/brig)
 "asX" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -6843,7 +6803,6 @@
 /area/crew_quarters/bar)
 "atg" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -6989,7 +6948,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "atx" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -6999,7 +6957,6 @@
 /area/hallway/secondary/entry)
 "atz" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -7017,7 +6974,6 @@
 /area/engine/atmos)
 "atC" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -7084,7 +7040,6 @@
 	name = "privacy shutters"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -7153,7 +7108,6 @@
 /area/tcommsat/computer)
 "atX" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /obj/structure/cable,
@@ -7416,7 +7370,6 @@
 /area/ai_monitored/security/armory)
 "auC" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /obj/structure/cable,
@@ -7618,7 +7571,6 @@
 /area/ai_monitored/storage/eva)
 "ave" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -7800,7 +7752,6 @@
 /area/engine/atmos)
 "avA" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -7868,7 +7819,6 @@
 /area/bridge)
 "avK" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -7893,7 +7843,6 @@
 /area/engine/atmos)
 "avO" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -7951,7 +7900,6 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -8086,7 +8034,6 @@
 /area/engine/atmos)
 "awq" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -9914,7 +9861,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -10296,28 +10242,24 @@
 /area/maintenance/fore)
 "aBD" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aBE" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aBF" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aBG" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -10446,7 +10388,6 @@
 /area/space/nearstation)
 "aCb" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -10528,14 +10469,12 @@
 /area/crew_quarters/dorms)
 "aCk" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "aCl" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -10567,7 +10506,6 @@
 /area/space/nearstation)
 "aCr" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -10653,11 +10591,9 @@
 "aCH" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -12085,7 +12021,6 @@
 /area/medical/genetics/cloning)
 "aFO" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -12096,7 +12031,6 @@
 /area/medical/genetics/cloning)
 "aFQ" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -12106,7 +12040,6 @@
 /area/medical/genetics/cloning)
 "aFS" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -12117,7 +12050,6 @@
 /area/medical/genetics)
 "aFU" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -12228,7 +12160,6 @@
 /area/medical/genetics/cloning)
 "aGi" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -12260,14 +12191,12 @@
 /area/medical/medbay/central)
 "aGl" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/medical/storage)
 "aGm" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -12479,7 +12408,6 @@
 	name = "Chemistry Privacy Shutters"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -12493,7 +12421,6 @@
 	name = "Chemistry Privacy Shutters"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -12561,14 +12488,12 @@
 /area/science/research)
 "aHc" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "aHd" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -12594,7 +12519,6 @@
 /area/crew_quarters/heads/hor)
 "aHf" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -12645,7 +12569,6 @@
 	name = "Chemistry Privacy Shutters"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -12685,7 +12608,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -12724,7 +12646,6 @@
 /area/hallway/primary/central)
 "aHx" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -13005,14 +12926,12 @@
 /area/medical/sleeper)
 "aIv" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/medical/cryo)
 "aIw" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -13180,7 +13099,6 @@
 /area/medical/virology)
 "aIV" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -13232,7 +13150,6 @@
 /area/medical/sleeper)
 "aJc" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -13506,7 +13423,6 @@
 /area/medical/chemistry)
 "aJI" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -13517,7 +13433,6 @@
 /area/medical/surgery)
 "aJK" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -13547,7 +13462,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -14195,7 +14109,6 @@
 /area/maintenance/port/fore)
 "aLw" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -14206,7 +14119,6 @@
 /area/library)
 "aLy" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -14430,7 +14342,6 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 1;
-	icon_state = "direction_evac";
 	pixel_x = -32;
 	pixel_y = -4
 	},
@@ -14495,7 +14406,6 @@
 /area/hallway/secondary/entry)
 "aMp" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -14509,7 +14419,6 @@
 /area/hydroponics/garden)
 "aMt" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -14519,14 +14428,12 @@
 /area/hydroponics/garden)
 "aMv" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 10
 	},
 /turf/open/floor/plating,
 /area/hydroponics/garden)
 "aMw" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -14543,28 +14450,24 @@
 /area/hydroponics/garden)
 "aMz" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/hydroponics/garden)
 "aMA" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 6
 	},
 /turf/open/floor/plating,
 /area/hydroponics/garden)
 "aMB" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/hydroponics/garden)
 "aMC" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -14985,7 +14888,6 @@
 /area/engine/engine_room/external)
 "aNU" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -15009,7 +14911,6 @@
 /area/security/main)
 "aNY" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -15244,7 +15145,6 @@
 /area/security/brig)
 "aOH" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -15311,7 +15211,6 @@
 /area/security/courtroom)
 "aOQ" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -15943,7 +15842,6 @@
 	name = "privacy shutters"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -15954,7 +15852,6 @@
 	name = "privacy shutters"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -15972,7 +15869,6 @@
 	name = "privacy shutters"
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -16020,7 +15916,6 @@
 /area/maintenance/starboard)
 "aQC" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -16190,7 +16085,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -16917,7 +16811,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -17485,14 +17378,12 @@
 /area/medical/chemistry)
 "aUC" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "aUD" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -17803,7 +17694,6 @@
 /area/construction/mining/aux_base)
 "aVs" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -17898,7 +17788,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -18050,7 +17939,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -18209,7 +18097,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -18221,7 +18108,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -18715,7 +18601,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -18742,7 +18627,6 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -20519,7 +20403,6 @@
 /area/crew_quarters/bar)
 "bcc" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -20776,7 +20659,9 @@
 	},
 /area/crew_quarters/kitchen)
 "bcJ" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bcK" = (
@@ -20845,6 +20730,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"bcU" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "bcV" = (
 /obj/structure/chair,
 /obj/machinery/light/small{
@@ -21561,7 +21452,6 @@
 "beN" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -21816,7 +21706,6 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -22024,7 +21913,6 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -22970,7 +22858,6 @@
 "bhY" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -23334,7 +23221,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -23346,7 +23232,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -23912,7 +23797,6 @@
 "bkf" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -24028,7 +23912,6 @@
 "bkq" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -24840,7 +24723,6 @@
 /area/maintenance/department/security)
 "bmh" = (
 /obj/effect/spawner/structure/window/hollow/plasma/end{
-	icon_state = "phwindow_spawner_end";
 	dir = 1
 	},
 /obj/structure/cable,
@@ -25744,6 +25626,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"boz" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "boA" = (
 /obj/effect/spawner/structure/window/hollow/plasma/reinforced,
 /turf/open/floor/plating,
@@ -26372,7 +26260,6 @@
 /area/science/xenobiology)
 "bqy" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	icon_state = "freezer_1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white/side{
@@ -26926,7 +26813,6 @@
 /area/maintenance/solars/starboard/aft)
 "brJ" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -27203,7 +27089,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -27543,7 +27428,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -27657,6 +27541,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"btr" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "bts" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -28957,7 +28847,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bwd" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /obj/structure/cable,
@@ -29578,14 +29467,12 @@
 /area/library)
 "bxz" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
 "bxA" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -29596,7 +29483,6 @@
 /area/ai_monitored/storage/eva)
 "bxC" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -29982,7 +29868,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -29994,7 +29879,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -30085,14 +29969,12 @@
 /area/hydroponics)
 "byR" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "byS" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -30126,7 +30008,6 @@
 /area/chapel/office)
 "byX" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -30204,7 +30085,6 @@
 /area/quartermaster/qm)
 "bzf" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -30682,7 +30562,6 @@
 /area/quartermaster/qm)
 "bAg" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -31308,7 +31187,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -31484,7 +31362,6 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/hollow/plasma/end{
-	icon_state = "phwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -31693,7 +31570,6 @@
 "bCt" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -32399,7 +32275,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -32494,7 +32369,6 @@
 /area/quartermaster/qm)
 "bEk" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -32941,7 +32815,6 @@
 /area/quartermaster/office)
 "bFf" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -34647,7 +34520,6 @@
 /area/tcommsat/computer)
 "bIP" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -35197,6 +35069,12 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"bKt" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/cryo)
 "bKu" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -35231,7 +35109,6 @@
 "bKB" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -35961,7 +35838,6 @@
 /area/maintenance/department/security)
 "bMq" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -37264,7 +37140,6 @@
 /area/maintenance/port/aft)
 "bQf" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -37279,7 +37154,6 @@
 /area/maintenance/fore)
 "bQi" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -37676,7 +37550,6 @@
 "bRo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 6
 	},
 /obj/structure/cable,
@@ -38356,7 +38229,6 @@
 /area/medical/storage)
 "bSW" = (
 /obj/effect/spawner/structure/window/hollow/directional{
-	icon_state = "hwindow_spawner_directional";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -38800,7 +38672,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -38846,7 +38717,6 @@
 /area/maintenance/port/aft)
 "bUd" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	icon_state = "connector_map-2";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -39062,7 +38932,6 @@
 /area/engine/gravity_generator)
 "bUG" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -39096,7 +38965,6 @@
 /area/quartermaster/office)
 "bUK" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -39614,7 +39482,6 @@
 /area/maintenance/port/aft)
 "bWK" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -39879,7 +39746,6 @@
 /area/maintenance/port/aft)
 "bXJ" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -39911,7 +39777,6 @@
 /area/maintenance/port)
 "bXP" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -39942,7 +39807,6 @@
 /area/maintenance/port/aft)
 "bXT" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -39971,7 +39835,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/white/corner{
-	icon_state = "warninglinecorner_white";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -40042,6 +39905,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"bYs" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "bYw" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -40419,7 +40288,6 @@
 "bZP" = (
 /obj/structure/girder,
 /obj/effect/spawner/structure/window/hollow/directional{
-	icon_state = "hwindow_spawner_directional";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -41454,7 +41322,6 @@
 /area/maintenance/disposal)
 "ccR" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -41946,7 +41813,6 @@
 /area/science/research)
 "cee" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -42329,6 +42195,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cfn" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "cgH" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -42340,18 +42212,29 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"chv" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "ciG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/library/abandoned)
+"ckv" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ckW" = (
 /obj/machinery/door/poddoor{
 	id = "Ferry_Bridge"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
-	icon_state = "warningline";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -42376,7 +42259,6 @@
 /area/medical/cryo)
 "cmL" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -42400,6 +42282,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"crE" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/library)
 "csr" = (
 /obj/machinery/airalarm/server{
 	dir = 4;
@@ -42446,6 +42334,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"cvR" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/hydroponics)
 "cxK" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -42464,6 +42358,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"czy" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemistryshutter";
+	name = "Chemistry Privacy Shutters"
+	},
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
+"czQ" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/fore)
 "czY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -42509,7 +42419,6 @@
 	dir = 4
 	},
 /obj/vehicle/ridden/wheelchair{
-	icon_state = "wheelchair";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -42550,7 +42459,6 @@
 /area/ai_monitored/turret_protected/ai)
 "cKV" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
-	icon_state = "filter_off_f";
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery/white,
@@ -42625,6 +42533,18 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"cQp" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
+"cRe" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "cRz" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/fitness/recreation";
@@ -42634,7 +42554,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -42658,12 +42577,21 @@
 "cUf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"cWH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "cWL" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "5;12"
@@ -42672,6 +42600,12 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"cXj" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "cXx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -42681,6 +42615,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"cYw" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "cYx" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -42705,9 +42645,14 @@
 	},
 /turf/open/floor/plasteel/white/side,
 /area/science/xenobiology)
+"dcK" = (
+/obj/effect/spawner/structure/window/hollow/plasma/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "deJ" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 1
 	},
 /obj/structure/girder,
@@ -42742,6 +42687,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"dgN" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/hydroponics)
 "dgR" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -42761,6 +42712,12 @@
 	dir = 5
 	},
 /area/science/research)
+"djp" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "dkO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -42783,6 +42740,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room/external)
+"dlK" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "dmk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42858,6 +42821,17 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating,
 /area/library/abandoned)
+"drH" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "medicalcheckpoint";
+	name = "checkpoint privacy shutters"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "dso" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -42900,7 +42874,6 @@
 "dyz" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Main 3";
-	dir = 2;
 	network = list("ss13","Research")
 	},
 /turf/open/floor/plasteel/white,
@@ -42920,6 +42893,23 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"dAy" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"dBg" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "medicalcheckpoint";
+	name = "checkpoint privacy shutters"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "dCc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -42967,6 +42957,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"dMI" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "brigexternalblast";
+	name = "External Security Blast Door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "dNx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -42996,6 +42997,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"dTr" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "dUa" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -43009,6 +43019,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"dUp" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "dUt" = (
 /obj/effect/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
@@ -43050,6 +43066,12 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"dYx" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "dYW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -43093,6 +43115,34 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/main)
+"edP" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"egr" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/courtroom)
+"egE" = (
+/obj/machinery/door/poddoor{
+	id = "Ferry_Bridge"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"eiy" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/medical/virology)
 "eiC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -43119,7 +43169,6 @@
 /area/quartermaster/miningdock)
 "elX" = (
 /obj/effect/spawner/structure/window/hollow/plasma/reinforced/end{
-	icon_state = "phrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -43336,12 +43385,30 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"eEJ" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/medical/genetics/cloning)
+"eFI" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "eHw" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
+"eHN" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/hydroponics)
 "eHU" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -43352,6 +43419,16 @@
 /obj/item/clothing/suit/cardborg,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"eJh" = (
+/obj/machinery/door/poddoor{
+	id = "Ferry_Bridge"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "eKx" = (
 /obj/machinery/smartfridge/drinks,
 /turf/closed/wall,
@@ -43400,7 +43477,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -43448,6 +43524,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"eQB" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "eRe" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -43474,11 +43556,16 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"eTE" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "eTR" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenocontainment";
@@ -43489,7 +43576,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -43537,7 +43623,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/vehicle/ridden/wheelchair{
-	icon_state = "wheelchair";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43568,7 +43653,6 @@
 /area/security/warden)
 "eZE" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "maintenance access";
 	req_access_txt = "10"
 	},
 /turf/open/floor/plating,
@@ -43681,6 +43765,12 @@
 /obj/item/mop,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"fni" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "fnB" = (
 /obj/item/trash/raisins,
 /turf/open/floor/plating,
@@ -43694,6 +43784,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"fon" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/courtroom)
 "fpA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -43717,14 +43813,29 @@
 "fqf" = (
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"fqU" = (
+/obj/effect/spawner/structure/window/hollow/plasma/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "fst" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"fsZ" = (
+/obj/machinery/door/poddoor{
+	id = "Ferry_Bridge"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ftY" = (
 /obj/effect/turf_decal/stripes/white/corner{
-	icon_state = "warninglinecorner_white";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -43773,6 +43884,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fwU" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "fxC" = (
 /obj/machinery/airalarm{
 	pixel_y = 28
@@ -43783,7 +43900,6 @@
 /area/science/research)
 "fzp" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -43867,6 +43983,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
+"fCj" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "fDg" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -43884,7 +44006,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -43915,6 +44036,12 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"fHA" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "fIN" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -43979,7 +44106,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -44014,6 +44140,12 @@
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"fTl" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "fVo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -44052,6 +44184,18 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room/external)
+"fXt" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"gbl" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "gbC" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -44090,6 +44234,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"giq" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "giB" = (
 /obj/machinery/pipedispenser,
 /turf/open/floor/plating,
@@ -44102,9 +44252,14 @@
 /obj/item/trash/cheesie,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"glw" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
 "gqb" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -44126,6 +44281,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"gqL" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/quartermaster/qm)
 "grg" = (
 /obj/structure/rack,
 /obj/item/poster/random_official,
@@ -44164,6 +44325,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"grs" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "grt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -44173,6 +44340,12 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"grS" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "gst" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44269,6 +44442,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"gEa" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "gEO" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -44277,7 +44456,6 @@
 /area/medical/virology)
 "gFA" = (
 /obj/effect/spawner/structure/window/hollow/plasma/reinforced/end{
-	icon_state = "phrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -44298,6 +44476,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
+"gHV" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "gIO" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -44332,6 +44516,13 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/ai_monitored/nuke_storage)
+"gKJ" = (
+/obj/machinery/conveyor/inverted{
+	dir = 8;
+	id = "QMLoad"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "gNl" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Output Toggle"
@@ -44362,6 +44553,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"gQm" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "gTd" = (
 /obj/machinery/power/terminal,
 /obj/effect/decal/cleanable/dirt,
@@ -44432,6 +44629,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"heP" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "hfx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -44517,6 +44720,12 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"hlE" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "hlK" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/item/camera_film,
@@ -44587,6 +44796,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"hpX" = (
+/obj/machinery/door/poddoor{
+	id = "Ferry_Bridge"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"hqU" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/explab)
 "hrD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -44652,6 +44877,12 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"hyt" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "hyH" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -44670,7 +44901,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/white/corner{
-	icon_state = "warninglinecorner_white";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -44832,6 +45062,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"hSs" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "hTm" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
@@ -44846,6 +45082,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"hUt" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hUQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -44858,6 +45100,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"hWK" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "hXd" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -44916,6 +45164,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room/external)
+"iaB" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ibF" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock{
@@ -44958,10 +45212,25 @@
 /obj/item/trash/cheesie,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"idi" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "ifH" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"igv" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "iif" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -45055,11 +45324,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"isj" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ith" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"itr" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/fore)
 "itU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -45069,6 +45350,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"iuc" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"ive" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "ixd" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -45093,6 +45386,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"iCA" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "iCB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -45101,6 +45400,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"iFh" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "iGD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -45141,7 +45446,6 @@
 /area/medical/cryo)
 "iIq" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -45184,6 +45488,12 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"iPU" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "iRn" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -45248,10 +45558,35 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"iZs" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"jcU" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jdu" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room/external)
+"jdG" = (
+/obj/machinery/door/poddoor{
+	id = "Ferry_Bridge"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jdP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/mineral/wood{
@@ -45272,6 +45607,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"jjn" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
 "jjG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -45312,6 +45653,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"joA" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/storage/eva)
 "jpL" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
@@ -45330,6 +45677,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"jpM" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jqa" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -45382,6 +45735,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"jwp" = (
+/obj/machinery/door/poddoor{
+	id = "Ferry_Bridge"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jws" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/landmark/start/station_engineer,
@@ -45392,6 +45755,15 @@
 /obj/machinery/power/supermatter_crystal/engine,
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"jya" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "jzE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -45424,6 +45796,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"jAA" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "jBs" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -45440,6 +45818,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"jBL" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "jDJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line,
@@ -45539,6 +45923,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"jXX" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "jXY" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/warning/vacuum{
@@ -45567,6 +45957,12 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"kaM" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "kcd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable,
@@ -45582,6 +45978,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"kdC" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "kfj" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -45594,6 +45999,12 @@
 /obj/effect/spawner/structure/window/hollow/plasma/reinforced/middle,
 /turf/open/floor/plating,
 /area/engine/engine_room)
+"kgN" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "klG" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hydroponics";
@@ -45607,6 +46018,12 @@
 "klK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"kmd" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "kmI" = (
@@ -45627,6 +46044,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"kot" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "ksW" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
@@ -45748,6 +46172,16 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"kIp" = (
+/obj/machinery/door/poddoor{
+	id = "Ferry_Bridge"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "kIO" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/disposal";
@@ -45758,7 +46192,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -45777,7 +46210,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -45794,7 +46226,6 @@
 /area/engine/engine_room/external)
 "kNb" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -45819,6 +46250,12 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"kSL" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "kTN" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -45862,7 +46299,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "kZr" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -45872,6 +46308,12 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"lbx" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "lcb" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12"
@@ -45884,11 +46326,16 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4;
-	icon_state = "warningline"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"lcS" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
 "ldB" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -45918,6 +46365,12 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"lgX" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "lhs" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/machinery/camera/autoname{
@@ -45944,10 +46397,51 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
+"ljZ" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "lkG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"lmU" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"lnW" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"loZ" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "medicalcheckpoint";
+	name = "checkpoint privacy shutters"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
+"lpg" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/courtroom)
+"lqj" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "ltw" = (
@@ -45964,6 +46458,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"luT" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/hydroponics)
 "lwp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -46044,7 +46544,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/white/corner{
-	icon_state = "warninglinecorner_white";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -46098,11 +46597,16 @@
 /area/crew_quarters/heads/hos)
 "lHe" = (
 /obj/effect/turf_decal/caution/white{
-	icon_state = "caution_white";
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"lHp" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "lKe" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -46164,6 +46668,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"lRc" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "lRf" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
@@ -46232,11 +46742,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"lWb" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "lYH" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"maU" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "mbb" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "5;12"
@@ -46250,11 +46772,9 @@
 "mbn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/holohoop{
-	icon_state = "hoop";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -46275,11 +46795,16 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"meM" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "mgs" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -46348,7 +46873,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -46440,6 +46964,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"mrQ" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "mtv" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/starboard";
@@ -46451,6 +46981,12 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"mtW" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "mui" = (
 /obj/item/trash/chips,
 /turf/open/floor/plating,
@@ -46495,17 +47031,43 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"myq" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"myv" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "myK" = (
 /obj/item/trash/chips,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"mzF" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "mBk" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"mBz" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "mBI" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -46645,6 +47207,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"mOw" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
+"mRN" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/chapel/office)
 "mSf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
@@ -46661,6 +47235,12 @@
 /obj/item/paicard,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"mSr" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
 "mUn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -46721,6 +47301,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/gateway)
+"mZA" = (
+/obj/machinery/conveyor/inverted{
+	dir = 8;
+	id = "QMLoad"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "naE" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/brig";
@@ -46777,6 +47364,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"nno" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "nnE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -46825,6 +47418,12 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"nvF" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "nwZ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -46895,6 +47494,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"nDa" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "nDW" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -46930,6 +47535,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"nGB" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "nIf" = (
 /obj/machinery/light{
 	dir = 1
@@ -46968,7 +47579,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -47023,7 +47633,6 @@
 /area/engine/engineering)
 "nUq" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	icon_state = "connector_map-2";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -47056,6 +47665,12 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"obr" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/qm)
 "odJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -47071,6 +47686,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"odW" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/science/explab)
 "oee" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
@@ -47107,6 +47728,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"oiI" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "okf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -47241,17 +47868,28 @@
 /area/maintenance/port/fore)
 "oug" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"ouC" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "ovO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"owm" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "oza" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -47338,6 +47976,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
+"oGJ" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/storage)
 "oHf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -47393,9 +48037,40 @@
 /obj/machinery/computer/atmos_control/toxinsmix,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"oNG" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"oOF" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "oPe" = (
 /turf/closed/wall/r_wall,
 /area/lawoffice)
+"oQg" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"oQS" = (
+/obj/machinery/door/poddoor{
+	id = "Ferry_Bridge"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "oRe" = (
 /obj/machinery/airalarm{
 	pixel_y = 28
@@ -47404,6 +48079,12 @@
 	dir = 6
 	},
 /area/science/research)
+"oUb" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "oUL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -47417,6 +48098,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room/external)
+"oVf" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"oVg" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "oVG" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/turret_protected/ai";
@@ -47480,6 +48173,12 @@
 	dir = 1
 	},
 /area/maintenance/port)
+"paW" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "pdk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -47550,7 +48249,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -47584,11 +48282,16 @@
 /area/security/checkpoint/medical)
 "pmD" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"pmT" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "pmZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -47607,6 +48310,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room/external)
+"ptb" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "ptm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -47663,17 +48372,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"pDd" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "pEW" = (
 /obj/structure/girder,
 /obj/effect/spawner/structure/window/hollow/directional{
-	icon_state = "hwindow_spawner_directional";
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"pFk" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "pFw" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -47689,6 +48409,25 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"pHJ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"pIJ" = (
+/obj/machinery/door/poddoor{
+	id = "Ferry_Bridge"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "pKr" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -47720,6 +48459,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"pNd" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/science/research)
+"pNz" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "pNR" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/courtroom";
@@ -47731,11 +48482,16 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"pQr" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "pRC" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/port/fore";
@@ -47845,6 +48601,18 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/engine/supermatter)
+"qga" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
+"qho" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qkE" = (
 /obj/machinery/power/smes/engineering,
 /obj/machinery/light{
@@ -47878,6 +48646,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/space)
+"qmw" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "qmH" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -47892,6 +48667,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"qoL" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "qpi" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -47906,6 +48687,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qpj" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/medical/storage)
 "qpo" = (
 /obj/structure/table/glass,
 /obj/machinery/power/apc{
@@ -47938,6 +48725,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"qri" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "medicalcheckpoint";
+	name = "checkpoint privacy shutters"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "qrk" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/turf_decal/tile/green,
@@ -47960,6 +48758,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"qsu" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qtx" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "5;12"
@@ -48026,6 +48830,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"qCc" = (
+/obj/machinery/conveyor/inverted{
+	dir = 8;
+	id = "QMLoad2"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "qCl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48048,6 +48859,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"qFj" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qHu" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -48068,6 +48885,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/fitness/locker_room)
+"qJo" = (
+/obj/machinery/door/poddoor{
+	id = "Ferry_Bridge"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qKn" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -48138,6 +48965,15 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"qPW" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "qSd" = (
 /obj/item/chair,
 /obj/item/chair{
@@ -48152,15 +48988,19 @@
 /area/maintenance/port/aft)
 "qUx" = (
 /obj/effect/spawner/structure/window/hollow/plasma/end{
-	icon_state = "phwindow_spawner_end";
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/virology)
+"qUJ" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "qVo" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -48173,6 +49013,13 @@
 "qXl" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/engine)
+"qXV" = (
+/obj/machinery/conveyor/inverted{
+	dir = 8;
+	id = "QMLoad2"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "qYj" = (
 /obj/machinery/power/apc{
 	areastring = "/area/chapel/office";
@@ -48182,11 +49029,16 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"qYx" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/office)
 "qYJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -48315,6 +49167,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"rwn" = (
+/obj/machinery/door/poddoor{
+	id = "Ferry_Bridge"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "rwy" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
@@ -48325,6 +49187,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"rwM" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"rzf" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"rAC" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "rBV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48374,6 +49254,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"rFB" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "rFU" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/delivery,
@@ -48383,6 +49270,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"rIt" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/chapel/office)
 "rIN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -48430,6 +49323,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine,
 /area/engine/engine_room/external)
+"rRG" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "rSs" = (
 /obj/machinery/computer/monitor,
 /obj/item/radio/intercom{
@@ -48524,6 +49423,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"sgd" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"sgT" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "shy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -48539,6 +49450,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"sjC" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "sjP" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -48568,6 +49486,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"skx" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "skG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -48577,6 +49501,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/supermatter)
+"skX" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "slB" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -48597,6 +49527,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"smG" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "snW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -48604,6 +49540,12 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"soi" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "son" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -48620,6 +49562,12 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plating,
 /area/space)
+"spM" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "spN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -48648,11 +49596,16 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"srS" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "stN" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
@@ -48669,11 +49622,16 @@
 /area/maintenance/aft)
 "svg" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"swU" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "sxb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48724,6 +49682,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"szF" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "szT" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Supermatter External Chamber";
@@ -48739,6 +49703,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"sBW" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "sCI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -48752,6 +49722,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"sCK" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "sEr" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -48821,6 +49798,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"sOF" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "sPB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -48830,6 +49813,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"sQe" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "sQk" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/portable_atmospherics/pump,
@@ -48838,11 +49827,16 @@
 /area/maintenance/aft)
 "sSZ" = (
 /obj/effect/spawner/structure/window/hollow/plasma/reinforced/end{
-	icon_state = "phrwindow_spawner_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engine_room)
+"sTR" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "sXg" = (
 /obj/structure/chair,
 /obj/item/radio/intercom{
@@ -48866,9 +49860,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"taN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "taQ" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -48892,7 +49893,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -48943,13 +49943,24 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"tid" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/library)
 "tjW" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
-	icon_state = "connector_map-2";
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"tkj" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "tlx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -48958,6 +49969,21 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"tmu" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"tnb" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "tnj" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Space Access Airlock";
@@ -48996,7 +50022,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -49010,6 +50035,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"tpH" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "tqi" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
@@ -49056,6 +50087,12 @@
 /obj/effect/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"tum" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "tus" = (
 /obj/structure/reflector/double,
 /turf/open/floor/plasteel/dark,
@@ -49076,12 +50113,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"tvM" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/storage/eva)
 "tvZ" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/circuit/telecomms,
 /area/space)
+"txq" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"txY" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "tzv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -49114,6 +50169,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"tCE" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "tCJ" = (
 /obj/structure/cable,
 /obj/machinery/light,
@@ -49142,7 +50203,6 @@
 /area/engine/engine_room/external)
 "tKp" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	icon_state = "hrwindow_spawner_directional";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -49155,13 +50215,18 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"tLT" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "tMz" = (
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "tMN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
@@ -49290,9 +50355,21 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard)
+"ufa" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/bridge)
+"ufp" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ufq" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	icon_state = "hrwindow_spawner_middle";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -49345,6 +50422,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"ujF" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "ujG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/weightmachine/weightlifter,
@@ -49456,7 +50539,6 @@
 "uwS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1,
@@ -49484,11 +50566,17 @@
 	pixel_x = -25
 	},
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"uzW" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "uBa" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -49508,6 +50596,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"uHe" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/library)
 "uIo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49543,12 +50637,17 @@
 "uJC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 10
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"uJS" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "uKV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -49559,6 +50658,12 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"uMw" = (
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "uMy" = (
 /obj/structure/chair/stool,
 /obj/machinery/light/small{
@@ -49579,6 +50684,12 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"uQA" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "uQL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -49626,6 +50737,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room/external)
+"uVn" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "uVU" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -49668,11 +50785,16 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"vbp" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "vbr" = (
 /obj/machinery/power/emitter/anchored{
 	dir = 4;
@@ -49735,6 +50857,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"vdT" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "vdV" = (
 /obj/structure/table,
 /obj/item/banhammer,
@@ -49760,6 +50891,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"viO" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "vjd" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
@@ -49802,6 +50939,12 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"vkq" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "vlx" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Excess Storage";
@@ -49819,6 +50962,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"vnn" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "voh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -49866,7 +51015,6 @@
 /area/crew_quarters/heads/captain/private)
 "vsg" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -49896,7 +51044,6 @@
 /area/engine/engine_room/external)
 "vvN" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -49907,6 +51054,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating,
 /area/library/abandoned)
+"vwQ" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/hydroponics)
 "vxm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -49929,6 +51082,21 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"vyl" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"vyo" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "vyZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -49988,7 +51156,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -50069,6 +51236,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vIG" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "vLi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/port";
@@ -50078,7 +51254,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -50162,6 +51337,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vSR" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "vUd" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Mix Bypass"
@@ -50210,6 +51391,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"weO" = (
+/obj/effect/spawner/structure/window/hollow/plasma/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "wia" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -50234,6 +51421,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"wkv" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "wkM" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -50338,11 +51531,18 @@
 "wpG" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
+"wrb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "wrV" = (
 /obj/structure/kitchenspike,
 /obj/item/radio/intercom{
@@ -50388,6 +51588,12 @@
 /obj/effect/holodeck_effect/cards,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"wws" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/library)
 "wwA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -50434,6 +51640,18 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
+"wyt" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"wyE" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "wzU" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -50462,6 +51680,18 @@
 /obj/item/lipstick/random,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wDx" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/storage/tools)
+"wEz" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "wFi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/captain/private";
@@ -50483,11 +51713,16 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"wGc" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "wIl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -50553,6 +51788,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"wMi" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "wMM" = (
 /obj/machinery/stasis,
 /obj/machinery/airalarm{
@@ -50570,7 +51814,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -50612,12 +51855,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"wVh" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "wVQ" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"wYh" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/processing)
+"wYq" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/storage/tools)
 "xaB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -50631,7 +51892,6 @@
 /area/engine/engine_room)
 "xaO" = (
 /obj/effect/spawner/structure/window/hollow/directional{
-	icon_state = "hwindow_spawner_directional";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -50643,6 +51903,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"xca" = (
+/obj/effect/spawner/structure/window/hollow/plasma/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "xdQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -50681,6 +51947,17 @@
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"xjG" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "brigexternalblast";
+	name = "External Security Blast Door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "xmg" = (
 /obj/structure/girder,
 /obj/effect/spawner/structure/window/hollow/directional,
@@ -50704,6 +51981,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"xoA" = (
+/obj/machinery/door/poddoor{
+	id = "Ferry_Bridge"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "xoZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -50759,9 +52046,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"xvP" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "xwC" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
-	icon_state = "hrwindow_spawner_end";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -50801,6 +52093,19 @@
 	dir = 6
 	},
 /area/science/xenobiology)
+"xza" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/bridge)
+"xzu" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "xBI" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/effect/turf_decal/stripes/corner{
@@ -50808,6 +52113,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"xBQ" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "xCE" = (
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -50870,6 +52181,12 @@
 /obj/item/circuitboard/computer/apc_control,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"xII" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "xJN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1,
@@ -50961,7 +52278,6 @@
 "yaX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -50976,7 +52292,6 @@
 "yck" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1{
@@ -51040,6 +52355,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ygh" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ygs" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -51077,10 +52398,22 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engine_room)
+"yhU" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "ykr" = (
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
+"ykB" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "ykD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
@@ -65350,14 +66683,14 @@ aaa
 aeS
 aeS
 aeS
-pFw
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+bYs
+wGc
+wGc
+wGc
+wGc
+wGc
+wGc
+wGc
 lAF
 aeS
 aeS
@@ -68452,12 +69785,12 @@ aeS
 acB
 acB
 adz
-ahO
-ahO
-ahO
-ahO
-ahO
-ahO
+bcU
+bcU
+bcU
+bcU
+bcU
+bcU
 aBw
 acB
 acB
@@ -68942,8 +70275,8 @@ bTy
 agU
 bSc
 ajM
-amk
-amk
+pNd
+pNd
 anh
 ano
 aBQ
@@ -69183,11 +70516,11 @@ aeS
 aeS
 aeS
 aeS
-pFw
-qVo
-qVo
-qVo
-qVo
+bYs
+wGc
+wGc
+wGc
+wGc
 lAF
 aeS
 aeS
@@ -69514,7 +70847,7 @@ bIx
 bIw
 bIw
 aCb
-aCr
+sOF
 aCG
 vut
 vut
@@ -69944,7 +71277,7 @@ aaa
 aaa
 aaa
 aal
-mBk
+qho
 bYa
 bTU
 bTU
@@ -70028,7 +71361,7 @@ bIw
 bIw
 bIw
 aCk
-aCr
+sOF
 aCH
 vut
 vut
@@ -70201,7 +71534,7 @@ aaa
 aaa
 aal
 aal
-cmL
+qFj
 bWZ
 bXa
 bTU
@@ -70707,13 +72040,13 @@ aeS
 aeS
 aeS
 aeS
-lcN
-lcN
-lcN
-lcN
-lcN
-lcN
-lcN
+kIp
+kIp
+kIp
+kIp
+kIp
+kIp
+kIp
 aeS
 aeS
 aeS
@@ -70960,7 +72293,7 @@ aaa
 aaa
 aaa
 aal
-mBk
+qho
 bTU
 yaX
 dSI
@@ -71020,8 +72353,8 @@ bMs
 cbF
 aGE
 aHf
-aHx
-aHx
+eiy
+eiy
 aIb
 aGO
 aGO
@@ -71035,7 +72368,7 @@ bRj
 acB
 aCK
 bAA
-ash
+wEz
 aaa
 aaa
 aaa
@@ -71217,7 +72550,7 @@ aaa
 aaa
 aal
 aal
-cmL
+qFj
 bTU
 cUf
 rFU
@@ -71292,7 +72625,7 @@ bmk
 acB
 bLA
 ccU
-asv
+fwU
 aal
 aaa
 aaa
@@ -71478,17 +72811,17 @@ unx
 bTU
 gOZ
 aeS
-ckW
-ckW
-ckW
-ckW
-ckW
-ckW
-ckW
+rwn
+rwn
+rwn
+rwn
+rwn
+rwn
+rwn
 aeS
-pFw
-qVo
-qVo
+bYs
+wGc
+wGc
 lAF
 aeS
 bXg
@@ -71747,10 +73080,10 @@ aaa
 aal
 aal
 aaa
-mBk
+qho
 bTU
 fEN
-mBk
+qho
 aal
 acm
 acr
@@ -71991,7 +73324,7 @@ yev
 unx
 bTU
 hSh
-mBk
+qho
 aaa
 aaa
 aal
@@ -72261,10 +73594,10 @@ aal
 aal
 aaa
 aaa
-cmL
+qFj
 bTU
 fEN
-cmL
+qFj
 aal
 acm
 acr
@@ -73019,7 +74352,7 @@ bTU
 bTU
 bTU
 bTU
-cmL
+qFj
 aal
 aaa
 aaa
@@ -73263,7 +74596,7 @@ aaa
 aaa
 aal
 aal
-mBk
+qho
 pgb
 bTU
 fkJ
@@ -73520,7 +74853,7 @@ aaa
 aaa
 aaa
 aal
-cmL
+qFj
 odT
 bTU
 avM
@@ -73811,9 +75144,9 @@ fEN
 bTU
 aeS
 aeS
-pFw
-qVo
-qVo
+bYs
+wGc
+wGc
 lAF
 aeS
 aeS
@@ -74097,7 +75430,7 @@ aYf
 aFk
 aEv
 gqB
-aFO
+eEJ
 aGf
 aFR
 cbJ
@@ -74122,7 +75455,7 @@ aIY
 aIY
 bMs
 bfq
-ash
+wEz
 rEa
 bMs
 cep
@@ -74574,7 +75907,7 @@ adO
 adO
 adO
 aCg
-abr
+jjn
 afD
 aCg
 adO
@@ -74621,7 +75954,7 @@ aHm
 aNN
 bdQ
 aIi
-aIw
+bKt
 aGt
 bBQ
 aIY
@@ -74844,7 +76177,7 @@ kLE
 acp
 anq
 acw
-adk
+odW
 bBT
 bBW
 bkW
@@ -75101,7 +76434,7 @@ cIZ
 acp
 acw
 acw
-adl
+hqU
 adG
 adW
 aik
@@ -75125,7 +76458,7 @@ aBe
 aEU
 aNd
 aIo
-aFO
+eEJ
 aIa
 aXy
 bew
@@ -75150,7 +76483,7 @@ aKn
 aIY
 oWU
 bdC
-asv
+fwU
 rEa
 bLQ
 acB
@@ -75392,7 +76725,7 @@ clO
 aQY
 azU
 aIl
-aIw
+bKt
 aGt
 bBQ
 aIY
@@ -75615,7 +76948,7 @@ ljF
 acp
 bef
 bcm
-adk
+odW
 adH
 aCX
 aik
@@ -75872,7 +77205,7 @@ ljF
 acp
 acw
 acw
-adl
+hqU
 adJ
 aen
 amp
@@ -76095,31 +77428,31 @@ ccw
 wSd
 avM
 avM
-aJc
-aVs
+chv
+mzF
 aVh
 aVo
-aJc
-aVs
-aVs
+chv
+mzF
+mzF
 aVh
 avM
-bcc
+heP
 avu
 avi
 aQS
 avi
-bcc
+heP
 avu
 adO
 adO
-abr
+jjn
 afD
 aCg
-abr
+jjn
 afD
 aCg
-abr
+jjn
 afD
 adO
 adO
@@ -76417,8 +77750,8 @@ beE
 aRt
 aGT
 aGT
-aQZ
-aVG
+drH
+loZ
 aYr
 aGT
 aGT
@@ -76668,17 +78001,17 @@ aFl
 aFA
 aFL
 aFV
-aGl
+qpj
 aGt
 beE
 aIM
-aqv
+qri
 pmp
 aHI
 gVW
 aNL
 aYt
-aqv
+qri
 bGO
 bBY
 bCb
@@ -76925,7 +78258,7 @@ aEV
 aHC
 aIy
 aFm
-aGm
+oGJ
 aGt
 beE
 aIM
@@ -77186,15 +78519,15 @@ aIL
 aKc
 bRp
 aIM
-aHs
+dBg
 aHt
 rnH
 aHT
 aVF
 blF
-aHs
+dBg
 bGP
-cCk
+cWH
 aJp
 aJD
 bFo
@@ -77363,7 +78696,7 @@ aaa
 aaa
 aaa
 aaa
-atz
+rwM
 aai
 bcd
 bcd
@@ -77444,14 +78777,14 @@ beu
 aRb
 aJG
 aGT
-aQZ
-aVG
+drH
+loZ
 aYr
 aXk
 aGT
 aGT
 aYa
-cCk
+cWH
 aJp
 aJp
 aJp
@@ -77620,7 +78953,7 @@ aaa
 aaa
 aaa
 aaa
-avA
+szF
 awe
 anQ
 awe
@@ -77696,7 +79029,7 @@ aHO
 aHE
 aSu
 aFm
-aGl
+qpj
 aGt
 aRe
 aUR
@@ -77880,17 +79213,17 @@ aaa
 avi
 awl
 avi
-aaW
+dAy
 avi
-aaW
+iZs
 avi
 abs
 azb
 abs
 avi
-aaW
+iZs
 avi
-aaW
+iZs
 avi
 aPS
 azb
@@ -77953,7 +79286,7 @@ aFn
 aFC
 aFM
 aGe
-aGm
+oGJ
 aGt
 aRe
 aRe
@@ -78141,23 +79474,23 @@ hQn
 avi
 hQn
 avi
-bcc
-avO
+heP
+xvP
 avu
 avi
 bcX
 avi
 bcX
 avi
-bcc
-avO
-avO
+heP
+xvP
+xvP
 avu
 avi
 avi
-bcc
-avO
-avO
+heP
+xvP
+xvP
 avu
 avi
 avY
@@ -78228,7 +79561,7 @@ azH
 bCg
 bba
 azH
-bMq
+hUt
 azH
 azH
 azH
@@ -78394,21 +79727,18 @@ aaa
 aaa
 aaa
 avi
-aQS
+qPW
 avi
-aQS
-avi
-aaa
-aaa
-aaa
-avi
-aQS
-avi
-aQS
+qPW
 avi
 aaa
 aaa
 aaa
+avi
+qPW
+avi
+qPW
+avi
 aaa
 aaa
 aaa
@@ -78416,11 +79746,14 @@ aaa
 aaa
 aaa
 aaa
-atz
+aaa
+aaa
+aaa
+rwM
 avY
 bvK
 avi
-bQf
+vyo
 aRA
 aaT
 bVq
@@ -78744,7 +80077,7 @@ bba
 azH
 azH
 azH
-bMq
+hUt
 azH
 bba
 aBx
@@ -79194,7 +80527,7 @@ avi
 aRA
 bQr
 aaT
-bQf
+vyo
 bQi
 aaT
 bQr
@@ -79444,7 +80777,7 @@ aaa
 aaa
 aaa
 aaa
-avA
+szF
 bvD
 bvN
 avi
@@ -79957,7 +81290,7 @@ aaa
 aaa
 aaa
 aaa
-atz
+rwM
 bfM
 avY
 bvK
@@ -80728,7 +82061,7 @@ aaa
 aaa
 aaa
 aaa
-avA
+szF
 bfO
 aEJ
 agp
@@ -80789,7 +82122,7 @@ aXR
 axM
 bfG
 aGU
-aHn
+czy
 bfn
 aIR
 aJf
@@ -81048,7 +82381,7 @@ aIn
 axM
 aTK
 bfI
-aHn
+czy
 aNO
 aHW
 bCg
@@ -81078,7 +82411,7 @@ aUk
 aUk
 bpR
 bUF
-aUC
+mOw
 bbt
 bby
 bbA
@@ -81243,7 +82576,7 @@ aaa
 aaa
 aaa
 aaa
-atz
+rwM
 avY
 bvK
 avi
@@ -81282,14 +82615,14 @@ aLn
 aLn
 aLn
 aLn
-aLw
-aLy
-aLy
+crE
+tid
+tid
 aLF
 bxx
-aLw
-aLy
-aLy
+crE
+tid
+tid
 aLF
 aLn
 aLn
@@ -81335,7 +82668,7 @@ bbm
 aUk
 bpS
 bVg
-aUD
+mSr
 bbu
 aUI
 aXg
@@ -81849,7 +83182,7 @@ bbo
 aUk
 bpY
 bbs
-aUC
+mOw
 bbw
 aXh
 aXg
@@ -82106,7 +83439,7 @@ aUk
 aUk
 bto
 aUz
-aUD
+mSr
 bbx
 bbz
 bbB
@@ -82249,21 +83582,18 @@ aaa
 aaa
 aaa
 avi
-aaW
+iZs
 avi
-aaW
-avi
-aaa
-aaa
-aaa
-avi
-aaW
-avi
-aaW
+iZs
 avi
 aaa
 aaa
 aaa
+avi
+iZs
+avi
+iZs
+avi
 aaa
 aaa
 aaa
@@ -82271,7 +83601,10 @@ aaa
 aaa
 aaa
 aaa
-avA
+aaa
+aaa
+aaa
+szF
 avY
 bvK
 avi
@@ -82294,7 +83627,7 @@ awO
 abP
 bsI
 axk
-bxA
+joA
 bxD
 auJ
 auJ
@@ -82334,7 +83667,7 @@ akx
 amv
 afa
 aoA
-aoE
+dgN
 azE
 azR
 btt
@@ -82510,23 +83843,23 @@ hQn
 avi
 bcN
 avi
-bcc
-avO
+heP
+xvP
 avu
 avi
 bcX
 avi
 bcX
 avi
-bcc
-avO
-avO
+heP
+xvP
+xvP
 avu
 avi
 avi
-bcc
-avO
-avO
+heP
+xvP
+xvP
 avu
 avi
 avU
@@ -82550,8 +83883,8 @@ bfC
 abP
 hYI
 axh
-bxA
-bxC
+joA
+tvM
 avo
 avs
 auJ
@@ -82591,8 +83924,8 @@ bUo
 akp
 bnS
 aoC
-aoF
-aoE
+cvR
+dgN
 azE
 azR
 btt
@@ -82763,17 +84096,17 @@ aaa
 avi
 awl
 avi
-aQS
+qPW
 avi
-aQS
+qPW
 avi
 aza
 aPK
 aza
 avi
-aQS
+qPW
 avi
-aQS
+qPW
 avi
 aQi
 aPK
@@ -82837,7 +84170,7 @@ pkz
 bQr
 bRZ
 bRZ
-aBF
+cYw
 bWU
 aRA
 afa
@@ -82849,8 +84182,8 @@ amA
 akp
 akp
 bCE
-aoF
-aoE
+cvR
+dgN
 azE
 azR
 aqe
@@ -83017,7 +84350,7 @@ aaa
 aaa
 abE
 aaa
-atz
+rwM
 awe
 boD
 awe
@@ -83064,7 +84397,7 @@ bAh
 bDD
 axh
 bxz
-bxC
+tvM
 xGX
 xGX
 axN
@@ -83107,7 +84440,7 @@ bul
 akp
 akp
 bCE
-aoF
+cvR
 aQz
 aAd
 arK
@@ -83274,7 +84607,7 @@ aaa
 aaa
 aaa
 aaa
-avA
+szF
 aam
 awh
 awh
@@ -83347,7 +84680,7 @@ aKC
 aLn
 aRA
 aaT
-aBD
+lnW
 acL
 aaT
 laG
@@ -83533,31 +84866,31 @@ aaa
 aaa
 avi
 avi
-bcc
-avO
-avO
-avO
-avO
-avO
-avO
-avO
+heP
+xvP
+xvP
+xvP
+xvP
+xvP
+xvP
+xvP
 avu
 avi
-bcc
-avO
-avO
-avO
-avO
-avO
-avO
-avO
-avO
-avO
-avO
-avO
+heP
+xvP
+xvP
+xvP
+xvP
+xvP
+xvP
+xvP
+xvP
+xvP
+xvP
+xvP
 avu
 avi
-bcc
+heP
 avu
 avi
 byc
@@ -83816,7 +85149,7 @@ aaa
 aaa
 aaa
 aaa
-atz
+rwM
 aLh
 awe
 awe
@@ -84073,7 +85406,7 @@ aaa
 aaa
 aaa
 aaa
-avA
+szF
 aLV
 awh
 awm
@@ -84393,7 +85726,7 @@ alZ
 alZ
 alZ
 bux
-aoF
+cvR
 aQz
 aAr
 arK
@@ -84873,8 +86206,8 @@ aBC
 bQr
 aRA
 aRA
-aBE
-aBF
+uVn
+cYw
 aaa
 aal
 aaa
@@ -84893,7 +86226,7 @@ aaa
 aaa
 aaT
 aaT
-aBD
+lnW
 ufq
 acL
 aaT
@@ -85111,7 +86444,7 @@ bxQ
 aty
 aty
 aty
-ard
+oUb
 byw
 ark
 abP
@@ -85129,8 +86462,8 @@ aRA
 aRA
 aRA
 aRA
-aBE
-aBF
+uVn
+cYw
 aaa
 aaa
 aaa
@@ -85368,7 +86701,7 @@ aMi
 aty
 aty
 aty
-aMp
+rRG
 bZO
 aeL
 aff
@@ -85385,8 +86718,8 @@ aaT
 aaT
 aaT
 aaT
-aBD
-aBF
+lnW
+cYw
 aaa
 aaa
 aaa
@@ -85396,7 +86729,7 @@ aal
 bAC
 uwV
 uwV
-elX
+weO
 yhJ
 wFk
 uwV
@@ -85721,7 +87054,7 @@ aAc
 ces
 aAc
 aAc
-taQ
+lgX
 csY
 aAc
 aaa
@@ -85860,13 +87193,13 @@ aaa
 aaa
 aaa
 aaa
-ard
-bcJ
+oUb
+uMw
 atA
 aaa
 aaa
 atA
-bcJ
+uMw
 atA
 aaa
 aaa
@@ -85906,7 +87239,7 @@ aaa
 aal
 aug
 uwV
-elX
+weO
 spN
 uwV
 lwp
@@ -85915,7 +87248,7 @@ vBp
 dFi
 tuR
 uwV
-elX
+weO
 yhJ
 wFk
 uwV
@@ -86120,13 +87453,13 @@ abm
 aro
 aty
 auG
-ave
+kSL
 auI
 auG
 aty
 auG
-ave
-atx
+kSL
+giq
 auI
 acc
 acc
@@ -86396,7 +87729,7 @@ aMm
 aty
 aty
 aty
-ard
+oUb
 anH
 ark
 dNx
@@ -86653,7 +87986,7 @@ bqc
 bqc
 arX
 aMn
-aMp
+rRG
 arv
 awF
 arK
@@ -86745,11 +88078,11 @@ cdL
 ceL
 acj
 aal
-avK
+viO
 bpL
 bXv
 aAc
-taQ
+lgX
 jTi
 aAc
 qOv
@@ -86889,7 +88222,7 @@ aaa
 aaa
 acO
 abo
-atx
+giq
 auI
 auG
 auG
@@ -87146,7 +88479,7 @@ aaa
 aaa
 aaa
 aiE
-aiS
+mZA
 awx
 aBa
 abD
@@ -87259,7 +88592,7 @@ cdL
 cdL
 acj
 aal
-fzp
+sgT
 bpL
 bXv
 aAc
@@ -87403,7 +88736,7 @@ aaa
 aaa
 aaa
 aiE
-aiS
+mZA
 awy
 aBO
 aAh
@@ -87425,7 +88758,7 @@ bzh
 bIv
 bAo
 bSk
-bUG
+qYx
 aJa
 byF
 awX
@@ -87657,10 +88990,10 @@ aaa
 aaa
 aaa
 aaa
-abd
-agK
+cXj
+skX
 aiG
-aiS
+mZA
 aAf
 aAh
 aAh
@@ -87773,7 +89106,7 @@ cdN
 ceM
 acj
 aal
-avK
+viO
 bpL
 bMu
 vsg
@@ -87925,12 +89258,12 @@ aBO
 aAh
 agc
 boq
-byS
+obr
 bze
 bAf
 bBi
 bEb
-byS
+obr
 bEv
 bEN
 bFc
@@ -88004,12 +89337,12 @@ brz
 asH
 asJ
 acj
-atg
-atC
+iCA
+hlE
 srD
 auN
 avl
-avK
+viO
 awf
 ayz
 axv
@@ -88184,8 +89517,8 @@ aQr
 brY
 byT
 bzf
-bAg
-bAg
+gqL
+gqL
 bEc
 byT
 bEw
@@ -88287,7 +89620,7 @@ cdN
 cdN
 acj
 aal
-fzp
+sgT
 bpL
 sqV
 svg
@@ -88428,7 +89761,7 @@ aaa
 aaa
 aaa
 aaa
-abd
+cXj
 aia
 aiI
 alO
@@ -88710,7 +90043,7 @@ bFp
 bMm
 bRH
 bUD
-bUG
+qYx
 awA
 dNx
 bcw
@@ -88801,7 +90134,7 @@ axn
 aDM
 acj
 aal
-avK
+viO
 bpL
 bXv
 bwZ
@@ -89199,10 +90532,10 @@ aaa
 aaa
 aaa
 aaa
-abd
-agK
+cXj
+skX
 aiJ
-asq
+qXV
 aAj
 aAh
 aAh
@@ -89315,7 +90648,7 @@ acF
 acF
 acj
 aal
-fzp
+sgT
 bpL
 bXv
 cbt
@@ -89459,7 +90792,7 @@ aaa
 aaa
 aaa
 aiE
-asq
+qXV
 awy
 aBO
 aAh
@@ -89467,7 +90800,7 @@ aPX
 aAh
 agv
 aAh
-aiK
+lWb
 bzs
 bAJ
 bAJ
@@ -89715,8 +91048,8 @@ aaa
 aaa
 aaa
 aaa
-aiK
-asq
+lWb
+qXV
 abM
 aAh
 aPO
@@ -90028,7 +91361,7 @@ amH
 mvv
 uwV
 dpT
-elX
+weO
 wFk
 uwV
 aal
@@ -90742,7 +92075,7 @@ aaa
 aaa
 aaa
 abk
-aie
+eFI
 aiL
 auV
 aAp
@@ -90777,10 +92110,10 @@ aRA
 bsp
 aMq
 aal
-aMz
-aMC
-aMC
-aMv
+oVg
+qga
+qga
+swU
 aal
 aal
 aaa
@@ -90793,7 +92126,7 @@ aal
 jsm
 uwV
 uwV
-elX
+weO
 yhJ
 wFk
 uwV
@@ -90862,7 +92195,7 @@ bcC
 bDr
 caw
 bcC
-xwC
+eTE
 ccR
 aal
 aaa
@@ -91033,12 +92366,12 @@ aaT
 aTs
 bPM
 aMq
-aMt
-aMA
+tpH
+gHV
 aMG
 aMD
-aMw
-aMv
+oiI
+swU
 aal
 aaa
 aaa
@@ -91295,8 +92628,8 @@ aMu
 btw
 aMu
 bCK
-aMw
-aMv
+oiI
+swU
 aaa
 aaa
 aaa
@@ -91553,8 +92886,8 @@ btx
 aMu
 aMu
 bCR
-aMw
-aMv
+oiI
+swU
 aaa
 aaa
 aaa
@@ -91608,16 +92941,16 @@ bXv
 bXv
 biu
 acj
-atg
-atC
+iCA
+hlE
 auN
 acj
-atg
-atC
+iCA
+hlE
 auN
 acj
-atg
-atC
+iCA
+hlE
 auN
 acj
 bpL
@@ -91770,7 +93103,7 @@ aaa
 aaa
 aaa
 agw
-aie
+eFI
 aiL
 auV
 bVB
@@ -92141,9 +93474,9 @@ bcC
 bcC
 bcC
 bcC
-xwC
-oug
-oug
+eTE
+vSR
+vSR
 jhT
 bcC
 bcC
@@ -92315,8 +93648,8 @@ aaZ
 act
 ark
 bsT
-aMt
-aMv
+tpH
+swU
 aMu
 aMu
 aMu
@@ -92324,8 +93657,8 @@ aMu
 aMu
 aMu
 aMu
-aMz
-aMA
+oVg
+gHV
 aaa
 aaa
 aaa
@@ -92573,15 +93906,15 @@ act
 ark
 bsN
 axe
-aMw
-aMv
+oiI
+swU
 aMu
 aMu
 aMy
 aMu
 aMu
 bCS
-aMB
+jXX
 aal
 aaa
 aaa
@@ -92831,8 +94164,8 @@ aSd
 bsO
 bsw
 axe
-aMw
-aMv
+oiI
+swU
 aMu
 aMu
 aMu
@@ -92845,7 +94178,7 @@ alk
 alk
 alk
 alk
-arY
+wYq
 arG
 alk
 aal
@@ -93056,8 +94389,8 @@ aaa
 aaa
 aaa
 aaa
-abp
-afR
+mRN
+rIt
 ags
 agZ
 byl
@@ -93089,8 +94422,8 @@ aSd
 dNx
 awZ
 axe
-aMw
-aMv
+oiI
+swU
 aMu
 aMu
 bCI
@@ -93138,13 +94471,13 @@ aqz
 aqz
 aqz
 aqz
-aOH
-aOQ
-aOQ
+fon
+egr
+egr
 aPb
 aZg
-aOH
-aOQ
+fon
+egr
 aPb
 aOp
 bXv
@@ -93347,7 +94680,7 @@ bsZ
 qYP
 bte
 axe
-aMB
+jXX
 bCC
 aMr
 bFr
@@ -93570,8 +94903,8 @@ aaa
 aaa
 aaa
 aaa
-abp
-afR
+mRN
+rIt
 agy
 agZ
 bzp
@@ -93866,10 +95199,10 @@ bPA
 iMs
 bFt
 axe
-arj
+wDx
 arG
 anm
-arY
+wYq
 asl
 asE
 alk
@@ -93921,9 +95254,9 @@ aOp
 bZs
 biu
 big
-brJ
+qoL
 brH
-brJ
+qoL
 big
 aaa
 aal
@@ -94127,7 +95460,7 @@ arA
 arA
 buG
 axe
-arj
+wDx
 bFv
 alk
 alk
@@ -94158,7 +95491,7 @@ ceA
 aOn
 aWg
 aqz
-wFz
+dMI
 biZ
 aqA
 baC
@@ -94412,7 +95745,7 @@ bua
 aOn
 aWg
 aqz
-wFz
+dMI
 aWb
 aqz
 bld
@@ -94435,9 +95768,9 @@ aOp
 aQI
 uoF
 aQK
-gqb
+qUJ
 xFo
-gqb
+qUJ
 aaa
 aaa
 aal
@@ -94920,7 +96253,7 @@ afB
 adr
 bZH
 bZW
-wFz
+dMI
 aWb
 aqz
 aWv
@@ -95172,7 +96505,7 @@ aED
 aED
 aED
 akk
-asO
+ajQ
 akj
 aok
 aqz
@@ -96147,16 +97480,16 @@ aQQ
 aal
 asj
 asj
-ajW
+rzf
 bQE
 asj
 asj
 asj
 asj
-ajW
-aIV
-aIV
-aIV
+rzf
+lHp
+lHp
+lHp
 bQE
 asj
 asj
@@ -96200,7 +97533,7 @@ cbb
 bHS
 aED
 aqP
-asO
+ajQ
 akj
 aBA
 aqA
@@ -97189,9 +98522,9 @@ aaa
 aaa
 aaa
 afQ
-asD
+czQ
 aur
-asD
+czQ
 afQ
 bAD
 aNV
@@ -97703,9 +99036,9 @@ aaa
 aaa
 aaa
 aaa
-awq
+itr
 uww
-awq
+itr
 aFz
 bAD
 aNV
@@ -98997,7 +100330,7 @@ asj
 aRR
 asj
 bDB
-ajW
+rzf
 bQE
 aiV
 aiV
@@ -99266,7 +100599,7 @@ aaa
 rfC
 aaa
 aED
-ajI
+uzW
 aic
 aiX
 ajL
@@ -99276,7 +100609,7 @@ bJD
 aAE
 aAP
 aBd
-ajI
+uzW
 aCS
 aCS
 aCS
@@ -99524,15 +100857,15 @@ avP
 aal
 aal
 ajJ
-bCt
-bCt
-bCt
-bCt
-bCt
-bCt
-bCt
-bCt
-bCt
+xza
+xza
+xza
+xza
+xza
+xza
+xza
+xza
+xza
 bKB
 aaa
 aCS
@@ -100839,8 +102172,8 @@ bad
 aEc
 aEs
 aFW
-aNU
-aNY
+wYh
+jBL
 aOb
 aaa
 aaa
@@ -101353,8 +102686,8 @@ bae
 aZs
 bax
 aFX
-aNU
-aNY
+wYh
+jBL
 aOb
 aaa
 aaa
@@ -101867,8 +103200,8 @@ oKN
 aDP
 caI
 aFX
-aNU
-aNY
+wYh
+jBL
 aOb
 aaa
 aaa
@@ -102381,8 +103714,8 @@ aDQ
 aDQ
 aZt
 aFZ
-aNU
-aNY
+wYh
+jBL
 aOb
 aaa
 aaa
@@ -102626,7 +103959,7 @@ bPa
 wio
 ioh
 akg
-aof
+taN
 ajB
 jDJ
 aZA
@@ -102883,7 +104216,7 @@ aEd
 okF
 blu
 xuR
-aof
+taN
 bls
 jDJ
 aYQ
@@ -103140,7 +104473,7 @@ shy
 xuR
 ajB
 ajB
-aof
+taN
 hKB
 jDJ
 ajB

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -67599,11 +67599,11 @@
 	},
 /area/chapel/main)
 "cQY" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cQZ" = (
@@ -72313,7 +72313,8 @@
 "djz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
-	name = "Arrival Airlock"
+	name = "Arrival Airlock";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -72330,7 +72331,8 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/external{
-	name = "Arrival Airlock"
+	name = "Arrival Airlock";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -73509,6 +73511,16 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
+"dUb" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Arrival Airlock";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "dYu" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Airlock"
@@ -73552,6 +73564,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"eCT" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Departure Lounge Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "eFN" = (
 /obj/structure/bodycontainer/crematorium{
 	dir = 1;
@@ -73641,6 +73663,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"fEb" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Departure Lounge Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "fEQ" = (
 /turf/closed/wall,
 /area/science/nanite)
@@ -73651,6 +73681,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"fFQ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Arrival Airlock";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "fGz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -73679,6 +73717,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"fRZ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Arrival Airlock";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "fUt" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -73698,6 +73746,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"gkB" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Arrival Airlock";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "gnd" = (
 /turf/closed/wall,
 /area/maintenance/department/science/central)
@@ -73943,6 +73999,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/main)
+"iRJ" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Departure Lounge Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "jah" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -73954,6 +74018,16 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"jpT" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Departure Lounge Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "jrE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -74843,6 +74917,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"szO" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Arrival Airlock";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "sFv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -74956,6 +75038,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"tSW" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Arrival Airlock";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "tVY" = (
 /obj/structure/closet/crate,
 /obj/item/target/alien,
@@ -74987,6 +75079,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"ujO" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Departure Lounge Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "urv" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/security/prison)
@@ -75036,6 +75136,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"uKC" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Departure Lounge Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "uLY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -85985,9 +86095,9 @@ aDb
 aDb
 aVu
 aWU
-djz
+fFQ
 aZZ
-djC
+tSW
 aaa
 aaa
 aaa
@@ -85995,9 +86105,9 @@ aaa
 aaa
 aaa
 aaa
-djz
+fFQ
 bsk
-djC
+tSW
 aVu
 bxu
 aRA
@@ -87784,9 +87894,9 @@ aSL
 aDb
 cZq
 aWZ
-djz
+fFQ
 aZZ
-djC
+tSW
 aaa
 aaa
 aaa
@@ -87794,9 +87904,9 @@ aaa
 aaa
 aaa
 aaa
-djz
+fFQ
 bsk
-djC
+tSW
 bvH
 bMw
 aRA
@@ -100454,7 +100564,7 @@ cMV
 cPO
 cQm
 cQJ
-cQY
+ujO
 cRs
 kzn
 aaa
@@ -100968,9 +101078,9 @@ cLm
 cPP
 cQo
 cQL
-cQY
+ujO
 cQK
-kzn
+uKC
 aaa
 aaa
 aaa
@@ -102510,9 +102620,9 @@ cPs
 cPU
 cQp
 cQN
-cQY
+ujO
 cQK
-kzn
+uKC
 cYJ
 aaa
 aaa
@@ -103024,9 +103134,9 @@ cPu
 cPV
 cQq
 cQP
-cQY
+ujO
 cRt
-kzn
+uKC
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -13785,7 +13785,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
+	name = "Escape Airlock";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
@@ -13808,7 +13809,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
+	name = "Escape Airlock";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
@@ -33064,6 +33066,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"bFg" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "bFh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -49941,7 +49953,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "Cargo Escape Airlock"
+	name = "Cargo Escape Airlock";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
@@ -50126,6 +50139,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"glR" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "gmp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -54437,7 +54460,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "Cargo Escape Airlock"
+	name = "Cargo Escape Airlock";
+	safety_mode = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
@@ -54970,6 +54994,16 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"sbw" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "sbY" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -56114,6 +56148,16 @@
 "uRk" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"uRx" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock";
+	safety_mode = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "uTI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -74533,15 +74577,15 @@ aaa
 aaa
 aaa
 aHA
-aKy
+bFg
 xee
-aKy
+bFg
 aHA
 aaa
 aaa
 aaa
 aHA
-aKy
+bFg
 xee
 qIC
 aHA
@@ -75561,15 +75605,15 @@ aiu
 aiu
 aHz
 xee
-aKB
+sbw
 nYn
-aKB
+sbw
 xee
 aHA
 aHA
 aHA
 xee
-aKB
+sbw
 nYn
 fTY
 xee

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -988,17 +988,14 @@
 	return !operating && density
 
 /obj/machinery/door/airlock/try_to_crowbar(obj/item/I, mob/living/user)
-	var/beingcrowbarred = null
-	if(I.tool_behaviour == TOOL_CROWBAR )
-		beingcrowbarred = 1
-	else
-		beingcrowbarred = 0
-	if(!security_level && (beingcrowbarred && panel_open && ((obj_flags & EMAGGED) || (density && welded && !operating && !hasPower() && !locked))))
-		user.visible_message("<span class='notice'>[user] removes the electronics from the airlock assembly.</span>", \
-							 "<span class='notice'>You start to remove electronics from the airlock assembly...</span>")
-		if(I.use_tool(src, user, 40, volume=100))
-			deconstruct(TRUE, user)
-			return
+	if(I)
+		var/beingcrowbarred = (I.tool_behaviour == TOOL_CROWBAR)
+		if(!security_level && (beingcrowbarred && panel_open && ((obj_flags & EMAGGED) || (density && welded && !operating && !hasPower() && !locked))))
+			user.visible_message("<span class='notice'>[user] removes the electronics from the airlock assembly.</span>", \
+							 	"<span class='notice'>You start to remove electronics from the airlock assembly...</span>")
+			if(I.use_tool(src, user, 40, volume=100))
+				deconstruct(TRUE, user)
+				return
 	else if(hasPower())
 		to_chat(user, "<span class='warning'>The airlock's motors resist your efforts to force it!</span>")
 	else if(locked)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -155,8 +155,8 @@
 	. = ..()
 	if(.)
 		return
-	if(safety_mode && !hasPower() && !density)
-		to_chat(user, "<span class='notice'>You begin unlock the airlock safety mechanism...</span>")
+	if(safety_mode && !hasPower() && density)
+		to_chat(user, "<span class='notice'>You begin unlocking the airlock safety mechanism...</span>")
 		if(do_after(user, 200, target = src))
 			try_to_crowbar(null, user)
 			return

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -86,6 +86,14 @@
 		spark_system = null
 	return ..()
 
+/obj/machinery/door/proc/try_safety_unlock(mob/user)
+	if(safety_mode && !hasPower() && density)
+		to_chat(user, "<span class='notice'>You begin unlocking the airlock safety mechanism...</span>")
+		if(do_after(user, 200, target = src))
+			try_to_crowbar(null, user)
+			return TRUE
+	return FALSE
+
 /obj/machinery/door/Bumped(atom/movable/AM)
 	. = ..()
 	if(operating || (obj_flags & EMAGGED))
@@ -100,6 +108,8 @@
 				return	//Can bump-open one airlock per second. This is to prevent shock spam.
 			M.last_bumped = world.time
 			if(M.restrained() && !check_access(null))
+				return
+			if(try_safety_unlock(M))
 				return
 			bumpopen(M)
 			return
@@ -155,11 +165,8 @@
 	. = ..()
 	if(.)
 		return
-	if(safety_mode && !hasPower() && density)
-		to_chat(user, "<span class='notice'>You begin unlocking the airlock safety mechanism...</span>")
-		if(do_after(user, 200, target = src))
-			try_to_crowbar(null, user)
-			return
+	if(try_safety_unlock(user))	
+		return
 	return try_to_activate_door(user)
 
 /obj/machinery/door/attack_tk(mob/user)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -36,6 +36,7 @@
 	var/red_alert_access = FALSE //if TRUE, this door will always open on red alert
 	var/poddoor = FALSE
 	var/unres_sides = 0 //Unrestricted sides. A bitflag for which direction (if any) can open the door with no access
+	var/safety_mode = FALSE ///Whether or not the airlock can be opened with bare hands while unpowered
 
 /obj/machinery/door/examine(mob/user)
 	. = ..()
@@ -46,6 +47,8 @@
 			. += "<span class='notice'>In the event of a red alert, its access requirements will automatically lift.</span>"
 	if(!poddoor)
 		. += "<span class='notice'>Its maintenance panel is <b>screwed</b> in place.</span>"
+	if(safety_mode)
+		. += "<span class='notice'>It has labels indicating that it has an emergency mechanism to open it with <b>just your hands</b> if there's no power.</span>"
 
 /obj/machinery/door/check_access_list(list/access_list)
 	if(red_alert_access && GLOB.security_level >= SEC_LEVEL_RED)
@@ -137,8 +140,8 @@
 /obj/machinery/door/proc/bumpopen(mob/user)
 	if(operating)
 		return
-	src.add_fingerprint(user)
-	if(!src.requiresID())
+	add_fingerprint(user)
+	if(!requiresID())
 		user = null
 
 	if(density && !(obj_flags & EMAGGED))
@@ -152,6 +155,11 @@
 	. = ..()
 	if(.)
 		return
+	if(safety_mode && !hasPower() && !density)
+		to_chat(user, "<span class='notice'>You begin unlock the airlock safety mechanism...</span>")
+		if(do_after(user, 200, target = src))
+			try_to_crowbar(null, user)
+			return
 	return try_to_activate_door(user)
 
 /obj/machinery/door/attack_tk(mob/user)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -89,7 +89,7 @@
 /obj/machinery/door/proc/try_safety_unlock(mob/user)
 	if(safety_mode && !hasPower() && density)
 		to_chat(user, "<span class='notice'>You begin unlocking the airlock safety mechanism...</span>")
-		if(do_after(user, 200, target = src))
+		if(do_after(user, 15 SECONDS, target = src))
 			try_to_crowbar(null, user)
 			return TRUE
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds a new var to doors that if set to true makes it so they can be opened while unpowered with bare hands after a delay.
Arrivals and departures has had every door have this set to true.

## Why It's Good For The Game

less gbj

## Changelog
:cl:
tweak: Every station has been outfitted with new NanoTrasen SafeDoors(tm) on arrivals and departures, simply use the easy-release safety mechanism to open them in the event of a power outage. (warning: NanoTrasen is not liable if you are harmed during the operation of the safety mechanism)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
