### PR TITLE
Adds a speech modifier to pAIs on EMP

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -52,6 +52,7 @@
 			var/mob/living/carbon/human/H = user
 			if(H.real_name == pai.master || H.dna.unique_enzymes == pai.master_dna)
 				dat += "<A href='byond://?src=[REF(src)];toggle_holo=1'>\[[pai.canholo? "Disable" : "Enable"] holomatrix projectors\]</a><br>"
+		dat += "<A href='byond://?src=[REF(src)];fix_speech=1'>\[Reset speech synthesis module\]</a><br>"
 		dat += "<A href='byond://?src=[REF(src)];wipe=1'>\[Wipe current pAI personality\]</a><br>"
 	else
 		dat += "No personality installed.<br>"
@@ -92,6 +93,10 @@
 					to_chat(pai, "<span class='userdanger'>Your mental faculties leave you.</span>")
 					to_chat(pai, "<span class='rose'>oblivion... </span>")
 					qdel(pai)
+		if(href_list["fix_speech"])
+			pai.stuttering = 0
+			pai.slurring = 0
+			pai.derpspeech = 0
 		if(href_list["toggle_transmit"] || href_list["toggle_receive"])
 			var/transmitting = href_list["toggle_transmit"] //it can't be both so if we know it's not transmitting it must be receiving. 
 			var/transmit_holder = (transmitting ? WIRE_TX : WIRE_RX)

--- a/code/modules/mob/living/silicon/pai/pai_defense.dm
+++ b/code/modules/mob/living/silicon/pai/pai_defense.dm
@@ -8,7 +8,7 @@
 		return
 	take_holo_damage(50/severity)
 	Paralyze(400/severity)
-	// silent = max(30/severity, silent)
+	silent = max(20/severity, silent)
 	if(holoform)
 		fold_in(force = TRUE)
 	//Need more effects that aren't instadeath or permanent law corruption.

--- a/code/modules/mob/living/silicon/pai/pai_defense.dm
+++ b/code/modules/mob/living/silicon/pai/pai_defense.dm
@@ -8,10 +8,24 @@
 		return
 	take_holo_damage(50/severity)
 	Paralyze(400/severity)
-	silent = max(30/severity, silent)
+	// silent = max(30/severity, silent)
 	if(holoform)
 		fold_in(force = TRUE)
 	//Need more effects that aren't instadeath or permanent law corruption.
+	//Ask and you shall receive
+	switch(rand(1, 3))
+		if(1)
+			stuttering = 1
+			to_chat(src, "<span class='danger'>Warning: Speech synthesis module damaged.</span>")
+		if(2)
+			slurring = 1
+			to_chat(src, "<span class='danger'>Warning: Speech synthesis module damaged.</span>")
+		if(3)
+			derpspeech = 1
+			to_chat(src, "<span class='danger'>Warning: Speech synthesis module damaged.</span>")
+	if(prob(40))
+		mind.language_holder.selected_default_language = pick(mind.language_holder.languages)
+
 
 /mob/living/silicon/pai/ex_act(severity, target)
 	take_holo_damage(severity * 50)

--- a/code/modules/mob/living/silicon/pai/pai_defense.dm
+++ b/code/modules/mob/living/silicon/pai/pai_defense.dm
@@ -16,13 +16,13 @@
 	switch(rand(1, 3))
 		if(1)
 			stuttering = 1
-			to_chat(src, "<span class='danger'>Warning: Speech synthesis module damaged.</span>")
+			to_chat(src, "<span class='danger'>Warning: Feedback loop detected in speech module.</span>")
 		if(2)
 			slurring = 1
-			to_chat(src, "<span class='danger'>Warning: Speech synthesis module damaged.</span>")
+			to_chat(src, "<span class='danger'>Warning: Audio synthesizer CPU stuck.</span>")
 		if(3)
 			derpspeech = 1
-			to_chat(src, "<span class='danger'>Warning: Speech synthesis module damaged.</span>")
+			to_chat(src, "<span class='danger'>Warning: Vocabulary databank corrupted.</span>")
 	if(prob(40))
 		mind.language_holder.selected_default_language = pick(mind.language_holder.languages)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so pAIs either stutter, slur, or talk like a brainlet when they're EMPed. This can be fixed by someone pressing the "Reset speech synthesis module" button on the pAI card. Additionally, adds a 40% chance for their default language to be swapped.
Readded the mute, albeit a bit shorter, due to feedback.
Idea courtesy of Rogus.
![image](https://user-images.githubusercontent.com/35442306/64497522-9a125a00-d263-11e9-861b-4ecad5824a06.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mutes are boring. This adds a debuff that while less severe, persists for longer and requires the help of another player to fix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: pAI speech modules have been upgraded to be more EMP resistant, but they can now malfunction on EMP.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
