### PR TITLE
makes dark wizards unable to get from gold slimes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/dark_wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/dark_wizard.dm
@@ -22,7 +22,7 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	aggro_vision_range = 9
 	turns_per_move = 5
-	gold_core_spawnable = HOSTILE_SPAWN
+	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	faction = list(ROLE_WIZARD)
 	do_footstep = TRUE
 	weather_immunities = list("lava","ash")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

also gives it mob types that should be there

## Why It's Good For The Game

you can spawn a dude with slime

## Changelog
:cl:
tweak: you can no longer spawn dark wizards with gold slimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
