### PR TITLE
Resubmmited alternate PR for Pepperspray rework, Fucked up my repo

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -156,9 +156,8 @@
 #define HEADCOVERSEYES		(1<<2)		// feel free to realloc these numbers for other purposes
 #define MASKCOVERSMOUTH		(1<<3)		// on other items, these are just for mask/head
 #define HEADCOVERSMOUTH		(1<<4)
-#define MASKPEPPERPROOF		(1<<5)	//protects against pepperspray 
+#define MASKPEPPERPROOF		(1<<5)	//protects against pepperspray
 #define HEADPEPPERPROOF		(1<<6)
-#define EYESPEPPERPROOF		(1<<7)
 #define TINT_DARKENED 2			//Threshold of tint level to apply weld mask overlay
 #define TINT_BLIND 3			//Threshold of tint level to obscure vision fully
 

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -156,8 +156,8 @@
 #define HEADCOVERSEYES		(1<<2)		// feel free to realloc these numbers for other purposes
 #define MASKCOVERSMOUTH		(1<<3)		// on other items, these are just for mask/head
 #define HEADCOVERSMOUTH		(1<<4)
-#define MASKPEPPERPROOF		(1<<5)	//protects against pepperspray
-#define HEADPEPPERPROOF		(1<<6)
+#define PEPPERPROOF			(1<<5)	//protects against pepperspray
+
 #define TINT_DARKENED 2			//Threshold of tint level to apply weld mask overlay
 #define TINT_BLIND 3			//Threshold of tint level to obscure vision fully
 

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -156,7 +156,8 @@
 #define HEADCOVERSEYES		(1<<2)		// feel free to realloc these numbers for other purposes
 #define MASKCOVERSMOUTH		(1<<3)		// on other items, these are just for mask/head
 #define HEADCOVERSMOUTH		(1<<4)
-
+#define MASKPEPPERPROOF		(1<<5)	//protects against pepperspray
+#define HEADPEPPERPROOF		(1<<6)
 #define TINT_DARKENED 2			//Threshold of tint level to apply weld mask overlay
 #define TINT_BLIND 3			//Threshold of tint level to obscure vision fully
 

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -156,8 +156,9 @@
 #define HEADCOVERSEYES		(1<<2)		// feel free to realloc these numbers for other purposes
 #define MASKCOVERSMOUTH		(1<<3)		// on other items, these are just for mask/head
 #define HEADCOVERSMOUTH		(1<<4)
-#define MASKPEPPERPROOF		(1<<5)	//protects against pepperspray
+#define MASKPEPPERPROOF		(1<<5)	//protects against pepperspray 
 #define HEADPEPPERPROOF		(1<<6)
+#define EYESPEPPERPROOF		(1<<7)
 #define TINT_DARKENED 2			//Threshold of tint level to apply weld mask overlay
 #define TINT_BLIND 3			//Threshold of tint level to obscure vision fully
 

--- a/code/__DEFINES/movespeed_modification.dm
+++ b/code/__DEFINES/movespeed_modification.dm
@@ -64,5 +64,7 @@
 #define MOVESPEED_ID_DIE_OF_FATE                        "DIE_OF_FATE"
 
 #define MOVESPEED_ID_SHOVE                              "SHOVE"
-#define MOVESPEED_ID_PRONE_DRAGGING                     "PRONE_DRAG"
+#define MOVESPEED_ID_BULKY_DRAGGING                     "BULKY_DRAG"
 #define MOVESPEED_ID_HUMAN_CARRYING                     "HUMAN_CARRY"
+#define MOVESPEED_ID_SHRINK_RAY							"SHRUNKEN_SPEED_MODIFIER"
+#define MOVESPEED_ID_PEPPER_SPRAY                       "PEPPER_SPRAYED"

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -196,7 +196,7 @@
 	tint = 1
 	glass_colour_type = /datum/client_colour/glass_colour/gray
 	dog_fashion = /datum/dog_fashion/head
-
+	flags_cover = EYESPEPPERPROOF
 /obj/item/clothing/glasses/sunglasses/reagent
 	name = "beer goggles"
 	desc = "A pair of sunglasses outfitted with apparatus to scan reagents, as well as providing an innate understanding of liquid viscosity while in motion."

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -196,7 +196,7 @@
 	tint = 1
 	glass_colour_type = /datum/client_colour/glass_colour/gray
 	dog_fashion = /datum/dog_fashion/head
-	flags_cover = EYESPEPPERPROOF
+
 /obj/item/clothing/glasses/sunglasses/reagent
 	name = "beer goggles"
 	desc = "A pair of sunglasses outfitted with apparatus to scan reagents, as well as providing an innate understanding of liquid viscosity while in motion."

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -5,6 +5,7 @@
 	var/hud_type = null
 	///Used for topic calls. Just because you have a HUD display doesn't mean you should be able to interact with stuff.
 	var/hud_trait = null
+	
 
 /obj/item/clothing/glasses/hud/equipped(mob/living/carbon/human/user, slot)
 	..()

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -104,7 +104,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	visor_flags_inv = HIDEEYES | HIDEFACE
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 
 /obj/item/clothing/head/hardhat/weldhat/Initialize()
 	. = ..()

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -104,7 +104,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	visor_flags_inv = HIDEEYES | HIDEFACE
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
 
 /obj/item/clothing/head/hardhat/weldhat/Initialize()
 	. = ..()

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -104,7 +104,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	visor_flags_inv = HIDEEYES | HIDEFACE
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 
 /obj/item/clothing/head/hardhat/weldhat/Initialize()
 	. = ..()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -104,8 +104,8 @@
 	actions_types = list(/datum/action/item_action/toggle)
 	visor_flags_inv = HIDEFACE
 	toggle_cooldown = 0
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	dog_fashion = null
 
 /obj/item/clothing/head/helmet/attack_self(mob/user)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -104,8 +104,8 @@
 	actions_types = list(/datum/action/item_action/toggle)
 	visor_flags_inv = HIDEFACE
 	toggle_cooldown = 0
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
 	dog_fashion = null
 
 /obj/item/clothing/head/helmet/attack_self(mob/user)

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -26,7 +26,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 	actions_types = list(/datum/action/item_action/toggle)
 	visor_flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = FIRE_PROOF
 	clothing_flags = SNUG_FIT
 

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -17,7 +17,7 @@
 	name = "welding helmet"
 	desc = "A head-mounted face cover designed to protect the wearer completely from space-arc eye."
 	icon_state = "welding"
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH 
 	item_state = "welding"
 	materials = list(/datum/material/iron=1750, /datum/material/glass=400)
 	flash_protect = 2
@@ -26,7 +26,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 	actions_types = list(/datum/action/item_action/toggle)
 	visor_flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
 	resistance_flags = FIRE_PROOF
 	clothing_flags = SNUG_FIT
 

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -8,7 +8,7 @@
 	item_state = "gas_alt"
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
-	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH | MASKPEPPERPROOF
+	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = NONE
 
 // **** Welding gas mask ****

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -8,7 +8,7 @@
 	item_state = "gas_alt"
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
-	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
+	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH | MASKPEPPERPROOF
 	resistance_flags = NONE
 
 // **** Welding gas mask ****

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -13,7 +13,7 @@
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	visor_flags_inv = HIDEFACE
 	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES
-	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES
+	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | MASKPEPPERPROOF
 	var/aggressiveness = 2
 	var/cooldown_special
 	var/recent_uses = 0

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -12,8 +12,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	visor_flags_inv = HIDEFACE
-	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES
-	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | MASKPEPPERPROOF
+	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
+	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
 	var/aggressiveness = 2
 	var/cooldown_special
 	var/recent_uses = 0

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -12,8 +12,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	visor_flags_inv = HIDEFACE
-	flags_cover = MASKCOVERSMOUTH
-	visor_flags_cover = MASKCOVERSMOUTH
+	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES
+	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES
 	var/aggressiveness = 2
 	var/cooldown_special
 	var/recent_uses = 0

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -227,7 +227,7 @@
 	name = "botany bandana"
 	desc = "A fine bandana with nanotech lining and a hydroponics pattern."
 	w_class = WEIGHT_CLASS_TINY
-	flags_cover = MASKCOVERSMOUTH
+	flags_cover = MASKCOVERSMOUTH 
 	flags_inv = HIDEFACE|HIDEFACIALHAIR
 	visor_flags_inv = HIDEFACE|HIDEFACIALHAIR
 	visor_flags_cover = MASKCOVERSMOUTH | MASKPEPPERPROOF

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -227,7 +227,7 @@
 	name = "botany bandana"
 	desc = "A fine bandana with nanotech lining and a hydroponics pattern."
 	w_class = WEIGHT_CLASS_TINY
-	flags_cover = MASKCOVERSMOUTH 
+	flags_cover = MASKCOVERSMOUTH
 	flags_inv = HIDEFACE|HIDEFACIALHAIR
 	visor_flags_inv = HIDEFACE|HIDEFACIALHAIR
 	visor_flags_cover = MASKCOVERSMOUTH | MASKPEPPERPROOF

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -230,7 +230,7 @@
 	flags_cover = MASKCOVERSMOUTH
 	flags_inv = HIDEFACE|HIDEFACIALHAIR
 	visor_flags_inv = HIDEFACE|HIDEFACIALHAIR
-	visor_flags_cover = MASKCOVERSMOUTH
+	visor_flags_cover = MASKCOVERSMOUTH | MASKPEPPERPROOF
 	slot_flags = ITEM_SLOT_MASK
 	adjusted_flags = ITEM_SLOT_HEAD
 	icon_state = "bandbotany"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -230,7 +230,7 @@
 	flags_cover = MASKCOVERSMOUTH
 	flags_inv = HIDEFACE|HIDEFACIALHAIR
 	visor_flags_inv = HIDEFACE|HIDEFACIALHAIR
-	visor_flags_cover = MASKCOVERSMOUTH | MASKPEPPERPROOF
+	visor_flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
 	slot_flags = ITEM_SLOT_MASK
 	adjusted_flags = ITEM_SLOT_HEAD
 	icon_state = "bandbotany"

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -18,7 +18,7 @@
 	flash_protect = 2
 	strip_delay = 50
 	equip_delay_other = 50
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
 	resistance_flags = NONE
 	dog_fashion = null
 

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -18,7 +18,7 @@
 	flash_protect = 2
 	strip_delay = 50
 	equip_delay_other = 50
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = NONE
 	dog_fashion = null
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -12,7 +12,8 @@
 	var/obj/item/clothing/suit/space/hardsuit/suit
 	var/hardsuit_type = "engineering" //Determines used sprites: hardsuit[on]-[type]
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	var/rad_count = 0
 	var/rad_record = 0
 	var/grace_count = 0

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -12,8 +12,8 @@
 	var/obj/item/clothing/suit/space/hardsuit/suit
 	var/hardsuit_type = "engineering" //Determines used sprites: hardsuit[on]-[type]
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH	| HEADPEPPERPROOF
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
 	var/rad_count = 0
 	var/rad_record = 0
 	var/grace_count = 0

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -12,8 +12,8 @@
 	var/obj/item/clothing/suit/space/hardsuit/suit
 	var/hardsuit_type = "engineering" //Determines used sprites: hardsuit[on]-[type]
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH	| HEADPEPPERPROOF
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH	| PEPPERPROOF
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	var/rad_count = 0
 	var/rad_record = 0
 	var/grace_count = 0

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -54,7 +54,7 @@
 	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_screen/plasmaman)
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
-	flags_cover = HEADCOVERSMOUTH|HEADCOVERSEYES | HEADPEPPERPROOF
+	flags_cover = HEADCOVERSMOUTH|HEADCOVERSEYES | PEPPERPROOF
 	visor_flags_inv = HIDEEYES|HIDEFACE|HIDEFACIALHAIR
 
 /obj/item/clothing/head/helmet/space/plasmaman/Initialize()

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -54,7 +54,7 @@
 	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_screen/plasmaman)
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
-	flags_cover = HEADCOVERSMOUTH|HEADCOVERSEYES
+	flags_cover = HEADCOVERSMOUTH|HEADCOVERSEYES | HEADPEPPERPROOF
 	visor_flags_inv = HIDEEYES|HIDEFACE|HIDEFACIALHAIR
 
 /obj/item/clothing/head/helmet/space/plasmaman/Initialize()

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -8,7 +8,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 80, "fire" = 30, "acid" = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDEFACE
 	resistance_flags = ACID_PROOF
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
 
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -8,7 +8,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 80, "fire" = 30, "acid" = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDEFACE
 	resistance_flags = ACID_PROOF
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -68,7 +68,7 @@
 	max_heat_protection_temperature = HELMET_MAX_TEMP_PROTECT
 	strip_delay = 70
 	equip_delay_other = 70
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
 	resistance_flags = NONE
 
 
@@ -125,7 +125,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 60, "rad" = 100, "fire" = 30, "acid" = 30)
 	strip_delay = 60
 	equip_delay_other = 60
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
 	resistance_flags = NONE
 	rad_flags = RAD_PROTECT_CONTENTS
 

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -68,7 +68,7 @@
 	max_heat_protection_temperature = HELMET_MAX_TEMP_PROTECT
 	strip_delay = 70
 	equip_delay_other = 70
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = NONE
 
 
@@ -125,7 +125,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 60, "rad" = 100, "fire" = 30, "acid" = 30)
 	strip_delay = 60
 	equip_delay_other = 60
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | HEADPEPPERPROOF
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = NONE
 	rad_flags = RAD_PROTECT_CONTENTS
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -32,9 +32,9 @@
 	if(check_glasses && glasses && (glasses.flags_cover & GLASSESCOVERSEYES))
 		return glasses
 /mob/living/carbon/is_pepper_proof(check_head = TRUE, check_mask = TRUE)
-	if(check_head && head && (head.flags_cover & HEADPEPPERPROOF))
+	if(check_head && head && (head.flags_cover & PEPPERPROOF))
 		return head
-	if(check_mask && wear_mask && (wear_mask.flags_cover & MASKPEPPERPROOF))
+	if(check_mask && wear_mask && (wear_mask.flags_cover & PEPPERPROOF))
 		return wear_mask
 	
 /mob/living/carbon/check_projectile_dismemberment(obj/item/projectile/P, def_zone)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -32,9 +32,9 @@
 	if(check_glasses && glasses && (glasses.flags_cover & GLASSESCOVERSEYES))
 		return glasses
 /mob/living/carbon/is_pepper_proof(check_head = TRUE, check_mask = TRUE)
-	if(check_head && head && (head.flags_cover & PEPPERPROOF))
+	if(check_head &&(head.flags_cover & PEPPERPROOF))
 		return head
-	if(check_mask && wear_mask && (wear_mask.flags_cover & PEPPERPROOF))
+	if(check_mask &&(wear_mask.flags_cover & PEPPERPROOF))
 		return wear_mask
 	
 /mob/living/carbon/check_projectile_dismemberment(obj/item/projectile/P, def_zone)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -23,7 +23,7 @@
 /mob/living/carbon/is_mouth_covered(head_only = 0, mask_only = 0)
 	if( (!mask_only && head && (head.flags_cover & HEADCOVERSMOUTH)) || (!head_only && wear_mask && (wear_mask.flags_cover & MASKCOVERSMOUTH)) )
 		return TRUE
-
+	
 /mob/living/carbon/is_eyes_covered(check_glasses = TRUE, check_head = TRUE, check_mask = TRUE)
 	if(check_head && head && (head.flags_cover & HEADCOVERSEYES))
 		return head
@@ -31,7 +31,12 @@
 		return wear_mask
 	if(check_glasses && glasses && (glasses.flags_cover & GLASSESCOVERSEYES))
 		return glasses
-
+/mob/living/carbon/is_pepper_proof(check_head = TRUE, check_mask = TRUE)
+	if(check_head && head && (head.flags_cover & HEADPEPPERPROOF))
+		return head
+	if(check_mask && wear_mask && (wear_mask.flags_cover & MASKPEPPERPROOF))
+		return wear_mask
+	
 /mob/living/carbon/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)
 	if(affecting && affecting.dismemberable && affecting.get_damage() >= (affecting.max_damage - P.dismemberment))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -31,16 +31,11 @@
 		return wear_mask
 	if(check_glasses && glasses && (glasses.flags_cover & GLASSESCOVERSEYES))
 		return glasses
-/mob/living/carbon/is_mouth_pepper_proof(check_head = TRUE, check_mask = TRUE)
+/mob/living/carbon/is_pepper_proof(check_head = TRUE, check_mask = TRUE)
 	if(check_head && head && (head.flags_cover & HEADPEPPERPROOF))
 		return head
 	if(check_mask && wear_mask && (wear_mask.flags_cover & MASKPEPPERPROOF))
 		return wear_mask
-/mob/living/carbon/is_eyes_pepper_proof(check_head = TRUE, check_glasses = TRUE)
-	if(check_head && head && (head.flags_cover & HEADPEPPERPROOF))
-		return head
-	if(check_glasses && glasses && (glasses.flags_cover & EYESPEPPERPROOF))
-		return glasses
 	
 /mob/living/carbon/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -32,9 +32,9 @@
 	if(check_glasses && glasses && (glasses.flags_cover & GLASSESCOVERSEYES))
 		return glasses
 /mob/living/carbon/is_pepper_proof(check_head = TRUE, check_mask = TRUE)
-	if(check_head &&(head.flags_cover & PEPPERPROOF))
+	if(check_head &&(head?.flags_cover & PEPPERPROOF))
 		return head
-	if(check_mask &&(wear_mask.flags_cover & PEPPERPROOF))
+	if(check_mask &&(wear_mask?.flags_cover & PEPPERPROOF))
 		return wear_mask
 	
 /mob/living/carbon/check_projectile_dismemberment(obj/item/projectile/P, def_zone)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -31,11 +31,16 @@
 		return wear_mask
 	if(check_glasses && glasses && (glasses.flags_cover & GLASSESCOVERSEYES))
 		return glasses
-/mob/living/carbon/is_pepper_proof(check_head = TRUE, check_mask = TRUE)
+/mob/living/carbon/is_mouth_pepper_proof(check_head = TRUE, check_mask = TRUE)
 	if(check_head && head && (head.flags_cover & HEADPEPPERPROOF))
 		return head
 	if(check_mask && wear_mask && (wear_mask.flags_cover & MASKPEPPERPROOF))
 		return wear_mask
+/mob/living/carbon/is_eyes_pepper_proof(check_head = TRUE, check_glasses = TRUE)
+	if(check_head && head && (head.flags_cover & HEADPEPPERPROOF))
+		return head
+	if(check_glasses && glasses && (glasses.flags_cover & EYESPEPPERPROOF))
+		return glasses
 	
 /mob/living/carbon/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -38,7 +38,9 @@
 
 /mob/living/proc/is_eyes_covered(check_glasses = 1, check_head = 1, check_mask = 1)
 	return FALSE
-/mob/living/proc/is_pepper_proof(check_head = 1, check_mask = 1)
+/mob/living/proc/is_mouth_pepper_proof(check_head = 1, check_mask = 1)
+	return FALSE
+/mob/living/proc/is_eyes_pepper_proof(check_head = 1, check_glasses = 1)
 	return FALSE
 /mob/living/proc/on_hit(obj/item/projectile/P)
 	return BULLET_ACT_HIT

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -38,7 +38,8 @@
 
 /mob/living/proc/is_eyes_covered(check_glasses = 1, check_head = 1, check_mask = 1)
 	return FALSE
-
+/mob/living/proc/is_pepper_proof(check_head = 1, check_mask = 1)
+	return FALSE
 /mob/living/proc/on_hit(obj/item/projectile/P)
 	return BULLET_ACT_HIT
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -38,9 +38,7 @@
 
 /mob/living/proc/is_eyes_covered(check_glasses = 1, check_head = 1, check_mask = 1)
 	return FALSE
-/mob/living/proc/is_mouth_pepper_proof(check_head = 1, check_mask = 1)
-	return FALSE
-/mob/living/proc/is_eyes_pepper_proof(check_head = 1, check_glasses = 1)
+/mob/living/proc/is_pepper_proof(check_head = 1, check_mask = 1)
 	return FALSE
 /mob/living/proc/on_hit(obj/item/projectile/P)
 	return BULLET_ACT_HIT

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -38,7 +38,7 @@
 
 /mob/living/proc/is_eyes_covered(check_glasses = 1, check_head = 1, check_mask = 1)
 	return FALSE
-/mob/living/proc/is_pepper_proof(check_head = 1, check_mask = 1)
+/mob/living/proc/is_pepper_proof(check_head = TRUE, check_mask = TRUE)
 	return FALSE
 /mob/living/proc/on_hit(obj/item/projectile/P)
 	return BULLET_ACT_HIT

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -279,14 +279,14 @@
 /datum/reagent/consumable/condensedcapsaicin/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(!ishuman(M) && !ismonkey(M))
 		return
-	
+		
 	var/mob/living/carbon/victim = M
 	if(method == TOUCH || method == VAPOR)
-		var/mouth_covered = victim.is_mouth_covered()
-		var/eyes_covered = victim.is_eyes_covered()
+		var/pepper_proof = victim.is_pepper_proof()
+	
 		//check for protection
 		//actually handle the pepperspray effects
-		if (!(eyes_covered && mouth_covered)) // you need both eye and mouth protection
+		if (!(pepper_proof)) // you need both eye and mouth protection
 			if(prob(5))
 				victim.emote("scream")
 			victim.blur_eyes(5) // 10 seconds

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -282,11 +282,11 @@
 		
 	var/mob/living/carbon/victim = M
 	if(method == TOUCH || method == VAPOR)
-		var/pepper_proof = victim.is_pepper_proof()
-	
+		var/mouth_pepper_proof = victim.is_mouth_pepper_proof()
+		var/eyes_pepper_proof  = victim.is_eyes_pepper_proof()
 		//check for protection
 		//actually handle the pepperspray effects
-		if (!(pepper_proof)) // you need both eye and mouth protection
+		if (!(eyes_pepper_proof && mouth_pepper_proof)) // you need both eye and mouth protection
 			if(prob(5))
 				victim.emote("scream")
 			victim.blur_eyes(5) // 10 seconds

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -282,8 +282,8 @@
 	
 	var/mob/living/carbon/victim = M
 	if(method == TOUCH || method == VAPOR)
-	var/mouth_covered = victim.is_mouth_covered()
-	var/eyes_covered = victim.is_eyes_covered()
+		var/mouth_covered = victim.is_mouth_covered()
+		var/eyes_covered = victim.is_eyes_covered()
 		//check for protection
 		//actually handle the pepperspray effects
 		if (!(eyes_covered && mouth_covered)) // you need both eye and mouth protection

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -282,11 +282,11 @@
 		
 	var/mob/living/carbon/victim = M
 	if(method == TOUCH || method == VAPOR)
-		var/mouth_pepper_proof = victim.is_mouth_pepper_proof()
-		var/eyes_pepper_proof  = victim.is_eyes_pepper_proof()
+		var/pepper_proof = victim.is_pepper_proof()
+	
 		//check for protection
 		//actually handle the pepperspray effects
-		if (!(eyes_pepper_proof && mouth_pepper_proof)) // you need both eye and mouth protection
+		if (!(pepper_proof)) // you need both eye and mouth protection
 			if(prob(5))
 				victim.emote("scream")
 			victim.blur_eyes(5) // 10 seconds

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -279,38 +279,38 @@
 /datum/reagent/consumable/condensedcapsaicin/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(!ishuman(M) && !ismonkey(M))
 		return
-	var/mob/living/carbon/victim = M
-    if(method == TOUCH || method == VAPOR)
-        //check for protection
-        var/eyes_covered = victim.is_eyes_covered()
 
-        //actually handle the pepperspray effects
-        if (eyes_covered && istype(victim.wear_mask, /obj/item/clothing/mask/gas))
-            return
-        else if(istype(victim.wear_mask, /obj/item/clothing/mask/gas))    // Reduced effects if partially protected
-            if(prob(5))
-                victim.emote("scream")
-            victim.blur_eyes(3) // 6 seconds
-            victim.blind_eyes(3) // 6 seconds
-            victim.confused = max(M.confused, 5)
-            return
-        else if ( eyes_covered ) // Eye cover is better than mouth cover
-            victim.blur_eyes(2) // 4 seconds
-            victim.Knockdown(3 SECONDS) 
-            victim.add_movespeed_modifier(MOVESPEED_ID_PEPPER_SPRAY, update=TRUE, priority=100, multiplicative_slowdown=0.25, blacklisted_movetypes=(FLYING|FLOATING))
-            addtimer(CALLBACK(victim, /mob.proc/remove_movespeed_modifier, MOVESPEED_ID_PEPPER_SPRAY), 10 SECONDS)
-            return
-        else // Oh dear :D
-            if(prob(5))
-                victim.emote("scream")
-            victim.blur_eyes(5) // 10 seconds
-            victim.blind_eyes(3) // 6 seconds
-            victim.confused = max(M.confused, 5) // 10 seconds
-            victim.Knockdown(3 SECONDS) 
-            victim.add_movespeed_modifier(MOVESPEED_ID_PEPPER_SPRAY, update=TRUE, priority=100, multiplicative_slowdown=0.25, blacklisted_movetypes=(FLYING|FLOATING))
-            addtimer(CALLBACK(victim, /mob.proc/remove_movespeed_modifier, MOVESPEED_ID_PEPPER_SPRAY), 10 SECONDS)
-        victim.update_damage_hud()
-	
+	var/mob/living/carbon/victim = M
+	if(method == TOUCH || method == VAPOR)
+		//check for protection
+		var/eyes_covered = victim.is_eyes_covered()
+
+		//actually handle the pepperspray effects
+		if (eyes_covered && istype(victim.wear_mask, /obj/item/clothing/mask/gas))
+			return
+		else if(istype(victim.wear_mask, /obj/item/clothing/mask/gas))	// Reduced effects if partially protected
+			if(prob(5))
+				victim.emote("scream")
+			victim.blur_eyes(3) // 6 seconds
+			victim.blind_eyes(3) // 6 seconds
+			victim.confused = max(M.confused, 5)
+			return
+		else if ( eyes_covered ) // Eye cover is better than mouth cover
+			victim.blur_eyes(2) // 4 seconds
+			victim.Knockdown(3 SECONDS)
+			victim.add_movespeed_modifier(MOVESPEED_ID_PEPPER_SPRAY, update=TRUE, priority=100, multiplicative_slowdown=0.25, blacklisted_movetypes=(FLYING|FLOATING))
+			addtimer(CALLBACK(victim, /mob.proc/remove_movespeed_modifier, MOVESPEED_ID_PEPPER_SPRAY), 10 SECONDS)
+			return
+		else // Oh dear :D
+			if(prob(5))
+				victim.emote("scream")
+			victim.blur_eyes(5) // 10 seconds
+			victim.blind_eyes(3) // 6 seconds
+			victim.confused = max(M.confused, 5) // 10 seconds
+			victim.Knockdown(3 SECONDS)
+			victim.add_movespeed_modifier(MOVESPEED_ID_PEPPER_SPRAY, update=TRUE, priority=100, multiplicative_slowdown=0.25, blacklisted_movetypes=(FLYING|FLOATING))
+			addtimer(CALLBACK(victim, /mob.proc/remove_movespeed_modifier, MOVESPEED_ID_PEPPER_SPRAY), 10 SECONDS)
+		victim.update_damage_hud()
 
 /datum/reagent/consumable/condensedcapsaicin/on_mob_life(mob/living/carbon/M)
 	if(prob(5))
@@ -351,13 +351,6 @@
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#302000" // rgb: 48, 32, 0
 	taste_description = "bitterness"
-
-/datum/reagent/consumable/coco/on_mob_add(mob/living/carbon/M)
-	.=..()
-	if(iscatperson(M))
-		to_chat(M, "<span class='warning'>Your insides revolt at the presence of lethal chocolate!</span>")
-		M.vomit(20)
-
 
 /datum/reagent/consumable/hot_coco
 	name = "Hot Chocolate"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -283,25 +283,10 @@
 	var/mob/living/carbon/victim = M
 	if(method == TOUCH || method == VAPOR)
 		//check for protection
-		var/eyes_covered = victim.is_eyes_covered()
-
 		//actually handle the pepperspray effects
-		if (eyes_covered && istype(victim.wear_mask, /obj/item/clothing/mask/gas))
-			return
-		else if(istype(victim.wear_mask, /obj/item/clothing/mask/gas))	// Reduced effects if partially protected
-			if(prob(5))
-				victim.emote("scream")
-			victim.blur_eyes(3) // 6 seconds
-			victim.blind_eyes(3) // 6 seconds
-			victim.confused = max(M.confused, 5)
-			return
-		else if ( eyes_covered ) // Eye cover is better than mouth cover
-			victim.blur_eyes(2) // 4 seconds
-			victim.Knockdown(3 SECONDS)
-			victim.add_movespeed_modifier(MOVESPEED_ID_PEPPER_SPRAY, update=TRUE, priority=100, multiplicative_slowdown=0.25, blacklisted_movetypes=(FLYING|FLOATING))
-			addtimer(CALLBACK(victim, /mob.proc/remove_movespeed_modifier, MOVESPEED_ID_PEPPER_SPRAY), 10 SECONDS)
-			return
-		else // Oh dear :D
+		if (istype(victim.wear_mask, /obj/item/clothing/mask/gas)) // gas mask is sunglasses but for pepperspray
+			
+		else // Oh dear :D All or nothing
 			if(prob(5))
 				victim.emote("scream")
 			victim.blur_eyes(5) // 10 seconds
@@ -351,7 +336,14 @@
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#302000" // rgb: 48, 32, 0
 	taste_description = "bitterness"
+/datum/reagent/consumable/coco/on_mob_add(mob/living/M)
+	.=..()
+	if(iscatperson(M))
+		to_chat(M, "<span class='warning'>Your insides revolt at the presence of lethal chocolate!</span>")
+		M.vomit(20)
 
+
+		
 /datum/reagent/consumable/hot_coco
 	name = "Hot Chocolate"
 	description = "Made with love! And coco beans."

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -279,14 +279,14 @@
 /datum/reagent/consumable/condensedcapsaicin/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(!ishuman(M) && !ismonkey(M))
 		return
-
+	
 	var/mob/living/carbon/victim = M
 	if(method == TOUCH || method == VAPOR)
+	var/mouth_covered = victim.is_mouth_covered()
+	var/eyes_covered = victim.is_eyes_covered()
 		//check for protection
 		//actually handle the pepperspray effects
-		if (istype(victim.wear_mask, /obj/item/clothing/mask/gas)) // gas mask is sunglasses but for pepperspray
-
-		else // Oh dear :D All or nothing
+		if (!(eyes_covered && mouth_covered)) // you need both eye and mouth protection
 			if(prob(5))
 				victim.emote("scream")
 			victim.blur_eyes(5) // 10 seconds
@@ -296,7 +296,7 @@
 			victim.add_movespeed_modifier(MOVESPEED_ID_PEPPER_SPRAY, update=TRUE, priority=100, multiplicative_slowdown=0.25, blacklisted_movetypes=(FLYING|FLOATING))
 			addtimer(CALLBACK(victim, /mob.proc/remove_movespeed_modifier, MOVESPEED_ID_PEPPER_SPRAY), 10 SECONDS)
 		victim.update_damage_hud()
-
+			
 /datum/reagent/consumable/condensedcapsaicin/on_mob_life(mob/living/carbon/M)
 	if(prob(5))
 		M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>")

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -285,7 +285,7 @@
 		//check for protection
 		//actually handle the pepperspray effects
 		if (istype(victim.wear_mask, /obj/item/clothing/mask/gas)) // gas mask is sunglasses but for pepperspray
-			
+
 		else // Oh dear :D All or nothing
 			if(prob(5))
 				victim.emote("scream")
@@ -336,14 +336,14 @@
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#302000" // rgb: 48, 32, 0
 	taste_description = "bitterness"
-/datum/reagent/consumable/coco/on_mob_add(mob/living/M)
+/datum/reagent/consumable/coco/on_mob_add(mob/living/carbon/M)
 	.=..()
 	if(iscatperson(M))
 		to_chat(M, "<span class='warning'>Your insides revolt at the presence of lethal chocolate!</span>")
 		M.vomit(20)
 
 
-		
+
 /datum/reagent/consumable/hot_coco
 	name = "Hot Chocolate"
 	description = "Made with love! And coco beans."

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -279,38 +279,38 @@
 /datum/reagent/consumable/condensedcapsaicin/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(!ishuman(M) && !ismonkey(M))
 		return
-
 	var/mob/living/carbon/victim = M
-	if(method == TOUCH || method == VAPOR)
-		//check for protection
-		var/mouth_covered = victim.is_mouth_covered()
-		var/eyes_covered = victim.is_eyes_covered()
+    if(method == TOUCH || method == VAPOR)
+        //check for protection
+        var/eyes_covered = victim.is_eyes_covered()
 
-		//actually handle the pepperspray effects
-		if ( eyes_covered && mouth_covered )
-			return
-		else if ( mouth_covered )	// Reduced effects if partially protected
-			if(prob(5))
-				victim.emote("scream")
-			victim.blur_eyes(3)
-			victim.blind_eyes(2)
-			victim.confused = max(M.confused, 3)
-			victim.damageoverlaytemp = 60
-			victim.Paralyze(60)
-			return
-		else if ( eyes_covered ) // Eye cover is better than mouth cover
-			victim.blur_eyes(3)
-			victim.damageoverlaytemp = 30
-			return
-		else // Oh dear :D
-			if(prob(5))
-				victim.emote("scream")
-			victim.blur_eyes(5)
-			victim.blind_eyes(3)
-			victim.confused = max(M.confused, 6)
-			victim.damageoverlaytemp = 75
-			victim.Paralyze(100)
-		victim.update_damage_hud()
+        //actually handle the pepperspray effects
+        if (eyes_covered && istype(victim.wear_mask, /obj/item/clothing/mask/gas))
+            return
+        else if(istype(victim.wear_mask, /obj/item/clothing/mask/gas))    // Reduced effects if partially protected
+            if(prob(5))
+                victim.emote("scream")
+            victim.blur_eyes(3) // 6 seconds
+            victim.blind_eyes(3) // 6 seconds
+            victim.confused = max(M.confused, 5)
+            return
+        else if ( eyes_covered ) // Eye cover is better than mouth cover
+            victim.blur_eyes(2) // 4 seconds
+            victim.Knockdown(3 SECONDS) 
+            victim.add_movespeed_modifier(MOVESPEED_ID_PEPPER_SPRAY, update=TRUE, priority=100, multiplicative_slowdown=0.25, blacklisted_movetypes=(FLYING|FLOATING))
+            addtimer(CALLBACK(victim, /mob.proc/remove_movespeed_modifier, MOVESPEED_ID_PEPPER_SPRAY), 10 SECONDS)
+            return
+        else // Oh dear :D
+            if(prob(5))
+                victim.emote("scream")
+            victim.blur_eyes(5) // 10 seconds
+            victim.blind_eyes(3) // 6 seconds
+            victim.confused = max(M.confused, 5) // 10 seconds
+            victim.Knockdown(3 SECONDS) 
+            victim.add_movespeed_modifier(MOVESPEED_ID_PEPPER_SPRAY, update=TRUE, priority=100, multiplicative_slowdown=0.25, blacklisted_movetypes=(FLYING|FLOATING))
+            addtimer(CALLBACK(victim, /mob.proc/remove_movespeed_modifier, MOVESPEED_ID_PEPPER_SPRAY), 10 SECONDS)
+        victim.update_damage_hud()
+	
 
 /datum/reagent/consumable/condensedcapsaicin/on_mob_life(mob/living/carbon/M)
 	if(prob(5))

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -197,10 +197,10 @@
 	item_state = "pepperspray"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
-	volume = 40
+	volume = 50
 	stream_range = 4
 	amount_per_transfer_from_this = 5
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 40)
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 50)
 
 /obj/item/reagent_containers/spray/pepper/empty //for protolathe printing
 	list_reagents = null


### PR DESCRIPTION
PR machine broke, had to resubmit

close #46269
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Volume increased to 50 for pepper spray, added knockdown of decreasing degree for decreasing importance pepper spray entrance organs, added confuse, blind, blur, slow down. Adds a new clothing flag for head and mouth, PEPPERPROOF, that will decide if you can be pepper-sprayed while wearing those. Decreases scope of pepperspray protection by a lot.
## Why It's Good For The Game

Pepper spray is not even worth using right now, and I routinely see sec officers throwing away their pepper spray for e-bolas, handcuffs or flashbangs. This PR will make pepper spray a viable option in the sec arsenal, but does account for the range and spam ability of pepper spray while still making it competitive. As we are moving away from hardstuns, I see it fit to replace the hard stun with some bad effects, slowdown and knockdown. Helmets, Hardsuits, Gas masks, and other things like that are pepperproof
## Changelog
:cl:
balance: increased volume of pepper sprays to 50
tweak: adds knockdown of 3 second for no protection, 3 for no mouth protection
tweak: Changes bluring and blindness of eyes
balance: Replaces Paralysis with blind
balance: vastly decreased the scope of pepperspray protection.
add: New variable for pepperspray protection, PEPPERPROOF, decides if you can be pepperproof with certain equipment
/:cl:

