### PR TITLE
shotguns are now a heavy weapon

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -461,6 +461,10 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 		item_state = "gun"
 		slot_flags &= ~ITEM_SLOT_BACK	//you can't sling it on your back
 		slot_flags |= ITEM_SLOT_BELT		//but you can wear it on your belt (poorly concealed under a trenchcoat, ideally)
+		if(weapon_weight == WEAPON_HEAVY)
+			weapon_weight = WEAPON_MEDIUM
+		else if(weapon_weight == WEAPON_MEDIUM)
+			weapon_weight = WEAPON_LIGHT
 		recoil = SAWN_OFF_RECOIL
 		sawn_off = TRUE
 		update_icon()

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -461,10 +461,6 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 		item_state = "gun"
 		slot_flags &= ~ITEM_SLOT_BACK	//you can't sling it on your back
 		slot_flags |= ITEM_SLOT_BELT		//but you can wear it on your belt (poorly concealed under a trenchcoat, ideally)
-		if(weapon_weight == WEAPON_HEAVY)
-			weapon_weight = WEAPON_MEDIUM
-		else if(weapon_weight == WEAPON_MEDIUM)
-			weapon_weight = WEAPON_LIGHT
 		recoil = SAWN_OFF_RECOIL
 		sawn_off = TRUE
 		update_icon()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -24,6 +24,7 @@
 	bolt_wording = "pump"
 	cartridge_wording = "shell"
 	tac_reloads = FALSE
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/ballistic/shotgun/blow_up(mob/user)
 	. = 0

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -174,6 +174,12 @@
 	. = ..()
 	if(unique_reskin && !current_skin && user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		reskin_obj(user)
+
+/obj/item/gun/ballistic/shotgun/doublebarrel/sawoff(mob/user)
+	. = ..()
+	if(.)
+		weapon_weight = WEAPON_MEDIUM
+
 // IMPROVISED SHOTGUN //
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

shotguns now have weapon_weight = HEAVY which makes them work like l6 where you have to have the other hand empty to use them
bulldog still has weapon_weight = MEDIUM and you can sawoff the bartender and improvised shotguns to have medium weapon weight

## Why It's Good For The Game

makes shotties more balanced, you cant hold an item like a shield now when firing them

## Changelog
:cl:
balance: shotguns are now "heavy" weight class.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
