### PR TITLE
Sleeping is now improved if you have a bedsheet.

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -69,17 +69,21 @@
 /datum/status_effect/incapacitating/sleeping/tick()
 	if(owner.maxHealth)
 		var/health_ratio = owner.health / owner.maxHealth
-		if(health_ratio > 0.8)
-			var/healing = -0.2
-			if((locate(/obj/structure/bed) in owner.loc))
-				healing -= 0.3
-			else
-				if((locate(/obj/structure/table) in owner.loc))
-					healing -= 0.1
+		var/healing = -0.2
+		if((locate(/obj/structure/bed) in owner.loc))
+			healing -= 0.3
+		else if((locate(/obj/structure/table) in owner.loc))
+			healing -= 0.1
+		for(var/obj/item/bedsheet/bedsheet in range(owner.loc,0))
+			if(bedsheet.loc != owner.loc) //bedsheets in your backpack/neck don't give you comfort
+				continue
+			healing -= 0.1
+			break //Only count the first bedsheet	
+		if(health_ratio > 0.8)	
 			owner.adjustBruteLoss(healing)
 			owner.adjustFireLoss(healing)
 			owner.adjustToxLoss(healing * 0.5, TRUE, TRUE)
-			owner.adjustStaminaLoss(healing)
+		owner.adjustStaminaLoss(healing)
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))


### PR DESCRIPTION
## About The Pull Request

Having a blanket on top of you while sleeping improves the effects of sleeping.
Also causes sleeping to help recover stamina, even if you're too injured to heal from it.

## Why It's Good For The Game

Adds a minor incentive to utilize blankets while sleeping, improving immersion.

Fixes intuitive behavior where injuries will prevent rest from removing fatigue.

## Lordpidey
:cl:
balance: Blankets now help you sleep more soundly.
balance: Sleeping now helps recover stamina even if you're injured.
/:cl:
