### PR TITLE
Space doesn't get hot anymore

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -267,7 +267,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 /datum/gas_mixture/parse_gas_string(gas_string)
 	gas_string = SSair.preprocess_gas_string(gas_string)
-	
+
 	var/list/gases = src.gases
 	var/list/gas = params2list(gas_string)
 	if(gas["TEMP"])
@@ -338,6 +338,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 		if(new_sharer_heat_capacity > MINIMUM_HEAT_CAPACITY)
 			sharer.temperature = (old_sharer_heat_capacity*sharer.temperature-heat_capacity_sharer_to_self*sharer.temperature_archived + heat_capacity_self_to_sharer*temperature_archived)/new_sharer_heat_capacity
+			sharer.garbage_collect()
 		//thermal energy of the system (self and sharer) is unchanged
 
 			if(abs(old_sharer_heat_capacity) > MINIMUM_HEAT_CAPACITY)
@@ -432,7 +433,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 					continue reaction_loop
 
 			//at this point, all requirements for the reaction are satisfied. we can now react()
-			
+
 			. |= reaction.react(src, holder)
 			if (. & STOP_REACTIONS)
 				break

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -43,7 +43,7 @@
 	. = ..()
 	temperature = initial_temperature
 
-/datum/gas_mixture/immutable/temperature_share(datum/gas_mixture/immutable/sharer, conduction_coefficient, sharer_temperature, sharer_heat_capacity)
+/datum/gas_mixture/temperature_share(datum/gas_mixture/immutable/sharer, conduction_coefficient, sharer_temperature, sharer_heat_capacity)
 	. = ..()
 	if(sharer)
 		sharer.temperature = sharer.initial_temperature

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -43,6 +43,11 @@
 	. = ..()
 	temperature = initial_temperature
 
+/datum/gas_mixture/immutable/temperature_share(datum/gas_mixture/immutable/sharer, conduction_coefficient, sharer_temperature, sharer_heat_capacity)
+	. = ..()
+	if(sharer)
+		sharer.temperature = sharer.initial_temperature
+
 //used by space tiles
 /datum/gas_mixture/immutable/space
 	initial_temperature = TCMB

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -43,11 +43,6 @@
 	. = ..()
 	temperature = initial_temperature
 
-/datum/gas_mixture/temperature_share(datum/gas_mixture/immutable/sharer, conduction_coefficient, sharer_temperature, sharer_heat_capacity)
-	. = ..()
-	if(sharer)
-		sharer.temperature = sharer.initial_temperature
-
 //used by space tiles
 /datum/gas_mixture/immutable/space
 	initial_temperature = TCMB


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes  #46621 

This should clear up the (most common?) situation where a  gas_mixture/immutable can have its temperature changed without having it be immediately changed back, which causes stuff like trillion degree space tiles, and therefore trillion degree SM coolant. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Doing fusion should not blow up the SM on the other side of the map 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Space can no longer get hot. In particular, doing fusion near space tiles won't wreck the SM.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
