### PR TITLE
Fixes security camera upgrades

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -195,12 +195,42 @@
 	update_icon()
 	return TRUE
 
+/obj/machinery/camera/crowbar_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(!panel_open)
+		return
+	var/list/droppable_parts = list()
+	if(assembly.xray_module)
+		droppable_parts += assembly.xray_module
+	if(assembly.emp_module)
+		droppable_parts += assembly.emp_module
+	if(assembly.proxy_module)
+		droppable_parts += assembly.proxy_module
+	if(!droppable_parts.len)
+		return
+	var/obj/item/choice = input(user, "Select a part to remove:", src) as null|obj in sortNames(droppable_parts)
+	if(!choice || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+		return
+	to_chat(user, "<span class='notice'>You remove [choice] from [src].</span>")
+	if(choice == assembly.xray_module)
+		assembly.drop_upgrade(assembly.xray_module)
+		removeXRay()
+	if(choice == assembly.emp_module)
+		assembly.drop_upgrade(assembly.emp_module)
+		removeEmpProof()
+	if(choice == assembly.proxy_module)
+		assembly.drop_upgrade(assembly.proxy_module)
+		removeMotion()
+	I.play_tool_sound(src)
+	return TRUE
+
 /obj/machinery/camera/wirecutter_act(mob/living/user, obj/item/I)
 	. = ..()
 	if(!panel_open)
 		return
 	toggle_cam(user, 1)
 	obj_integrity = max_integrity //this is a pretty simplistic way to heal the camera, but there's no reason for this to be complex.
+	stat &= ~BROKEN
 	I.play_tool_sound(src)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Adds crowbar_act to machinery/camera
Also, added `stat &= ~BROKEN` to wirecutter_act
Fixes #47224 
Fixes #46754 

## Changelog
:cl: Neotw
fix: You can now remove an upgrade from a security camera as it should
/:cl:

tested locally without any issue