### PR TITLE
Fixes microwave runtime.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -309,7 +309,7 @@
 	var/metal = 0
 	for(var/obj/item/O in ingredients)
 		O.microwave_act(src)
-		if(O.custom_materials || O.custom_materials.len)
+		if(O.custom_materials && length(O.custom_materials))
 			if(O.custom_materials[getmaterialref(/datum/material/iron)])
 				metal += O.custom_materials[getmaterialref(/datum/material/iron)]
 


### PR DESCRIPTION
## About The Pull Request
fixes #47181 

## Changelog
:cl:
fix: Microwaves work again with items that do not have custom materials.
/:cl: