### PR TITLE
chap things now cover what they should

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -77,6 +77,7 @@
 /obj/item/clothing/head/helmet/chaplain/cage
 	name = "cage"
 	desc = "A cage that restrains the will of the self, allowing one to see the profane world for what it is."
+	flags_inv = HIDEHAIR //bald
 	mob_overlay_icon = 'icons/mob/large-worn-icons/64x64/head.dmi'
 	icon_state = "cage"
 	item_state = "cage"
@@ -123,6 +124,7 @@
 	icon_state = "witchhunterhat"
 	item_state = "witchhunterhat"
 	flags_cover = HEADCOVERSEYES
+	flags_inv = HIDEEYES|HIDEHAIR
 
 /obj/item/storage/box/holy/adept
 	name = "Divine Adept Kit"
@@ -137,6 +139,7 @@
 	icon_state = "crusader"
 	item_state = "crusader"
 	flags_cover = HEADCOVERSEYES
+	flags_inv = HIDEHAIR|HIDEFACE|HIDEEARS
 
 /obj/item/clothing/suit/armor/riot/chaplain/adept
 	name = "adept robes"


### PR DESCRIPTION
## About The Pull Request

chap adept helmet now covers the same things as the hood, and witchhunter hat now covers hair and eyes, and the cage covers nothing except the hair because i like chaplain turning bald

## Why It's Good For The Game

visible things shouldnt make things under them invisible

## Changelog
:cl:
fix: chaplain things now cover proper stuff
/:cl: