### PR TITLE
Fixes a runtime when ethereals try to move on a server with moods disabled

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1166,7 +1166,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					. += hungry / 50
 			else if(isethereal(H))
 				var/datum/species/ethereal/E = H.dna.species
-				var/charge = E.get_charge()
+				var/charge = E.get_charge(H)
 				if(charge <= ETHEREAL_CHARGE_NORMAL)
 					. += 1.5 * (1 - charge / 100)
 


### PR DESCRIPTION
Basically, get_charge() needs a human passed as an argument, otherwise it'll runtime