### PR TITLE
Fixes Runtime with Determining Resource Amounts in Items

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -306,7 +306,7 @@
 
 ///returns the amount of material relevant to this container; if this container does not support glass, any glass in 'I' will not be taken into account
 /datum/component/material_container/proc/get_item_material_amount(obj/item/I)
-	if(!istype(I) || I.custom_materials == null)
+	if(!istype(I) || !I.custom_materials)
 		return FALSE
 	var/material_amount = 0
 	for(var/MAT in materials)

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -306,7 +306,7 @@
 
 ///returns the amount of material relevant to this container; if this container does not support glass, any glass in 'I' will not be taken into account
 /datum/component/material_container/proc/get_item_material_amount(obj/item/I)
-	if(!istype(I))
+	if(!istype(I) || I.custom_materials == null)
 		return FALSE
 	var/material_amount = 0
 	for(var/MAT in materials)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes runtime from getting material counts from items without materials.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Was generating hundreds of runtimes, also removed feedback from machines when you should be getting messages like "this item does not contain enough material!".

Fixes https://github.com/tgstation/tgstation/issues/47236

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
fix: Objects will once again properly report when they do not contain materials.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
