### PR TITLE
Waterbottle fix

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -13,7 +13,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,29)
+	var/loot = rand(1,28)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)
@@ -79,8 +79,6 @@
 			new /obj/item/bedsheet/cult(src)
 		if(28)
 			new /obj/item/clothing/neck/necklace/memento_mori(src)
-		if(29)
-			new /obj/item/reagent_containers/glass/waterbottle/relic(src)
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc
@@ -323,11 +321,6 @@
 	user.sight |= sight_flags
 	if(!isnull(lighting_alpha))
 		user.lighting_alpha = min(user.lighting_alpha, lighting_alpha)
-
-// Relic water bottle
-/obj/item/reagent_containers/glass/waterbottle/relic
-	desc = "A bottle of water filled at an old Earth bottling facility. It seems to be radiating some kind of energy."
-	flip_chance = 100 // FLIPP
 
 //Red/Blue Cubes
 /obj/item/warp_cube

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -294,7 +294,7 @@
 	icon_state = "smallbottle"
 	item_state = "bottle"
 	list_reagents = list(/datum/reagent/water = 49.5, /datum/reagent/fluorine = 0.5)//see desc, don't think about it too hard
-	custom_materials = list(/datum/material/plastic=1000)
+	custom_materials = list(/datum/material/plastic=0)
 	volume = 50
 	amount_per_transfer_from_this = 10
 	fill_icon_thresholds = list(0, 10, 25, 50, 75, 80, 90)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -294,7 +294,7 @@
 	icon_state = "smallbottle"
 	item_state = "bottle"
 	list_reagents = list(/datum/reagent/water = 49.5, /datum/reagent/fluorine = 0.5)//see desc, don't think about it too hard
-	custom_materials = list(/datum/material/plastic=0)
+	custom_materials = list(/datum/material/plastic=1000)
 	volume = 50
 	amount_per_transfer_from_this = 10
 	fill_icon_thresholds = list(0, 10, 25, 50, 75, 80, 90)
@@ -394,7 +394,7 @@
 /obj/item/reagent_containers/glass/waterbottle/large
 	desc = "A fresh commercial-sized bottle of water."
 	icon_state = "largebottle"
-	custom_materials = list(/datum/material/glass=0)
+	custom_materials = list(/datum/material/plastic=3000)
 	list_reagents = list(/datum/reagent/water = 100)
 	volume = 100
 	amount_per_transfer_from_this = 20

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -294,7 +294,7 @@
 	icon_state = "smallbottle"
 	item_state = "bottle"
 	list_reagents = list(/datum/reagent/water = 49.5, /datum/reagent/fluorine = 0.5)//see desc, don't think about it too hard
-	custom_materials = list(/datum/material/glass=0)
+	custom_materials = list(/datum/material/plastic=1000)
 	volume = 50
 	amount_per_transfer_from_this = 10
 	fill_icon_thresholds = list(0, 10, 25, 50, 75, 80, 90)
@@ -403,6 +403,18 @@
 /obj/item/reagent_containers/glass/waterbottle/large/empty
 	list_reagents = list()
 	cap_on = FALSE
+
+// Admin spawn
+/obj/item/reagent_containers/glass/waterbottle/relic
+	name = "mysterious bottle"
+	desc = "A bottle quite similar to a water bottle, but with some words scribbled on with a marker. It seems to be radiating some kind of energy."
+	flip_chance = 100 // FLIPP
+
+/obj/item/reagent_containers/glass/waterbottle/relic/Initialize()
+	var/datum/reagent/random_reagent = get_random_reagent_id()
+	list_reagents = list(random_reagent = 50)
+	. = ..()
+	desc +=  "<span class='notice'>The writing reads '[random_reagent.name]'.</span>"
 
 /obj/item/pestle
 	name = "pestle"


### PR DESCRIPTION
## About The Pull Request

Examining water bottles no longer shows that they're made out of glass, instead they now show plastic as the material.

Removed the relic water bottle from the necropolis chest gamer loot pool, due to some people's justified salt, but made the bottle contain a random reagent for a possible future use in a lavaland ruin / something similar.

## Why It's Good For The Game

Miners no longer mad, fixes examine inconsistency

## Changelog
:cl:
del: Removed relic water bottle from necropolis chests
fix: Water bottles now show the correct material they're made of
/:cl: