### PR TITLE
AI combat software upgrade gives proper malf abilities

### DIFF
--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -20,6 +20,7 @@
 		to_chat(AI, "<span class='userdanger'>[user] has upgraded you with combat software!</span>")
 		to_chat(AI, "<span class='userdanger'>Your current laws and objectives remain unchanged.</span>") //this unlocks malf powers, but does not give the license to plasma flood
 		AI.add_malf_picker()
+		AI.hack_software = TRUE
 		log_game("[key_name(user)] has upgraded [key_name(AI)] with a [src].")
 		message_admins("[ADMIN_LOOKUPFLW(user)] has upgraded [ADMIN_LOOKUPFLW(AI)] with a [src].")
 	to_chat(user, "<span class='notice'>You upgrade [AI]. [src] is consumed in the process.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR gives combat software upgrades the same abilities that malf AIs have. Right now, the missing ones were:
* Brute forcing message encryption keys
* Taking direct control of turrets
* Emagging borgs via borgo console
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It looks like the missing `hack_software = TRUE` is just an oversight. I'd also rather have the combat software update be consistent with malf powers.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
balance: The AI combat software upgrade now adds missing malf AI abilities, like being able to emag borgs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
