### PR TITLE
adds plumbing to box

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -22261,7 +22261,7 @@
 /area/crew_quarters/heads/captain)
 "bfF" = (
 /turf/closed/wall,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bfG" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -22617,7 +22617,7 @@
 	pixel_x = -27
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bgG" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway West";
@@ -22672,7 +22672,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bgQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -22746,19 +22746,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgZ" = (
+/obj/structure/cable,
 /obj/machinery/power/apc{
-	areastring = "/area/medical/chemistry";
+	areastring = "/area/medical/apothecary";
 	dir = 1;
-	name = "Chemistry APC";
+	name = "Apothecary APC";
+	pixel_x = 0;
 	pixel_y = 23
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bha" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bhb" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow{
@@ -22768,7 +22769,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bhc" = (
 /obj/machinery/camera{
 	c_tag = "Chemistry"
@@ -22778,7 +22779,7 @@
 	},
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bhd" = (
 /obj/machinery/chem_master,
 /obj/machinery/button/door{
@@ -22796,7 +22797,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bhe" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/white,
@@ -23320,7 +23321,7 @@
 "bin" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bio" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
@@ -23336,7 +23337,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bip" = (
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -23351,7 +23352,7 @@
 /obj/machinery/door/window/eastright{
 	dir = 8;
 	name = "Chemistry Desk";
-	req_access_txt = "33"
+	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -23359,18 +23360,17 @@
 	name = "Chemistry shutters"
 	},
 /turf/open/floor/plating,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bis" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/landmark/start/chemist,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bit" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
@@ -23862,7 +23862,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bjL" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -23888,7 +23888,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bjP" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 8
@@ -23899,7 +23899,7 @@
 "bjQ" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bjR" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -23919,7 +23919,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bjS" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24247,12 +24247,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bkL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bkM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -24440,7 +24440,7 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "blg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24462,7 +24462,7 @@
 	dir = 8;
 	icon_state = "left";
 	name = "Chemistry Desk";
-	req_access_txt = "33"
+	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -24470,7 +24470,7 @@
 	name = "Chemistry shutters"
 	},
 /turf/open/floor/plating,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bli" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -25027,10 +25027,6 @@
 /area/hallway/primary/central)
 "bmF" = (
 /obj/structure/table/glass,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/item/assembly/igniter{
 	pixel_x = -2;
 	pixel_y = 2
@@ -25064,7 +25060,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bmG" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow,
@@ -25072,7 +25068,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bmH" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -25091,7 +25087,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bmJ" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
@@ -25409,7 +25405,7 @@
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bnE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25615,7 +25611,7 @@
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "boc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -25634,7 +25630,7 @@
 /obj/item/folder/white,
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "boe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -26138,7 +26134,7 @@
 /obj/item/hand_labeler,
 /obj/item/stack/packageWrap,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bpu" = (
 /obj/structure/bed/roller,
 /obj/structure/extinguisher_cabinet{
@@ -26197,14 +26193,14 @@
 /area/hallway/primary/central)
 "bpD" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab";
-	req_access_txt = "5; 33"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Apothecary";
+	req_access_txt = "5; 59"
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bpE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26214,12 +26210,12 @@
 /obj/machinery/door/window/southleft{
 	dir = 1;
 	name = "Chemistry Desk";
-	req_access_txt = "33"
+	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bpG" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/genetics";
@@ -26277,7 +26273,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "bpN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -40904,6 +40900,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
+/obj/structure/closet/l3closet,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cdK" = (
@@ -40922,6 +40919,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/light/small,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cdN" = (
@@ -41132,26 +41131,18 @@
 "ceH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/maintenance/aft)
-"ceI" = (
 /obj/structure/sign/warning/biohazard,
-/turf/closed/wall,
-/area/maintenance/aft)
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
+"ceI" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/space/basic,
+/area/medical/chemistry)
 "ceJ" = (
 /obj/structure/disposalpipe/segment,
-/turf/closed/wall,
-/area/maintenance/aft)
-"ceK" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/closet/l3closet,
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"ceL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "ceM" = (
 /obj/machinery/meter,
 /obj/structure/disposalpipe/segment,
@@ -41294,36 +41285,35 @@
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "cfm" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/item/toy/minimeteor,
-/obj/item/poster/random_contraband,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/power/apc{
+	areastring = "/area/medical/chemistry";
+	dir = 1;
+	name = "Chemistry APC";
+	pixel_y = 23
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/head/welding,
+/obj/structure/cable,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cfn" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/reagent_containers/food/snacks/donkpocket,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cfo" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/roller,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/hand_labeler,
+/obj/structure/table/glass,
+/obj/structure/cable,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cfp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/c_tube,
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"cfq" = (
-/obj/structure/mopbucket,
-/obj/item/caution,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cfr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	external_pressure_bound = 140;
@@ -41510,58 +41500,49 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cgc" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/machinery/requests_console{
+	department = "Chemistry";
+	departmentType = 2;
+	pixel_x = -30;
+	receive_ore_updates = 1
 	},
-/area/maintenance/aft)
+/obj/item/wrench,
+/obj/item/wrench,
+/obj/structure/rack,
+/obj/item/construction/plumbing,
+/obj/item/construction/plumbing,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cgd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cge" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cgf" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"cgg" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"cgh" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cgi" = (
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "cgj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
 "cgk" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -41923,7 +41904,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
 "chq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -42298,21 +42279,17 @@
 /turf/open/space,
 /area/space/nearstation)
 "ciF" = (
-/obj/structure/table,
-/obj/item/cartridge/medical,
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"ciG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "ciH" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/item/latexballon,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "ciI" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -42571,11 +42548,12 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cjw" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/closet/secure_closet/chemical,
+/obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cjx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42583,24 +42561,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"cjy" = (
-/obj/structure/disposalpipe/segment,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "cjz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/closed/wall,
-/area/maintenance/aft)
-"cjA" = (
-/obj/structure/disposalpipe/segment,
-/obj/item/cigbutt/roach,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cjB" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -42863,19 +42831,21 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "ckl" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"ckm" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Biohazard Disposals";
-	req_access_txt = "12"
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"ckm" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "ckn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -43146,47 +43116,38 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "clk" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"cll" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"clm" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	dir = 1
+/obj/item/book/manual/wiki/grenades,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/item/book/manual/wiki/plumbing{
+	pixel_x = 4;
+	pixel_y = -4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cln" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"clo" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/meter,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "clp" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+/obj/machinery/camera{
+	c_tag = "Xenobiology Test Chamber";
+	network = list("xeno","rd")
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "clq" = (
 /obj/structure/rack,
 /obj/structure/disposalpipe/segment,
@@ -43380,39 +43341,26 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"cmg" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "cmh" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 2
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cmi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cmj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"cmk" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cml" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -43606,46 +43554,37 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"cnb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"cnc" = (
-/obj/machinery/light/small,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "cnd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cne" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cnf" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cng" = (
-/obj/machinery/light/small,
-/obj/structure/table,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/clipboard,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cnj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -43734,34 +43673,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"cnD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/closed/wall,
-/area/maintenance/aft)
 "cnE" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"cnF" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Waste Out"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"cnG" = (
-/obj/structure/closet/emcloset,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cnH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -43854,11 +43771,6 @@
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"cot" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "cou" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -44680,11 +44592,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"csc" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/space,
-/area/maintenance/aft)
 "csd" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -44728,11 +44635,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "csm" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/maintenance/aft)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "csn" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/space,
@@ -46677,11 +46582,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"czI" = (
-/obj/item/wrench,
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
 "czJ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 1
@@ -46819,9 +46719,9 @@
 /area/maintenance/starboard/aft)
 "cAe" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cAf" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -48781,6 +48681,9 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"cMl" = (
+/turf/open/space,
+/area/space/nearstation)
 "cMm" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -49317,6 +49220,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"djq" = (
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "dqu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -49474,6 +49381,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"efK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "eja" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/nanite_chamber_control{
@@ -49651,6 +49564,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"fPm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "fXM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -49820,6 +49742,14 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"haX" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "hcE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -49848,6 +49778,12 @@
 	dir = 5
 	},
 /area/science/research)
+"hpH" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "hAK" = (
 /obj/structure/table,
 /obj/item/storage/box/disks_nanite,
@@ -49865,6 +49801,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"hJq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "5; 33"
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "hQK" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -49883,6 +49827,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"hTU" = (
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "hYR" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plating,
@@ -49907,6 +49854,13 @@
 	dir = 4
 	},
 /area/science/explab)
+"igT" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "ijc" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -49955,6 +49909,15 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"iKL" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"iMP" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/chemist,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "iNn" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room"
@@ -50014,6 +49977,14 @@
 	},
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
+"jox" = (
+/obj/machinery/chem_dispenser,
+/obj/machinery/camera{
+	c_tag = "Engineering Storage";
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "joy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -50043,6 +50014,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"jsP" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "jxy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50123,6 +50100,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jVL" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/medical/apothecary)
 "jYO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -50141,6 +50122,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"kdR" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "keW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/sorting/mail{
@@ -50261,7 +50249,6 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/landmark/start/chemist,
 /obj/machinery/button/door{
 	id = "chemistry_shutters";
 	name = "Chemistry shutters";
@@ -50274,7 +50261,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "kGS" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
@@ -50396,12 +50383,16 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "lqJ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"lrg" = (
+/obj/effect/landmark/start/chemist,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "ltd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -50425,6 +50416,12 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"lwc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "lxd" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
@@ -50541,6 +50538,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lZN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "mdr" = (
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
@@ -50549,6 +50555,9 @@
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"mtK" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/starboard/aft)
 "muM" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -50628,6 +50637,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"mSR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "nbv" = (
 /turf/closed/wall,
 /area/science/explab)
@@ -50707,6 +50722,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"nEk" = (
+/obj/machinery/chem_master,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "nEm" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 8;
@@ -50751,7 +50770,7 @@
 /obj/structure/closet/secure_closet/chemical,
 /obj/item/radio/headset/headset_med,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/apothecary)
 "nRG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -50898,6 +50917,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"owD" = (
+/turf/open/floor/plasteel/white,
+/area/medical/apothecary)
 "ozs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -50906,6 +50928,13 @@
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"oBu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "oDF" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
@@ -50965,6 +50994,13 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"oZc" = (
+/obj/machinery/camera{
+	c_tag = "Chapel South";
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "pfj" = (
 /obj/machinery/power/apc{
 	areastring = "/area/storage/tools";
@@ -51077,6 +51113,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"pxd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "pzA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -51105,6 +51147,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"pAR" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/apothecary)
 "pDu" = (
 /obj/machinery/computer/nanite_cloud_controller,
 /obj/effect/turf_decal/bot,
@@ -51296,6 +51345,18 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"qBr" = (
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "qGG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -51365,6 +51426,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"rFI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"rGg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/maintenance/starboard/aft)
 "rHZ" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -51423,6 +51492,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"rZB" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "rZR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -51887,6 +51962,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"uDP" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "uES" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -52006,6 +52085,10 @@
 	dir = 8
 	},
 /area/science/research)
+"vjm" = (
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "vkD" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -52138,6 +52221,9 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"vOY" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/aft)
 "vPE" = (
 /obj/item/assembly/signaler{
 	pixel_y = 8
@@ -52160,6 +52246,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"vQQ" = (
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = 10
+	},
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "wba" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -52237,6 +52331,12 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"wBC" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "wHs" = (
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
@@ -52276,6 +52376,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"wRd" = (
+/turf/open/space/basic,
+/area/space/nearstation)
 "wUs" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -52333,6 +52436,24 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"xfL" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/glass/bottle/multiver{
+	pixel_x = 7;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "xhV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -52405,6 +52526,13 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xUg" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "xUZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -52418,6 +52546,12 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/engine,
 /area/science/explab)
+"xYA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "xYY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -86789,12 +86923,12 @@ aYV
 aYV
 bfF
 bhc
-bip
+owD
 bgP
-bjL
+jVL
 bkL
-bmT
-bjL
+pAR
+jVL
 bpM
 bqT
 bFD
@@ -87046,9 +87180,9 @@ aYV
 ber
 bfF
 bhb
-bip
+owD
 bjO
-bip
+owD
 bmG
 lhu
 bnC
@@ -89668,7 +89802,7 @@ cfj
 aoV
 aoV
 aoV
-aoV
+aaa
 aoV
 aoV
 aoV
@@ -90438,7 +90572,7 @@ csq
 xEu
 wHz
 cmd
-cmd
+cos
 cmd
 aag
 aag
@@ -91456,19 +91590,19 @@ bzs
 bzs
 bzs
 bzs
-cfj
-cfj
-cfj
-cfj
+cmd
+cmd
+cmd
+cmd
 cjx
-cfl
-cfl
+dqu
+dqu
 dqu
 tXL
 cmd
-cos
 cmd
-czI
+cmd
+cmd
 aag
 aag
 aag
@@ -91712,20 +91846,20 @@ bKL
 keW
 cbM
 cdJ
-bzs
+hTU
 cfm
 cgc
-bAw
+qBr
 ciF
 cjw
 ckl
 clk
-clk
-bAw
-bzs
-aaf
-aaa
-aaf
+xfL
+vQQ
+jox
+nEk
+djq
+hTU
 aaf
 aaf
 aaa
@@ -91971,19 +92105,19 @@ ccI
 cdL
 ceI
 cfo
-bAw
-bAw
-bAw
+bip
+lrg
+bip
 cjz
-ceJ
-clm
-cmg
-cnc
-cnD
-bzs
-aaf
-aaf
-aaa
+iMP
+bjL
+bjL
+bjL
+cmi
+bip
+bip
+hTU
+wRd
 aaa
 aaa
 aaa
@@ -92229,18 +92363,18 @@ cdK
 ceH
 cfn
 cgd
-ceJ
-ccM
-cjy
-ceJ
-cll
-ccM
-cnb
-bHd
-ceI
-aaa
-aaa
-aaa
+bjL
+bjL
+bjL
+bjL
+bjL
+bjL
+cmi
+xYA
+bip
+uDP
+vjm
+wRd
 aaa
 aaa
 aaa
@@ -92484,20 +92618,20 @@ bzs
 ccK
 ccM
 ceJ
-ceJ
+kdR
 cgf
-ceJ
-ccM
-ccM
-ceJ
-clo
+bjL
+bjL
+bjL
+bjL
+bjL
 cmi
-cbQ
-cnF
-cot
-csc
+xYA
+xYA
+bip
+bip
 csm
-aaa
+wRd
 aaa
 aaa
 aaa
@@ -92740,21 +92874,21 @@ caP
 cbO
 ccJ
 bLS
-bLS
+hJq
 cfp
 cge
-cbK
-ciG
-bLS
+cfp
+cfp
+cfp
 ckm
 cln
 cmh
 cnd
 cnE
-bPn
-aoV
-aoV
-aaa
+bip
+bip
+csm
+cMl
 aaa
 aaa
 aaa
@@ -92997,21 +93131,21 @@ caR
 bzs
 ccL
 ccM
-ceL
 ceJ
-cgh
-ceJ
-ceJ
-ccM
-ceJ
+xUg
+cgf
+bjL
+bjL
+bjL
+igT
 cAe
 cmj
 cne
-bHd
-bPn
-aaa
-aaa
-aaa
+xYA
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -93254,21 +93388,21 @@ bzs
 bzs
 bJs
 bFr
-ceK
 ceJ
-cgg
-ccM
-ccM
-cjA
-ceJ
-ccM
-cdN
-bFr
-cnG
-bzs
-aaa
-aaa
-aaa
+bjL
+cgf
+bjL
+bmT
+bjL
+bjL
+bjL
+lwc
+fPm
+lwc
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -93511,21 +93645,21 @@ caS
 caO
 ccN
 bHd
-bzs
-bzs
-bKT
-bAw
-bAw
-bFr
-ceJ
-ccM
-ccM
+hTU
+bip
+rZB
+rFI
+jsP
+oBu
+cfn
+cfn
+cgd
 cng
-bzs
-bzs
-aaa
-aaa
-aaa
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -93768,21 +93902,21 @@ bJs
 bFr
 ccM
 cdN
-bzs
-cfq
-bKT
-bAw
+hTU
+bip
+mSR
+haX
 ciH
-bHd
-bzs
-bAw
-cmk
+xYA
+hpH
+bip
+mSR
 cnf
-bzs
-aaa
-aaa
-aaa
-aaa
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -94025,21 +94159,21 @@ pjk
 qae
 cNY
 cNY
-cNY
-cNY
+rGg
+rGg
 cgj
-cNY
-cNY
+rGg
+rGg
 chp
-bzs
+vOY
 clp
-bzs
-bzs
-bzs
-aaf
-aaa
-aaa
-aaa
+mSR
+cnf
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -94288,15 +94422,15 @@ cnH
 nXU
 jCq
 czY
-cNW
-bAw
-bAw
-clp
-aag
-aaa
-aaa
-aaa
-aaa
+mtK
+bip
+mSR
+lZN
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -94545,15 +94679,15 @@ cNW
 cNW
 ccq
 czY
-cNW
-bPn
-bPn
-bPn
-aag
-aaa
-aaa
-aaa
-aaa
+mtK
+bip
+mSR
+cnf
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -94803,14 +94937,14 @@ cNW
 ccq
 czY
 cOT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bip
+mSR
+cnf
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -95060,14 +95194,14 @@ cOT
 ccq
 czY
 cOT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bip
+mSR
+efK
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -95317,14 +95451,14 @@ cOT
 ccq
 czY
 cOT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bip
+mSR
+bip
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -95573,15 +95707,15 @@ aaa
 cNW
 ccq
 czY
-cNW
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mtK
+wBC
+mSR
+bip
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -95830,15 +95964,15 @@ aaa
 cNW
 cBN
 czY
-cNW
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mtK
+bip
+mSR
+bip
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -96088,14 +96222,14 @@ cOT
 ccq
 cAa
 cOT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bip
+pxd
+bip
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -96345,14 +96479,14 @@ czQ
 czU
 czZ
 cOT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bip
+bip
+bip
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -96602,14 +96736,14 @@ cOT
 cgm
 czY
 cOT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bip
+bip
+bip
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -96858,15 +96992,15 @@ aaa
 cNW
 cgm
 czY
-cNW
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mtK
+bip
+bip
+bip
+bip
+bip
+bip
+csm
+wRd
 aaa
 aaa
 aaa
@@ -97115,15 +97249,15 @@ aaa
 cNW
 cgm
 czY
+mtK
+bip
+bip
+bip
+bip
+iKL
+bip
+hTU
 cNW
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cOT
 cOT
 cOT
 aag
@@ -97373,14 +97507,14 @@ cOT
 cgm
 czY
 cOT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cOT
+bip
+bip
+bip
+bip
+bip
+bip
+hTU
+cNW
 cOe
 cqu
 aag
@@ -97630,14 +97764,14 @@ cOT
 cgm
 czY
 cOT
-aaf
-aaf
-aaf
-aaf
-aaf
+bip
+bip
+bip
+bip
+bip
+mtK
+mtK
 cNW
-cNW
-cOT
 cqu
 cOT
 aag
@@ -97887,12 +98021,12 @@ cOT
 cgm
 czY
 cOT
-aaa
-aaa
-aaa
-aaf
-aaf
-cNW
+bip
+bip
+oZc
+hpH
+bip
+mtK
 cwy
 cmn
 cmn
@@ -98143,13 +98277,13 @@ cNW
 cNW
 czX
 cAc
-cNW
-cNW
-cNW
-cNW
-cNW
-cNW
-cNW
+mtK
+mtK
+mtK
+mtK
+mtK
+mtK
+mtK
 cmn
 cmn
 cmn


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

This just adds a plumbing room to box very similar to meta's, and of course makes old chemistry the 'apothecary' that should totally be called the pharmacy. 
![image](https://user-images.githubusercontent.com/18406892/67635293-8cf50d00-f89b-11e9-8816-558a19b6fb16.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Time-green probably woulda added this if they weren't exhausted, every map should have the new plumbing. I had to slip it into maint below medbay, but I don't see that as much an issue. A bit of traffic from chemists going through a strip of maint should add """conflict""" but that died long ago.

Here's hoping I didn't screw up the map merger.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Boxstation has a large chemistry room in maintenance similarly to metastation, and the old chemistry was made into the apothecary.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
