### PR TITLE
brings back the miracle ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/miracle.dmm
+++ b/_maps/RandomRuins/SpaceRuins/miracle.dmm
@@ -1,0 +1,11 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/item/storage/backpack/satchel/flat/secret/miracle_ruin,
+/turf/open/floor/fakespace{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/fakespace)
+
+(1,1,1) = {"
+a
+"}

--- a/_maps/RandomRuins/SpaceRuins/miracle.dmm
+++ b/_maps/RandomRuins/SpaceRuins/miracle.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/item/storage/backpack/satchel/flat/secret/miracle_ruin,
+/obj/item/storage/backpack/satchel/flat/miracle,
 /turf/open/floor/fakespace{
 	initial_gas_mix = "TEMP=2.7"
 	},

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -291,7 +291,7 @@
 	icon_state = "satchel-flat"
 	w_class = WEIGHT_CLASS_NORMAL //Can fit in backpacks itself.
 	level = 1
-	secret = FALSE
+	var/secret = FALSE
 
 /obj/item/storage/backpack/satchel/flat/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -291,6 +291,7 @@
 	icon_state = "satchel-flat"
 	w_class = WEIGHT_CLASS_NORMAL //Can fit in backpacks itself.
 	level = 1
+	secret = FALSE
 
 /obj/item/storage/backpack/satchel/flat/ComponentInitialize()
 	. = ..()
@@ -300,15 +301,20 @@
 
 /obj/item/storage/backpack/satchel/flat/hide(intact)
 	if(intact)
-		invisibility = INVISIBILITY_OBSERVER
+		if(secret)
+			invisibility = INVISIBILITY_MAXIMUM
+		else
+			invisibility = INVISIBILITY_OBSERVER
 		anchored = TRUE //otherwise you can start pulling, cover it, and drag around an invisible backpack.
 		icon_state = "[initial(icon_state)]2"
-		ADD_TRAIT(src, TRAIT_T_RAY_VISIBLE, TRAIT_GENERIC)
+		if(!secret)
+			ADD_TRAIT(src, TRAIT_T_RAY_VISIBLE, TRAIT_GENERIC)
 	else
 		invisibility = initial(invisibility)
 		anchored = FALSE
 		icon_state = initial(icon_state)
-		REMOVE_TRAIT(src, TRAIT_T_RAY_VISIBLE, TRAIT_GENERIC)
+		if(!secret)
+			REMOVE_TRAIT(src, TRAIT_T_RAY_VISIBLE, TRAIT_GENERIC)
 
 /obj/item/storage/backpack/satchel/flat/PopulateContents()
 	var/datum/supply_pack/costumes_toys/randomised/contraband/C = new
@@ -326,6 +332,9 @@
 
 /obj/item/storage/backpack/satchel/flat/empty/PopulateContents()
 	return
+
+/obj/item/storage/backpack/satchel/flat/miracle/PopulateContents()
+	new /obj/item/gun/energy/pulse/prize(src)
 
 /obj/item/storage/backpack/duffelbag
 	name = "duffel bag"

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -333,6 +333,10 @@
 /obj/item/storage/backpack/satchel/flat/empty/PopulateContents()
 	return
 
+/obj/item/storage/backpack/satchel/flat/miracle
+	desc = "A magical satchel that can easily fit into the very fabric of space."
+	secret = TRUE
+
 /obj/item/storage/backpack/satchel/flat/miracle/PopulateContents()
 	new /obj/item/gun/energy/pulse/prize(src)
 


### PR DESCRIPTION
## About The Pull Request

when the smuggler satchel deletion thing was merged, this ruin was taken with it
this brings it back but i think its still blocked in config
i took it from an old repo
closes #46494
Closes #46565

## Why It's Good For The Game

it disappeared from code, and even if its disabled its good to have it back because theres things that check for that ruin

## Changelog
:cl:
add: Brings back the Miracle, still locked away behind config, I think
/:cl: