### PR TITLE
prevents fried foods from duplicating

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1121,11 +1121,6 @@
 	item_state = "beachball"
 	w_class = WEIGHT_CLASS_BULKY //Stops people from hiding it in their bags/pockets
 
-/obj/item/toy/beach_ball/afterattack(atom/target as mob|obj|turf|area, mob/user)
-	. = ..()
-	if(user.dropItemToGround(src))
-		throw_at(target, throw_range, throw_speed)
-
 /*
  * Clockwork Watch
  */

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -228,6 +228,11 @@
 		fried.forceMove(src)
 		trash = fried
 
+/obj/item/reagent_containers/food/snacks/deepfryholder/generate_trash(atom/location)
+	if(trash)
+		QDEL_NULL(trash)
+	. = ..()
+	
 /obj/item/reagent_containers/food/snacks/deepfryholder/Destroy()
 	if(trash)
 		QDEL_NULL(trash)

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -226,21 +226,15 @@
 		qdel(fried)
 	else
 		fried.forceMove(src)
-		trash = fried
-
-/obj/item/reagent_containers/food/snacks/deepfryholder/generate_trash(atom/location)
-	if(trash)
-		QDEL_NULL(trash)
-	. = ..()
 	
 /obj/item/reagent_containers/food/snacks/deepfryholder/Destroy()
-	if(trash)
-		QDEL_NULL(trash)
+	if(contents)
+		QDEL_LIST(contents)
 	. = ..()
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/On_Consume(mob/living/eater)
-	if(trash)
-		QDEL_NULL(trash)
+	if(contents)
+		QDEL_LIST(contents)
 	..()
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/proc/fry(cook_time = 30)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fried food no longer clones itself when added to anything
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
fixes: #44123 #46484 #39446
## Why It's Good For The Game
fixes bugs
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: deep fried foods no longer duplicate when added to other things
del: beach balls no longer randomly drop when you click on walls or fryers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
