### PR TITLE
Optimizes duct reconnecting

### DIFF
--- a/code/datums/ductnet.dm
+++ b/code/datums/ductnet.dm
@@ -14,19 +14,20 @@
 ///Remove a duct from our network and commit suicide, because this is probably easier than to check who that duct was connected to and what part of us was lost
 /datum/ductnet/proc/remove_duct(obj/machinery/duct/ducting)
 	destroy_network(FALSE)
-	for(var/A in ducting.neighbours)
-		var/obj/machinery/duct/D = A
-		D.attempt_connect() //we destroyed the network, so now we tell the disconnected ducts neighbours they can start making a new ductnet
+	for(var/obj/machinery/duct/D in ducting.neighbours)
+		addtimer(CALLBACK(D, /obj/machinery/duct/proc/reconnect), 0) //all needs to happen after the original duct that was destroyed finishes destroying itself
+		addtimer(CALLBACK(D, /obj/machinery/duct/proc/generate_connects), 0)
 	qdel(src)
 ///add a plumbing object to either demanders or suppliers
 /datum/ductnet/proc/add_plumber(datum/component/plumbing/P, dir)
 	if(!P.can_add(src, dir))
-		return
+		return FALSE
 	P.ducts[num2text(dir)] = src
 	if(dir & P.supply_connects)
 		suppliers += P
 	else if(dir & P.demand_connects)
 		demanders += P
+	return TRUE
 ///remove a plumber. we dont delete ourselves because ductnets dont persist through plumbing objects
 /datum/ductnet/proc/remove_plumber(datum/component/plumbing/P)
 	suppliers.Remove(P) //we're probably only in one of these, but Remove() is inherently sane so this is fine

--- a/code/modules/plumbing/ducts.dm
+++ b/code/modules/plumbing/ducts.dm
@@ -198,8 +198,7 @@ All the important duct code:
 		D.neighbours[src] = turn(direction, 180)
 ///remove all our neighbours, and remove us from our neighbours aswell
 /obj/machinery/duct/proc/lose_neighbours()
-	for(var/A in neighbours)
-		var/obj/machinery/duct/D = A
+	for(var/obj/machinery/duct/D in neighbours)
 		D.neighbours.Remove(src)
 	neighbours = list()
 ///add a connect direction

--- a/code/modules/plumbing/ducts.dm
+++ b/code/modules/plumbing/ducts.dm
@@ -93,7 +93,7 @@ All the important duct code:
 
 	if(!dumb && D.dumb && !(opposite_dir & D.connects))
 		return
-	if(dumb && D.dumb && !(connects & D.connects)) //we eliminated a few more scenario in attempt connect
+	if(dumb && D.dumb && !(connects & D.connects)) //we eliminated a few more scenarios in attempt connect
 		return
 
 	if((duct == D.duct) && duct)//check if we're not just comparing two null values
@@ -120,7 +120,14 @@ All the important duct code:
 			create_duct()
 			duct.add_duct(D)
 	add_neighbour(D)
-	D.attempt_connect()//tell our buddy its time to pass on the torch of connecting to pipes. This shouldn't ever infinitely loop since it only works on pipes that havent been inductrinated
+	//tell our buddy its time to pass on the torch of connecting to pipes. This shouldn't ever infinitely loop since it only works on pipes that havent been inductrinated
+	if(!neighbours.len) //we have not yet connected to anyone, that only happens at roundstart
+		D.attempt_connect() 
+	else //kinda shitty, but this way we properly connect without going through unnecessary checks 
+		D.add_neighbour(src)
+		D.add_connects(opposite_dir) 
+		D.update_icon()
+
 	return TRUE
 ///connect to a plumbing object
 /obj/machinery/duct/proc/connect_plumber(datum/component/plumbing/P, direction)


### PR DESCRIPTION
closes #47392 
Plumbing ducts work fine one by one, but byond mistakes it for an infinite loop when reconnecting giant parts of ducts.

I added a simple reconnect function that handles reconnecting, but does it disturbingly faster by just using already established connections. 

You could probably still get a false infinite recursion runtime by placing down 10,000 ducts next to each other. Looking at you tlal.

:cl:
fix: fixes duct networks in the > 50 glitching out when unwrenching
/:cl:

