### PR TITLE
Makes the health analyzer's damage list into columns

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -253,23 +253,26 @@ GENE SCANNER
 		var/mob/living/carbon/C = M
 		var/list/damaged = C.get_damaged_bodyparts(1,1)
 		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
-			var/dmgreportlist = "<pre><span class='info'>&#9;Damage:&#9;&#9;\
-							<font color='red'><b>Brute</font></span>&#9;\
+			var/dmgreportlist = "<pre>&#9;<font color='#0000CC'>Damage:</font>&#9;&#9;\
+							<font color='red'><b>Brute</font>&#9;\
 							<font color='orange'>Burn</font>&#9;\
 							<font color='green'>Toxin</font>&#9;\
 							<font color='purple'>Suffocation</b></font><br>\
 
-							&#9;&nbsp;&nbsp;&nbsp;&nbsp;<span class='info'>Overall:&#9;\
+							&#9;&nbsp;&nbsp;&nbsp;&nbsp;<font color='#0000CC'>Overall:</font>&#9;\
 							<font color='red'>[brute_loss]</font>&#9;\
 							<font color='orange'>[fire_loss]</font>&#9;\
 							<font color='green'>[tox_loss]</font>&#9;\
-							<font color='purple'>[oxy_loss]</font></span><br>"
-			for(var/obj/item/bodypart/org in damaged) //head, left arm, right arm, etc.
-				dmgreportlist += "&#9;&nbsp;&nbsp;&nbsp;&nbsp;<span class='info'>[capitalize(org.name)]:&nbsp;&#9;\
-							[(org.brute_dam > 0) ? "<font color='red'>[org.brute_dam]</font></span>" : "<font color='red'>0</font>"]&#9;\
-							[(org.burn_dam > 0) ? "<font color='orange'>[org.burn_dam]</font>" : "<font color='orange'>0</font>"]<br>"
+							<font color='purple'>[oxy_loss]</font><br>"
+
+			for(var/o in damaged)
+				var/obj/item/bodypart/org = o //head, left arm, right arm, etc.
+				dmgreportlist += "&#9;&nbsp;&nbsp;&nbsp;&nbsp;<font color='#0000CC'>[capitalize(org.name)]:</font>&nbsp;&#9;\
+							<font color='red'>[(org.brute_dam > 0) ? "[org.brute_dam]" : "0"]</font>&#9;\
+							<font color='orange'>[(org.burn_dam > 0) ? "[org.burn_dam]" : "0"]</font><br>"
 			dmgreportlist += "</pre>"
 			to_chat(user, "[dmgreportlist]")
+
 
 	//Organ damages report
 	if(ishuman(M))

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -146,7 +146,7 @@ GENE SCANNER
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.undergoing_cardiac_arrest() && H.stat != DEAD)
-			to_chat(user, "<span class='danger'>Subject suffering from heart attack: Apply defibrillation or other electric shock immediately!</span>")
+			to_chat(user, "<span class='alert'>Subject suffering from heart attack: Apply defibrillation or other electric shock immediately!</span>")
 
 	to_chat(user, "<span class='info'>Analyzing results for [M]:\n\tOverall status: [mob_status]</span>")
 
@@ -253,9 +253,23 @@ GENE SCANNER
 		var/mob/living/carbon/C = M
 		var/list/damaged = C.get_damaged_bodyparts(1,1)
 		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
-			to_chat(user, "<span class='info'>\tDamage: <span class='info'><font color='red'>Brute</font></span>-<font color='#FF8000'>Burn</font>-<font color='green'>Toxin</font>-<font color='blue'>Suffocation</font>\n\t\tSpecifics: <font color='red'>[brute_loss]</font>-<font color='#FF8000'>[fire_loss]</font>-<font color='green'>[tox_loss]</font>-<font color='blue'>[oxy_loss]</font></span>")
-			for(var/obj/item/bodypart/org in damaged)
-				to_chat(user, "\t\t<span class='info'>[capitalize(org.name)]: [(org.brute_dam > 0) ? "<font color='red'>[org.brute_dam]</font></span>" : "<font color='red'>0</font>"]-[(org.burn_dam > 0) ? "<font color='#FF8000'>[org.burn_dam]</font>" : "<font color='#FF8000'>0</font>"]")
+			var/dmgreportlist = "<pre><span class='info'>&#9;Damage:&#9;&#9;\
+							<font color='red'><b>Brute</font></span>&#9;\
+							<font color='orange'>Burn</font>&#9;\
+							<font color='green'>Toxin</font>&#9;\
+							<font color='purple'>Suffocation</b></font><br>\
+
+							&#9;&nbsp;&nbsp;&nbsp;&nbsp;<span class='info'>Overall:&#9;\
+							<font color='red'>[brute_loss]</font>&#9;\
+							<font color='orange'>[fire_loss]</font>&#9;\
+							<font color='green'>[tox_loss]</font>&#9;\
+							<font color='purple'>[oxy_loss]</font></span><br>"
+			for(var/obj/item/bodypart/org in damaged) //head, left arm, right arm, etc.
+				dmgreportlist += "&#9;&nbsp;&nbsp;&nbsp;&nbsp;<span class='info'>[capitalize(org.name)]:&nbsp;&#9;\
+							[(org.brute_dam > 0) ? "<font color='red'>[org.brute_dam]</font></span>" : "<font color='red'>0</font>"]&#9;\
+							[(org.burn_dam > 0) ? "<font color='orange'>[org.burn_dam]</font>" : "<font color='orange'>0</font>"]<br>"
+			dmgreportlist += "</pre>"
+			to_chat(user, "[dmgreportlist]")
 
 	//Organ damages report
 	if(ishuman(M))
@@ -348,10 +362,10 @@ GENE SCANNER
 
 	// Time of death
 	if(M.tod && (M.stat == DEAD || ((HAS_TRAIT(M, TRAIT_FAKEDEATH)) && !advanced)))
-		to_chat(user, "<span class='info'>Time of Death:</span> [M.tod]")
+		to_chat(user, "<span class='info'>Time of Death: [M.tod]</span>")
 		var/tdelta = round(world.time - M.timeofdeath)
 		if(tdelta < (DEFIB_TIME_LIMIT * 10))
-			to_chat(user, "<span class='danger'>Subject died [DisplayTimeText(tdelta)] ago, defibrillation may be possible!</span>")
+			to_chat(user, "<span class='alert'><b>Subject died [DisplayTimeText(tdelta)] ago, defibrillation may be possible!</b></span>")
 
 	for(var/thing in M.diseases)
 		var/datum/disease/D = thing
@@ -366,7 +380,7 @@ GENE SCANNER
 			if(ishuman(C))
 				var/mob/living/carbon/human/H = C
 				if(H.bleed_rate)
-					to_chat(user, "<span class='danger'>Subject is bleeding!</span>")
+					to_chat(user, "<span class='alert'><b>Subject is bleeding!</b></span>")
 			var/blood_percent =  round((C.blood_volume / BLOOD_VOLUME_NORMAL)*100)
 			var/blood_type = C.dna.blood_type
 			if(blood_id != /datum/reagent/blood)//special blood substance
@@ -376,11 +390,11 @@ GENE SCANNER
 				else
 					blood_type = blood_id
 			if(C.blood_volume <= BLOOD_VOLUME_SAFE && C.blood_volume > BLOOD_VOLUME_OKAY)
-				to_chat(user, "<span class='danger'>LOW blood level [blood_percent] %, [C.blood_volume] cl,</span> <span class='info'>type: [blood_type]</span>")
+				to_chat(user, "<span class='alert'>Blood level: LOW [blood_percent] %, [C.blood_volume] cl,</span> <span class='info'>type: [blood_type]</span>")
 			else if(C.blood_volume <= BLOOD_VOLUME_OKAY)
-				to_chat(user, "<span class='danger'>CRITICAL blood level [blood_percent] %, [C.blood_volume] cl,</span> <span class='info'>type: [blood_type]</span>")
+				to_chat(user, "<span class='alert'>Blood level: <b>CRITICAL [blood_percent] %</b>, [C.blood_volume] cl,</span> <span class='info'>type: [blood_type]</span>")
 			else
-				to_chat(user, "<span class='info'>Blood level [blood_percent] %, [C.blood_volume] cl, type: [blood_type]</span>")
+				to_chat(user, "<span class='info'>Blood level: [blood_percent] %, [C.blood_volume] cl, type: [blood_type]</span>")
 
 		var/cyberimp_detect
 		for(var/obj/item/organ/cyberimp/CI in C.internal_organs)
@@ -403,7 +417,7 @@ GENE SCANNER
 			if(M.reagents.addiction_list.len)
 				to_chat(user, "<span class='boldannounce'>Subject is addicted to the following reagents:</span>")
 				for(var/datum/reagent/R in M.reagents.addiction_list)
-					to_chat(user, "<span class='danger'>[R.name]</span>")
+					to_chat(user, "<span class='alert'>[R.name]</span>")
 			else
 				to_chat(user, "<span class='notice'>Subject is not addicted to any reagents.</span>")
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -253,28 +253,27 @@ GENE SCANNER
 		var/mob/living/carbon/C = M
 		var/list/damaged = C.get_damaged_bodyparts(1,1)
 		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
-			var/dmgreportlist = "<pre><font face='Verdana'>&#9;\
-							<font color='#0000CC'>Damage:</font>&#9;&#9;\
-							<font color='red'><b>Brute</font>&#9;\
-							<font color='orange'>Burn</font>&#9;\
-							<font color='green'>Toxin</font>&#9;\
-							<font color='purple'>Suffocation</b></font><br>\
+			var/list/dmgreport = list()
+			dmgreport += "<table style='margin-left:33px'><tr><font face='Verdana'>\
+							<td style='width: 90px;'><font color='#0000CC'>Damage:</font></td>\
+							<td style='width: 55px;'><font color='red'><b>Brute</b></font></td>\
+							<td style='width: 45px;'><font color='orange'><b>Burn</b></font></td>\
+							<td style='width: 45px;'><font color='green'><b>Toxin</b></font></td>\
+							<td style='width: 90px;'><font color='purple'><b>Suffocation</b></font></td></tr>\
 
-							&#9;&nbsp;&nbsp;&nbsp;&nbsp;\
-							<font color='#0000CC'>Overall:</font>&#9;\
-							<font color='red'>[brute_loss]</font>&#9;\
-							<font color='orange'>[fire_loss]</font>&#9;\
-							<font color='green'>[tox_loss]</font>&#9;\
-							<font color='purple'>[oxy_loss]</font><br>"
+							<tr><td><font color='#0000CC'>Overall:</font></td>\
+							<td><font color='red'>[brute_loss]</font></td>\
+							<td><font color='orange'>[fire_loss]</font></td>\
+							<td><font color='green'>[tox_loss]</font></td>\
+							<td><font color='purple'>[oxy_loss]</font></td></tr>"
 
 			for(var/o in damaged)
 				var/obj/item/bodypart/org = o //head, left arm, right arm, etc.
-				dmgreportlist += "&#9;&nbsp;&nbsp;&nbsp;&nbsp;\
-							<font color='#0000CC'>[capitalize(org.name)]:</font>&nbsp;&nbsp;&#9;\
-							<font color='red'>[(org.brute_dam > 0) ? "[org.brute_dam]" : "0"]</font>&#9;\
-							<font color='orange'>[(org.burn_dam > 0) ? "[org.burn_dam]" : "0"]</font><br>"
-			dmgreportlist += "</pre>"
-			to_chat(user, "[dmgreportlist]")
+				dmgreport += "<tr><td><font color='#0000CC'>[capitalize(org.name)]:</font></td>\
+								<td><font color='red'>[(org.brute_dam > 0) ? "[org.brute_dam]" : "0"]</font></td>\
+								<td><font color='orange'>[(org.burn_dam > 0) ? "[org.burn_dam]" : "0"]</font></td></tr>"
+			dmgreport += "</table>"
+			to_chat(user, dmgreport.Join())
 
 
 	//Organ damages report

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -253,13 +253,15 @@ GENE SCANNER
 		var/mob/living/carbon/C = M
 		var/list/damaged = C.get_damaged_bodyparts(1,1)
 		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
-			var/dmgreportlist = "<pre>&#9;<font color='#0000CC'>Damage:</font>&#9;&#9;\
+			var/dmgreportlist = "<pre><font face='Verdana'>&#9;\
+							<font color='#0000CC'>Damage:</font>&#9;&#9;\
 							<font color='red'><b>Brute</font>&#9;\
 							<font color='orange'>Burn</font>&#9;\
 							<font color='green'>Toxin</font>&#9;\
 							<font color='purple'>Suffocation</b></font><br>\
 
-							&#9;&nbsp;&nbsp;&nbsp;&nbsp;<font color='#0000CC'>Overall:</font>&#9;\
+							&#9;&nbsp;&nbsp;&nbsp;&nbsp;\
+							<font color='#0000CC'>Overall:</font>&#9;\
 							<font color='red'>[brute_loss]</font>&#9;\
 							<font color='orange'>[fire_loss]</font>&#9;\
 							<font color='green'>[tox_loss]</font>&#9;\
@@ -267,7 +269,8 @@ GENE SCANNER
 
 			for(var/o in damaged)
 				var/obj/item/bodypart/org = o //head, left arm, right arm, etc.
-				dmgreportlist += "&#9;&nbsp;&nbsp;&nbsp;&nbsp;<font color='#0000CC'>[capitalize(org.name)]:</font>&nbsp;&#9;\
+				dmgreportlist += "&#9;&nbsp;&nbsp;&nbsp;&nbsp;\
+							<font color='#0000CC'>[capitalize(org.name)]:</font>&nbsp;&nbsp;&#9;\
 							<font color='red'>[(org.brute_dam > 0) ? "[org.brute_dam]" : "0"]</font>&#9;\
 							<font color='orange'>[(org.burn_dam > 0) ? "[org.burn_dam]" : "0"]</font><br>"
 			dmgreportlist += "</pre>"


### PR DESCRIPTION
## About The Pull Request
Makes the health analyzer's body part damage list into straight columns, making it a bit neater looking, thus easier to read. Also a few small span changes.

**Before:**
![Untitled](https://user-images.githubusercontent.com/5420151/65856013-2f87a200-e369-11e9-9376-75bbd3beb776.png)

**After:**
![Capture](https://user-images.githubusercontent.com/5420151/66507056-2b7d2200-ead7-11e9-8083-c26aa3d81f66.PNG)



## Why It's Good For The Game
Easier to read.

## Changelog
:cl:
spellcheck: The health analyzer's body part damage list is now a bit easier to read.
/:cl:
