### PR TITLE
Fixes soda cans.

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -444,7 +444,7 @@
 		crushed_can.icon_state = icon_state
 		qdel(src)
 		return TRUE
-	 . = ..()
+	. = ..()
 
 /obj/item/reagent_containers/food/drinks/soda_cans/bullet_act(obj/projectile/P)
 	. = ..()


### PR DESCRIPTION
## Why It's Good For The Game

Unepic error.
Fixes https://github.com/tgstation/tgstation/issues/47121

## Changelog
:cl:
fix: Soda cans work again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
