### PR TITLE
Tesla code improvements and qdel checks

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -229,6 +229,8 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 
 ///Called when the obj is hit by a tesla bolt.
 /obj/proc/tesla_act(power, tesla_flags, shocked_targets)
+	if(QDELETED(src))
+		return
 	obj_flags |= BEING_SHOCKED
 	var/power_bounced = power / 2
 	tesla_zap(src, 3, power_bounced, tesla_flags, shocked_targets)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -39,7 +39,7 @@
 
 	for(var/ball in orbiting_balls)
 		var/obj/singularity/energy_ball/EB = ball
-		qdel(EB)
+		QDEL_NULL(EB)
 
 	. = ..()
 
@@ -253,7 +253,7 @@
 				closest_atom = A
 				closest_dist = dist
 
-		else if(closest_mob)
+		else if(closest_machine)
 			continue
 
 		else if(istype(A, /obj/structure/blob))
@@ -286,13 +286,13 @@
 			. = zapdir
 
 	//per type stuff:
-	if(closest_tesla_coil)
+	if(!QDELETED(closest_tesla_coil))
 		closest_tesla_coil.tesla_act(power, tesla_flags, shocked_targets)
 
-	else if(closest_grounding_rod)
+	else if(!QDELETED(closest_grounding_rod))
 		closest_grounding_rod.tesla_act(power, tesla_flags, shocked_targets)
 
-	else if(closest_mob)
+	else if(!QDELETED(closest_mob))
 		var/shock_damage = (tesla_flags & TESLA_MOB_DAMAGE)? (min(round(power/600), 90) + rand(-5, 5)) : 0
 		closest_mob.electrocute_act(shock_damage, source, 1, tesla_shock = 1, stun = (tesla_flags & TESLA_MOB_STUN))
 		if(issilicon(closest_mob))
@@ -303,11 +303,11 @@
 		else
 			tesla_zap(closest_mob, 5, power / 1.5, tesla_flags, shocked_targets)
 
-	else if(closest_machine)
+	else if(!QDELETED(closest_machine))
 		closest_machine.tesla_act(power, tesla_flags, shocked_targets)
 
-	else if(closest_blob)
+	else if(!QDELETED(closest_blob))
 		closest_blob.tesla_act(power, tesla_flags, shocked_targets)
 
-	else if(closest_structure)
+	else if(!QDELETED(closest_structure))
 		closest_structure.tesla_act(power, tesla_flags, shocked_targets)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -274,6 +274,9 @@
 				closest_structure = S
 				closest_atom = A
 				closest_dist = dist
+				
+		else if(closest_structure)
+			continue
 
 	//Alright, we've done our loop, now lets see if was anything interesting in range
 	if(closest_atom)


### PR DESCRIPTION
Potentially stops machines from getting tesla zap multiple times which could result in explosions occuring dozens of times even when they've been deleted.


Edit: I was doing some testing for this and forgot to run tgstation.dmb instead of hippiestation.dmb so I was wondering why I didn't see anything change lol