### PR TITLE
Adds the Reduced Diagnostics nanite program

### DIFF
--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -11,7 +11,8 @@
 	var/list/datum/nanite_program/programs = list()
 	var/max_programs = NANITE_PROGRAM_LIMIT
 
-	var/stealth = FALSE //if TRUE, does not appear on HUDs and health scans, and does not display the program list on nanite scans
+	var/stealth = FALSE //if TRUE, does not appear on HUDs and health scans
+	var/diagnostics = TRUE //if TRUE, displays program list when scanned by nanite scanners
 
 /datum/component/nanites/Initialize(amount = 100, cloud = 0)
 	if(!isliving(parent) && !istype(parent, /datum/nanite_cloud_backup))
@@ -262,8 +263,8 @@
 		to_chat(user, "<span class='info'>Cloud ID: [cloud_id ? cloud_id : "Disabled"]</span>")
 		to_chat(user, "<span class='info'>================</span>")
 		to_chat(user, "<span class='info'>Program List:</span>")
-		if(stealth)
-			to_chat(user, "<span class='alert'>%#$ENCRYPTED&^@</span>")
+		if(!diagnostics)
+			to_chat(user, "<span class='alert'>Diagnostics Disabled</span>")
 		else
 			for(var/X in programs)
 				var/datum/nanite_program/NP = X

--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -46,6 +46,14 @@
 	program_type = /datum/nanite_program/stealth
 	category = list("Utility Nanites")
 
+/datum/design/nanites/reduced_diagnostics
+	name = "Reduced Diagnostics"
+	desc = "Disables some high-cost diagnostics in the nanites, making them unable to communicate their program list to portable scanners. \
+	Doing so saves some power, slightly increasing their replication speed."
+	id = "red_diag_nanites"
+	program_type = /datum/nanite_program/reduced_diagnostics
+	category = list("Utility Nanites")
+
 /datum/design/nanites/access
 	name = "Subdermal ID"
 	desc = "The nanites store the host's ID access rights in a subdermal magnetic strip. Updates when triggered, copying the host's current access."

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -130,7 +130,7 @@
 
 /datum/nanite_program/stealth
 	name = "Stealth"
-	desc = "The nanites hide their activity and programming from superficial scans."
+	desc = "The nanites mask their activity from superficial scans, becoming undetectable by HUDs and non-specialized scanners."
 	rogue_types = list(/datum/nanite_program/toxic)
 	use_rate = 0.2
 
@@ -141,6 +141,21 @@
 /datum/nanite_program/stealth/disable_passive_effect()
 	. = ..()
 	nanites.stealth = FALSE
+
+/datum/nanite_program/reduced_diagnostics
+	name = "Reduced Diagnostics"
+	desc = "Disables some high-cost diagnostics in the nanites, making them unable to communicate their program list to portable scanners. \
+	Doing so saves some power, slightly increasing their replication speed."
+	rogue_types = list(/datum/nanite_program/toxic)
+	use_rate = -0.1
+
+/datum/nanite_program/reduced_diagnostics/enable_passive_effect()
+	. = ..()
+	nanites.diagnostics = FALSE
+
+/datum/nanite_program/reduced_diagnostics/disable_passive_effect()
+	. = ..()
+	nanites.diagnostics = TRUE
 
 /datum/nanite_program/relay
 	name = "Relay"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -915,7 +915,7 @@
 	prereq_ids = list("datatheory","robotics")
 	design_ids = list("nanite_disk","nanite_remote","nanite_comm_remote","nanite_scanner",\
 						"nanite_chamber","public_nanite_chamber","nanite_chamber_control","nanite_programmer","nanite_program_hub","nanite_cloud_control",\
-						"relay_nanites", "monitoring_nanites", "access_nanites", "repairing_nanites","sensor_nanite_volume", "repeater_nanites", "relay_repeater_nanites")
+						"relay_nanites", "monitoring_nanites", "access_nanites", "repairing_nanites","sensor_nanite_volume", "repeater_nanites", "relay_repeater_nanites","red_diag_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the Reduced Diagnostics nanite program: it simply hides the program list when scanned by portable nanite scanners, in return for a minor increase in replication speed. The functionality has been removed from the Stealth program, but they can easily be stacked together if the programmer so wishes.

## Why It's Good For The Game

Gives plausible deniability to people who want to sneak in programs without being found out by anyone with a scanner; stealth did the same, but there was no non-antagonistic reason to use it, so it was a giveaway on its own. Now there's a tradeoff between efficiency and trustworthiness, since running this program is a 20% increase over the base regen value.

Nanite chambers and the cloud console can still be used to detect malicious programs, if you so wish, or you can purge your nanites as usual if you don't trust a program without diagnostics.

## Changelog
:cl: XDTM
add: Added the Reduced Diagnostics nanite program: it disables the program list when scanned by portable nanite scanners, in return for a minor increase in replication speed. 
tweak: The functionality has been removed from the Stealth program, but they can easily be stacked together if needed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
