### PR TITLE
Arm implants work again for the left arm

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -98,7 +98,7 @@
 		var/obj/item/assembly/flash/F = holder
 		F.set_light(7)
 
-	var/side = zone == BODY_ZONE_R_ARM? "r" : "l"
+	var/side = zone == BODY_ZONE_R_ARM? RIGHT_HANDS : LEFT_HANDS
 	var/hand = owner.get_empty_held_index_for_side(side)
 	if(hand)
 		owner.put_in_hand(holder, hand)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Feck.
Fixes #https://github.com/tgstation/tgstation/issues/46532

## Changelog
:cl:
fix: Tool implants now always place their tools into the correct hands.
/:cl:
