### PR TITLE
Fixes seiver healing more rads than intended + cleanup

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -245,6 +245,3 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define ANTI_DROP_IMPLANT_TRAIT "anti-drop-implant"
 #define VR_ZONE_TRAIT "vr_zone_trait"
 #define SLEEPING_CARP_TRAIT "sleeping_carp"
-#define SANGUIOSE_TRAIT "sanguiose"
-#define FROGENITE_TRAIT "frogenite"
-#define FERVEATIUM_TRAIT "ferveatium"

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -109,7 +109,7 @@
 	. = ..()
 /datum/reagent/medicine/C2/lenturi/on_mob_end_metabolize(mob/living/carbon/M)
 	M.remove_movespeed_modifier(MOVESPEED_ID_LENTURI)
-	
+
 	. = ..()
 /datum/reagent/medicine/C2/aiuri
 	name = "Aiuri"
@@ -206,7 +206,7 @@
 		if(chemtemp < radbonustemp*0.1) //if you're super chilly, it takes off 25% of your current rads
 			M.radiation = round(M.radiation * 0.75)
 		else if(chemtemp < radbonustemp)//else if you're under the chill-zone, it takes off 10% of your current rads
-			M.radiation = round(M.radiation * 0.25)
+			M.radiation = round(M.radiation * 0.9)
 		M.radiation -= radcalc
 		healypoints += (radcalc/5)
 

--- a/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
+++ b/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
@@ -49,7 +49,7 @@
 /*****TOX*****/
 
 /datum/chemical_reaction/seiver
-	name = "Fiziver"
+	name = "Seiver"
 	id = /datum/reagent/medicine/C2/seiver
 	results = list(/datum/reagent/medicine/C2/seiver = 3)
 	required_reagents = list(/datum/reagent/nitrogen = 1, /datum/reagent/potassium = 1, /datum/reagent/aluminium = 1)


### PR DESCRIPTION
## About The Pull Request

Seiver's rad bonus is supposed to remove 10% of your current rads per cycle, not 75%. This fixes that.

Also fixes the seiver reaction being called "fiziver" and removes a couple unused trait defines.

## Why It's Good For The Game

Bugs bad, unused defines bad, correct reaction names good

## Changelog
:cl: Bumtickley00
fix: Fixed seiver removing much more radiation than intended
/:cl:
