### PR TITLE
Makes CentCom tomb of the unknown employee statue indestructible

### DIFF
--- a/code/game/objects/structures/memorial.dm
+++ b/code/game/objects/structures/memorial.dm
@@ -19,3 +19,4 @@ This memorial has been designed for him and any future coders to perish.
 	icon_state = "memorial"
 	density = TRUE
 	anchored = TRUE
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF


### PR DESCRIPTION
This PR makes the CentCom Tomb of the Unknown Employee statue indestructible. It won't have any gameplay impact and simply brings the statue in line with other indestructible fluff objects that are scattered around CentCom.