### PR TITLE
Fixes proximity checks

### DIFF
--- a/code/datums/components/bane.dm
+++ b/code/datums/components/bane.dm
@@ -8,7 +8,7 @@
 /datum/component/bane/Initialize(mobtype, damage_multiplier=1)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
-	
+
 	if(ispath(mobtype, /mob/living))
 		src.mobtype = mobtype
 	else if(ispath(mobtype, /datum/species))
@@ -28,12 +28,12 @@
 	UnregisterSignal(parent, COMSIG_ITEM_AFTERATTACK)
 
 /datum/component/bane/proc/speciesCheck(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
-	if(!is_species(target, speciestype))
+	if(!proximity_flag || !is_species(target, speciestype))
 		return
 	activate(source, target, user)
 
 /datum/component/bane/proc/mobCheck(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
-	if(!istype(target, mobtype))
+	if(!proximity_flag || !istype(target, mobtype))
 		return
 	activate(source, target, user)
 

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -29,6 +29,9 @@
 	item_state = "zapper"
 
 /obj/item/melee/touch_attack/shock/afterattack(atom/target, mob/living/carbon/user, proximity)
+	. = ..()
+	if(!proximity)
+		return
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
 		if(C.electrocute_act(15, user, 1, FALSE, FALSE, FALSE, FALSE, FALSE))//doesnt stun. never let this stun
@@ -36,15 +39,15 @@
 			C.dropItemToGround(C.get_inactive_held_item())
 			C.confused += 15
 			C.visible_message("<span class='danger'>[user] electrocutes [target]!</span>","<span class='userdanger'>[user] electrocutes you!</span>")
-			return ..()
+			return
 		else
 			user.visible_message("<span class='warning'>[user] fails to electrocute [target]!</span>")
-			return ..()
+			return
 	else if(isliving(target))
 		var/mob/living/L = target
 		L.electrocute_act(15, user, 1, FALSE, FALSE, FALSE, FALSE)
 		L.visible_message("<span class='danger'>[user] electrocutes [target]!</span>","<span class='userdanger'>[user] electrocutes you!</span>")
-		return ..()
+		return
 	else
 		to_chat(user,"<span class='warning'>The electricity doesn't seem to affect [target]...</span>")
-		return ..()
+		return

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -29,7 +29,6 @@
 	item_state = "zapper"
 
 /obj/item/melee/touch_attack/shock/afterattack(atom/target, mob/living/carbon/user, proximity)
-	. = ..()
 	if(!proximity)
 		return
 	if(iscarbon(target))

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -38,15 +38,15 @@
 			C.dropItemToGround(C.get_inactive_held_item())
 			C.confused += 15
 			C.visible_message("<span class='danger'>[user] electrocutes [target]!</span>","<span class='userdanger'>[user] electrocutes you!</span>")
-			return
+			return ..()
 		else
 			user.visible_message("<span class='warning'>[user] fails to electrocute [target]!</span>")
-			return
+			return ..()
 	else if(isliving(target))
 		var/mob/living/L = target
 		L.electrocute_act(15, user, 1, FALSE, FALSE, FALSE, FALSE)
 		L.visible_message("<span class='danger'>[user] electrocutes [target]!</span>","<span class='userdanger'>[user] electrocutes you!</span>")
-		return
+		return ..()
 	else
 		to_chat(user,"<span class='warning'>The electricity doesn't seem to affect [target]...</span>")
-		return
+		return ..()

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -147,8 +147,10 @@
 	attack_verb = list("slashed", "stung", "prickled", "poked")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 
-/obj/item/melee/beesword/afterattack(atom/target, mob/user, proximity = TRUE)
+/obj/item/melee/beesword/afterattack(atom/target, mob/user, proximity)
 	. = ..()
+	if(!proximity)
+		return
 	user.changeNext_move(CLICK_CD_RAPID)
 	if(iscarbon(target))
 		var/mob/living/carbon/H = target
@@ -239,7 +241,7 @@
 
 		user.Paralyze(knockdown_time_carbon * force)
 		user.adjustStaminaLoss(stamina_damage)
-		
+
 		additional_effects_carbon(user) // user is the target here
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
@@ -386,7 +388,7 @@
 
 	cooldown = 25
 	stamina_damage = 85
-	affect_silicon = TRUE 
+	affect_silicon = TRUE
 	on_sound = 'sound/weapons/contractorbatonextend.ogg'
 	on_stun_sound = 'sound/effects/contractorbatonhit.ogg'
 

--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -9,8 +9,10 @@
 	icon_state = "datadisk3"
 
 
-/obj/item/malf_upgrade/afterattack(mob/living/silicon/ai/AI, mob/user)
+/obj/item/malf_upgrade/afterattack(mob/living/silicon/ai/AI, mob/user, proximity)
 	. = ..()
+	if(!proximity)
+		return
 	if(!istype(AI))
 		return
 	if(AI.malf_picker)
@@ -33,8 +35,10 @@
 	icon = 'icons/obj/module.dmi'
 	icon_state = "datadisk3"
 
-/obj/item/surveillance_upgrade/afterattack(mob/living/silicon/ai/AI, mob/user)
+/obj/item/surveillance_upgrade/afterattack(mob/living/silicon/ai/AI, mob/user, proximity)
 	. = ..()
+	if(!proximity)
+		return
 	if(!istype(AI))
 		return
 	if(AI.eyeobj)

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -22,6 +22,8 @@
 
 /obj/item/stack/telecrystal/afterattack(obj/item/I, mob/user, proximity)
 	. = ..()
+	if(!proximity)
+		return
 	if(istype(I, /obj/item/cartridge/virus/frame))
 		var/obj/item/cartridge/virus/frame/cart = I
 		if(!cart.charges)

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -219,8 +219,10 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "electricity2"
 
-/obj/item/wizard_armour_charge/afterattack(obj/item/clothing/suit/space/hardsuit/shielded/wizard/W, mob/user)
+/obj/item/wizard_armour_charge/afterattack(obj/item/clothing/suit/space/hardsuit/shielded/wizard/W, mob/user, proximity)
 	. = ..()
+	if(!proximity)
+		return
 	if(!istype(W))
 		to_chat(user, "<span class='warning'>The rune can only be used on battlemage armour!</span>")
 		return

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -6,8 +6,10 @@
 	desc = "Inject certain types of monster organs with this stabilizer to preserve their healing powers indefinitely."
 	w_class = WEIGHT_CLASS_TINY
 
-/obj/item/hivelordstabilizer/afterattack(obj/item/organ/M, mob/user)
+/obj/item/hivelordstabilizer/afterattack(obj/item/organ/M, mob/user, proximity)
 	. = ..()
+	if(!proximity)
+		return
 	var/obj/item/organ/regenerative_core/C = M
 	if(!istype(C, /obj/item/organ/regenerative_core))
 		to_chat(user, "<span class='warning'>The stabilizer only works on certain types of monster organs, generally regenerative in nature.</span>")

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -90,7 +90,9 @@
 	name = "cyborg-hand labeler"
 
 /obj/item/hand_labeler/borg/afterattack(atom/A, mob/user, proximity)
-	. = ..(A, user, proximity)
+	. = ..()
+	if(!proximity)
+		return
 	if(!iscyborg(user))
 		return
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -611,6 +611,8 @@
 
 /obj/item/slimepotion/afterattack(obj/item/reagent_containers/target, mob/user , proximity)
 	. = ..()
+	if(!proximity)
+		return
 	if (istype(target))
 		to_chat(user, "<span class='warning'>You cannot transfer [src] to [target]! It appears the potion must be given directly to a slime to absorb.</span>" )
 		return
@@ -713,7 +715,9 @@
 	var/prompted = 0
 	var/animal_type = SENTIENCE_ORGANIC
 
-/obj/item/slimepotion/transference/afterattack(mob/living/M, mob/user)
+/obj/item/slimepotion/transference/afterattack(mob/living/M, mob/user, proximity)
+	if(!proximity)
+		return
 	if(prompted || !ismob(M))
 		return
 	if(!isanimal(M) || M.ckey) //much like sentience, these will not work on something that is already player controlled
@@ -833,8 +837,10 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "potyellow"
 
-/obj/item/slimepotion/speed/afterattack(obj/C, mob/user)
+/obj/item/slimepotion/speed/afterattack(obj/C, mob/user, proximity)
 	. = ..()
+	if(!proximity)
+		return
 	if(!istype(C))
 		to_chat(user, "<span class='warning'>The potion can only be used on items or vehicles!</span>")
 		return
@@ -868,8 +874,10 @@
 	resistance_flags = FIRE_PROOF
 	var/uses = 3
 
-/obj/item/slimepotion/fireproof/afterattack(obj/item/clothing/C, mob/user)
+/obj/item/slimepotion/fireproof/afterattack(obj/item/clothing/C, mob/user, proximity)
 	. = ..()
+	if(!proximity)
+		return
 	if(!uses)
 		qdel(src)
 		return

--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -31,6 +31,8 @@
 
 /obj/item/melee/touch_attack/afterattack(atom/target, mob/user, proximity)
 	. = ..()
+	if(!proximity)
+		return
 	user.say(catchphrase, forced = "spell")
 	playsound(get_turf(user), on_use_sound,50,TRUE)
 	charges--


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Wanted to do it like in https://github.com/tgstation/tgstation/pull/46650 originally but motivation and time is a bit on the short end. This will have to do for now.

## Changelog
:cl:
fix: bane component now only works in melee range.
fix: shock touch now only works in melee range.
fix: stupid beesword no longer injects toxins at range
fix: AI malf and surveillance upgrade now only work in melee range
fix: You can no longer insert TC into the frame cartridge at range.
fix: Wizard armor charges can now only be used in melee range.
fix: You can no longer stabilize hivelord (legion) cores from range.
fix: Borg hand labeler now only does its extra effect if you are in melee range.
fix: Slime potions can no longer be applied from anything but melee range.
fix: The base version of the touch spell (unused without admin intervention) can now only be used in melee.
/:cl: