### PR TITLE
Riot Shotguns can be bought from Cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -477,6 +477,22 @@
 					/obj/item/storage/belt/bandolier)
 	crate_name = "combat shotguns crate"
 
+/datum/supply_pack/security/armory/riotshotgun
+	name = "Riot Shotguns Crate"
+	desc = "Tip: techically, it counts as non-lethally subduing a target as long as they don't die before Medbay can get to them. Contains three security-grade riot shotguns. Requires Armory access to open."
+	cost = 6000
+	contains = list(/obj/item/gun/ballistic/shotgun/riot,
+					/obj/item/gun/ballistic/shotgun/riot,
+					/obj/item/gun/ballistic/shotgun/riot)
+	crate_name = "riot shotguns crate"
+
+/datum/supply_pack/security/armory/riotshotgun_single
+	name = "Riot Shotgun Single-Pack"
+	desc = "Stop that Clown in his tracks with this magic stick of non-lethal subduction! Contains one security-grade riot shotgun. Requires Armory access to open."
+	cost = 2500
+	small_item = TRUE
+	contains = list(/obj/item/gun/ballistic/shotgun/riot)
+
 /datum/supply_pack/security/armory/dragnet
 	name = "DRAGnet Crate"
 	desc = "Contains three \"Dynamic Rapid-Apprehension of the Guilty\" netting devices, a recent breakthrough in law enforcement prisoner management technology. Requires armory access to open."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

**THE WHAT:**
This PR adds Riot Shotguns to the Cargo supply catalog under the 'Armory' tab. These shotguns are identical to the ones that spawn in the armory at roundstart. Riot Shotguns can be bought in a three-pack for 6000 credits, or a single-pack for 2500 credits.

**THE HOW:**
Simply adding a few lines of code to the 'packs.dm' file makes this simple PR possible.

**THE WHY:**
Firstly, I found it odd that you can't get Riot Shotguns from anywhere except the armory, and even then you only get three or four to work with. So here we are.

Secondly, Cargo has access to a large amount of ranged weaponry; however, the only weapon that they can buy that is capable of using shotgun shells is the Combat Shotgun, which is both unwieldy and makes security extremely nervous -- which is justified, considering that it can drop a person to crit in literally one second ( Fires once per 0.5 seconds, two buckshots point-blank makes someone go horizontal ). The Riot Shotgun aims to solve this by being more versatile to store (can be sawn-off, unlike the combat shotgun), as a cheaper alternative to the Combat Shotgun, and as a firearm that makes security a little less antsy than the Combat Shotgun does.

## Changelog
:cl:
add: Riot Shotguns can be bought in Cargo for 6000 credits for a 3-pack, or 2500 credits for a 1-pack.
/:cl:
