### PR TITLE
Fixes Mining Port, Runtime

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1925,16 +1925,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/primary)
-"gh" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/computer/shuttle/mining,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
 "gi" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -2073,6 +2063,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "gE" = (
@@ -2298,6 +2291,9 @@
 /turf/open/floor/plating,
 /area/storage/primary)
 "vy" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "vP" = (
@@ -4260,7 +4256,7 @@ II
 II
 Td
 II
-gh
+II
 gl
 gD
 kj


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes some stuff on runtime station.
Removes a duplicate mining shuttle console.
Removes a rogue light fixture
Adds some corner stripes to the dock.

## Why It's Good For The Game

If I'm gonna test shit, my testing area should look nice. This is workplace cleanup.

## Changelog

don't think this is needed.