### PR TITLE
Makes the health analyzer round the damage values up

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -262,16 +262,16 @@ GENE SCANNER
 							<td style='width:8em;'><font color='purple'><b>Suffocation</b></font></td></tr>\
 
 							<tr><td><font color='#0000CC'>Overall:</font></td>\
-							<td><font color='red'>[round(brute_loss,1)]</font></td>\
-							<td><font color='orange'>[round(fire_loss,1)]</font></td>\
-							<td><font color='green'>[round(tox_loss,1)]</font></td>\
-							<td><font color='purple'>[round(oxy_loss,1)]</font></td></tr>"
+							<td><font color='red'>[CEILING(brute_loss,1)]</font></td>\
+							<td><font color='orange'>[CEILING(fire_loss,1)]</font></td>\
+							<td><font color='green'>[CEILING(tox_loss,1)]</font></td>\
+							<td><font color='purple'>[CEILING(oxy_loss,1)]</font></td></tr>"
 
 			for(var/o in damaged)
 				var/obj/item/bodypart/org = o //head, left arm, right arm, etc.
 				dmgreport += "<tr><td><font color='#0000CC'>[capitalize(org.name)]:</font></td>\
-								<td><font color='red'>[(org.brute_dam > 0) ? "[round(org.brute_dam,1)]" : "0"]</font></td>\
-								<td><font color='orange'>[(org.burn_dam > 0) ? "[round(org.burn_dam,1)]" : "0"]</font></td></tr>"
+								<td><font color='red'>[(org.brute_dam > 0) ? "[CEILING(org.brute_dam,1)]" : "0"]</font></td>\
+								<td><font color='orange'>[(org.burn_dam > 0) ? "[CEILING(org.burn_dam,1)]" : "0"]</font></td></tr>"
 			dmgreport += "</font></table>"
 			to_chat(user, dmgreport.Join())
 


### PR DESCRIPTION
What it says on the title. I forgot to add this in my previous PR. Now there won't be a case of someone looking perfectly fine on the analyzer but actually still having damage.

Working as intended:
![kuva](https://user-images.githubusercontent.com/5420151/67118542-c1a6fb80-f1ed-11e9-8c4c-c47c0ea90425.png)
