### PR TITLE
Adds back GPS functionality to the teleportation console

### DIFF
--- a/code/datums/components/gps.dm
+++ b/code/datums/components/gps.dm
@@ -3,6 +3,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 ///GPS component. Atoms that have this show up on gps. Pretty simple stuff.
 /datum/component/gps
 	var/gpstag = "COM0"
+	var/turf/locked_location
 	var/tracking = TRUE
 	var/emped = FALSE
 
@@ -101,6 +102,8 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	if(!tracking || emped) //Do not bother scanning if the GPS is off or EMPed
 		return data
 
+	locked_location = get_turf(parent)
+
 	var/turf/curr = get_turf(parent)
 	data["current"] = "[get_area_name(curr, TRUE)] ([curr.x], [curr.y], [curr.z])"
 
@@ -138,7 +141,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 		if("rename")
 			var/atom/parentasatom = parent
 			var/a = input("Please enter desired tag.", parentasatom.name, gpstag) as text|null
-			
+
 			if (!a)
 				return
 

--- a/code/datums/components/gps.dm
+++ b/code/datums/components/gps.dm
@@ -104,8 +104,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 
 	locked_location = get_turf(parent)
 
-	var/turf/curr = get_turf(parent)
-	data["current"] = "[get_area_name(curr, TRUE)] ([curr.x], [curr.y], [curr.z])"
+	data["current"] = "[get_area_name(locked_location, TRUE)] ([locked_location.x], [locked_location.y], [locked_location.z])"
 
 	var/list/signals = list()
 	data["signals"] = list()
@@ -115,16 +114,16 @@ GLOBAL_LIST_EMPTY(GPS_list)
 		if(G.emped || !G.tracking || G == src)
 			continue
 		var/turf/pos = get_turf(G.parent)
-		if(!pos || !global_mode && pos.z != curr.z)
+		if(!pos || !global_mode && pos.z != locked_location.z)
 			continue
 		var/list/signal = list()
 		signal["entrytag"] = G.gpstag //Name or 'tag' of the GPS
 		signal["area"] = get_area_name(G, TRUE)
 		signal["coord"] = "[pos.x], [pos.y], [pos.z]"
-		if(pos.z == curr.z) //Distance/Direction calculations for same z-level only
-			signal["dist"] = max(get_dist(curr, pos), 0) //Distance between the src and remote GPS turfs
-			signal["degrees"] = round(Get_Angle(curr, pos)) //0-360 degree directional bearing, for more precision.
-			var/direction = uppertext(dir2text(get_dir(curr, pos))) //Direction text (East, etc). Not as precise, but still helpful.
+		if(pos.z == locked_location.z) //Distance/Direction calculations for same z-level only
+			signal["dist"] = max(get_dist(locked_location, pos), 0) //Distance between the src and remote GPS turfs
+			signal["degrees"] = round(Get_Angle(locked_location, pos)) //0-360 degree directional bearing, for more precision.
+			var/direction = uppertext(dir2text(get_dir(locked_location, pos))) //Direction text (East, etc). Not as precise, but still helpful.
 			if(!direction)
 				direction = "CENTER"
 				signal["degrees"] = "N/A"

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -1,4 +1,3 @@
-
 /obj/item/gps
 	name = "global positioning system"
 	desc = "Helping lost spacemen find their way through the planets since 2016."

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -1,3 +1,4 @@
+
 /obj/item/gps
 	name = "global positioning system"
 	desc = "Helping lost spacemen find their way through the planets since 2016."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds back the ability to insert the GPS into the teleportation console and use its stored coordinates as a target. The GPS stores the coordinates by being set to manual update.
![Capture](https://user-images.githubusercontent.com/50007631/65559849-7273ff00-df90-11e9-90f1-54bb96ea67c4.PNG)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds more functionality to the teleporation console, allowing more intresting things to be done with it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: GPS functionality back to the teleportation console
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
