### PR TITLE
Nitryl gas reaction now uses pluoxium as a catalyst

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -343,7 +343,7 @@
 	min_requirements = list(
 		/datum/gas/oxygen = 20,
 		/datum/gas/nitrogen = 20,
-		/datum/gas/nitrous_oxide = 5,
+		/datum/gas/pluoxium = 5,
 		"TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST*60
 	)
 


### PR DESCRIPTION
## About The Pull Request
Title

## Why It's Good For The Game
Since the introduction of the n2o decomposition reaction it has been essentially impossible to get nitryl gas, because all the n2o you add as a catalyst burns away stopping the reaction. In this one line PR I swap out n2o for pluoxium, which makes nitryl slightly harder to get, but makes it actually possible to get more than single digit mole counts in the first place. If swapping n2o for pluoxium adds too much difficulty, the required temp could be dropped a bit to compensate.

## Changelog
:cl:
tweak: The nitryl gas reaction now uses pluoxium as a catalyst
/:cl: