### PR TITLE
buffs multiver to have a lung damage rate of 0.1 per chemical per tick from 1.0

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -185,7 +185,7 @@
 		if(istype(the_reagent, /datum/reagent/medicine))
 			medibonus += 1
 	M.adjustToxLoss(-0.5 * medibonus)
-	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, medibonus)
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, 0.1 * medibonus)
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		M.reagents.remove_reagent(R.type, medibonus*0.5)
 	..()


### PR DESCRIPTION


## About The Pull Request

Buffs multiver to have a lower lung damage per chemical

## Why It's Good For The Game

Multiver is not very good, and Cobby approves these changes. He said he forgot to change the rate.

## Changelog
:cl:
balance: Multiver now has 0.1 lung damage * the number of positive medicines in the body
/:cl:


