### PR TITLE
Soul stone tweaks

### DIFF
--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -146,7 +146,7 @@
 			user.Dizzy(30)
 			return
 		if(SS.purified && iscultist(user))
-			hot_potato(user)
+			SS.hot_potato(user)
 			return
 		SS.transfer_soul("CONSTRUCT",src,user)
 		SS.was_used()

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -26,11 +26,13 @@
 /obj/item/soulstone/anybody
 	usability = TRUE
 
+/obj/item/soulstone/anybody/revolver
+	old_shard = TRUE
+
 /obj/item/soulstone/anybody/purified
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "purified_soulstone"
 	purified = TRUE
-
 
 /obj/item/soulstone/anybody/chaplain
 	name = "mysterious old shard"
@@ -57,6 +59,13 @@
 		A.death()
 	return ..()
 
+/obj/item/soulstone/proc/hot_potato(mob/living/user)
+	to_chat(user, "<span class='userdanger'>Holy magics residing in \the [src] burn your hand!</span>")
+	var/obj/item/bodypart/affecting = user.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
+	affecting.receive_damage( 0, 10 )	// 10 burn damage
+	user.update_damage_overlays()
+	user.dropItemToGround(src)
+
 //////////////////////////////Capturing////////////////////////////////////////////////////////
 
 /obj/item/soulstone/attack(mob/living/carbon/human/M, mob/living/user)
@@ -74,7 +83,7 @@
 			to_chat(user, "<span class='cultlarge'>\"Come now, do not capture your bretheren's soul.\"</span>")
 			return
 	if(purified && iscultist(user))
-		to_chat(user, "<span class='warning'>Holy magic resides within the stone, you cannot use it.</span>")
+		hot_potato(user)
 		return
 	log_combat(user, M, "captured [M.name]'s soul", src)
 	transfer_soul("VICTIM", M, user)
@@ -89,7 +98,7 @@
 		to_chat(user, "<span class='userdanger'>Your body is wracked with debilitating pain!</span>")
 		return
 	if(purified && iscultist(user))
-		to_chat(user, "<span class='warning'>Holy magic resides within the stone, you cannot use it.</span>")
+		hot_potato(user)
 		return
 	release_shades(user)
 
@@ -136,7 +145,7 @@
 			user.Dizzy(30)
 			return
 		if(SS.purified && iscultist(user))
-			to_chat(user, "<span class='warning'>Holy magic resides within the stone, you cannot use it.</span>")
+			hot_potato(user)
 			return
 		SS.transfer_soul("CONSTRUCT",src,user)
 		SS.was_used()

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -63,6 +63,7 @@
 	to_chat(user, "<span class='userdanger'>Holy magics residing in \the [src] burn your hand!</span>")
 	var/obj/item/bodypart/affecting = user.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
 	affecting.receive_damage( 0, 10 )	// 10 burn damage
+	user.emote("scream")
 	user.update_damage_overlays()
 	user.dropItemToGround(src)
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -241,7 +241,7 @@
 
 /obj/item/gun/ballistic/revolver/russian/soul/shoot_self(mob/living/user)
 	..()
-	var/obj/item/soulstone/anybody/SS = new /obj/item/soulstone/anybody(get_turf(src))
+	var/obj/item/soulstone/anybody/revolver/SS = new /obj/item/soulstone/anybody/revolver(get_turf(src))
 	if(!SS.transfer_soul("FORCE", user)) //Something went wrong
 		qdel(SS)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Two soul stone tweaks:
- Cultists attempting to use purified soul stones now drop the stone and burn their hands
- Cursed Russian revolvers now create non-cult soul stones, similar to the ones Chaplains start with on Meta and Donut
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cult items always have some sort of interesting effect when someone isn't allowed to use them. I think that the flavor text and burned hands are more interesting than a "you can't do that" message.
Cursed Russian revolvers also only create one soul stone per victim, so it makes more sense if they spawn a single use, non-cult soul stone.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
tweak: Cultists that attempt to use purified soul stones now burn their hands. 
tweak: Cursed Russian revolvers now spawn non-cult soul shards.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
