### PR TITLE
Metastation plumbing/maint edits

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -24839,6 +24839,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bcc" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/chair,
+/obj/structure/sign/poster/official/build{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "bcd" = (
 /turf/closed/wall,
 /area/janitor)
@@ -44070,6 +44086,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bTs" = (
@@ -44729,10 +44746,8 @@
 /area/maintenance/solars/port/aft)
 "bUO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "bUP" = (
@@ -44754,6 +44769,7 @@
 /obj/structure/closet,
 /obj/item/storage/box/donkpockets,
 /obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bUS" = (
@@ -45181,10 +45197,10 @@
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
 "bVQ" = (
-/obj/structure/chair/stool,
-/obj/machinery/camera{
-	c_tag = "Aft Port Solar Maintenance";
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
@@ -45204,6 +45220,9 @@
 /area/maintenance/port)
 "bVU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -45926,12 +45945,15 @@
 	pixel_x = 32
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/solars/port/aft)
 "bXx" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bXy" = (
@@ -46913,10 +46935,6 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
-"bZN" = (
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/maintenance/solars/port/aft)
 "bZO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room";
@@ -50201,6 +50219,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cgJ" = (
@@ -51407,20 +51426,6 @@
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
-"cjp" = (
-/obj/machinery/vending/boozeomat/all_access,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
-"cjq" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/maintenance/port/aft)
 "cjr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -51465,10 +51470,6 @@
 "cjt" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
-/area/maintenance/port/aft)
-"cjv" = (
-/obj/machinery/computer/arcade,
-/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cjw" = (
 /obj/structure/sign/warning/nosmoking{
@@ -52041,14 +52042,6 @@
 "ckN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
-"ckO" = (
-/obj/structure/closet/secure_closet/bar{
-	pixel_x = -3;
-	pixel_y = -1;
-	req_access_txt = "25"
-	},
-/turf/open/floor/wood,
 /area/maintenance/port/aft)
 "ckP" = (
 /turf/open/floor/wood,
@@ -52676,17 +52669,6 @@
 "cmf" = (
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
-"cmg" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
 "cmh" = (
 /obj/item/reagent_containers/food/drinks/ale,
 /obj/structure/table/wood,
@@ -53088,11 +53070,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
-"cni" = (
-/obj/item/reagent_containers/food/drinks/bottle/tequila,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
 "cnj" = (
 /obj/item/reagent_containers/food/drinks/beer,
 /obj/structure/table/wood,
@@ -53104,7 +53081,7 @@
 	doorOpen = 'sound/effects/doorcreaky.ogg';
 	name = "The Gobetting Barmaid"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cnm" = (
 /obj/structure/table,
@@ -53371,7 +53348,7 @@
 	},
 /obj/structure/table/glass,
 /obj/machinery/camera{
-	c_tag = "Chemistry";
+	c_tag = "Apothecary";
 	dir = 4;
 	network = list("ss13","medbay")
 	},
@@ -54453,10 +54430,16 @@
 /turf/open/space,
 /area/space/nearstation)
 "cpQ" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
 	},
+/obj/item/reagent_containers/dropper,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
 /area/maintenance/port/aft)
 "cpR" = (
 /obj/effect/turf_decal/stripes/line{
@@ -55152,11 +55135,6 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"crg" = (
-/obj/item/toy/cards/deck,
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
 "crh" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
@@ -55618,6 +55596,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "csj" = (
@@ -56216,17 +56198,8 @@
 /turf/open/space,
 /area/space/nearstation)
 "ctn" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"cto" = (
-/obj/machinery/vending/assist,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/computer/arcade,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ctq" = (
@@ -57082,17 +57055,6 @@
 "cuZ" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab/range)
-"cvk" = (
-/obj/structure/closet/crate,
-/obj/item/crowbar/red,
-/obj/item/pen,
-/obj/item/flashlight/pen{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cvl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -65065,6 +65027,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cLI" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cLJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/closet,
@@ -71853,6 +71820,7 @@
 /obj/structure/rack,
 /obj/item/poster/random_contraband,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "diy" = (
@@ -71926,9 +71894,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-08"
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -71936,17 +71901,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"diG" = (
-/obj/structure/chair/stool,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/port/aft)
 "diH" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -71958,49 +71915,17 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "diI" = (
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/drinks/ale,
-/obj/structure/table/wood,
-/obj/item/instrument/eguitar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"diJ" = (
-/obj/structure/light_construct/small,
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/light_construct/small{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
-"diK" = (
-/obj/item/dice/d20,
-/obj/item/dice,
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"diJ" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "diL" = (
 /obj/item/tank/internals/oxygen,
@@ -72346,6 +72271,18 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_y = 3
+	},
+/obj/machinery/camera{
+	c_tag = "Chemistry Plumbing Lobby";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "dnr" = (
@@ -72599,6 +72536,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dwr" = (
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/maintenance/port/aft)
 "dwv" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -72637,11 +72582,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"dxv" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/port/aft)
 "dxQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -73016,9 +72956,6 @@
 	},
 /area/maintenance/port/fore)
 "dCy" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -73498,12 +73435,25 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"eqt" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/aft)
 "eqG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"eyv" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "eAa" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -73523,6 +73473,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"eDt" = (
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/maintenance/port/aft)
 "eEi" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -73538,6 +73496,19 @@
 /obj/item/plunger,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"eEu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"eEU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "eEV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -73561,6 +73532,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"eOp" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "eRo" = (
 /obj/machinery/light{
 	dir = 8
@@ -73584,6 +73560,12 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"eSY" = (
+/obj/structure/chair/stool,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/maintenance/port/aft)
 "eZe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -73614,6 +73596,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"fht" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	dir = 4;
+	icon_state = "sink_alt";
+	name = "old sink";
+	pixel_x = -12;
+	pixel_y = 0;
+	pixel_z = 0
+	},
+/obj/structure/mirror{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "fiv" = (
 /obj/structure/sign/directions/evac,
 /turf/closed/wall,
@@ -73647,6 +73645,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"fvT" = (
+/obj/structure/cable,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fwb" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -73669,10 +73675,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"fBD" = (
-/obj/structure/sign/poster/contraband/random,
-/turf/closed/wall,
-/area/maintenance/port/aft)
 "fDD" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -73688,6 +73690,14 @@
 "fEQ" = (
 /turf/closed/wall,
 /area/science/nanite)
+"fFJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fFM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -73702,6 +73712,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;5;39;6"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fGz" = (
@@ -73755,6 +73766,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"fWc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "gcu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -73767,12 +73786,17 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"gll" = (
-/obj/structure/closet,
-/obj/item/extinguisher,
-/obj/item/flashlight,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
+"gka" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/solar/port/aft)
+"glz" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
 /area/maintenance/port/aft)
 "gnd" = (
 /turf/closed/wall,
@@ -73821,6 +73845,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Chemistry Plumbing Lab";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "gHh" = (
@@ -73834,6 +73862,11 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"gJK" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gLC" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
@@ -73863,6 +73896,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"hdh" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"hdX" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hev" = (
 /obj/machinery/chem_dispenser{
 	layer = 2.7
@@ -73908,6 +73951,18 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hwW" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/camera{
+	c_tag = "Chemistry Plumbing South";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "hyP" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -73917,6 +73972,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"hEP" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/aft)
 "hFj" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -73924,8 +73987,24 @@
 	},
 /obj/item/storage/box/matches,
 /obj/structure/table,
+/obj/item/folder/yellow{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/folder/yellow{
+	pixel_x = -5;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"hFE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hFV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -73993,13 +74072,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "ibz" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Surgery Maintenance";
-	req_access_txt = "45"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;5;39;6"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ifN" = (
@@ -74052,6 +74133,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"ixo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iyU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -74160,17 +74250,6 @@
 "jwW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/crew_quarters/fitness/recreation)
-"jyQ" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "jHw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -74205,6 +74284,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"jNy" = (
+/obj/structure/chair,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jOR" = (
 /obj/machinery/light{
 	dir = 4
@@ -74225,6 +74308,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "jUk" = (
@@ -74233,6 +74317,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"jYJ" = (
+/obj/item/reagent_containers/food/drinks/bottle/tequila,
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "kcI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/janitor,
@@ -74242,6 +74332,16 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"kfZ" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "kge" = (
 /turf/open/floor/plasteel/white,
 /area/medical/apothecary)
@@ -74265,9 +74365,31 @@
 /obj/item/key/janitor,
 /turf/open/floor/plasteel,
 /area/janitor)
+"klh" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "krD" = (
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"kwl" = (
+/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/port)
 "kwI" = (
 /obj/item/wrench,
 /obj/item/clothing/suit/apron,
@@ -74302,6 +74424,19 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"kyW" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Chemistry Plumbing North";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "kzn" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -74358,6 +74493,9 @@
 "kPN" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "kSB" = (
@@ -74446,6 +74584,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"luh" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lwA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -74543,6 +74686,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"mnS" = (
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/ale,
+/obj/structure/table/wood,
+/obj/item/instrument/eguitar,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "mom" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -74595,6 +74760,18 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"mxt" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "mzh" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -74640,6 +74817,25 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"mSk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"mTs" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/obj/structure/bed/dogbed,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/maintenance/port/aft)
 "mWg" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -74694,6 +74890,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"nfn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "nnV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -74703,6 +74903,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/chair,
+/obj/structure/sign/poster/official/here_for_your_safety{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -74723,8 +74927,18 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"nwq" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "nyo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -74831,6 +75045,12 @@
 /obj/structure/target_stake,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"obv" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "obX" = (
 /obj/docking_port/stationary{
 	dheight = 4;
@@ -74925,6 +75145,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "owR" = (
@@ -74970,6 +75192,12 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/storage_shared)
+"oKP" = (
+/obj/item/toy/cards/deck,
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "oPU" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
@@ -74996,7 +75224,21 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
+/area/maintenance/port/aft)
+"oXP" = (
+/obj/structure/closet/crate,
+/obj/item/crowbar/red,
+/obj/item/pen,
+/obj/item/flashlight/pen{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/port/aft)
 "oZg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -75007,6 +75249,30 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"oZs" = (
+/obj/structure/cable,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"pai" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"pay" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "pcn" = (
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
@@ -75060,11 +75326,23 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"ppz" = (
+/obj/machinery/vending/boozeomat/all_access,
+/obj/effect/decal/cleanable/cobweb,
+/turf/closed/wall,
+/area/maintenance/port/aft)
 "pqy" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"ptP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/light_construct{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "pvL" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/door/firedoor,
@@ -75190,7 +75468,7 @@
 "qit" = (
 /obj/structure/sign/poster/ripped,
 /turf/closed/wall,
-/area/maintenance/port/aft)
+/area/medical/chemistry)
 "qjB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -75238,6 +75516,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"qyH" = (
+/obj/machinery/vending/assist,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "qAO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -75281,6 +75567,11 @@
 /obj/item/storage/photo_album/library,
 /turf/open/floor/engine/cult,
 /area/library)
+"qNO" = (
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "qUR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -75311,6 +75602,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"reI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rfi" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -75321,13 +75616,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "riP" = (
-/obj/machinery/door/airlock/medical{
-	name = "Chemistry Acces";
-	req_access_txt = "5"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -75336,15 +75628,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lobby";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "rrB" = (
 /turf/closed/wall,
 /area/vacant_room/commissary)
-"rsp" = (
-/obj/structure/sign/poster/random,
-/turf/closed/wall,
-/area/maintenance/port)
 "rxn" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -26
@@ -75487,6 +75779,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "sfQ" = (
+/obj/structure/closet,
+/obj/item/extinguisher,
+/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -75624,6 +75920,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"tCB" = (
+/obj/structure/closet/secure_closet/bar{
+	pixel_x = -3;
+	pixel_y = -1;
+	req_access_txt = "25"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "tDM" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -75682,6 +75987,19 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"tSO" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/aft)
+"tTw" = (
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "tTR" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -75730,6 +76048,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"uqB" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/aft)
 "urv" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/security/prison)
@@ -75818,6 +76142,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"uYL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "vgd" = (
 /obj/item/taperecorder,
 /obj/item/camera,
@@ -75827,6 +76158,10 @@
 	},
 /turf/open/floor/engine/cult,
 /area/library)
+"vhx" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "vhG" = (
 /obj/structure/table/glass,
 /obj/machinery/camera/autoname{
@@ -75834,6 +76169,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"vrW" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
+"vub" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "vwi" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -75859,6 +76210,18 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port)
+"vDb" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
+"vHP" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "vIO" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -75883,7 +76246,8 @@
 "vKU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
-	name = "Observation"
+	name = "Observation";
+	req_one_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -75917,7 +76281,7 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/maintenance/port/aft)
+/area/medical/chemistry)
 "vVq" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -75944,7 +76308,12 @@
 /area/hallway/secondary/entry)
 "wen" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/grille,
 /turf/open/floor/plating,
+/area/maintenance/port/aft)
+"wfq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/green,
 /area/maintenance/port/aft)
 "wgP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -75973,6 +76342,15 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"wkM" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "wmt" = (
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/plating,
@@ -76018,6 +76396,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"wGG" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "wIh" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/corner{
@@ -76044,6 +76429,27 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"wOn" = (
+/turf/open/floor/carpet/green,
+/area/maintenance/port/aft)
+"wOA" = (
+/obj/item/dice/d20,
+/obj/item/dice,
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/pill_bottle/dice,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/light_construct/small,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "wOE" = (
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
@@ -76070,18 +76476,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
-"wXf" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+"wYq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "xdW" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -76125,6 +76523,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"xuA" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xvg" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -76222,6 +76624,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"ybh" = (
+/obj/structure/light_construct{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "ybn" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/blobstart,
@@ -85435,7 +85843,7 @@ aaa
 aaa
 aaa
 aaa
-dux
+aaa
 aaa
 aaa
 aac
@@ -86702,13 +87110,13 @@ aaa
 aaa
 aaa
 aaa
+lMJ
+lMJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+lMJ
+lMJ
 aaa
 aaa
 aaa
@@ -86953,24 +87361,24 @@ aaa
 aaa
 aaa
 aaa
-ckN
-ckN
-ckN
-ckN
-ckN
-ckN
-ckN
-ckN
-ckN
-ckN
-ckN
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lMJ
+dux
+ckN
+ckN
+dux
+dux
+dux
+ckN
+ckN
+ckN
+ckN
+ckN
+lMJ
 aaa
 aaa
 aaa
@@ -87209,26 +87617,26 @@ aaa
 aaa
 aaa
 aaa
-ckN
-ckN
-cjp
-ckP
-ckO
-cmg
-cnh
-ckN
+aaa
+aaa
+aaa
+aaa
+aaa
+lMJ
+dux
+ppz
 cpQ
-crg
+cnh
+mTs
+fht
+kfZ
+ckN
+dwr
+oKP
 cjt
 ckN
 ckN
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -87466,26 +87874,26 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 ckN
-ckP
-cjq
-ckP
-ckP
-ckS
+tCB
+wOn
+wOn
+wfq
+wOn
 ckP
 ckP
 auR
 cjt
 crh
-ckP
+vDb
 ckN
 ckN
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -87723,26 +88131,26 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 ckN
-crh
-ckP
 eew
-ckQ
-ckP
-cni
+wfq
+wOn
+wOn
+wOn
+jYJ
 cjt
 dbq
 ckQ
-cjt
+wYq
 ckP
-ckP
+qNO
 ckN
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -87980,27 +88388,27 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+lMJ
 dux
-tOc
-tOc
 cjs
+tOc
+tOc
 ckR
 cmh
 cnj
-cjt
-ckP
-cjt
+tTw
 ckP
 ckP
-crh
+ckP
+ckP
+eOp
 ckN
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 cue
@@ -88237,28 +88645,28 @@ aaa
 aaa
 aaa
 aaa
-fBD
-ckP
-ckP
-cjt
-cjt
-cjt
-cjt
-ckP
-ckP
-crh
-dxv
-ckP
-diJ
+aaa
+aaa
+aaa
+aaa
+aaa
+lMJ
 dux
+wGG
+ckP
+tTw
+cjt
+eSY
+diJ
+ckP
+ckS
+ckP
+ckP
+wYq
+eSY
+ckN
+lMJ
 aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-aaf
 aaf
 cue
 cda
@@ -88489,33 +88897,33 @@ aaf
 cwf
 ack
 aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-dux
-crh
-crh
-ckP
-ckS
-ckP
-ckP
+lMJ
+gJK
+gJK
+gJK
+eyv
+gJK
+gJK
+eyv
+gJK
+lMJ
+lMJ
+ckN
+eDt
+eSY
 ckP
 ckP
 dvt
 csf
 bXE
-bXE
-dux
-aaf
-aaf
-aaf
-aaa
-aaf
-aaf
-aaa
-aaa
+ckP
+ckP
+ckS
+ckP
+ckN
+ckN
+lMJ
+lMJ
 aaf
 aaf
 cda
@@ -88748,30 +89156,30 @@ ack
 ack
 aaa
 aaa
+lMJ
 aaa
 aaa
 aaa
-dux
+aaa
+lMJ
+aaa
+aaa
+aaa
+ckN
 cxQ
-ckP
+cjt
 ckS
 ckP
 ckP
-ckP
-ckP
-ckP
-ckP
 bXE
-bXE
-bXE
+ptP
+ckP
+ckP
+ybh
+ckP
+wOA
 dux
 aaa
-aaf
-cej
-cej
-cej
-cej
-cej
 cej
 cej
 cej
@@ -89008,28 +89416,28 @@ aai
 aaf
 aaf
 aaf
-dux
+lMJ
+aaa
+vrW
+vrW
+aaa
+nYJ
+ckN
 nZb
-cjt
-cjt
-cjt
-cjt
+qNO
 ckP
+obv
 ckP
-crh
-dxv
-ckP
-ckP
-bXE
+glz
 dux
-aaa
-aaa
+qyH
+vHP
+dux
+mnS
+dux
+dux
+lMJ
 cej
-aaa
-aaa
-aaa
-aaa
-aaf
 aaa
 aaf
 cda
@@ -89254,39 +89662,39 @@ bMA
 alK
 bPD
 bbL
-alK
+ako
 alK
 otq
 qAO
 vAs
-alK
+cga
 rAF
 odU
 odU
 odU
 rAF
 cga
-nZb
-ckP
-cjv
-diG
-dux
-cto
-ctn
-dux
-diI
-diK
-dux
-bXE
-dux
+lMJ
 aaf
-bYC
-jyQ
-bYC
-aai
+lMJ
+lMJ
+fwb
+dux
+ctn
+tSO
+diI
+dux
+uYL
+ckP
+dux
+dux
+dux
+dux
+dux
+dux
+lMJ
 aaa
-aaa
-aaa
+gka
 aaa
 cue
 cda
@@ -89516,7 +89924,7 @@ alK
 alK
 lZn
 alK
-alK
+cga
 npl
 cZs
 cZs
@@ -89524,9 +89932,9 @@ cZs
 dVT
 snr
 cga
-cga
-cga
-cga
+odU
+odU
+odU
 cga
 cga
 cga
@@ -89536,14 +89944,14 @@ cga
 cga
 cnl
 dux
+aaf
+aaf
+aai
+anT
+nYJ
 aaa
-bYC
-bZN
-bYC
 aaa
-aaa
-aaa
-aaa
+gka
 aaa
 cue
 cda
@@ -89771,17 +90179,17 @@ bbL
 bPL
 alK
 kPN
-aob
+kwl
 alC
-alK
+cga
 ibr
 cmB
 cmB
 cmB
 tBC
-eRo
-cZs
+vub
 qJK
+cZs
 cZs
 cZs
 eRo
@@ -89791,16 +90199,16 @@ cZs
 cZs
 dVT
 cga
-bXF
+eqt
 dux
 bTn
 bTn
-bYD
-bYC
 qJB
+qJB
+bYC
+lMJ
 aaa
-aaa
-aaa
+gka
 aaa
 cue
 cda
@@ -90026,12 +90434,12 @@ bbL
 bPG
 bxT
 bSn
+nfn
 aob
 aob
-aob
-alC
-alK
-ibr
+auF
+cga
+mxt
 cmB
 cmB
 gcu
@@ -90048,16 +90456,16 @@ gcu
 cmB
 tQS
 cga
-bXE
-cxR
+cbx
+wkM
 bTn
 bUN
 bVQ
 bXt
-qJB
-aaf
-aaa
-aaa
+bYC
+bYC
+bYC
+gka
 aaa
 cue
 cda
@@ -90284,10 +90692,10 @@ bPF
 aGN
 bbL
 alC
-aob
+eEU
 aob
 bXy
-alK
+cga
 ibr
 cmB
 cmB
@@ -90305,17 +90713,17 @@ fwL
 cmB
 wij
 cga
-bXE
-bXE
+cbx
+reI
 bTn
 bUO
 bVR
 bXu
-qJB
-aaf
-aaf
-aaa
-aaa
+bYD
+vhx
+pay
+gka
+lMJ
 cue
 cda
 cue
@@ -90544,8 +90952,8 @@ alK
 alK
 alK
 alK
-rsp
-wXf
+hLm
+ibr
 cmB
 cmB
 fwL
@@ -90562,16 +90970,16 @@ fwL
 cmB
 wij
 cga
-bXE
-dvq
+cbx
+uqB
 bTp
 bUP
 ntG
 bXv
-qJB
-aaa
-aaa
-aaa
+bYC
+bYC
+bYC
+lMJ
 aaa
 aaa
 aaf
@@ -90798,11 +91206,11 @@ bzx
 alC
 cgH
 alK
-aob
+hdh
 aob
 dix
-alK
-ibr
+cga
+kyW
 cmB
 cmB
 vZx
@@ -90819,15 +91227,15 @@ gUb
 cmB
 wij
 snr
-bXE
+cbx
 dux
 bTn
 bTn
 lcm
 bTn
-qJB
-aaa
-aaa
+bYC
+lMJ
+lMJ
 aaa
 aaa
 anT
@@ -91058,8 +91466,8 @@ bTr
 bUQ
 bVT
 aob
-alK
-ibr
+cga
+mxt
 cmB
 cmB
 qnE
@@ -91074,16 +91482,16 @@ liQ
 liQ
 qhK
 cmB
-tQS
+hwW
 cga
-bXE
+luh
 cbx
-cbx
+fvT
 cbx
 cwh
-cxR
+hEP
 dux
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -91315,7 +91723,7 @@ alK
 bJs
 bVU
 bXx
-alK
+cga
 ibr
 cmB
 cmB
@@ -91333,12 +91741,12 @@ dZG
 cmB
 jPu
 cga
-bXE
-cbx
-bXE
-bXE
-bXE
 cxR
+cbx
+ceu
+dyw
+bXE
+cdl
 dux
 aaa
 aaa
@@ -91572,7 +91980,7 @@ alK
 bUR
 alK
 alK
-alK
+cga
 dCy
 cjV
 hOP
@@ -91594,7 +92002,7 @@ ceu
 cbx
 dux
 dux
-dux
+ckN
 dux
 dux
 aaa
@@ -91829,14 +92237,14 @@ alK
 alK
 alK
 bXy
-dux
-dux
-dux
-dux
-dux
-dux
-dux
-dux
+cga
+cga
+cga
+cga
+cga
+cga
+cga
+cga
 pcL
 wQV
 avr
@@ -91847,11 +92255,11 @@ iGO
 tRO
 cga
 cga
-bXE
+cLI
 cbx
 dux
-aaa
 anT
+aaf
 aaf
 aaf
 aai
@@ -92088,12 +92496,12 @@ bVV
 bXz
 bYE
 bYE
+pai
+eEu
 uOc
-uOc
-uOc
-uOc
+mSk
 cbp
-dux
+cga
 rfi
 qUR
 hFj
@@ -92106,9 +92514,9 @@ cga
 sfQ
 bXE
 cbx
-dux
-aaa
+ckN
 aaf
+aaa
 aaa
 aaa
 aaf
@@ -92345,12 +92753,12 @@ dux
 dux
 dux
 dux
-bXE
+oZg
 dux
 dux
 dux
 nPC
-dux
+cga
 nnV
 fwL
 dnp
@@ -92361,11 +92769,11 @@ cmB
 xTm
 cga
 ceu
-bXE
+dvt
 cbx
-dux
-aaa
+ckN
 aaf
+aaa
 aaa
 aaa
 cBR
@@ -92602,13 +93010,13 @@ bVW
 bXA
 diy
 dux
-bXE
-bXE
+xuA
+reI
 cbs
 wen
 jdp
 qit
-nnV
+klh
 jUk
 qpg
 uFC
@@ -92617,12 +93025,12 @@ gcu
 cmB
 sDj
 cga
+cga
 dux
-gll
-cbx
-dux
-aaa
+oZs
+ckN
 aaf
+aaa
 aaa
 aaa
 cBR
@@ -92864,8 +93272,8 @@ dux
 cen
 dux
 cbq
-dux
-nnV
+cga
+bcc
 rLL
 hvf
 yih
@@ -92874,12 +93282,12 @@ gOM
 laN
 ndC
 xZy
-dux
-bXE
+cga
+hdX
 cbx
-dux
-aaa
+ckN
 aaf
+aaa
 aaa
 aaa
 cBR
@@ -93121,7 +93529,7 @@ cdb
 ceo
 dux
 cdc
-dux
+cga
 diF
 nap
 qZf
@@ -93131,14 +93539,14 @@ xHr
 xHr
 wpK
 eSm
-dux
-bXE
+cga
+ceu
 cbx
-dux
+ckN
+aaf
 aaa
-aaf
-aaf
-aaf
+aaa
+aaa
 dBN
 dBO
 cDC
@@ -93374,26 +93782,26 @@ bXD
 bYI
 bZO
 cbt
-oZg
+hFE
 dux
 dux
 csT
-dux
+cga
 vRF
 riP
-dux
-dux
+cga
+cga
 gAj
 cmB
 cnJ
 cmB
 cqt
-dux
-bXE
+cga
+jNy
 cbx
 dux
-aaa
-aaa
+aaf
+aaf
 aaa
 aaa
 cBR
@@ -93634,25 +94042,25 @@ mWg
 cdd
 dux
 cfC
-cdc
+fWc
 oPU
 ovU
 jkQ
 fJl
-oPU
+snr
 mrv
 aGp
 hev
 mtp
 vQt
+cga
+oXP
+luh
 dux
-bXE
-cbx
 dux
 dux
-dux
-aaa
-aaa
+aaf
+aaf
 cBR
 cCK
 cDA
@@ -93896,15 +94304,15 @@ dux
 oSw
 jkQ
 lVu
-dux
-dux
-dux
-dux
-dux
-dux
-dux
-cvk
-cbx
+cga
+cga
+cga
+cga
+cga
+cga
+cga
+ceu
+luh
 bXE
 dvq
 dux
@@ -94154,9 +94562,9 @@ wAn
 lce
 cBr
 ibz
-chZ
+ixo
 cpS
-chZ
+fFJ
 csi
 chZ
 chZ
@@ -94420,7 +94828,7 @@ ceu
 dyg
 dvt
 bXE
-dvE
+nwq
 dux
 aaf
 aaf
@@ -95964,7 +96372,7 @@ dyw
 dux
 cxS
 dux
-aaa
+aaf
 aaa
 aaa
 aaf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #47158 (sorry)
- Adds cameras and lights to the new plumbing area.
- Fixes plumbing maint access and adds a cycle to it, much like the virology maint doors.
- Changes the plumbing front door to act more like a lobby door.
- Restricts access to the second observatory door so its no longer a free pass into medbay.
- Shifts the abandoned bar down to avoid whiteship docking inside of it.
- Shifts south solar to fit with the new bar placement.
- Various edits to the plumbing lobby, abandoned bar and surrounding maints to add more detail.
- Some extra windows.
- Birdboat gets a bed.

![dreamseeker_nP0n2BMWn3](https://user-images.githubusercontent.com/46540570/67057614-3eb76f80-f11f-11e9-9a56-5d849f1d6d1b.png)
Lobby

![dreamseeker_GuNyWKAwwW](https://user-images.githubusercontent.com/46540570/67057619-42e38d00-f11f-11e9-957e-c639b7602fda.png)
Bar


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Giant camera-free room bad.
Uncrushable bar good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Various edits to the new plumbing area, abandoned bar, and the surrounding maintenance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
