### PR TITLE
Field Generators block gasses and shield floors from melting

### DIFF
--- a/code/game/objects/effects/effect_system/effect_shield.dm
+++ b/code/game/objects/effects/effect_system/effect_shield.dm
@@ -15,9 +15,12 @@
 
 /obj/effect/shield/Destroy()
 	location = get_turf(src)	
-	location.heat_capacity=old_heat_capacity
+	location.heat_capacity=max(old_heat_capacity, location.heat_capacity)
 	..()
 
 /obj/effect/shield/singularity_act()
 	return
-	
+
+/obj/effect/shield/singularity_pull(S, current_size)
+	return
+		

--- a/code/game/objects/effects/effect_system/effect_shield.dm
+++ b/code/game/objects/effects/effect_system/effect_shield.dm
@@ -1,0 +1,23 @@
+/obj/effect/shield
+	/var/old_heat_capacity
+	/var/turf/location
+	name = "shield"
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "wave2"
+	layer = ABOVE_NORMAL_TURF_LAYER
+	flags_1 = PREVENT_CLICK_UNDER_1
+
+/obj/effect/shield/Initialize()
+	. = ..()
+	location = get_turf(src)	
+	old_heat_capacity=location.heat_capacity
+	location.heat_capacity = INFINITY
+
+/obj/effect/shield/Destroy()
+	location = get_turf(src)	
+	location.heat_capacity=old_heat_capacity
+	..()
+
+/obj/effect/shield/singularity_act()
+	return
+	

--- a/code/game/objects/effects/effect_system/effect_shield.dm
+++ b/code/game/objects/effects/effect_system/effect_shield.dm
@@ -1,21 +1,20 @@
-/obj/effect/shield
-	/var/old_heat_capacity
-	/var/turf/location
+/obj/effect/shield	
 	name = "shield"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "wave2"
 	layer = ABOVE_NORMAL_TURF_LAYER
 	flags_1 = PREVENT_CLICK_UNDER_1
+	var/old_heat_capacity
 
 /obj/effect/shield/Initialize()
 	. = ..()
-	location = get_turf(src)	
+	var/location = get_turf(src)	
 	old_heat_capacity=location.heat_capacity
 	location.heat_capacity = INFINITY
 
 /obj/effect/shield/Destroy()
-	location = get_turf(src)	
-	location.heat_capacity=max(old_heat_capacity, location.heat_capacity)
+	var/location = get_turf(src)	
+	location.heat_capacity=old_heat_capacity
 	..()
 
 /obj/effect/shield/singularity_act()

--- a/code/game/objects/effects/effect_system/effect_shield.dm
+++ b/code/game/objects/effects/effect_system/effect_shield.dm
@@ -8,12 +8,12 @@
 
 /obj/effect/shield/Initialize()
 	. = ..()
-	var/location = get_turf(src)	
+	var/turf/location = get_turf(src)	
 	old_heat_capacity=location.heat_capacity
 	location.heat_capacity = INFINITY
 
 /obj/effect/shield/Destroy()
-	var/location = get_turf(src)	
+	var/turf/location = get_turf(src)	
 	location.heat_capacity=old_heat_capacity
 	..()
 

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -11,14 +11,21 @@
 	use_power = NO_POWER_USE
 	interaction_flags_atom = NONE
 	interaction_flags_machine = NONE
+	CanAtmosPass = ATMOS_PASS_NO
 	light_range = 4
 	layer = ABOVE_OBJ_LAYER
 	var/obj/machinery/field/generator/FG1 = null
 	var/obj/machinery/field/generator/FG2 = null
 
+/obj/machinery/field/containment/Initialize()
+	. = ..()
+	air_update_turf(TRUE)
+
 /obj/machinery/field/containment/Destroy()
 	FG1.fields -= src
 	FG2.fields -= src
+	CanAtmosPass = ATMOS_PASS_YES
+	air_update_turf(TRUE)
 	return ..()
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -39,7 +39,7 @@ field_generator power level display
 	var/power_level = 0
 	var/active = FG_OFFLINE
 	var/power = 20  // Current amount of power
-	var/state = FG_UNSECURED	
+	var/state = FG_UNSECURED
 	var/warming_up = 0
 	var/list/obj/machinery/field/containment/fields
 	var/list/obj/machinery/field/generator/connected_gens

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -32,13 +32,14 @@ field_generator power level display
 	density = TRUE
 	use_power = NO_POWER_USE
 	max_integrity = 500
+	CanAtmosPass = ATMOS_PASS_YES
 	//100% immune to lasers and energy projectiles since it absorbs their energy.
 	armor = list("melee" = 25, "bullet" = 10, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 70)
 	var/const/num_power_levels = 6	// Total number of power level icon has
 	var/power_level = 0
 	var/active = FG_OFFLINE
 	var/power = 20  // Current amount of power
-	var/state = FG_UNSECURED
+	var/state = FG_UNSECURED	
 	var/warming_up = 0
 	var/list/obj/machinery/field/containment/fields
 	var/list/obj/machinery/field/generator/connected_gens
@@ -179,6 +180,8 @@ field_generator power level display
 
 /obj/machinery/field/generator/proc/turn_off()
 	active = FG_OFFLINE
+	CanAtmosPass = ATMOS_PASS_YES
+	air_update_turf(TRUE)
 	INVOKE_ASYNC(src, .proc/cleanup)
 	addtimer(CALLBACK(src, .proc/cool_down), 50)
 
@@ -255,6 +258,8 @@ field_generator power level display
 		turn_off()
 		return
 	move_resist = INFINITY
+	CanAtmosPass = ATMOS_PASS_NO
+	air_update_turf(TRUE)
 	addtimer(CALLBACK(src, .proc/setup_field, 1), 1)
 	addtimer(CALLBACK(src, .proc/setup_field, 2), 2)
 	addtimer(CALLBACK(src, .proc/setup_field, 4), 3)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -203,8 +203,7 @@ field_generator power level display
 	warming_up++
 	update_icon()
 	if(warming_up >= 3)
-		start_fields()
-		shield_floor(TRUE)
+		start_fields()		
 	else
 		addtimer(CALLBACK(src, .proc/warm_up), 50)
 
@@ -315,6 +314,7 @@ field_generator power level display
 
 	connected_gens |= G
 	G.connected_gens |= src
+	shield_floor(TRUE)
 	update_icon()
 
 
@@ -375,7 +375,7 @@ field_generator power level display
 /obj/machinery/field/generator/proc/place_floor(Location,create)
 	if(create && !locate(/obj/effect/shield) in Location)
 		new/obj/effect/shield(Location)
-	else		
+	else if(!create)		
 		var/obj/effect/shield/S=locate(/obj/effect/shield) in Location
 		if(S)			
 			qdel(S)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -822,6 +822,7 @@
 #include "code\game\objects\effects\decals\turfdecal\markings.dm"
 #include "code\game\objects\effects\decals\turfdecal\tilecoloring.dm"
 #include "code\game\objects\effects\decals\turfdecal\weather.dm"
+#include "code\game\objects\effects\effect_system\effect_shield.dm"
 #include "code\game\objects\effects\effect_system\effect_system.dm"
 #include "code\game\objects\effects\effect_system\effects_explosion.dm"
 #include "code\game\objects\effects\effect_system\effects_foam.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows Field Generators and their containment fields to block Gasses when active. Field Generators now project shielding over the floor that prevents melting. Intended as a prelude to making turfs melt easier under high heat.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows for setting up safe gas containment with some risk for containment breach.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Jdawg1290
balance: Field Generators now block gasses and shield floors from melting when active
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
