### PR TITLE
Adds toggle wire to emitters

### DIFF
--- a/code/__DEFINES/wires.dm
+++ b/code/__DEFINES/wires.dm
@@ -43,6 +43,7 @@
 #define WIRE_STRENGTH "Strength"
 #define WIRE_THROW "Throw"
 #define WIRE_TIMING "Timing"
+#define WIRE_TOGGLE "Toggle"
 #define WIRE_TX "Transmit"
 #define WIRE_UNBOLT "Unbolt"
 #define WIRE_ZAP "High Voltage Circuit"

--- a/code/datums/wires/emitter.dm
+++ b/code/datums/wires/emitter.dm
@@ -18,7 +18,5 @@
 			if(E.active == TRUE)
 				E.active = FALSE
 			else
-				E.active = TRUE
-				E.shot_number = 0
-				E.fire_delay = E.maximum_fire_delay
+				E.interact(usr)
 	..()

--- a/code/datums/wires/emitter.dm
+++ b/code/datums/wires/emitter.dm
@@ -15,8 +15,5 @@
 			E.mode = !E.mode
 			E.set_projectile()
 		if(WIRE_TOGGLE)
-			if(E.active == TRUE)
-				E.active = FALSE
-			else
-				E.interact(usr)
+			E.interact(usr)
 	..()

--- a/code/datums/wires/emitter.dm
+++ b/code/datums/wires/emitter.dm
@@ -3,7 +3,7 @@
 	holder_type = /obj/machinery/power/emitter
 
 /datum/wires/emitter/New(atom/holder)
-	wires = list(WIRE_ZAP,WIRE_HACK)
+	wires = list(WIRE_ZAP,WIRE_HACK,WIRE_TOGGLE)
 	..()
 
 /datum/wires/emitter/on_pulse(wire)
@@ -14,4 +14,11 @@
 		if(WIRE_HACK)
 			E.mode = !E.mode
 			E.set_projectile()
+		if(WIRE_TOGGLE)
+			if(E.active == TRUE)
+				E.active = FALSE
+			else
+				E.active = TRUE
+				E.shot_number = 0
+				E.fire_delay = E.maximum_fire_delay
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds a "toggle" wire to emitters that switches them on/off when pulsed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This lets players be more creative with emitters, for example by remotely shutting down the SME emitters.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
tweak: Added a third wire to emitters that toggles them on/off when pulsed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
