### PR TITLE
Splits the ranged and the melee part of afterattack into two different procs.

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -163,7 +163,7 @@
 #define COMSIG_MOB_ITEM_ATTACK "mob_item_attack"				//from base of /obj/item/attack(): (mob/M, mob/user)
 	#define COMPONENT_ITEM_NO_ATTACK 1
 #define COMSIG_MOB_APPLY_DAMGE	"mob_apply_damage"				//from base of /mob/living/proc/apply_damage(): (damage, damagetype, def_zone)
-#define COMSIG_MOB_ITEM_AFTERATTACK "mob_item_afterattack"		//from base of obj/item/afterattack(): (atom/target, mob/user, proximity_flag, click_parameters)
+#define COMSIG_MOB_ITEM_AFTERATTACK "mob_item_afterattack"		//from base of obj/item/afterattack(): (atom/target, mob/user, click_parameters)
 #define COMSIG_MOB_ATTACK_RANGED "mob_attack_ranged"			//from base of mob/RangedAttack(): (atom/A, params)
 #define COMSIG_MOB_THROW "mob_throw"							//from base of /mob/throw_item(): (atom/target)
 #define COMSIG_MOB_EXAMINATE "mob_examinate"					//from base of /mob/verb/examinate(): (atom/target)
@@ -223,6 +223,7 @@
 #define COMSIG_ITEM_PRE_ATTACK "item_pre_attack"				//from base of obj/item/pre_attack(): (atom/target, mob/user, params)
 	#define COMPONENT_NO_ATTACK 1
 #define COMSIG_ITEM_AFTERATTACK "item_afterattack"				//from base of obj/item/afterattack(): (atom/target, mob/user, params)
+#define COMSIG_ITEM_RANGEDATTACK "item_rangedattack"			//from base of obj/item/ranged_attack(): (atom/target, mob/user, params)
 #define COMSIG_ITEM_EQUIPPED "item_equip"						//from base of obj/item/equipped(): (/mob/equipper, slot)
 #define COMSIG_ITEM_DROPPED "item_drop"							//from base of obj/item/dropped(): (mob/user)
 #define COMSIG_ITEM_PICKUP "item_pickup"						//from base of obj/item/pickup(): (/mob/taker)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -61,7 +61,7 @@
 	The most common are:
 	* mob/UnarmedAttack(atom,adjacent) - used here only when adjacent, with no item in hand; in the case of humans, checks gloves
 	* atom/attackby(item,user) - used only when adjacent
-	* item/afterattack(atom,user,adjacent,params) - used both ranged and adjacent
+	* item/ranged_attack(atom,user,params) - used for ranged
 	* mob/RangedAttack(atom,params) - used only ranged, only used for tk and laser eyes but could be changed
 */
 /mob/proc/ClickOn( atom/A, params )
@@ -131,32 +131,21 @@
 
 	//These are always reachable.
 	//User itself, current loc, and user inventory
-	if(A in DirectAccess())
+	var/proximity = !loc.AllowClick() ? CanReach(A,W) : FALSE
+
+	if(proximity || A in DirectAccess())
 		if(W)
 			W.melee_attack_chain(src, A, params)
-		else
-			if(ismob(A))
-				changeNext_move(CLICK_CD_MELEE)
-			UnarmedAttack(A)
+			return
+		if(ismob(A))
+			changeNext_move(CLICK_CD_MELEE)
+		UnarmedAttack(A, proximity)
 		return
 
-	//Can't reach anything else in lockers or other weirdness
-	if(!loc.AllowClick())
+	if(W)
+		W.ranged_attack(A, src, params)
 		return
-
-	//Standard reach turf to turf or reaching inside storage
-	if(CanReach(A,W))
-		if(W)
-			W.melee_attack_chain(src, A, params)
-		else
-			if(ismob(A))
-				changeNext_move(CLICK_CD_MELEE)
-			UnarmedAttack(A,1)
-	else
-		if(W)
-			W.afterattack(A,src,0,params)
-		else
-			RangedAttack(A,params)
+	RangedAttack(A, params)
 
 //Is the atom obscured by a PREVENT_CLICK_UNDER_1 object above it
 /atom/proc/IsObscured()

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -131,7 +131,7 @@
 
 	//These are always reachable.
 	//User itself, current loc, and user inventory
-	var/proximity = !loc.AllowClick() ? CanReach(A,W) : FALSE
+	var/proximity = loc.AllowClick() ? CanReach(A,W) : FALSE
 
 	if(proximity || A in DirectAccess())
 		if(W)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -82,7 +82,7 @@
 				W.melee_attack_chain(src, A, params)
 				return
 			else
-				W.afterattack(A, src, 0, params)
+				W.ranged_attack(A, src, params)
 				return
 
 //Middle click cycles through selected modules.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -20,7 +20,7 @@
 	if(QDELETED(target))
 		stack_trace("The target of an item attack got deleted and melee_attack_chain was not stopped.")
 		return
-	afterattack(target, user, TRUE, params)
+	afterattack(target, user, params)
 
 // Called when the item is in the active hand, and clicked; alternately, there is an 'activate held object' verb or you can hit pagedown.
 /obj/item/proc/attack_self(mob/user)
@@ -115,12 +115,14 @@
 	else
 		return ..()
 
-// Proximity_flag is 1 if this afterattack was called on something adjacent, in your square, or on your person.
-// Click parameters is the params string from byond Click() code, see that documentation.
-/obj/item/proc/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	SEND_SIGNAL(src, COMSIG_ITEM_AFTERATTACK, target, user, proximity_flag, click_parameters)
-	SEND_SIGNAL(user, COMSIG_MOB_ITEM_AFTERATTACK, target, user, proximity_flag, click_parameters)
+///Called as the last part of the melee_attack_chain
+/obj/item/proc/afterattack(atom/target, mob/user, click_parameters)
+	SEND_SIGNAL(src, COMSIG_ITEM_AFTERATTACK, target, user, click_parameters)
+	SEND_SIGNAL(user, COMSIG_MOB_ITEM_AFTERATTACK, target, user, click_parameters)
 
+///Called when trying to click something that you can not reach.
+/obj/item/proc/ranged_attack(atom/target, mob/user, click_parameters)
+	SEND_SIGNAL(src, COMSIG_ITEM_RANGEDATTACK, target, user, click_parameters)
 
 /obj/item/proc/get_clamped_volume()
 	if(w_class)

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -119,8 +119,16 @@
 	focus.attack_self_tk(user)
 	update_icon()
 
-/obj/item/tk_grab/afterattack(atom/target, mob/living/carbon/user, proximity, params)//TODO: go over this
+/obj/item/tk_grab/ranged_attack(atom/target, mob/living/carbon/user, params)
 	. = ..()
+	tk_attack(target, user, params)
+
+/obj/item/tk_grab/pre_attack(atom/target, mob/living/carbon/user, params)
+	..()
+	tk_attack(target, user, params)
+	return TRUE
+
+/obj/item/tk_grab/proc/tk_attack(atom/target, mob/living/carbon/user, params)
 	if(!target || !user)
 		return
 
@@ -134,7 +142,6 @@
 		target.attack_self_tk(user)
 		update_icon()
 		return
-
 
 	if(!isturf(target) && isitem(focus) && target.Adjacent(focus))
 		apply_focus_overlay()

--- a/code/datums/components/bane.dm
+++ b/code/datums/components/bane.dm
@@ -8,7 +8,7 @@
 /datum/component/bane/Initialize(mobtype, damage_multiplier=1)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
-	
+
 	if(ispath(mobtype, /mob/living))
 		src.mobtype = mobtype
 	else if(ispath(mobtype, /datum/species))
@@ -27,12 +27,12 @@
 /datum/component/bane/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_ITEM_AFTERATTACK)
 
-/datum/component/bane/proc/speciesCheck(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
+/datum/component/bane/proc/speciesCheck(obj/item/source, atom/target, mob/user, click_parameters)
 	if(!is_species(target, speciestype))
 		return
 	activate(source, target, user)
 
-/datum/component/bane/proc/mobCheck(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
+/datum/component/bane/proc/mobCheck(obj/item/source, atom/target, mob/user, click_parameters)
 	if(!istype(target, mobtype))
 		return
 	activate(source, target, user)

--- a/code/datums/components/igniter.dm
+++ b/code/datums/components/igniter.dm
@@ -18,9 +18,7 @@
 /datum/component/igniter/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_ITEM_AFTERATTACK, COMSIG_HOSTILE_ATTACKINGTARGET, COMSIG_PROJECTILE_ON_HIT))
 
-/datum/component/igniter/proc/item_afterattack(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
-	if(!proximity_flag)
-		return
+/datum/component/igniter/proc/item_afterattack(obj/item/source, atom/target, mob/user, click_parameters)
 	do_igniter(target)
 
 /datum/component/igniter/proc/hostile_attackingtarget(mob/living/simple_animal/hostile/attacker, atom/target)

--- a/code/datums/components/knockback.dm
+++ b/code/datums/components/knockback.dm
@@ -20,9 +20,7 @@
 /datum/component/knockback/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_ITEM_AFTERATTACK, COMSIG_HOSTILE_ATTACKINGTARGET, COMSIG_PROJECTILE_ON_HIT))
 
-/datum/component/knockback/proc/item_afterattack(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
-	if(!proximity_flag)
-		return
+/datum/component/knockback/proc/item_afterattack(obj/item/source, atom/target, mob/user, click_parameters)
 	do_knockback(target, user, get_dir(source, target))
 
 /datum/component/knockback/proc/hostile_attackingtarget(mob/living/simple_animal/hostile/attacker, atom/target)

--- a/code/datums/components/lifesteal.dm
+++ b/code/datums/components/lifesteal.dm
@@ -19,9 +19,7 @@
 /datum/component/lifesteal/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_ITEM_AFTERATTACK, COMSIG_HOSTILE_ATTACKINGTARGET, COMSIG_PROJECTILE_ON_HIT))
 
-/datum/component/lifesteal/proc/item_afterattack(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
-	if(!proximity_flag)
-		return
+/datum/component/lifesteal/proc/item_afterattack(obj/item/source, atom/target, mob/user, click_parameters)
 	do_lifesteal(user, target)
 
 /datum/component/lifesteal/proc/hostile_attackingtarget(mob/living/simple_animal/hostile/attacker, atom/target)

--- a/code/datums/components/summoning.dm
+++ b/code/datums/components/summoning.dm
@@ -33,9 +33,7 @@
 /datum/component/summoning/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_ITEM_AFTERATTACK, COMSIG_HOSTILE_ATTACKINGTARGET, COMSIG_PROJECTILE_ON_HIT))
 
-/datum/component/summoning/proc/item_afterattack(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
-	if(!proximity_flag)
-		return
+/datum/component/summoning/proc/item_afterattack(obj/item/source, atom/target, mob/user, click_parameters)
 	do_spawn_mob(get_turf(target), user)
 
 /datum/component/summoning/proc/hostile_attackingtarget(mob/living/simple_animal/hostile/attacker, atom/target)

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -28,7 +28,7 @@
 	icon_state = "zapper"
 	item_state = "zapper"
 
-/obj/item/melee/touch_attack/shock/afterattack(atom/target, mob/living/carbon/user, proximity)
+/obj/item/melee/touch_attack/shock/afterattack(atom/target, mob/living/carbon/user)
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
 		if(C.electrocute_act(15, user, 1, FALSE, FALSE, FALSE, FALSE, FALSE))//doesnt stun. never let this stun

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -167,12 +167,6 @@ RLD
 	else
 		return TRUE
 
-/obj/item/construction/proc/prox_check(proximity)
-	if(proximity)
-		return TRUE
-	else
-		return FALSE
-
 
 /obj/item/construction/rcd
 	name = "rapid-construction-device (RCD)"
@@ -556,10 +550,8 @@ RLD
 	else
 		return FALSE
 
-/obj/item/construction/rcd/afterattack(atom/A, mob/user, proximity)
+/obj/item/construction/rcd/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!prox_check(proximity))
-		return
 	rcd_create(A, user)
 
 /obj/item/construction/rcd/proc/detonate_pulse()
@@ -670,14 +662,13 @@ RLD
 	item_state = "oldrcd"
 	has_ammobar = FALSE
 
-/obj/item/construction/rcd/arcd/afterattack(atom/A, mob/user)
+/obj/item/construction/rcd/arcd/ranged_attack(atom/A, mob/user)
 	. = ..()
 	if(!range_check(A,user))
 		return
 	if(target_check(A,user))
 		user.Beam(A,icon_state="rped_upgrade",time=30)
 	rcd_create(A,user)
-
 
 
 // RAPID LIGHTING DEVICE
@@ -741,10 +732,17 @@ RLD
 			. |= dupe
 
 
-/obj/item/construction/rld/afterattack(atom/A, mob/user)
+/obj/item/construction/rld/ranged_attack(atom/A, mob/user)
 	. = ..()
 	if(!range_check(A,user))
 		return
+	rld_create(A, user)
+
+/obj/item/construction/rld/afterattack(atom/A, mob/user)
+	. = ..()
+	rld_create(A, user)
+
+/obj/item/construction/rld/proc/rld_create(atom/A, mob/user)
 	var/turf/start = get_turf(src)
 	switch(mode)
 		if(REMOVE_MODE)

--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -58,10 +58,8 @@ RSF
 			to_chat(user, "Changed dispensing mode to 'Cigarette'")
 	// Change mode
 
-/obj/item/rsf/afterattack(atom/A, mob/user, proximity)
+/obj/item/rsf/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if (!(istype(A, /obj/structure/table) || isfloorturf(A)))
 		return
 
@@ -152,11 +150,9 @@ RSF
 	if(matter < 10)
 		matter++
 
-/obj/item/cookiesynth/afterattack(atom/A, mob/user, proximity)
+/obj/item/cookiesynth/afterattack(atom/A, mob/user)
 	. = ..()
 	if(cooldown > world.time)
-		return
-	if(!proximity)
 		return
 	if (!(istype(A, /obj/structure/table) || isfloorturf(A)))
 		return

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -10,11 +10,10 @@
 /obj/item/bodybag/attack_self(mob/user)
 	deploy_bodybag(user, user.loc)
 
-/obj/item/bodybag/afterattack(atom/target, mob/user, proximity)
+/obj/item/bodybag/afterattack(atom/target, mob/user)
 	. = ..()
-	if(proximity)
-		if(isopenturf(target))
-			deploy_bodybag(user, target)
+	if(isopenturf(target))
+		deploy_bodybag(user, target)
 
 /obj/item/bodybag/proc/deploy_bodybag(mob/user, atom/location)
 	var/obj/structure/closet/body_bag/R = new unfoldedbag_path(location)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -73,24 +73,24 @@
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	item_flags = NO_MAT_REDEMPTION | NOBLUDGEON
-	var/prox_check = TRUE //If the emag requires you to be in range
+
+/obj/item/card/emag/attack()
+	return
+
+/obj/item/card/emag/afterattack(atom/target, mob/user)
+	. = ..()
+	log_combat(user, target, "attempted to emag")
+	target.emag_act(user)
 
 /obj/item/card/emag/bluespace
 	name = "bluespace cryptographic sequencer"
 	desc = "It's a blue card with a magnetic strip attached to some circuitry. It appears to have some sort of transmitter attached to it."
 	color = rgb(40, 130, 255)
-	prox_check = FALSE
 
-/obj/item/card/emag/attack()
-	return
-
-/obj/item/card/emag/afterattack(atom/target, mob/user, proximity)
+/obj/item/card/emag/bluespace/ranged_attack(atom/target, mob/user)
 	. = ..()
-	var/atom/A = target
-	if(!proximity && prox_check)
-		return
-	log_combat(user, A, "attempted to emag")
-	A.emag_act(user)
+	log_combat(user, target, "attempted to bluespace emag") //Technically not duplicate code.
+	target.emag_act(user)
 
 /obj/item/card/emagfake
 	desc = "It's a card with a magnetic strip attached to some circuitry. Closer inspection shows that this card is a poorly made replica, with a \"DonkCo\" logo stamped on the back."
@@ -376,9 +376,7 @@ update_label()
 	chameleon_action.chameleon_name = "ID Card"
 	chameleon_action.initialize_disguises()
 
-/obj/item/card/id/syndicate/afterattack(obj/item/O, mob/user, proximity)
-	if(!proximity)
-		return
+/obj/item/card/id/syndicate/afterattack(obj/item/O, mob/user)
 	if(istype(O, /obj/item/card/id))
 		var/obj/item/card/id/I = O
 		src.access |= I.access

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -158,9 +158,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	else
 		return ..()
 
-/obj/item/clothing/mask/cigarette/afterattack(obj/item/reagent_containers/glass/glass, mob/user, proximity)
+/obj/item/clothing/mask/cigarette/afterattack(obj/item/reagent_containers/glass/glass, mob/user)
 	. = ..()
-	if(!proximity || lit) //can't dip if cigarette is lit (it will heat the reagents in the glass instead)
+	if(lit) //can't dip if cigarette is lit (it will heat the reagents in the glass instead)
 		return
 	if(istype(glass))	//you can dip cigarettes into beakers
 		if(glass.reagents.trans_to(src, chem_volume, transfered_by = user))	//if reagents were transfered, show the message
@@ -734,10 +734,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "cig_paper"
 	w_class = WEIGHT_CLASS_TINY
 
-/obj/item/rollingpaper/afterattack(atom/target, mob/user, proximity)
+/obj/item/rollingpaper/afterattack(atom/target, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(istype(target, /obj/item/reagent_containers/food/snacks/grown))
 		var/obj/item/reagent_containers/food/snacks/grown/O = target
 		if(O.dry)

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -85,9 +85,9 @@
 		to_chat(user, "<span class='warning'>[src] crumbles into tiny bits!</span>")
 		qdel(src)
 
-/obj/item/soap/afterattack(atom/target, mob/user, proximity)
+/obj/item/soap/afterattack(atom/target, mob/user)
 	. = ..()
-	if(!proximity || !check_allowed_items(target))
+	if(!check_allowed_items(target))
 		return
 	//I couldn't feasibly  fix the overlay bugs caused by cleaning items we are wearing.
 	//So this is a workaround. This also makes more sense from an IC standpoint. ~Carn

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -30,10 +30,14 @@
 			mode = WAND_OPEN
 	to_chat(user, "Now in mode: [mode].")
 
+/obj/item/door_remote/ranged_attack(atom/A, mob/user)
+	. = ..()
+	afterattack(A, user)
+
 // Airlock remote works by sending NTNet packets to whatever it's pointed at.
 /obj/item/door_remote/afterattack(atom/A, mob/user)
 	. = ..()
-	var/datum/component/ntnet_interface/target_interface = A.GetComponent(/datum/component/ntnet_interface)
+	var/datum/component/ntnet_interface/target_interface = A.GetComponent(/datum/component/ntnet_interface) //OOF
 
 	if(!target_interface)
 		return

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -238,7 +238,7 @@
 				if (!isnull(chosen_colour))
 					paint_color = chosen_colour
 					. = TRUE
-				else 
+				else
 					. = FALSE
 		if("enter_text")
 			var/txt = stripped_input(usr,"Choose what to write.",
@@ -253,9 +253,9 @@
 	var/static/regex/crayon_r = new /regex(@"[^\w!?,.=%#&+\/\-]")
 	return replacetext(lowertext(text), crayon_r, "")
 
-/obj/item/toy/crayon/afterattack(atom/target, mob/user, proximity, params)
+/obj/item/toy/crayon/afterattack(atom/target, mob/user, params)
 	. = ..()
-	if(!proximity || !check_allowed_items(target))
+	if(!check_allowed_items(target))
 		return
 
 	var/static/list/punctuation = list("!","?",".",",","/","+","-","=","%","#","&")
@@ -501,7 +501,7 @@
 	charges = -1
 	dye_color = DYE_RAINBOW
 
-/obj/item/toy/crayon/rainbow/afterattack(atom/target, mob/user, proximity, params)
+/obj/item/toy/crayon/rainbow/afterattack(atom/target, mob/user, params)
 	paint_color = rgb(rand(0,255), rand(0,255), rand(0,255))
 	. = ..()
 
@@ -627,9 +627,7 @@
 		. += "It is empty."
 	. += "<span class='notice'>Alt-click [src] to [ is_capped ? "take the cap off" : "put the cap on"].</span>"
 
-/obj/item/toy/crayon/spraycan/afterattack(atom/target, mob/user, proximity, params)
-	if(!proximity)
-		return
+/obj/item/toy/crayon/spraycan/afterattack(atom/target, mob/user, params)
 
 	if(is_capped)
 		to_chat(user, "<span class='warning'>Take the cap off first!</span>")
@@ -669,7 +667,7 @@
 			if(color_hex2num(paint_color) < 350 && !istype(target, /obj/structure/window)) //Colors too dark are rejected
 				to_chat(usr, "<span class='warning'>A colour that dark on an object like this? Surely not...</span>")
 				return FALSE
-				
+
 			target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 
 			if(istype(target, /obj/structure/window))
@@ -703,8 +701,8 @@
 	desc = "A metallic container containing shiny synthesised paint."
 	charges = -1
 
-/obj/item/toy/crayon/spraycan/borg/afterattack(atom/target,mob/user,proximity, params)
-	var/diff = ..()
+/obj/item/toy/crayon/spraycan/borg/afterattack(atom/target,mob/user, params)
+	. = ..()
 	if(!iscyborg(user))
 		to_chat(user, "<span class='notice'>How did you get this?</span>")
 		qdel(src)
@@ -712,11 +710,11 @@
 
 	var/mob/living/silicon/robot/borgy = user
 
-	if(!diff)
+	if(!.)
 		return
 	// 25 is our cost per unit of paint, making it cost 25 energy per
 	// normal tag, 50 per window, and 250 per attack
-	var/cost = diff * 25
+	var/cost = . * 25
 	// Cyborgs shouldn't be able to use modules without a cell. But if they do
 	// it's free.
 	if(borgy.cell)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -858,10 +858,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 				else
 					user.show_message("<span class='notice'>No radiation detected.</span>")
 
-/obj/item/pda/afterattack(atom/A as mob|obj|turf|area, mob/user, proximity)
+/obj/item/pda/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	switch(scanmode)
 		if(PDA_SCANNER_REAGENT)
 			if(!isnull(A.reagents))

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -26,10 +26,8 @@
 	user.visible_message("<span class='suicide'>[user] is trying to upload [user.p_them()]self into [src]! That's not going to work out well!</span>")
 	return BRUTELOSS
 
-/obj/item/aicard/afterattack(atom/target, mob/user, proximity)
+/obj/item/aicard/afterattack(atom/target, mob/user)
 	. = ..()
-	if(!proximity || !target)
-		return
 	if(AI) //AI is on the card, implies user wants to upload it.
 		log_combat(user, AI, "uploaded", src, "to [target].")
 		target.transfer_ai(AI_TRANS_FROM_CARD, user, AI, src)

--- a/code/game/objects/items/devices/anomaly_neutralizer.dm
+++ b/code/game/objects/items/devices/anomaly_neutralizer.dm
@@ -10,10 +10,8 @@
 	slot_flags = ITEM_SLOT_BELT
 	item_flags = NOBLUDGEON
 
-/obj/item/anomaly_neutralizer/afterattack(atom/target, mob/user, proximity)
+/obj/item/anomaly_neutralizer/afterattack(atom/target, mob/user)
 	..()
-	if(!proximity || !target)
-		return
 	if(istype(target, /obj/effect/anomaly))
 		var/obj/effect/anomaly/A = target
 		to_chat(user, "<span class='notice'>The circuitry of [src] fries from the strain of neutralizing [A]!</span>")

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -35,10 +35,8 @@
 	else
 		to_chat(user, "<span class='warning'>You can't use [src] while inside something!</span>")
 
-/obj/item/chameleon/afterattack(atom/target, mob/user , proximity)
+/obj/item/chameleon/afterattack(atom/target, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(!check_sprite(target))
 		return
 	if(active_dummy)//I now present you the blackli(f)st

--- a/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
+++ b/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
@@ -46,10 +46,8 @@
 	addtimer(CALLBACK(src, .proc/recharge), recharge_time)
 	return TRUE //The actual circuit magic itself is done on a per-object basis
 
-/obj/item/electroadaptive_pseudocircuit/afterattack(atom/target, mob/living/user, proximity)
+/obj/item/electroadaptive_pseudocircuit/afterattack(atom/target, mob/living/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(!is_type_in_typecache(target, recycleable_circuits))
 		return
 	circuits++

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -170,17 +170,16 @@
 	brightness_on = 2
 	var/holo_cooldown = 0
 
-/obj/item/flashlight/pen/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/flashlight/pen/ranged_attack(atom/target, mob/user)
 	. = ..()
-	if(!proximity_flag)
-		if(holo_cooldown > world.time)
-			to_chat(user, "<span class='warning'>[src] is not ready yet!</span>")
-			return
-		var/T = get_turf(target)
-		if(locate(/mob/living) in T)
-			new /obj/effect/temp_visual/medical_holosign(T,user) //produce a holographic glow
-			holo_cooldown = world.time + 100
-			return
+	if(holo_cooldown > world.time)
+		to_chat(user, "<span class='warning'>[src] is not ready yet!</span>")
+		return
+	var/T = get_turf(target)
+	if(locate(/mob/living) in T)
+		new /obj/effect/temp_visual/medical_holosign(T,user) //produce a holographic glow
+		holo_cooldown = world.time + 100
+		return
 
 /obj/effect/temp_visual/medical_holosign
 	name = "medical holosign"
@@ -392,10 +391,8 @@
 		..()
 	return
 
-/obj/item/flashlight/emp/afterattack(atom/movable/A, mob/user, proximity)
+/obj/item/flashlight/emp/afterattack(atom/movable/A, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 
 	if(emp_cur_charges > 0)
 		emp_cur_charges -= 1

--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -16,8 +16,15 @@
 	var/list/current_fields
 	var/field_distance_limit = 7
 
-/obj/item/forcefield_projector/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/forcefield_projector/ranged_attack(atom/target, mob/user)
 	. = ..()
+	generate_forcefield(target, user)
+
+/obj/item/forcefield_projector/afterattack(atom/target, mob/user)
+	. = ..()
+	generate_forcefield(target, user)
+
+/obj/item/forcefield_projector/proc/generate_forcefield(atom/target, mob/user)
 	if(!check_allowed_items(target, 1))
 		return
 	if(istype(target, /obj/structure/projected_forcefield))

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -131,6 +131,10 @@
 	update_icon()
 	to_chat(user, "<span class='notice'>[icon2html(src, user)] You switch [scanning ? "on" : "off"] [src].</span>")
 
+/obj/item/geiger_counter/ranged_attack(atom/target, mob/user)
+	. = ..()
+	afterattack(target, user)
+
 /obj/item/geiger_counter/afterattack(atom/target, mob/user)
 	. = ..()
 	if(user.a_intent == INTENT_HELP)

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -64,7 +64,11 @@
 		else
 			. += "<span class='notice'>A class <b>[diode.rating]</b> laser diode is installed. It is <i>screwed</i> in place.</span>"
 
-/obj/item/laser_pointer/afterattack(atom/target, mob/living/user, flag, params)
+/obj/item/laser_pointer/afterattack(atom/target, mob/living/user, params)
+	. = ..()
+	laser_act(target, user, params)
+
+/obj/item/laser_pointer/ranged_attack(atom/target, mob/user, params)
 	. = ..()
 	laser_act(target, user, params)
 

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -236,8 +236,6 @@
 
 /obj/item/lightreplacer/afterattack(atom/T, mob/U, proximity)
 	. = ..()
-	if(!proximity)
-		return
 	if(!isturf(T))
 		return
 

--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -8,11 +8,8 @@
 
 	materials = list(/datum/material/iron=5000, /datum/material/glass=2000)
 
-/obj/item/pipe_painter/afterattack(atom/A, mob/user, proximity_flag)
+/obj/item/pipe_painter/afterattack(atom/A, mob/user)
 	. = ..()
-	//Make sure we only paint adjacent items
-	if(!proximity_flag)
-		return
 
 	if(!istype(A, /obj/machinery/atmospherics/pipe))
 		return

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -747,11 +747,8 @@ GENE SCANNER
 /obj/item/sequence_scanner/attack_self_tk(mob/user)
 	return
 
-/obj/item/sequence_scanner/afterattack(obj/O, mob/user, proximity)
+/obj/item/sequence_scanner/afterattack(obj/O, mob/user)
 	. = ..()
-	if(!istype(O) || !proximity)
-		return
-
 	if(istype(O, /obj/machinery/computer/scan_consolenew))
 		var/obj/machinery/computer/scan_consolenew/C = O
 		if(C.stored_research)

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -63,7 +63,7 @@
 /obj/item/extinguisher/suicide_act(mob/living/carbon/user)
 	if (!safety && (reagents.total_volume >= 1))
 		user.visible_message("<span class='suicide'>[user] puts the nozzle to [user.p_their()] mouth. It looks like [user.p_theyre()] trying to extinguish the spark of life!</span>")
-		afterattack(user,user)
+		spray_load(user,user)
 		return OXYLOSS
 	else if (safety && (reagents.total_volume >= 1))
 		user.visible_message("<span class='warning'>[user] puts the nozzle to [user.p_their()] mouth... The safety's still on!</span>")
@@ -120,13 +120,19 @@
 	else
 		return 0
 
-/obj/item/extinguisher/afterattack(atom/target, mob/user , flag)
+/obj/item/extinguisher/afterattack(atom/target, mob/user)
 	. = ..()
 	// Make it so the extinguisher doesn't spray yourself when you click your inventory items
 	if (target.loc == user)
 		return
-	//TODO; Add support for reagents in water.
+	spray_load(target, user)
 
+/obj/item/extinguisher/ranged_attack(atom/target, mob/user)
+	. = ..()
+	spray_load(target, user)
+
+/obj/item/extinguisher/proc/spray_load(atom/target, mob/user)
+	//TODO; Add support for reagents in water.
 	if(refilling)
 		refilling = FALSE
 		return

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -65,10 +65,8 @@
 		M.update_inv_hands()
 	return
 
-/obj/item/flamethrower/afterattack(atom/target, mob/user, flag)
+/obj/item/flamethrower/ranged_attack(atom/target, mob/user)
 	. = ..()
-	if(flag)
-		return // too close
 	if(ishuman(user))
 		if(!can_trigger_gun(user))
 			return

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -128,7 +128,7 @@
 		prime()
 		return TRUE //It hit the grenade, not them
 
-/obj/item/grenade/afterattack(atom/target, mob/user)
+/obj/item/grenade/ranged_attack(atom/target, mob/user)
 	. = ..()
 	if(active)
 		user.throw_item(target)

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -67,7 +67,7 @@
 
 /obj/item/grenade/c4/attack_self(mob/user)
 	var/newtime = input(usr, "Please set the timer.", "Timer", 10) as num|null
-	
+
 	if (isnull(newtime))
 		return
 
@@ -76,11 +76,9 @@
 		det_time = newtime
 		to_chat(user, "Timer set for [det_time] seconds.")
 
-/obj/item/grenade/c4/afterattack(atom/movable/AM, mob/user, flag)
+/obj/item/grenade/c4/afterattack(atom/movable/AM, mob/user)
 	. = ..()
 	aim_dir = get_dir(user,AM)
-	if(!flag)
-		return
 
 	to_chat(user, "<span class='notice'>You start planting [src]. The timer is set to [det_time]...</span>")
 

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -18,37 +18,37 @@
 	var/holosign_type = /obj/structure/holosign/wetsign
 	var/holocreator_busy = FALSE //to prevent placing multiple holo barriers at once
 
-/obj/item/holosign_creator/afterattack(atom/target, mob/user, flag)
+/obj/item/holosign_creator/afterattack(atom/target, mob/user)
 	. = ..()
-	if(flag)
-		if(!check_allowed_items(target, 1))
-			return
-		var/turf/T = get_turf(target)
-		var/obj/structure/holosign/H = locate(holosign_type) in T
-		if(H)
-			to_chat(user, "<span class='notice'>You use [src] to deactivate [H].</span>")
-			qdel(H)
-		else
-			if(!is_blocked_turf(T, TRUE)) //can't put holograms on a tile that has dense stuff
-				if(holocreator_busy)
-					to_chat(user, "<span class='notice'>[src] is busy creating a hologram.</span>")
-					return
-				if(signs.len < max_signs)
-					playsound(src.loc, 'sound/machines/click.ogg', 20, TRUE)
-					if(creation_time)
-						holocreator_busy = TRUE
-						if(!do_after(user, creation_time, target = target))
-							holocreator_busy = FALSE
-							return
-						holocreator_busy = FALSE
-						if(signs.len >= max_signs)
-							return
-						if(is_blocked_turf(T, TRUE)) //don't try to sneak dense stuff on our tile during the wait.
-							return
-					H = new holosign_type(get_turf(target), src)
-					to_chat(user, "<span class='notice'>You create \a [H] with [src].</span>")
-				else
-					to_chat(user, "<span class='notice'>[src] is projecting at max capacity!</span>")
+	if(!check_allowed_items(target, 1))
+		return
+	var/turf/T = get_turf(target)
+	var/obj/structure/holosign/H = locate(holosign_type) in T
+	if(H)
+		to_chat(user, "<span class='notice'>You use [src] to deactivate [H].</span>")
+		qdel(H)
+		return
+	if(is_blocked_turf(T, TRUE)) //can't put holograms on a tile that has dense stuff
+		return
+	if(holocreator_busy)
+		to_chat(user, "<span class='notice'>[src] is busy creating a hologram.</span>")
+		return
+	if(signs.len < max_signs)
+		playsound(src.loc, 'sound/machines/click.ogg', 20, TRUE)
+		if(creation_time)
+			holocreator_busy = TRUE
+			if(!do_after(user, creation_time, target = target))
+				holocreator_busy = FALSE
+				return
+			holocreator_busy = FALSE
+			if(signs.len >= max_signs)
+				return
+			if(is_blocked_turf(T, TRUE)) //don't try to sneak dense stuff on our tile during the wait.
+				return
+		H = new holosign_type(get_turf(target), src)
+		to_chat(user, "<span class='notice'>You create \a [H] with [src].</span>")
+	else
+		to_chat(user, "<span class='notice'>[src] is projecting at max capacity!</span>")
 
 /obj/item/holosign_creator/attack(mob/living/carbon/human/M, mob/user)
 	return

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -504,10 +504,8 @@
 	attack_verb = list("attacked", "smashed", "crushed", "splattered", "cracked")
 	hitsound = 'sound/weapons/blade1.ogg'
 
-/obj/item/nullrod/pride_hammer/afterattack(atom/A as mob|obj|turf|area, mob/user, proximity)
+/obj/item/nullrod/pride_hammer/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(prob(30) && ishuman(A))
 		var/mob/living/carbon/human/H = A
 		user.reagents.trans_to(H, user.reagents.total_volume, 1, 1, 0, transfered_by = user)

--- a/code/game/objects/items/hot_potato.dm
+++ b/code/game/objects/items/hot_potato.dm
@@ -92,9 +92,9 @@
 	if(active)
 		to_chat(user, "<span class='userdanger'>You have a really bad feeling about [src]!</span>")
 
-/obj/item/hot_potato/afterattack(atom/target, mob/user, adjacent, params)
+/obj/item/hot_potato/afterattack(atom/target, mob/user, params)
 	. = ..()
-	if(!adjacent || !ismob(target))
+	if(!ismob(target))
 		return
 	force_onto(target, user)
 

--- a/code/game/objects/items/implants/implant_chem.dm
+++ b/code/game/objects/items/implants/implant_chem.dm
@@ -57,9 +57,9 @@
 	desc = "A glass case containing a remote chemical implant."
 	imp_type = /obj/item/implant/chem
 
-/obj/item/implantcase/chem/attackby(obj/item/W, mob/user, params)
+/obj/item/implantcase/chem/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/reagent_containers/syringe) && imp)
-		W.afterattack(imp, user, TRUE, params)
+		W.afterattack(imp, user)
 		return TRUE
 	else
 		return ..()

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -600,8 +600,7 @@
 		held_sausage = null
 		update_icon()
 
-/obj/item/melee/roastingstick/afterattack(atom/target, mob/user)
-	. = ..()
+/obj/item/melee/roastingstick/proc/handle_roasting(atom/target, mob/user)
 	if (!on)
 		return
 	if (is_type_in_typecache(target, ovens))
@@ -612,7 +611,7 @@
 			to_chat(user, "You send [held_sausage] towards [target].")
 			playsound(src, 'sound/items/rped.ogg', 50, TRUE)
 			beam = user.Beam(target,icon_state="rped_upgrade",time=100)
-		else if (user.Adjacent(target))
+		else if(user.Adjacent(target))
 			to_chat(user, "You extend [src] towards [target].")
 			playsound(src.loc, 'sound/weapons/batonextend.ogg', 50, TRUE)
 		else
@@ -622,6 +621,14 @@
 		else
 			QDEL_NULL(beam)
 			playsound(src, 'sound/weapons/batonextend.ogg', 50, TRUE)
+
+/obj/item/melee/roastingstick/ranged_attack(atom/target, mob/user)
+	. = ..()
+	handle_roasting(target, user)
+
+/obj/item/melee/roastingstick/afterattack(atom/target, mob/user)
+	. = ..()
+	handle_roasting(target, user)
 
 /obj/item/melee/roastingstick/proc/finish_roasting(user, atom/target)
 	to_chat(user, "You finish roasting [held_sausage]")

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -147,7 +147,7 @@
 	attack_verb = list("slashed", "stung", "prickled", "poked")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 
-/obj/item/melee/beesword/afterattack(atom/target, mob/user, proximity = TRUE)
+/obj/item/melee/beesword/afterattack(atom/target, mob/user)
 	. = ..()
 	user.changeNext_move(CLICK_CD_RAPID)
 	if(iscarbon(target))
@@ -239,7 +239,7 @@
 
 		user.Paralyze(knockdown_time_carbon * force)
 		user.adjustStaminaLoss(stamina_damage)
-		
+
 		additional_effects_carbon(user) // user is the target here
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
@@ -386,7 +386,7 @@
 
 	cooldown = 25
 	stamina_damage = 85
-	affect_silicon = TRUE 
+	affect_silicon = TRUE
 	on_sound = 'sound/weapons/contractorbatonextend.ogg'
 	on_stun_sound = 'sound/effects/contractorbatonhit.ogg'
 
@@ -440,12 +440,11 @@
 		if(!isspaceturf(T))
 			consume_turf(T)
 
-/obj/item/melee/supermatter_sword/afterattack(target, mob/user, proximity_flag)
+/obj/item/melee/supermatter_sword/afterattack(target, mob/user)
 	. = ..()
 	if(user && target == user)
 		user.dropItemToGround(src)
-	if(proximity_flag)
-		consume_everything(target)
+	consume_everything(target)
 
 /obj/item/melee/supermatter_sword/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	..()
@@ -515,9 +514,9 @@
 	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
 	hitsound = 'sound/weapons/whip.ogg'
 
-/obj/item/melee/curator_whip/afterattack(target, mob/user, proximity_flag)
+/obj/item/melee/curator_whip/afterattack(target, mob/user)
 	. = ..()
-	if(ishuman(target) && proximity_flag)
+	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		H.drop_all_held_items()
 		H.visible_message("<span class='danger'>[user] disarms [H]!</span>", "<span class='userdanger'>[user] disarmed you!</span>")
@@ -601,7 +600,7 @@
 		held_sausage = null
 		update_icon()
 
-/obj/item/melee/roastingstick/afterattack(atom/target, mob/user, proximity)
+/obj/item/melee/roastingstick/afterattack(atom/target, mob/user)
 	. = ..()
 	if (!on)
 		return

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -36,8 +36,6 @@
 
 /obj/item/mop/afterattack(atom/A, mob/user, proximity)
 	. = ..()
-	if(!proximity)
-		return
 
 	if(reagents.total_volume < 1)
 		to_chat(user, "<span class='warning'>Your mop is dry!</span>")

--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -80,8 +80,6 @@
 
 /obj/item/paint/afterattack(atom/target, mob/user, proximity)
 	. = ..()
-	if(!proximity)
-		return
 	if(paintleft <= 0)
 		icon_state = "paint_empty"
 		return
@@ -98,8 +96,6 @@
 
 /obj/item/paint/paint_remover/afterattack(atom/target, mob/user, proximity)
 	. = ..()
-	if(!proximity)
-		return
 	if(!isturf(target) || !isobj(target))
 		return
 	if(target.color != initial(target.color))

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -132,12 +132,14 @@
 		loadedWeightClass++
 	return TRUE
 
-/obj/item/pneumatic_cannon/afterattack(atom/target, mob/living/user, flag, params)
+/obj/item/pneumatic_cannon/afterattack(atom/target, mob/living/user, params)
 	. = ..()
-	if(flag && user.a_intent == INTENT_HARM) //melee attack
+	if(user.a_intent == INTENT_HARM) //melee attack
 		return
-	if(!istype(user))
-		return
+	Fire(user, target)
+
+/obj/item/pneumatic_cannon/ranged_attack(atom/target, mob/living/user)
+	. = ..()
 	Fire(user, target)
 
 /obj/item/pneumatic_cannon/proc/Fire(mob/living/user, var/atom/target)

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -303,8 +303,11 @@
 	var/staffcooldown = 0
 	var/staffwait = 30
 
+/obj/item/godstaff/afterattack(atom/target, mob/user, click_parameters)
+	. = ..()
+	ranged_attack(target, user, click_parameters)
 
-/obj/item/godstaff/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+/obj/item/godstaff/ranged_attack(atom/target, mob/user, click_parameters)
 	. = ..()
 	if(staffcooldown + staffwait > world.time)
 		return

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -169,9 +169,9 @@
 	to_chat(user, "<span class='notice'>You toggle [src] to \"[mode]\" mode.</span>")
 	update_icon()
 
-/obj/item/borg/charger/afterattack(obj/item/target, mob/living/silicon/robot/user, proximity_flag)
+/obj/item/borg/charger/afterattack(obj/item/target, mob/living/silicon/robot/user)
 	. = ..()
-	if(!proximity_flag || !iscyborg(user))
+	if(!iscyborg(user))
 		return
 	if(mode == "draw")
 		if(is_type_in_list(target, charge_machines))
@@ -446,8 +446,15 @@
 	user.visible_message("<span class='warning'>[user] shoots a high-velocity gumball at [target]!</span>")
 	check_amount()
 
-/obj/item/borg/lollipop/afterattack(atom/target, mob/living/user, proximity, click_params)
+/obj/item/borg/lollipop/afterattack(atom/target, mob/living/user, params)
 	. = ..()
+	do_candy_attack(target, user, TRUE, params)
+
+/obj/item/borg/lollipop/ranged_attack(atom/target, mob/living/user, params)
+	. = ..()
+	do_candy_attack(target, user, FALSE, params)
+
+/obj/item/borg/lollipop/proc/do_candy_attack(atom/target, mob/living/user, proximity, click_params)
 	check_amount()
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/R = user

--- a/code/game/objects/items/singularityhammer.dm
+++ b/code/game/objects/items/singularityhammer.dm
@@ -56,10 +56,8 @@
 				step_towards(H,pull)
 	return
 
-/obj/item/twohanded/singularityhammer/afterattack(atom/A as mob|obj|turf|area, mob/user, proximity)
+/obj/item/twohanded/singularityhammer/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(wielded)
 		if(charged == 5)
 			charged = 0

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -281,9 +281,9 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	if(T && is_station_level(T.z))
 		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
 
-/obj/item/shard/afterattack(atom/A as mob|obj, mob/user, proximity)
+/obj/item/shard/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity || !(src in user))
+	if(!(src in user))
 		return
 	if(isturf(A))
 		return

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -20,7 +20,7 @@
 	else
 		return ..()
 
-/obj/item/stack/telecrystal/afterattack(obj/item/I, mob/user, proximity)
+/obj/item/stack/telecrystal/afterattack(obj/item/I, mob/user)
 	. = ..()
 	if(istype(I, /obj/item/cartridge/virus/frame))
 		var/obj/item/cartridge/virus/frame/cart = I

--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -60,10 +60,8 @@
 /obj/item/smallDelivery/can_be_package_wrapped()
 	return 0
 
-/obj/item/stack/packageWrap/afterattack(obj/target, mob/user, proximity)
+/obj/item/stack/packageWrap/afterattack(obj/target, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(!istype(target))
 		return
 	if(target.anchored)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -161,10 +161,8 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 		M.visible_message("<span class='danger'>[user] smacks [M]'s lifeless corpse with [src].</span>")
 		playsound(src.loc, "punch", 25, TRUE, -1)
 
-/obj/item/storage/book/bible/afterattack(atom/A, mob/user, proximity)
+/obj/item/storage/book/bible/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(isfloorturf(A))
 		to_chat(user, "<span class='notice'>You hit the floor with the bible.</span>")
 		if(user.mind && (user.mind.isholy))

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -134,7 +134,7 @@
 		destination = tank
 	..()
 
-/obj/item/reagent_containers/spray/mister/afterattack(obj/target, mob/user, proximity)
+/obj/item/reagent_containers/spray/mister/ranged_attack(obj/target, mob/user)
 	if(target.loc == loc) //Safety check so you don't fill your mister with mutagen or something and then blast yourself in the face with it
 		return
 	..()
@@ -255,7 +255,7 @@
 			return
 	return
 
-/obj/item/extinguisher/mini/nozzle/afterattack(atom/target, mob/user)
+/obj/item/extinguisher/mini/nozzle/spray_load(atom/target, mob/user)
 	if(nozzle_mode == EXTINGUISHER)
 		..()
 		return

--- a/code/game/objects/items/taster.dm
+++ b/code/game/objects/items/taster.dm
@@ -10,11 +10,8 @@
 
 	var/taste_sensitivity = 15
 
-/obj/item/taster/afterattack(atom/O, mob/user, proximity)
+/obj/item/taster/afterattack(atom/O, mob/user)
 	. = ..()
-	if(!proximity)
-		return
-
 	if(O.reagents)
 		var/message = O.reagents.generate_taste_message(taste_sensitivity)
 		to_chat(user, "<span class='notice'>[src] tastes <span class='italics'>[message]</span> in [O].</span>")

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -149,6 +149,10 @@
 		return TRUE
 	return FALSE
 
+/obj/item/hand_tele/ranged_attack(atom/target, mob/user)
+	. = ..()
+	try_dispel_portal(target, user)
+
 /obj/item/hand_tele/afterattack(atom/target, mob/user)
 	try_dispel_portal(target, user)
 	. = ..()

--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -230,11 +230,11 @@
 	else
 		icon_state = "supermatter_tongs"
 
-/obj/item/hemostat/supermatter/afterattack(atom/O, mob/user, proximity)
+/obj/item/hemostat/supermatter/afterattack(atom/O, mob/user)
 	. = ..()
 	if(!sliver)
 		return
-	if(proximity && ismovableatom(O) && O != sliver)
+	if(ismovableatom(O) && O != sliver)
 		Consume(O, user)
 
 /obj/item/hemostat/supermatter/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum) // no instakill supermatter javelins

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -119,10 +119,8 @@
 		return ..()
 
 
-/obj/item/weldingtool/afterattack(atom/O, mob/user, proximity)
+/obj/item/weldingtool/afterattack(atom/O, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(!status && O.is_refillable())
 		reagents.trans_to(O, reagents.total_volume, transfered_by = user)
 		to_chat(user, "<span class='notice'>You empty [src]'s fuel tank into [O].</span>")

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -50,10 +50,8 @@
 /obj/item/toy/waterballoon/attack(mob/living/carbon/human/M, mob/user)
 	return
 
-/obj/item/toy/waterballoon/afterattack(atom/A as mob|obj, mob/user, proximity)
+/obj/item/toy/waterballoon/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if (istype(A, /obj/structure/reagent_dispensers))
 		var/obj/structure/reagent_dispensers/RD = A
 		if(RD.reagents.total_volume <= 0)
@@ -218,10 +216,8 @@
 	else
 		return ..()
 
-/obj/item/toy/gun/afterattack(atom/target as mob|obj|turf|area, mob/user, flag)
+/obj/item/toy/gun/ranged_attack(atom/target, mob/user)
 	. = ..()
-	if (flag)
-		return
 	if (!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
@@ -1097,10 +1093,9 @@
 	icon_state = "snowball"
 	throwforce = 12 //pelt your enemies to death with lumps of snow
 
-/obj/item/toy/snowball/afterattack(atom/target as mob|obj|turf|area, mob/user)
+/obj/item/toy/snowball/ranged_attack(atom/target, mob/user)
 	. = ..()
-	if(user.dropItemToGround(src))
-		throw_at(target, throw_range, throw_speed)
+	user.throw_item(target)
 
 /obj/item/toy/snowball/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(!..())
@@ -1117,10 +1112,9 @@
 	item_state = "beachball"
 	w_class = WEIGHT_CLASS_BULKY //Stops people from hiding it in their bags/pockets
 
-/obj/item/toy/beach_ball/afterattack(atom/target as mob|obj|turf|area, mob/user)
+/obj/item/toy/beach_ball/ranged_attack(atom/target, mob/user)
 	. = ..()
-	if(user.dropItemToGround(src))
-		throw_at(target, throw_range, throw_speed)
+	user.throw_item(target)
 
 /*
  * Clockwork Watch

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -246,10 +246,8 @@
 	user.visible_message("<span class='suicide'>[user] axes [user.p_them()]self from head to toe! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return (BRUTELOSS)
 
-/obj/item/twohanded/fireaxe/afterattack(atom/A, mob/user, proximity)
+/obj/item/twohanded/fireaxe/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(wielded) //destroys windows and grilles in one hit
 		if(istype(A, /obj/structure/window) || istype(A, /obj/structure/grille))
 			var/obj/structure/W = A
@@ -541,10 +539,8 @@
 			if(input)
 				src.war_cry = input
 
-/obj/item/twohanded/spear/explosive/afterattack(atom/movable/AM, mob/user, proximity)
+/obj/item/twohanded/spear/explosive/afterattack(atom/movable/AM, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(wielded)
 		user.say("[war_cry]", forced="spear warcry")
 		explosive.forceMove(AM)
@@ -633,10 +629,8 @@
 	force_wielded = 25
 	attack_verb = list("gored")
 
-/obj/item/twohanded/spear/grey_tide/afterattack(atom/movable/AM, mob/living/user, proximity)
+/obj/item/twohanded/spear/grey_tide/afterattack(atom/movable/AM, mob/living/user)
 	. = ..()
-	if(!proximity)
-		return
 	user.faction |= "greytide([REF(user)])"
 	if(isliving(AM))
 		var/mob/living/L = AM
@@ -714,9 +708,9 @@
 		user.apply_damage(rand(force/2, force), BURN, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 	..()
 
-/obj/item/twohanded/pitchfork/demonic/ascended/afterattack(atom/target, mob/user, proximity)
+/obj/item/twohanded/pitchfork/demonic/ascended/afterattack(atom/target, mob/user)
 	. = ..()
-	if(!proximity || !wielded)
+	if(!wielded)
 		return
 	if(iswallturf(target))
 		var/turf/closed/wall/W = target

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -631,17 +631,16 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	))
 
 
-/obj/item/melee/flyswatter/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/melee/flyswatter/afterattack(atom/target, mob/user)
 	. = ..()
-	if(proximity_flag)
-		if(is_type_in_typecache(target, strong_against))
-			new /obj/effect/decal/cleanable/insectguts(target.drop_location())
-			to_chat(user, "<span class='warning'>You easily splat the [target].</span>")
-			if(istype(target, /mob/living/))
-				var/mob/living/bug = target
-				bug.death(1)
-			else
-				qdel(target)
+	if(is_type_in_typecache(target, strong_against))
+		new /obj/effect/decal/cleanable/insectguts(target.drop_location())
+		to_chat(user, "<span class='warning'>You easily splat the [target].</span>")
+		if(istype(target, /mob/living/))
+			var/mob/living/bug = target
+			bug.death(1)
+		else
+			qdel(target)
 
 /obj/item/circlegame
 	name = "circled hand"

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -126,10 +126,8 @@
 /obj/item/roller/attack_self(mob/user)
 	deploy_roller(user, user.loc)
 
-/obj/item/roller/afterattack(obj/target, mob/user , proximity)
+/obj/item/roller/afterattack(obj/target, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(isopenturf(target))
 		deploy_roller(user, target)
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -319,10 +319,8 @@
 		return 1
 	return 0
 
-/obj/item/chair/afterattack(atom/target, mob/living/carbon/user, proximity)
+/obj/item/chair/afterattack(atom/target, mob/living/carbon/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(prob(break_chance))
 		user.visible_message("<span class='danger'>[user] smashes \the [src] to pieces against \the [target]</span>")
 		if(iscarbon(target))

--- a/code/game/objects/structures/manned_turret.dm
+++ b/code/game/objects/structures/manned_turret.dm
@@ -208,9 +208,16 @@
 	M.attacked_by(src, user)
 	add_fingerprint(user)
 
-/obj/item/gun_control/afterattack(atom/targeted_atom, mob/user, flag, params)
+/obj/item/gun_control/afterattack(atom/A, mob/user, params)
 	. = ..()
-	var/obj/machinery/manned_turret/E = user.buckled
+	set_turret_values(user.buckled, user, A, params)
+
+/obj/item/gun_control/ranged_attack(atom/A, mob/user, params)
+	. = ..()
+	set_turret_values(user.buckled, user, A, params)
+
+///I have no trust in this actually working out fine.
+/obj/item/gun_control/proc/set_turret_values(obj/machinery/manned_turret/E, mob/user, atom/targeted_atom, params)
 	E.calculated_projectile_vars = calculate_projectile_angle_and_pixel_offsets(user, params)
 	E.direction_track(user, targeted_atom)
 	E.checkfire(targeted_atom, user)

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -99,9 +99,9 @@
 	resistance_flags = FLAMMABLE
 	var/sign_path = /obj/structure/sign/basic //the type of sign that will be created when placed on a turf
 
-/obj/item/sign_backing/afterattack(atom/target, mob/user, proximity)
+/obj/item/sign_backing/afterattack(atom/target, mob/user)
 	. = ..()
-	if(isturf(target) && proximity)
+	if(isturf(target))
 		var/turf/T = target
 		user.visible_message("<span class='notice'>[user] fastens [src] to [T].</span>", \
 							 "<span class='notice'>You attach the sign to [T].</span>")

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -196,10 +196,8 @@
 			mark(M, user)
 
 
-/obj/item/abductor/gizmo/afterattack(atom/target, mob/living/user, flag, params)
+/obj/item/abductor/gizmo/ranged_attack(atom/target, mob/living/user, params)
 	. = ..()
-	if(flag)
-		return
 	if(!ScientistCheck(user))
 		return
 	if(!console)
@@ -253,10 +251,8 @@
 		return
 	radio_off(M, user)
 
-/obj/item/abductor/silencer/afterattack(atom/target, mob/living/user, flag, params)
+/obj/item/abductor/silencer/ranged_attack(atom/target, mob/living/user, params)
 	. = ..()
-	if(flag)
-		return
 	if(!AbductorCheck(user))
 		return
 	radio_off(target, user)
@@ -304,7 +300,7 @@
 		icon_state = "mind_device_message"
 	to_chat(user, "<span class='notice'>You switch the device to [mode==MIND_DEVICE_MESSAGE? "TRANSMISSION": "COMMAND"] MODE</span>")
 
-/obj/item/abductor/mind_device/afterattack(atom/target, mob/living/user, flag, params)
+/obj/item/abductor/mind_device/ranged_attack(atom/target, mob/living/user, params)
 	. = ..()
 	if(!ScientistCheck(user))
 		return

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -174,10 +174,8 @@
 		can_drop = TRUE
 	AddComponent(/datum/component/butchering, 60, 80)
 
-/obj/item/melee/arm_blade/afterattack(atom/target, mob/user, proximity)
+/obj/item/melee/arm_blade/afterattack(atom/target, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(istype(target, /obj/structure/table))
 		var/obj/structure/table/T = target
 		T.deconstruct(FALSE)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -372,9 +372,6 @@
 			source.UpdateButtonIcon()
 	..()
 
-/obj/item/melee/blood_magic/attack_self(mob/living/user)
-	afterattack(user, user, TRUE)
-
 /obj/item/melee/blood_magic/attack(mob/living/M, mob/living/carbon/user)
 	if(!iscarbon(user) || !iscultist(user))
 		uses = 0
@@ -384,7 +381,19 @@
 	M.lastattacker = user.real_name
 	M.lastattackerckey = user.ckey
 
+/obj/item/melee/blood_magic/attack_self(mob/living/user)
+	. = ..()
+	spell_effect(user, user, TRUE)
+
 /obj/item/melee/blood_magic/afterattack(atom/target, mob/living/carbon/user, proximity)
+	. = ..()
+	spell_effect(user, user, TRUE)
+
+/obj/item/melee/blood_magic/ranged_attack(atom/target, mob/living/carbon/user, proximity)
+	. = ..()
+	spell_effect(user, user, FALSE)
+
+/obj/item/melee/blood_magic/proc/spell_effect(atom/target, mob/living/carbon/user, proximity)
 	. = ..()
 	if(invocation)
 		user.whisper(invocation, language = /datum/language/common)
@@ -407,7 +416,7 @@
 	color = RUNE_COLOR_RED
 	invocation = "Fuu ma'jin!"
 
-/obj/item/melee/blood_magic/stun/afterattack(atom/target, mob/living/carbon/user, proximity)
+/obj/item/melee/blood_magic/stun/spell_effect(atom/target, mob/living/carbon/user, proximity)
 	if(!isliving(target) || !proximity)
 		return
 	var/mob/living/L = target
@@ -459,7 +468,7 @@
 	desc = "Will teleport a cultist to a teleport rune on contact."
 	invocation = "Sas'so c'arta forbici!"
 
-/obj/item/melee/blood_magic/teleport/afterattack(atom/target, mob/living/carbon/user, proximity)
+/obj/item/melee/blood_magic/teleport/spell_effect(atom/target, mob/living/carbon/user, proximity)
 	if(!iscultist(target) || !proximity)
 		to_chat(user, "<span class='warning'>You can only teleport adjacent cultists with this spell!</span>")
 		return
@@ -505,7 +514,7 @@
 	invocation = "In'totum Lig'abis!"
 	color = "#000000" // black
 
-/obj/item/melee/blood_magic/shackles/afterattack(atom/target, mob/living/carbon/user, proximity)
+/obj/item/melee/blood_magic/shackles/spell_effect(atom/target, mob/living/carbon/user, proximity)
 	if(iscultist(user) && iscarbon(target) && proximity)
 		var/mob/living/carbon/C = target
 		if(C.get_num_arms(FALSE) >= 2 || C.get_arm_ignore())
@@ -565,7 +574,7 @@
 	Cyborg shells into construct shells\n
 	Airlocks into brittle runed airlocks after a delay (harm intent)"}
 
-/obj/item/melee/blood_magic/construction/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+/obj/item/melee/blood_magic/construction/spell_effect(atom/target, mob/user, proximity_flag, click_parameters)
 	if(proximity_flag && iscultist(user))
 		if(channeling)
 			to_chat(user, "<span class='cultitalic'>You are already invoking twisted construction!</span>")
@@ -653,7 +662,7 @@
 	desc = "Will equipt cult combat gear onto a cultist on contact."
 	color = "#33cc33" // green
 
-/obj/item/melee/blood_magic/armor/afterattack(atom/target, mob/living/carbon/user, proximity)
+/obj/item/melee/blood_magic/armor/spell_effect(atom/target, mob/living/carbon/user, proximity)
 	if(iscarbon(target) && proximity)
 		uses--
 		var/mob/living/carbon/C = target
@@ -677,7 +686,7 @@
 	. = ..()
 	. += "Blood spear, blood bolt barrage, and blood beam cost [BLOOD_SPEAR_COST], [BLOOD_BARRAGE_COST], and [BLOOD_BEAM_COST] charges respectively."
 
-/obj/item/melee/blood_magic/manipulator/afterattack(atom/target, mob/living/carbon/human/user, proximity)
+/obj/item/melee/blood_magic/manipulator/spell_effect(atom/target, mob/living/carbon/human/user, proximity)
 	if(proximity)
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = target

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -180,24 +180,25 @@
 			return TRUE
 	return FALSE
 
-/obj/item/twohanded/required/cult_bastard/afterattack(atom/target, mob/user, proximity, click_parameters)
+/obj/item/twohanded/required/cult_bastard/ranged_attack(atom/target, mob/user, click_parameters)
 	. = ..()
-	if(dash_toggled && !proximity)
+	if(dash_toggled)
 		jaunt.Teleport(user, target)
 		return
-	if(proximity)
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = target
-			if(H.stat != CONSCIOUS)
-				var/obj/item/soulstone/SS = new /obj/item/soulstone(src)
-				SS.attack(H, user)
-				if(!LAZYLEN(SS.contents))
-					qdel(SS)
-		if(istype(target, /obj/structure/constructshell) && contents.len)
-			var/obj/item/soulstone/SS = contents[1]
-			if(istype(SS))
-				SS.transfer_soul("CONSTRUCT",target,user)
+
+/obj/item/twohanded/required/cult_bastard/afterattack(atom/target, mob/user, click_parameters)
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(H.stat != CONSCIOUS)
+			var/obj/item/soulstone/SS = new /obj/item/soulstone(src)
+			SS.attack(H, user)
+			if(!LAZYLEN(SS.contents))
 				qdel(SS)
+	if(istype(target, /obj/structure/constructshell) && contents.len)
+		var/obj/item/soulstone/SS = contents[1]
+		if(istype(SS))
+			SS.transfer_soul("CONSTRUCT",target,user)
+			qdel(SS)
 
 /datum/action/innate/dash/cult
 	name = "Rend the Veil"
@@ -593,9 +594,7 @@
 	on = TRUE
 	var/charges = 5
 
-/obj/item/flashlight/flare/culttorch/afterattack(atom/movable/A, mob/user, proximity)
-	if(!proximity)
-		return
+/obj/item/flashlight/flare/culttorch/afterattack(atom/movable/A, mob/user)
 	if(!iscultist(user))
 		to_chat(user, "That doesn't seem to do anything useful.")
 		return
@@ -803,7 +802,11 @@
 	ADD_TRAIT(src, TRAIT_NODROP, CULT_TRAIT)
 
 
-/obj/item/blood_beam/afterattack(atom/A, mob/living/user, flag, params)
+/obj/item/blood_beam/afterattack(atom/A, mob/user, params)
+	. = ..()
+	ranged_attack(A, user, params)
+
+/obj/item/blood_beam/ranged_attack(atom/A, mob/living/user, params)
 	. = ..()
 	if(firing || charging)
 		return

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -476,7 +476,7 @@
 
 /obj/machinery/nuclearbomb/beer/attackby(obj/item/W, mob/user, params)
 	if(W.is_refillable())
-		W.afterattack(keg, user, TRUE) 	// redirect refillable containers to the keg, allowing them to be filled
+		W.afterattack(keg, user) 	// redirect refillable containers to the keg, allowing them to be filled
 		return TRUE 										// pretend we handled the attack, too.
 	if(istype(W, /obj/item/nuke_core_container))
 		to_chat(user, "<span class='notice'>[src] has had its plutonium core removed as a part of being decommissioned.</span>")

--- a/code/modules/cargo/export_scanner.dm
+++ b/code/modules/cargo/export_scanner.dm
@@ -16,9 +16,9 @@
 	if(!cargo_console)
 		. += "<span class='notice'>[src] is not currently linked to a cargo console.</span>"
 
-/obj/item/export_scanner/afterattack(obj/O, mob/user, proximity)
+/obj/item/export_scanner/afterattack(obj/O, mob/user)
 	. = ..()
-	if(!istype(O) || !proximity)
+	if(!istype(O))
 		return
 
 	if(istype(O, /obj/machinery/computer/cargo))

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -8,9 +8,9 @@
 	item_state = ""
 	w_class = WEIGHT_CLASS_TINY
 
-/obj/item/evidencebag/afterattack(obj/item/I, mob/user,proximity)
+/obj/item/evidencebag/afterattack(obj/item/I, mob/user)
 	. = ..()
-	if(!proximity || loc == I)
+	if(loc == I)
 		return
 	evidencebagEquip(I, user)
 

--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -23,10 +23,8 @@
 	user.visible_message("<span class='suicide'>[user] is smothering [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return (OXYLOSS)
 
-/obj/item/reagent_containers/glass/rag/afterattack(atom/A as obj|turf|area, mob/user,proximity)
+/obj/item/reagent_containers/glass/rag/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(iscarbon(A) && A.reagents && reagents.total_volume)
 		var/mob/living/carbon/C = A
 		var/reagentlist = pretty_string_from_reagent_list(reagents)

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -67,7 +67,10 @@
 /obj/item/detective_scanner/afterattack(atom/A, mob/user, params)
 	. = ..()
 	scan(A, user)
-	return FALSE
+
+/obj/item/detective_scanner/ranged_attack(atom/A, mob/user, params)
+	. = ..()
+	scan(A, user)
 
 /obj/item/detective_scanner/proc/scan(atom/A, mob/user)
 	set waitfor = 0

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -40,9 +40,9 @@
 	var/can_backfire = TRUE
 	var/uses = 1
 
-/obj/item/upgradescroll/afterattack(obj/item/target, mob/user , proximity)
+/obj/item/upgradescroll/afterattack(obj/item/target, mob/user)
 	. = ..()
-	if(!proximity || !istype(target))
+	if(!istype(target))
 		return
 
 	target.AddComponent(/datum/component/fantasy, upgrade_amount, null, null, can_backfire, TRUE)

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -58,10 +58,8 @@
 	playsound(M.loc,'sound/items/drink.ogg', rand(10,50), TRUE)
 	return 1
 
-/obj/item/reagent_containers/food/drinks/afterattack(obj/target, mob/user , proximity)
+/obj/item/reagent_containers/food/drinks/afterattack(obj/target, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 
 	if(target.is_refillable() && is_drainable()) //Something like a glass. Player probably wants to transfer TO it.
 		if(!reagents.total_volume)

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -117,9 +117,9 @@
 		return
 	..()
 
-/obj/item/reagent_containers/food/drinks/drinkingglass/afterattack(obj/target, mob/user, proximity)
+/obj/item/reagent_containers/food/drinks/drinkingglass/afterattack(obj/target, mob/user)
 	. = ..()
-	if((!proximity) || !check_allowed_items(target,target_self=1))
+	if(!check_allowed_items(target,target_self=1))
 		return
 
 	else if(reagents.total_volume && user.a_intent == INTENT_HARM)

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -112,10 +112,8 @@
 	playsound(M.loc,'sound/items/drink.ogg', rand(10,50), TRUE)
 	return 1
 
-/obj/item/reagent_containers/food/condiment/afterattack(obj/target, mob/user , proximity)
+/obj/item/reagent_containers/food/condiment/afterattack(obj/target, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(istype(target, /obj/structure/reagent_dispensers)) //A dispenser. Transfer FROM it TO us.
 
 		if(!target.reagents.total_volume)
@@ -175,10 +173,8 @@
 	desc = "Salt. From dead crew, presumably."
 	return (TOXLOSS)
 
-/obj/item/reagent_containers/food/condiment/saltshaker/afterattack(obj/target, mob/living/user, proximity)
+/obj/item/reagent_containers/food/condiment/saltshaker/afterattack(obj/target, mob/living/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(isturf(target))
 		if(!reagents.has_reagent(/datum/reagent/consumable/sodiumchloride, 2))
 			to_chat(user, "<span class='warning'>You don't have enough salt to make a pile!</span>")
@@ -271,10 +267,8 @@
 /obj/item/reagent_containers/food/condiment/pack/attack(mob/M, mob/user, def_zone) //Can't feed these to people directly.
 	return
 
-/obj/item/reagent_containers/food/condiment/pack/afterattack(obj/target, mob/user , proximity)
+/obj/item/reagent_containers/food/condiment/pack/afterattack(obj/target, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 
 	//You can tear the bag open above food to put the condiments on it, obviously.
 	if(istype(target, /obj/item/reagent_containers/food/snacks))

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -334,7 +334,7 @@ All foods are distributed among various categories. Use common sense.
 
 /obj/item/reagent_containers/food/snacks/afterattack(obj/item/reagent_containers/M, mob/user, proximity)
 	. = ..()
-	if(!dunkable || !proximity)
+	if(!dunkable)
 		return
 	if(istype(M, /obj/item/reagent_containers/glass) || istype(M, /obj/item/reagent_containers/food/drinks))	//you can dunk dunkable snacks into beakers or drinks
 		if(!M.is_drainable())

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -237,10 +237,8 @@
 			message_admins("[ADMIN_LOOKUPFLW(user)] set [ADMIN_LOOKUPFLW(M)] on fire with [src] at [AREACOORD(user)]")
 			log_game("[key_name(user)] set [key_name(M)] on fire with [src] at [AREACOORD(user)]")
 
-/obj/item/grown/novaflower/afterattack(atom/A as mob|obj, mob/user,proximity)
+/obj/item/grown/novaflower/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(force > 0)
 		force -= rand(1, (force / 3) + 1)
 	else

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -66,10 +66,8 @@
 	to_chat(C, "<span class='userdanger'>The nettle burns your bare hand!</span>")
 	return TRUE
 
-/obj/item/reagent_containers/food/snacks/grown/nettle/afterattack(atom/A as mob|obj, mob/user,proximity)
+/obj/item/reagent_containers/food/snacks/grown/nettle/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(force > 0)
 		force -= rand(1, (force / 3) + 1) // When you whack someone with it, leaves fall off
 	else

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -18,11 +18,9 @@
 	if(remaining_uses != -1)
 		. += "It has [remaining_uses] uses left."
 
-/obj/item/soapstone/afterattack(atom/target, mob/user, proximity)
+/obj/item/soapstone/afterattack(atom/target, mob/user)
 	. = ..()
 	var/turf/T = get_turf(target)
-	if(!proximity)
-		return
 
 	var/obj/structure/chisel_message/existing_message = locate() in T
 

--- a/code/modules/mining/aux_base_camera.dm
+++ b/code/modules/mining/aux_base_camera.dm
@@ -182,7 +182,7 @@
 			rcd_target = S //If we don't break out of this loop we'll get the last placed thing
 
 	owner.changeNext_move(CLICK_CD_RANGE)
-	B.RCD.afterattack(rcd_target, owner, TRUE) //Activate the RCD and force it to work remotely!
+	B.RCD.afterattack(rcd_target, owner) //Activate the RCD and force it to work remotely!
 	playsound(target_turf, 'sound/items/deconstruct.ogg', 60, TRUE)
 
 /datum/action/innate/aux_base/switch_mode

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -11,7 +11,7 @@
 	force = 0 //You can't hit stuff unless wielded
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
-	force_unwielded = 0 
+	force_unwielded = 0
 	force_wielded = 20
 	throwforce = 5
 	throw_speed = 4
@@ -76,11 +76,11 @@
 	if(!QDELETED(C) && !QDELETED(target))
 		C.total_damage += target_health - target.health //we did some damage, but let's not assume how much we did
 
-/obj/item/twohanded/kinetic_crusher/afterattack(atom/target, mob/living/user, proximity_flag, clickparams)
+/obj/item/twohanded/kinetic_crusher/ranged_attack(atom/target, mob/living/user, clickparams)
 	. = ..()
 	if(!wielded)
 		return
-	if(!proximity_flag && charged)//Mark a target, or mine a tile.
+	if(charged)//Mark a target, or mine a tile.
 		var/turf/proj_turf = user.loc
 		if(!isturf(proj_turf))
 			return
@@ -97,7 +97,10 @@
 		update_icon()
 		addtimer(CALLBACK(src, .proc/Recharge), charge_time)
 		return
-	if(proximity_flag && isliving(target))
+
+/obj/item/twohanded/kinetic_crusher/afterattack(atom/target, mob/living/user, clickparams)
+	. = ..()
+	if(isliving(target))
 		var/mob/living/L = target
 		var/datum/status_effect/crusher_mark/CM = L.has_status_effect(STATUS_EFFECT_CRUSHERMARK)
 		if(!CM || CM.hammer_synced != src || !L.remove_status_effect(STATUS_EFFECT_CRUSHERMARK))

--- a/code/modules/mining/equipment/lazarus_injector.dm
+++ b/code/modules/mining/equipment/lazarus_injector.dm
@@ -15,11 +15,11 @@
 	var/malfunctioning = 0
 	var/revive_type = SENTIENCE_ORGANIC //So you can't revive boss monsters or robots with it
 
-/obj/item/lazarus_injector/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/lazarus_injector/afterattack(atom/target, mob/user)
 	. = ..()
 	if(!loaded)
 		return
-	if(isliving(target) && proximity_flag)
+	if(isliving(target))
 		if(isanimal(target))
 			var/mob/living/simple_animal/M = target
 			if(M.sentience_type != revive_type)

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -89,8 +89,7 @@
 
 /obj/item/organ/regenerative_core/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
-	if(proximity_flag)
-		applyto(target, user)
+	applyto(target, user)
 
 /obj/item/organ/regenerative_core/attack_self(mob/user)
 	if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 		beacon = A
 		to_chat(user, "You link the extraction pack to the beacon system.")
 
-/obj/item/extraction_pack/afterattack(atom/movable/A, mob/living/carbon/human/user, flag, params)
+/obj/item/extraction_pack/afterattack(atom/movable/A, mob/living/carbon/human/user, params)
 	. = ..()
 	if(!beacon)
 		to_chat(user, "<span class='warning'>[src] is not linked to a beacon, and cannot be used!</span>")
@@ -48,8 +48,6 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 		if(!area.outdoors)
 			to_chat(user, "<span class='warning'>[src] can only be used on things that are outdoors!</span>")
 			return
-	if(!flag)
-		return
 	if(!istype(A))
 		return
 	else

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -206,9 +206,9 @@
 	desc = "A small card, that when used on any ID, will add mining access."
 	icon_state = "data_1"
 
-/obj/item/card/mining_access_card/afterattack(atom/movable/AM, mob/user, proximity)
+/obj/item/card/mining_access_card/afterattack(atom/movable/AM, mob/user)
 	. = ..()
-	if(istype(AM, /obj/item/card/id) && proximity)
+	if(istype(AM, /obj/item/card/id))
 		var/obj/item/card/id/I = AM
 		I.access |=	ACCESS_MINING
 		I.access |= ACCESS_MINING_STATION

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -176,7 +176,7 @@
 /mob/living/simple_animal/hostile/mining_drone/OpenFire(atom/A)
 	if(CheckFriendlyFire(A))
 		return
-	stored_gun.afterattack(A, src) //of the possible options to allow minebots to have KA mods, would you believe this is the best?
+	stored_gun.ranged_attack(A, src) //of the possible options to allow minebots to have KA mods, would you believe this is the best?
 
 /mob/living/simple_animal/hostile/mining_drone/proc/CollectOre()
 	for(var/obj/item/stack/ore/O in range(1, src))
@@ -272,7 +272,7 @@
 
 /obj/item/mine_bot_upgrade/afterattack(mob/living/simple_animal/hostile/mining_drone/M, mob/user, proximity)
 	. = ..()
-	if(!istype(M) || !proximity)
+	if(!istype(M))
 		return
 	upgrade_bot(M, user)
 

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -172,10 +172,8 @@
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
 	AddComponent(/datum/component/butchering, 80, 70)
 
-/obj/item/light_eater/afterattack(atom/movable/AM, mob/user, proximity)
+/obj/item/light_eater/afterattack(atom/movable/AM, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(isopenturf(AM)) //So you can actually melee with it
 		return
 	if(isliving(AM))

--- a/code/modules/mob/living/simple_animal/bot/firebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/firebot.dm
@@ -62,7 +62,7 @@
 	if(!on)
 		return
 	if(internal_ext)
-		internal_ext.afterattack(A, src)
+		internal_ext.spray_load(A, src)
 	else
 		return ..()
 
@@ -70,7 +70,7 @@
 	if(!on)
 		return
 	if(internal_ext)
-		internal_ext.afterattack(A, src)
+		internal_ext.spray_load(A, src)
 	else
 		return ..()
 
@@ -282,7 +282,7 @@
 		flick("firebots_use", user)
 	else
 		flick("firebot1_use", user)
-	internal_ext.afterattack(target, user, null)
+	internal_ext.spray_load(target, user)
 
 /mob/living/simple_animal/bot/firebot/update_icon()
 	if(!on)

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -223,7 +223,7 @@
 						return
 
 					if(istype(item_to_add, /obj/item/grenade/c4)) // last thing he ever wears, I guess
-						item_to_add.afterattack(src,usr,1)
+						item_to_add.afterattack(src,usr)
 						return
 
 					//The objects that corgis can wear on their backs.
@@ -258,7 +258,7 @@
 /mob/living/simple_animal/pet/dog/corgi/proc/place_on_head(obj/item/item_to_add, mob/user)
 
 	if(istype(item_to_add, /obj/item/grenade/c4)) // last thing he ever wears, I guess
-		item_to_add.afterattack(src,user,1)
+		item_to_add.afterattack(src,user)
 		return
 
 	if(inventory_head)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -129,8 +129,8 @@
 	else
 		return ..()
 
-/obj/item/reagent_containers/food/snacks/deadmouse/afterattack(obj/target, mob/living/user, proximity_flag)
-	if(proximity_flag && reagents && target.is_open_container())
+/obj/item/reagent_containers/food/snacks/deadmouse/afterattack(obj/target, mob/living/user)
+	if(reagents && target.is_open_container())
 		// is_open_container will not return truthy if target.reagents doesn't exist
 		var/datum/reagents/target_reagents = target.reagents
 		var/trans_amount = reagents.maximum_volume - reagents.total_volume * (4 / 3)

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -82,9 +82,9 @@
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "bear_armor_upgrade"
 
-/obj/item/bear_armor/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/bear_armor/afterattack(atom/target, mob/user)
 	. = ..()
-	if(istype(target, /mob/living/simple_animal/hostile/bear) && proximity_flag)
+	if(istype(target, /mob/living/simple_animal/hostile/bear))
 		var/mob/living/simple_animal/hostile/bear/A = target
 		if(A.armored)
 			to_chat(user, "<span class='warning'>[A] has already been armored up!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
@@ -126,9 +126,9 @@
 	layer = MOB_LAYER
 	var/list/banned_mobs
 
-/obj/item/fugu_gland/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/fugu_gland/afterattack(atom/target, mob/user)
 	. = ..()
-	if(proximity_flag && isanimal(target))
+	if(isanimal(target))
 		var/mob/living/simple_animal/A = target
 		if(A.buffed || (A.type in banned_mobs) || A.stat)
 			to_chat(user, "<span class='warning'>Something's interfering with [src]'s effects. It's no use.</span>")

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -32,11 +32,14 @@
 	dash_toggled = !dash_toggled
 	to_chat(user, "<span class='notice'>You [dash_toggled ? "enable" : "disable"] the dash function on [src].</span>")
 
-/obj/item/energy_katana/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+/obj/item/energy_katana/ranged_attack(atom/target, mob/user, click_parameters)
 	. = ..()
 	if(dash_toggled)
 		jaunt.Teleport(user, target)
-	if(proximity_flag && (isobj(target) || issilicon(target)))
+
+/obj/item/energy_katana/afterattack(atom/target, mob/user, click_parameters)
+	. = ..()
+	if(isobj(target) || issilicon(target))
 		spark_system.start()
 		playsound(user, "sparks", 50, TRUE)
 		playsound(user, 'sound/weapons/blade1.ogg', 50, TRUE)

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -35,10 +35,8 @@
 
 	return OXYLOSS
 
-/obj/item/hand_labeler/afterattack(atom/A, mob/user,proximity)
+/obj/item/hand_labeler/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(!mode)	//if it's off, give up.
 		return
 
@@ -89,8 +87,8 @@
 /obj/item/hand_labeler/borg
 	name = "cyborg-hand labeler"
 
-/obj/item/hand_labeler/borg/afterattack(atom/A, mob/user, proximity)
-	. = ..(A, user, proximity)
+/obj/item/hand_labeler/borg/afterattack(atom/A, mob/user)
+	. = ..()
 	if(!iscyborg(user))
 		return
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -121,10 +121,10 @@
 	else
 		. = ..()
 
-/obj/item/pen/afterattack(obj/O, mob/living/user, proximity)
+/obj/item/pen/afterattack(obj/O, mob/living/user)
 	. = ..()
 	//Changing Name/Description of items. Only works if they have the 'unique_rename' flag set
-	if(isobj(O) && proximity && (O.obj_flags & UNIQUE_RENAME))
+	if(isobj(O) && (O.obj_flags & UNIQUE_RENAME))
 		var/penchoice = input(user, "What would you like to edit?", "Rename or change description?") as null|anything in list("Rename","Change description")
 		if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 			return

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -55,7 +55,7 @@
 		return
 
 	var/desired_y = input(user, "How wide do you want the camera to shoot, between [picture_size_y_min] and [picture_size_y_max]?", "Zoom", picture_size_y) as num|null
-	
+
 	if (isnull(desired_y))
 		return
 
@@ -116,7 +116,15 @@
 			return FALSE
 	return TRUE
 
-/obj/item/camera/afterattack(atom/target, mob/user, flag)
+/obj/item/camera/ranged_attack(atom/target, mob/user)
+	. = ..()
+	try_to_take_picture(target, user, FALSE)
+
+/obj/item/camera/afterattack(atom/target, mob/user)
+	. = ..()
+	try_to_take_picture(target, user, TRUE)
+
+/obj/item/camera/proc/try_to_take_picture(atom/target, mob/user, proximity)
 	if (disk)
 		if(ismob(target))
 			if (disk.record)
@@ -130,7 +138,7 @@
 			to_chat(user, "<span class='warning'>Invalid holodisk target.</span>")
 			return
 
-	if(!can_target(target, user, flag))
+	if(!can_target(target, user, proximity))
 		return
 
 	on = FALSE
@@ -143,7 +151,7 @@
 
 	icon_state = state_off
 
-	INVOKE_ASYNC(src, .proc/captureimage, target, user, flag, picture_size_x - 1, picture_size_y - 1)
+	INVOKE_ASYNC(src, .proc/captureimage, target, user, proximity, picture_size_x - 1, picture_size_y - 1)
 
 
 /obj/item/camera/proc/cooldown()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -468,8 +468,15 @@
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
 
-/obj/item/turret_control/afterattack(atom/targeted_atom, mob/user, proxflag, clickparams)
+/obj/item/turret_control/afterattack(atom/target, mob/user, params)
 	. = ..()
+	on_click_target(target, user, params)
+
+/obj/item/turret_control/ranged_attack(atom/target, mob/user, params)
+	. = ..()
+	on_click_target(target, user, params)
+
+/obj/item/turret_control/proc/on_click_target(atom/targeted_atom, mob/user, clickparams)
 	var/obj/machinery/power/emitter/E = user.buckled
 	E.setDir(get_dir(E,targeted_atom))
 	user.setDir(E.dir)

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -18,23 +18,22 @@
 	if(istype(newloc, /obj/item/gun))
 		gun = newloc
 
-/obj/item/firing_pin/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/firing_pin/afterattack(atom/target, mob/user)
 	. = ..()
-	if(proximity_flag)
-		if(istype(target, /obj/item/gun))
-			var/obj/item/gun/G = target
-			if(G.pin && (force_replace || G.pin.pin_removeable))
-				G.pin.forceMove(get_turf(G))
-				G.pin.gun_remove(user)
-				to_chat(user, "<span class='notice'>You remove [G]'s old pin.</span>")
+	if(istype(target, /obj/item/gun))
+		var/obj/item/gun/G = target
+		if(G.pin && (force_replace || G.pin.pin_removeable))
+			G.pin.forceMove(get_turf(G))
+			G.pin.gun_remove(user)
+			to_chat(user, "<span class='notice'>You remove [G]'s old pin.</span>")
 
-			if(!G.pin)
-				if(!user.temporarilyRemoveItemFromInventory(src))
-					return
-				gun_insert(user, G)
-				to_chat(user, "<span class='notice'>You insert [src] into [G].</span>")
-			else
-				to_chat(user, "<span class='notice'>This firearm already has a firing pin installed.</span>")
+		if(!G.pin)
+			if(!user.temporarilyRemoveItemFromInventory(src))
+				return
+			gun_insert(user, G)
+			to_chat(user, "<span class='notice'>You insert [src] into [G].</span>")
+		else
+			to_chat(user, "<span class='notice'>This firearm already has a firing pin installed.</span>")
 
 /obj/item/firing_pin/emag_act(mob/user)
 	if(obj_flags & EMAGGED)
@@ -159,9 +158,9 @@
 	fail_message = "<span class='warning'>DNA CHECK FAILED.</span>"
 	var/unique_enzymes = null
 
-/obj/item/firing_pin/dna/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/firing_pin/dna/afterattack(atom/target, mob/user)
 	. = ..()
-	if(proximity_flag && iscarbon(target))
+	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(M.dna && M.dna.unique_enzymes)
 			unique_enzymes = M.dna.unique_enzymes
@@ -220,7 +219,7 @@
 		return
 	gun.desc += "<span class='notice'> This [gun.name] has a license permit cost of [payment_amount] credit[( payment_amount > 1 ) ? "s" : ""].</span>"
 	return
-	
+
 
 /obj/item/firing_pin/paywall/gun_remove(mob/living/user)
 	gun.desc = initial(desc)
@@ -246,12 +245,12 @@
 			to_chat(user, "<span class='warning'>ERROR: Invalid amount designated.</span>")
 			return
 		if(!transaction_amount)
-			return	
+			return
 		pin_owner = id
 		owned = TRUE
 		payment_amount = transaction_amount
 		gun_owners += user
-		to_chat(user, "<span class='notice'>You link the card to the firing pin.</span>")		
+		to_chat(user, "<span class='notice'>You link the card to the firing pin.</span>")
 
 /obj/item/firing_pin/paywall/pin_auth(mob/living/user)
 	if(!istype(user))//nice try commie
@@ -266,9 +265,9 @@
 				if(credit_card_details.adjust_money(-payment_amount))
 					pin_owner.registered_account.adjust_money(payment_amount)
 					return TRUE
-				to_chat(user, "<span class='warning'>ERROR: User balance insufficent for successful transaction!</span>")	
-				return FALSE	
-			return TRUE				
+				to_chat(user, "<span class='warning'>ERROR: User balance insufficent for successful transaction!</span>")
+				return FALSE
+			return TRUE
 		if(credit_card_details && !active_prompt)
 			var/license_request = alert(usr, "Do you wish to pay [payment_amount] credit[( payment_amount > 1 ) ? "s" : ""] for [( multi_payment ) ? "each shot of [gun.name]" : "usage license of [gun.name]"]?", "Weapon Purchase", "Yes", "No")
 			active_prompt = TRUE

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -219,12 +219,10 @@ Borg Shaker
 					R.cell.use(charge_cost)
 					RG.add_reagent(reagent_ids[valueofi], 5)
 
-/obj/item/reagent_containers/borghypo/borgshaker/afterattack(obj/target, mob/user, proximity)
+/obj/item/reagent_containers/borghypo/borgshaker/afterattack(obj/target, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 
-	else if(target.is_refillable())
+	if(target.is_refillable())
 		var/datum/reagents/R = reagent_list[mode]
 		if(!R.total_volume)
 			to_chat(user, "<span class='warning'>[src] is currently out of this ingredient! Please allow some time for the synthesizer to produce more.</span>")

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -10,8 +10,6 @@
 
 /obj/item/reagent_containers/dropper/afterattack(obj/target, mob/user , proximity)
 	. = ..()
-	if(!proximity)
-		return
 	if(!target.reagents)
 		return
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -51,9 +51,9 @@
 			addtimer(CALLBACK(reagents, /datum/reagents.proc/trans_to, M, 5, TRUE, TRUE, FALSE, user, FALSE, INGEST), 5)
 			playsound(M.loc,'sound/items/drink.ogg', rand(10,50), TRUE)
 
-/obj/item/reagent_containers/glass/afterattack(obj/target, mob/user, proximity)
+/obj/item/reagent_containers/glass/afterattack(obj/target, mob/user)
 	. = ..()
-	if((!proximity) || !check_allowed_items(target,target_self=1))
+	if(!check_allowed_items(target,target_self=1))
 		return
 
 	if(!spillable)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -59,8 +59,6 @@
 
 /obj/item/reagent_containers/pill/afterattack(obj/target, mob/user , proximity)
 	. = ..()
-	if(!proximity)
-		return
 	if(!dissolvable || !target.is_refillable())
 		return
 	if(target.is_drainable() && !target.reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -25,6 +25,10 @@
 
 /obj/item/reagent_containers/spray/afterattack(atom/A, mob/user)
 	. = ..()
+	ranged_attack(A, user)
+
+/obj/item/reagent_containers/spray/ranged_attack(atom/A, mob/user)
+	. = ..()
 	if(istype(A, /obj/structure/sink) || istype(A, /obj/structure/janitorialcart) || istype(A, /obj/machinery/hydroponics))
 		return
 
@@ -210,7 +214,7 @@
 	return OXYLOSS
 
 // Fix pepperspraying yourself
-/obj/item/reagent_containers/spray/pepper/afterattack(atom/A as mob|obj, mob/user)
+/obj/item/reagent_containers/spray/pepper/afterattack(atom/A, mob/user)
 	if (A.loc == user)
 		return
 	. = ..()
@@ -296,7 +300,7 @@
 	amount_per_transfer_from_this = 10
 	volume = 600
 
-/obj/item/reagent_containers/spray/chemsprayer/afterattack(atom/A as mob|obj, mob/user)
+/obj/item/reagent_containers/spray/chemsprayer/afterattack(atom/A, mob/user)
 	// Make it so the bioterror spray doesn't spray yourself when you click your inventory items
 	if (A.loc == user)
 		return

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -47,11 +47,9 @@
 /obj/item/reagent_containers/syringe/attackby(obj/item/I, mob/user, params)
 	return
 
-/obj/item/reagent_containers/syringe/afterattack(atom/target, mob/user , proximity)
+/obj/item/reagent_containers/syringe/afterattack(atom/target, mob/user)
 	. = ..()
 	if(busy)
-		return
-	if(!proximity)
 		return
 	if(!target.reagents)
 		return

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -346,9 +346,9 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		var/obj/item/conveyor_switch_construct/C = I
 		id = C.id
 
-/obj/item/conveyor_construct/afterattack(atom/A, mob/user, proximity)
+/obj/item/conveyor_construct/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity || user.stat || !isfloorturf(A) || istype(A, /area/shuttle))
+	if(user.stat || !isfloorturf(A) || istype(A, /area/shuttle))
 		return
 	var/cdir = get_dir(A, user)
 	if(A == user.loc)
@@ -375,9 +375,9 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		C.id = id
 	to_chat(user, "<span class='notice'>You have linked all nearby conveyor belt assemblies to this switch.</span>")
 
-/obj/item/conveyor_switch_construct/afterattack(atom/A, mob/user, proximity)
+/obj/item/conveyor_switch_construct/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!proximity || user.stat || !isfloorturf(A) || istype(A, /area/shuttle))
+	if(user.stat || !isfloorturf(A) || istype(A, /area/shuttle))
 		return
 	var/found = 0
 	for(var/obj/machinery/conveyor/C in view())

--- a/code/modules/research/nanites/nanite_hijacker.dm
+++ b/code/modules/research/nanites/nanite_hijacker.dm
@@ -40,7 +40,15 @@
 	disk = null
 	program = null
 
-/obj/item/nanite_hijacker/afterattack(atom/target, mob/user, etc)
+/obj/item/nanite_hijacker/ranged_attack(atom/target, mob/user, params)
+	. = ..()
+	try_to_add_program(target, user)
+
+/obj/item/nanite_hijacker/afterattack(atom/target, mob/user, params)
+	. = ..()
+	try_to_add_program(target, user)
+
+/obj/item/nanite_hijacker/proc/try_to_add_program(atom/target, mob/user)
 	if(!disk || !disk.program)
 		return
 	if(isliving(target))

--- a/code/modules/research/nanites/nanite_remote.dm
+++ b/code/modules/research/nanites/nanite_remote.dm
@@ -53,7 +53,15 @@
 	if(locked)
 		add_overlay("nanite_remote_locked")
 
-/obj/item/nanite_remote/afterattack(atom/target, mob/user, etc)
+/obj/item/nanite_remote/ranged_attack(atom/target, mob/user, params)
+	. = ..()
+	perform_remote_action(target, user)
+
+/obj/item/nanite_remote/afterattack(atom/target, mob/user, params)
+	. = ..()
+	perform_remote_action(target, user)
+
+/obj/item/nanite_remote/proc/perform_remote_action(atom/target, mob/user)
 	switch(mode)
 		if(REMOTE_MODE_OFF)
 			return
@@ -172,7 +180,7 @@
 	var/comm_code = 0
 	var/comm_message = ""
 
-/obj/item/nanite_remote/comm/afterattack(atom/target, mob/user, etc)
+/obj/item/nanite_remote/comm/perform_remote_action(atom/target, mob/user, etc)
 	switch(mode)
 		if(REMOTE_MODE_OFF)
 			return

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -24,8 +24,8 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 		return TRUE
 	return ..()
 
-/obj/item/storage/part_replacer/afterattack(obj/machinery/T, mob/living/user, adjacent, params)
-	if(adjacent || !istype(T) || !T.component_parts)
+/obj/item/storage/part_replacer/afterattack(obj/machinery/T, mob/living/user, params)
+	if(!istype(T) || !T.component_parts)
 		return ..()
 	if(works_from_distance)
 		user.Beam(T, icon_state = "rped_upgrade", time = 5)

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -132,7 +132,7 @@ Slimecrossing Items
 
 
 
-/obj/item/camera/rewind/afterattack(atom/target, mob/user, flag)
+/obj/item/camera/rewind/try_to_take_picture(atom/target, mob/user)
 	if(!on || !pictures_left || !isturf(target.loc))
 		return
 	if(!used)//selfie time
@@ -157,7 +157,7 @@ Slimecrossing Items
 	pictures_max = 1
 	var/used = FALSE
 
-/obj/item/camera/timefreeze/afterattack(atom/target, mob/user, flag)
+/obj/item/camera/timefreeze/try_to_take_picture(atom/target, mob/user)
 	if(!on || !pictures_left || !isturf(target.loc))
 		return
 	if(!used) //refilling the film does not refill the timestop

--- a/code/modules/research/xenobiology/crossbreeding/_potions.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_potions.dm
@@ -11,11 +11,10 @@ Slimecrossing Potions
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "potpurple"
 
-/obj/item/slimepotion/extract_cloner/afterattack(obj/item/target, mob/user , proximity)
-	if(!proximity)
-		return
+/obj/item/slimepotion/extract_cloner/afterattack(obj/item/target, mob/user)
+	. = ..()
 	if(istype(target, /obj/item/reagent_containers))
-		return ..(target, user, proximity)
+		return
 	if(istype(target, /obj/item/slimecross))
 		to_chat(user, "<span class='warning'>[target] is too complex for the potion to clone!</span>")
 		return
@@ -108,12 +107,10 @@ Slimecrossing Potions
 	icon_state = "potblue"
 	var/uses = 2
 
-/obj/item/slimepotion/spaceproof/afterattack(obj/item/clothing/C, mob/user, proximity)
+/obj/item/slimepotion/spaceproof/afterattack(obj/item/clothing/C, mob/user)
 	. = ..()
 	if(!uses)
 		qdel(src)
-		return
-	if(!proximity)
 		return
 	if(!istype(C))
 		to_chat(user, "<span class='warning'>The potion can only be used on clothing!</span>")
@@ -148,16 +145,14 @@ Slimecrossing Potions
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	var/uses = 2
 
-/obj/item/slimepotion/lavaproof/afterattack(obj/item/C, mob/user, proximity)
+/obj/item/slimepotion/lavaproof/afterattack(obj/item/C, mob/user)
 	. = ..()
 	if(!uses)
 		qdel(src)
-		return ..()
-	if(!proximity)
-		return ..()
+		return
 	if(!istype(C))
 		to_chat(user, "<span class='warning'>You can't coat this with lavaproofing fluid!</span>")
-		return ..()
+		return
 	to_chat(user, "<span class='notice'>You slather the red gunk over the [C], making it lavaproof.</span>")
 	C.name = "lavaproof [C.name]"
 	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -967,7 +967,7 @@ datum/status_effect/stabilized/blue/on_remove()
 		var/obj/item/slimecross/stabilized/rainbow/X = linked_extract
 		if(istype(X))
 			if(X.regencore)
-				X.regencore.afterattack(owner,owner,TRUE)
+				X.regencore.afterattack(owner,owner)
 				X.regencore = null
 				owner.visible_message("<span class='warning'>[owner] flashes a rainbow of colors, and [owner.p_their()] skin is coated in a milky regenerative goo!</span>")
 				qdel(src)

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -27,9 +27,11 @@ Slimecrossing Weapons
 	throwforce = 15
 	damtype = BRUTE
 
-/obj/item/kitchen/knife/rainbowknife/afterattack(atom/O, mob/user, proximity)
-	if(proximity && istype(O, /mob/living))
-		damtype = pick(BRUTE, BURN, TOX, OXY, CLONE)
+/obj/item/kitchen/knife/rainbowknife/afterattack(atom/O, mob/user)
+	. = ..()
+	if(!istype(O, /mob/living))
+		return
+	damtype = pick(BRUTE, BURN, TOX, OXY, CLONE)
 	switch(damtype)
 		if(BRUTE)
 			hitsound = 'sound/weapons/bladeslice.ogg'
@@ -46,7 +48,6 @@ Slimecrossing Weapons
 		if(CLONE)
 			hitsound = 'sound/items/geiger/ext1.ogg'
 			attack_verb = list("irradiated","mutated","maligned")
-	return ..()
 
 //Adamantine shield - Chilling Adamantine
 /obj/item/twohanded/required/adamantineshield

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -146,8 +146,8 @@ Chilling extracts:
 	var/list/allies = list()
 	var/active = FALSE
 
-/obj/item/slimecross/chilling/bluespace/afterattack(atom/target, mob/user, proximity)
-	if(!proximity || !isliving(target) || active)
+/obj/item/slimecross/chilling/bluespace/afterattack(atom/target, mob/user)
+	if(!isliving(target) || active)
 		return
 	if(target in allies)
 		allies -= target
@@ -185,8 +185,8 @@ Chilling extracts:
 	effect_desc = "Touching someone with it adds/removes them from a list. Activating the extract stops time for 30 seconds, and everyone on the list is immune, except the user."
 	var/list/allies = list()
 
-/obj/item/slimecross/chilling/sepia/afterattack(atom/target, mob/user, proximity)
-	if(!proximity || !isliving(target))
+/obj/item/slimecross/chilling/sepia/afterattack(atom/target, mob/user)
+	if(!isliving(target))
 		return
 	if(target in allies)
 		allies -= target

--- a/code/modules/research/xenobiology/crossbreeding/prismatic.dm
+++ b/code/modules/research/xenobiology/crossbreeding/prismatic.dm
@@ -10,9 +10,7 @@ Prismatic extracts:
 	icon_state = "prismatic"
 	var/paintcolor = "#FFFFFF"
 
-/obj/item/slimecross/prismatic/afterattack(turf/target, mob/user, proximity)
-	if(!proximity)
-		return
+/obj/item/slimecross/prismatic/afterattack(turf/target, mob/user)
 	if(!istype(target) || isspaceturf(target))
 		return
 	target.add_atom_colour(paintcolor, WASHABLE_COLOUR_PRIORITY)
@@ -22,10 +20,8 @@ Prismatic extracts:
 	colour = "grey"
 	desc = "It's constantly wet with a pungent-smelling, clear chemical."
 
-/obj/item/slimecross/prismatic/grey/afterattack(turf/target, mob/user, proximity)
+/obj/item/slimecross/prismatic/grey/afterattack(turf/target, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(istype(target) && target.color != initial(target.color))
 		target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 		playsound(target, 'sound/effects/slosh.ogg', 20, TRUE)

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -14,9 +14,9 @@ Regenerative extracts:
 /obj/item/slimecross/regenerative/proc/core_effect_before(mob/living/carbon/human/target, mob/user)
 	return
 
-/obj/item/slimecross/regenerative/afterattack(atom/target,mob/user,prox)
+/obj/item/slimecross/regenerative/afterattack(atom/target,mob/user)
 	. = ..()
-	if(!prox || !isliving(target))
+	if(!isliving(target))
 		return
 	var/mob/living/H = target
 	if(H.stat == DEAD)

--- a/code/modules/ruins/lavalandruin_code/puzzle.dm
+++ b/code/modules/ruins/lavalandruin_code/puzzle.dm
@@ -34,7 +34,7 @@
 			return get_step(center,SOUTH)
 		if(9)
 			return get_step(center,SOUTHEAST)
-		
+
 /obj/effect/sliding_puzzle/Initialize(mapload)
 	..()
 	return INITIALIZE_HINT_LATELOAD
@@ -56,7 +56,7 @@
 /obj/effect/sliding_puzzle/proc/validate()
 	if(finished)
 		return
-	
+
 	if(elements.len < 8) //Someone broke it
 		qdel(src)
 
@@ -86,7 +86,7 @@
 		shake_camera(M, COLLAPSE_DURATION , 1)
 	for(var/obj/structure/puzzle_element/E in elements)
 		E.collapse()
-	
+
 	dispense_reward()
 
 /obj/effect/sliding_puzzle/proc/dispense_reward()
@@ -103,7 +103,7 @@
 		for(var/j in i to current_ordering.len)
 			if(current_ordering[j] < checked_value)
 				swap_tally++
-	
+
 	return swap_tally % 2 == 0
 
 //swap two tiles in same row
@@ -113,13 +113,13 @@
 	if(empty_tile_id == 1 || empty_tile_id == 2) //Can't swap with empty one so just grab some in second row
 		first_tile_id = 4
 		other_tile_id = 5
-	
+
 	var/turf/T1 = get_turf_for_id(first_tile_id)
 	var/turf/T2 = get_turf_for_id(other_tile_id)
-	
+
 	var/obj/structure/puzzle_element/E1 = locate() in T1
 	var/obj/structure/puzzle_element/E2 = locate() in T2
-	
+
 	E1.forceMove(T2)
 	E2.forceMove(T1)
 
@@ -305,9 +305,9 @@
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	icon_state = "prison_cube"
 
-/obj/item/prisoncube/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+/obj/item/prisoncube/afterattack(atom/target, mob/user, click_parameters)
 	. = ..()
-	if(!proximity_flag || !isliving(target))
+	if(!isliving(target))
 		return
 	var/mob/living/victim = target
 	var/mob/living/carbon/carbon_victim = victim
@@ -342,7 +342,7 @@
 	for(var/atom/movable/AM in things_to_throw)
 		var/throwtarget = get_edge_target_turf(T, get_dir(T, get_step_away(AM, T)))
 		AM.throw_at(throwtarget, 2, 3)
-	
+
 	//Create puzzle itself
 	cube.prisoner = prisoner
 	cube.setup()

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -137,8 +137,6 @@
 
 /obj/item/kitchen/knife/envy/afterattack(atom/movable/AM, mob/living/carbon/human/user, proximity)
 	. = ..()
-	if(!proximity)
-		return
 	if(!istype(user))
 		return
 	if(ishuman(AM))

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -419,12 +419,9 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
     desc = "A hand-held environmental scanner which reports current gas levels. This one seems custom rigged to additionally be able to analyze some sort of bluespace device."
     icon_state = "hilbertsanalyzer"
 
-/obj/item/analyzer/hilbertsanalyzer/afterattack(atom/target, mob/user, proximity)
+/obj/item/analyzer/hilbertsanalyzer/afterattack(atom/target, mob/user)
     . = ..()
     if(istype(target, /obj/item/hilbertshotel))
-        if(!proximity)
-            to_chat(user, "<span class='warning'>It's to far away to scan!</span>")
-            return
         var/obj/item/hilbertshotel/sphere = target
         if(sphere.activeRooms.len)
             to_chat(user, "Currently Occupied Rooms:")

--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -29,7 +29,7 @@
 		return
 	..()
 
-/obj/item/melee/touch_attack/afterattack(atom/target, mob/user, proximity)
+/obj/item/melee/touch_attack/afterattack(atom/target, mob/user)
 	. = ..()
 	user.say(catchphrase, forced = "spell")
 	playsound(get_turf(user), on_use_sound,50,TRUE)
@@ -50,8 +50,8 @@
 	icon_state = "disintegrate"
 	item_state = "disintegrate"
 
-/obj/item/melee/touch_attack/disintegrate/afterattack(atom/target, mob/living/carbon/user, proximity)
-	if(!proximity || target == user || !ismob(target) || !iscarbon(user) || !(user.mobility_flags & MOBILITY_USE)) //exploding after touching yourself would be bad
+/obj/item/melee/touch_attack/disintegrate/afterattack(atom/target, mob/living/carbon/user)
+	if(target == user || !ismob(target) || !iscarbon(user) || !(user.mobility_flags & MOBILITY_USE)) //exploding after touching yourself would be bad
 		return
 	if(!user.can_speak_vocal())
 		to_chat(user, "<span class='warning'>You can't get the words out!</span>")
@@ -89,8 +89,8 @@
 	icon_state = "fleshtostone"
 	item_state = "fleshtostone"
 
-/obj/item/melee/touch_attack/fleshtostone/afterattack(atom/target, mob/living/carbon/user, proximity)
-	if(!proximity || target == user || !isliving(target) || !iscarbon(user)) //getting hard after touching yourself would also be bad
+/obj/item/melee/touch_attack/fleshtostone/afterattack(atom/target, mob/living/carbon/user)
+	if(target == user || !isliving(target) || !iscarbon(user)) //getting hard after touching yourself would also be bad
 		return
 	if(!(user.mobility_flags & MOBILITY_USE))
 		to_chat(user, "<span class='warning'>You can't reach out!</span>")

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -79,8 +79,6 @@
 
 /obj/item/dna_probe/afterattack(atom/target, mob/user, proximity)
 	. = ..()
-	if(!proximity || !target)
-		return
 	//tray plants
 	if(istype(target, /obj/machinery/hydroponics))
 		var/obj/machinery/hydroponics/H = target

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -212,10 +212,8 @@
 	icon_state = "evidenceobj"
 	item_flags = SURGICAL_TOOL
 
-/obj/item/organ_storage/afterattack(obj/item/I, mob/user, proximity)
+/obj/item/organ_storage/afterattack(obj/item/I, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(contents.len)
 		to_chat(user, "<span class='notice'>[src] already has something inside it.</span>")
 		return
@@ -259,10 +257,8 @@
 	item_flags = NOBLUDGEON
 	var/list/advanced_surgeries = list()
 
-/obj/item/surgical_processor/afterattack(obj/item/O, mob/user, proximity)
+/obj/item/surgical_processor/afterattack(obj/item/O, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(istype(O, /obj/item/disk/surgery))
 		to_chat(user, "<span class='notice'>You load the surgery protocol from [O] into [src].</span>")
 		var/obj/item/disk/surgery/D = O

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -975,10 +975,8 @@ GLOBAL_LIST_EMPTY(vending_products)
 	price = max(1, round(input(user,"set price","price") as num|null, 1))
 	to_chat(user, "<span class='notice'> The [src] will now give things an $[price] tag.</span>")
 
-/obj/item/price_tagger/afterattack(atom/target, mob/user, proximity)
+/obj/item/price_tagger/afterattack(atom/target, mob/user)
 	. = ..()
-	if(!proximity)
-		return
 	if(isitem(target))
 		var/obj/item/I = target
 		I.custom_price = price

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -27,11 +27,9 @@
 	else
 		icon_state = icon_right
 
-/obj/item/zombie_hand/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/zombie_hand/afterattack(atom/target, mob/user)
 	. = ..()
-	if(!proximity_flag)
-		return
-	else if(isliving(target))
+	if(isliving(target))
 		if(ishuman(target))
 			try_to_zombie_infect(target)
 		else


### PR DESCRIPTION
## About The Pull Request

ranged_attack() is what is called for attacks that are out of melee range.
afterattack() is now ONLY used as the last part of melee_attack_chain

This is almost done. The main and well... also biggest thing missing is guns. Haven't
even touched those yet.

The second pain point is that this is completely untested. I would like some feedback on if this is even needed/wanted.

This also fixes a bunch of related issues that are caused by things not respecting the proximity flag.

## Changelog
:cl:
fix: bane component now only works in melee range.
fix: shock touch now only works in melee range.
fix: stupid beesword no longer injects toxins at range
fix: AI malf and surveillance upgrade now only work in melee range
fix: You can no longer insert TC into the frame cartridge at range.
fix: Wizard armor charges can now only be used in melee range.
fix: You can now only stabilize legion cores in melee range.
fix: Borg hand labeler now only does its extra effect if you are in melee range.
fix: Slime potions can no longer be applied from anything but melee range.
fix: The base version of the touch spell (unused without admin intervention) can now only be used in melee
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
