### PR TITLE
Bike horns, golden horns, rubber ducks, and air horns no longer plays sounds when crossed in Zero-G or by flying mobs.

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -65,6 +65,8 @@
 				return
 	if(istype(AM, /obj/effect/dummy/phased_mob)) //don't squeek if they're in a phased/jaunting container.
 		return
+	if(!AM.has_gravity())
+		return
 	var/atom/current_parent = parent
 	if(isturf(current_parent.loc))
 		play_squeak()

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -67,6 +67,10 @@
 		return
 	if(!AM.has_gravity())
 		return
+	if(ismob(AM))
+		var/mob/M = AM
+		if(M.is_flying())
+			return
 	var/atom/current_parent = parent
 	if(isturf(current_parent.loc))
 		play_squeak()

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -65,11 +65,9 @@
 				return
 	if(istype(AM, /obj/effect/dummy/phased_mob)) //don't squeek if they're in a phased/jaunting container.
 		return
-	if(!AM.has_gravity())
-		return
 	if(ismob(AM))
 		var/mob/M = AM
-		if(M.is_flying())
+		if(M.movement_type & (FLYING|FLOATING))
 			return
 	var/atom/current_parent = parent
 	if(isturf(current_parent.loc))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR makes it so that bike horns, golden horns, rubber ducks, and air horns no longer plays their respective sounds when they are crossed in Zero Gravity by mobs, nor when they are crossed by flying mobs. Thus some clown annoyance is removed.

Update: Due now using FLOATING instead of has_gravity(), and just for mobs, items going over bikehorns in Zero G still makes them squeak. No idea why that even exists, but what can you do.

Fixes #45854

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Honestly, anything which makes the damn air horn screech less in my ear is a good thing.

## Changelog
:cl:
fix: Bike horns, golden horns, rubber ducks, and air horns no longer plays their respective sounds when crossed in zero gravity, nor when crossed by flying mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
