### PR TITLE
wooden barricade wall runtime fix.

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -74,7 +74,8 @@
 			to_chat(user, "<span class='notice'>You start adding [I] to [src]...</span>")
 			if(do_after(user, 50, target=src))
 				W.use(5)
-				new /turf/closed/wall/mineral/wood/nonmetal(get_turf(src))
+				var/turf/T = get_turf(src)
+				T.PlaceOnTop(/turf/closed/wall/mineral/wood/nonmetal)
 				qdel(src)
 				return
 	return ..()


### PR DESCRIPTION
## About The Pull Request
Nonmetal wooden wall making was using no ChangeTurf() or PlaceOnTop(), thus breaking the turf lighting and angering LINDA.

## Why It's Good For The Game
Fixing an issue which I believe went unreported for more than a year, search shown nothing.

## Changelog
:cl:
fix: wooden barricade walls should break turf lighting no more.
/:cl:
