### PR TITLE
Highlander event tries to drop items, heals and uncuffs

### DIFF
--- a/code/modules/antagonists/highlander/highlander.dm
+++ b/code/modules/antagonists/highlander/highlander.dm
@@ -42,11 +42,11 @@
 	if(!istype(H))
 		return
 
-	for(var/obj/item/I in H.get_equipped_items(TRUE))
-		qdel(I)
-	for(var/obj/item/I in H.held_items)
-		qdel(I)
-	H.uncuff()
+	for(var/obj/item/I in H)
+		if(!H.dropItemToGround(I))
+			qdel(I)
+	H.regenerate_icons()
+	H.revive(full_heal = 1, admin_revive = 1)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/costume/kilt/highlander(H), SLOT_W_UNIFORM)
 	H.equip_to_slot_or_del(new /obj/item/radio/headset/heads/captain(H), SLOT_EARS)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/beret/highlander(H), SLOT_HEAD)

--- a/code/modules/antagonists/highlander/highlander.dm
+++ b/code/modules/antagonists/highlander/highlander.dm
@@ -46,7 +46,7 @@
 		if(!H.dropItemToGround(I))
 			qdel(I)
 	H.regenerate_icons()
-	H.revive(full_heal = 1, admin_revive = 1)
+	H.revive(full_heal = TRUE, admin_revive = TRUE)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/costume/kilt/highlander(H), SLOT_W_UNIFORM)
 	H.equip_to_slot_or_del(new /obj/item/radio/headset/heads/captain(H), SLOT_EARS)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/beret/highlander(H), SLOT_HEAD)

--- a/code/modules/antagonists/highlander/highlander.dm
+++ b/code/modules/antagonists/highlander/highlander.dm
@@ -46,6 +46,7 @@
 		qdel(I)
 	for(var/obj/item/I in H.held_items)
 		qdel(I)
+	H.uncuff()
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/costume/kilt/highlander(H), SLOT_W_UNIFORM)
 	H.equip_to_slot_or_del(new /obj/item/radio/headset/heads/captain(H), SLOT_EARS)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/beret/highlander(H), SLOT_HEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In response to feedback on the forum and the comments here, the event will try to drop what you were wearing beforehand instead of deleting it, and will fully heal you and remove your restraints.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More even playing field, post-round griff items remain intact. Prompted by [this thread](https://tgstation13.org/phpBB/viewtopic.php?f=9&t=23675).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
tweak: Highlander event now tries to drop your items instead of deleting them, It also fully heals you and removes your restraints.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
