### PR TITLE
Nerf budgets so Cargo can't spam orders forever

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -15,36 +15,36 @@ SUBSYSTEM_DEF(economy)
 	var/list/generated_accounts = list()
 	var/full_ancap = FALSE // Enables extra money charges for things that normally would be free, such as sleepers/cryo/cloning.
 							//Take care when enabling, as players will NOT respond well if the economy is set up for low cash flows.
-	var/alive_humans_bounty = 100
-	var/crew_safety_bounty = 1500
-	var/monster_bounty = 150
-	var/mood_bounty = 100
-	var/techweb_bounty = 250
-	var/slime_bounty = list("grey" = 10,
+	var/alive_humans_bounty = 20
+	var/crew_safety_bounty = 300
+	var/monster_bounty = 30
+	var/mood_bounty = 20
+	var/techweb_bounty = 50
+	var/slime_bounty = list("grey" = 2,
 							// tier 1
-							"orange" = 100,
-							"metal" = 100,
-							"blue" = 100,
-							"purple" = 100,
+							"orange" = 20,
+							"metal" = 20,
+							"blue" = 20,
+							"purple" = 20,
 							// tier 2
-							"dark purple" = 500,
-							"dark blue" = 500,
-							"green" = 500,
-							"silver" = 500,
-							"gold" = 500,
-							"yellow" = 500,
-							"red" = 500,
-							"pink" = 500,
+							"dark purple" = 100,
+							"dark blue" = 100,
+							"green" = 100,
+							"silver" = 100,
+							"gold" = 100,
+							"yellow" = 100,
+							"red" = 100,
+							"pink" = 100,
 							// tier 3
-							"cerulean" = 750,
-							"sepia" = 750,
-							"bluespace" = 750,
-							"pyrite" = 750,
-							"light pink" = 750,
-							"oil" = 750,
-							"adamantine" = 750,
+							"cerulean" = 150,
+							"sepia" = 150,
+							"bluespace" = 150,
+							"pyrite" = 150,
+							"light pink" = 150,
+							"oil" = 150,
+							"adamantine" = 150,
 							// tier 4
-							"rainbow" = 1000)
+							"rainbow" = 200)
 	var/list/bank_accounts = list() //List of normal accounts (not department accounts)
 	var/list/dep_cards = list()
 
@@ -70,7 +70,7 @@ SUBSYSTEM_DEF(economy)
 			return D
 
 /datum/controller/subsystem/economy/proc/eng_payout()
-	var/engineering_cash = 3000
+	var/engineering_cash = 600
 	var/datum/bank_account/D = get_dep_account(ACCOUNT_ENG)
 	if(D)
 		D.adjust_money(engineering_cash)
@@ -125,7 +125,7 @@ SUBSYSTEM_DEF(economy)
 		D.adjust_money(min(science_bounty, MAX_GRANT_SCI))
 
 /datum/controller/subsystem/economy/proc/civ_payout()
-	var/civ_cash = (rand(1,5) * 500)
+	var/civ_cash = (rand(1,5) * 100)
 	var/datum/bank_account/D = get_dep_account(ACCOUNT_CIV)
 	if(D)
 		D.adjust_money(min(civ_cash, MAX_GRANT_CIV))


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title. Requested by Cobby, among many others. Should reduce all budget money generation to 1/5th the current values.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cargo currently has unlimited money without even having to do bounties or sell materials as long as they can only get two or three budget cards. This change nerfs generation of credits so it's generally only a bit higher than the loss for salaries. Hopefully Cargo will actually need to bother with exports even if they do get budget cards.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: A major economic crash has cut the amount of credits paid to each department budget down to 20%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
