### PR TITLE
Emitters no longer require unwrenching and rewrenching to weld upon creation.

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -27,7 +27,7 @@
 	var/minimum_fire_delay = 20
 	var/last_shot = 0
 	var/shot_number = 0
-	var/state = EMITTER_UNWRENCHED
+	var/state = EMITTER_WRENCHED
 	var/locked = FALSE
 	var/allow_switch_interact = TRUE
 


### PR DESCRIPTION
## About The Pull Request

When emitters are created from an anchored machine frame, they are now considered anchored and ready to weld.

Fixes [#43498](https://github.com/tgstation/tgstation/issues/43498)

## Why It's Good For The Game

You shouldn't have to unwrench and rewrench just to weld an emitter down if you already wrenched the machine frame down to begin with. Bug fix.

## Changelog
:cl: smolveg
fix: emitters properly require welding upon creation, no more unwrench and rewrench just to weld!
/:cl:
