### PR TITLE
fixes toggling flashlight removing bayonet overlay

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -482,7 +482,6 @@
 		flashlight_overlay.pixel_x = flight_x_offset
 		flashlight_overlay.pixel_y = flight_y_offset
 		add_overlay(flashlight_overlay, TRUE)
-		if(bayonet)
 		add_overlay(knife_overlay, TRUE)
 	else
 		set_light(0)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -482,6 +482,8 @@
 		flashlight_overlay.pixel_x = flight_x_offset
 		flashlight_overlay.pixel_y = flight_y_offset
 		add_overlay(flashlight_overlay, TRUE)
+		if(bayonet)
+		add_overlay(knife_overlay, TRUE)
 	else
 		set_light(0)
 		cut_overlays(flashlight_overlay, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a visual bug when  pressing the button on a gun with both a bayonet and flashlight. Doing so would remove the bayonet from the sprite. 

## Why It's Good For The Game

This is just a small visual fix with no big game impact: however, it adds clarity to items you may pick up.  Some miner mains might be happy about this. 


## Changelog
:cl:IradT
fix: fixed sprites on guns with both bayonet and toggle-able lights removing the bayonet when toggled. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
