### PR TITLE
Fixes Adult Slimes Dealing No Damage

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -132,7 +132,7 @@
 /obj/attack_slime(mob/living/simple_animal/slime/user)
 	if(!user.is_adult)
 		return
-	attack_generic(user, rand(10, 15), "melee", 1)
+	attack_generic(user, rand(10, 15), BRUTE, "melee", 1)
 
 /obj/mech_melee_attack(obj/mecha/M)
 	M.do_attack_animation(src)


### PR DESCRIPTION
Found this over at Paradise. I'm surprised this didn't get spotted prior to now.

Guess people don't play slimes that much....and with how fast paced Xenobio is with the slime console, adult slimes never got hungry enough to start getting grumpy and attack the windows/grilles.

:cl: Fox McCloud
fix: Fixes adult slimes not dealing damage to objects
/:cl: