### PR TITLE
Fixes Tendrils Spawning Inside Ruins

### DIFF
--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -20,11 +20,13 @@
 
 		for(var/i in get_affected_turfs(central_turf, 1))
 			var/turf/T = i
+			for(var/obj/structure/spawner/nest in T)
+				qdel(nest)
 			for(var/mob/living/simple_animal/monster in T)
 				qdel(monster)
 			for(var/obj/structure/flora/ash/plant in T)
 				qdel(plant)
-		
+
 		load(central_turf,centered = TRUE)
 		loaded++
 
@@ -94,7 +96,7 @@
 			//TODO : handle forced ruins with multiple variants
 			forced_ruins -= current_pick
 			forced = FALSE
-		
+
 		if(failed_to_place)
 			for(var/datum/map_template/ruin/R in ruins_availible)
 				if(R.id == current_pick.id)
@@ -131,5 +133,5 @@
 		for(var/datum/map_template/ruin/R in ruins_availible)
 			if(R.cost > budget)
 				ruins_availible -= R
-	
+
 	log_world("Ruin loader finished with [budget] left to spend.")


### PR DESCRIPTION
Sometimes a random tendril will be inside a lavaland ruin--this is a consequence, as far as I know, of the refactor that made spawners into a structure subtype instead of being a simple mob.

While that's generally better, there is no code to delete existing tendrils before a ruins is placed--but there is code to handle deleting flora and mobs.

:cl:
fix: Fixed Tendrils spawning inside lavaland ruins
/:cl:
