### PR TITLE
Fixes AI Swarmers Doing Nothing

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -87,9 +87,10 @@
 		return ..()
 	else
 		. = list() // The following code is only very slightly slower than just returning oview(vision_range, targets_from), but it saves us much more work down the line
-		for(var/obj/A in oview(vision_range, targets_from))
+		var/list/searched_for = oview(vision_range, targets_from)
+		for(var/obj/A in searched_for)
 			. += A
-		for(var/mob/A in oview(vision_range, targets_from))
+		for(var/mob/A in searched_for)
 			. += A
 
 /mob/living/simple_animal/hostile/poison/bees/proc/generate_bee_visuals()

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -82,7 +82,7 @@
 	if(!beehome)
 		. += "<span class='warning'>This bee is homeless!</span>"
 
-/mob/living/simple_animal/hostile/ListTargets() // Bee processing is expessive, so we override them finding targets here.
+/mob/living/simple_animal/hostile/poison/bees/ListTargets() // Bee processing is expessive, so we override them finding targets here.
 	if(!search_objects) //In case we want to have purely hostile bees
 		return ..()
 	else

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -82,6 +82,15 @@
 	if(!beehome)
 		. += "<span class='warning'>This bee is homeless!</span>"
 
+/mob/living/simple_animal/hostile/ListTargets() // Bee processing is expessive, so we override them finding targets here.
+	if(!search_objects) //In case we want to have purely hostile bees
+		return ..()
+	else
+		. = list() // The following code is only very slightly slower than just returning oview(vision_range, targets_from), but it saves us much more work down the line
+		for(var/obj/A in oview(vision_range, targets_from))
+			. += A
+		for(var/mob/A in oview(vision_range, targets_from))
+			. += A
 
 /mob/living/simple_animal/hostile/poison/bees/proc/generate_bee_visuals()
 	cut_overlays()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -127,7 +127,7 @@
 
 //////////////HOSTILE MOB TARGETTING AND AGGRESSION////////////
 
-/mob/living/simple_animal/hostile/proc/ListTargets()//Step 1, find out what we can see
+/mob/living/simple_animal/hostile/proc/ListTargets() //Step 1, find out what we can see
 	if(!search_objects)
 		. = hearers(vision_range, targets_from) - src //Remove self, so we don't suicide
 
@@ -137,11 +137,7 @@
 			if(can_see(targets_from, HM, vision_range))
 				. += HM
 	else
-		. = list() // The following code is only very slightly slower than just returning oview(vision_range, targets_from), but it saves us much more work down the line, particularly when bees are involved
-		for (var/obj/A in oview(vision_range, targets_from))
-			. += A
-		for (var/mob/A in oview(vision_range, targets_from))
-			. += A
+		. = oview(vision_range, targets_from)
 
 /mob/living/simple_animal/hostile/proc/FindTarget(var/list/possible_targets, var/HasTargetsList = 0)//Step 2, filter down possible targets to things we actually care about
 	. = list()


### PR DESCRIPTION
## About The Pull Request

AI swarmers are supposed to go after nearly everything in sight, including turfs, but this behavior is broken; I wouldn't be all surprised if other mobs targeting behavior is also broken.

In an attempt to make bees perform better, `ListTargets` behavior was changed here: https://github.com/tgstation/tgstation/pull/31250

While it does, supposedly, perform better, it also breaks swarmers---andddd I suspect other mobs, as well, as this effectively means anything that's not a mob or an object (primarily turfs).

Either case, this reverts `ListTargets` back to what it originally was, restoring intended behavior.

That said, since bees are so problematic, they use the current `ListTargets` behavior to only search for objects and mobs.

fixes: https://github.com/tgstation/tgstation/issues/46938

## Changelog

:cl: Fox McCloud
fix: Fixes AI swarmers just sitting in their base doing nothing
/:cl:
