### PR TITLE
fix names and ids of apothecary shutters

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -49916,8 +49916,8 @@
 "cfX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters";
-	name = "chemistry shutters"
+	id = "apothecary_shutters";
+	name = "apothecary shutters"
 	},
 /turf/open/floor/plating,
 /area/medical/apothecary)
@@ -53435,8 +53435,8 @@
 "cnL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters_2";
-	name = "chemistry shutters"
+	id = "apothecary_shutters_2";
+	name = "apothecary shutters"
 	},
 /turf/open/floor/plating,
 /area/medical/apothecary)


### PR DESCRIPTION
## About The Pull Request
This allows all of the shutters in the apothecary can be opened/closed with the buttons on the wall and renames the ones that still had 'chemistry' in their name.
Fixes https://github.com/tgstation/tgstation/issues/47160

## Changelog
:cl:
fix: apothecary shutters can be properly controlled with the wall buttons
/:cl:
