### PR TITLE
Moves drunk healing to quirk process

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -39,17 +39,16 @@
 
 /datum/quirk/drunkhealing/on_process()
 	var/mob/living/carbon/C = quirk_holder
-	if(C.drunkenness >= 6)
-		switch(C.drunkenness)
-			if (6 to 40)
-				C.adjustBruteLoss(-0.10, FALSE)
-				C.adjustFireLoss(-0.05, FALSE)
-			if (41 to 60)
-				C.adjustBruteLoss(-0.4, FALSE)
-				C.adjustFireLoss(-0.2, FALSE)
-			if (61 to INFINITY)
-				C.adjustBruteLoss(-0.8, FALSE)
-				C.adjustFireLoss(-0.4, FALSE)
+	switch(C.drunkenness)
+		if (6 to 40)
+			C.adjustBruteLoss(-0.1, FALSE)
+			C.adjustFireLoss(-0.05, FALSE)
+		if (41 to 60)
+			C.adjustBruteLoss(-0.4, FALSE)
+			C.adjustFireLoss(-0.2, FALSE)
+		if (61 to INFINITY)
+			C.adjustBruteLoss(-0.8, FALSE)
+			C.adjustFireLoss(-0.4, FALSE)
 
 /datum/quirk/empath
 	name = "Empath"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -37,6 +37,20 @@
 	lose_text = "<span class='danger'>You no longer feel like drinking would ease your pain.</span>"
 	medical_record_text = "Patient has unusually efficient liver metabolism and can slowly regenerate wounds by drinking alcoholic beverages."
 
+/datum/quirk/drunkhealing/on_process()
+	var/mob/living/carbon/C = quirk_holder
+	if(C.drunkenness >= 6)
+		switch(C.drunkenness)
+			if (6 to 40)
+				C.adjustBruteLoss(-0.10, FALSE)
+				C.adjustFireLoss(-0.05, FALSE)
+			if (41 to 60)
+				C.adjustBruteLoss(-0.4, FALSE)
+				C.adjustFireLoss(-0.2, FALSE)
+			if (61 to INFINITY)
+				C.adjustBruteLoss(-0.8, FALSE)
+				C.adjustFireLoss(-0.4, FALSE)
+
 /datum/quirk/empath
 	name = "Empath"
 	desc = "Whether it's a sixth sense or careful study of body language, it only takes you a quick glance at someone to understand how they feel."

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -508,9 +508,6 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 			if(prob(25))
 				slurring += 2
 			jitteriness = max(jitteriness - 3, 0)
-			if(HAS_TRAIT(src, TRAIT_DRUNK_HEALING))
-				adjustBruteLoss(-0.12, FALSE)
-				adjustFireLoss(-0.06, FALSE)
 		else
 			SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "drunk")
 
@@ -538,9 +535,6 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 			if(prob(25))
 				confused += 2
 			Dizzy(10)
-			if(HAS_TRAIT(src, TRAIT_DRUNK_HEALING)) // effects stack with lower tiers
-				adjustBruteLoss(-0.3, FALSE)
-				adjustFireLoss(-0.15, FALSE)
 
 		if(drunkenness >= 51)
 			if(prob(3))
@@ -551,9 +545,6 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 		if(drunkenness >= 61)
 			if(prob(50))
 				blur_eyes(5)
-			if(HAS_TRAIT(src, TRAIT_DRUNK_HEALING))
-				adjustBruteLoss(-0.4, FALSE)
-				adjustFireLoss(-0.2, FALSE)
 
 		if(drunkenness >= 71)
 			blur_eyes(5)


### PR DESCRIPTION
I figured it's better to keep quirks compartmentalized where possible, also made the code a bit better

I rounded the numbers for simplicity which causes a decrease in healing by a whopping 0.02 per tick

## Changelog
:cl:
code: Moved drunk healing quirk processing out of generic drunkenness and into quirk process
/:cl: