### PR TITLE
fixes the arcade pulse rifle exploit

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -78,7 +78,9 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "arcade", /datum/mood_event/arcade)
 	if(prob(0.0001)) //1 in a million
 		new /obj/item/gun/energy/pulse/prize(src)
+		visible_message("<span class='notice'>[src] dispenses.. woah, a gun! Way past cool.</span>", "<span class='notice'>You hear a chime and a shot.</span>")
 		SSmedals.UnlockMedal(MEDAL_PULSE, user.client)
+		return
 
 	if(!contents.len)
 		var/prizeselect


### PR DESCRIPTION
## About The Pull Request

you now get a message when you win the pulse rifle
you now dont get another prize when you win the rifle
fixes #46290

## Why It's Good For The Game

awoo

## Changelog
:cl:
fix: fixes the pulse rifle arcade exploit
/:cl: