### PR TITLE
Adds M1911 crate and single-pack to Cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -603,6 +603,24 @@
 	for(var/i in 1 to 10)
 		var/item = pick(contains)
 		new item(C)
+		
+/datum/supply_pack/security/armory/m1911
+	name = "M1911 Single-Pack"	
+	desc = "High power, low practicality. Contains one M1911 pistol and a spare magazine. Requires Armory access to open."
+	cost = 2500
+	contains = list(/obj/item/gun/ballistic/automatic/pistol/m1911
+					/obj/item/ammo_box/magazine/m45)
+	small_item = TRUE
+
+/datum/supply_pack/security/armory/m1911
+	name = "M1911 Crate"
+	desc = "High power, low practicality. Contains two M1911 pistols and magazines. Requires Armory access to open."
+	cost = 4500
+	contains = list(/obj/item/gun/ballistic/automatic/pistol/m1911
+					/obj/item/gun/ballistic/automatic/pistol/m1911
+					/obj/item/ammo_box/magazine/m45
+					/obj/item/ammo_box/magazine/m45)
+	crate_name = "m1911 crate"
 
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -501,6 +501,25 @@
 					/obj/item/gun/energy/e_gun)
 	crate_name = "energy gun crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
+	
+/datum/supply_pack/security/armory/m1911
+	name = "M1911 Single-Pack"	
+	desc = "High power, low practicality. Contains one M1911 pistol and a spare magazine. Requires Armory access to open."
+	cost = 2500
+	contains = list(/obj/item/gun/ballistic/automatic/pistol/m1911,
+					/obj/item/ammo_box/magazine/m45)
+	small_item = TRUE
+
+/datum/supply_pack/security/armory/m1911
+	name = "M1911 Crate"
+	desc = "High power, low practicality. Contains two M1911 pistols and magazines. Requires Armory access to open."
+	cost = 4500
+	contains = list(/obj/item/gun/ballistic/automatic/pistol/m1911,
+					/obj/item/gun/ballistic/automatic/pistol/m1911,
+					/obj/item/ammo_box/magazine/m45,
+					/obj/item/ammo_box/magazine/m45)
+	crate_name = "m1911 crate"
+
 
 /datum/supply_pack/security/armory/exileimp
 	name = "Exile Implants Crate"
@@ -604,24 +623,6 @@
 		var/item = pick(contains)
 		new item(C)
 		
-/datum/supply_pack/security/armory/m1911
-	name = "M1911 Single-Pack"	
-	desc = "High power, low practicality. Contains one M1911 pistol and a spare magazine. Requires Armory access to open."
-	cost = 2500
-	contains = list(/obj/item/gun/ballistic/automatic/pistol/m1911
-					/obj/item/ammo_box/magazine/m45)
-	small_item = TRUE
-
-/datum/supply_pack/security/armory/m1911
-	name = "M1911 Crate"
-	desc = "High power, low practicality. Contains two M1911 pistols and magazines. Requires Armory access to open."
-	cost = 4500
-	contains = list(/obj/item/gun/ballistic/automatic/pistol/m1911
-					/obj/item/gun/ballistic/automatic/pistol/m1911
-					/obj/item/ammo_box/magazine/m45
-					/obj/item/ammo_box/magazine/m45)
-	crate_name = "m1911 crate"
-
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds M1911 crates to Cargo's Armory tab, at 2500 for one and 4500 for two, bundled with a magazine per gun. No option for ordering additional spare magazines to hopefully discourage Gun Cargo abuse like Mosins and WTs tend to get.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Security currently doesn't actually have a reason to ever order anything from Cargo, except in cases of supply shortages; the Armory plus all the guns at round start are always more than enough, with the only exceptions being Combat Shotguns that usually aren't practical except for arming the entire crew on Wizard and Operative round types due to size, and spam-ordering Laser Guns to fight the Blob. The M1911 is a more-powerful alternative to the Laser Gun with the drawback of being a ballistic, and currently is almost nonexistent because it's incredibly rare for someone to find one in deep space and make their way back to the Autolathe to print ammo for it. It would serve as a more-powerful lethal option for Officers when the station starts getting hectic, or as an emergency weapon issued to Heads of Staff for the same reason, while current Cargo-exclusive options are only really good for Gun Cargo - no Officer needs a Mosin Nagant, and no Officer can reasonably even use a Combat Shotgun. The high price point and lack of a magazine crate should discourage Gun Cargo - they'd probably rather just order a Russian crate and get armor bundled with more-powerful Mosins, or the even more powerful and less practical Combat Shotguns.

Yes, I know it's similar to the Stechkin, but size is the major drawback here - same for the researched ebow against the minibow, and a slug-loaded Combat Shotgun against a revolver. Pocket-size is an attractive enough attribute to keep it a reasonable TC buy.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: M1911 pistols are now available at the Cargo Bay thanks to a Nanotrasen salvage initiative.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
