### PR TITLE
Fixes not being able to put items in a medical first aid kit that's inside a bag

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -46,7 +46,7 @@
 /obj/item/storage/firstaid/medical/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_w_class = WEIGHT_CLASS_BULKY //holds the same equipment as a medibelt
+	STR.max_w_class = WEIGHT_CLASS_NORMAL //holds the same equipment as a medibelt
 	STR.max_items = 12
 	STR.max_combined_w_class = 24
 	STR.set_holdable(list(


### PR DESCRIPTION
## About The Pull Request

Fixes not being able to put items inside a medical first aid kit that's inside a bag

## Why It's Good For The Game

Makes the medical first aid kit not awful to use

## Changelog
:cl: Bumtickley00
fix: You can now put items inside a medical first aid kit that's inside a bag again
/:cl:
