### PR TITLE
Self-Sustaining Rainbow Potion fix

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/selfsustaining.dm
+++ b/code/modules/research/xenobiology/crossbreeding/selfsustaining.dm
@@ -45,7 +45,7 @@ Self-sustaining extracts:
 		reagentselect = "plasma"
 	if(reagentselect == "holy water and uranium")
 		reagentselect = /datum/reagent/water/holywater
-		secondary = "uranium"
+		secondary = /datum/reagent/uranium
 	extract.forceMove(user.drop_location())
 	qdel(src)
 	user.put_in_active_hand(extract)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the xenobio SS rainbow spawn a potion now
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes: #46442

## Changelog
:cl:
Fix: Self Sustaining rainbow extracts properly react with uranium and holy water again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->