### PR TITLE
fixes antag token vendor sprite and kinda fixes cargo exports text

### DIFF
--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -32,48 +32,48 @@
 /datum/export/material/bananium
 	cost = 1000
 	material_id = /datum/material/bananium
-	message = "cm<sup>3</sup> of bananium"
+	message = "cm3 of bananium"
 
 /datum/export/material/diamond
 	cost = 500
 	material_id = /datum/material/diamond
-	message = "cm<sup>3</sup> of diamonds"
+	message = "cm3 of diamonds"
 
 /datum/export/material/plasma
 	cost = 200
 	k_elasticity = 0
 	material_id = /datum/material/plasma
-	message = "cm<sup>3</sup> of plasma"
+	message = "cm3 of plasma"
 
 /datum/export/material/uranium
 	cost = 100
 	material_id = /datum/material/uranium
-	message = "cm<sup>3</sup> of uranium"
+	message = "cm3 of uranium"
 
 /datum/export/material/gold
 	cost = 125
 	material_id = /datum/material/gold
-	message = "cm<sup>3</sup> of gold"
+	message = "cm3 of gold"
 
 /datum/export/material/silver
 	cost = 50
 	material_id = /datum/material/silver
-	message = "cm<sup>3</sup> of silver"
+	message = "cm3 of silver"
 
 /datum/export/material/titanium
 	cost = 125
 	material_id = /datum/material/titanium
-	message = "cm<sup>3</sup> of titanium"
+	message = "cm3 of titanium"
 
 /datum/export/material/adamantine
 	cost = 500
 	material_id = /datum/material/adamantine
-	message = "cm<sup>3</sup> of adamantine"
+	message = "cm3 of adamantine"
 
 /datum/export/material/mythril
 	cost = 1500
 	material_id = /datum/material/mythril
-	message = "cm<sup>3</sup> of mythril"
+	message = "cm3 of mythril"
 
 /datum/export/material/bscrystal
 	cost = 300
@@ -82,17 +82,17 @@
 
 /datum/export/material/plastic
 	cost = 25
-	message = "cm<sup>3</sup> of plastic"
+	message = "cm3 of plastic"
 	material_id = /datum/material/plastic
 
 /datum/export/material/runite
 	cost = 600
-	message = "cm<sup>3</sup> of runite"
+	message = "cm3 of runite"
 	material_id = /datum/material/runite
 
 /datum/export/material/metal
 	cost = 5
-	message = "cm<sup>3</sup> of metal"
+	message = "cm3 of metal"
 	material_id = /datum/material/iron
 	export_types = list(
 		/obj/item/stack/sheet/metal, /obj/item/stack/tile/plasteel,
@@ -100,7 +100,7 @@
 
 /datum/export/material/glass
 	cost = 5
-	message = "cm<sup>3</sup> of glass"
+	message = "cm3 of glass"
 	material_id = /datum/material/glass
 	export_types = list(/obj/item/stack/sheet/glass, /obj/item/stack/ore,
 		/obj/item/shard)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -443,7 +443,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 /obj/item/coin/antagtoken
 	name = "antag token"
 	desc = "A novelty coin that helps the heart know what hard evidence cannot prove."
-	icon = "coin_valid"
+	icon_state = "coin_valid"
 	custom_materials = list(/datum/material/plastic = 400)
 	sideslist = list("valid", "salad")
 	material_flags = MATERIAL_NO_COLOR

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -443,6 +443,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 /obj/item/coin/antagtoken
 	name = "antag token"
 	desc = "A novelty coin that helps the heart know what hard evidence cannot prove."
+	icon = "coin_valid"
 	custom_materials = list(/datum/material/plastic = 400)
 	sideslist = list("valid", "salad")
 	material_flags = MATERIAL_NO_COLOR


### PR DESCRIPTION
## About The Pull Request

changes antag token default sprite to coin_valid so it looks good in vendor
replaces < sup>3</ sup> in cargo exports with just 3, i couldnt find a way to make it superscript

## Why It's Good For The Game

fix man bad

## Changelog
:cl:
fix: antag token now shows up in the vendor properly
spellcheck: exporting materials should look ok again
/:cl: