### PR TITLE
Stops CRAB-17 from spawning in space or the engine chamber or the inc…

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1128,14 +1128,15 @@ B --><-- A
 /proc/get_random_station_turf()
 	return safepick(get_area_turfs(pick(GLOB.the_station_areas)))
 
-/proc/get_safe_random_station_turf()
+/proc/get_safe_random_station_turf() //excludes dense turfs (like walls) and areas that have valid_territory set to FALSE
 	for (var/i in 1 to 5)
 		var/list/L = get_area_turfs(pick(GLOB.the_station_areas))
 		var/turf/target
 		while (L.len && !target)
 			var/I = rand(1, L.len)
 			var/turf/T = L[I]
-			if(!T.density)
+			var/area/X = get_area(T)
+			if(!T.density && X.valid_territory)
 				var/clear = TRUE
 				for(var/obj/O in T)
 					if(O.density)

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -484,6 +484,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/engine/atmospherics_engine
 	name = "Atmospherics Engine"
 	icon_state = "atmos_engine"
+	valid_territory = FALSE
 
 /area/engine/engine_room //donut station specific
 	name = "Engine Room"
@@ -496,6 +497,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/engine/supermatter
 	name = "Supermatter Engine"
 	icon_state = "engine_sm"
+	valid_territory = FALSE
 
 /area/engine/break_room
 	name = "Engineering Foyer"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -16,7 +16,7 @@
 
 	var/map_name // Set in New(); preserves the name set by the map maker, even if renamed by the Blueprints.
 
-	var/valid_territory = TRUE // If it's a valid territory for gangs to claim
+	var/valid_territory = TRUE // If it's a valid territory for cult summoning or the CRAB-17 phone to spawn
 	var/blob_allowed = TRUE // Does it count for blobs score? By default, all areas count.
 	var/clockwork_warp_allowed = TRUE // Can servants warp into this area from Reebe?
 	var/clockwork_warp_fail = "The structure there is too dense for warping to pierce. (This is normal in high-security areas.)"


### PR DESCRIPTION
## Why It's Good For The Game
![fuck](https://user-images.githubusercontent.com/32391752/66081829-2402c980-e569-11e9-8e48-4503bbb7fe93.PNG)
Closes: #45920
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
fix: CRAB-17 will no longer spawn in areas like the solar array or the engine chamber. This should decrease pink Wojak levels considerably.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
