### PR TITLE
nanite scanner can now be constructed in security and medical lathes

### DIFF
--- a/code/modules/research/designs/electronics_designs.dm
+++ b/code/modules/research/designs/electronics_designs.dm
@@ -64,7 +64,7 @@
 	materials = list(/datum/material/glass = 500, /datum/material/iron = 500)
 	build_path = /obj/item/nanite_scanner
 	category = list("Electronics")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_MEDICAL
 
 
 ////////////////////////////////////////


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

nanites can be sabotaged with nobody knowing, since you need to be a scientist to even get access to one
now security and medical may check other people's nanites or theirs to make sure that they dont have gay baby stuff

## Changelog
:cl:
balance: nanite scanner can now be printed in security and medical lathes
/:cl: