### PR TITLE
Adding disability support crate

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -424,7 +424,7 @@
 					/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/clothing/suit/armor/bulletproof)
 	crate_name = "bulletproof armor crate"
-	
+
 /datum/supply_pack/security/armory/bullethelmets
 	name = "Bulletproof Helmets Crate"
 	desc = "Contains three bulletproof helmets. Requires Armory access to open."
@@ -1221,6 +1221,15 @@
 	cost = 1000
 	contains = list(/obj/machinery/iv_drip)
 	crate_name = "iv drip crate"
+
+/datum/supply_pack/medical/disability_support
+	name = "Disability Support Crate"
+	desc = "Contains two roller beds and a wheelchair. Not an excuse to leave legs unattached!"
+	cost = 3000
+	contains = list(/obj/vehicle/ridden/wheelchair,
+					/obj/item/roller,
+					/obj/item/roller)
+	crate_name = "disability support crate"
 
 /datum/supply_pack/medical/supplies
 	name = "Medical Supplies Crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new medical crate that contains two roller beds and a wheelchair. It costs 3000 credits.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The only way to get roller beds currently is the surgical supplies crate, which is dumb. Also adds a way to get a wheelchair.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a disability support crate, contains two roller beds and a wheelchair.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
