### PR TITLE
[s]Restoring the safeties on the holodeck actually works.

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -109,7 +109,7 @@
 			if(!ispath(program_to_load))
 				return FALSE
 			var/valid = FALSE
-			var/list/checked = program_cache
+			var/list/checked = typecacheof(program_cache)
 			if(obj_flags & EMAGGED)
 				checked |= emag_programs
 			for(var/prog in checked)
@@ -124,10 +124,10 @@
 			if(A)
 				load_program(A)
 		if("safety")
-			obj_flags ^= EMAGGED
-			if((obj_flags & EMAGGED) && program && emag_programs[program.name])
+			if((obj_flags & EMAGGED) && program)
 				emergency_shutdown()
 			nerf(obj_flags & EMAGGED)
+			obj_flags ^= EMAGGED
 
 /obj/machinery/computer/holodeck/process()
 	if(damaged && prob(10))

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -128,6 +128,7 @@
 				emergency_shutdown()
 			nerf(obj_flags & EMAGGED)
 			obj_flags ^= EMAGGED
+			say("Safeties restored. Restarting...")
 
 /obj/machinery/computer/holodeck/process()
 	if(damaged && prob(10))

--- a/tgui/src/interfaces/holodeck.ract
+++ b/tgui/src/interfaces/holodeck.ract
@@ -5,7 +5,7 @@
 		</ui-button>
 	{{/partial}}
 	{{#each data.default_programs}}
-	<ui-button action='load_program' params='{"type": {{type}}}' style='{{data.program == type ? "selected" : null}}'>
+		<ui-button action='load_program' params='{"type": {{type}}}' style='{{data.program == type ? "selected" : null}}'>
 				{{name}}
 	</ui-button><br>
 	{{/each}}


### PR DESCRIPTION
 ## About The Pull Request

Restoring the holodeck safeties actually works; in addition, it actually removes the currently running unsafe program as intended. (Technically speaking now it removes any currently running programs, but that makes more sense fluff-wise.)

Adds a say message from the computer when safeties are restored. It should be obvious already since the program suddenly disappears but it was weird it didn't have one.

fucking list pointer memery

Fixes https://github.com/tgstation/tgstation/issues/47136.

## Why It's Good For The Game

patches an exploit

## Changelog 
:cl: bandit
fix: Restoring the holodeck safeties works again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
