### PR TITLE
Makes a generic recursive movement tracker

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -41,6 +41,7 @@
 	for(var/i in orbiters)
 		end_orbit(i)
 	orbiters = null
+	QDEL_NULL(tracker)
 	return ..()
 
 /datum/component/orbiter/InheritComponent(datum/component/orbiter/newcomp, original, list/arguments)

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -2,6 +2,7 @@
 	can_transfer = TRUE
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 	var/list/orbiters
+	var/datum/movement_detector/tracker
 
 //radius: range to orbit at, radius of the circle formed by orbiting (in pixels)
 //clockwise: whether you orbit clockwise or anti clockwise
@@ -22,10 +23,10 @@
 
 /datum/component/orbiter/RegisterWithParent()
 	var/atom/target = parent
+
 	target.orbiters = src
-	while(ismovableatom(target))
-		RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/move_react)
-		target = target.loc
+	if(ismovableatom(target))
+		tracker = new(target, CALLBACK(src, .proc/move_react))
 
 /datum/component/orbiter/UnregisterFromParent()
 	var/atom/target = parent
@@ -99,29 +100,15 @@
 		qdel(src)
 
 // This proc can receive signals by either the thing being directly orbited or anything holding it
-/datum/component/orbiter/proc/move_react(atom/orbited, atom/oldloc, direction)
+/datum/component/orbiter/proc/move_react(atom/movable/master, atom/mover, atom/oldloc, direction)
 	set waitfor = FALSE // Transfer calls this directly and it doesnt care if the ghosts arent done moving
 
-	var/atom/movable/master = parent
 	if(master.loc == oldloc)
 		return
 
 	var/turf/newturf = get_turf(master)
 	if(!newturf)
 		qdel(src)
-
-	// Handling the signals of stuff holding us (or not anymore)
-	// These are prety rarely activated, how often are you following something in a bag?
-	if(oldloc && !isturf(oldloc)) // We used to be registered to it, probably
-		var/atom/target = oldloc
-		while(ismovableatom(target))
-			UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
-			target = target.loc
-	if(orbited?.loc && orbited.loc != newturf) // We want to know when anything holding us moves too
-		var/atom/target = orbited.loc
-		while(ismovableatom(target))
-			RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/move_react, TRUE)
-			target = target.loc
 
 	var/atom/curloc = master.loc
 	for(var/i in orbiters)

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -31,9 +31,7 @@
 /datum/component/orbiter/UnregisterFromParent()
 	var/atom/target = parent
 	target.orbiters = null
-	while(ismovableatom(target))
-		UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
-		target = target.loc
+	QDEL_NULL(tracker)
 
 /datum/component/orbiter/Destroy()
 	var/atom/master = parent
@@ -41,7 +39,6 @@
 	for(var/i in orbiters)
 		end_orbit(i)
 	orbiters = null
-	QDEL_NULL(tracker)
 	return ..()
 
 /datum/component/orbiter/InheritComponent(datum/component/orbiter/newcomp, original, list/arguments)

--- a/code/datums/movement_detector.dm
+++ b/code/datums/movement_detector.dm
@@ -1,0 +1,42 @@
+/// A datum to handle the busywork of registering signals to handle in depth tracking of a movable
+/datum/movement_detector
+	var/atom/movable/tracked
+	var/datum/callback/listener
+
+/datum/movement_detector/New(atom/movable/target, datum/callback/listener)
+	if(target)
+		track(target, listener)
+
+/datum/movement_detector/Destroy()
+	tracked = null
+	listener = null
+	return ..()
+
+/// Sets up tracking of the given movable atom
+/datum/movement_detector/proc/track(atom/movable/target, datum/callback/listener)
+	tracked = target
+	src.listener = listener
+	
+	while(ismovableatom(target))
+		RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/move_react)
+		target = target.loc
+
+/**
+  * Reacts to any movement that would cause a change in coordinates of the tracked movable atom
+  * This works by detecting movement of either the tracked object, or anything it is inside, recursively
+  */
+/datum/movement_detector/proc/move_react(atom/movable/mover, atom/oldloc, direction)
+	var/turf/newturf = get_turf(tracked)
+	
+	if(oldloc && !isturf(oldloc))
+		var/atom/target = oldloc
+		while(ismovableatom(target))
+			UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
+			target = target.loc
+	if(tracked.loc != newturf)
+		var/atom/target = mover.loc
+		while(ismovableatom(target))
+			RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/move_react, TRUE)
+			target = target.loc
+
+	listener.Invoke(tracked, mover, oldloc, direction)

--- a/code/datums/movement_detector.dm
+++ b/code/datums/movement_detector.dm
@@ -14,6 +14,12 @@
 
 /// Sets up tracking of the given movable atom
 /datum/movement_detector/proc/track(atom/movable/target, datum/callback/listener)
+	if(tracked)
+		var/atom/movable/untrack = tracked
+		while(ismovableatom(untrack))
+			untrack.UnregisterSignal(untrack, COMSIG_MOVABLE_MOVED)
+			untrack = untrack.loc
+
 	tracked = target
 	src.listener = listener
 	

--- a/code/datums/movement_detector.dm
+++ b/code/datums/movement_detector.dm
@@ -8,23 +8,28 @@
 		track(target, listener)
 
 /datum/movement_detector/Destroy()
+	untrack()
 	tracked = null
 	listener = null
 	return ..()
 
 /// Sets up tracking of the given movable atom
 /datum/movement_detector/proc/track(atom/movable/target, datum/callback/listener)
-	if(tracked)
-		var/atom/movable/untrack = tracked
-		while(ismovableatom(untrack))
-			untrack.UnregisterSignal(untrack, COMSIG_MOVABLE_MOVED)
-			untrack = untrack.loc
-
+	untrack()
 	tracked = target
 	src.listener = listener
 	
 	while(ismovableatom(target))
 		RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/move_react)
+		target = target.loc
+
+/// Stops tracking
+/datum/movement_detector/proc/untrack()
+	if(!tracked)
+		return
+	var/atom/movable/target = tracked
+	while(ismovableatom(target))
+		UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
 		target = target.loc
 
 /**

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -321,6 +321,7 @@
 #include "code\datums\hud.dm"
 #include "code\datums\map_config.dm"
 #include "code\datums\mind.dm"
+#include "code\datums\movement_detector.dm"
 #include "code\datums\mutable_appearance.dm"
 #include "code\datums\numbered_display.dm"
 #include "code\datums\outfit.dm"


### PR DESCRIPTION
Moves out the recursive movement tracker found in the orbiting components to a datum usable by other things. This is mainly so #46891 can make use of it.
