### PR TITLE
Improves the code by removing irrelevant damage deflection code from secure_closets.dm

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -6,8 +6,4 @@
 	max_integrity = 250
 	armor = list("melee" = 30, "bullet" = 50, "laser" = 50, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
 	secure = TRUE
-
-/obj/structure/closet/secure_closet/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
-	if(damage_flag == "melee" && damage_amount < 20)
-		return 0
-	. = ..()
+	damage_deflection = 20


### PR DESCRIPTION
Something I ruminated on in https://github.com/tgstation/tgstation/pull/41551 that didn't get caught when Actioninja made the change himself in https://github.com/tgstation/tgstation/pull/45609. It's on the obj level now so copypaste code can begone. 