### PR TITLE
Tgui source maps

### DIFF
--- a/tgui-next/README.md
+++ b/tgui-next/README.md
@@ -67,8 +67,10 @@ For MSys2, WSL, Linux or macOS users:
 - `bin/tgui` - build the project in production mode.
 - `bin/tgui --dev` - launch a development server, with live log collection,
 cache reloading and hot module replacement.
-- `bin/tgui --dev --reload-once` - reload byond cache once.
+- `bin/tgui --dev --reload` - reload byond cache once.
 - `bin/tgui --dev --debug` - run server with debug logging enabled.
+- `bin/tgui --dev --no-hot` - disable hot module replacement (helps when
+doing development on IE8).
 - `bin/tgui --lint` - show problems with the code.
 - `bin/tgui --lint --fix` - auto-fix problems with the code.
 - `bin/tgui --analyze` - run a bundle analyzer.

--- a/tgui-next/packages/tgui-dev-server/index.js
+++ b/tgui-next/packages/tgui-dev-server/index.js
@@ -1,16 +1,13 @@
-import { setupLink } from './link/server.js';
 import { setupWebpack, getWebpackConfig } from './webpack.js';
 import { reloadByondCache } from './reloader.js';
 
-const hot = process.platform === 'win32'
-  || process.argv.includes('--hot');
-
-const reloadOnce = process.argv.includes('--reload-once');
+const noHot = process.argv.includes('--no-hot');
+const reloadOnce = process.argv.includes('--reload');
 
 const setupServer = async () => {
   const config = await getWebpackConfig({
     mode: 'development',
-    hot,
+    hot: !noHot,
   });
   // Reload cache once
   if (reloadOnce) {
@@ -19,8 +16,7 @@ const setupServer = async () => {
     return;
   }
   // Run a development server
-  const link = setupLink();
-  await setupWebpack(link, config);
+  await setupWebpack(config);
 };
 
 setupServer();

--- a/tgui-next/packages/tgui-dev-server/link/client.js
+++ b/tgui-next/packages/tgui-dev-server/link/client.js
@@ -36,18 +36,27 @@ const subscribe = fn => subscribers.push(fn);
  * A json serializer which handles circular references and other junk.
  */
 const serializeObject = obj => {
-  let cache = [];
+  let refs = [];
   const json = JSON.stringify(obj, (key, value) => {
     if (typeof value === 'object' && value !== null) {
-      if (cache.indexOf(value) !== -1) {
+      // Circular reference
+      if (refs.includes(value)) {
         return '[circular ref]';
       }
-      cache.push(value);
+      refs.push(value);
+      // Error object
+      if (value instanceof Error) {
+        return {
+          __type__: 'error',
+          string: String(value),
+          stack: value.stack,
+        };
+      }
       return value;
     }
     return value;
   });
-  cache = null;
+  refs = null;
   return json;
 };
 

--- a/tgui-next/packages/tgui-dev-server/link/retrace.js
+++ b/tgui-next/packages/tgui-dev-server/link/retrace.js
@@ -1,0 +1,73 @@
+import { createLogger } from 'common/logging.js';
+import fs from 'fs';
+import { basename } from 'path';
+import SourceMap from 'source-map';
+import StackTraceParser from 'stacktrace-parser';
+import { resolveGlob } from '../util.js';
+
+const logger = createLogger('retrace');
+
+const { SourceMapConsumer } = SourceMap;
+const sourceMaps = [];
+
+export const loadSourceMaps = async bundleDir => {
+  // Destroy and garbage collect consumers
+  while (sourceMaps.length !== 0) {
+    const { consumer } = sourceMaps.shift();
+    consumer.destroy(consumer);
+  }
+  // Load new sourcemaps
+  const paths = await resolveGlob(bundleDir, '*.map');
+  for (let path of paths) {
+    try {
+      const file = basename(path).replace('.map', '');
+      const consumer = await new SourceMapConsumer(
+        JSON.parse(fs.readFileSync(path, 'utf8')));
+      sourceMaps.push({ file, consumer });
+    }
+    catch (err) {
+      logger.error(err);
+    }
+  }
+  logger.log(`loaded ${sourceMaps.length} source maps`);
+};
+
+export const retrace = stack => {
+  const header = stack.split('\n')[0];
+  const mappedStack = StackTraceParser.parse(stack)
+    .map(frame => {
+      if (!frame.file) {
+        return frame;
+      }
+      // Find the correct source map
+      const sourceMap = sourceMaps.find(sourceMap => {
+        return frame.file.includes(sourceMap.file);
+      });
+      if (!sourceMap) {
+        return frame;
+      }
+      // Map the frame
+      const { consumer } = sourceMap;
+      const mappedFrame = consumer.originalPositionFor({
+        source: basename(frame.file),
+        line: frame.lineNumber,
+        column: frame.column,
+      });
+      return {
+        ...frame,
+        file: mappedFrame.source,
+        lineNumber: mappedFrame.line,
+        column: mappedFrame.column,
+      };
+    })
+    .map(frame => {
+      // Stringify the frame
+      const { file, methodName, lineNumber } = frame;
+      const compactPath = file
+        .replace(/^webpack:\/\/\/?/, './')
+        .replace(/.*node_modules\//, '');
+      return `  at ${methodName} (${compactPath}:${lineNumber})`;
+    })
+    .join('\n');
+  return header + '\n' + mappedStack;
+};

--- a/tgui-next/packages/tgui-dev-server/package.json
+++ b/tgui-next/packages/tgui-dev-server/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "dependencies": {
     "glob": "^7.1.4",
+    "source-map": "^0.7.3",
+    "stacktrace-parser": "^0.1.7",
     "ws": "^7.1.2"
   }
 }

--- a/tgui-next/packages/tgui/index.js
+++ b/tgui-next/packages/tgui/index.js
@@ -33,8 +33,6 @@ const renderLayout = () => {
     const state = store.getState();
     // Initial render setup
     if (initialRender) {
-      initialRender = false;
-
       // ----- Old TGUI chain-loader: begin -----
       const route = getRoute(state);
       // Route was not found, load old TGUI
@@ -68,6 +66,7 @@ const renderLayout = () => {
       // ----- Old TGUI chain-loader: end -----
 
       logger.log('initial render', state);
+
       // Setup dragging
       setupDrag(state);
     }
@@ -77,7 +76,7 @@ const renderLayout = () => {
     render(element, reactRoot);
   }
   catch (err) {
-    logger.error('rendering error', err.stack || String(err));
+    logger.error('rendering error', err);
   }
   // Report rendering time
   if (process.env.NODE_ENV !== 'production') {
@@ -85,12 +84,14 @@ const renderLayout = () => {
     const diff = finishedAt - startedAt;
     const diffFrames = (diff / 16.6667).toFixed(2);
     logger.debug(`rendered in ${diff}ms (${diffFrames} frames)`);
-    if (window.__inception__) {
+    if (initialRender) {
       const diff = finishedAt - window.__inception__;
       const diffFrames = (diff / 16.6667).toFixed(2);
       logger.log(`fully loaded in ${diff}ms (${diffFrames} frames)`);
-      window.__inception__ = null;
     }
+  }
+  if (initialRender) {
+    initialRender = false;
   }
 };
 

--- a/tgui-next/packages/tgui/logging.js
+++ b/tgui-next/packages/tgui/logging.js
@@ -25,6 +25,9 @@ const log = (level, ns, ...args) => {
         if (typeof value === 'string') {
           return value;
         }
+        if (value instanceof Error) {
+          return value.stack || String(value);
+        }
         return JSON.stringify(value);
       })
       .filter(value => value)

--- a/tgui-next/packages/tgui/webpack.config.js
+++ b/tgui-next/packages/tgui/webpack.config.js
@@ -103,7 +103,6 @@ module.exports = (env = {}, argv) => {
     performance: {
       hints: false,
     },
-    // Unfortunately, source maps don't work with BYOND's IE.
     devtool: false,
     plugins: [
       new webpack.EnvironmentPlugin({
@@ -171,6 +170,7 @@ module.exports = (env = {}, argv) => {
     if (argv.hot) {
       config.plugins.push(new webpack.HotModuleReplacementPlugin());
     }
+    config.devtool = 'cheap-module-source-map';
     config.devServer = {
       // Informational flags
       progress: false,

--- a/tgui-next/yarn.lock
+++ b/tgui-next/yarn.lock
@@ -5509,6 +5509,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -5540,6 +5545,13 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
+
+stacktrace-parser@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/stacktrace-parser/-/stacktrace-parser-0.1.7.tgz#9ed005638a5e79dcf256611da1dfb4871e6fd14d"
+  integrity sha512-Evm+NuZ2ZTwGazsbsZC+EV1EGsvyxgIvtNwbyFfeXaq/8L78M5Kdh0qpmQaTkUpbOAKbbPP7c7qZa7u8XFsrUA==
+  dependencies:
+    type-fest "^0.7.1"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -5914,6 +5926,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-fest@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
+  integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
# About The Pull Request

> Depends on #47282, merge that before merging this.

- Enables source maps in webpack.
- Adds support for the log receiving side to retrace errors using source maps.
- Enables Webpack HMR for all platforms (including WSL), opt out using `--no-hot`.

## Why It's Good For The Game

Improved developer experience.

## Changelog
:cl:
tweak: tgui dev server can now show real stack traces using source maps.
/:cl:
