### PR TITLE
Zombie-Powder is now a drink from shakespeare: Stress tested edition

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -189,7 +189,7 @@
 			M.slurring += 3
 		if(5 to 8)
 			M.adjustStaminaLoss(60, 0)
-		if(8 to INFINITY)
+		if(9 to INFINITY)
 			fakedeath_active = TRUE
 			M.fakedeath(type)
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -162,7 +162,7 @@
 	color = "#669900" // rgb: 102, 153, 0
 	toxpwr = 0.5
 	taste_description = "death"
-	var/ingested = FALSE
+	var/fakedeath_active = FALSE
 
 /datum/reagent/toxin/zombiepowder/on_mob_metabolize(mob/living/L)
 	..()
@@ -175,18 +175,22 @@
 /datum/reagent/toxin/zombiepowder/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
 	L.adjustOxyLoss(0.5*REM, 0)
 	if(method == INGEST)
-		ingested = TRUE //Created Var for ZP
+		fakedeath_active = TRUE
 		L.fakedeath(type)
 
 /datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/M)
 	..()
-	if(ingested)
+	if(fakedeath_active)
 		return TRUE
 	switch(current_cycle)
 		if(1 to 5)
 			M.confused += 1
 			M.drowsyness += 1
-		if(5 to INFINITY)
+			M.slurring += 3
+		if(5 to 8)
+			M.adjustStaminaLoss(60, 0)
+		if(8 to INFINITY)
+			fakedeath_active = TRUE
 			M.fakedeath(type)
 
 /datum/reagent/toxin/ghoulpowder

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -162,19 +162,32 @@
 	color = "#669900" // rgb: 102, 153, 0
 	toxpwr = 0.5
 	taste_description = "death"
+	var/ingested = FALSE
 
 /datum/reagent/toxin/zombiepowder/on_mob_metabolize(mob/living/L)
 	..()
-	L.fakedeath(type)
+	ADD_TRAIT(L, TRAIT_FAKEDEATH, type)
 
 /datum/reagent/toxin/zombiepowder/on_mob_end_metabolize(mob/living/L)
 	L.cure_fakedeath(type)
 	..()
 
-/datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/carbon/M)
-	M.adjustOxyLoss(0.5*REM, 0)
+/datum/reagent/toxin/zombiepowder/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
+	L.adjustOxyLoss(0.5*REM, 0)
+	if(method == INGEST)
+		ingested = TRUE //Created Var for ZP
+		L.fakedeath(type)
+
+/datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/M)
 	..()
-	. = 1
+	if(ingested)
+		return TRUE
+	switch(current_cycle)
+		if(1 to 5)
+			M.confused += 1
+			M.drowsyness += 1
+		if(5 to INFINITY)
+			M.fakedeath(type)
 
 /datum/reagent/toxin/ghoulpowder
 	name = "Ghoul Powder"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -188,7 +188,7 @@
 			M.drowsyness += 1
 			M.slurring += 3
 		if(5 to 8)
-			M.adjustStaminaLoss(60, 0)
+			M.adjustStaminaLoss(40, 0)
 		if(9 to INFINITY)
 			fakedeath_active = TRUE
 			M.fakedeath(type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This time it's a bittersweet drink that'll knock you right out. Whilst also being a delayed shot to make you go to sleep.
Old PR:  #46817
PRs it intends to close: #46803 #46815

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Zombie-Powder on injection has very similar cycles to chloral hydrate. But it's a faster ranged KO then CH. At least by one-tier.  It's instant via ingestion.

## Why It's Good For The Game
Functions like the new ranged stuns we have in the game, and the melee stuns.
If someone's trying to KO you. They're either going to have to stand beside you and force you to eat a pill, offer you a drugged drink. Or come behind you with a damp rag and ask the simple question "Does this smell like chloroform to you?"
## Changelog
:cl:
balance: Zombie-Powder is now instant upon ingest. Delayed upon touch and injection.
/:cl:

