### PR TITLE
Cleans up zone_sel and fixes init selection

### DIFF
--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -32,6 +32,6 @@
 	static_inventory += using
 
 	zone_select = new /obj/screen/zone_sel/alien()
-	zone_select.update_icon()
 	zone_select.hud = src
+	zone_select.update_icon()
 	static_inventory += zone_select

--- a/code/_onclick/hud/generic_dextrous.dm
+++ b/code/_onclick/hud/generic_dextrous.dm
@@ -46,8 +46,8 @@
 
 	zone_select = new /obj/screen/zone_sel()
 	zone_select.icon = ui_style
-	zone_select.update_icon()
 	zone_select.hud = src
+	zone_select.update_icon()
 	static_inventory += zone_select
 
 	using = new /obj/screen/area_creator

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -344,8 +344,8 @@
 
 	zone_select =  new /obj/screen/zone_sel()
 	zone_select.icon = ui_style
-	zone_select.update_icon()
 	zone_select.hud = src
+	zone_select.update_icon()
 	static_inventory += zone_select
 
 	for(var/obj/screen/inventory/inv in (static_inventory + toggleable_inventory))

--- a/code/_onclick/hud/monkey.dm
+++ b/code/_onclick/hud/monkey.dm
@@ -115,8 +115,8 @@
 
 	zone_select = new /obj/screen/zone_sel()
 	zone_select.icon = ui_style
-	zone_select.update_icon()
 	zone_select.hud = src
+	zone_select.update_icon()
 	static_inventory += zone_select
 
 	mymob.client.screen = list()

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -452,10 +452,10 @@
 	name = "damage zone"
 	icon_state = "zone_sel"
 	screen_loc = ui_zonesel
+	var/overlay_icon = 'icons/mob/screen_gen.dmi'
 	var/selecting = BODY_ZONE_CHEST
 	var/static/list/hover_overlays_cache = list()
 	var/hovering
-	var/mutable_appearance/selecting_appearance
 
 /obj/screen/zone_sel/Click(location, control,params)
 	if(isobserver(usr))
@@ -551,30 +551,21 @@
 
 	if(choice != selecting)
 		selecting = choice
+		hud?.mymob?.zone_selected = choice
 		update_icon()
 	
 	return TRUE
 
-/obj/screen/zone_sel/update_icon()
+/obj/screen/zone_sel/update_overlays()
 	. = ..()
-	cut_overlay(selecting_appearance)
-	selecting_appearance = mutable_appearance('icons/mob/screen_gen.dmi', "[selecting]")
-	add_overlay(selecting_appearance)
-	hud?.mymob?.zone_selected = selecting
+	. += mutable_appearance(overlay_icon, "[selecting]")
 
 /obj/screen/zone_sel/alien
 	icon = 'icons/mob/screen_alien.dmi'
-
-/obj/screen/zone_sel/alien/update_icon()
-	. = ..()
-	cut_overlay(selecting_appearance)
-	selecting_appearance = mutable_appearance('icons/mob/screen_alien.dmi', "[selecting]")
-	add_overlay(selecting_appearance)
-	hud?.mymob?.zone_selected = selecting
+	overlay_icon = 'icons/mob/screen_alien.dmi'
 
 /obj/screen/zone_sel/robot
 	icon = 'icons/mob/screen_cyborg.dmi'
-
 
 /obj/screen/flash
 	name = "flash"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -453,7 +453,6 @@
 	icon_state = "zone_sel"
 	screen_loc = ui_zonesel
 	var/overlay_icon = 'icons/mob/screen_gen.dmi'
-	var/selecting = BODY_ZONE_CHEST
 	var/static/list/hover_overlays_cache = list()
 	var/hovering
 
@@ -549,16 +548,17 @@
 	if(user != hud?.mymob)
 		return
 
-	if(choice != selecting)
-		selecting = choice
-		hud?.mymob?.zone_selected = choice
+	if(choice != hud.mymob.zone_selected)
+		hud.mymob.zone_selected = choice
 		update_icon()
 	
 	return TRUE
 
 /obj/screen/zone_sel/update_overlays()
 	. = ..()
-	. += mutable_appearance(overlay_icon, "[selecting]")
+	if(!hud?.mymob)
+		return
+	. += mutable_appearance(overlay_icon, "[hud.mymob.zone_selected]")
 
 /obj/screen/zone_sel/alien
 	icon = 'icons/mob/screen_alien.dmi'

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -41,7 +41,7 @@
 	*/
 
 	/// The zone this mob is currently targeting
-	var/zone_selected = null
+	var/zone_selected = BODY_ZONE_CHEST
 
 	var/computer_id = null
 	var/list/logging = list()


### PR DESCRIPTION
## About The Pull Request

Cleans up some previous changes I made before deciding on the more generic refactor of update_icon. In the process this deals with the bug where the starting selected zone wasn't working.

fixes  #47346 

## Changelog
:cl:
fix: Body targeting should work without any initial interaction again
/:cl:
