### PR TITLE
Hacked cargo consoles can sell contraband again

### DIFF
--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -42,11 +42,11 @@
 	..()
 
 /obj/machinery/computer/cargo/proc/get_export_categories()
-	var/cat = EXPORT_CARGO
+	. = EXPORT_CARGO
 	if(contraband)
-		cat |= EXPORT_CONTRABAND
+		. |= EXPORT_CONTRABAND
 	if(obj_flags & EMAGGED)
-		cat |= EXPORT_EMAG
+		. |= EXPORT_EMAG
 
 /obj/machinery/computer/cargo/emag_act(mob/user)
 	if(obj_flags & EMAGGED)


### PR DESCRIPTION
## About The Pull Request
This has been broken since https://github.com/tgstation/tgstation/pull/39749 as the added `get_export_categories` proc never returned a value.

Fixes https://github.com/tgstation/tgstation/issues/41612

## Changelog
:cl:
fix: Hacked cargo consoles can sell contraband again
/:cl: