### PR TITLE
Cryo cell QOL shortcuts

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -414,6 +414,20 @@
 				beaker = null
 				. = TRUE
 
+/obj/machinery/atmospherics/components/unary/cryo_cell/CtrlClick(mob/user)
+	if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK) && !state_open)
+		on = !on
+		update_icon()
+	return ..()
+
+/obj/machinery/atmospherics/components/unary/cryo_cell/AltClick(mob/user)
+	if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+		if(state_open)
+			close_machine()
+		else
+			open_machine()
+	return ..()
+
 /obj/machinery/atmospherics/components/unary/cryo_cell/update_remote_sight(mob/living/user)
 	return // we don't see the pipe network while inside cryo.
 


### PR DESCRIPTION
## About The Pull Request

Alt-clicking a cryo cell will toggle the doors, and ctrl-clicking it will toggle the power

## Why It's Good For The Game

Makes cryo cells less annoying to work with

## Changelog
:cl: Bumtickley00
add: Cryo cell shortcuts: alt-click toggles the doors, ctrl-click toggles the power
/:cl: