### PR TITLE
Soap for Mediborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -283,7 +283,8 @@
 		/obj/item/borg/cyborghug/medical,
 		/obj/item/stack/medical/gauze/cyborg,
 		/obj/item/organ_storage,
-		/obj/item/borg/lollipop)
+		/obj/item/borg/lollipop,
+		/obj/item/soap/nanotrasen)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/hacked)
 	ratvar_modules = list(
 		/obj/item/clockwork/slab/cyborg/medical,


### PR DESCRIPTION
### About The Pull Request
Gives the mediborg soap so it can actually disinfect surfaces and help stop the spread of disease.

### Why It's Good For The Game
As per above. In practice I find that cleanliness is in practice often elusive, especially in Medbay which rapidly becomes a massive, festering, teeming disease vector while you are completely powerless to do anything to stem the disgusting tide of puke puddles, blood and gibs strewn everywhere, causing disease to rapidly hit epidemic levels. It doesn't encroach on the Janiborg meaningfully because you won't even be a tenth as efficient at cleaning; Janiborg integrated scrubbers alone, without any module use at all, are vastly more efficient at cleaning than soap; it simply gives you a much needed tool to help stem the spread of disease via basic hygiene as needed. Moreover, there is existing precedent of limited module overlap and it's also thematic.

It should also be noted that medborgs can already clean large areas efficiently using chemical reactions; soap is more QoL than anything else, as it's a PITA to keep minting those reactions. 

### Changelog
🆑
add: Mediborgs can finally use soap to clean up disease bearing blood, puke and mucus.
/🆑