### PR TITLE
APC UI autoupdates properly

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -850,8 +850,6 @@
 	if(!ui)
 		ui = new(user, src, ui_key, "apc", name, ui_x, ui_y, master_ui, state)
 		ui.open()
-	if(ui)
-		ui.set_autoupdate(state = (failure_timer ? 1 : 0))
 
 /obj/machinery/power/apc/ui_data(mob/user)
 	var/list/data = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#20028 over 3 years ago seems to have copypasted a line erroneously in attempting to port grid checks, making APC uis only autoupdate when power failed.

https://github.com/tgstation/tgstation/pull/20028/files#diff-ad09118440f5c936a8bbee05e2d3c8bbR631

I initially assumed this was for optimization reasons considering that APCs are placed in so many places, but that doesn't make any sense because 1. UIs are only autoupdated when open, and 2. this specific change is _completely_ unmentioned in the original PR, and in the original baycode.

This deletes that block making APCs always autoupdate no matter what state of their ui, you no longer need to click them again to get them to update.

## Changelog
:cl:
fix: APC UI autoupdates correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
