### PR TITLE
More Green Slime Mutation Toxins

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -90,7 +90,7 @@
 	name = "Shadowperson Mutation Toxin"
 	id = "shadowmuttoxin"
 	results = list(/datum/reagent/mutationtoxin/shadow = 1)
-	required_reagents = list(/datum/reagent/consumable/liquid_dark_matter = 1)
+	required_reagents = list(/datum/reagent/liquid_dark_matter = 1)
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/green
 

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -70,6 +70,38 @@
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/green
 
+/datum/chemical_reaction/slime/slimeandroid
+	name = "Android Mutation Toxin"
+	id = "androidmuttoxin"
+	results = list(/datum/reagent/mutationtoxin/android = 1)
+	required_reagents = list(/datum/reagent/silicon = 1)
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimepod
+	name = "Podperson Mutation Toxin"
+	id = "podmuttoxin"
+	results = list(/datum/reagent/mutationtoxin/pod = 1)
+	required_reagents = list(/datum/reagent/consumable/nutriment = 1)
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimeshadow
+	name = "Shadowperson Mutation Toxin"
+	id = "shadowmuttoxin"
+	results = list(/datum/reagent/mutationtoxin/shadow = 1)
+	required_reagents = list(/datum/reagent/consumable/liquid_dark_matter = 1)
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimeplasma
+	name = "Plasmaman Mutation Toxin"
+	id = "plasmamuttoxin"
+	results = list(/datum/reagent/mutationtoxin/plasma = 1)
+	required_reagents = list(/datum/reagent/phlogiston = 1)
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+	
 //Metal
 /datum/chemical_reaction/slime/slimemetal
 	name = "Slime Metal"

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -357,7 +357,7 @@
 	name = "green slime extract"
 	icon_state = "green slime extract"
 	effectmod = "mutative"
-	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/uranium/radium)
+	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/uranium/radium,/datum/reagent/silicon,/datum/reagent/consumable/nutriment,/datum/reagent/liquid_dark_matter,/datum/reagent/phlogiston)
 
 /obj/item/slime_extract/green/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)


### PR DESCRIPTION
## About The Pull Request

Adds four new recipies for mutation toxins to green slimes: androids, podpeople, shadowpeople, and plasmamen. Android toxin requires silicon, podperson toxin requires nutriment, shadowperson toxin requires liquid dark matter, and plasmaman toxin requires phlogiston.

## Why It's Good For The Game

Mutation toxin is a fun mechanic that Xenobiology (eventually) gets access to, and it would be neat to see more of the exotic races going around. Also adds a new option for traitor xenobiologists other than "rush gold slimes and spam hostile mobs" in the form of plasmaman mutation toxin, which can be used to turn people into un-cloneable, asphyxiating, self-immolating messes.

## Changelog
:cl: Zenog
add: added recipies for android, podperson, shadowperson, and plasmaman mutation toxins to green slimes
/:cl: