### PR TITLE
Updates Survival Medipen to use C3s (as replacement for lost Tricord from previous PRs)

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -217,9 +217,9 @@
 	desc = "A medipen for surviving in the harshest of environments, heals and protects from environmental hazards. WARNING: Do not inject more than one pen in quick succession."
 	icon_state = "stimpen"
 	item_state = "stimpen"
-	volume = 57
-	amount_per_transfer_from_this = 57
-	list_reagents = list(/datum/reagent/medicine/salbutamol = 10, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/lavaland_extract = 2, /datum/reagent/medicine/omnizine = 5)
+	volume = 60
+	amount_per_transfer_from_this = 60
+	list_reagents = list(/datum/reagent/medicine/salbutamol = 10, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/lavaland_extract = 2, /datum/reagent/medicine/omnizine = 5, /datum/reagent/medicine/oxandrolone = 8, /datum/reagent/medicine/sal_acid = 8, /datum/reagent/medicine/morphine = 2)
 
 /obj/item/reagent_containers/hypospray/medipen/atropine
 	name = "atropine autoinjector"


### PR DESCRIPTION

## About The Pull Request

Increases the nerfed amount of healing survival medipens got, raising it from being barely more useful than a bruise pack, back up to what it used to be, the oh shit button you use when greatly injured.

## Why It's Good For The Game

During some gameplay I noticed Survival Medipens did a lot less healing. So I decided to code dive and find out why. After reading the file, I back checked through all Pr's to find where it got removed and found it had been an undocumented change in #45105. I spoke with cobby and we came up with the amount and the additions to the pen.

## Changelog
:cl:
balance: Buffed Survival Pens. They are now no longer worse than a bruise pack.
/:cl: