### PR TITLE
Skeletons can no longer be facehugged

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -134,7 +134,7 @@
 		var/mob/living/carbon/target = M
 		// gotta have a head to be implanted (no changelings or sentient plants)
 		// gotta have a stomach to be implanted (no skeletons)
-		if(!target.get_bodypart(BODY_ZONE_HEAD) || !target.getorgan(/obj/item/organ/stomach)
+		if(!target.get_bodypart(BODY_ZONE_HEAD) || !target.getorgan(/obj/item/organ/stomach))
 			return FALSE
 
 		if(target.getorgan(/obj/item/organ/alien/hivenode) || target.getorgan(/obj/item/organ/body_egg/alien_embryo))

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -120,7 +120,7 @@
 		Leap(hit_atom)
 
 /obj/item/clothing/mask/facehugger/proc/valid_to_attach(mob/living/M)
-	// valid targets: carbons except aliens and devils
+	// valid targets: carbons except aliens, devils, skeletons and plasmamen
 	// facehugger state early exit checks
 	if(stat != CONSCIOUS)
 		return FALSE
@@ -128,7 +128,7 @@
 		return FALSE
 	if(iscarbon(M))
 		// disallowed carbons
-		if(isalien(M) || istruedevil(M))
+		if(isalien(M) || istruedevil(M) || isskeleton(M) || isplasmaman(M))
 			return FALSE
 		var/mob/living/carbon/target = M
 		// gotta have a head to be implanted (no changelings or sentient plants)

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -130,12 +130,14 @@
 		// disallowed carbons
 		if(isalien(M) || istruedevil(M))
 			return FALSE
+			
 		var/mob/living/carbon/target = M
 		// gotta have a head to be implanted (no changelings or sentient plants)
-		if(!target.get_bodypart(BODY_ZONE_HEAD))
+		// gotta have a stomach to be implanted (no skeletons)
+		if(!target.get_bodypart(BODY_ZONE_HEAD) || !target.getorgan(/obj/item/organ/stomach)
 			return FALSE
 
-		if(target.getorgan(/obj/item/organ/alien/hivenode) || target.getorgan(/obj/item/organ/body_egg/alien_embryo) || !target.getorgan(/obj/item/organ/stomach))
+		if(target.getorgan(/obj/item/organ/alien/hivenode) || target.getorgan(/obj/item/organ/body_egg/alien_embryo))
 			return FALSE
 		// carbon, has head, has stomach, not alien or devil, has no hivenode or embryo: valid
 		return TRUE

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -120,7 +120,7 @@
 		Leap(hit_atom)
 
 /obj/item/clothing/mask/facehugger/proc/valid_to_attach(mob/living/M)
-	// valid targets: carbons except aliens, devils, skeletons and plasmamen
+	// valid targets: carbons except aliens and devils
 	// facehugger state early exit checks
 	if(stat != CONSCIOUS)
 		return FALSE

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -128,16 +128,16 @@
 		return FALSE
 	if(iscarbon(M))
 		// disallowed carbons
-		if(isalien(M) || istruedevil(M) || isskeleton(M) || isplasmaman(M))
+		if(isalien(M) || istruedevil(M))
 			return FALSE
 		var/mob/living/carbon/target = M
 		// gotta have a head to be implanted (no changelings or sentient plants)
 		if(!target.get_bodypart(BODY_ZONE_HEAD))
 			return FALSE
 
-		if(target.getorgan(/obj/item/organ/alien/hivenode) || target.getorgan(/obj/item/organ/body_egg/alien_embryo))
+		if(target.getorgan(/obj/item/organ/alien/hivenode) || target.getorgan(/obj/item/organ/body_egg/alien_embryo) || !target.getorgan(/obj/item/organ/stomach))
 			return FALSE
-		// carbon, has head, not alien or devil, has no hivenode or embryo: valid
+		// carbon, has head, has stomach, not alien or devil, has no hivenode or embryo: valid
 		return TRUE
 
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Prevents facehuggers from leaping at / implanting skeletons.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Skeletons have no organs and thus have nowhere for the chestburster to be implanted. This just stops them from attempting to implant skeles.

## Changelog
:cl:
balance: skeletons can no longer be facehugged or implanted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
