### PR TITLE
Humanizing a monkey no longer yeets any buried smuggler's satchels from the tile onto their person.

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -206,8 +206,13 @@
 	invisibility = INVISIBILITY_MAXIMUM
 	new /obj/effect/temp_visual/monkeyify/humanify(loc)
 	sleep(22)
+
+
+	var/list/equippable_blacklist = typecacheof(list(/obj/item/storage/backpack/satchel/flat)) // stuff in human's loc we don't want equipped
 	var/mob/living/carbon/human/O = new( loc )
 	for(var/obj/item/C in O.loc)
+		if(is_type_in_typecache(C, equippable_blacklist))
+			continue
 		O.equip_to_appropriate_slot(C)
 
 	dna.transfer_identity(O)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -207,11 +207,9 @@
 	new /obj/effect/temp_visual/monkeyify/humanify(loc)
 	sleep(22)
 
-
-	var/list/equippable_blacklist = typecacheof(list(/obj/item/storage/backpack/satchel/flat)) // stuff in human's loc we don't want equipped
 	var/mob/living/carbon/human/O = new( loc )
 	for(var/obj/item/C in O.loc)
-		if(is_type_in_typecache(C, equippable_blacklist))
+		if(C.anchored)
 			continue
 		O.equip_to_appropriate_slot(C)
 


### PR DESCRIPTION
## About The Pull Request

Anchored items (like hidden smugglers' satchels) will not be moved to a mob's contents when they get humanized from monkey.

Fixes https://github.com/tgstation/tgstation/issues/39205.

## Why It's Good For The Game

bugfix 

## Changelog
:cl: bandit
fix: Humanizing a monkey no longer yeets any buried smuggler's satchels from the tile invisibly onto their person.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
