### PR TITLE
Adds new chaplain armor to the armament beacon

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -133,13 +133,14 @@
 
 /obj/item/clothing/head/helmet/chaplain/adept
 	name = "adept hood"
-	desc = "Its only heretical when others do it"
+	desc = "Its only heretical when others do it."
 	icon_state = "crusader"
 	item_state = "crusader"
+	flags_cover = HEADCOVERSEYES
 
 /obj/item/clothing/suit/armor/riot/chaplain/adept
 	name = "adept robes"
-	desc = "The ideal outfit for burning the unfaithful"
+	desc = "The ideal outfit for burning the unfaithful."
 	icon_state = "crusader"
 	item_state = "crusader"
 

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -124,6 +124,25 @@
 	item_state = "witchhunterhat"
 	flags_cover = HEADCOVERSEYES
 
+/obj/item/storage/box/holy/adept
+	name = "Divine Adept Kit"
+
+/obj/item/storage/box/holy/adept/PopulateContents()
+	new /obj/item/clothing/suit/armor/riot/chaplain/adept(src)
+	new /obj/item/clothing/head/helmet/chaplain/adept(src)
+
+/obj/item/clothing/head/helmet/chaplain/adept
+	name = "adept hood"
+	desc = "Its only heretical when others do it"
+	icon_state = "crusader"
+	item_state = "crusader"
+
+/obj/item/clothing/suit/armor/riot/chaplain/adept
+	name = "adept robes"
+	desc = "The ideal outfit for burning the unfaithful"
+	icon_state = "crusader"
+	item_state = "crusader"
+
 /obj/item/storage/box/holy/follower
 	name = "Followers of the Chaplain Kit"
 


### PR DESCRIPTION
### About The Pull Request
Adds a new set of chaplain armor to the armament beacon using admin only crusader armor that I believe was used for the Hand of God mode
![Screenshot (818)](https://user-images.githubusercontent.com/41690870/65566054-c0045380-df1f-11e9-8e1f-bed7c2076498.png)
### Why It's Good For The Game
Adds more variation to chaplain aesthetics, I felt the previous armament beacon armors weren't varied enough like the null rod options are
### Changelog
:cl: NoxVS
rscadd: New chaplain armor using unused crusader armor
/:cl: