### PR TITLE
canisters no longer runtime in update_icon when spawned mid-round

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -239,7 +239,7 @@
 		update |= CANISTER_UPDATE_HOLDING
 	if(connected_port)
 		update |= CANISTER_UPDATE_CONNECTED
-	var/pressure = air_contents ? air_contents.return_pressure() : 0
+	var/pressure = air_contents.return_pressure()
 	if(pressure < 10)
 		update |= CANISTER_UPDATE_EMPTY
 	else if(pressure < 5 * ONE_ATMOSPHERE)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -197,8 +197,6 @@
 	pump.stat = 0
 	pump.build_network()
 
-	update_icon()
-
 /obj/machinery/portable_atmospherics/canister/Destroy()
 	qdel(pump)
 	pump = null

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -186,10 +186,8 @@
 	filled = 1
 	release_pressure = ONE_ATMOSPHERE*2
 
-
-
-/obj/machinery/portable_atmospherics/canister/New(loc, datum/gas_mixture/existing_mixture)
-	..()
+/obj/machinery/portable_atmospherics/canister/Initialize(mapload, datum/gas_mixture/existing_mixture)
+	. = ..()
 	if(existing_mixture)
 		air_contents.copy_from(existing_mixture)
 	else

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -239,7 +239,7 @@
 		update |= CANISTER_UPDATE_HOLDING
 	if(connected_port)
 		update |= CANISTER_UPDATE_CONNECTED
-	var/pressure = air_contents.return_pressure()
+	var/pressure = air_contents ? air_contents.return_pressure() : 0
 	if(pressure < 10)
 		update |= CANISTER_UPDATE_EMPTY
 	else if(pressure < 5 * ONE_ATMOSPHERE)

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -18,11 +18,11 @@
 	..()
 	SSair.atmos_machinery += src
 
+/obj/machinery/portable_atmospherics/Initialize()
+	. = ..()
 	air_contents = new
 	air_contents.volume = volume
 	air_contents.temperature = T20C
-
-	return 1
 
 /obj/machinery/portable_atmospherics/Destroy()
 	SSair.atmos_machinery -= src


### PR DESCRIPTION
## About The Pull Request
~~This fixes a runtime when spawning canisters or creating canisters with metal stacks. I'm just checking that air_contents isn't null because the alternative would be some ugly overriding of LateInitialize or power_change to stop the early update_icon call.~~

~~Another update_icon call comes along later in the case of spawning a pre-filled canister, so the correct icons are still displayed.~~

I've replaced the New proc in portable_atmospherics and canisters with an Initialize proc so that update_icon will never be called before air_contents has been initialized.

The runtime was:
```
[2019-09-23 13:08:53.597] runtime error: Cannot execute null.return pressure().
 - proc name: update icon (/obj/machinery/portable_atmospherics/canister/update_icon)
 -   source file: canister.dm,242
 -   usr: Ximena Thomas (/mob/living/carbon/human)
 -   src: the canister (/obj/machinery/portable_atmospherics/canister)
 -   usr.loc: the floor (146,118,2) (/turf/open/floor/plasteel/white)
 -   src.loc: the floor (146,118,2) (/turf/open/floor/plasteel/white)
 -   call stack:
 - the canister (/obj/machinery/portable_atmospherics/canister): update icon()
 - the canister (/obj/machinery/portable_atmospherics/canister): power change()
 - the canister (/obj/machinery/portable_atmospherics/canister): LateInitialize()
 - Atoms (/datum/controller/subsystem/atoms): InitAtom(the canister (/obj/machinery/portable_atmospherics/canister), /list (/list))
 - the canister (/obj/machinery/portable_atmospherics/canister): New(0, null)
 - the canister (/obj/machinery/portable_atmospherics/canister): New(the floor (146,118,2) (/turf/open/floor/plasteel/white), null)
 - the canister (/obj/machinery/portable_atmospherics/canister): New(the floor (146,118,2) (/turf/open/floor/plasteel/white), null)
 - the metal (/obj/item/stack/sheet/metal/fifty): Topic("src=\[0x20283f6];sublist=;make...", /list (/list))
 - Guest-1592535968 (/client): Topic("src=\[0x20283f6];sublist=;make...", /list (/list), the metal (/obj/item/stack/sheet/metal/fifty))
 - Guest-1592535968 (/client): Topic("src=\[0x20283f6];sublist=;make...", /list (/list), the metal (/obj/item/stack/sheet/metal/fifty))
```

## Changelog
:cl:
code: canisters no longer runtime in update_icon when spawned mid-round
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
