### PR TITLE
chili and ice-chili botany bounties are no longer overridden by ghost chilis

### DIFF
--- a/code/modules/cargo/bounties/botany.dm
+++ b/code/modules/cargo/bounties/botany.dm
@@ -98,12 +98,12 @@
 	name = "Chili Peppers"
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/chili)
 
-/datum/bounty/item/botany/chili
+/datum/bounty/item/botany/ice_chili
 	name = "Ice Chili Peppers"
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/icepepper)
 	multiplier = 2
 
-/datum/bounty/item/botany/chili
+/datum/bounty/item/botany/ghost_chili
 	name = "Ghost Chili Peppers"
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/ghost_chili)
 	multiplier = 2


### PR DESCRIPTION
## About The Pull Request
The types on these bounty datums all had the same name, leading to only ghost chilis ever being a bounty

## Why It's Good For The Game
Maybe botany wants to do these bounties, idk. The code needs to be fixed either this way or by removing the bounties.

## Changelog
:cl:
fix: chili and ice chili bounties can now occur
/:cl:
