### PR TITLE
Split personalities can now communicate directly

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -20,10 +20,18 @@
 	..()
 	make_backseats()
 	get_ghost()
+	var/obj/effect/proc_holder/spell/targeted/personality_commune/primary_spell = new(src, TRUE)
+	owner.AddSpell(primary_spell)
 
 /datum/brain_trauma/severe/split_personality/proc/make_backseats()
 	stranger_backseat = new(owner, src)
+	var/obj/effect/proc_holder/spell/targeted/personality_commune/stranger_spell = new(src, FALSE)
+	stranger_backseat.AddSpell(stranger_spell)
+
 	owner_backseat = new(owner, src)
+	var/obj/effect/proc_holder/spell/targeted/personality_commune/owner_spell = new(src, FALSE)
+	owner_backseat.AddSpell(owner_spell)
+
 
 /datum/brain_trauma/severe/split_personality/proc/get_ghost()
 	set waitfor = FALSE

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -58,6 +58,7 @@
 		switch_personalities()
 	QDEL_NULL(stranger_backseat)
 	QDEL_NULL(owner_backseat)
+	owner.RemoveSpell(/obj/effect/proc_holder/spell/targeted/personality_commune)
 	..()
 
 /datum/brain_trauma/severe/split_personality/proc/switch_personalities()

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -56,7 +56,6 @@
 		switch_personalities()
 	QDEL_NULL(stranger_backseat)
 	QDEL_NULL(owner_backseat)
-	owner.RemoveSpell(/obj/effect/proc_holder/spell/targeted/personality_commune)
 	..()
 
 /datum/brain_trauma/severe/split_personality/proc/switch_personalities()

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -20,16 +20,14 @@
 	..()
 	make_backseats()
 	get_ghost()
-	var/obj/effect/proc_holder/spell/targeted/personality_commune/primary_spell = new(src, TRUE)
-	owner.AddSpell(primary_spell)
 
 /datum/brain_trauma/severe/split_personality/proc/make_backseats()
 	stranger_backseat = new(owner, src)
-	var/obj/effect/proc_holder/spell/targeted/personality_commune/stranger_spell = new(src, FALSE)
+	var/obj/effect/proc_holder/spell/targeted/personality_commune/stranger_spell = new(src)
 	stranger_backseat.AddSpell(stranger_spell)
 
 	owner_backseat = new(owner, src)
-	var/obj/effect/proc_holder/spell/targeted/personality_commune/owner_spell = new(src, FALSE)
+	var/obj/effect/proc_holder/spell/targeted/personality_commune/owner_spell = new(src)
 	owner_backseat.AddSpell(owner_spell)
 
 

--- a/code/modules/spells/spell_types/personality_commune.dm
+++ b/code/modules/spells/spell_types/personality_commune.dm
@@ -9,8 +9,6 @@
 	action_background_icon_state = "bg_spell"
 	var/datum/brain_trauma/severe/split_personality/trauma
 	var/flufftext = "You hear an echoing voice in the back of your head..."
-	var/boldnotice = "boldnotice"
-	var/notice = "notice"
 
 /obj/effect/proc_holder/spell/targeted/personality_commune/New(datum/brain_trauma/severe/split_personality/T)
 	. = ..()
@@ -25,11 +23,10 @@
 	if(!msg)
 		charge_counter = charge_max
 		return
-	to_chat(user, "<span class='[boldnotice]'>You concentrate and send thoughts to your other self:</span> <span class='[notice]'>[msg]</span>")
-	to_chat(trauma.owner, "<span class='[boldnotice]'>[flufftext]</span> <span class='[notice]'>[msg]</span>")
+	to_chat(user, "<span class='boldnotice'>You concentrate and send thoughts to your other self:</span> <span class='notice'>[msg]</span>")
+	to_chat(trauma.owner, "<span class='boldnotice'>[flufftext]</span> <span class='notice'>[msg]</span>")
 	log_directed_talk(user, trauma.owner, msg, LOG_SAY ,"[name]")
 	for(var/ded in GLOB.dead_mob_list)
 		if(!isobserver(ded))
 			continue
-		var/follow = FOLLOW_LINK(ded, user)
-		to_chat(ded, "[follow] <span class='[boldnotice]'>[user] [name]:</span> <span class='[notice]'>\"[msg]\" to</span><span class='name'>[trauma]</span>")
+		to_chat(ded, "[FOLLOW_LINK(ded, user)] <span class='[boldnotice]'>[user] [name]:</span> <span class='[notice]'>\"[msg]\" to</span><span class='name'>[trauma]</span>")

--- a/code/modules/spells/spell_types/personality_commune.dm
+++ b/code/modules/spells/spell_types/personality_commune.dm
@@ -1,0 +1,45 @@
+/obj/effect/proc_holder/spell/targeted/personality_commune
+	name = "Personality Commune"
+	desc = "Sends thoughts to your alternate consciousness."
+	charge_max = 0
+	clothes_req = FALSE
+	range = -1
+	include_user = TRUE
+	action_icon_state = "telepathy"
+	action_background_icon_state = "bg_spell"
+	var/datum/brain_trauma/severe/split_personality/trauma
+	var/ishost = FALSE
+	var/flufftext = "You hear an echoing voice in the back of your head..."
+	var/boldnotice = "boldnotice"
+	var/notice = "notice"
+
+/obj/effect/proc_holder/spell/targeted/personality_commune/New(datum/brain_trauma/severe/split_personality/T, host)
+	. = ..()
+	trauma = T
+	ishost = host
+
+// Pillaged and adapted from telepathy code
+/obj/effect/proc_holder/spell/targeted/personality_commune/cast(list/targets, mob/user)
+	if(!istype(trauma))
+		to_chat(user, "<span class='warning'>Something is wrong; Either due a bug or admemes, you are trying to cast this spell without a split personality!</span>")
+		return
+	var/msg = stripped_input(usr, "What would you like to tell your other self?", null , "")
+	if(!msg)
+		charge_counter = charge_max
+		return
+	to_chat(user, "<span class='[boldnotice]'>You concentrate and send thoughts to your other self:</span> <span class='[notice]'>[msg]</span>")
+	if(ishost)
+		if(trauma.current_controller == 1)
+			to_chat(trauma.owner_backseat, "<span class='[boldnotice]'>[flufftext]</span> <span class='[notice]'>[msg]</span>")
+			log_directed_talk(user, trauma.owner_backseat, msg, LOG_SAY ,"[name]")
+		else
+			to_chat(trauma.stranger_backseat, "<span class='[boldnotice]'>[flufftext]</span> <span class='[notice]'>[msg]</span>")
+			log_directed_talk(user, trauma.stranger_backseat, msg, LOG_SAY ,"[name]")
+	else
+		to_chat(trauma.owner, "<span class='[boldnotice]'>[flufftext]</span> <span class='[notice]'>[msg]</span>")
+		log_directed_talk(user, trauma.owner, msg, LOG_SAY ,"[name]")
+	for(var/ded in GLOB.dead_mob_list)
+		if(!isobserver(ded))
+			continue
+		var/follow = FOLLOW_LINK(ded, user)
+		to_chat(ded, "[follow] <span class='[boldnotice]'>[user] [name]:</span> <span class='[notice]'>\"[msg]\" to</span><span class='name'>[trauma]</span>")

--- a/code/modules/spells/spell_types/personality_commune.dm
+++ b/code/modules/spells/spell_types/personality_commune.dm
@@ -29,13 +29,13 @@
 		return
 	to_chat(user, "<span class='[boldnotice]'>You concentrate and send thoughts to your other self:</span> <span class='[notice]'>[msg]</span>")
 	if(ishost)
-		if(trauma.current_controller == 1)
+		if(trauma.current_controller == 1) // Stranger in control, send to owner backseat
 			to_chat(trauma.owner_backseat, "<span class='[boldnotice]'>[flufftext]</span> <span class='[notice]'>[msg]</span>")
 			log_directed_talk(user, trauma.owner_backseat, msg, LOG_SAY ,"[name]")
-		else
+		else // Owner in control, send to stranger backseat
 			to_chat(trauma.stranger_backseat, "<span class='[boldnotice]'>[flufftext]</span> <span class='[notice]'>[msg]</span>")
 			log_directed_talk(user, trauma.stranger_backseat, msg, LOG_SAY ,"[name]")
-	else
+	else //  We're in the backseat, send to body
 		to_chat(trauma.owner, "<span class='[boldnotice]'>[flufftext]</span> <span class='[notice]'>[msg]</span>")
 		log_directed_talk(user, trauma.owner, msg, LOG_SAY ,"[name]")
 	for(var/ded in GLOB.dead_mob_list)

--- a/code/modules/spells/spell_types/personality_commune.dm
+++ b/code/modules/spells/spell_types/personality_commune.dm
@@ -29,4 +29,4 @@
 	for(var/ded in GLOB.dead_mob_list)
 		if(!isobserver(ded))
 			continue
-		to_chat(ded, "[FOLLOW_LINK(ded, user)] <span class='[boldnotice]'>[user] [name]:</span> <span class='[notice]'>\"[msg]\" to</span><span class='name'>[trauma]</span>")
+		to_chat(ded, "[FOLLOW_LINK(ded, user)] <span class='boldnotice'>[user] [name]:</span> <span class='notice'>\"[msg]\" to</span><span class='name'>[trauma]</span>")

--- a/code/modules/spells/spell_types/personality_commune.dm
+++ b/code/modules/spells/spell_types/personality_commune.dm
@@ -8,15 +8,13 @@
 	action_icon_state = "telepathy"
 	action_background_icon_state = "bg_spell"
 	var/datum/brain_trauma/severe/split_personality/trauma
-	var/ishost = FALSE
 	var/flufftext = "You hear an echoing voice in the back of your head..."
 	var/boldnotice = "boldnotice"
 	var/notice = "notice"
 
-/obj/effect/proc_holder/spell/targeted/personality_commune/New(datum/brain_trauma/severe/split_personality/T, host)
+/obj/effect/proc_holder/spell/targeted/personality_commune/New(datum/brain_trauma/severe/split_personality/T)
 	. = ..()
 	trauma = T
-	ishost = host
 
 // Pillaged and adapted from telepathy code
 /obj/effect/proc_holder/spell/targeted/personality_commune/cast(list/targets, mob/user)
@@ -28,16 +26,8 @@
 		charge_counter = charge_max
 		return
 	to_chat(user, "<span class='[boldnotice]'>You concentrate and send thoughts to your other self:</span> <span class='[notice]'>[msg]</span>")
-	if(ishost)
-		if(trauma.current_controller == 1) // Stranger in control, send to owner backseat
-			to_chat(trauma.owner_backseat, "<span class='[boldnotice]'>[flufftext]</span> <span class='[notice]'>[msg]</span>")
-			log_directed_talk(user, trauma.owner_backseat, msg, LOG_SAY ,"[name]")
-		else // Owner in control, send to stranger backseat
-			to_chat(trauma.stranger_backseat, "<span class='[boldnotice]'>[flufftext]</span> <span class='[notice]'>[msg]</span>")
-			log_directed_talk(user, trauma.stranger_backseat, msg, LOG_SAY ,"[name]")
-	else //  We're in the backseat, send to body
-		to_chat(trauma.owner, "<span class='[boldnotice]'>[flufftext]</span> <span class='[notice]'>[msg]</span>")
-		log_directed_talk(user, trauma.owner, msg, LOG_SAY ,"[name]")
+	to_chat(trauma.owner, "<span class='[boldnotice]'>[flufftext]</span> <span class='[notice]'>[msg]</span>")
+	log_directed_talk(user, trauma.owner, msg, LOG_SAY ,"[name]")
 	for(var/ded in GLOB.dead_mob_list)
 		if(!isobserver(ded))
 			continue

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2787,6 +2787,7 @@
 #include "code\modules\spells\spell_types\lightning.dm"
 #include "code\modules\spells\spell_types\mime.dm"
 #include "code\modules\spells\spell_types\mind_transfer.dm"
+#include "code\modules\spells\spell_types\personality_commune.dm"
 #include "code\modules\spells\spell_types\projectile.dm"
 #include "code\modules\spells\spell_types\rightandwrong.dm"
 #include "code\modules\spells\spell_types\rod_form.dm"


### PR DESCRIPTION
## About The Pull Request
This PR allows people with the split personality trauma to communicate with the stranger and vice versa through an action button. I also considered adding an option for the active player to release control but I felt that would be breaking the spirit of brain traumas a bit much.

## Why It's Good For The Game
Split personality has always been a situation where the second player's only real option is "How many times can I shout "I'm Gay"/WGW over radio and try and avoid surgery until I inevitably get removed?" Don't get me wrong, you can still do that, but I aim in this PR to give players another option to get some of that sweet RP in. The main argument I can see coming up against this change is that traumas are supposed to be negatives, but how I see it, this doesn't make Split Personality a positive trauma so much as it allows roleplay similar to how you can roleplay as a paraplegic war veteran or as an ex-security officer who developed a phobia following an 'incident'. I'm happy to add a cooldown to the action if it proves to be an issue.

## Changelog
:cl:
add: Split personalities can now communicate with an action button
/:cl: