### PR TITLE
Fixes Multiple Bubblegum Spawns

### DIFF
--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -133,6 +133,8 @@
 #define SPAWN_MEGAFAUNA "bluh bluh huge boss"
 #define SPAWN_BUBBLEGUM 6
 
+GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/megafauna/dragon = 4, /mob/living/simple_animal/hostile/megafauna/colossus = 2, /mob/living/simple_animal/hostile/megafauna/bubblegum = SPAWN_BUBBLEGUM))
+
 /turf/open/floor/plating/asteroid/airless/cave
 	var/length = 100
 	var/list/mob_spawn_list
@@ -167,7 +169,7 @@
 	if (!mob_spawn_list)
 		mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goldgrub = 1, /mob/living/simple_animal/hostile/asteroid/goliath = 5, /mob/living/simple_animal/hostile/asteroid/basilisk = 4, /mob/living/simple_animal/hostile/asteroid/hivelord = 3)
 	if (!megafauna_spawn_list)
-		megafauna_spawn_list = list(/mob/living/simple_animal/hostile/megafauna/dragon = 4, /mob/living/simple_animal/hostile/megafauna/colossus = 2, /mob/living/simple_animal/hostile/megafauna/bubblegum = SPAWN_BUBBLEGUM)
+		megafauna_spawn_list = GLOB.megafauna_spawn_list
 	if (!flora_spawn_list)
 		flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2)
 	if(!terrain_spawn_list)
@@ -266,7 +268,7 @@
 				if(megafauna_spawn_list[maybe_boss])
 					randumb = maybe_boss
 					if(ispath(maybe_boss, /mob/living/simple_animal/hostile/megafauna/bubblegum)) //there can be only one bubblegum, so don't waste spawns on it
-						megafauna_spawn_list[maybe_boss] = 0
+						megafauna_spawn_list.Remove(maybe_boss)
 			else //this is not danger, don't spawn a boss, spawn something else
 				randumb = pickweight(mob_spawn_list)
 


### PR DESCRIPTION
If you profile the garbage collector (or just do a SDQL2 call near round start), you'll see that there are multiple Bubblegums that are created.

I suspect that this was a problem along ago and, after being unable to resolve it, someone put the "only one Bubblegum" code directly into Bubblegum's `Initialize` to prevent duplicate spawns from happening....so a patchwork.

Either case, this properly ensures that Bubblegum will well and truly only spawn in once.

:cl: Fox McCloud
fix: Fixes multiple bubblegum spawns
/:cl: