### PR TITLE
Fixes the monastery shuttle of Pubby Station.

### DIFF
--- a/_maps/shuttles/escape_pod_large.dmm
+++ b/_maps/shuttles/escape_pod_large.dmm
@@ -72,6 +72,7 @@
 /obj/docking_port/mobile/pod{
 	dwidth = 2;
 	height = 6;
+	id = "pod1";
 	port_direction = 2;
 	width = 5
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR fixes the longstanding issue where you could not use the monastery shuttle's console's located on the station and on the chapel monastery. And in the event the shuttle's console got screwdrivered, that one also couldn't be used. Now it can. Basically, the consoles all had their "Shuttle ID" as "pod1", but the port on the shuttle itself had it's id as just "pod". Hence, they didn't see each other as valid targets.

I did test it thoroughly to make sure it does properly work and that nothing else is wrong. Using the consoles on the shuttle, the one on the chapel, and the one onstation. And deconstructing and reconstructing the onshuttle one. Everything works. This thus Fixes #46470 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Simply, we now have access once more to a working monastery shuttle which isn't horribly bugged.

## Changelog
:cl:
fix: The Monastery Shuttle on Pubby Station is fully functional once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
