### PR TITLE
Attempt to reduce load from updatehealth()

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -330,3 +330,5 @@
 #define WABBAJACK     (1<<6)
 
 #define SLEEP_CHECK_DEATH(X) sleep(X); if(QDELETED(src) || stat == DEAD) return;
+
+#define UPDATEHEALTH(MOB) addtimer(CALLBACK(MOB, /mob/living.proc/updatehealth), 1, TIMER_UNIQUE)

--- a/code/modules/antagonists/devil/true_devil/_true_devil.dm
+++ b/code/modules/antagonists/devil/true_devil/_true_devil.dm
@@ -169,7 +169,7 @@
 						"<span class='userdanger'>[M] punches you!</span>")
 				adjustBruteLoss(damage)
 				log_combat(M, src, "attacked")
-				updatehealth()
+				UPDATEHEALTH(src)
 			if ("disarm")
 				if (!(mobility_flags & MOBILITY_STAND) && !ascended) //No stealing the arch devil's pitchfork.
 					if (prob(5))

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -42,7 +42,7 @@ In all, this is a lot like the monkey code. /N
 				to_chat(M, "<span class='danger'>You bite [src]!</span>")
 				adjustBruteLoss(1)
 				log_combat(M, src, "attacked")
-				updatehealth()
+				UPDATEHEALTH(src)
 			else
 				to_chat(M, "<span class='warning'>[name] is too injured for that.</span>")
 
@@ -101,7 +101,7 @@ In all, this is a lot like the monkey code. /N
 			damage = rand(10, 40)
 		adjustBruteLoss(damage)
 		log_combat(M, src, "attacked")
-		updatehealth()
+		UPDATEHEALTH(src)
 
 /mob/living/carbon/alien/ex_act(severity, target, origin)
 	if(origin && istype(origin, /datum/spacevine_mutation) && isvineimmune(src))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -174,7 +174,7 @@
 					stuttering = power
 				if (prob(stunprob) && M.powerlevel >= 8)
 					adjustFireLoss(M.powerlevel * rand(6,10))
-					updatehealth()
+					UPDATEHEALTH(src)
 		return 1
 
 /mob/living/carbon/proc/dismembering_strike(mob/living/attacker, dam_zone)

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -210,7 +210,7 @@
 
 		parts -= picked
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 		update_stamina()
 	if(update)
 		update_damage_overlays()
@@ -241,7 +241,7 @@
 
 		parts -= picked
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 	if(update)
 		update_damage_overlays()
 	update_stamina()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -371,7 +371,7 @@
 					return
 			if(update)
 				update_damage_overlays()
-			updatehealth()
+			UPDATEHEALTH(src)
 
 		visible_message("<span class='danger'>[M.name] hits [src]!</span>", \
 						"<span class='userdanger'>[M.name] hits you!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, M)

--- a/code/modules/mob/living/carbon/monkey/monkey_defense.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey_defense.dm
@@ -128,7 +128,7 @@
 				else
 					I = null
 			log_combat(M, src, "disarmed", "[I ? " removing \the [I]" : ""]")
-			updatehealth()
+			UPDATEHEALTH(src)
 
 
 /mob/living/carbon/monkey/attack_animal(mob/living/simple_animal/M)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -151,7 +151,7 @@
 		return FALSE
 	bruteloss = CLAMP((bruteloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 	return amount
 
 /mob/living/proc/getOxyLoss()
@@ -162,7 +162,7 @@
 		return FALSE
 	oxyloss = CLAMP((oxyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 	return amount
 
 /mob/living/proc/setOxyLoss(amount, updating_health = TRUE, forced = FALSE)
@@ -170,7 +170,7 @@
 		return 0
 	oxyloss = amount
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 	return amount
 
 /mob/living/proc/getToxLoss()
@@ -181,7 +181,7 @@
 		return FALSE
 	toxloss = CLAMP((toxloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 	return amount
 
 /mob/living/proc/setToxLoss(amount, updating_health = TRUE, forced = FALSE)
@@ -189,7 +189,7 @@
 		return FALSE
 	toxloss = amount
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 	return amount
 
 /mob/living/proc/getFireLoss()
@@ -200,7 +200,7 @@
 		return FALSE
 	fireloss = CLAMP((fireloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 	return amount
 
 /mob/living/proc/getCloneLoss()
@@ -211,7 +211,7 @@
 		return FALSE
 	cloneloss = CLAMP((cloneloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 	return amount
 
 /mob/living/proc/setCloneLoss(amount, updating_health = TRUE, forced = FALSE)
@@ -219,7 +219,7 @@
 		return FALSE
 	cloneloss = amount
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 	return amount
 
 /mob/living/proc/adjustOrganLoss(slot, amount, maximum)
@@ -246,7 +246,7 @@
 	adjustFireLoss(-burn, FALSE)
 	adjustStaminaLoss(-stamina, FALSE)
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 		update_stamina()
 
 // damage ONE external organ, organ gets randomly selected from damaged ones.
@@ -255,7 +255,7 @@
 	adjustFireLoss(burn, FALSE)
 	adjustStaminaLoss(stamina, FALSE)
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 		update_stamina()
 
 // heal MANY bodyparts, in random order
@@ -264,7 +264,7 @@
 	adjustFireLoss(-burn, FALSE)
 	adjustStaminaLoss(-stamina, FALSE)
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 		update_stamina()
 
 // damage MANY bodyparts, in random order
@@ -273,7 +273,7 @@
 	adjustFireLoss(burn, FALSE)
 	adjustStaminaLoss(stamina, FALSE)
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 		update_stamina()
 
 //heal up to amount damage, in a given order

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -106,7 +106,7 @@
 				M.mech_toxin_damage(src)
 			else
 				return
-		updatehealth()
+		UPDATEHEALTH(src)
 		visible_message("<span class='danger'>[M.name] hits [src]!</span>", \
 						"<span class='userdanger'>[M.name] hits you!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, M)
 		to_chat(M, "<span class='danger'>You hit [src]!</span>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -372,7 +372,7 @@
 				return
 
 		adjustBruteLoss(-30)
-		updatehealth()
+		UPDATEHEALTH(src)
 		add_fingerprint(user)
 		visible_message("<span class='notice'>[user] has fixed some of the dents on [src].</span>")
 		return
@@ -388,7 +388,7 @@
 			if (coil.use(1))
 				adjustFireLoss(-30)
 				adjustToxLoss(-30)
-				updatehealth()
+				UPDATEHEALTH(src)
 				user.visible_message("<span class='notice'>[user] has fixed some of the burnt wires on [src].</span>", "<span class='notice'>You fix some of the burnt wires on [src].</span>")
 			else
 				to_chat(user, "<span class='warning'>You need more cable to repair [src]!</span>")

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		damage = rand(5, 35)
 	damage = round(damage / 2) // borgs receive half damage
 	adjustBruteLoss(damage)
-	updatehealth()
+	UPDATEHEALTH(src)
 
 	return
 
@@ -177,6 +177,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 
 /mob/living/silicon/robot/bullet_act(obj/projectile/Proj, def_zone)
 	. = ..()
-	updatehealth()
+	UPDATEHEALTH(src)
 	if(prob(75) && Proj.damage > 0)
 		spark_system.start()

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -18,7 +18,7 @@
 				flash_act(affect_silicon = 1)
 			log_combat(M, src, "attacked")
 			adjustBruteLoss(damage)
-			updatehealth()
+			UPDATEHEALTH(src)
 		else
 			playsound(loc, 'sound/weapons/slashmiss.ogg', 25, TRUE, -1)
 			visible_message("<span class='danger'>[M]'s swipe misses [src]!</span>", \

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -24,7 +24,7 @@
 			playsound(loc, attacked_sound, 25, TRUE, -1)
 			attack_threshold_check(harm_intent_damage)
 			log_combat(M, src, "attacked")
-			updatehealth()
+			UPDATEHEALTH(src)
 			return TRUE
 
 /mob/living/simple_animal/attack_hulk(mob/living/carbon/human/user)

--- a/code/modules/mob/living/simple_animal/damage_procs.dm
+++ b/code/modules/mob/living/simple_animal/damage_procs.dm
@@ -4,7 +4,7 @@
 		return FALSE
 	bruteloss = round(CLAMP(bruteloss + amount, 0, maxHealth),DAMAGE_PRECISION)
 	if(updating_health)
-		updatehealth()
+		UPDATEHEALTH(src)
 	return amount
 
 /mob/living/simple_animal/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -301,7 +301,7 @@
 			M.add_nutrition(50 + (40 * M.is_adult))
 		if(health > 0)
 			M.adjustBruteLoss(-10 + (-10 * M.is_adult))
-			M.updatehealth()
+			UPDATEHEALTH(M)
 
 /mob/living/simple_animal/slime/attack_animal(mob/living/simple_animal/M)
 	. = ..()

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -119,7 +119,7 @@
 		"<span class='userdanger'>Energy pulse detected, system damaged!</span>", \
 		"<span class='hear'>You hear an electrical crack.</span>")
 
-	user.updatehealth()
+	UPDATEHEALTH(user)
 	bump_field(user)
 
 /obj/machinery/field/proc/clear_shock()

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -109,7 +109,7 @@
 			var/head_slot = H.get_item_by_slot(SLOT_HEAD)
 			if(!head_slot || !(istype(head_slot,/obj/item/clothing/head/helmet) || istype(head_slot,/obj/item/clothing/head/hardhat)))
 				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
-				H.updatehealth()
+				UPDATEHEALTH(H)
 			visible_message("<span class='danger'>[src] crashes into [A], sending [H] flying!</span>")
 			H.Paralyze(80)
 		else
@@ -292,6 +292,6 @@
 		var/head_slot = H.get_item_by_slot(SLOT_HEAD)
 		if(!head_slot || !(istype(head_slot,/obj/item/clothing/head/helmet) || istype(head_slot,/obj/item/clothing/head/hardhat)))
 			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1)
-			H.updatehealth()
+			UPDATEHEALTH(H)
 		visible_message("<span class='danger'>[src] crashes into [A], sending [H] flying!</span>")
 		playsound(src, 'sound/effects/bang.ogg', 50, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I came up with the idea for this talking to @Rohesie who is attempting to reduce the number of calls to updatehealth() in TGMC, namely where taking damage multiple times in the same tick from eg, rapid gunfire.

There's going to be a bunch of places this cant be used but anywhere a mob is taking damage it probably should be used, it might need to be extended to other similar procs.

Note: this heavily abuses TIMER_UNIQUE and I am unsure how costly the hashing/checking is.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less unneeded proc calls on mobs, in theory