### PR TITLE
fix missing areas in medical lobby on metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -48802,7 +48802,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
-/area)
+/area/medical/medbay/central)
 "cdz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -49249,7 +49249,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area)
+/area/medical/medbay/central)
 "ceF" = (
 /obj/structure/bed/roller,
 /obj/item/radio/intercom{


### PR DESCRIPTION
## About The Pull Request
These two tiles in the lobby of medical on metastation had no area. This broke the air alarm.

## Changelog
:cl:
fix: air alarm in medical lobby is no longer a Space air alarm
/:cl:
