### PR TITLE
Tweaks space cave generation

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -21,7 +21,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
 "ah" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/space/has_grav/abandonedzoo)
 "ai" = (
 /turf/open/floor/plating/asteroid,

--- a/_maps/RandomRuins/SpaceRuins/asteroid2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/asteroid2.dmm
@@ -6,7 +6,7 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered/no_grav)
 "c" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/unpowered/no_grav)
 "d" = (
 /turf/closed/mineral/random/high_chance,
@@ -247,7 +247,7 @@ d
 c
 c
 c
-d
+b
 c
 b
 a

--- a/_maps/RandomRuins/SpaceRuins/asteroid3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/asteroid3.dmm
@@ -6,7 +6,7 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered/no_grav)
 "c" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/unpowered/no_grav)
 "d" = (
 /turf/closed/mineral/random/high_chance,

--- a/_maps/RandomRuins/SpaceRuins/asteroid4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/asteroid4.dmm
@@ -3,13 +3,13 @@
 /turf/template_noop,
 /area/template_noop)
 "b" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/unpowered/no_grav)
 "c" = (
 /turf/closed/mineral/random/high_chance,
 /area/ruin/unpowered/no_grav)
 "d" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/unpowered)
 "e" = (
 /turf/open/floor/plating/asteroid/airless,

--- a/_maps/RandomRuins/SpaceRuins/asteroid5.dmm
+++ b/_maps/RandomRuins/SpaceRuins/asteroid5.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "b" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/unpowered)
 "c" = (
 /turf/closed/mineral/random/high_chance,

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -146,7 +146,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "aC" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/unpowered/no_grav)
 "aD" = (
 /obj/machinery/door/poddoor{
@@ -1397,7 +1397,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost)
 "ds" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/space/has_grav/derelictoutpost)
 "dt" = (
 /obj/structure/alien/weeds{

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1902,6 +1902,9 @@
 "wh" = (
 /turf/template_noop,
 /area/awaymission/BMPship)
+"xA" = (
+/turf/closed/mineral/random/no_caves,
+/area/awaymission/BMPship)
 "ya" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "packerMine"
@@ -1994,9 +1997,9 @@ aa
 aa
 aa
 aa
-gb
-gb
-gb
+xA
+xA
+xA
 aa
 aa
 aa
@@ -2045,9 +2048,9 @@ aa
 aa
 aa
 fS
-gb
-gb
-gb
+xA
+xA
+xA
 aa
 aa
 aa
@@ -2096,10 +2099,10 @@ aa
 aa
 aa
 fS
-gb
-gb
-gb
-gb
+xA
+xA
+xA
+xA
 aa
 aa
 aa
@@ -2148,8 +2151,8 @@ aa
 aa
 aa
 fS
-gb
-gb
+xA
+xA
 fS
 fS
 aa
@@ -2210,9 +2213,9 @@ aa
 aa
 aa
 aa
-gb
-gb
-gb
+xA
+xA
+xA
 aa
 aa
 aa
@@ -2260,11 +2263,11 @@ aa
 wh
 fS
 fS
-gb
-gb
-gb
-gb
-gb
+xA
+xA
+xA
+xA
+xA
 aa
 aa
 aa
@@ -2310,13 +2313,13 @@ aa
 fS
 fS
 fS
-gb
-gb
-gb
-gb
-gb
-gb
-gb
+xA
+xA
+xA
+xA
+xA
+xA
+xA
 aa
 aa
 aa
@@ -2361,14 +2364,14 @@ hn
 fS
 fS
 fS
-gb
-gb
-gb
-gb
-gb
-gb
-gb
-gb
+xA
+xA
+xA
+xA
+xA
+xA
+xA
+xA
 aa
 aa
 aa
@@ -2414,13 +2417,13 @@ fS
 fS
 fS
 fS
-gb
-gb
-gb
-gb
-gb
-gb
-gb
+xA
+xA
+xA
+xA
+xA
+xA
+xA
 aa
 aa
 "}
@@ -2468,10 +2471,10 @@ fS
 fS
 fS
 fS
-gb
-gb
-gb
-gb
+xA
+xA
+xA
+xA
 aa
 aa
 "}
@@ -2520,8 +2523,8 @@ fS
 fS
 fS
 fS
-gb
-gb
+xA
+xA
 fS
 aa
 aa
@@ -3643,8 +3646,8 @@ gb
 fS
 fS
 fS
-gb
-gb
+xA
+xA
 aa
 aa
 "}
@@ -3694,9 +3697,9 @@ fS
 fS
 fS
 fS
-gb
-gb
-gb
+xA
+xA
+xA
 aa
 "}
 (35,1,1) = {"
@@ -3744,10 +3747,10 @@ fS
 fS
 fS
 fS
-gb
-gb
-gb
-gb
+xA
+xA
+xA
+xA
 aa
 "}
 (36,1,1) = {"
@@ -3795,10 +3798,10 @@ aa
 aa
 aa
 aa
-gb
-gb
-gb
-gb
+xA
+xA
+xA
+xA
 aa
 "}
 (37,1,1) = {"
@@ -3847,8 +3850,8 @@ aa
 aa
 aa
 aa
-gb
-gb
+xA
+xA
 aa
 aa
 "}

--- a/_maps/RandomRuins/SpaceRuins/derelict4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict4.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "b" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/unpowered)
 "c" = (
 /turf/open/floor/plating/asteroid/airless,

--- a/_maps/RandomRuins/SpaceRuins/derelict5.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict5.dmm
@@ -3,13 +3,13 @@
 /turf/template_noop,
 /area/template_noop)
 "b" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/unpowered/no_grav)
 "c" = (
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered/no_grav)
 "d" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/unpowered)
 "e" = (
 /turf/closed/wall,

--- a/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "b" = (
-/turf/closed/mineral/random,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/space/has_grav)
 "c" = (
 /turf/open/floor/plating/asteroid/airless,

--- a/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
@@ -194,7 +194,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "J" = (
-/turf/closed/mineral/random,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/unpowered/no_grav)
 "K" = (
 /turf/open/floor/plasteel/stairs/right{

--- a/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "ab" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/unpowered/no_grav)
 "ac" = (
 /turf/open/floor/plating/asteroid/airless,

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -7,7 +7,7 @@
 /turf/template_noop,
 /area/template_noop)
 "ac" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/unpowered)
 "ad" = (
 /turf/closed/wall/r_wall,
@@ -4882,7 +4882,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "lU" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/space/has_grav/ancientstation/betanorth)
 "lV" = (
 /obj/structure/grille/broken,
@@ -4927,7 +4927,7 @@
 /area/ruin/space/has_grav/ancientstation)
 "md" = (
 /obj/structure/girder,
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/space/has_grav/ancientstation/betanorth)
 "me" = (
 /turf/open/floor/plating/airless,
@@ -4938,7 +4938,7 @@
 /area/ruin/space/has_grav/ancientstation/betanorth)
 "mg" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/space/has_grav/ancientstation/betanorth)
 "mh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5363,7 +5363,7 @@
 /area/ruin/space/has_grav/ancientstation/betanorth)
 "ni" = (
 /obj/structure/lattice,
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/ruin/unpowered)
 "nj" = (
 /obj/structure/lattice,

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -1832,7 +1832,7 @@
 	},
 /area/awaymission/moonoutpost19/main)
 "dA" = (
-/turf/closed/mineral,
+/turf/closed/mineral/random/no_caves,
 /area/awaymission/moonoutpost19/main)
 "dB" = (
 /obj/structure/sign/warning/vacuum{

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -252,9 +252,10 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 			break
 	if(!sanity)
 		return
-	SpawnFlora(T)
+	if(is_mining_level(z))
+		SpawnFlora(T)	//No space mushrooms, cacti.
 	// SpawnTerrain(T)
-	SpawnMonster(T)
+	SpawnMonster(T)		//Checks for danger area.
 	T.ChangeTurf(turf_type, null, CHANGETURF_IGNORE_AIR)
 
 /turf/open/floor/plating/asteroid/airless/cave/proc/SpawnMonster(turf/T)

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -132,7 +132,7 @@
 /turf/closed/mineral/random
 	var/list/mineralSpawnChanceList = list(/turf/closed/mineral/uranium = 5, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 10,
 		/turf/closed/mineral/silver = 12, /turf/closed/mineral/plasma = 20, /turf/closed/mineral/iron = 40, /turf/closed/mineral/titanium = 11,
-		/turf/closed/mineral/gibtonite = 4, /turf/closed/mineral/bscrystal = 1)
+		/turf/closed/mineral/gibtonite = 4, /turf/open/floor/plating/asteroid/airless/cave = 2, /turf/closed/mineral/bscrystal = 1)
 		//Currently, Adamantine won't spawn as it has no uses. -Durandan
 	var/mineralChance = 13
 	var/display_icon_state = "rock"
@@ -156,6 +156,11 @@
 			M.baseturfs = src.baseturfs
 			src = M
 			M.levelupdate()
+
+/turf/closed/mineral/random/no_caves
+	mineralSpawnChanceList = list(/turf/closed/mineral/uranium = 5, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 10,
+		/turf/closed/mineral/silver = 12, /turf/closed/mineral/plasma = 20, /turf/closed/mineral/iron = 40, /turf/closed/mineral/titanium = 11,
+		/turf/closed/mineral/gibtonite = 4, /turf/closed/mineral/bscrystal = 1)
 
 /turf/closed/mineral/random/high_chance
 	icon_state = "rock_highchance"

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -132,7 +132,7 @@
 /turf/closed/mineral/random
 	var/list/mineralSpawnChanceList = list(/turf/closed/mineral/uranium = 5, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 10,
 		/turf/closed/mineral/silver = 12, /turf/closed/mineral/plasma = 20, /turf/closed/mineral/iron = 40, /turf/closed/mineral/titanium = 11,
-		/turf/closed/mineral/gibtonite = 4, /turf/open/floor/plating/asteroid/airless/cave = 2, /turf/closed/mineral/bscrystal = 1)
+		/turf/closed/mineral/gibtonite = 4, /turf/closed/mineral/bscrystal = 1)
 		//Currently, Adamantine won't spawn as it has no uses. -Durandan
 	var/mineralChance = 13
 	var/display_icon_state = "rock"
@@ -156,7 +156,6 @@
 			M.baseturfs = src.baseturfs
 			src = M
 			M.levelupdate()
-
 
 /turf/closed/mineral/random/high_chance
 	icon_state = "rock_highchance"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
closes #43207
closes #40930

Space caves no longer spawn flora, and a few more space ruins now have random mineral spaws as I replaced non-mineral walls with the no_caves variant. Replacements generally made where: The rock was too small, or previously of the no mineral variety.

No changes for lavaland.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugs bugs bugs
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Space asteroids no longer spawn caves or cacti/mushrooms.
tweak: Additional space ruins will have ores spawn in mineral walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
