### PR TITLE
soulstones now cant absorb things with no SOUL

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -89,7 +89,7 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 
 #define isalienqueen(A) (istype(A, /mob/living/carbon/alien/humanoid/royal/queen))
 
-#define isdevil(A) (istype(A, /mob/living/carbon/true_devil))
+#define istruedevil(A) (istype(A, /mob/living/carbon/true_devil))
 
 //Silicon mobs
 #define issilicon(A) (istype(A, /mob/living/silicon))

--- a/code/game/gamemodes/devil/game_mode.dm
+++ b/code/game/gamemodes/devil/game_mode.dm
@@ -34,3 +34,6 @@
 	var/datum/atom_hud/antag/hud = GLOB.huds[ANTAG_HUD_SOULLESS]
 	hud.leave_hud(soulless_mind.current)
 	set_antag_hud(soulless_mind.current, null)
+
+/proc/isdevil(mob/living/M)
+	return istype(M) && M.mind && M.mind.has_antag_datum(/datum/antagonist/devil)

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -79,6 +79,9 @@
 		return
 	if(!ishuman(M))//If target is not a human.
 		return ..()
+	if(!M.mind.hasSoul || isdevil(M))
+		to_chat(user, "<span class='warning'>This... thing has no soul! It's filled with evil!</span>")
+		return
 	if(iscultist(M))
 		if(iscultist(user))
 			to_chat(user, "<span class='cultlarge'>\"Come now, do not capture your bretheren's soul.\"</span>")

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -128,7 +128,7 @@
 		return FALSE
 	if(iscarbon(M))
 		// disallowed carbons
-		if(isalien(M) || isdevil(M))
+		if(isalien(M) || istruedevil(M))
 			return FALSE
 		var/mob/living/carbon/target = M
 		// gotta have a head to be implanted (no changelings or sentient plants)


### PR DESCRIPTION
## About The Pull Request

soulstones now cant absorb things with no soul or devils
things with no soul:
wizard after using lich or soultap
people that sold their soul to devil

## Why It's Good For The Game

it ruins the revival mechanics of both antags and also makes no sense in the lore, how can a soul shard capture a nonexistant soul

## Changelog
:cl:
balance: soulstones now cant absorb ungodly beings with no SOUL
/:cl: