### PR TITLE
Plumbing: Fixes the splitter not switching.

### DIFF
--- a/code/datums/components/plumbing/splitter.dm
+++ b/code/datums/components/plumbing/splitter.dm
@@ -25,7 +25,7 @@
 				return TRUE
 		if(EAST)
 			if(!S.turn_straight && S.transfer_side <= amount)
-				S.turn_straight = FALSE
+				S.turn_straight = TRUE
 				return TRUE
 
 /datum/component/plumbing/splitter/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net)


### PR DESCRIPTION
Fixes the problem that the splitter does not switch back to sending
chemicals straight. This resulted in the splitter sending chemicals
straight exactly once, then forever sending them to the side.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the problem that the splitter does not switch back to sending
chemicals straight. This resulted in the splitter sending chemicals
straight exactly once, then forever sending them to the side.

## Why It's Good For The Game

Fixes problem a bug with plumbing.

Please close if redundant.

## Changelog
:cl:
fix: Splitter sends chemicals both ways.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
