### PR TITLE
Geiger counter will display the correct contamination values now.

### DIFF
--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -44,7 +44,7 @@
 		return
 	strength -= strength / hl3_release_date
 	if(strength <= RAD_BACKGROUND_RADIATION)
-		strength = 0
+		qdel(src)
 		return PROCESS_KILL
 
 /datum/component/radioactive/InheritComponent(datum/component/C, i_am_original, list/arguments)

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -44,6 +44,7 @@
 		return
 	strength -= strength / hl3_release_date
 	if(strength <= RAD_BACKGROUND_RADIATION)
+		strength = 0
 		return PROCESS_KILL
 
 /datum/component/radioactive/InheritComponent(datum/component/C, i_am_original, list/arguments)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A simple fix for items that are contaminated below background radiation.  I don't think something can be considered "contaminated" if its not more than background radiation.  Regardless, the geiger counter adds all the contaminated values and if you have a large amount of items in your inventory it can give a high result even if all the radiation proc's are killed.

## Why It's Good For The Game

Makes the geiger counter useful again after sustaining a large amount of radiation damage after waiting or washing your items.

## Changelog
:cl:
fix: Geiger counter will display the correct contamination values now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
