### PR TITLE
Makes iron sheets build the normal metal table again

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -105,6 +105,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/metal
 	grind_results = list(/datum/reagent/iron = 20)
 	point_value = 2
+	tableVariant = /obj/structure/table
 	material_type = /datum/material/iron
 
 /obj/item/stack/sheet/metal/ratvar_act()


### PR DESCRIPTION
## About The Pull Request

Makes tables built out of iron look the same as roundstart iron tables

## Why It's Good For The Game

Consistency issue

## Changelog
:cl: Bumtickley00
tweak: Iron sheets build the normal metal table again
/:cl: