### PR TITLE
fix access and name on south door between chem and surgery

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -73992,16 +73992,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"ibz" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Surgery Maintenance";
-	req_access_txt = "45"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "ifN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -94153,7 +94143,7 @@ fGm
 wAn
 lce
 cBr
-ibz
+fGm
 chZ
 cpS
 chZ


### PR DESCRIPTION
## About The Pull Request
This door right here was a copy of Surgery's maint door. I've changed the whole tile to be a copy of the door north of it instead (the pipes, wires, disposals all match.)

![image](https://user-images.githubusercontent.com/1499676/67008016-8f5ba800-f0e0-11e9-9546-8028d8897a2f.png)


## Changelog
:cl:
fix: south door between chemistry and surgery observation now lets people with normal maint access past
/:cl:
