### PR TITLE
Explosions no longer destroy photos inside albums

### DIFF
--- a/code/modules/photography/photos/album.dm
+++ b/code/modules/photography/photos/album.dm
@@ -55,6 +55,9 @@
 			if(!SEND_SIGNAL(src, COMSIG_TRY_STORAGE_INSERT, P, null, TRUE, TRUE))
 				qdel(P)
 
+/obj/item/storage/photo_album/prevent_content_explosion()
+	return TRUE
+
 /obj/item/storage/photo_album/HoS
 	name = "photo album (Head of Security)"
 	persistence_id = "HoS"


### PR DESCRIPTION
Closes #46309
## About The Pull Request
Makes album contents not be damaged by being at the epicenter of an explosion

## Why It's Good For The Game
It's annoying for persistent albums and I don't see the harm in it since it's fluff content

## Changelog
:cl:
tweak: Photos stored in photo albums will no longer occasionally be destroyed by explosions
/:cl: