### PR TITLE
adds mutagen and saltpetre to the biogen

### DIFF
--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -410,3 +410,7 @@
 /obj/item/reagent_containers/glass/bottle/bromine
 	name = "bromine bottle"
 	list_reagents = list(/datum/reagent/bromine = 30)
+
+/obj/item/reagent_containers/glass/bottle/saltpetre
+    name = "saltpetre bottle"
+    list_reagents = list(/datum/reagent/saltpetre = 30)

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -99,6 +99,22 @@
 	build_path = /obj/item/reagent_containers/glass/bottle/nutrient/rh
 	category = list("initial","Botany Chemicals")
 
+/datum/design/saltpetre
+    name = "Saltpetre Bottle"
+    id = "saltpetre"
+    build_type = BIOGENERATOR
+    materials = list(/datum/material/biomass= 300)
+    build_path = /obj/item/reagent_containers/glass/bottle/saltpetre
+    category = list("initial","Botany Chemicals")
+
+/datum/design/mutagen
+    name = "Unstable Mutagen Bottle"
+    id = "mutagen"
+    build_type = BIOGENERATOR
+    materials = list(/datum/material/biomass= 750)
+    build_path = /obj/item/reagent_containers/glass/bottle/mutagen
+    category = list("initial","Botany Chemicals")
+
 /datum/design/weed_killer
 	name = "Weed Killer"
 	id = "weed_killer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what it says on the tin
currently mutagen is 750u of biomass per a 30u bottle
Saltpetre is 300u of biomass per a 30u bottle
If this isn't balanced it's open to be changed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Botany finally doesn't have to molest chemistry or break into tech storage every round and instead can just blend wheat en mass. I figure this also makes the biogen something botany will interact with more.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: mutagen and saltpetre to the biogen
code: defined a bottle of saltpetre and added that+mutagen to the biogen designs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
