### PR TITLE
[WIP] Adds surgery skill, trainable by department dissection movie nights

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -33,6 +33,8 @@ SUBSYSTEM_DEF(research)
 	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 54.3)
 	var/multiserver_calculation = FALSE
 	var/last_income
+	var/surgery_exp = 0
+
 	//^^^^^^^^ ALL OF THESE ARE PER SECOND! ^^^^^^^^
 
 	//Aiming for 1.5 hours to max R&D

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -66,6 +66,8 @@
 
 	var/list/learned_recipes //List of learned recipe TYPES.
 
+	var/surgery_skill = 0
+
 /datum/mind/New(var/key)
 	src.key = key
 	soulOwner = src

--- a/code/game/machinery/computer/surgery_television.dm
+++ b/code/game/machinery/computer/surgery_television.dm
@@ -1,0 +1,161 @@
+#define SURGERY_EXP_LEVEL_1 3
+#define SURGERY_EXP_LEVEL_2 7
+#define SURGERY_EXP_LEVEL_3 12
+
+#define SURGERY_UNTRAINED 0
+#define SURGERY_FAMILIAR 1
+#define SURGERY_TRAINED 2
+#define SURGERY_EXPERT 3
+
+/obj/machinery/computer/surgery_television
+	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN
+	icon = 'icons/obj/computer.dmi'
+	icon_state = "television"
+	icon_keyboard = null
+	icon_screen = "detective_tv"
+	name = "surgery tape monitor"
+	desc = "An old Juked Micronics CRT screen hooked up to the research network that plays back recordings of dissections for educational value. Despite the attached tape player, it only displays videos of graphic dismemberment from the server, making it a poor choice for movie nights."
+	circuit = /obj/item/circuitboard/computer/surgery_television
+	var/stored_exp = 0
+	var/operating_time = 200 // how long it takes to view the surgeries
+	var/playing = FALSE
+	var/list/cur_viewers = list()
+	var/sound_vol = 60
+	var/list/play_sounds = list('sound/weapons/bladeslice.ogg', 'sound/effects/blobattack.ogg', 'sound/weapons/drill.ogg', 'sound/effects/splat.ogg', 'sound/weapons/sear.ogg')
+	var/list/play_by_play_descs = list("What fascinating technique...", "Are you allowed to do that like that?", "Hahaha, ewwwwwwww...", "You won\'t see THAT in the textbooks...")
+	var/list/skill_titles = list("unskilled in", "familiar with", "trained in", "an expert in")
+
+/obj/machinery/computer/surgery_television/examine(mob/user)
+	. = ..()
+	var/level = get_level()
+
+	if(level == SURGERY_UNTRAINED)
+		. += "<span class='danger'>The screen reads \"NO MEDIA\".</span>"
+	else
+		. += "<span class='notice'>The screen indicates it has enough material to teach to level [level].</span>"
+
+
+/obj/machinery/computer/surgery_television/proc/get_level()
+	switch(stored_exp)
+		if(-INFINITY to SURGERY_EXP_LEVEL_1 - 1)
+			return SURGERY_UNTRAINED
+		if(SURGERY_EXP_LEVEL_1 to SURGERY_EXP_LEVEL_2 - 1)
+			return SURGERY_FAMILIAR
+		if(SURGERY_EXP_LEVEL_2 to SURGERY_EXP_LEVEL_3 - 1)
+			return SURGERY_TRAINED
+		if(SURGERY_EXP_LEVEL_3 to INFINITY)
+			return SURGERY_EXPERT
+
+/obj/machinery/computer/surgery_television/interact(mob/user)
+	if(playing)
+		finish(FALSE)
+		return
+
+	var/choice = alert(user, "What would you like to do?", "Choose action", "Update tapes", "Play tapes", "Cancel")
+
+	switch(choice)
+		if("Update tapes")
+			var/old_level = get_level()
+			stored_exp = SSresearch.surgery_exp
+			var/level = get_level()
+			if(!level > old_level)
+				to_chat(user, "<span class='danger'>\The [src] doesn\'t have enough new material to be worth updating.</span>")
+			else
+				visible_message("<span class='notice'>You update the tape archive on \the [src]. It is now capable of teaching to level [level].</span>", \
+					"<span class='notice'>[user] updates the tape archive on \the [src].</span>", \
+					"<span class='hear'>You hear the sound of a click and the rapid rewinding of tapes.</span>")
+		if("Play tapes")
+			play(user)
+
+/obj/machinery/computer/surgery_television/proc/isViewing(mob/user)
+	if(playing)
+		if(cur_viewers)
+			if(user in cur_viewers)
+				return TRUE
+	return FALSE
+
+
+/obj/machinery/computer/surgery_television/proc/play(mob/user)
+	if(playing)
+		to_chat(user, "<span class='danger'>\The [src] is already playing!</span>")
+		return
+
+	if(get_level() == SURGERY_UNTRAINED)
+		to_chat(user, "<span class='danger'>\The [src] doesn\'t have enough material to learn from.</span>")
+		return
+
+	playing = TRUE
+
+	visible_message("<span class='notice'>You hit 'play' on \the [src].</span>", \
+		"<span class='notice'>[user] presses 'play' on \the [src].</span>", \
+		"<span class='hear'>You hear the sound of a tape whirring.</span>")
+
+	START_PROCESSING(SSmachines, src)
+
+
+	var/in_view = get_hearers_in_view(3, get_turf(src))
+	for(var/mob/living/L in in_view)
+		if(iscarbon(L))
+			var/mob/living/carbon/C = L
+			//if(C.mind)
+			testing(C.name)
+			cur_viewers += C
+			//var/datum/progressbar/progress = new(C, operating_time / 10, src)
+			//while (do_after(C, 10, FALSE, src, FALSE, CALLBACK(src, isViewing(C)))
+			to_chat(C, "<span class='notice'>Your attention is turned towards the grotesque dissections on \the [src].</span>")
+
+
+	addtimer(CALLBACK(src, .proc/finish, TRUE), operating_time)
+
+
+/obj/machinery/computer/surgery_television/proc/finish(var/success, mob/user)
+	if(success)
+		visible_message("<span class='notice'>\The [src] clicks once, then goes black as the tape finishes.</span>", \
+		"<span class='hear'>You hear a click.</span>")
+		for(var/mob/living/carbon/C in cur_viewers)
+			testing(C.name)
+			if(C.mind)
+				if(C.mind.surgery_skill < level)
+					to_chat(C, "<span class='notice'>You have gained proficiency in surgery! You are now [skill_titles[level + 1]] surgery!</span>")
+					C.mind.surgery_skill = level
+				else
+					to_chat(C, "<span class='danger'>You don\'t feel like you learned anything from those tapes.</span>")
+	else
+		if(user)
+			visible_message("<span class='notice'>You hit 'stop' on \the [src].</span>", \
+				"<span class='notice'>[user] halts the playback on \the [src].</span>", \
+				"<span class='hear'>You hear a click.</span>")
+		else
+			visible_message("<span class='notice'>\The [src] clicks, then goes black.</span>", \
+				"<span class='hear'>You hear a click.</span>")
+
+	cur_viewers = list()
+	playing = FALSE
+
+/obj/machinery/computer/surgery_television/process()
+	if(playing)
+		var/in_view = get_hearers_in_view(3, get_turf(src))
+
+		for(var/mob/living/carbon/C in cur_viewers)
+			if(!(C in in_view))
+				cur_viewers -= C
+				to_chat(C, "<span class='danger'>You turn your attention away from \the [src].</span>")
+				continue
+
+			if(prob(15))
+				to_chat(C, "<span class='notice'><i>[pick(play_by_play_descs)]</i></span>")
+
+		if(prob(33))
+			playsound(src, pick(play_sounds), sound_vol)
+
+
+//obj/machinery/computer/surgery_television/proc/update()
+
+#undef SURGERY_EXP_LEVEL_1
+#undef SURGERY_EXP_LEVEL_2
+#undef SURGERY_EXP_LEVEL_3
+
+#undef SURGERY_UNTRAINED
+#undef SURGERY_FAMILIAR
+#undef SURGERY_TRAINED
+#undef SURGERY_EXPERT

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -288,6 +288,11 @@
 	icon_state = "medical"
 	build_path = /obj/machinery/computer/operating
 
+/obj/item/circuitboard/computer/surgery_television
+	name = "Surgery Tape Monitor (Computer Board)"
+	icon_state = "medical"
+	build_path = /obj/machinery/computer/surgery_television
+
 /obj/item/circuitboard/computer/pandemic
 	name = "PanD.E.M.I.C. 2200 (Computer Board)"
 	icon_state = "medical"

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -80,6 +80,14 @@
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/board/surgery_television
+	name = "Surgery Tape Monitor (Operating Computer)"
+	desc = "Allows for the construction of circuit boards used to build a surgery tape monitor console."
+	id = "surgery_television"
+	build_path = /obj/item/circuitboard/computer/surgery_television
+	category = list("Computer Boards")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+
 /datum/design/board/pandemic
 	name = "Computer Design (PanD.E.M.I.C. 2200)"
 	desc = "Allows for the construction of circuit boards used to build a PanD.E.M.I.C. 2200 console."
@@ -303,7 +311,7 @@
 	build_path = /obj/item/circuitboard/computer/nanite_cloud_controller
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
-	
+
 /datum/design/board/advanced_camera
 	name = "Computer Design (Advanced Camera Console)"
 	desc = "Allows for the construction of circuit boards used to build advanced camera consoles."

--- a/code/modules/surgery/experimental_dissection.dm
+++ b/code/modules/surgery/experimental_dissection.dm
@@ -72,8 +72,10 @@
 
 /datum/surgery_step/dissection/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/points_earned = check_value(target, surgery)
-	user.visible_message("<span class='notice'>[user] dissects [target], discovering [points_earned] point\s of data!</span>", "<span class='notice'>You dissect [target], and add your [points_earned] point\s worth of discoveries to the research database!</span>")
+	var/surgery_exp_earned = points_earned / BASE_HUMAN_REWARD
+	user.visible_message("<span class='notice'>[user] dissects [target], discovering [points_earned] point\s of research data and cataloging [surgery_exp_earned] point\s of surgical knowledge!</span>", "<span class='notice'>You dissect [target], and add your [points_earned] point\s of research material and and cataloging [surgery_exp_earned] point\s of surgical knowledge to the research database!</span>")
 	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points_earned))
+	SSresearch.surgery_exp += surgery_exp_earned
 	var/obj/item/bodypart/L = target.get_bodypart(BODY_ZONE_CHEST)
 	target.apply_damage(80, BRUTE, L)
 	ADD_TRAIT(target, TRAIT_DISSECTED, "[surgery.name]")

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -60,6 +60,19 @@
 /datum/surgery_step/proc/initiate(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	surgery.step_in_progress = TRUE
 	var/speed_mod = 1
+	switch(user.mind.surgery_skill)
+		if(0)
+			testing("Level 0")
+		if(1)
+			speed_mod *= 0.9
+			testing("Level 1")
+		if(2)
+			speed_mod *= 0.85
+			testing("Level 2")
+		if(3)
+			speed_mod *= 0.8
+			testing("Level 3")
+
 	var/advance = FALSE
 
 	if(preop(user, target, target_zone, tool, surgery) == -1)
@@ -67,7 +80,7 @@
 		return FALSE
 
 	if(tool)
-		speed_mod = tool.toolspeed
+		speed_mod *= tool.toolspeed
 
 	if(do_after(user, time * speed_mod, target = target))
 		var/prob_chance = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds a surgery skill that confers a minor buff to surgery speed. All spacemen start at level 0, and contribute "surgery experience points" to a pool in the research servers by completing dissections. Once enough communal surgery points have been earned, anyone can level their skill by reviewing dissection tapes at a new surgery tape player located in the medical break rooms. The benefits are small, yet will still be worth earning when things are slow. 

Level 0- Untrained: No change to speed
Level 1- Familiar: 10% faster surgery (requires 3 surgery points)
Level 2- Skilled: 15% faster surgery (requires 7 surgery points)
Level 3- Expert: 20% faster surgery (requires 12 surgery points)

Here's how it works:

1. Perform dissections to gain surgery points added to the research network. You get 1 point per dissection base, and the normal research point multipliers apply, so better dissections give 2, 5, or 10 points, and dissecting non-humanoids give different bases.
2. Once enough surgery points are earned, go to the break room and update the tape player.
3. "Watch" the tapes (sit in front of the television for a little while) and voila, you are now better at surgery!

While doctors will likely be the ones who contribute the most to earning the surgery points and have the easiest access to it, anyone who gets in front of the TV and sticks around for a bit can get the same buffs from it.

It currently works on anyone in a 3 tile radius of the TV, as I'd like to offer a small bonus to viewing the tapes along with other people to simulate the benefits of a study group and encourage people to treat it as a little social event (who didn't like getting to watch videos in class?) I'm not sure what the bonus will be, maybe a positive moodie that scales with the number of people watched with, or a small "half-level" buff? I'd like suggestions and thoughts!


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds another reason for doctors to do dissections that primarily benefits them rather than science, will provide a small incentive for the medical department/whoever else to come together for something.

TODO: 
- [ ] Polish the viewing experience (messages, progress bars, balance, etc)
- [ ] Add an incentive to view in a group
- [ ] Add the surgery tape monitors to the medical break rooms/equivalent.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Shaps/Ryll
add: You can now improve your surgery skills by reviewing dissection tapes in the medical break rooms. It's more fun with friends!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
