### PR TITLE
Neck Slice no longer divides by zero.

### DIFF
--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -23,11 +23,14 @@
 		RegisterSignal(parent, COMSIG_ITEM_ATTACK, .proc/onItemAttack)
 
 /datum/component/butchering/proc/onItemAttack(obj/item/source, mob/living/M, mob/living/user)
-	if(user.a_intent == INTENT_HARM && M.stat == DEAD && (M.butcher_results || M.guaranteed_butcher_results)) //can we butcher it?
+	if(user.a_itent != INTENT_HARM)
+		return
+	if(M.stat == DEAD && (M.butcher_results || M.guaranteed_butcher_results)) //can we butcher it?
 		if(butchering_enabled && (can_be_blunt || source.get_sharpness()))
 			INVOKE_ASYNC(src, .proc/startButcher, source, M, user)
 			return COMPONENT_ITEM_NO_ATTACK
-	if(user.a_intent == INTENT_HARM && ishuman(M) && source.get_sharpness())
+
+	if(ishuman(M) && source.force && source.get_sharpness())
 		var/mob/living/carbon/human/H = M
 		if((H.health <= H.crit_threshold || (user.pulling == H && user.grab_state >= GRAB_NECK) || H.IsSleeping()) && user.zone_selected == BODY_ZONE_HEAD) // Only sleeping, neck grabbed, or crit, can be sliced.
 			if(H.has_status_effect(/datum/status_effect/neck_slice))

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -23,7 +23,7 @@
 		RegisterSignal(parent, COMSIG_ITEM_ATTACK, .proc/onItemAttack)
 
 /datum/component/butchering/proc/onItemAttack(obj/item/source, mob/living/M, mob/living/user)
-	if(user.a_itent != INTENT_HARM)
+	if(user.a_intent != INTENT_HARM)
 		return
 	if(M.stat == DEAD && (M.butcher_results || M.guaranteed_butcher_results)) //can we butcher it?
 		if(butchering_enabled && (can_be_blunt || source.get_sharpness()))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You now require and item with a force that's not equal 0 to start a neck slice.

## Why It's Good For The Game

Division by zero is not epic.

## Changelog
:cl:
tweak: You can no longer start a neck slice with an item that does not have any force.
/:cl: