### PR TITLE
Removes dead acid armor code.

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -180,18 +180,15 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 
 ///the proc called by the acid subsystem to process the acid that's on the obj
 /obj/proc/acid_processing()
-	. = 1
+	. = TRUE
 	if(!(resistance_flags & ACID_PROOF))
-		for(var/armour_value in armor)
-			if(armour_value != "acid" && armour_value != "fire")
-				armor = armor.modifyAllRatings(0 - round(sqrt(acid_level)*0.1))
 		if(prob(33))
 			playsound(loc, 'sound/items/welder.ogg', 150, TRUE)
 		take_damage(min(1 + round(sqrt(acid_level)*0.3), 300), BURN, "acid", 0)
 
 	acid_level = max(acid_level - (5 + 3*round(sqrt(acid_level))), 0)
 	if(!acid_level)
-		return 0
+		return FALSE
 
 ///called when the obj is destroyed by acid.
 /obj/proc/acid_melt()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This code is presumably supposed to make armor decay when acid is applied to an obj. Long story short, this is broken for multiple reasons. ``for(var/armour_value in armor)`` doesn't/can't run. modifyAllRatings modifies ALL ratings. High acid values get you into extreme negative armor values hilariously fast. It creates a bunch of unique armor datums that only get used for one tick, then discarded and then never get eaten by GC.

Over all, I don't think this really is a good feature, even if it did work.

## Changelog
:cl:
tweak: Removed non functional code that's supposed to make acid reduce armor values.
/:cl:
