### PR TITLE
recycler safe mode is now safe 

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -115,7 +115,7 @@
 		if(istype(AM, /obj/item/organ/brain) || (istype(as_head) && as_head.brain) || (istype(as_mmi) && as_mmi.brain) || istype(AM, /mob/living/brain))
 			emergency_stop(AM)
 		else if(isliving(AM))
-			if((obj_flags & EMAGGED)||!ishuman(AM))
+			if((obj_flags & EMAGGED)||!ishuman(AM)||!isguardian(AM))
 				crush_living(AM)
 			else
 				emergency_stop(AM)
@@ -162,8 +162,6 @@
 	update_icon()
 
 /obj/machinery/recycler/proc/crush_living(mob/living/L)
-	if(isguardian(L))
-		return
 
 	L.forceMove(loc)
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -162,6 +162,8 @@
 	update_icon()
 
 /obj/machinery/recycler/proc/crush_living(mob/living/L)
+	if(isguardian(L))
+		return
 
 	L.forceMove(loc)
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -115,7 +115,7 @@
 		if(istype(AM, /obj/item/organ/brain) || (istype(as_head) && as_head.brain) || (istype(as_mmi) && as_mmi.brain) || istype(AM, /mob/living/brain))
 			emergency_stop(AM)
 		else if(isliving(AM))
-			if((obj_flags & EMAGGED)||!ishuman(AM)||!isguardian(AM))
+			if(obj_flags & EMAGGED)
 				crush_living(AM)
 			else
 				emergency_stop(AM)
@@ -170,7 +170,6 @@
 	else
 		playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
 
-	// By default, the emagged recycler will gib all non-carbons. (human simple animal mobs don't count)
 	if(iscarbon(L))
 		if(L.stat == CONSCIOUS)
 			L.say("ARRRRRRRRRRRGH!!!", forced="recycler grinding")


### PR DESCRIPTION
## About The Pull Request

the nonemagged recycler now doesnt consume mobs

## Why It's Good For The Game

most players dont know about it at all and run into the recycler as a stand, xeno, monkey, instantly dying

## Changelog
:cl:
balance: the recycler when not emagged wont grind any mobs anymore
/:cl: