### PR TITLE
Pellets from spread projectiles don't freeze clients

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
@@ -5,6 +5,8 @@
 	damage = 5
 	damage_type = BRUTE
 	armour_penetration = 100
+	lagshot = TRUE
+	chat_timeout = 5 SECONDS
 
 /mob/living/simple_animal/hostile/guardian/ranged
 	a_intent = INTENT_HELP

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -194,3 +194,5 @@
 	var/registered_z = null
 
 	var/memory_throttle_time = 0
+	//this kills tactical buckshot lagging
+	var/list/message_timeouts = null

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -20,6 +20,7 @@
 	var/firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect	//the visual effect appearing when the ammo is fired.
 	var/heavy_metal = TRUE
 	var/harmful = TRUE //pacifism check for boolet, set to FALSE if bullet is non-lethal
+	var/lagshot = FALSE //overrides to_chat for things like buckshot so Dell computers don't crash
 
 /obj/item/ammo_casing/spent
 	name = "spent bullet casing"

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -20,7 +20,6 @@
 	var/firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect	//the visual effect appearing when the ammo is fired.
 	var/heavy_metal = TRUE
 	var/harmful = TRUE //pacifism check for boolet, set to FALSE if bullet is non-lethal
-	var/lagshot = FALSE //overrides to_chat for things like buckshot so Dell computers don't crash
 
 /obj/item/ammo_casing/spent
 	name = "spent bullet casing"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -192,7 +192,7 @@
 			if(hitsound)
 				var/volume = vol_by_damage()
 				playsound(loc, hitsound, volume, TRUE, -1)
-			if(lagshot == FALSE)
+			if(!lagshot)
 				L.visible_message("<span class='danger'>[L] is hit by \a [src][organ_hit_text]!</span>", \
 						"<span class='userdanger'>You're hit by \a [src][organ_hit_text]!</span>", null, COMBAT_MESSAGE_RANGE)
 		L.on_hit(src)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -108,7 +108,7 @@
 	var/log_override = FALSE //is this type spammed enough to not log? (KAs)
 
 	var/temporary_unstoppable_movement = FALSE
-	var/lagshot = FALSE //used for buckshotlikes so dell computers dont crash
+	var/lagshot = FALSE //used for buckshotlikes so dell computers dont crash, blocks to_chat
 
 /obj/projectile/Initialize()
 	. = ..()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -109,6 +109,7 @@
 
 	var/temporary_unstoppable_movement = FALSE
 	var/lagshot = FALSE //used for buckshotlikes so dell computers dont crash, blocks to_chat
+	var/chat_timeout = 1 SECOND //longer for shotguns and spammers
 
 /obj/projectile/Initialize()
 	. = ..()
@@ -195,6 +196,10 @@
 			if(!lagshot)
 				L.visible_message("<span class='danger'>[L] is hit by \a [src][organ_hit_text]!</span>", \
 						"<span class='userdanger'>You're hit by \a [src][organ_hit_text]!</span>", null, COMBAT_MESSAGE_RANGE)
+			if(!message_timeouts || message_timeouts[type] <= world.time)
+				L.visible_message("<span class='danger'>[L] is debugged by \a [src][organ_hit_text]!</span>", \
+						"<span class='userdanger'>You're hit by \a [src][organ_hit_text]!</span>", null, COMBAT_MESSAGE_RANGE)
+				LAZYSET(message_timeouts,type,world.time+ 10 SECONDS)
 		L.on_hit(src)
 
 	var/reagent_note

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -109,7 +109,7 @@
 
 	var/temporary_unstoppable_movement = FALSE
 	var/lagshot = FALSE //used for buckshotlikes so dell computers dont crash, blocks to_chat
-	var/chat_timeout = 1 SECOND //longer for shotguns and spammers
+	var/chat_timeout = 1 SECONDS //longer for shotguns and spammers
 
 /obj/projectile/Initialize()
 	. = ..()
@@ -193,13 +193,11 @@
 			if(hitsound)
 				var/volume = vol_by_damage()
 				playsound(loc, hitsound, volume, TRUE, -1)
-			if(!lagshot)
+			if(!L.message_timeouts || L.message_timeouts <= world.time)
 				L.visible_message("<span class='danger'>[L] is hit by \a [src][organ_hit_text]!</span>", \
 						"<span class='userdanger'>You're hit by \a [src][organ_hit_text]!</span>", null, COMBAT_MESSAGE_RANGE)
-			if(!message_timeouts || message_timeouts[type] <= world.time)
-				L.visible_message("<span class='danger'>[L] is debugged by \a [src][organ_hit_text]!</span>", \
-						"<span class='userdanger'>You're hit by \a [src][organ_hit_text]!</span>", null, COMBAT_MESSAGE_RANGE)
-				LAZYSET(message_timeouts,type,world.time+ 10 SECONDS)
+				if(lagshot)
+					LAZYSET(L.message_timeouts,type,world.time+ chat_timeout)
 		L.on_hit(src)
 
 	var/reagent_note

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -108,6 +108,7 @@
 	var/log_override = FALSE //is this type spammed enough to not log? (KAs)
 
 	var/temporary_unstoppable_movement = FALSE
+	var/lagshot = FALSE //used for buckshotlikes so dell computers dont crash
 
 /obj/projectile/Initialize()
 	. = ..()
@@ -191,8 +192,9 @@
 			if(hitsound)
 				var/volume = vol_by_damage()
 				playsound(loc, hitsound, volume, TRUE, -1)
-			L.visible_message("<span class='danger'>[L] is hit by \a [src][organ_hit_text]!</span>", \
-					"<span class='userdanger'>You're hit by \a [src][organ_hit_text]!</span>", null, COMBAT_MESSAGE_RANGE)
+			if(lagshot == FALSE)
+				L.visible_message("<span class='danger'>[L] is hit by \a [src][organ_hit_text]!</span>", \
+						"<span class='userdanger'>You're hit by \a [src][organ_hit_text]!</span>", null, COMBAT_MESSAGE_RANGE)
 		L.on_hit(src)
 
 	var/reagent_note

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -196,8 +196,7 @@
 			if(!L.message_timeouts || L.message_timeouts <= world.time)
 				L.visible_message("<span class='danger'>[L] is hit by \a [src][organ_hit_text]!</span>", \
 						"<span class='userdanger'>You're hit by \a [src][organ_hit_text]!</span>", null, COMBAT_MESSAGE_RANGE)
-				if(lagshot)
-					LAZYSET(L.message_timeouts,type,world.time+ chat_timeout)
+				LAZYSET(L.message_timeouts,type,world.time+ chat_timeout)
 		L.on_hit(src)
 
 	var/reagent_note

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -193,12 +193,11 @@
 			if(hitsound)
 				var/volume = vol_by_damage()
 				playsound(loc, hitsound, volume, TRUE, -1)
-			if(!L.message_timeouts || !L.message_timeouts[type] || L.message_timeouts[type] <= world.time)
+			if(!L.message_timeouts || L.message_timeouts <= world.time)
 				L.visible_message("<span class='danger'>[L] is hit by \a [src][organ_hit_text]!</span>", \
 						"<span class='userdanger'>You're hit by \a [src][organ_hit_text]!</span>", null, COMBAT_MESSAGE_RANGE)
-			if(lagshot)
-				L.visible_message("e", \
-						"e", null, COMBAT_MESSAGE_RANGE)
+				if(lagshot)
+					LAZYSET(L.message_timeouts,type,world.time+ chat_timeout)
 		L.on_hit(src)
 
 	var/reagent_note

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -193,7 +193,7 @@
 			if(hitsound)
 				var/volume = vol_by_damage()
 				playsound(loc, hitsound, volume, TRUE, -1)
-			if(!L.message_timeouts || L.message_timeouts <= world.time)
+			if(!L.message_timeouts[type] || L.message_timeouts[type] <= world.time)
 				L.visible_message("<span class='danger'>[L] is hit by \a [src][organ_hit_text]!</span>", \
 						"<span class='userdanger'>You're hit by \a [src][organ_hit_text]!</span>", null, COMBAT_MESSAGE_RANGE)
 				LAZYSET(L.message_timeouts,type,world.time+ chat_timeout)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -193,11 +193,12 @@
 			if(hitsound)
 				var/volume = vol_by_damage()
 				playsound(loc, hitsound, volume, TRUE, -1)
-			if(!L.message_timeouts || L.message_timeouts <= world.time)
+			if(!L.message_timeouts || !L.message_timeouts[type] || L.message_timeouts[type] <= world.time)
 				L.visible_message("<span class='danger'>[L] is hit by \a [src][organ_hit_text]!</span>", \
 						"<span class='userdanger'>You're hit by \a [src][organ_hit_text]!</span>", null, COMBAT_MESSAGE_RANGE)
-				if(lagshot)
-					LAZYSET(L.message_timeouts,type,world.time+ chat_timeout)
+			if(lagshot)
+				L.visible_message("e", \
+						"e", null, COMBAT_MESSAGE_RANGE)
 		L.on_hit(src)
 
 	var/reagent_note

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -51,6 +51,8 @@
 	name = "laser pellet"
 	icon_state = "scatterlaser"
 	damage = 5
+	lagshot = TRUE
+	chat_timeout = 5 SECONDS
 
 /obj/projectile/beam/xray
 	name = "\improper X-ray beam"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -14,6 +14,7 @@
 /obj/projectile/bullet/incendiary/shotgun/dragonsbreath
 	name = "dragonsbreath pellet"
 	damage = 5
+	lagshot = FALSE //why is this not a pellet subtype....
 
 /obj/projectile/bullet/shotgun_stunslug
 	name = "stunslug"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -15,6 +15,7 @@
 	name = "dragonsbreath pellet"
 	damage = 5
 	lagshot = FALSE //why is this not a pellet subtype....
+	chat_timeout = 5 SECONDS
 
 /obj/projectile/bullet/shotgun_stunslug
 	name = "stunslug"
@@ -60,6 +61,7 @@
 	var/tile_dropoff = 0.75
 	var/tile_dropoff_s = 0.5
 	lagshot = TRUE
+	chat_timeout = 5 SECONDS
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -58,6 +58,7 @@
 /obj/projectile/bullet/pellet
 	var/tile_dropoff = 0.75
 	var/tile_dropoff_s = 0.5
+	lagshot = TRUE
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"

--- a/code/modules/projectiles/projectile/magic/spellcard.dm
+++ b/code/modules/projectiles/projectile/magic/spellcard.dm
@@ -4,3 +4,5 @@
 	icon_state = "spellcard"
 	damage_type = BURN
 	damage = 2
+	lagshot = TRUE
+	chat_timeout = 5 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
to be more precise they no longer send 12 messages in a row to your chat that freeze the game via a shitty var that prevents visible_message from appearing

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
i'm tired of dying not to the bullet, but to the massive freezing buckshot causes
very often it feels like i could have done something if it wasn't for the effective tasing shotguns do when they hit you via pellets
i HIGHLY doubt this is going to make shotguns a 'stealth killer' or anything as they still have 
1. the fuckhuge sprite ninja made
2. the obvious sound they make
3. the fact that combat shotguns are OP and riot shotgun pumps are a joke, making it highly unlikely for an unarmored person to react or defend themselves properly due to the blitzing fast way you get damage from buckshot anyways
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: buckshot no longer freezes your game, but also doesn't show up in chat anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
