### PR TITLE
Variable definition path cleanup

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -84,12 +84,6 @@
 /obj/item/proc/onMouseUp(object, location, params, mob)
 	return
 
-/obj/item
-	var/canMouseDown = FALSE
-
-/obj/item/gun
-	var/automatic = 0 //can gun use it, 0 is no, anything above 0 is the delay between clicks in ds
-
 /obj/item/gun/CanItemAutoclick(object, location, params)
 	. = automatic
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -607,9 +607,6 @@ so as to remain in compliance with the most up-to-date laws."
 		mymob.client.screen |= alert
 	return 1
 
-/mob
-	var/list/alerts = list() // contains /obj/screen/alert only // On /mob so clientless mobs will throw alerts properly
-
 /obj/screen/alert/Click(location, control, params)
 	if(!usr || !usr.client)
 		return

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -1,7 +1,3 @@
-
-/mob
-	var/list/screens = list()
-
 /mob/proc/overlay_fullscreen(category, type, severity)
 	var/obj/screen/fullscreen/screen = screens[category]
 	if (!screen || screen.type != type)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -114,9 +114,6 @@ GLOBAL_LIST_INIT(available_ui_styles, sortList(list(
 
 	return ..()
 
-/mob
-	var/hud_type = /datum/hud
-
 /mob/proc/create_mob_hud()
 	if(!client || hud_used)
 		return

--- a/code/datums/soullink.dm
+++ b/code/datums/soullink.dm
@@ -1,24 +1,4 @@
 
-
-/mob/living
-	var/list/ownedSoullinks //soullinks we are the owner of
-	var/list/sharedSoullinks //soullinks we are a/the sharer of
-
-/mob/living/Destroy()
-	for(var/s in ownedSoullinks)
-		var/datum/soullink/S = s
-		S.ownerDies(FALSE)
-		qdel(s) //If the owner is destroy()'d, the soullink is destroy()'d
-	ownedSoullinks = null
-	for(var/s in sharedSoullinks)
-		var/datum/soullink/S = s
-		S.sharerDies(FALSE)
-		S.removeSoulsharer(src) //If a sharer is destroy()'d, they are simply removed
-	sharedSoullinks = null
-	return ..()
-
-
-
 //Keeps track of a Mob->Mob (potentially Player->Player) connection
 //Can be used to trigger actions on one party when events happen to another
 //Eg: shared deaths

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -11,9 +11,6 @@
 		if(A.attachable)
 			return TRUE
 
-/atom
-	var/datum/wires/wires = null
-
 /atom/proc/attempt_wire_interaction(mob/user)
 	if(!wires)
 		return WIRE_INTERACTION_FAIL

--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -1,9 +1,5 @@
 GLOBAL_LIST_EMPTY(active_alternate_appearances)
 
-
-/atom
-	var/list/alternate_appearances
-
 /atom/proc/remove_alt_appearance(key)
 	if(alternate_appearances)
 		for(var/K in alternate_appearances)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -77,6 +77,9 @@
 	///Modifier that raises/lowers the effect of the amount of a material, prevents small and easy to get items from being death machines.
 	var/material_modifier = 1
 
+	var/datum/wires/wires = null
+
+	var/list/alternate_appearances
 
 /**
   * Called when an atom is created in byond (built in engine proc)

--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -1,9 +1,5 @@
-
-
 GLOBAL_VAR_INIT(hsboxspawn, TRUE)
 
-/mob
-	var/datum/hSB/sandbox = null
 /mob/proc/CanBuild()
 	sandbox = new/datum/hSB
 	sandbox.owner = src.ckey

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -124,6 +124,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/list/grind_results //A reagent list containing the reagents this item produces when ground up in a grinder - this can be an empty list to allow for reagent transferring only
 	var/list/juice_results //A reagent list containing blah blah... but when JUICED in a grinder!
 
+	var/canMouseDown = FALSE
+
 
 /obj/item/Initialize()
 

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -17,11 +17,6 @@
 	//eg: "Bloody screen" > "goggles colour" as the former is much more important
 
 
-/mob
-	var/list/client_colours = list()
-
-
-
 /*
 	Adds an instance of colour_type to the mob's client_colours list
 	colour_type - a typepath (subtyped from /datum/client_colour)

--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -1,7 +1,4 @@
 
-/mob
-	var/bloody_hands = 0
-
 /obj/item/clothing/gloves
 	var/transfer_blood = 0
 

--- a/code/modules/keybindings/focus.dm
+++ b/code/modules/keybindings/focus.dm
@@ -1,6 +1,3 @@
-/mob
-	var/datum/focus //What receives our keyboard inputs. src by default
-
 /mob/proc/set_focus(datum/new_focus)
 	if(focus == new_focus)
 		return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1,6 +1,3 @@
-/mob/living/carbon
-	blood_volume = BLOOD_VOLUME_NORMAL
-
 /mob/living/carbon/Initialize()
 	. = ..()
 	create_reagents(1000)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon
+	blood_volume = BLOOD_VOLUME_NORMAL
 	gender = MALE
 	pressure_resistance = 15
 	possible_a_intents = list(INTENT_HELP, INTENT_HARM)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1,10 +1,3 @@
-/mob/living/carbon/human
-	name = "Unknown"
-	real_name = "Unknown"
-	icon = 'icons/mob/human.dmi'
-	icon_state = "human_basic"
-	appearance_flags = KEEP_TOGETHER|TILE_BOUND|PIXEL_SCALE
-
 /mob/living/carbon/human/Initialize()
 	verbs += /mob/living/proc/mob_sleep
 	verbs += /mob/living/proc/lay_down

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -1,4 +1,9 @@
 /mob/living/carbon/human
+	name = "Unknown"
+	real_name = "Unknown"
+	icon = 'icons/mob/human.dmi'
+	icon_state = "human_basic"
+	appearance_flags = KEEP_TOGETHER|TILE_BOUND|PIXEL_SCALE
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ID_HUD,WANTED_HUD,IMPLOYAL_HUD,IMPCHEM_HUD,IMPTRACK_HUD, NANITE_HUD, DIAG_NANITE_FULL_HUD,ANTAG_HUD,GLAND_HUD,SENTIENT_DISEASE_HUD)
 	hud_type = /datum/hud/human
 	possible_a_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -34,6 +34,16 @@
 	remove_from_all_data_huds()
 	GLOB.mob_living_list -= src
 	QDEL_LIST(diseases)
+	for(var/s in ownedSoullinks)
+		var/datum/soullink/S = s
+		S.ownerDies(FALSE)
+		qdel(s) //If the owner is destroy()'d, the soullink is destroy()'d
+	ownedSoullinks = null
+	for(var/s in sharedSoullinks)
+		var/datum/soullink/S = s
+		S.sharerDies(FALSE)
+		S.removeSoulsharer(src) //If a sharer is destroy()'d, they are simply removed
+	sharedSoullinks = null
 	return ..()
 
 /mob/living/onZImpact(turf/T, levels)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -118,3 +118,6 @@
 	var/list/disease_resistances = list()
 
 	var/slowed_by_drag = TRUE //Whether the mob is slowed down when dragging another prone mob
+
+	var/list/ownedSoullinks //soullinks we are the owner of
+	var/list/sharedSoullinks //soullinks we are a/the sharer of

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -194,3 +194,14 @@
 	var/registered_z = null
 
 	var/memory_throttle_time = 0
+
+	var/list/alerts = list() // contains /obj/screen/alert only // On /mob so clientless mobs will throw alerts properly
+	var/list/screens = list()
+	var/list/client_colours = list()
+	var/hud_type = /datum/hud
+
+	var/datum/hSB/sandbox = null
+
+	var/bloody_hands = 0
+
+	var/datum/focus //What receives our keyboard inputs. src by default

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -69,6 +69,8 @@
 	var/zoom_out_amt = 0
 	var/datum/action/toggle_scope_zoom/azoom
 
+	var/automatic = 0 //can gun use it, 0 is no, anything above 0 is the delay between clicks in ds
+
 /obj/item/gun/Initialize()
 	. = ..()
 	if(pin)


### PR DESCRIPTION
Moved several variable definitions to their object definitions.

This both makes it easier to check the default variables of a specific type, and makes the language server's go-to-definition functionality work.