### PR TITLE
Vampire gui minor fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -11,10 +11,14 @@
 	use_skintones = TRUE
 	mutant_heart = /obj/item/organ/heart/vampire
 	mutanttongue = /obj/item/organ/tongue/vampire
+	
 	limbs_id = "human"
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	var/info_text = "You are a <span class='danger'>Vampire</span>. You will slowly but constantly lose blood if outside of a coffin. If inside a coffin, you will slowly heal. You may gain more blood by grabbing a live victim and using your drain ability."
 	var/obj/effect/proc_holder/spell/targeted/shapeshift/bat/batform //attached to the datum itself to avoid cloning memes, and other duplicates
+
+
+
 
 /datum/species/vampire/check_roundstart_eligible()
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
@@ -44,7 +48,7 @@
 		C.adjustOxyLoss(-4)
 		C.adjustCloneLoss(-4)
 		return
-	C.blood_volume -= 0.75
+	C.blood_volume -= 0.25
 	if(C.blood_volume <= BLOOD_VOLUME_SURVIVE)
 		to_chat(C, "<span class='danger'>You ran out of blood!</span>")
 		var/obj/shapeshift_holder/H = locate() in C
@@ -117,6 +121,16 @@
 
 #undef VAMP_DRAIN_AMOUNT
 
+
+/mob/living/carbon/Stat()
+	..()
+	if(statpanel("Status"))	
+		var/obj/item/organ/heart/vampire/darkheart = getorgan(/obj/item/organ/heart/vampire)
+		if(darkheart)
+			stat(null, "<span class='notice'>Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM].</span>")
+			return 1
+
+
 /obj/item/organ/heart/vampire
 	name = "vampire heart"
 	actions_types = list(/datum/action/item_action/organ_action/vampire_heart)
@@ -139,3 +153,15 @@
 	charge_max = 50
 	cooldown_min = 50
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat
+/*
+/mob/living/carbon/proc/getBlood()
+	var/obj/item/organ/heart/vampire/vessel = getorgan(/obj/item/organ/heart/vampire)
+	if(!vessel)
+		return 0
+	return blood_volume
+
+/mob/living/carbon/vampire/proc/updateBloodDisplay()
+	if(hud_used) //clientless aliens
+		 
+		hud_used.vampire_blood_display.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='red'>[round(getBlood())]</font></div>"
+*/

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -11,7 +11,6 @@
 	use_skintones = TRUE
 	mutant_heart = /obj/item/organ/heart/vampire
 	mutanttongue = /obj/item/organ/tongue/vampire
-	
 	limbs_id = "human"
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	var/info_text = "You are a <span class='danger'>Vampire</span>. You will slowly but constantly lose blood if outside of a coffin. If inside a coffin, you will slowly heal. You may gain more blood by grabbing a live victim and using your drain ability."
@@ -143,15 +142,3 @@
 	charge_max = 50
 	cooldown_min = 50
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat
-/*
-/mob/living/carbon/proc/getBlood()
-	var/obj/item/organ/heart/vampire/vessel = getorgan(/obj/item/organ/heart/vampire)
-	if(!vessel)
-		return 0
-	return blood_volume
-
-/mob/living/carbon/vampire/proc/updateBloodDisplay()
-	if(hud_used) //clientless aliens
-		 
-		hud_used.vampire_blood_display.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='red'>[round(getBlood())]</font></div>"
-*/

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -133,18 +133,8 @@
 
 /obj/item/organ/heart/vampire
 	name = "vampire heart"
-	actions_types = list(/datum/action/item_action/organ_action/vampire_heart)
 	color = "#1C1C1C"
 
-/datum/action/item_action/organ_action/vampire_heart
-	name = "Check Blood Level"
-	desc = "Check how much blood you have remaining."
-
-/datum/action/item_action/organ_action/vampire_heart/Trigger()
-	. = ..()
-	if(iscarbon(owner))
-		var/mob/living/carbon/H = owner
-		to_chat(H, "<span class='notice'>Current blood level: [H.blood_volume]/[BLOOD_VOLUME_MAXIMUM].</span>")
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/bat
 	name = "Bat Form"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -482,6 +482,8 @@
 		flashlight_overlay.pixel_x = flight_x_offset
 		flashlight_overlay.pixel_y = flight_y_offset
 		add_overlay(flashlight_overlay, TRUE)
+		if(bayonet)
+		add_overlay(knife_overlay, TRUE)
 	else
 		set_light(0)
 		cut_overlays(flashlight_overlay, TRUE)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -482,8 +482,6 @@
 		flashlight_overlay.pixel_x = flight_x_offset
 		flashlight_overlay.pixel_y = flight_y_offset
 		add_overlay(flashlight_overlay, TRUE)
-		if(bayonet)
-		add_overlay(knife_overlay, TRUE)
 	else
 		set_light(0)
 		cut_overlays(flashlight_overlay, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the GUI element for checking your blood level from a GUI button into a status bar tab 

## Why It's Good For The Game

Sanity check: is it reasonable to check a health/mana/resource element through a button? no. Moved it into a sidebar instead. Might also add a actual gui element, like xeno bar for measuring blood level in the future, some commented out code exists for this. 

**Also:** 
Changed blood loss to 1/3 of what it is now - playing vampire is nearly impossible unless you got monkey/genetics access. Given that it has neither antag status, large benefits, or access, i think this is not unreasonable. 


## Changelog
:cl:IradT
tweak: moved vampire blood counter into status bar
balance: vampire blood loss is now 1/3 of previous value
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
