### PR TITLE
Adds a bluespace RCD to techweb

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -633,6 +633,17 @@ RLD
 	matter = 500
 	canRturf = TRUE
 
+/obj/item/construction/rcd/bluespace
+	name = "bluespace RCD"
+	desc = "Compact, efficient bluespace RCD that is linked to the ORM,"
+	icon_state = "ircd"
+	sheetmultiplier = 4.4 //slightly better than original RCD due to tech advancement
+	w_class = WEIGHT_CLASS_SMALL
+	upgrade = RCD_UPGRADE_SILO_LINK
+	delay_mod = 0.85 
+	item_state = "ircd"
+	max_matter = 180
+
 /obj/item/rcd_ammo
 	name = "compressed matter cartridge"
 	desc = "Highly compressed matter for the RCD."

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -60,7 +60,8 @@
 		/obj/item/holosign_creator/engineering,
 		/obj/item/forcefield_projector,
 		/obj/item/assembly/signaler,
-		/obj/item/lightreplacer
+		/obj/item/lightreplacer,
+		/obj/item/construction/rcd/bluespace
 		))
 
 /obj/item/storage/belt/utility/chief

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -63,6 +63,16 @@
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
+/datum/design/rcd_bluespace
+	name = "Bluespace RCD"
+	desc = "A compact RCD linked with the ore silo using bluespace technology, with additional uppgraded efficiency."
+	id = "rcd_bluespace"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 60000, /datum/material/glass = 7500, /datum/material/plasma = 4000, /datum/material/uranium = 4500 /datum/material/bluespace = 2500 )
+	build_path = /obj/item/construction/rcd/bluespace
+	category = list("Tool Designs")
+	departmental_flags =  DEPARTMENTAL_FLAG_ENGINEERING	
+
 /////////////////////////////////////////
 //////////////Alien Tools////////////////
 /////////////////////////////////////////

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -68,7 +68,7 @@
 	desc = "A compact RCD linked with the ore silo using bluespace technology, with additional uppgraded efficiency."
 	id = "rcd_bluespace"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 60000, /datum/material/glass = 7500, /datum/material/plasma = 4000, /datum/material/uranium = 4500 /datum/material/bluespace = 2500 )
+	materials = list(/datum/material/iron = 60000, /datum/material/glass = 7500, /datum/material/plasma = 4000, /datum/material/uranium = 4500, /datum/material/bluespace = 2500 )
 	build_path = /obj/item/construction/rcd/bluespace
 	category = list("Tool Designs")
 	departmental_flags =  DEPARTMENTAL_FLAG_ENGINEERING	

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -597,11 +597,11 @@
 
 /datum/techweb_node/adv_rcd_upgrade
 	id = "adv_rcd_upgrade"
-	display_name = "Advanced RCD designs upgrade"
+	display_name = "Advanced Bluespace RCD designs."
 	description = "Unlocks new RCD designs."
-	design_ids = list("rcd_upgrade_silo_link")
+	design_ids = list("RCD_bluespace", "rcd_upgrade_silo_link")
 	prereq_ids = list("rcd_upgrade", "bluespace_travel")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 25000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 20000)
 	export_price = 5000
 
 /////////////////////////weaponry tech/////////////////////////

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -597,7 +597,7 @@
 
 /datum/techweb_node/adv_rcd_upgrade
 	id = "adv_rcd_upgrade"
-	display_name = "Advanced Bluespace RCD designs."
+	display_name = "Bluespace-Integrated Rapid Construction"
 	description = "Unlocks new RCD designs."
 	design_ids = list("RCD_bluespace", "rcd_upgrade_silo_link")
 	prereq_ids = list("rcd_upgrade", "bluespace_travel")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a compact bluespace RCD that fits into belt slots, that is linked to the ore silo

## Why It's Good For The Game

This adds a upgraded RCD that fits into belt slots, a complaint that i and many others have about the RCD. This is done using bluespace designs, and thus it is also linked into the ore silo. 

This shouldn't affect game balance too much, as it is behind several expensive techs, and is only printable at the engineering lathe. 

The advantages it has is faster construction time and slightly lower construction cost, fits into belt slots, and is autolinked to the ore silo

Right now there is a  no sprite for the bluespace RCD, and as such it is using the Combat RCD as a placeholder.

The price on the techweb is also lowered. 

## Changelog
:cl:IradT
add: Adds a compact RCD design. Make engineering great again.
rebalance: Lowers cost of the corresponding techweb from 25000->2000
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
