### PR TITLE
Zombie Powder is instant upon ingestion and delayed upon injection and touch.

### DIFF
--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -72,8 +72,8 @@
 /datum/chemical_reaction/zombiepowder
 	name = "Zombie Powder"
 	id = /datum/reagent/toxin/zombiepowder
-	results = list(/datum/reagent/toxin/zombiepowder = 2)
-	required_reagents = list(/datum/reagent/toxin/carpotoxin = 5, /datum/reagent/medicine/morphine = 5, /datum/reagent/copper = 5)
+	results = list(/datum/reagent/toxin/zombiepowder = 15)
+	required_reagents = list(/datum/reagent/toxin/carpotoxin = 5, /datum/reagent/medicine/morphine = 5, /datum/reagent/water/holywater = 5)
 
 /datum/chemical_reaction/ghoulpowder
 	name = "Ghoul Powder"

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -73,7 +73,7 @@
 	name = "Zombie Powder"
 	id = /datum/reagent/toxin/zombiepowder
 	results = list(/datum/reagent/toxin/zombiepowder = 15)
-	required_reagents = list(/datum/reagent/toxin/carpotoxin = 5, /datum/reagent/medicine/morphine = 5, /datum/reagent/water/holywater = 5)
+	required_reagents = list(/datum/reagent/toxin/carpotoxin = 5, /datum/reagent/consumable/ethanol/neurotoxin = 5, /datum/reagent/water/holywater = 5)
 
 /datum/chemical_reaction/ghoulpowder
 	name = "Ghoul Powder"


### PR DESCRIPTION
## About The Pull Request
In an act spurred on from remembering how Romeo and Juliet went. Along with not liking the other balance changes very much. I've decided to add in more cooperation to get the highest tier of Knock-Out Chem, Zombie Powder.


## Why It's Good For The Game
This change would drive in the point that to get the highest tier of knock out chem. You must be willing to put in a whole lot of effort. I feel that by lessening it like the other changes, it would simply be better to use the lower tier knock out chems. That don't require any cooperation or effort at all.

With this, all three chemicals in zombie powder. Are limited use, or have a very high chance of revealing the mischief you're planning.  For example, now you must ask the chaplain to bless something for you. So they'll remember that they've did that. If there's no chaplain, you're going to have to find some way to get into his office and steal the holy-water. 

You're going to go through the chaplain, the botanist, and the limited supply of morphine in medical for your instant KO chem. I believe it's well deserved if you can fabricate some sort of excuse to get past them when people start going down thanks to Zombie Powder.
## Changelog
:cl:

balance: Removed copper from the Zombie-Powder recipe. Replaced it with Holy-Water.
balance: Zombie Powder now makes 15u per 5 units of all three reagents.
balance: Removed and Replaced morphine with Neurotoxin.
/:cl:

Closes #46803

Closes #46815