### PR TITLE
meteorslugs now knockdown instead of stunning

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -30,7 +30,7 @@
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "dust"
 	damage = 20
-	paralyze = 80
+	knockdown = 80
 	hitsound = 'sound/effects/meteorimpact.ogg'
 
 /obj/item/projectile/bullet/shotgun_meteorslug/on_hit(atom/target, blocked = FALSE)

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -29,7 +29,7 @@
 	name = "meteorslug"
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "dust"
-	damage = 20
+	damage = 30
 	knockdown = 80
 	hitsound = 'sound/effects/meteorimpact.ogg'
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -30,6 +30,7 @@
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "dust"
 	damage = 30
+	paralyze = 15
 	knockdown = 80
 	hitsound = 'sound/effects/meteorimpact.ogg'
 


### PR DESCRIPTION
## About The Pull Request

replaces meteorslug 8 second stun with 8 second knockdown and 1.5 second stun
gives it 10 more damage as recompensation

## Why It's Good For The Game

meteorslug is one of the strongest slugs, with 20 damage and 8 second stuns and moving items wherever the fuck
ranged stuns supposed to be gone

## Changelog
:cl:
balance: meteorslugs now do a teeny tiny stun and a long knockdown instead of stunning for a long time, but do slightly more damage
/:cl: