### PR TITLE
Rainbow slime extracts don't get deleted after a use if they have more than one use.

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -652,7 +652,6 @@
 		S.icon_state = "[S.base_state]_active"
 		S.active = TRUE
 		addtimer(CALLBACK(S, /obj/item/grenade.proc/prime), rand(15,60))
-		qdel(holder.my_atom) //deleto
 	else
 		var/mob/living/simple_animal/slime/random/S = new (get_turf(holder.my_atom))
 		S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and a new baby slime emerges from it!</span>")
@@ -666,12 +665,19 @@
 	required_container = /obj/item/slime_extract/rainbow
 
 /datum/chemical_reaction/slime/slimebomb/on_reaction(datum/reagents/holder, created_volume)
-	var/obj/item/grenade/clusterbuster/slime/volatile/S = new (holder.my_atom.loc)
+	var/obj/item/grenade/clusterbuster/slime/volatile/S = new (get_turf(holder.my_atom))
 	S.visible_message("<span class='danger'>Infused with slime jelly, the core begins to expand uncontrollably!</span>")
 	S.icon_state = "[S.base_state]_active"
 	S.active = TRUE
 	addtimer(CALLBACK(S, /obj/item/grenade.proc/prime), rand(15,60))
-	qdel(holder.my_atom) //deleto
+	var/turf/T = get_turf(holder.my_atom)
+	var/lastkey = holder.my_atom.fingerprintslast
+	var/touch_msg = "N/A"
+	if(lastkey)
+		var/mob/toucher = get_mob_by_key(lastkey)
+		touch_msg = "[ADMIN_LOOKUPFLW(toucher)]."
+	message_admins("Brorble Brorble primed at [ADMIN_VERBOSEJMP(T)]. Last Fingerprint: [touch_msg]")
+	log_game("Brorble Brorble primed at [AREACOORD(T)]. Last Fingerprint: [lastkey ? lastkey : "N/A"].")
 	..()
 
 /datum/chemical_reaction/slime/slime_transfer

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -665,12 +665,12 @@
 	required_container = /obj/item/slime_extract/rainbow
 
 /datum/chemical_reaction/slime/slimebomb/on_reaction(datum/reagents/holder, created_volume)
-	var/obj/item/grenade/clusterbuster/slime/volatile/S = new (get_turf(holder.my_atom))
+	var/turf/T = get_turf(holder.my_atom)
+	var/obj/item/grenade/clusterbuster/slime/volatile/S = new (T)
 	S.visible_message("<span class='danger'>Infused with slime jelly, the core begins to expand uncontrollably!</span>")
 	S.icon_state = "[S.base_state]_active"
 	S.active = TRUE
 	addtimer(CALLBACK(S, /obj/item/grenade.proc/prime), rand(15,60))
-	var/turf/T = get_turf(holder.my_atom)
 	var/lastkey = holder.my_atom.fingerprintslast
 	var/touch_msg = "N/A"
 	if(lastkey)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR's main change is that the rainbow slime extract no longer gets deleted from its reaction with plasma and slime jelly if it still has uses left.

The other change is adding a simple logging so admins are notified when a Xenobiologist(or random tider or Captain) uses the slime jelly reaction, the volatile one, which can make things go quite bad.

Closes #45003

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Well, it probably does not matter to much anymore regardless, though this would likely have been better served if it happened prior to crossbreeding, since currently we can effectively get infinite rainbow slime extracts now.

Regardless of that though, even if it was an intentional design, it is fairly silly that, unlike the other extracts, this one would suddenly end up deleted even if it had, say, 5 more uses left.

Now, from the normal reaction using plasma I see no big problems, just the scientist getting a bunch of random slime extracts to play with. A problem I do see though, would be with the volatile reaction, since there probably would be someone who would abuse the hell out of them. Ideas would be welcome.

## Changelog
:cl:
balance: Rainbow slime extracts, when they have more than one use, are no longer deleted when injected with plasma or slime jelly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
