### PR TITLE
Plasma now "boils" at 50C, Reagent effects can now trigger on Temp Change

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -857,8 +857,10 @@
 	return english_list(out, "something indescribable")
 
 /datum/reagents/proc/expose_temperature(var/temperature, var/coeff=0.02)
-	if(reagent_flags & NO_REACT) //stasis holders IE cryobeaker
-		return
+	if(istype(my_atom,/obj/item/reagent_containers))
+		var/obj/item/reagent_containers/RCs = my_atom
+		if(RCs.reagent_flags & NO_REACT) //stasis holders IE cryobeaker
+			return
 	var/temp_delta = (temperature - chem_temp) * coeff
 	if(temp_delta > 0)
 		chem_temp = min(chem_temp + max(temp_delta, 1), temperature)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -863,6 +863,9 @@
 	else
 		chem_temp = max(chem_temp + min(temp_delta, -1), temperature)
 	chem_temp = round(chem_temp)
+	for(var/i in reagent_list)
+		var/datum/reagent/R = i
+		R.on_temp_change()
 	handle_reactions()
 
 ///////////////////////////////////////////////////////////////////////////////////

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -857,6 +857,8 @@
 	return english_list(out, "something indescribable")
 
 /datum/reagents/proc/expose_temperature(var/temperature, var/coeff=0.02)
+	if(reagent_flags & NO_REACT) //stasis holders IE cryobeaker
+		return
 	var/temp_delta = (temperature - chem_temp) * coeff
 	if(temp_delta > 0)
 		chem_temp = min(chem_temp + max(temp_delta, 1), temperature)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -102,6 +102,9 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 /datum/reagent/proc/on_update(atom/A)
 	return
 
+//called on expose_temperature
+/datum/reagent/proc/on_temp_change()
+	return
 // Called when the reagent container is hit by an explosion
 /datum/reagent/proc/on_ex_act(severity)
 	return

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -51,6 +51,8 @@
 	C.apply_effect(5,EFFECT_IRRADIATE,0)
 	return ..()
 
+#define	LIQUID_PLASMA_BP (50+T0C)
+
 /datum/reagent/toxin/plasma
 	name = "Plasma"
 	description = "Plasma in its liquid form."
@@ -66,17 +68,27 @@
 	C.adjustPlasma(20)
 	return ..()
 
+/datum/reagent/toxin/plasma/on_temp_change()
+	if(holder.chem_temp < LIQUID_PLASMA_BP)
+		return
+	if(holder.my_atom)
+		var/atom/A = holder.my_atom
+		A.atmos_spawn_air("plasma=[volume];TEMP=[holder.chem_temp]")
+		holder.del_reagent(type)
+
 /datum/reagent/toxin/plasma/reaction_obj(obj/O, reac_volume)
 	if((!O) || (!reac_volume))
 		return 0
 	var/temp = holder ? holder.chem_temp : T20C
-	O.atmos_spawn_air("plasma=[reac_volume];TEMP=[temp]")
+	if(temp >= LIQUID_PLASMA_BP)
+		O.atmos_spawn_air("plasma=[reac_volume];TEMP=[temp]")
 
 /datum/reagent/toxin/plasma/reaction_turf(turf/open/T, reac_volume)
-	if(istype(T))
-		var/temp = holder ? holder.chem_temp : T20C
+	if(!istype(T))
+		return
+	var/temp = holder ? holder.chem_temp : T20C
+	if(temp >= LIQUID_PLASMA_BP)
 		T.atmos_spawn_air("plasma=[reac_volume];TEMP=[temp]")
-	return
 
 /datum/reagent/toxin/plasma/reaction_mob(mob/living/M, method=TOUCH, reac_volume)//Splashing people with plasma is stronger than fuel!
 	if(method == TOUCH || method == VAPOR)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
closes #46100 
closes #45020
closes #46191

## About The Pull Request
Elevates issues brought up in #46100 & #45020 into a feature by having it only do such based on temperature. Also fixes an exploit where you could make on-demand fire traps by heating plasma prior to splashing, or simply heat it up to avoid having to use reactions and/or pyrotechnics in grenades.

If the temperature is 50C or above, plasma will "boil" aka become gaseous and spread as it would had you previously harm intent.

Consequently, this adds the framework for having special effects depending on the temperature of the reagent.

Minorly, Cryostasis beakers now will not have chem temperature shifts (forever chilly)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes 2 issues without snowflaking react_obj or beakers or anything to compensate for plasma, while still keeping syringes and the like using react_obj

Also makes it consistent if you're into immersion and stuff.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Plasma now "boils" at 50C. This means you will need to heat the liquid form up to make it into a gas (previously you could just splash it)
tweak: containers that halt reactions (IE cryostasis beakers) will keep reagents at a set temperature.
fix: Plasma will no longer summon gas whenever transferring via syringe. AKA you can now do xenobio again.
fix: Plasma can no longer be cheesed grenade-style by heating the beaker. It will now require reaction/pyrotechnics.
code: Reagents now have the framework to perform different effects on temperature change.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
