### PR TITLE
Stops non-alphanumeric graffiti decals from being named "letter".

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -303,7 +303,7 @@
 
 
 	var/temp = "rune"
-	var/ascii = (length(drawing) == 1) ? TRUE : FALSE
+	var/ascii = (length(drawing) == 1)
 	if(ascii && is_alpha(drawing))
 		temp = "letter"
 	else if(ascii && is_digit(drawing))

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -238,7 +238,7 @@
 				if (!isnull(chosen_colour))
 					paint_color = chosen_colour
 					. = TRUE
-				else 
+				else
 					. = FALSE
 		if("enter_text")
 			var/txt = stripped_input(usr,"Choose what to write.",
@@ -303,9 +303,10 @@
 
 
 	var/temp = "rune"
-	if(is_alpha(drawing))
+	var/ascii = (length(drawing) == 1) ? TRUE : FALSE
+	if(ascii && is_alpha(drawing))
 		temp = "letter"
-	else if(is_digit(drawing))
+	else if(ascii && is_digit(drawing))
 		temp = "number"
 	else if(drawing in punctuation)
 		temp = "punctuation mark"
@@ -669,7 +670,7 @@
 			if(color_hex2num(paint_color) < 350 && !istype(target, /obj/structure/window)) //Colors too dark are rejected
 				to_chat(usr, "<span class='warning'>A colour that dark on an object like this? Surely not...</span>")
 				return FALSE
-				
+
 			target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 
 			if(istype(target, /obj/structure/window))


### PR DESCRIPTION
## About The Pull Request
Does exactly what it says on the tin. 
text2ascii accepts text strings with length higher than one character as first arg, so we need to check against that beforehand.

## Why It's Good For The Game
Fixing a (likely unreported) mild issue with the game.

## Changelog
:cl:
fix: non-alphanumeric graffiti decals will no longer display as "letter".
/:cl: