### PR TITLE
xeno helmet now covers mouth and eyes

### DIFF
--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -206,6 +206,7 @@
 	desc = "A helmet made out of chitinous alien hide."
 	clothing_flags = SNUG_FIT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 
 /obj/item/clothing/head/fedora
 	name = "fedora"


### PR DESCRIPTION
## About The Pull Request

does what title says, this makes the helmet facehugger proof because of the mouth covering

## Why It's Good For The Game

its a helmet covering the entirety of your head, so it should cover everything, made of alien chitin, makes a fun interaction that an item made of xeno skin is facehugger proof

## Changelog
:cl:
tweak: the xeno helmet is now facehugger proof
/:cl: