### PR TITLE
remove warning lints from grep travis check

### DIFF
--- a/tools/travis/check_grep.sh
+++ b/tools/travis/check_grep.sh
@@ -18,9 +18,6 @@ if grep -P 'step_[xy]' _maps/**/*.dmm;	then
     echo "ERROR: step_x/step_y variables detected in maps, please remove them."
     st=1
 fi;
-if grep -P 'pixel_[xy] = 0' _maps/**/*.dmm;	then
-    echo "WARNING: pixel_x/pixel_y = 0 variables detected in maps, please review to ensure they are not dirty varedits."
-fi;
 if grep -P '\td[1-2] =' _maps/**/*.dmm;	then
     echo "ERROR: d1/d2 cable variables detected in maps, please remove them."
     st=1
@@ -40,9 +37,6 @@ fi;
 if pcregrep --buffer-size=100K -LMr '\n$' code/**/*.dm; then
     echo "ERROR: No newline at end of file detected"
     st=1
-fi;
-if grep -P '^/[\w/]\S+\(.*(var/|, ?var/.*).*\)' code/**/*.dm; then
-    echo "WARNING: changed files contains proc argument starting with 'var'"
 fi;
 if grep -i 'centcomm' code/**/*.dm; then
     echo "ERROR: Misspelling(s) of CENTCOM detected in code, please remove the extra M(s)."


### PR DESCRIPTION
I am sick and tired of having to help people wade through hundreds of lines of irrelevant output about vars that are warning only in order to find the actual errors.
