### PR TITLE
Makes ui_act() return a value to children

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -839,7 +839,8 @@ SUBSYSTEM_DEF(shuttle)
 	return data
 
 /datum/controller/subsystem/shuttle/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 
 	var/mob/user = usr

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -354,7 +354,8 @@
 
 
 /datum/component/personal_crafting/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("make")

--- a/code/datums/components/gps.dm
+++ b/code/datums/components/gps.dm
@@ -132,7 +132,8 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	return data
 
 /datum/component/gps/item/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("rename")

--- a/code/datums/spawners_menu.dm
+++ b/code/datums/spawners_menu.dm
@@ -35,7 +35,8 @@
 	return data
 
 /datum/spawners_menu/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 
 	var/group_name = params["name"]

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -254,7 +254,8 @@
 	return data
 
 /datum/wires/ui_act(action, params)
-	if(..() || !interactable(usr))
+	. = ..()
+	if(. || !interactable(usr))
 		return
 	var/target_wire = params["wire"]
 	var/mob/living/L = usr

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -209,7 +209,8 @@
 	return data
 
 /obj/machinery/sleeper/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	var/mob/living/mob_occupant = occupant
 	check_nap_violations()

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -130,7 +130,8 @@
 	return data
 
 /obj/machinery/computer/operating/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("change_menu")

--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -41,7 +41,8 @@
 	return data
 
 /obj/machinery/computer/atmos_alert/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("clear")

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -294,7 +294,8 @@ GLOBAL_LIST_EMPTY(atmos_air_controllers)
 	return data
 
 /obj/machinery/computer/atmos_control/tank/ui_act(action, params)
-	if(..() || !radio_connection)
+	. = ..()
+	if(. || !radio_connection)
 		return
 	var/datum/signal/signal = new(list("sigtype" = "command", "user" = usr))
 	switch(action)

--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -96,7 +96,8 @@
 	return data
 
 /obj/machinery/computer/launchpad/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("return")

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1409,7 +1409,8 @@
 	return data
 
 /obj/machinery/door/airlock/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	if(!user_allowed(usr))
 		return

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -41,7 +41,8 @@
 	return data
 
 /obj/item/electronics/airlock/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("clear_all")

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -207,7 +207,8 @@
 
 
 /obj/machinery/door_timer/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	. = TRUE
 

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -346,7 +346,8 @@
 	pad.doteleport(user, sending)
 
 /obj/item/launchpad_remote/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("right")

--- a/code/game/machinery/roulette_machine.dm
+++ b/code/game/machinery/roulette_machine.dm
@@ -81,7 +81,8 @@
 	return data
 
 /obj/machinery/roulette/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("anchor")

--- a/code/game/machinery/scan_gate.dm
+++ b/code/game/machinery/scan_gate.dm
@@ -163,7 +163,8 @@
 	return data
 
 /obj/machinery/scanner_gate/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("set_mode")

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -199,7 +199,8 @@
 	return data
 
 /obj/machinery/space_heater/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("power")

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -443,7 +443,8 @@
 	return data
 
 /obj/machinery/suit_storage_unit/ui_act(action, params)
-	if(..() || uv)
+	. = ..()
+	if(. || uv)
 		return
 	switch(action)
 		if("door")

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -98,7 +98,8 @@
 		ui.open()
 
 /obj/machinery/computer/mech_bay_power_console/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("reconnect")

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -302,7 +302,8 @@ GLOBAL_LIST_INIT(fluid_duct_recipes, list(
 	return data
 
 /obj/item/pipe_dispenser/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	if(!usr.canUseTopic(src, BE_CLOSE))
 		return

--- a/code/game/objects/items/eightball.dm
+++ b/code/game/objects/items/eightball.dm
@@ -199,7 +199,8 @@
 	return data
 
 /obj/item/toy/eightball/haunted/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	var/mob/user = usr
 

--- a/code/game/objects/items/implants/implantchair.dm
+++ b/code/game/objects/items/implants/implantchair.dm
@@ -55,7 +55,8 @@
 	return data
 
 /obj/machinery/implantchair/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("door")

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -175,7 +175,8 @@
 	return data
 
 /obj/item/tank/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("pressure")

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -82,7 +82,8 @@
 	return data
 
 /obj/structure/tank_dispenser/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("plasma")

--- a/code/modules/NTNet/relays.dm
+++ b/code/modules/NTNet/relays.dm
@@ -83,7 +83,8 @@
 
 
 /obj/machinery/ntnet_relay/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("restart")

--- a/code/modules/admin/verbs/borgpanel.dm
+++ b/code/modules/admin/verbs/borgpanel.dm
@@ -79,7 +79,8 @@
 
 
 /datum/borgpanel/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch (action)
 		if ("set_charge")

--- a/code/modules/antagonists/changeling/cellular_emporium.dm
+++ b/code/modules/antagonists/changeling/cellular_emporium.dm
@@ -57,7 +57,8 @@
 	return data
 
 /datum/cellular_emporium/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 
 	switch(action)

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -280,7 +280,8 @@
 	return data
 
 /obj/machinery/nuclearbomb/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("eject_disk")

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -368,7 +368,8 @@
 	return data
 
 /obj/machinery/airalarm/ui_act(action, params)
-	if(..() || buildstage != 2)
+	. = ..()
+	if(. || buildstage != 2)
 		return
 	if((locked && !usr.has_unlimited_silicon_privilege) || (usr.has_unlimited_silicon_privilege && aidisabled))
 		return

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -105,7 +105,8 @@ Passive gate is similar to the regular pump except:
 	return data
 
 /obj/machinery/atmospherics/components/binary/passive_gate/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("power")

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -111,7 +111,8 @@
 	return data
 
 /obj/machinery/atmospherics/components/binary/pump/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("power")

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -129,7 +129,8 @@
 	set_frequency(frequency)
 
 /obj/machinery/atmospherics/components/binary/volume_pump/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("power")

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -141,7 +141,8 @@
 	return data
 
 /obj/machinery/atmospherics/components/trinary/filter/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("power")

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -142,7 +142,8 @@
 	return data
 
 /obj/machinery/atmospherics/components/trinary/mixer/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("power")

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -387,7 +387,8 @@
 	return data
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("power")

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -145,7 +145,8 @@
 	return data
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 
 	switch(action)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -400,7 +400,8 @@
 	return data
 
 /obj/machinery/portable_atmospherics/canister/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("relabel")

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -107,7 +107,8 @@
 	return data
 
 /obj/machinery/portable_atmospherics/pump/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("power")

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -106,7 +106,8 @@
 			investigate_log("[key_name(user)] started a transfer into [holding].<br>", INVESTIGATE_ATMOS)
 
 /obj/machinery/portable_atmospherics/scrubber/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("power")

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -96,7 +96,8 @@ force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.adm
 	return data
 
 /datum/centcom_podlauncher/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		////////////////////////////UTILITIES//////////////////

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -100,7 +100,8 @@
 	return data
 
 /obj/machinery/computer/holodeck/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	. = TRUE
 	switch(action)

--- a/code/modules/language/language_menu.dm
+++ b/code/modules/language/language_menu.dm
@@ -61,7 +61,8 @@
 	return data
 
 /datum/language_menu/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	var/mob/user = usr
 	var/atom/movable/AM = language_holder.get_atom()

--- a/code/modules/library/lib_codex_gigas.dm
+++ b/code/modules/library/lib_codex_gigas.dm
@@ -65,7 +65,8 @@
 	ui_interact(reader)
 
 /obj/item/book/codex_gigas/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	if(!action)
 		return FALSE

--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -70,7 +70,8 @@ GLOBAL_LIST(labor_sheet_values)
 	return data
 
 /obj/machinery/mineral/labor_claim_console/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("claim_points")

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -248,7 +248,8 @@
 	return data
 
 /obj/machinery/mineral/ore_redemption/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	var/datum/component/material_container/mat_container = materials.mat_container
 	switch(action)

--- a/code/modules/mob/dead/observer/notificationprefs.dm
+++ b/code/modules/mob/dead/observer/notificationprefs.dm
@@ -39,7 +39,8 @@
 
 
 /datum/notificationpanel/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch (action)
 		if ("toggle_ignore")

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -328,7 +328,8 @@
 	return data
 
 /datum/action/innate/swap_body/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	var/mob/living/carbon/human/H = owner
 	if(!isslimeperson(owner))

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -202,7 +202,8 @@
 	return data
 
 /mob/living/simple_animal/bot/mulebot/ui_act(action, params)
-	if(..() || (locked && !usr.has_unlimited_silicon_privilege))
+	. = ..()
+	if(. || (locked && !usr.has_unlimited_silicon_privilege))
 		return
 	switch(action)
 		if("lock")

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -62,7 +62,8 @@
 
 // Handles user's GUI input
 /obj/item/modular_computer/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	var/obj/item/computer_hardware/hard_drive/hard_drive = all_components[MC_HDD]
 	switch(action)

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -33,7 +33,8 @@
 	return null
 
 /datum/computer_file/program/aidiag/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return TRUE
 
 	var/mob/living/silicon/ai/A = get_ai()

--- a/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
@@ -20,7 +20,8 @@
 	. = ..(user)
 
 /datum/computer_file/program/contract_uplink/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return 1
 
 	var/mob/living/user = usr

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -42,7 +42,8 @@
 	..()
 
 /datum/computer_file/program/ntnet_dos/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return 1
 	switch(action)
 		if("PRG_target_relay")

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -43,7 +43,8 @@
 
 
 /datum/computer_file/program/revelation/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return 1
 	switch(action)
 		if("PRG_arm")

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -95,7 +95,8 @@
 	return formatted
 
 /datum/computer_file/program/card_mod/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return 1
 
 	var/obj/item/computer_hardware/card_slot/card_slot

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -13,7 +13,8 @@
 	var/error
 
 /datum/computer_file/program/filemanager/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return 1
 
 	var/obj/item/computer_hardware/hard_drive/HDD = computer.all_components[MC_HDD]

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -89,7 +89,8 @@
 	download_completion += download_netspeed
 
 /datum/computer_file/program/ntnetdownload/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return 1
 	switch(action)
 		if("PRG_downloadfile")

--- a/code/modules/modular_computers/file_system/programs/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmonitor.dm
@@ -10,7 +10,8 @@
 	tgui_id = "ntos_net_monitor"
 
 /datum/computer_file/program/ntnetmonitor/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return 1
 	switch(action)
 		if("resetIDS")

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -21,7 +21,8 @@
 	username = "DefaultUser[rand(100, 999)]"
 
 /datum/computer_file/program/chatclient/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return 1
 
 	switch(action)

--- a/code/modules/modular_computers/file_system/programs/nttransfer.dm
+++ b/code/modules/modular_computers/file_system/programs/nttransfer.dm
@@ -84,7 +84,8 @@
 	download_completion = 0
 
 /datum/computer_file/program/nttransfer/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return 1
 	switch(action)
 		if("PRG_downloadfile")

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -108,7 +108,8 @@
 	return data
 
 /datum/computer_file/program/supermatter_monitor/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return TRUE
 
 	switch(action)

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -170,7 +170,8 @@
 
 
 /obj/machinery/lapvend/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return 1
 
 	switch(action)

--- a/code/modules/plumbing/plumbers/acclimator.dm
+++ b/code/modules/plumbing/plumbers/acclimator.dm
@@ -84,7 +84,8 @@
 	return data
 
 /obj/machinery/plumbing/acclimator/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	. = TRUE
 	switch(action)

--- a/code/modules/plumbing/plumbers/filter.dm
+++ b/code/modules/plumbing/plumbers/filter.dm
@@ -33,7 +33,8 @@
 	return data
 
 /obj/machinery/plumbing/filter/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	. = TRUE
 	switch(action)

--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -84,7 +84,8 @@
 	return data
 
 /obj/machinery/plumbing/pill_press/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	. = TRUE
 	switch(action)

--- a/code/modules/plumbing/plumbers/reaction_chamber.dm
+++ b/code/modules/plumbing/plumbers/reaction_chamber.dm
@@ -47,7 +47,8 @@
 	return data
 
 /obj/machinery/plumbing/reaction_chamber/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	. = TRUE
 	switch(action)

--- a/code/modules/plumbing/plumbers/splitters.dm
+++ b/code/modules/plumbing/plumbers/splitters.dm
@@ -33,7 +33,8 @@
 	return data
 
 /obj/machinery/plumbing/splitter/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	. = TRUE
 	switch(action)

--- a/code/modules/plumbing/plumbers/synthesizer.dm
+++ b/code/modules/plumbing/plumbers/synthesizer.dm
@@ -89,7 +89,8 @@
 	return data
 
 /obj/machinery/plumbing/synthesizer/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	. = TRUE
 	switch(action)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -918,7 +918,8 @@
 		. = UI_INTERACTIVE
 
 /obj/machinery/power/apc/ui_act(action, params)
-	if(..() || !can_use(usr, 1) || (locked && !usr.has_unlimited_silicon_privilege && !failure_timer))
+	. = ..()
+	if(. || !can_use(usr, 1) || (locked && !usr.has_unlimited_silicon_privilege && !failure_timer))
 		return
 	switch(action)
 		if("lock")

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -247,7 +247,8 @@
 	. =  data
 
 /obj/machinery/power/port_gen/pacman/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("toggle_power")

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -349,7 +349,8 @@
 	return data
 
 /obj/machinery/power/smes/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("tryinput")

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -366,7 +366,8 @@
 	return data
 
 /obj/machinery/power/solar_control/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("angle")

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -354,7 +354,8 @@
 	return data
 
 /obj/machinery/computer/turbine_computer/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("power-on")

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -215,7 +215,8 @@
 	return data
 
 /obj/machinery/chem_dispenser/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("amount")

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -117,7 +117,8 @@
 	return data
 
 /obj/machinery/chem_heater/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("power")

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -187,7 +187,8 @@
 	return data
 
 /obj/machinery/chem_master/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 
 	if(action == "eject")

--- a/code/modules/reagents/chemistry/machinery/chem_synthesizer.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_synthesizer.dm
@@ -22,7 +22,8 @@
 		ui.open()
 
 /obj/machinery/chem_dispenser/chem_synthesizer/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("ejectBeaker")

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -180,7 +180,8 @@
 	return data
 
 /obj/machinery/computer/pandemic/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("eject_beaker")

--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -129,7 +129,8 @@
 	return data
 
 /obj/machinery/smoke_machine/ui_act(action, params)
-	if(..() || !anchored)
+	. = ..()
+	if(. || !anchored)
 		return
 	switch(action)
 		if("purge")

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -303,7 +303,8 @@
 	return data
 
 /obj/machinery/disposal/bin/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 
 	switch(action)

--- a/code/modules/research/nanites/nanite_chamber_computer.dm
+++ b/code/modules/research/nanites/nanite_chamber_computer.dm
@@ -108,7 +108,8 @@
 	return data
 
 /obj/machinery/computer/nanite_chamber_control/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("toggle_lock")

--- a/code/modules/research/nanites/nanite_cloud_controller.dm
+++ b/code/modules/research/nanites/nanite_cloud_controller.dm
@@ -141,7 +141,8 @@
 	return data
 
 /obj/machinery/computer/nanite_cloud_controller/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("eject")

--- a/code/modules/research/nanites/nanite_hijacker.dm
+++ b/code/modules/research/nanites/nanite_hijacker.dm
@@ -94,7 +94,8 @@
 	return data
 
 /obj/item/nanite_hijacker/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("eject")

--- a/code/modules/research/nanites/nanite_program_hub.dm
+++ b/code/modules/research/nanites/nanite_program_hub.dm
@@ -87,7 +87,8 @@
 	return data
 
 /obj/machinery/nanite_program_hub/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("eject")

--- a/code/modules/research/nanites/nanite_programmer.dm
+++ b/code/modules/research/nanites/nanite_programmer.dm
@@ -73,7 +73,8 @@
 	return data
 
 /obj/machinery/nanite_programmer/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("eject")

--- a/code/modules/research/nanites/nanite_remote.dm
+++ b/code/modules/research/nanites/nanite_remote.dm
@@ -97,7 +97,8 @@
 	return data
 
 /obj/item/nanite_remote/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("set_code")
@@ -217,7 +218,8 @@
 	return data
 
 /obj/item/nanite_remote/comm/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("set_comm_code")

--- a/code/modules/ruins/spaceruin_code/TheDerelict.dm
+++ b/code/modules/ruins/spaceruin_code/TheDerelict.dm
@@ -138,7 +138,8 @@
 
 
 /obj/machinery/computer/vaultcontroller/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("togglelock")

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -58,7 +58,8 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 	return ..()
 
 /obj/machinery/keycard_auth/ui_act(action, params)
-	if(..() || waiting || !allowed(usr))
+	. = ..()
+	if(. || waiting || !allowed(usr))
 		return
 	switch(action)
 		if("red_alert")

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -240,7 +240,8 @@
 	return data
 
 /obj/machinery/computer/bsa_control/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("build")

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -215,7 +215,8 @@
 	return data
 
 /obj/machinery/dna_vault/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("gene")

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -52,7 +52,8 @@
 		ui.open()
 
 /obj/machinery/computer/sat_control/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("toggle")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This came up while porting tgui-next to TGMC, if you just use `if(..())` then child overrides won't function correctly as the return value isn't preserved.