### PR TITLE
zombie powder is delayed now instead of isntant

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -175,7 +175,6 @@
 			M.drowsyness += 1
 		if(5 to INFINITY)
 			M.fakedeath(type)
-			. = 1
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -163,16 +163,19 @@
 	toxpwr = 0.5
 	taste_description = "death"
 
-/datum/reagent/toxin/zombiepowder/on_mob_metabolize(mob/living/L)
-	..()
-	L.fakedeath(type)
-
 /datum/reagent/toxin/zombiepowder/on_mob_end_metabolize(mob/living/L)
 	L.cure_fakedeath(type)
 	..()
 
 /datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/carbon/M)
 	M.adjustOxyLoss(0.5*REM, 0)
+	switch(current_cycle)
+		if(1 to 5)
+			M.confused += 1
+			M.drowsyness += 1
+		if(5 to INFINITY)
+			M.fakedeath(type)
+			. = 1
 	..()
 	. = 1
 


### PR DESCRIPTION
## About The Pull Request
zombie powder now gives you confusion and drowsyness for 10 seconds
zombie powder now makes you fakedeath after 10 seconds and cures when you lose the reagent although i might have fucked it up but it should cure
closes #46803

## Why It's Good For The Game

i find it better than the solution acapitala took, changing it into not zombie powder at all
also cobbyman said that it should be like this

## Changelog
:cl:
balance: zombie powder now activates on the 5th cycle, around 10 seconds
:cl: