### PR TITLE
Fixes R&D Materials Exploit

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -62,7 +62,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	var/datum/component/material_container/storage = linked_console?.linked_lathe?.materials.mat_container
 	if(storage) //Also sends salvaged materials to a linked protolathe, if any.
 		for(var/material in thing.custom_materials)
-			var/can_insert = min((storage.max_amount - storage.total_amount), (max(thing.custom_materials[material]*(decon_mod/10), thing.custom_materials[material])))
+			var/can_insert = min((storage.max_amount - storage.total_amount), (min(thing.custom_materials[material]*(decon_mod/10), thing.custom_materials[material])))
 			storage.insert_amount_mat(can_insert, material)
 			. += can_insert
 		if (.)


### PR DESCRIPTION
@kevinz000 still doesn't understand min/max. 😛 

He fixed it once (https://github.com/tgstation/tgstation/pull/31397), only to make the same, exact mistake, at the same exact codeded spot when he implemented techwebs: https://github.com/tgstation/tgstation/commit/caa1e1f400c8b6a535e03cff28cf57f919e9378c#diff-44e2de26588995a2ad4a144963fbf251R62

:cl: Fox McCloud
fix: Fixes being able to exploit fully upgraded destructive analyzers to multiply materials
/:cl: