### PR TITLE
Biogen doesn't dispense reagent containers anymore

### DIFF
--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -3,35 +3,27 @@
 ///////////////////////////////////
 
 /datum/design/milk
-	name = "10 Milk"
+	name = "10u Milk"
 	id = "milk"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 20)
 	make_reagents = list(/datum/reagent/consumable/milk = 10)
 	category = list("initial","Food")
 
+/datum/design/ethanol
+	name = "10u Ethanol"
+	id = "ethanol"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 30)
+	make_reagents = list(/datum/reagent/consumable/ethanol = 10)
+	category = list("initial","Food")
+
 /datum/design/cream
-	name = "10 Cream"
+	name = "10u Cream"
 	id = "cream"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 30)
 	make_reagents = list(/datum/reagent/consumable/cream = 10)
-	category = list("initial","Food")
-
-/datum/design/milk_carton
-	name = "Milk Carton"
-	id = "milk_carton"
-	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass= 100)
-	build_path = /obj/item/reagent_containers/food/condiment/milk
-	category = list("initial","Food")
-
-/datum/design/cream_carton
-	name = "Cream Carton"
-	id = "cream_carton"
-	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass= 300)
-	build_path = /obj/item/reagent_containers/food/drinks/bottle/cream
 	category = list("initial","Food")
 
 /datum/design/black_pepper
@@ -42,15 +34,6 @@
 	make_reagents = list(/datum/reagent/consumable/blackpepper = 10)
 	category = list("initial","Food")
 
-/datum/design/pepper_mill
-	name = "Pepper Mill"
-	id = "pepper_mill"
-	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass= 50)
-	build_path = /obj/item/reagent_containers/food/condiment/peppermill
-	make_reagents = list()
-	category = list("initial","Food")
-
 /datum/design/enzyme
 	name = "10u Universal Enzyme"
 	id = "enzyme"
@@ -59,12 +42,12 @@
 	make_reagents = list(/datum/reagent/consumable/enzyme = 10)
 	category = list("initial","Food")
 
-/datum/design/flour_sack
-	name = "Flour Sack"
+/datum/design/flour
+	name = "10u Flour"
 	id = "flour_sack"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass= 150)
-	build_path = /obj/item/reagent_containers/food/condiment/flour
+	materials = list(/datum/material/biomass= 30)
+	make_reagents = list(/datum/reagent/consumable/flour = 10)
 	category = list("initial","Food")
 
 /datum/design/monkey_cube
@@ -75,53 +58,45 @@
 	build_path = /obj/item/reagent_containers/food/snacks/monkeycube
 	category = list("initial", "Food")
 
-/datum/design/ez_nut
-	name = "E-Z Nutrient"
+/datum/design/ez_nut   //easy nut :)
+	name = "30u E-Z Nutrient"
 	id = "ez_nut"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 10)
-	build_path = /obj/item/reagent_containers/glass/bottle/nutrient/ez
+	make_reagents = list(/datum/reagent/plantnutriment/ezdnutriment = 30)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/l4z_nut
-	name = "Left 4 Zed"
+	name = "30u Left 4 Zed"
 	id = "l4z_nut"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 20)
-	build_path = /obj/item/reagent_containers/glass/bottle/nutrient/l4z
+	make_reagents = list(/datum/reagent/plantnutriment/left4zednutriment = 30)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/rh_nut
-	name = "Robust Harvest"
+	name = "30u Robust Harvest"
 	id = "rh_nut"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 25)
-	build_path = /obj/item/reagent_containers/glass/bottle/nutrient/rh
+	make_reagents = list(/datum/reagent/plantnutriment/robustharvestnutriment = 30)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/weed_killer
-	name = "Weed Killer"
+	name = "30u Weed Killer"
 	id = "weed_killer"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 50)
-	build_path = /obj/item/reagent_containers/glass/bottle/killer/weedkiller
+	make_reagents = list(/datum/reagent/toxin/plantbgone/weedkiller = 30)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/pest_spray
-	name = "Pest Killer"
+	name = "30u Pest Killer"
 	id = "pest_spray"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 50)
-	build_path = /obj/item/reagent_containers/glass/bottle/killer/pestkiller
+	make_reagents = list(/datum/reagent/toxin/pestkiller = 30)
 	category = list("initial","Botany Chemicals")
-
-/datum/design/botany_bottle
-	name = "Empty Bottle"
-	id = "botany_bottle"
-	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass= 5)
-	build_path = /obj/item/reagent_containers/glass/bottle/nutrient/empty
-	category = list("initial", "Botany Chemicals")
 
 /datum/design/cloth
 	name = "Roll of Cloth"

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -63,7 +63,7 @@
 	id = "ez_nut"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 10)
-	make_reagents = list(/datum/reagent/plantnutriment/ezdnutriment = 30)
+	make_reagents = list(/datum/reagent/plantnutriment/eznutriment = 30)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/l4z_nut


### PR DESCRIPTION

## About The Pull Request
This only changes it so that the reagent container you put in the biogenerator gets used much more since you cannot create reagent containers with it anymore

## Why It's Good For The Game
Removes conistency issue and makes the bucket you put in there be actually necessary and not just fluff for the most part.

## Changelog
:cl:
del: Removed all reagent container outputs from biogen designs, replaced with reagent designs that feed into the container currently placed in the biogen
tweak: all plant nutriment produce 30u instead of 50 for the same biomass price
/:cl:


