### PR TITLE
Buffs The Xeno Armblade

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -8,7 +8,7 @@ Slimecrossing Weapons
 /obj/item/melee/arm_blade/slime
 	name = "slimy boneblade"
 	desc = "What remains of the bones in your arm. Incredibly sharp, and painful for both you and your opponents."
-	force = 15
+	force = 25
 	force_string = "painful"
 
 /obj/item/melee/arm_blade/slime/attack(mob/living/L, mob/user)

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -8,7 +8,7 @@ Slimecrossing Weapons
 /obj/item/melee/arm_blade/slime
 	name = "slimy boneblade"
 	desc = "What remains of the bones in your arm. Incredibly sharp, and painful for both you and your opponents."
-	force = 25
+	force = 20
 	force_string = "painful"
 
 /obj/item/melee/arm_blade/slime/attack(mob/living/L, mob/user)

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -210,7 +210,7 @@ Burning extracts:
 
 /obj/item/slimecross/burning/green
 	colour = "green"
-	effect_desc = "The user gets a dull arm blade in the hand it is used in."
+	effect_desc = "The user gets a permanent arm blade formed from their flesh in the hand it is used in."
 
 /obj/item/slimecross/burning/green/do_effect(mob/user)
 	var/which_hand = "l_hand"


### PR DESCRIPTION
Xeno arm-blade takes time to get as well as it requires a sacrifice from the player. Permanently losing their arm for a weapon doesn't make sense when they could just protolathe a circular saw for the same damage without any downsides.

## About The Pull Request

The request simply changes the force damage for the blade from 15 to 25. This may be too much as 20 could be the sweet spot. I feel this should be open for discussion.

I've also updated the text to make it more clear, my first impressions was that that extract would turn into the blade, not my arm itself.

-- Please give any feedback for the rework you can! --

## Why It's Good For The Game

This rewards players that decide to use xeno for a weapon. Xeno takes time to get something out of it and for a weapon to remove the ability to use an arm as well as requiring a time investment to get there it makes no sense for it to do 15 damage given that other surgical tools that are easily accessible from round start do the exact same damage.

## PR Update

After discussion with the community the changes will be as follows:

- The arm is now retractable. A player will take 3 brute and 3 toxin damage on equipping the weapon
- The arm will do 10 brute damage and 5 cellular damage on hit
- MAYBE: The arm athestitcs will be updated to be more slime related.



