### PR TITLE
Makes roller beds craftable

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -392,6 +392,14 @@
 				/obj/item/stack/rods = 12)
 	category = CAT_MISC
 
+/datum/crafting_recipe/rollerbed
+	name = "Roller Bed"
+	result = /obj/structure/bed/roller
+	reqs = list(/obj/item/stack/sheet/metal = 2,
+				/obj/item/stack/rods = 2)
+	time = 70
+	category = CAT_MISC
+
 /datum/crafting_recipe/wheelchair
 	name = "Wheelchair"
 	result = /obj/vehicle/ridden/wheelchair

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -75,6 +75,11 @@
 	else
 		return ..()
 
+/obj/structure/bed/roller/deconstruct(disassembled = TRUE)
+	if(!(flags_1 & NODECONSTRUCT_1))
+		new /obj/item/stack/rods(loc,2)
+	..()
+
 /obj/structure/bed/roller/MouseDrop(over_object, src_location, over_location)
 	. = ..()
 	if(over_object == usr && Adjacent(usr))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Puts roller beds in the misc crafting menu, costing 2 metal sheets and 2 metal rods. Also makes roller beds drop those when wrenched.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Currently the only way to get more roller beds is to order a surgical crate, even though they can be wrenched into materials. The use of proper crafting over the metal sheet construction menu is to not let docs carry around 20 metal to instantly make 10 beds.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Roller beds now craftable from 2 metal sheets and 2 metal rods.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
