### PR TITLE
Changeling Alt click Fix

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -154,7 +154,8 @@
 /datum/antagonist/changeling/proc/stingAtom(mob/living/carbon/ling, atom/A)
 	if(!chosen_sting || A == ling || !istype(ling) || ling.stat)
 		return
-	chosen_sting.try_to_sting(ling, A)
+	if(!chosen_sting.try_to_sting(ling, A))
+		return
 	ling.changeNext_move(CLICK_CD_MELEE)
 	return COMSIG_MOB_CANCEL_CLICKON
 

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -35,13 +35,25 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 		return
 	try_to_sting(user)
 
+/**
+  *Contrary to the name, this proc isn't just used by changeling stings. It handles the activation of the action and the deducation of its cost.
+  *The order of the proc chain is:
+  *can_sting(). Should this fail, the process gets aborted early.
+  *sting_action(). This proc usually handles the actual effect of the action.
+  *Should sting_action succeed the following will be done:
+  *sting_feedback(). Produces feedback on the performed action. Don't ask me why this isn't handled in sting_action()
+  *The deduction of the cost of this power.
+  *Returns TRUE on a successful activation.
+  */
 /datum/action/changeling/proc/try_to_sting(mob/user, mob/target)
 	if(!can_sting(user, target))
-		return
+		return FALSE
 	var/datum/antagonist/changeling/c = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	if(sting_action(user, target))
 		sting_feedback(user, target)
 		c.chem_charges -= chemical_cost
+		return TRUE
+	return FALSE
 
 /datum/action/changeling/proc/sting_action(mob/user, mob/target)
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changelings can alt click stuff once again while having a sting selected.

## Changelog
:cl:
fix: Changelings can perform other alt click actions while having a sting collected once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
