### PR TITLE
Applies the Felinid reaction to Hot Coco too because its inconsistent otherwise.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -92,7 +92,7 @@
 			
 /datum/species/human/felinid/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/M)
 	.=..()
-	if(chem.type == /datum/reagent/consumable/coco)
+	if(chem.type == /datum/reagent/consumable/coco || chem.type == /datum/reagent/consumable/hot_coco)
 		if(prob(20))
 			M.adjust_disgust(20)
 		if(prob(5))

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -92,7 +92,7 @@
 			
 /datum/species/human/felinid/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/M)
 	.=..()
-	if(chem.type == /datum/reagent/consumable/coco || chem.type == /datum/reagent/consumable/hot_coco)
+	if(chem.type == /datum/reagent/consumable/coco || chem.type == /datum/reagent/consumable/hot_coco || chem.type ==/datum/reagent/consumable/milk/chocolate_milk)
 		if(prob(20))
 			M.adjust_disgust(20)
 		if(prob(5))


### PR DESCRIPTION
Coco refactor to come later.

:cl: GuyonBroadway
fix: Turns out making chocolate hot or mixing it with milk does not make it any less lethal to cats.
/:cl: