### PR TITLE
Lets people start messages with asterisks in deadchat

### DIFF
--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -1,3 +1,8 @@
+/mob/dead/observer/check_emote(message, forced)
+	if(message == "*spin" || message == "*flip")
+		emote(copytext(message, 2), intentional = !forced)
+		return 1
+
 /mob/dead/observer/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 	if (!message)

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -15,6 +15,9 @@
 			client.dsay(message)
 		return
 
+	if(check_emote(message, forced))
+		return
+
 	. = say_dead(message)
 
 /mob/dead/observer/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -15,9 +15,6 @@
 			client.dsay(message)
 		return
 
-	if(check_emote(message, forced))
-		return
-
 	. = say_dead(message)
 
 /mob/dead/observer/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the check_emote() call from observer's say proc so you can say "*scream" in deadchat 
without getting "_'scream' emote does not exist. Say *help for a list._" back

Proof of my 200 hours of testing, also showing you still can't emote in deadchat by using "me 'screams":

![dreamseeker_2019-10-16_23-30-10.png](https://i.imgur.com/Z6FAb12.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lets me LARP as an IRC user in deadchat better
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Shaps/Ryll
tweak: You can start messages with asterisks in deadchat now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
