### PR TITLE
Better Slime and Xenobiology Equipment Garbage Collection

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -21,10 +21,11 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 		GLOB.monkey_recyclers += src
 
 /obj/machinery/monkey_recycler/Destroy()
-	if(src in GLOB.monkey_recyclers)
-		GLOB.monkey_recyclers -= src
-	for(var/obj/machinery/computer/camera_advanced/xenobio/console in connected)
+	GLOB.monkey_recyclers -= src
+	for(var/thing in connected)
+		var/obj/machinery/computer/camera_advanced/xenobio/console = thing
 		console.connected_recycler = null
+	connected.Cut()
 	return ..()
 
 /obj/machinery/monkey_recycler/RefreshParts()	//Ranges from 0.2 to 0.8 per monkey recycled

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -107,6 +107,10 @@
 	for (var/A in actions)
 		var/datum/action/AC = A
 		AC.Remove(src)
+	Target = null
+	Leader = null
+	Friends.Cut()
+	speech_buffer.Cut()
 	return ..()
 
 /mob/living/simple_animal/slime/proc/set_colour(new_colour)


### PR DESCRIPTION
Taking a glance at the garbage collection code for some of the Xenobio equipment promptly made me scowl. 

I get that you guys like signals and components, and they're definitely useful, but registering Xenobio to listen for a signal,  then later, when a slime or slime potion gets `qdel`'d, which will call `Destroy`, which will eventually call `loc.handle_atom_del`, which will then send a signal to listen in on the Xenobio console to eventually call the terribly named proc `on_contents_del` (which is also a concrete storage component proc name...) is *ridiculous* and insanely overly convoluted. The heck? Just putting that in `handle_atom_del` is the sane thing to do. Less proc call overhead, easier to understand, and easier to follow. I guess someone just had a fondness for overly complicated code.

In any event, aside from that, just some generic better de-referencing of things in Xenobio, completely with istypeless loop improvements.