### PR TITLE
Health analyzer font scaling hotfix

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -254,25 +254,25 @@ GENE SCANNER
 		var/list/damaged = C.get_damaged_bodyparts(1,1)
 		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
 			var/list/dmgreport = list()
-			dmgreport += "<table style='margin-left:33px'><tr><font face='Verdana'>\
-							<td style='width: 90px;'><font color='#0000CC'>Damage:</font></td>\
-							<td style='width: 55px;'><font color='red'><b>Brute</b></font></td>\
-							<td style='width: 45px;'><font color='orange'><b>Burn</b></font></td>\
-							<td style='width: 45px;'><font color='green'><b>Toxin</b></font></td>\
-							<td style='width: 90px;'><font color='purple'><b>Suffocation</b></font></td></tr>\
+			dmgreport += "<table style='margin-left:3em'><tr><font face='Verdana'>\
+							<td style='width:7em;'><font color='#0000CC'>Damage:</font></td>\
+							<td style='width:5em;'><font color='red'><b>Brute</b></font></td>\
+							<td style='width:4em;'><font color='orange'><b>Burn</b></font></td>\
+							<td style='width:4em;'><font color='green'><b>Toxin</b></font></td>\
+							<td style='width:8em;'><font color='purple'><b>Suffocation</b></font></td></tr>\
 
 							<tr><td><font color='#0000CC'>Overall:</font></td>\
-							<td><font color='red'>[brute_loss]</font></td>\
-							<td><font color='orange'>[fire_loss]</font></td>\
-							<td><font color='green'>[tox_loss]</font></td>\
-							<td><font color='purple'>[oxy_loss]</font></td></tr>"
+							<td><font color='red'>[round(brute_loss,1)]</font></td>\
+							<td><font color='orange'>[round(fire_loss,1)]</font></td>\
+							<td><font color='green'>[round(tox_loss,1)]</font></td>\
+							<td><font color='purple'>[round(oxy_loss,1)]</font></td></tr>"
 
 			for(var/o in damaged)
 				var/obj/item/bodypart/org = o //head, left arm, right arm, etc.
 				dmgreport += "<tr><td><font color='#0000CC'>[capitalize(org.name)]:</font></td>\
-								<td><font color='red'>[(org.brute_dam > 0) ? "[org.brute_dam]" : "0"]</font></td>\
-								<td><font color='orange'>[(org.burn_dam > 0) ? "[org.burn_dam]" : "0"]</font></td></tr>"
-			dmgreport += "</table>"
+								<td><font color='red'>[(org.brute_dam > 0) ? "[round(org.brute_dam,1)]" : "0"]</font></td>\
+								<td><font color='orange'>[(org.burn_dam > 0) ? "[round(org.burn_dam,1)]" : "0"]</font></td></tr>"
+			dmgreport += "</font></table>"
 			to_chat(user, dmgreport.Join())
 
 


### PR DESCRIPTION
## About The Pull Request
Fixes my overlook of not making the health analyzer's damage report table scaleable by changing the units from px to em (percent didn't work). Also rounds the damage numbers.

Here's how it looks with a small font:
![smallfont](https://user-images.githubusercontent.com/5420151/66772108-9e660e80-eec4-11e9-9292-43226f3d765d.PNG)

And big font:
![bigfont](https://user-images.githubusercontent.com/5420151/66772115-a160ff00-eec4-11e9-9537-a5789b79b139.PNG)


## Why It's Good For The Game
Table looks like it should in all font sizes now.