### PR TITLE
Moves RCD from autolathe into advanced engineering

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -684,14 +684,6 @@
 	build_path = /obj/item/flamethrower/full
 	category = list("hacked", "Security")
 
-/datum/design/rcd
-	name = "Rapid Construction Device (RCD)"
-	id = "rcd"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 30000)
-	build_path = /obj/item/construction/rcd
-	category = list("hacked", "Construction")
-
 /datum/design/rpd
 	name = "Rapid Pipe Dispenser (RPD)"
 	id = "rpd"

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -33,6 +33,18 @@
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
 
+
+/datum/design/rcd_loaded
+	name = "Rapid Construction Device"
+	desc = "A tool that can construct and deconstruct walls, airlocks and floors on the fly."
+	id = "rcd_loaded"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 60000, /datum/material/glass = 5000)  // costs more than what it did in the autolathe, this one comes loaded.
+	build_path = /obj/item/construction/rcd/loaded
+	category = list("Tool Designs")
+	departmental_flags =  DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
+
+
 /datum/design/rcd_upgrade/frames
 	name = "RCD frames designs upgrade"
 	desc = "Adds the computer frame and machine frame to the RCD."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -144,7 +144,7 @@
 	display_name = "Advanced Engineering"
 	description = "Pushing the boundaries of physics, one chainsaw-fist at a time."
 	prereq_ids = list("engineering", "emp_basic")
-	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask")
+	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask", "rcd_loaded")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This moves the RCD from the hacked autolathe into the Advanced engineering techweb, making it printable at engineering and cargo lathes.  

## Why It's Good For The Game

This removes roundstart access RCD in the hacked autolathe that is available in cargo into the engineering techweb, allowing it to be printed at prolathes instead. It can be printed from both the Engineering and Cargo protolathe, meaning that the same roles has access to them. 

The fact that it is no longer printable from autolathe means fewer greytide will have instant access to RCD, since you could simply unwrench the ORM and hack the autolathe very rapidly. This means that the only ones at roundstart will be the ones in engineering and EVA.  

No changes has been made to techweb costs to compensate. 

## Changelog
:cl: IradT
balance: moved RCD from Autolathe -> Protolathe
/:cl:


