### PR TITLE
Floor obscurity fix

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1054,6 +1054,7 @@
 	update_freelook_sight()
 	sleep(4)
 	density = FALSE
+	flags_1 &= ~PREVENT_CLICK_UNDER_1
 	air_update_turf(1)
 	sleep(1)
 	layer = OPEN_DOOR_LAYER
@@ -1096,10 +1097,12 @@
 	layer = CLOSED_DOOR_LAYER
 	if(air_tight)
 		density = TRUE
+		flags_1 |= PREVENT_CLICK_UNDER_1
 		air_update_turf(1)
 	sleep(1)
 	if(!air_tight)
 		density = TRUE
+		flags_1 |= PREVENT_CLICK_UNDER_1
 		air_update_turf(1)
 	sleep(4)
 	if(!safe)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -63,6 +63,10 @@
 	GLOB.airlocks += src
 	spark_system = new /datum/effect_system/spark_spread
 	spark_system.set_up(2, 1, src)
+	if(density)
+		flags_1 |= PREVENT_CLICK_UNDER_1
+	else
+		flags_1 &= ~PREVENT_CLICK_UNDER_1
 
 	//doors only block while dense though so we have to use the proc
 	real_explosion_block = explosion_block

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -24,6 +24,7 @@
 
 /obj/machinery/door/window/Initialize(mapload, set_dir)
 	. = ..()
+	flags_1 &= ~PREVENT_CLICK_UNDER_1
 	if(set_dir)
 		setDir(set_dir)
 	if(req_access && req_access.len)
@@ -148,7 +149,6 @@
 	icon_state ="[base_state]open"
 	sleep(10)
 	density = FALSE
-	flags_1 &= ~PREVENT_CLICK_UNDER_1
 	air_update_turf(1)
 	update_freelook_sight()
 
@@ -171,7 +171,6 @@
 	icon_state = base_state
 
 	density = TRUE
-	flags_1 |= PREVENT_CLICK_UNDER_1
 	air_update_turf(1)
 	update_freelook_sight()
 	sleep(10)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -147,8 +147,8 @@
 	playsound(src, 'sound/machines/windowdoor.ogg', 100, TRUE)
 	icon_state ="[base_state]open"
 	sleep(10)
-
 	density = FALSE
+	flags_1 &= ~PREVENT_CLICK_UNDER_1
 	air_update_turf(1)
 	update_freelook_sight()
 
@@ -171,6 +171,7 @@
 	icon_state = base_state
 
 	density = TRUE
+	flags_1 |= PREVENT_CLICK_UNDER_1
 	air_update_turf(1)
 	update_freelook_sight()
 	sleep(10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Airlocks now properly toggle obscurity. Fixes #47139 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a bug where airlocks prevented interacting with the turf underneath them. Sets windoors to never obscure.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: JDawg1290
fix: Doors now properly toggle obscurity. Windoors will not obscure floors ever.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
