### PR TITLE
fixes changeling faking death doing stuff twice

### DIFF
--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -23,9 +23,6 @@
 		to_chat(user, "<span class='notice'>We have revived ourselves.</span>")
 	else
 		to_chat(user, "<span class='notice'>We begin our stasis, preparing energy to arise once more.</span>")
-		if(user.stat != DEAD)
-			user.emote("deathgasp")
-			user.tod = station_time_timestamp()
 		user.fakedeath("changeling") //play dead
 		user.update_stat()
 		user.update_mobility()


### PR DESCRIPTION
## About The Pull Request

/mob/living/proc/fakedeath already deathgasps so this made faking death deathgasp twice making it obvious you are a ling

## Why It's Good For The Game

bad thing bad

## Changelog
:cl:
fix: lings no longer gasp twice
/:cl:
