### PR TITLE
removes dead goose actions

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goose.dm
@@ -38,6 +38,8 @@
 
 /mob/living/simple_animal/hostile/retaliate/goose/handle_automated_movement()
 	. = ..()
+	if (stat == DEAD)
+		return
 	if(prob(5) && random_retaliate == TRUE)
 		Retaliate()
 
@@ -80,6 +82,8 @@
 		feed(O)
 
 /mob/living/simple_animal/hostile/retaliate/goose/vomit/proc/feed(obj/item/reagent_containers/food/tasty)
+	if (stat == DEAD) // plapatin I swear to god
+		return
 	if (contents.len > GOOSE_SATIATED)
 		visible_message("<span class='notice'>[src] looks too full to eat \the [tasty]!</span>")
 		return
@@ -93,6 +97,8 @@
 		visible_message("<span class='notice'>[src] refuses to eat \the [tasty].</span>")
 
 /mob/living/simple_animal/hostile/retaliate/goose/vomit/proc/vomit()
+	if (stat == DEAD)
+		return
 	var/turf/T = get_turf(src)
 	var/obj/item/reagent_containers/food/consumed = locate() in contents //Barf out a single food item from our guts
 	if (prob(50) && consumed)
@@ -102,6 +108,8 @@
 		T.add_vomit_floor(src)
 
 /mob/living/simple_animal/hostile/retaliate/goose/vomit/proc/barf_food(atom/A, hard = FALSE)
+	if (stat == DEAD)
+		return
 	if(!istype(A, /obj/item/reagent_containers/food))
 		return
 	var/turf/currentTurf = get_turf(src)
@@ -141,6 +149,8 @@
 	icon_state = initial(icon_state)
 
 /mob/living/simple_animal/hostile/retaliate/goose/vomit/proc/goosement(atom/movable/AM, OldLoc, Dir, Forced)
+	if(stat == DEAD)
+		return
 	if(vomiting)
 		vomit() // its supposed to keep vomiting if you move
 		return


### PR DESCRIPTION
## About The Pull Request

Vomitgeese can no longer vomit, feed, attack you, or do fucking anything when they're dead. Fixes https://github.com/tgstation/tgstation/issues/46724.

I probably put in too many checks but I hate this fucking bug

## Why It's Good For The Game

because it's a bug, and because we are having multiple page policy threads on when it is and is not appropriate to prevent the goose from vomiting, all of which are even more pointless than usual if you can't

in before people complaining

## Changelog
:cl: bandit
fix: Major victory for Nanotrasen! The Space Wizard Federation is no longer turning geese into vomiting necromancers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
