### PR TITLE
Fixes fultons teleporting people into the shadow realm

### DIFF
--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -43,6 +43,10 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 	if(!beacon)
 		to_chat(user, "<span class='warning'>[src] is not linked to a beacon, and cannot be used!</span>")
 		return
+	if(!(beacon in GLOB.total_extraction_beacons))
+		beacon = null
+		to_chat(user, "<span class='warning'>The connected beacon has been destroyed!</span>")
+		return
 	if(!can_use_indoors)
 		var/area/area = get_area(A)
 		if(!area.outdoors)


### PR DESCRIPTION
Fultons don't have a check if their assigned beacon still exists, which is pretty bad since it can get people stuck indefinitely. This PR fixes that.
Closes: #46233

## Changelog
:cl: Denton
fix: Fulton packs no longer try to send people to destroyed beacons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
