### PR TITLE
Timestop improvements

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -141,7 +141,7 @@
 
 /datum/spellbook_entry/timestop
 	name = "Time Stop"
-	spell_type = /obj/effect/proc_holder/spell/aoe_turf/conjure/timestop
+	spell_type = /obj/effect/proc_holder/spell/aoe_turf/timestop
 	category = "Defensive"
 
 /datum/spellbook_entry/smoke

--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -27,10 +27,10 @@
 	for(var/A in immune_atoms)
 		immune[A] = TRUE
 	for(var/mob/living/L in GLOB.player_list)
-		if(locate(/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop) in L.mind.spell_list) //People who can stop time are immune to its effects
+		if(locate(/obj/effect/proc_holder/spell/aoe_turf/timestop) in L.mind.spell_list) //People who can stop time are immune to its effects
 			immune[L] = TRUE
 	for(var/mob/living/simple_animal/hostile/guardian/G in GLOB.parasites)
-		if(G.summoner && locate(/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop) in G.summoner.mind.spell_list) //It would only make sense that a person's stand would also be immune.
+		if(G.summoner && locate(/obj/effect/proc_holder/spell/aoe_turf/timestop) in G.summoner.mind.spell_list) //It would only make sense that a person's stand would also be immune.
 			immune[G] = TRUE
 	if(start)
 		timestop()
@@ -46,9 +46,8 @@
 	chronofield = make_field(/datum/proximity_monitor/advanced/timestop, list("current_range" = freezerange, "host" = src, "immune" = immune, "check_anti_magic" = check_anti_magic, "check_holy" = check_holy))
 	QDEL_IN(src, duration)
 
-/obj/effect/timestop/wizard
+/obj/effect/timestop/magic
 	check_anti_magic = TRUE
-	duration = 100
 
 /datum/proximity_monitor/advanced/timestop
 	name = "chronofield"
@@ -58,6 +57,8 @@
 	var/list/immune = list()
 	var/list/frozen_things = list()
 	var/list/frozen_mobs = list() //cached separately for processing
+	var/list/frozen_structures = list() //Also machinery, and only frozen aestethically
+	var/list/frozen_turfs = list() //Only aesthetically
 	var/check_anti_magic = FALSE
 	var/check_holy = FALSE
 
@@ -85,6 +86,8 @@
 		freeze_projectile(A)
 	else if(istype(A, /obj/mecha))
 		freeze_mecha(A)
+	else if(ismachinery(A) || isstructure(A))
+		freeze_structure(A)
 	else
 		frozen = FALSE
 	if(A.throwing)
@@ -105,6 +108,8 @@
 /datum/proximity_monitor/advanced/timestop/proc/unfreeze_all()
 	for(var/i in frozen_things)
 		unfreeze_atom(i)
+	for(var/T in frozen_turfs)
+		unfreeze_turf(T)
 
 /datum/proximity_monitor/advanced/timestop/proc/unfreeze_atom(atom/movable/A)
 	if(A.throwing)
@@ -140,6 +145,20 @@
 	if(T)
 		T.paused = FALSE
 
+/datum/proximity_monitor/advanced/timestop/proc/freeze_turf(turf/T)
+	into_the_negative_zone(T)
+	frozen_turfs += T
+
+/datum/proximity_monitor/advanced/timestop/proc/unfreeze_turf(turf/T)
+	escape_the_negative_zone(T)
+
+/datum/proximity_monitor/advanced/timestop/proc/freeze_structure(obj/O)
+	into_the_negative_zone(O)
+	frozen_structures += O
+
+/datum/proximity_monitor/advanced/timestop/proc/unfreeze_structure(obj/O)
+	escape_the_negative_zone(O)
+
 /datum/proximity_monitor/advanced/timestop/process()
 	for(var/i in frozen_mobs)
 		var/mob/living/m = i
@@ -148,6 +167,7 @@
 /datum/proximity_monitor/advanced/timestop/setup_field_turf(turf/T)
 	for(var/i in T.contents)
 		freeze_atom(i)
+	freeze_turf(T)
 	return ..()
 
 

--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -86,7 +86,7 @@
 		freeze_projectile(A)
 	else if(istype(A, /obj/mecha))
 		freeze_mecha(A)
-	else if(ismachinery(A) || isstructure(A))
+	else if((ismachinery(A) && !istype(A, /obj/machinery/light)) || isstructure(A)) //Special exception for light fixtures since recoloring causes them to change light
 		freeze_structure(A)
 	else
 		frozen = FALSE

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -165,7 +165,7 @@
 	clothes_req = FALSE
 	say_destination = FALSE // Santa moves in mysterious ways
 
-/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop
+/obj/effect/proc_holder/spell/aoe_turf/timestop
 	name = "Stop Time"
 	desc = "This spell stops time for everyone except for you, allowing you to move freely while your enemies and even projectiles are frozen."
 	charge_max = 500
@@ -174,10 +174,12 @@
 	invocation_type = "shout"
 	range = 0
 	cooldown_min = 100
-	summon_amt = 1
 	action_icon_state = "time"
+	var/timestop_range = 2
+	var/timestop_duration = 100
 
-	summon_type = list(/obj/effect/timestop/wizard)
+/obj/effect/proc_holder/spell/aoe_turf/timestop/cast(list/targets, mob/user = usr)
+	new /obj/effect/timestop/magic(get_turf(user), timestop_range, timestop_duration, list(user))
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/carp
 	name = "Summon Carp"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Code bounty from @Arianya 
https://tgstation13.org/phpBB/viewtopic.php?f=5&t=24121&p=516708#p516658

Makes the timestop range and duration var-editable from the spell. The icon will remain the same size regardless of range.
Since i was touching timestop i also made it so all affected turfs, structures and machinery also get the inverted color effect; along with minor mechanical effects like anchoring mobile structures like lockers.
<s>An extra effect of this, currently, is that light fixtures do not give off light while timestopped, due to the color change being the same as spraypainting them apparently. I can blacklist them if it's not desirable.</s> Done

## Why It's Good For The Game

More immersive timestop, more potential for admin abuse.

## Changelog
:cl: XDTM
tweak: Time stop now applies its visual effect on floors, walls and static structures (with no change otherwise)
tweak: Movable structures are now anchored while time stopped.
/:cl: