### PR TITLE
Big storage containers (like bags) in smaller ones (like boxes) can't have items placed in them

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -615,11 +615,10 @@
 			to_chat(M, "<span class='warning'>[I] is too big for [host]!</span>")
 		return FALSE
 	var/datum/component/storage/biggerfish = real_location.loc.GetComponent(/datum/component/storage)
-	if(biggerfish)//return false if we are inside of another container,
-		if(biggerfish.max_w_class < max_w_class)//and that container has a smaller max_w_class than us (like if we're a bag in a box)
-			if(!stop_messages)
-				to_chat(M, "<span class='warning'>[I] can't fit in [host] while [real_location.loc] is in the way!</span>")
-			return FALSE
+	if(biggerfish && biggerfish.max_w_class < max_w_class)//return false if we are inside of another container, and that container has a smaller max_w_class than us (like if we're a bag in a box)
+		if(!stop_messages)
+			to_chat(M, "<span class='warning'>[I] can't fit in [host] while [real_location.loc] is in the way!</span>")
+		return FALSE
 	var/sum_w_class = I.w_class
 	for(var/obj/item/_I in real_location)
 		sum_w_class += _I.w_class //Adds up the combined w_classes which will be in the storage item if the item is added to it.

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -614,8 +614,8 @@
 		if(!stop_messages)
 			to_chat(M, "<span class='warning'>[I] is too big for [host]!</span>")
 		return FALSE
-	if(real_location.loc.GetComponent(/datum/component/storage))//return false if we are inside of another container,
-		var/datum/component/storage/biggerfish = real_location.loc.GetComponent(/datum/component/storage)
+	var/datum/component/storage/biggerfish = real_location.loc.GetComponent(/datum/component/storage)
+	if(biggerfish)//return false if we are inside of another container,
 		if(biggerfish.max_w_class < max_w_class)//and that container has a smaller max_w_class than us (like if we're a bag in a box)
 			if(!stop_messages)
 				to_chat(M, "<span class='warning'>[I] can't fit in [host] while [real_location.loc] is in the way!</span>")

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -614,6 +614,12 @@
 		if(!stop_messages)
 			to_chat(M, "<span class='warning'>[I] is too big for [host]!</span>")
 		return FALSE
+	if(real_location.loc.GetComponent(/datum/component/storage))//return false if we are inside of another container,
+		var/datum/component/storage/biggerfish = real_location.loc.GetComponent(/datum/component/storage)
+		if(biggerfish.max_w_class < max_w_class)//and that container has a smaller max_w_class than us (like if we're a bag in a box)
+			if(!stop_messages)
+				to_chat(M, "<span class='warning'>[I] can't fit in [host] while [real_location.loc] is in the way!</span>")
+			return FALSE
 	var/sum_w_class = I.w_class
 	for(var/obj/item/_I in real_location)
 		sum_w_class += _I.w_class //Adds up the combined w_classes which will be in the storage item if the item is added to it.


### PR DESCRIPTION
~~Untested webedit~~ Tested and functional
Fixes https://github.com/tgstation/tgstation/issues/46345

:cl:
fix: If you somehow manage to get a container into a another container that is smaller than it, like a bag in a box, you're no longer able to put things into that bigger container (such as the bag in the box).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
