### PR TITLE
Obscured turf check no longer requires density

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -171,7 +171,8 @@
 	return FALSE
 
 /turf/IsObscured()
-	for(var/atom/movable/AM in src)
+	for(var/item in src)
+		var/atom/movable/AM = item
 		if(AM.flags_1 & PREVENT_CLICK_UNDER_1)
 			return TRUE
 	return FALSE

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -172,7 +172,7 @@
 
 /turf/IsObscured()
 	for(var/atom/movable/AM in src)
-		if(AM.flags_1 & PREVENT_CLICK_UNDER_1 && AM.density)
+		if(AM.flags_1 & PREVENT_CLICK_UNDER_1)
 			return TRUE
 	return FALSE
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -283,6 +283,7 @@
 	set_opacity(0)
 	sleep(5)
 	density = FALSE
+	flags_1 ^= PREVENT_CLICK_UNDER_1
 	sleep(5)
 	layer = initial(layer)
 	update_icon()
@@ -312,6 +313,7 @@
 	layer = closingLayer
 	sleep(5)
 	density = TRUE
+	flags_1 |= PREVENT_CLICK_UNDER_1
 	sleep(5)
 	update_icon()
 	if(visible && !glass)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -283,7 +283,7 @@
 	set_opacity(0)
 	sleep(5)
 	density = FALSE
-	flags_1 ^= PREVENT_CLICK_UNDER_1
+	flags_1 &= ~PREVENT_CLICK_UNDER_1
 	sleep(5)
 	layer = initial(layer)
 	update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the check for density in the IsObscured() proc for turfs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's possible to have atoms that prevent interacting with the turf without impeding passage over the turf. We already explicitly set a flag (PREVENT_CLICK_UNDER_1) to check obscurity against that MUST be present anyway.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Jdawg1290
tweak: Non-dense atoms can now obscure (prevent interaction with) turfs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
