### PR TITLE
Fixes emptying fire extinguishers from inside storage

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -222,6 +222,9 @@
 /obj/item/extinguisher/AltClick(mob/user)
 	if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
+	if(!user.is_holding(src))
+		to_chat(user, "<span class='notice'>You must be holding the [src] in your hands do this!</span>")
+		return
 	EmptyExtinguisher(user)
 
 /obj/item/extinguisher/proc/EmptyExtinguisher(var/mob/user)


### PR DESCRIPTION
You could trigger the alt click from inside storage slots due to missing a check if you were actually holding it
:cl:
fix: Fixes fire extinguisher being able to be emptied from storage slots
/:cl: