### PR TITLE
fixes my spelling mistaek

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -271,6 +271,7 @@
 		icon_state = "scalpel_a"
 
 /obj/item/scalpel/advanced/examine()
+	. = ..()
 	. += " It's set to [tool_behaviour == TOOL_SCALPEL ? "scalpel" : "saw"] mode."
 
 /obj/item/retractor/advanced
@@ -292,6 +293,7 @@
 		icon_state = "retractor_a"
 
 /obj/item/retractor/advanced/examine()
+	. = ..()
 	. += " It resembles a [tool_behaviour == TOOL_RETRACTOR ? "retractor" : "hemostat"]."
 
 /obj/item/surgicaldrill/advanced
@@ -319,4 +321,5 @@
 		icon_state = "surgicaldrill_a"
 
 /obj/item/surgicaldrill/advanced/examine()
+	. = ..()
 	. += " It's set to [tool_behaviour == TOOL_DRILL ? "drilling" : "mending"] mode."

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -292,7 +292,7 @@
 		icon_state = "retractor_a"
 
 /obj/item/retractor/advanced/examine()
-	. += " It resembles a retractor[tool_behaviour == TOOL_RETRACTOR ? "retractor" : "hemostat"]."
+	. += " It resembles a [tool_behaviour == TOOL_RETRACTOR ? "retractor" : "hemostat"]."
 
 /obj/item/surgicaldrill/advanced
 	name = "searing tool"


### PR DESCRIPTION

## Changelog
:cl:
spellcheck: advanced retractor/hemostat description now doesnt mention a hemostat and another hemostat or a retractor
/:cl:
