### PR TITLE
Replaces the stetchkin in the caravan ambush with a cham kit.

### DIFF
--- a/_maps/shuttles/ruin_syndicate_dropship.dmm
+++ b/_maps/shuttles/ruin_syndicate_dropship.dmm
@@ -306,7 +306,7 @@
 /obj/structure/closet/syndicate{
 	anchored = 1
 	},
-/obj/item/gun/ballistic/automatic/pistol,
+/obj/item/storage/box/syndie_kit/chameleon,
 /obj/item/crowbar/red,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/caravan/syndicate3)


### PR DESCRIPTION

## About The Pull Request

Takes the free stetchkin out of the easy-cheese 'syndicate dropship' in the caravan ambush and (after asking the coding channel for ideas) replaces it with a chameleon kit.
## Why It's Good For The Game
Replaces a free anteg gun in space with almost no effort to get with a more harmless gimmick item
## Changelog
:cl:
add: the syndicate now stock a chameleon kit in their dropship.
del: someone fumbled the stetchkin in the caravan ambush in shipping.
/:cl:
