### PR TITLE
Some KS13 improvements

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -392,6 +392,10 @@
 "bV" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/circuit_imprinter,
+/obj/item/aiModule/core/full/drone{
+	pixel_x = -4;
+	pixel_y = -2
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/ai_upload)
 "bW" = (
@@ -1259,7 +1263,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/access)
 "fw" = (
-/obj/effect/mob_spawn/drone/dusty,
+/obj/effect/mob_spawn/drone/derelict,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/access)
 "fx" = (
@@ -1980,7 +1984,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "in" = (
-/obj/effect/mob_spawn/drone/dusty,
+/obj/effect/mob_spawn/drone/derelict,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "io" = (
@@ -3424,7 +3428,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/effect/mob_spawn/drone/dusty,
+/obj/effect/mob_spawn/drone/derelict,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/se_solar)
 "nV" = (
@@ -3581,6 +3585,10 @@
 "tS" = (
 /turf/template_noop,
 /area/ruin/unpowered/no_grav)
+"ux" = (
+/obj/structure/cable,
+/turf/closed/wall,
+/area/ruin/space/derelict/solar_control)
 "vf" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -3712,6 +3720,12 @@
 	icon_state = "floorscorched2"
 	},
 /area/space/nearstation)
+"JI" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel/airless{
+	icon_state = "damaged4"
+	},
+/area/ruin/space/derelict/bridge/ai_upload)
 "Kf" = (
 /obj/item/paper/fluff/ruins/thederelict/vaultraider,
 /obj/effect/decal/remains/human{
@@ -3725,6 +3739,10 @@
 "KN" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/hallway/primary/port)
+"KP" = (
+/obj/item/dronespeak_manual,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/derelict/bridge/ai_upload)
 "KS" = (
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plasteel/airless,
@@ -3824,6 +3842,15 @@
 "Sv" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
+"ST" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/ruin/space/derelict/solar_control)
 "Tm" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/primary/port)
@@ -3837,6 +3864,13 @@
 "Uz" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"UG" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/bridge/ai_upload)
 "Vt" = (
 /obj/structure/cable,
 /turf/closed/indestructible/riveted{
@@ -3885,16 +3919,18 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/ai_upload)
 "ZA" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
+/obj/structure/grille,
 /obj/structure/cable,
-/turf/closed/wall/r_wall,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/bridge/ai_upload)
 "ZB" = (
 /obj/structure/lattice,
 /turf/template_noop,
 /area/space/nearstation)
+"ZM" = (
+/obj/machinery/droneDispenser/derelict,
+/turf/open/floor/plasteel,
+/area/ruin/space/derelict/bridge/access)
 
 (1,1,1) = {"
 aa
@@ -10467,11 +10503,11 @@ Uz
 ax
 bj
 bj
-bj
-bj
-ax
-bO
-bE
+ZA
+ZA
+ce
+xr
+JI
 bO
 bO
 bO
@@ -10580,7 +10616,7 @@ Sv
 ax
 bj
 bj
-bj
+ZA
 bj
 ax
 bK
@@ -10588,7 +10624,7 @@ Lr
 xr
 YQ
 LX
-ZA
+UG
 ce
 ce
 ce
@@ -10693,7 +10729,7 @@ Uz
 ax
 bj
 bj
-bj
+ZA
 bj
 ax
 ax
@@ -10703,10 +10739,10 @@ ce
 ax
 ax
 bj
-bj
+ZA
 bj
 cs
-cx
+ZM
 cF
 cx
 cT
@@ -10806,7 +10842,7 @@ Uz
 ax
 bj
 bj
-bj
+ZA
 bj
 bW
 bW
@@ -10816,7 +10852,7 @@ Vt
 bW
 bW
 bj
-bj
+ZA
 bj
 cs
 cx
@@ -10919,7 +10955,7 @@ Uz
 ax
 bj
 bj
-bj
+ZA
 bj
 bW
 Xu
@@ -10929,7 +10965,7 @@ Ni
 Xu
 bW
 bj
-bj
+ZA
 bj
 cs
 cy
@@ -11032,7 +11068,7 @@ Uz
 ax
 bj
 bj
-bj
+ZA
 bj
 bW
 my
@@ -11042,7 +11078,7 @@ bz
 DX
 bW
 bj
-bj
+ZA
 bj
 cs
 cz
@@ -11145,17 +11181,17 @@ Uz
 ax
 bj
 bj
-bj
+ZA
 bj
 bW
 Zu
 bz
 rC
-bz
+KP
 vo
 bW
 bj
-bj
+ZA
 bj
 cs
 cA
@@ -11258,8 +11294,8 @@ Uz
 ax
 bj
 bj
+ZA
 bj
-bj
 bW
 bW
 bW
@@ -11268,7 +11304,7 @@ bW
 bW
 bW
 bj
-bj
+ZA
 bj
 cs
 cB
@@ -11371,17 +11407,17 @@ aS
 aS
 bj
 bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
+ZA
+ZA
+ZA
+ZA
+ZA
+ZA
+ZA
+ZA
+ZA
+ZA
+ZA
 bj
 cs
 cs
@@ -11487,7 +11523,7 @@ bj
 bj
 bj
 bj
-bj
+ZA
 bj
 bj
 bj
@@ -11600,7 +11636,7 @@ bj
 as
 as
 as
-as
+ux
 as
 as
 as
@@ -11713,7 +11749,7 @@ as
 as
 bk
 bA
-bH
+ST
 az
 az
 az
@@ -11826,7 +11862,7 @@ as
 bq
 az
 az
-az
+aB
 az
 az
 az

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -3585,10 +3585,6 @@
 "tS" = (
 /turf/template_noop,
 /area/ruin/unpowered/no_grav)
-"ux" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/ruin/space/derelict/solar_control)
 "vf" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -3681,6 +3677,10 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/ruin/unpowered/no_grav)
+"GP" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/derelict/bridge/ai_upload)
 "Ih" = (
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged3"
@@ -3720,12 +3720,6 @@
 	icon_state = "floorscorched2"
 	},
 /area/space/nearstation)
-"JI" = (
-/obj/structure/cable,
-/turf/open/floor/plasteel/airless{
-	icon_state = "damaged4"
-	},
-/area/ruin/space/derelict/bridge/ai_upload)
 "Kf" = (
 /obj/item/paper/fluff/ruins/thederelict/vaultraider,
 /obj/effect/decal/remains/human{
@@ -3842,15 +3836,6 @@
 "Sv" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
-"ST" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/ruin/space/derelict/solar_control)
 "Tm" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/primary/port)
@@ -3917,11 +3902,6 @@
 	amount = 15
 	},
 /turf/open/floor/plasteel/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"ZA" = (
-/obj/structure/grille,
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/bridge/ai_upload)
 "ZB" = (
 /obj/structure/lattice,
@@ -10395,10 +10375,10 @@ bj
 ax
 bG
 Ob
-bO
-bz
-bO
-ax
+xr
+GP
+YQ
+ce
 aa
 aa
 aa
@@ -10503,15 +10483,15 @@ Uz
 ax
 bj
 bj
-ZA
-ZA
-ce
-xr
-JI
-bO
-bO
-bO
+bj
+bj
 ax
+bO
+bE
+bO
+bO
+bO
+ce
 aa
 aa
 aa
@@ -10616,7 +10596,7 @@ Sv
 ax
 bj
 bj
-ZA
+bj
 bj
 ax
 bK
@@ -10729,7 +10709,7 @@ Uz
 ax
 bj
 bj
-ZA
+bj
 bj
 ax
 ax
@@ -10739,7 +10719,7 @@ ce
 ax
 ax
 bj
-ZA
+bj
 bj
 cs
 ZM
@@ -10842,7 +10822,7 @@ Uz
 ax
 bj
 bj
-ZA
+bj
 bj
 bW
 bW
@@ -10852,7 +10832,7 @@ Vt
 bW
 bW
 bj
-ZA
+bj
 bj
 cs
 cx
@@ -10955,7 +10935,7 @@ Uz
 ax
 bj
 bj
-ZA
+bj
 bj
 bW
 Xu
@@ -10965,7 +10945,7 @@ Ni
 Xu
 bW
 bj
-ZA
+bj
 bj
 cs
 cy
@@ -11068,7 +11048,7 @@ Uz
 ax
 bj
 bj
-ZA
+bj
 bj
 bW
 my
@@ -11078,7 +11058,7 @@ bz
 DX
 bW
 bj
-ZA
+bj
 bj
 cs
 cz
@@ -11181,7 +11161,7 @@ Uz
 ax
 bj
 bj
-ZA
+bj
 bj
 bW
 Zu
@@ -11191,7 +11171,7 @@ KP
 vo
 bW
 bj
-ZA
+bj
 bj
 cs
 cA
@@ -11294,7 +11274,7 @@ Uz
 ax
 bj
 bj
-ZA
+bj
 bj
 bW
 bW
@@ -11304,7 +11284,7 @@ bW
 bW
 bW
 bj
-ZA
+bj
 bj
 cs
 cB
@@ -11407,17 +11387,17 @@ aS
 aS
 bj
 bj
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
-ZA
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+bj
 bj
 cs
 cs
@@ -11523,7 +11503,7 @@ bj
 bj
 bj
 bj
-ZA
+bj
 bj
 bj
 bj
@@ -11636,7 +11616,7 @@ bj
 as
 as
 as
-ux
+as
 as
 as
 as
@@ -11749,7 +11729,7 @@ as
 as
 bk
 bA
-ST
+bH
 az
 az
 az
@@ -11862,7 +11842,7 @@ as
 bq
 az
 az
-aB
+az
 az
 az
 az

--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -85,6 +85,17 @@
 	power_used = 2000
 	starting_amount = 10000
 
+// If the derelict gets lonely, make more friends.
+/obj/machinery/droneDispenser/derelict
+	name = "derelict drone shell dispenser"
+	desc = "A rusty machine that, when supplied with metal and glass, will periodically create a derelict drone shell. Does not need to be manually operated."
+	dispense_type = /obj/effect/mob_spawn/drone/derelict
+	end_create_message = "dispenses a derelict drone shell."
+	metal_cost = 10000
+	glass_cost = 5000
+	starting_amount = 0
+	cooldownTime = 600
+
 // An example of a custom drone dispenser.
 // This one requires no materials and creates basic hivebots
 /obj/machinery/droneDispenser/hivebot

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -96,7 +96,7 @@
 	icon_living = icon_state
 	icon_dead = "[visualAppearence]_dead"
 
-/obj/effect/mob_spawn/drone/dusty
+/obj/effect/mob_spawn/drone/derelict
 	name = "derelict drone shell"
 	desc = "A long-forgotten drone shell. It seems kind of... Space Russian."
 	icon = 'icons/mob/drone.dmi'

--- a/code/modules/ruins/spaceruin_code/TheDerelict.dm
+++ b/code/modules/ruins/spaceruin_code/TheDerelict.dm
@@ -164,3 +164,42 @@
 	if(C.tool_behaviour == TOOL_SCREWDRIVER)
 		return
 	..()
+
+
+// So drones can teach borgs and AI dronespeak. For best effect, combine with mother drone lawset.
+/obj/item/dronespeak_manual
+	name = "dronespeak manual"
+	desc = "The book's cover reads: \"Understanding Dronespeak - An exercise in futility.\""
+	icon = 'icons/obj/library.dmi'
+	icon_state = "book2"
+
+/obj/item/dronespeak_manual/attack_self(mob/living/user)
+	..()
+	if(isdrone(user) || issilicon(user))
+		if(user.has_language(/datum/language/drone))
+			to_chat(user, "<span class='boldannounce'>You start skimming through [src], but you already know dronespeak.</span>")
+		else
+			to_chat(user, "<span class='boldannounce'>You start skimming through [src], and suddenly the drone chittering makes sense.</span>")
+			user.grant_language(/datum/language/drone)
+		return
+
+	if(user.has_language(/datum/language/drone))
+		to_chat(user, "<span class='boldannounce'>You start skimming through [src], but you already know dronespeak.</span>")
+	else
+		to_chat(user, "<span class='boldannounce'>You start skimming through [src], but you can't make any sense of the contents.</span>")
+
+/obj/item/dronespeak_manual/attack(mob/living/M, mob/living/user)
+	if(!istype(M) || !istype(user))
+		return
+	if(M == user)
+		attack_self(user)
+		return
+	
+	playsound(loc, "punch", 25, TRUE, -1)
+	if(isdrone(M) || issilicon(M))
+		if(M.has_language(/datum/language/drone))
+			M.visible_message("<span class='danger'>[user] beats [M] over the head with [src]!</span>", "<span class='userdanger'>[user] beats you over the head with [src]!</span>", "<span class='hear'>You hear smacking.</span>")
+		else
+			M.visible_message("<span class='notice'>[user] teaches [M] by beating [M.p_them()] over the head with [src]!</span>", "<span class='boldnotice'>As [user] hits you with [src], chitters resonate in your mind.</span>", "<span class='hear'>You hear smacking.</span>")
+			M.grant_language(/datum/language/drone)
+		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Having observed a bit of how people play the derelict drones after #45965, I got a few additions and changes to the derelict to make it more enjoyable.

 - Power cable into the AI core/vault area was hard to find under an rwall, have run an additional one into the room to give easier access to pre-smes power.
 - Added a derelict drone printer, so more friends can be printed. Starts without materials
 - Added mother drone core lawset to secure storage. This was intended in the last PR, but forgotten.
 - Added a dronespeak manual that drones can use to teach other drones or silicons the drone language. Works like the codespeak manual.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
KS13 is frequently made great again.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
tweak: Slight mapping improvement to KS13
add: KS13 now has mother drone board, a dronespeak granter and a drone printer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
