### PR TITLE
Nerfs shotguns, buffs lasers

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -41,6 +41,7 @@
 	desc = "A sturdy shotgun with a longer magazine and a fixed tactical stock designed for non-lethal riot control."
 	icon_state = "riotshotgun"
 	item_state = "shotgun"
+	fire_delay = 7
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
 	can_be_sawn_off  = TRUE
@@ -56,6 +57,7 @@
 	desc = "A semi automatic shotgun with tactical furniture and a six-shell capacity underneath."
 	icon_state = "cshotgun"
 	item_state = "shotgun_combat"
+	fire_delay = 5
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
 
@@ -63,6 +65,7 @@
 	name = "compact combat shotgun"
 	desc = "A compact version of the semi automatic combat shotgun. For close encounters."
 	icon_state = "cshotgunc"
+	fire_delay = 5
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com/compact
 	w_class = WEIGHT_CLASS_BULKY
 

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -65,7 +65,6 @@
 	name = "compact combat shotgun"
 	desc = "A compact version of the semi automatic combat shotgun. For close encounters."
 	icon_state = "cshotgunc"
-	fire_delay = 5
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com/compact
 	w_class = WEIGHT_CLASS_BULKY
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -2,7 +2,7 @@
 	name = "laser"
 	icon_state = "laser"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	damage = 20
+	damage = 30
 	light_range = 2
 	damage_type = BURN
 	hitsound = 'sound/weapons/sear.ogg'

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,11 +1,11 @@
 /obj/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 60
+	damage = 45
 
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
 	damage = 5
-	stamina = 55
+	stamina = 40
 
 /obj/projectile/bullet/incendiary/shotgun
 	name = "incendiary slug"
@@ -48,7 +48,7 @@
 /obj/projectile/bullet/shotgun_frag12
 	name ="frag12 slug"
 	damage = 25
-	paralyze = 50
+	knockdown = 50
 
 /obj/projectile/bullet/shotgun_frag12/on_hit(atom/target, blocked = FALSE)
 	..()
@@ -61,12 +61,12 @@
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 12.5
+	damage = 10 //60
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
 	damage = 3
-	stamina = 11
+	stamina = 10
 
 /obj/projectile/bullet/pellet/shotgun_incapacitate
 	name = "incapacitating pellet"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,6 +1,6 @@
 /obj/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 45
+	damage = 40
 
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes the following changes:
Slug damage lowered 60 -> 40
Buckshot damage lowered 75 -> 60
Riot shotgun has a fire_delay of 7
Combat shotgun has a fire_delay of 5
Laser gun damage upped to 30.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Shotguns have slowly power creeped, _hard_. Right now, instead of lugging around a fire axe, you could very easily just carry around a combat shotgun, or even a normal sized sawn off riot gun, for easy 75 melee-range damage, plus the lag from the buckshot hitting you all at once (which i'm aiming to fix in another PR)

This is compounded by the fact that for some reason shotguns didn't have any real fire delay. You could kill people in a literal _second_ with a combat shotgun, whereas with a fire axe you need at least, 6 or 10.

The ammo 'problem' that's supposed to counter that isn't real. Reloading a shotgun is extremely easy due to the four buckshot boxes in the armory, the hacked autolathe, and the massive amounts of shells you can very easily get via the security protolathe. Instead of the ballistics ammo being a downside, to a 60/75 damage weapon, it becomes an upside, allowing you to reload on the go at very minimal cost.

Additionally, combat shotguns are easily orderable en-masse during war-ops, or cult, or other such reasons to hoard every budget card and bloat the cargo budget. This results in the rounds being near-unwinnable by the antagonists as 5 nuke ops or 10 cultists try to beat 70 people that are equally, if not better, equipped than them.

The results of this are that non-shotgun weapons (particularly lasers) are very rarely used in an emergency, at least in my experience. I know I have never even thought of picking up a laser gun to fight a cult, always opting for a shotgun instead. Why would I grab a gun that fires 12 slow shots of 20 damage when I could grab a gun that instantly unloads 7 shells of 75/60 damage on an enemy? At best, I'd settle for twohanding disablers. Lasers guns themselves are not only far weaker than slugs, but weaker than disablers, too. They need 5 shots to drop while disablers need only 4, _and_ they have double the ammo consumption. It's more common to find someone disabling then executing with melee than a standard lasering to death, which I feel is silly. If you're aiming to kill, you should probably use the kill option.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Rebalanced shotguns and lasers.
balance: Riot shotguns and combat shotguns now have a fire delay, combat shotties being faster.
balance: Laser guns deal 30 burn damage.
balance: Buckshot now deals 60 damage in total, 10 each pellet, and slugs deal 40.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
