### PR TITLE
Non temp workaround for admins matching stickybans because of a byond bug.

### DIFF
--- a/code/_globalvars/lists/admin.dm
+++ b/code/_globalvars/lists/admin.dm
@@ -1,0 +1,3 @@
+GLOBAL_LIST_EMPTY(stickybanadminexemptions)	//stores a list of ckeys exempted from a stickyban (workaround for a bug)
+GLOBAL_LIST_EMPTY(stickybanadmintexts) //stores the entire stickyban list temporarily
+GLOBAL_VAR(stickbanadminexemptiontimerid) //stores the timerid of the callback that restores all stickybans after an admin joins

--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -10,11 +10,15 @@ SUBSYSTEM_DEF(stickyban)
 
 
 /datum/controller/subsystem/stickyban/Initialize(timeofday)
+	if (length(stickybanadminexemptions))
+		restore_stickybans()
 	var/list/bannedkeys = sticky_banned_ckeys()
 	//sanitize the sticky ban list
 
 	//delete db bans that no longer exist in the database and add new legacy bans to the database
 	if (SSdbcore.Connect() || length(SSstickyban.dbcache))
+		if (length(stickybanadminexemptions))
+			restore_stickybans()
 		for (var/oldban in (world.GetConfig("ban") - bannedkeys))
 			var/ckey = ckey(oldban)
 			if (ckey != oldban && (ckey in bannedkeys))
@@ -29,6 +33,8 @@ SUBSYSTEM_DEF(stickyban)
 				bannedkeys += ckey
 			world.SetConfig("ban", oldban, null)
 
+	if (length(stickybanadminexemptions)) //the previous loop can sleep
+		restore_stickybans()
 
 	for (var/bannedkey in bannedkeys)
 		var/ckey = ckey(bannedkey)

--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -10,14 +10,14 @@ SUBSYSTEM_DEF(stickyban)
 
 
 /datum/controller/subsystem/stickyban/Initialize(timeofday)
-	if (length(stickybanadminexemptions))
+	if (length(GLOB.stickybanadminexemptions))
 		restore_stickybans()
 	var/list/bannedkeys = sticky_banned_ckeys()
 	//sanitize the sticky ban list
 
 	//delete db bans that no longer exist in the database and add new legacy bans to the database
 	if (SSdbcore.Connect() || length(SSstickyban.dbcache))
-		if (length(stickybanadminexemptions))
+		if (length(GLOB.stickybanadminexemptions))
 			restore_stickybans()
 		for (var/oldban in (world.GetConfig("ban") - bannedkeys))
 			var/ckey = ckey(oldban)
@@ -33,7 +33,7 @@ SUBSYSTEM_DEF(stickyban)
 				bannedkeys += ckey
 			world.SetConfig("ban", oldban, null)
 
-	if (length(stickybanadminexemptions)) //the previous loop can sleep
+	if (length(GLOB.stickybanadminexemptions)) //the previous loop can sleep
 		restore_stickybans()
 
 	for (var/bannedkey in bannedkeys)

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -5,9 +5,7 @@
 #define STICKYBAN_MAX_MATCHES 15
 #define STICKYBAN_MAX_EXISTING_USER_MATCHES 3 //ie, users who were connected before the ban triggered
 #define STICKYBAN_MAX_ADMIN_MATCHES 1
-var/list/stickybanadminexemptions = list()
-var/list/stickybanadmintexts = list()
-var/stickbanadminexemptiontimerid
+
 /world/IsBanned(key, address, computer_id, type, real_bans_only=FALSE)
 	debug_world_log("isbanned(): '[args.Join("', '")]'")
 	if (!key || (!real_bans_only && (!address || !computer_id)))
@@ -98,15 +96,15 @@ var/stickbanadminexemptiontimerid
 		//oh boy, so basically, because of a bug in byond, sometimes stickyban matches don't trigger here, so we can't exempt admins.
 		//	Whitelisting the ckey with the byond whitelist field doesn't work.
 		//	So we instead have to remove every stickyban than later re-add them.
-		if (!length(stickybanadminexemptions))
+		if (!length(GLOB.stickybanadminexemptions))
 			for (var/banned_ckey in world.GetConfig("ban"))
-				stickybanadmintexts[banned_ckey] = world.GetConfig("ban", banned_ckey)
+				GLOB.stickybanadmintexts[banned_ckey] = world.GetConfig("ban", banned_ckey)
 				world.SetConfig("ban", banned_ckey, null)
 		if (!SSstickyban.initialized)
 			return
-		stickybanadminexemptions[ckey] = world.time
+		GLOB.stickybanadminexemptions[ckey] = world.time
 		stoplag() // sleep a byond tick
-		stickbanadminexemptiontimerid = addtimer(CALLBACK(GLOBAL_PROC, /proc/restore_stickybans), 5 SECONDS, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_OVERRIDE)
+		GLOB.stickbanadminexemptiontimerid = addtimer(CALLBACK(GLOBAL_PROC, /proc/restore_stickybans), 5 SECONDS, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_OVERRIDE)
 		return
 	var/list/ban = ..()	//default pager ban stuff
 
@@ -218,13 +216,13 @@ var/stickbanadminexemptiontimerid
 	return .
 
 /proc/restore_stickybans()
-	for (var/banned_ckey in stickybanadmintexts)
-		world.SetConfig("ban", banned_ckey, stickybanadmintexts[banned_ckey])
-	stickybanadminexemptions = list()
-	stickybanadmintexts = list()
-	if (stickbanadminexemptiontimerid)
-		deltimer(stickbanadminexemptiontimerid)
-	stickbanadminexemptiontimerid = null
+	for (var/banned_ckey in GLOB.stickybanadmintexts)
+		world.SetConfig("ban", banned_ckey, GLOB.stickybanadmintexts[banned_ckey])
+	GLOB.stickybanadminexemptions = list()
+	GLOB.stickybanadmintexts = list()
+	if (GLOB.stickbanadminexemptiontimerid)
+		deltimer(GLOB.stickbanadminexemptiontimerid)
+	GLOB.stickbanadminexemptiontimerid = null
 
 #undef STICKYBAN_MAX_MATCHES
 #undef STICKYBAN_MAX_EXISTING_USER_MATCHES

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -278,6 +278,10 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 
 
 	. = ..()	//calls mob.Login()
+	if (length(stickybanadminexemptions))
+		stickybanadminexemptions -= ckey
+		if (!length(stickybanadminexemptions))
+			restore_stickybans()
 
 	if (byond_version >= 512)
 		if (!byond_build || byond_build < 1386)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -278,9 +278,9 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 
 
 	. = ..()	//calls mob.Login()
-	if (length(stickybanadminexemptions))
-		stickybanadminexemptions -= ckey
-		if (!length(stickybanadminexemptions))
+	if (length(GLOB.stickybanadminexemptions))
+		GLOB.stickybanadminexemptions -= ckey
+		if (!length(GLOB.stickybanadminexemptions))
 			restore_stickybans()
 
 	if (byond_version >= 512)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -162,6 +162,7 @@
 #include "code\_globalvars\misc.dm"
 #include "code\_globalvars\regexes.dm"
 #include "code\_globalvars\traits.dm"
+#include "code\_globalvars\lists\admin.dm"
 #include "code\_globalvars\lists\flavor_misc.dm"
 #include "code\_globalvars\lists\maintenance_loot.dm"
 #include "code\_globalvars\lists\mapping.dm"


### PR DESCRIPTION
Workaround for the byond bug with stickybans causing the admin whitelist code to not get called.

How does it work? when an admin is connecting, just before byond asks the hub about the current stickybans, we remove all of the stickybans from byond's database. later, when either 5 seconds have passed, or the admin's client/New is called, we restore the stickybans we deleted earlier.

This uses a stack and overriding timers to properly handle cases where multiple admins are joining within the same window.

>Lummox said he will look into this bug on monday now that its impacting one of our admins.

Lol yeah

closes #43148
