### PR TITLE
Nerfs Zombie Powder

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -156,7 +156,7 @@
 
 /datum/reagent/toxin/zombiepowder
 	name = "Zombie Powder"
-	description = "A strong neurotoxin that puts the subject into a death-like state."
+	description = "A strong neurotoxin that slows metabolism and motor functions to a death-like state. Causes toxin buildup if used too long."
 	silent_toxin = TRUE
 	reagent_state = SOLID
 	color = "#669900" // rgb: 102, 153, 0
@@ -165,14 +165,15 @@
 
 /datum/reagent/toxin/zombiepowder/on_mob_metabolize(mob/living/L)
 	..()
-	L.fakedeath(type)
+	ADD_TRAIT(L, TRAIT_FAKEDEATH, type)
 
 /datum/reagent/toxin/zombiepowder/on_mob_end_metabolize(mob/living/L)
-	L.cure_fakedeath(type)
+	REMOVE_TRAIT(L, TRAIT_FAKEDEATH, type)
 	..()
 
 /datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/carbon/M)
 	M.adjustOxyLoss(0.5*REM, 0)
+	M.adjustStaminaLoss(20, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -72,7 +72,7 @@
 /datum/chemical_reaction/zombiepowder
 	name = "Zombie Powder"
 	id = /datum/reagent/toxin/zombiepowder
-	results = list(/datum/reagent/toxin/zombiepowder = 2)
+	results = list(/datum/reagent/toxin/zombiepowder = 10)
 	required_reagents = list(/datum/reagent/toxin/carpotoxin = 5, /datum/reagent/medicine/morphine = 5, /datum/reagent/copper = 5)
 
 /datum/chemical_reaction/ghoulpowder


### PR DESCRIPTION
## About The Pull Request

Plain and simple.
Instead of sleeping people on the spot it now does a good amount of stamina damage. (20 per tick)

## Why It's Good For The Game

Ranged stuns and the like are getting thrown out, this is just another one of those cases.
Instead of instantly sleeping people, it will now do a good amount of stamina damage. All the same reasons as with tasers and other ranged stuns.

## Changelog
🆑
balance: Zombie Powder became less potent, resulting in large amounts of stamina damage instead of instant fake death. Thankfully the host still looks just as dead.
/🆑