### PR TITLE
turrets now properly yield their gun on deconstruction

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -239,6 +239,7 @@
 				if(prob(70))
 					if(stored_gun)
 						stored_gun.forceMove(loc)
+						stored_gun = null
 					to_chat(user, "<span class='notice'>You remove the turret and salvage some components.</span>")
 					if(prob(50))
 						new /obj/item/stack/sheet/metal(loc, rand(1,4))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
basically turrets delete their stored gun when the turret gets deleted. that's fine and good, but when you deconstruct a turret, it can eject the gun prior, but still has it marked as its stored gun, deleting it immediately. this pr makes it not have a stored gun after the deconstruction ejects it.
## Why It's Good For The Game
get guns out of turrets now as god intended
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: turrets are now able to drop guns on deconstruction properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
