### PR TITLE
Chameleon projector exploit fixes

### DIFF
--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -30,6 +30,7 @@
 	icon_state = "nothing"
 	name = "invisible wall"
 	desc = "You have a bad feeling about this."
+	alpha = 0
 
 /obj/effect/forcefield/mime/advanced
 	name = "invisible blockade"

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -49,16 +49,14 @@
 		return
 	if(istype(target, /obj/structure/falsewall))
 		return
-	if(target.alpha == 0)
+	if(target.alpha != 255)
 		return
-	if(!target.invisibility == 0)
+	if(target.invisibility != 0)
 		return
 	if(iseffect(target))
 		if(!(istype(target, /obj/effect/decal))) //be a footprint
 			return
-	if(istype(target, /obj/structure/closet/cardboard/agent) || istype(target, /obj/structure/holosign))
-		to_chat(user, "<span class='warning'>[src] emits a soft buzzing noise.</span>")
-		playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, TRUE, -6)
+	if(istype(target, /obj/structure/closet/cardboard/agent))
 		return
 	playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, TRUE, -6)
 	to_chat(user, "<span class='notice'>Scanned [target].</span>")

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -52,6 +52,8 @@
 	if(iseffect(target))
 		if(!(istype(target, /obj/effect/decal))) //be a footprint
 			return
+	if(istype(target, /obj/structure/closet/cardboard/agent))
+		return
 	playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, TRUE, -6)
 	to_chat(user, "<span class='notice'>Scanned [target].</span>")
 	var/obj/temp = new/obj()

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -1,5 +1,5 @@
 /obj/item/chameleon
-	name = "chameleon-projector"
+	name = "chameleon projector"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "shield0"
 	flags_1 = CONDUCT_1
@@ -52,7 +52,9 @@
 	if(iseffect(target))
 		if(!(istype(target, /obj/effect/decal))) //be a footprint
 			return
-	if(istype(target, /obj/structure/closet/cardboard/agent))
+	if(istype(target, /obj/structure/closet/cardboard/agent) || istype(target, /obj/structure/holosign))
+		to_chat(user, "<span class='warning'>[src] emits a soft buzzing noise.</span>")
+		playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, TRUE, -6)
 		return
 	playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, TRUE, -6)
 	to_chat(user, "<span class='notice'>Scanned [target].</span>")
@@ -88,7 +90,7 @@
 /obj/item/chameleon/proc/disrupt(delete_dummy = 1)
 	if(active_dummy)
 		for(var/mob/M in active_dummy)
-			to_chat(M, "<span class='danger'>Your chameleon-projector deactivates.</span>")
+			to_chat(M, "<span class='danger'>Your chameleon projector deactivates.</span>")
 		var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread
 		spark_system.set_up(5, 0, src)
 		spark_system.attach(src)

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -56,8 +56,6 @@
 	if(iseffect(target))
 		if(!(istype(target, /obj/effect/decal))) //be a footprint
 			return
-	if(istype(target, /obj/structure/closet/cardboard/agent))
-		return
 	playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, TRUE, -6)
 	to_chat(user, "<span class='notice'>Scanned [target].</span>")
 	var/obj/temp = new/obj()

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -49,7 +49,9 @@
 		return
 	if(istype(target, /obj/structure/falsewall))
 		return
-	if(istype(target, /obj/structure/chair/mime) || istype(target, /obj/item/storage/box/mime))
+	if(target.alpha == 0)
+		return
+	if(!target.invisibility == 0)
 		return
 	if(iseffect(target))
 		if(!(istype(target, /obj/effect/decal))) //be a footprint

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -49,6 +49,8 @@
 		return
 	if(istype(target, /obj/structure/falsewall))
 		return
+	if(istype(target, /obj/structure/chair/mime) || istype(target, /obj/item/storage/box/mime))
+		return
 	if(iseffect(target))
 		if(!(istype(target, /obj/effect/decal))) //be a footprint
 			return

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -428,6 +428,7 @@
 	buildstacktype = null
 	item_chair = null
 	flags_1 = NODECONSTRUCT_1
+	alpha = 0
 
 /obj/structure/chair/mime/post_buckle_mob(mob/living/M)
 	M.pixel_y += 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR prevents the chameleon projector from scanning objects that are either invisible or don't get displayed properly.
Fixes: #46098
Fixes: #46777
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mime spells and the stealth box are invisible; holosigns don't get displayed properly and end up turning people invisible as well.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
fix: Chameleon projectors can no longer scan invisible items, like the stealth box or mime spells.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
