### PR TITLE
laser pointer buff

### DIFF
--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -11,9 +11,9 @@
 	materials = list(/datum/material/iron=500, /datum/material/glass=500)
 	w_class = WEIGHT_CLASS_SMALL
 	var/turf/pointer_loc
-	var/energy = 5
-	var/max_energy = 5
-	var/effectchance = 25
+	var/energy = 10
+	var/max_energy = 10
+	var/effectchance = 30
 	var/recharging = 0
 	var/recharge_locked = FALSE
 	var/obj/item/stock_parts/micro_laser/diode //used for upgrading!
@@ -186,7 +186,7 @@
 	icon_state = "pointer"
 
 /obj/item/laser_pointer/process()
-	if(prob(20 - recharge_locked*5))
+	if(prob(20 + diode.rating*20 - recharge_locked*2)) //t1 is 20, 2 40
 		energy += 1
 		if(energy >= max_energy)
 			energy = max_energy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Doubled laser pointer maximum capacity, increased the recharge speed and made it increase depending on your micro-laser's rating, and made it more likely to trigger an effect by default. (from 25 to 30)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Laser pointers are fun to mess around and blind people with, but the low chance and huge cooldown makes it very slow and clunky to use. This rectifies it and still encourages upgrading the laser.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: laser pointer has twice as much capacity and is slightly more likely to actually blind people
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
![image](https://user-images.githubusercontent.com/53100513/64929503-5092b380-d7fd-11e9-94d0-845422dbfd57.png)
