### PR TITLE
Makes the hide action_button not clear all the overlays every time

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -72,6 +72,23 @@
 	var/hide_icon = 'icons/mob/actions.dmi'
 	var/hide_state = "hide"
 	var/show_state = "show"
+	var/mutable_appearance/hide_appearance
+	var/mutable_appearance/show_appearance
+
+/obj/screen/movable/action_button/hide_toggle/Initialize()
+	. = ..()
+	var/static/list/icon_cache = list()
+	
+	var/cache_key = "[hide_icon][hide_state]"
+	hide_appearance = icon_cache[cache_key]
+	if(!hide_appearance)
+		hide_appearance = icon_cache[cache_key] = mutable_appearance(hide_icon, hide_state)
+
+	cache_key = "[hide_icon][show_state]"
+	show_appearance = icon_cache[cache_key]
+	if(!show_appearance)
+		show_appearance = icon_cache[cache_key] = mutable_appearance(hide_icon, show_state)
+
 
 /obj/screen/movable/action_button/hide_toggle/Click(location,control,params)
 	if (!can_use(usr))
@@ -137,8 +154,11 @@
 	update_icon()
 
 /obj/screen/movable/action_button/hide_toggle/update_icon()
-	cut_overlays()
-	add_overlay(mutable_appearance(hide_icon, hidden ? show_state : hide_state))
+	cut_overlay(list(hide_appearance, show_appearance))
+	if(hidden)
+		add_overlay(show_appearance)
+	else
+		add_overlay(hide_appearance)
 
 
 /obj/screen/movable/action_button/MouseEntered(location,control,params)


### PR DESCRIPTION
This makes the hide toggle button stop clearing every overlay instead of just its own so other things can apply overlays.

Let's see if I can manage to do all the requisite work to make every update_icon call parent.