### PR TITLE
Biosuit buffs

### DIFF
--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -138,7 +138,6 @@
 /obj/item/clothing/head/helmet/space/syndicate/contract
 	name = "contractor helmet"
 	desc = "A specialised black and gold helmet that's more compact than its standard Syndicate counterpart. Can be ultra-compressed into even the tightest of spaces."
-	slowdown = 0.55
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "syndicate-contract-helm"
 	item_state = "syndicate-contract-helm"
@@ -146,7 +145,7 @@
 /obj/item/clothing/suit/space/syndicate/contract
 	name = "contractor space suit"
 	desc = "A specialised black and gold space suit that's quicker, and more compact than its standard Syndicate counterpart. Can be ultra-compressed into even the tightest of spaces."
-	slowdown = 0.55
+	slowdown = 1
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "syndicate-contract"
 	item_state = "syndicate-contract"

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -21,7 +21,7 @@
 	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	slowdown = 0.5
-	allowed = list(/obj/item/tank/internals, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/reagent_containers/glass/beaker)
+	allowed = list(/obj/item/tank/internals, /obj/item/reagent_containers/dropper, /obj/item/flashlight/pen, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/reagent_containers/glass/beaker)
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 80, "fire" = 30, "acid" = 100)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	strip_delay = 70
@@ -92,6 +92,9 @@
 	desc = "It protected doctors from the Black Death, back then. You bet your arse it's gonna help you against viruses."
 	icon_state = "plaguedoctor"
 	item_state = "bio_suit"
-	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/cane)
 	strip_delay = 40
 	equip_delay_other = 20
+
+/obj/item/clothing/suit/bio_suit/plaguedoctorsuit/Initialize()
+	. = ..()
+	allowed += list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/cane)

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -20,8 +20,8 @@
 	permeability_coefficient = 0.01
 	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	slowdown = 1
-	allowed = list(/obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/pen, /obj/item/flashlight/pen, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray)
+	slowdown = 0.5
+	allowed = list(/obj/item/tank/internals, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/reagent_containers/glass/beaker)
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 80, "fire" = 30, "acid" = 100)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	strip_delay = 70
@@ -51,8 +51,8 @@
 
 /obj/item/clothing/suit/bio_suit/security
 	armor = list("melee" = 25, "bullet" = 15, "laser" = 25, "energy" = 10, "bomb" = 25, "bio" = 100, "rad" = 80, "fire" = 30, "acid" = 100)
+	allowed = list(/obj/item/tank/internals, /obj/item/gun/ballistic, /obj/item/gun/energy, /obj/item/kitchen/knife/combat, /obj/item/melee/baton, /obj/item/melee/classic_baton/telescopic, /obj/item/reagent_containers/spray/pepper, /obj/item/restraints/handcuffs)
 	icon_state = "bio_security"
-
 
 //Janitor's biosuit, grey with purple arms
 /obj/item/clothing/head/bio_hood/janitor
@@ -60,7 +60,7 @@
 
 /obj/item/clothing/suit/bio_suit/janitor
 	icon_state = "bio_janitor"
-	allowed = list(/obj/item/storage/bag/trash)
+	allowed = list(/obj/item/tank/internals, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/reagent_containers/glass/beaker, /obj/item/storage/bag/trash)
 
 //Scientist's biosuit, white with a pink-ish hue
 /obj/item/clothing/head/bio_hood/scientist
@@ -69,14 +69,13 @@
 /obj/item/clothing/suit/bio_suit/scientist
 	icon_state = "bio_scientist"
 
-
 //CMO's biosuit, blue stripe
-/obj/item/clothing/suit/bio_suit/cmo
-	icon_state = "bio_cmo"
-
 /obj/item/clothing/head/bio_hood/cmo
 	icon_state = "bio_cmo"
 
+/obj/item/clothing/suit/bio_suit/cmo
+	icon_state = "bio_cmo"
+	allowed = list(/obj/item/tank/internals, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/reagent_containers/glass/beaker, /obj/item/melee/classic_baton/telescopic)
 
 //Plague Dr mask can be found in clothing/masks/gasmask.dm
 /obj/item/clothing/suit/bio_suit/plaguedoctorsuit
@@ -84,5 +83,6 @@
 	desc = "It protected doctors from the Black Death, back then. You bet your arse it's gonna help you against viruses."
 	icon_state = "plaguedoctor"
 	item_state = "bio_suit"
+	allowed = list(/obj/item/cane)
 	strip_delay = 40
 	equip_delay_other = 20

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -48,11 +48,14 @@
 /obj/item/clothing/head/bio_hood/security
 	armor = list("melee" = 25, "bullet" = 15, "laser" = 25, "energy" = 10, "bomb" = 25, "bio" = 100, "rad" = 80, "fire" = 30, "acid" = 100)
 	icon_state = "bio_security"
-
+	
 /obj/item/clothing/suit/bio_suit/security
 	armor = list("melee" = 25, "bullet" = 15, "laser" = 25, "energy" = 10, "bomb" = 25, "bio" = 100, "rad" = 80, "fire" = 30, "acid" = 100)
-	allowed = list(/obj/item/tank/internals, /obj/item/gun/ballistic, /obj/item/gun/energy, /obj/item/kitchen/knife/combat, /obj/item/melee/baton, /obj/item/melee/classic_baton/telescopic, /obj/item/reagent_containers/spray/pepper, /obj/item/restraints/handcuffs)
 	icon_state = "bio_security"
+
+/obj/item/clothing/suit/bio_suit/security/Initialize()
+	. = ..()
+	allowed += GLOB.security_vest_allowed
 
 //Janitor's biosuit, grey with purple arms
 /obj/item/clothing/head/bio_hood/janitor
@@ -60,7 +63,10 @@
 
 /obj/item/clothing/suit/bio_suit/janitor
 	icon_state = "bio_janitor"
-	allowed = list(/obj/item/tank/internals, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/reagent_containers/glass/beaker, /obj/item/storage/bag/trash)
+
+/obj/item/clothing/suit/bio_suit/janitor/Initialize()
+	. = ..()
+	allowed += list(/obj/item/storage/bag/trash, /obj/item/reagent_containers/spray)
 
 //Scientist's biosuit, white with a pink-ish hue
 /obj/item/clothing/head/bio_hood/scientist
@@ -75,7 +81,10 @@
 
 /obj/item/clothing/suit/bio_suit/cmo
 	icon_state = "bio_cmo"
-	allowed = list(/obj/item/tank/internals, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/reagent_containers/glass/beaker, /obj/item/melee/classic_baton/telescopic)
+
+/obj/item/clothing/suit/bio_suit/cmo/Initialize()
+	. = ..()
+	allowed += list(/obj/item/melee/classic_baton/telescopic)
 
 //Plague Dr mask can be found in clothing/masks/gasmask.dm
 /obj/item/clothing/suit/bio_suit/plaguedoctorsuit

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -83,6 +83,6 @@
 	desc = "It protected doctors from the Black Death, back then. You bet your arse it's gonna help you against viruses."
 	icon_state = "plaguedoctor"
 	item_state = "bio_suit"
-	allowed = list(/obj/item/cane)
+	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/cane)
 	strip_delay = 40
 	equip_delay_other = 20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR buffs biosuits a little, by halving their slowdown and adding a lot more possible things to be fit on exoslots.
Security biosuits can carry anything a vest can.
Janitor biosuit can carry everything a normal suit can carry, plus the trashbag.
CMO biosuit can carry the telescopic baton (and, because it's a subtype, the contractor baton)
Plague doctor 'biosuit' can carry only a cane.
In addition, they can all (minus the plague doctor) carry one of the normal sized internals tanks and a beaker.

Contractor space suit now has 1 slowdown, instead of spreading 0.55 slowdown across both helmet and suit.

## Why It's Good For The Game
Biosuits are rarely used, even if they're very beneficial in outbreaks. This is, I feel, in part due to how little the game rewards you for doing so; You're immune to outbreaks, but you're a little too slowed down, and you can barely carry anything in the suit storage slot. Bio lockers have normal-sized oxygen tanks, but you can't actually put one in your suit storage. Security couldn't even put a stun baton on their biosuit, which is already weaker than their normal armor.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Biosuit buff! Biosuits can carry most of what you'd expect them to have (Large tanks, guns and etc for security suits, telescopic baton for CMO suit, cane for plague doctor suit), and they also have less slowdown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
