### PR TITLE
[READY] Welders consume fuel when they destroy an object during attack

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -186,6 +186,7 @@
 	#define COMPONENT_ITEM_NO_ATTACK 1
 #define COMSIG_MOB_APPLY_DAMGE	"mob_apply_damage"				//from base of /mob/living/proc/apply_damage(): (damage, damagetype, def_zone)
 #define COMSIG_MOB_ITEM_AFTERATTACK "mob_item_afterattack"		//from base of obj/item/afterattack(): (atom/target, mob/user, proximity_flag, click_parameters)
+#define COMSIG_MOB_ITEM_ATTACK_QDELETED "mob_item_attack_qdeleted"	//from base of obj/item/attack_qdeleted(): (atom/target, mob/user, proxiumity_flag, click_parameters)
 #define COMSIG_MOB_ATTACK_RANGED "mob_attack_ranged"			//from base of mob/RangedAttack(): (atom/A, params)
 #define COMSIG_MOB_THROW "mob_throw"							//from base of /mob/throw_item(): (atom/target)
 #define COMSIG_MOB_EXAMINATE "mob_examinate"					//from base of /mob/verb/examinate(): (atom/target)
@@ -250,6 +251,7 @@
 #define COMSIG_ITEM_PRE_ATTACK "item_pre_attack"				//from base of obj/item/pre_attack(): (atom/target, mob/user, params)
 	#define COMPONENT_NO_ATTACK 1
 #define COMSIG_ITEM_AFTERATTACK "item_afterattack"				//from base of obj/item/afterattack(): (atom/target, mob/user, params)
+#define COMSIG_ITEM_ATTACK_QDELETED "item_attack_qdeleted"		//from base of obj/item/attack_qdeleted(): (atom/target, mob/user, params)
 #define COMSIG_ITEM_EQUIPPED "item_equip"						//from base of obj/item/equipped(): (/mob/equipper, slot)
 #define COMSIG_ITEM_DROPPED "item_drop"							//from base of obj/item/dropped(): (mob/user)
 #define COMSIG_ITEM_PICKUP "item_pickup"						//from base of obj/item/pickup(): (/mob/taker)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -15,6 +15,7 @@
 	if(target.attackby(src,user, params))
 		return
 	if(QDELETED(src) || QDELETED(target))
+		attack_qdeleted(target, user, TRUE, params)
 		return
 	afterattack(target, user, TRUE, params)
 
@@ -117,6 +118,10 @@
 	SEND_SIGNAL(src, COMSIG_ITEM_AFTERATTACK, target, user, proximity_flag, click_parameters)
 	SEND_SIGNAL(user, COMSIG_MOB_ITEM_AFTERATTACK, target, user, proximity_flag, click_parameters)
 
+// Called if the target gets deleted by our attack
+/obj/item/proc/attack_qdeleted(atom/target, mob/user, proximity_flag, click_parameters)
+	SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_QDELETED, target, user, proximity_flag, click_parameters)
+	SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK_QDELETED, target, user, proximity_flag, click_parameters)
 
 /obj/item/proc/get_clamped_volume()
 	if(w_class)

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -102,17 +102,17 @@
 	qdel(src)
 
 /obj/item/weldingtool/attack(mob/living/carbon/human/H, mob/user)
-	if(!istype(H))
-		return ..()
-
-	var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
-
 	if(isOn())
 		use(1)
 		var/turf/location = get_turf(user)
 		location.hotspot_expose(700, 50, 1)
 		if(get_fuel() <= 0)
 			set_light(0)
+
+	if(!istype(H))
+		return ..()
+
+	var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
 
 	if(affecting && affecting.status == BODYPART_ROBOTIC && user.a_intent != INTENT_HARM)
 		if(src.use_tool(H, user, 0, volume=50, amount=1))

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -103,11 +103,13 @@
 
 /obj/item/weldingtool/attack(mob/living/carbon/human/H, mob/user)
 	if(isOn())
-		use(1)
-		var/turf/location = get_turf(user)
-		location.hotspot_expose(700, 50, 1)
-		if(get_fuel() <= 0)
-			set_light(0)
+		handle_fuel_and_temps(1, user)
+		
+		if(isliving(H))
+			var/mob/living/L = H
+			if(L.IgniteMob())
+				message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(L)] on fire with [src] at [AREACOORD(user)]")
+				log_game("[key_name(user)] set [key_name(L)] on fire with [src] at [AREACOORD(user)]")
 
 	if(!istype(H))
 		return ..()
@@ -128,11 +130,7 @@
 /obj/item/weldingtool/attack_obj(obj/O, mob/living/user)
 	. = ..()
 	if(isOn())
-		use(1)
-		var/turf/location = get_turf(user)
-		location.hotspot_expose(700, 50, 1)
-		if(get_fuel() <= 0)
-			set_light(0)
+		handle_fuel_and_temps(1, user)
 
 /obj/item/weldingtool/afterattack(atom/O, mob/user, proximity)
 	. = ..()
@@ -144,13 +142,6 @@
 		to_chat(user, "<span class='notice'>You empty [src]'s fuel tank into [O].</span>")
 		update_icon()
 
-	if(isOn() && isliving(O))
-		var/mob/living/L = O
-		if(L.IgniteMob())
-			message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(L)] on fire with [src] at [AREACOORD(user)]")
-			log_game("[key_name(user)] set [key_name(L)] on fire with [src] at [AREACOORD(user)]")
-
-
 /obj/item/weldingtool/attack_self(mob/user)
 	if(src.reagents.has_reagent(/datum/reagent/toxin/plasma))
 		message_admins("[ADMIN_LOOKUPFLW(user)] activated a rigged welder at [AREACOORD(user)].")
@@ -161,6 +152,11 @@
 
 	update_icon()
 
+// Ah fuck, I can't believe you've done this
+/obj/item/weldingtool/proc/handle_fuel_and_temps(used = 0, mob/living/user)
+	use(used)
+	var/turf/location = get_turf(user)
+	location.hotspot_expose(700, 50, 1)
 
 // Returns the amount of fuel in the welder
 /obj/item/weldingtool/proc/get_fuel()
@@ -185,6 +181,7 @@
 //Turns off the welder if there is no more fuel (does this really need to be its own proc?)
 /obj/item/weldingtool/proc/check_fuel(mob/user)
 	if(get_fuel() <= 0 && welding)
+		set_light(0)
 		switched_on(user)
 		update_icon()
 		//mob icon update

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -107,6 +107,13 @@
 
 	var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
 
+	if(isOn())
+		use(1)
+		var/turf/location = get_turf(user)
+		location.hotspot_expose(700, 50, 1)
+		if(get_fuel() <= 0)
+			set_light(0)
+
 	if(affecting && affecting.status == BODYPART_ROBOTIC && user.a_intent != INTENT_HARM)
 		if(src.use_tool(H, user, 0, volume=50, amount=1))
 			if(user == H)
@@ -123,22 +130,17 @@
 	. = ..()
 	if(!proximity)
 		return
+
 	if(!status && O.is_refillable())
 		reagents.trans_to(O, reagents.total_volume, transfered_by = user)
 		to_chat(user, "<span class='notice'>You empty [src]'s fuel tank into [O].</span>")
 		update_icon()
-	if(isOn())
-		use(1)
-		var/turf/location = get_turf(user)
-		location.hotspot_expose(700, 50, 1)
-		if(get_fuel() <= 0)
-			set_light(0)
 
-		if(isliving(O))
-			var/mob/living/L = O
-			if(L.IgniteMob())
-				message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(L)] on fire with [src] at [AREACOORD(user)]")
-				log_game("[key_name(user)] set [key_name(L)] on fire with [src] at [AREACOORD(user)]")
+	if(isOn() && isliving(O))
+		var/mob/living/L = O
+		if(L.IgniteMob())
+			message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(L)] on fire with [src] at [AREACOORD(user)]")
+			log_game("[key_name(user)] set [key_name(L)] on fire with [src] at [AREACOORD(user)]")
 
 
 /obj/item/weldingtool/attack_self(mob/user)

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -120,28 +120,6 @@
 
 /obj/item/weldingtool/afterattack(atom/O, mob/user, proximity)
 	. = ..()
-	handle_mob_ignite(O, user, proximity)
-
-	if(!status && O.is_refillable())
-		reagents.trans_to(O, reagents.total_volume, transfered_by = user)
-		to_chat(user, "<span class='notice'>You empty [src]'s fuel tank into [O].</span>")
-		update_icon()
-
-/obj/item/weldingtool/attack_qdeleted(atom/O, mob/user, proximity)
-	. = ..()
-	handle_mob_ignite(O, user, proximity)
-
-/obj/item/weldingtool/attack_self(mob/user)
-	if(src.reagents.has_reagent(/datum/reagent/toxin/plasma))
-		message_admins("[ADMIN_LOOKUPFLW(user)] activated a rigged welder at [AREACOORD(user)].")
-		explode()
-	switched_on(user)
-	if(welding)
-		set_light(light_intensity)
-
-	update_icon()
-
-/obj/item/weldingtool/proc/handle_mob_ignite(atom/O, mob/user, proximity)
 	if(!proximity)
 		return
 	
@@ -153,6 +131,35 @@
 			if(L.IgniteMob())
 				message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(L)] on fire with [src] at [AREACOORD(user)]")
 				log_game("[key_name(user)] set [key_name(L)] on fire with [src] at [AREACOORD(user)]")
+
+	if(!status && O.is_refillable())
+		reagents.trans_to(O, reagents.total_volume, transfered_by = user)
+		to_chat(user, "<span class='notice'>You empty [src]'s fuel tank into [O].</span>")
+		update_icon()
+
+/obj/item/weldingtool/attack_qdeleted(atom/O, mob/user, proximity)
+	. = ..()
+	if(!proximity)
+		return
+	
+	if(isOn())
+		handle_fuel_and_temps(1, user)
+		
+		if(!QDELETED(O) && isliving(O)) // can't ignite something that doesn't exist
+			var/mob/living/L = O
+			if(L.IgniteMob())
+				message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(L)] on fire with [src] at [AREACOORD(user)]")
+				log_game("[key_name(user)] set [key_name(L)] on fire with [src] at [AREACOORD(user)]")
+
+/obj/item/weldingtool/attack_self(mob/user)
+	if(src.reagents.has_reagent(/datum/reagent/toxin/plasma))
+		message_admins("[ADMIN_LOOKUPFLW(user)] activated a rigged welder at [AREACOORD(user)].")
+		explode()
+	switched_on(user)
+	if(welding)
+		set_light(light_intensity)
+
+	update_icon()
 
 // Ah fuck, I can't believe you've done this
 /obj/item/weldingtool/proc/handle_fuel_and_temps(used = 0, mob/living/user)

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -125,6 +125,14 @@
 	else
 		return ..()
 
+/obj/item/weldingtool/attack_obj(obj/O, mob/living/user)
+	. = ..()
+	if(isOn())
+		use(1)
+		var/turf/location = get_turf(user)
+		location.hotspot_expose(700, 50, 1)
+		if(get_fuel() <= 0)
+			set_light(0)
 
 /obj/item/weldingtool/afterattack(atom/O, mob/user, proximity)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Welders didn't actually consume fuel if their attack deleted an object. This was first noticed when welding space vines, in that the welder didn't consume any fuel to do so. Further testing showed that this was the case for any object that gets destroyed on hit, including APCs, Air Alarms, Girders etc.

Problem was that the code for actually consuming fuel after an attack is in the afterattack proc which doesn't actually get called if the target is QDELETED. PR moves that code to the attack proc, along with (regrettably) implementing attack_obj too. This feels hacky and reeks of duplicate code, so if anyone has a better option for how I could implement this fix I'm all ears.

## Why It's Good For The Game
Fixes unintentional behavior

## Changelog
:cl:
fix: Welders now consume fuel when they destroy an object
/:cl: