### PR TITLE
Add AcetylCysteine to heal liver damage

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1354,5 +1354,5 @@
 	var/obj/item/organ/liver/liver = M.getorganslot(ORGAN_SLOT_LIVER)
 	if (!liver || holder.get_reagents() != "AcetylCysteine")
 		return
-	liver.applyOrganDamage(-0.05)
+	liver.applyOrganDamage(-0.25)
 	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1342,3 +1342,17 @@
 	L.unignore_slowdown(type)
 	L.Dizzy(0)
 	L.Jitter(0)
+
+/datum/reagent/medicine/AcetylCysteine
+	name = "AcetylCysteine"
+	description = "Slowly restores liver damage, as long as there are no other chemicals in the patient's system"
+	reagent_state = LIQUID
+	color = "#85E085"
+	metabolization_rate = 0.1 * REAGENTS_METABOLISM
+
+/datum/reagent/medicine/AcetylCysteine/on_mob_life(mob/living/carbon/M)
+	var/obj/item/organ/liver/liver = M.getorganslot(ORGAN_SLOT_LIVER)
+	if (!liver || holder.get_reagents() != "AcetylCysteine")
+		return
+	liver.applyOrganDamage(-0.05)
+	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1343,16 +1343,16 @@
 	L.Dizzy(0)
 	L.Jitter(0)
 
-/datum/reagent/medicine/AcetylCysteine
-	name = "AcetylCysteine"
+/datum/reagent/medicine/acetyl_cysteine
+	name = "Acetyl-Cysteine"
 	description = "Slowly restores liver damage, as long as there are no other chemicals in the patient's system"
 	reagent_state = LIQUID
 	color = "#85E085"
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 
-/datum/reagent/medicine/AcetylCysteine/on_mob_life(mob/living/carbon/M)
+/datum/reagent/medicine/acetyl_cysteine/on_mob_life(mob/living/carbon/M)
 	var/obj/item/organ/liver/liver = M.getorganslot(ORGAN_SLOT_LIVER)
-	if (!liver || holder.get_reagents() != "AcetylCysteine")
+	if (!liver || holder.get_reagents() != "Acetyl-Cysteine")
 		return
 	liver.applyOrganDamage(-0.25)
 	..()

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -233,8 +233,8 @@
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/space_cleaner/sterilizine = 1) //haha guys totally not some sort of saline reference!
 	required_temp = 373
 
-/datum/chemical_reaction/AcetylCysteine
-	name = "AcetylCysteine"
-	id = /datum/reagent/medicine/AcetylCysteine
-	results = list(/datum/reagent/medicine/AcetylCysteine = 3)
+/datum/chemical_reaction/acetyl_cysteine
+	name = "Acetyl-Cysteine"
+	id = /datum/reagent/medicine/acetyl_cysteine
+	results = list(/datum/reagent/medicine/acetyl_cysteine = 3)
 	required_reagents = list(/datum/reagent/medicine/C2/multiver = 1, /datum/reagent/phenol = 1, /datum/reagent/toxin/acid = 1)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -232,3 +232,9 @@
 	results = list(/datum/reagent/medicine/granibitaluri = 1)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/space_cleaner/sterilizine = 1) //haha guys totally not some sort of saline reference!
 	required_temp = 373
+
+/datum/chemical_reaction/AcetylCysteine
+	name = "AcetylCysteine"
+	id = /datum/reagent/medicine/AcetylCysteine
+	results = list(/datum/reagent/medicine/AcetylCysteine = 3)
+	required_reagents = list(/datum/reagent/medicine/C2/multiver = 1, /datum/reagent/phenol = 1, /datum/reagent/toxin/acid = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds AcetylCysteine, a new chemical that heals liver damage.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Recipe:
1u part multiver
1u part phenol
1u part sulphuric acid 
makes 3u AcetylCysteine

Slowly heals liver damage, as long as there are no other chemicals present in the patient.

Heals liver damage at 0.25 / tick
metabolises at 0.1u/tick



## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Currently, the negative side effects of Aiuri are easily dealt with by oculine. This adds AcetylCysteine, which acts as an equvalent chemical to match libital. 
At the moment liver damage can only be dealt with either by replacement or just waiting. Hopefully this chemical can make people more happy to use libital, especially if the latest CobbyChem change gets merged

(Also first PR, be gentle!)

## Changelog
:cl:
add: Added AcetylCysteine, a medicine which heals liver damage as long as the patient has no other chemicals in their body
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
