### PR TITLE
Emergency Medical Holodeck is a Workplace Hazard

### DIFF
--- a/code/game/area/areas/holodeck.dm
+++ b/code/game/area/areas/holodeck.dm
@@ -75,9 +75,6 @@
 /area/holodeck/rec_center/lounge
 	name = "Holodeck - Lounge"
 
-/area/holodeck/rec_center/medical
-	name = "Holodeck - Emergency Medical"
-
 /area/holodeck/rec_center/pet_lounge
 	name = "Holodeck - Pet Park"
 
@@ -104,6 +101,14 @@
 
 // Bad programs
 
+/area/holodeck/rec_center/medical
+	name = "Holodeck - Emergency Medical"
+	restricted = 1
+
+/area/holodeck/rec_center/thunderdome1218
+	name = "Holodeck - 1218 AD"
+	restricted = 1
+
 /area/holodeck/rec_center/burn
 	name = "Holodeck - Atmospheric Burn Test"
 	restricted = 1
@@ -122,8 +127,4 @@
 
 /area/holodeck/rec_center/refuel
 	name = "Holodeck - Refueling Station"
-	restricted = 1
-
-/area/holodeck/rec_center/thunderdome1218
-	name = "Holodeck - 1218 AD"
 	restricted = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I moved the Emergency Medical module for the Holodeck behind the safety / emag lock, while also moving up 1218 AD Thunderdome a few slots, so there are less chances of someone miss clicking the first thing that would have been underneath Emergency Medical, the Atmos burn test.

## Why It's Good For The Game

To be quite honest, the Emergency Medical Holodeck module is used by those who want to bypass other departments to cure their ailments. If there was a chem dispenser in the module, the holodeck would be able to pretty much replace the entire medical department. 

Need surgery? Have a meta-friend perform surgery with no chances of failure because the holodeck provides all of the tools needed, including an operating computer.
Need to cure your common cold? Magic space holodeck has a Pandemic machine. 
Need to keep your friend's rotting corpse defibbable? Holodeck has stasis beds.

I believe this particular holodeck module reduces departmental cooperation and reliance, because you have consequence free alternatives to get your harmies fixed. Ghetto surgery, for example, isn't a viable alternative because you don't need to find and use improvised surgical tools when proper tools exist with no strings attached. The abandoned medbay exists and can be used as a backup medical or hub to get back alley procedures done.

"But Synn, I am not an antagonist with access to an Emag to unlock the safety." 
Silicon players are able to toggle the Holodeck's safety features, and enable the medical module from there, if the situation is serious enough to require said action when it comes to preventing human harm if they are still on Asimov's laws. A smart move afterwards would be turning the safety back on once the module is already loaded, thus to prevent harm from someone selecting the more... flavorful choices.

"But Synn, I don't want Doctor Jimbo or Roboticist Karen to perform surgery on me. I would rather have Assistant Dave do it because I know them." 
Assistants aren't trained surgeons from Centcom, and the solution for bypassing the proper department that already has a surgical setup should be through ghetto alternatives. Considering how medical lately has been moving more towards surgery as the answer to curing most ailments, this should give Doctors more opportunities for work as there would be less people bypassing the system using holograms.

Honestly, if my tiny brain knew how to properly code, a better alternative to locking the **_emergency_** medical module would be having the station to be on a code red alert level, but I am not sure how to do that without breaking a lot of eggs.

![Holodick](https://user-images.githubusercontent.com/6519623/66454792-e0133700-ea36-11e9-9fc5-f413ce8720cd.png)


## Changelog
:cl:
balance: CentCom has deemed use of the holodeck's emergency medical module unsafe, as it allows for procedures to be carried out by untrained crew members. If emergency medical procedures are needed, do not tamper with the machines and have your station's AI or cyborgs unlock the safeties.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
