### PR TITLE
Fixes Regenerative Mesh bringing up the inhand crafting menu.

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -268,6 +268,7 @@
 		to_chat(user, "<span class='notice'>You open the sterile mesh package.</span>")
 		update_icon()
 		playsound(src, 'sound/items/poster_ripped.ogg', 20, TRUE)
+		return
 	. = ..()
 
 	/*


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This one line PR prevents the regen mesh from displaying the inhand crafting window when it is being opened.

Thanks to @carlarctg for bringing this issue to my attention.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

 window annoying.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Packs of regenerative mesh no longer show you the inhand crafting menu when you open the pack. 
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
