### PR TITLE
Removes standalone porta-turret covers from the derelict, which was causing runtimes.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -182,11 +182,30 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/porta_turret_cover,
+/obj/machinery/porta_turret/ai{
+	desc = "An obsolete model of turret, long non-functional.";
+	icon_state = "turretCover";
+	installation = null;
+	name = "broken turret";
+	stat = 1
+	},
+/obj/machinery/porta_turret/ai{
+	desc = "An obsolete model of turret, long non-functional.";
+	icon_state = "turretCover";
+	installation = null;
+	name = "broken turret";
+	stat = 1
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/ai_upload)
 "bg" = (
-/obj/machinery/porta_turret_cover,
+/obj/machinery/porta_turret/ai{
+	desc = "An obsolete model of turret, long non-functional.";
+	icon_state = "turretCover";
+	installation = null;
+	name = "broken turret";
+	stat = 1
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/ai_upload)
 "bh" = (
@@ -356,7 +375,13 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/bridge/ai_upload)
 "bP" = (
-/obj/machinery/porta_turret_cover,
+/obj/machinery/porta_turret/ai{
+	desc = "An obsolete model of turret, long non-functional.";
+	icon_state = "turretCover";
+	installation = null;
+	name = "broken turret";
+	stat = 1
+	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/ai_upload)
 "bQ" = (

--- a/code/game/machinery/porta_turret/portable_turret_cover.dm
+++ b/code/game/machinery/porta_turret/portable_turret_cover.dm
@@ -27,8 +27,6 @@
 	. = ..()
 	if(.)
 		return
-	if (!parent_turret)
-		return
 	return parent_turret.attack_ai(user)
 
 
@@ -36,14 +34,10 @@
 	. = ..()
 	if(.)
 		return
-	if (!parent_turret)
-		return
 	return parent_turret.attack_hand(user)
 
 
 /obj/machinery/porta_turret_cover/attackby(obj/item/I, mob/user, params)
-	if(!parent_turret)
-		return ..()
 	if(I.tool_behaviour == TOOL_WRENCH && !parent_turret.on)
 		if(parent_turret.raised)
 			return
@@ -77,31 +71,21 @@
 		return ..()
 
 /obj/machinery/porta_turret_cover/attacked_by(obj/item/I, mob/user)
-	if(!parent_turret)
-		return ..()
 	parent_turret.attacked_by(I, user)
 
 /obj/machinery/porta_turret_cover/attack_alien(mob/living/carbon/alien/humanoid/user)
-	if(!parent_turret)
-		return ..()
 	parent_turret.attack_alien(user)
 
 /obj/machinery/porta_turret_cover/attack_animal(mob/living/simple_animal/user)
-	if(!parent_turret)
-		return ..()
 	parent_turret.attack_animal(user)
 
 /obj/machinery/porta_turret_cover/attack_hulk(mob/living/carbon/human/user)
-	if(!parent_turret)
-		return ..()
 	return parent_turret.attack_hulk(user)
 
 /obj/machinery/porta_turret_cover/can_be_overridden()
 	. = 0
 
 /obj/machinery/porta_turret_cover/emag_act(mob/user)
-	if(!parent_turret)
-		return
 	if(!(parent_turret.obj_flags & EMAGGED))
 		to_chat(user, "<span class='notice'>You short out [parent_turret]'s threat assessment circuits.</span>")
 		visible_message("<span class='hear'>[parent_turret] hums oddly...</span>")

--- a/code/game/machinery/porta_turret/portable_turret_cover.dm
+++ b/code/game/machinery/porta_turret/portable_turret_cover.dm
@@ -27,7 +27,8 @@
 	. = ..()
 	if(.)
 		return
-
+	if (!parent_turret)
+		return
 	return parent_turret.attack_ai(user)
 
 
@@ -35,11 +36,14 @@
 	. = ..()
 	if(.)
 		return
-
+	if (!parent_turret)
+		return
 	return parent_turret.attack_hand(user)
 
 
 /obj/machinery/porta_turret_cover/attackby(obj/item/I, mob/user, params)
+	if(!parent_turret)
+		return ..()
 	if(I.tool_behaviour == TOOL_WRENCH && !parent_turret.on)
 		if(parent_turret.raised)
 			return
@@ -73,21 +77,31 @@
 		return ..()
 
 /obj/machinery/porta_turret_cover/attacked_by(obj/item/I, mob/user)
+	if(!parent_turret)
+		return ..()
 	parent_turret.attacked_by(I, user)
 
 /obj/machinery/porta_turret_cover/attack_alien(mob/living/carbon/alien/humanoid/user)
+	if(!parent_turret)
+		return ..()
 	parent_turret.attack_alien(user)
 
 /obj/machinery/porta_turret_cover/attack_animal(mob/living/simple_animal/user)
+	if(!parent_turret)
+		return ..()
 	parent_turret.attack_animal(user)
 
 /obj/machinery/porta_turret_cover/attack_hulk(mob/living/carbon/human/user)
+	if(!parent_turret)
+		return ..()
 	return parent_turret.attack_hulk(user)
 
 /obj/machinery/porta_turret_cover/can_be_overridden()
 	. = 0
 
 /obj/machinery/porta_turret_cover/emag_act(mob/user)
+	if(!parent_turret)
+		return
 	if(!(parent_turret.obj_flags & EMAGGED))
 		to_chat(user, "<span class='notice'>You short out [parent_turret]'s threat assessment circuits.</span>")
 		visible_message("<span class='hear'>[parent_turret] hums oddly...</span>")


### PR DESCRIPTION
## About The Pull Request

Removes all portable turret covers from the derelict and replaces them with nonfunctional turrets **with no guns**. Unless I fucked up the search these are the only standalone cover objects across the maps. Fixes https://github.com/tgstation/tgstation/issues/34929.

## Why It's Good For The Game

bug preventative measures

## Changelog
:cl: bandit
fix: The turrets on the derelict are less fucky.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
