### PR TITLE
less log spam to mat explosions

### DIFF
--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -101,7 +101,10 @@
 /// Expldoe and remove the object
 /datum/component/explodable/proc/detonate()
 	var/atom/A = parent
-	explosion(A, devastation_range, heavy_impact_range, light_impact_range, flash_range) //epic explosion time
+	var/log = TRUE
+	if(light_impact_range < 1)
+		log = FALSE
+	explosion(A, devastation_range, heavy_impact_range, light_impact_range, flash_range, log) //epic explosion time
 	qdel(A)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevents shitloads of tiny <1 light impact explosions from spamming the logs any time any explosion goes off.

## Why It's Good For The Game

Less annoying of adminning and parsing of logs

## Changelog
:cl:
admin: material explosions with a <1 light impact no longer get logged. Less spam.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
