### PR TITLE
Request console announcements have deadchat broadcasts now.

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -267,6 +267,7 @@ GLOBAL_LIST_EMPTY(req_console_ckey_departments)
 		GLOB.news_network.SubmitArticle(message, department, "Station Announcements", null)
 		usr.log_talk(message, LOG_SAY, tag="station announcement from [src]")
 		message_admins("[ADMIN_LOOKUPFLW(usr)] has made a station announcement from [src] at [AREACOORD(usr)].")
+		deadchat_broadcast(" made a station announcement from <span class='name'>[get_area_name(usr, TRUE)]</span>.", "<span class='name'>[usr.real_name]</span>", usr)
 		announceAuth = FALSE
 		message = ""
 		screen = REQ_SCREEN_MAIN


### PR DESCRIPTION
## About The Pull Request

Request console announcements, like the ones in Head of Staff offices, have deadchat broadcasts. Fixes https://github.com/tgstation/tgstation/issues/40349. (I don't know if that's a bug per se, but.)

## Why It's Good For The Game

At least one person wanted it. 

## Changelog
:cl: bandit
tweak: Request console announcements, like the ones in Head of Staff offices, have deadchat broadcasts. 
/:cl: