### PR TITLE
Adds RCD to CE locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -27,6 +27,7 @@
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/clothing/glasses/meson/engine(src)
 	new /obj/item/door_remote/chief_engineer(src)
+	new /obj/item/construction/rcd(src)
 	new /obj/item/pipe_dispenser(src)
 	new /obj/item/inducer(src)
 	new /obj/item/circuitboard/machine/techfab/department/engineering(src)


### PR DESCRIPTION
Adds RCD to CE locker

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This Adds an RCD to the CE locker

## Why It's Good For The Game

The Engineers and by extension, the CE needs RCD's to do construction work. As it is now, the station starts with 3 RCD's in the engineering vending machine, which is shared between the engineers and the CE. The chief of the department should have access to a RCD of his own, and not have to compete over them with his fellow engineers. This is especially notable as a problem if the department is full. 

This should not be a balance problem, as the RCD's are quite easy to make, by making a hacked Autolathe, but the CE should not have to do this at roundstart if he is not fast enough to grab one on his own. 

The ease of access to RCD's may be an issue in itself, but that is for another day.

## Changelog
:cl:IradT
add: Added a RCD to the CE locker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
