### PR TITLE
Removes unused & undefined spans

### DIFF
--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -2506,7 +2506,7 @@
 "gD" = (
 /turf/open/chasm{
 	color = "#000000";
-	desc = "<span class='neovgre'>Leave this place, insect.</span>";
+	desc = "<span class='boldwarning'>Leave this place, insect.</span>";
 	name = "Abyss"
 	},
 /area/awaymission/cabin/caves/mountain)
@@ -2562,7 +2562,7 @@
 /area/awaymission/cabin/caves/mountain)
 "gI" = (
 /obj/structure/signpost/salvation{
-	desc = "<span class='neovgre_small'>Come closer, insect.</span>";
+	desc = "<span class='danger'>Come closer, insect.</span>";
 	icon = 'icons/mob/nest.dmi';
 	icon_state = "nether";
 	max_integrity = 99999;
@@ -2995,7 +2995,7 @@
 "hJ" = (
 /obj/item/storage/book/bible{
 	deity_name = "Netherworld";
-	desc = "<span class='shadowling'>Suffering and pain waits for you.<br> Death will not be your end for, with every step you take, your soul moves closer to me.<br> Your darkest fears will soon be realized. <br>There is nowhere to run, for I am <b>everywhere.</b> </span>";
+	desc = "<span class='danger'>Suffering and pain waits for you.<br> Death will not be your end for, with every step you take, your soul moves closer to me.<br> Your darkest fears will soon be realized. <br>There is nowhere to run, for I am <b>everywhere.</b> </span>";
 	icon_state = "tome";
 	name = "Void Tome"
 	},

--- a/code/datums/components/fantasy/_fantasy.dm
+++ b/code/datums/components/fantasy/_fantasy.dm
@@ -73,7 +73,7 @@
 		alignment |= AFFIX_GOOD
 	if(quality <= 0)
 		alignment |= AFFIX_EVIL
-	
+
 	var/usedSlots = NONE
 	for(var/i in 1 to max(1, abs(quality))) // We want at least 1 affix applied
 		var/datum/fantasy_affix/affix = pickweight(affixListing)
@@ -88,7 +88,7 @@
 
 /datum/component/fantasy/proc/modify()
 	var/obj/item/master = parent
-	
+
 	master.force = max(0, master.force + quality)
 	master.throwforce = max(0, master.throwforce + quality)
 	master.armor = master.armor?.modifyAllRatings(quality)
@@ -103,7 +103,7 @@
 
 	if(canFail && prob((quality - 9)*10))
 		var/turf/place = get_turf(parent)
-		place.visible_message("<span class='danger'>[parent] <span class='inathneq_large'>violently glows blue</span> for a while, then evaporates.</span>")
+		place.visible_message("<span class='danger'>[parent] <span class='blue'>violently glows blue</span> for a while, then evaporates.</span>")
 		master.burn()
 		return
 	else if(announce)
@@ -135,6 +135,6 @@
 		effect_description = "<span class='heavy_brass'>shimmering golden glow</span>"
 	else
 		span = "<span class='danger'>"
-		effect_description = "<span class='umbra_emphasis'>mottled black glow</span>"
+		effect_description = "<span class='bold'>mottled black glow</span>"
 
 	location.visible_message("[span][originalName] is covered by a [effect_description] and then transforms into [parent]!</span>")

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -448,7 +448,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 							updateUsrDialog()
 							break
 					if(!jobdatum)
-						to_chat(usr, "<span class='error'>No log exists for this job.</span>")
+						to_chat(usr, "<span class='alert'>No log exists for this job.</span>")
 						updateUsrDialog()
 						return
 					if(inserted_modify_id.registered_account)
@@ -463,7 +463,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 				inserted_modify_id.assignment = "Unassigned"
 				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			else
-				to_chat(usr, "<span class='error'>You are not authorized to demote this position.</span>")
+				to_chat(usr, "<span class='alert'>You are not authorized to demote this position.</span>")
 		if ("reg")
 			if (authenticated)
 				var/t2 = inserted_modify_id
@@ -473,7 +473,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 						inserted_modify_id.registered_name = newName
 						playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 					else
-						to_chat(usr, "<span class='error'>Invalid name entered.</span>")
+						to_chat(usr, "<span class='alert'>Invalid name entered.</span>")
 						updateUsrDialog()
 						return
 		if ("mode")

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -15,15 +15,15 @@
 		if(stat & (NOPOWER|BROKEN|MAINT))
 			return
 		if(!current)
-			to_chat(user, "<span class='caution'>You haven't selected anything to transmit laws to!</span>")
+			to_chat(user, "<span class='alert'>You haven't selected anything to transmit laws to!</span>")
 			return
 		if(!can_upload_to(current))
-			to_chat(user, "<span class='caution'>Upload failed!</span> Check to make sure [current.name] is functioning properly.")
+			to_chat(user, "<span class='alert'>Upload failed! Check to make sure [current.name] is functioning properly.</span>")
 			current = null
 			return
 		var/turf/currentloc = get_turf(current)
 		if(currentloc && user.z != currentloc.z)
-			to_chat(user, "<span class='caution'>Upload failed!</span> Unable to establish a connection to [current.name]. You're too far away!")
+			to_chat(user, "<span class='alert'>Upload failed! Unable to establish a connection to [current.name]. You're too far away!</span>")
 			current = null
 			return
 		M.install(current.laws, user)
@@ -44,7 +44,7 @@
 	current = select_active_ai(user)
 
 	if (!current)
-		to_chat(user, "<span class='caution'>No active AIs detected!</span>")
+		to_chat(user, "<span class='alert'>No active AIs detected!</span>")
 	else
 		to_chat(user, "<span class='notice'>[current.name] selected for law changes.</span>")
 
@@ -65,7 +65,7 @@
 	current = select_active_free_borg(user)
 
 	if(!current)
-		to_chat(user, "<span class='caution'>No active unslaved cyborgs detected!</span>")
+		to_chat(user, "<span class='alert'>No active unslaved cyborgs detected.</span>")
 	else
 		to_chat(user, "<span class='notice'>[current.name] selected for law changes.</span>")
 

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -124,7 +124,7 @@
 			//Just build whatever it is
 			new buildpath(loc)
 	else
-		src.visible_message("<span class=\"error\"> Something went very wrong and there isnt enough instabitaluri anymore!</span>")
+		src.visible_message("<span class='warning'>Something went very wrong, there isn't enough instabitaluri anymore!</span>")
 	busy = FALSE
 	flick("limbgrower_unfill",src)
 	icon_state = "limbgrower_idleoff"

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -166,13 +166,13 @@
 		var/obj/item/multitool/M = W
 		if(panel_open)
 			M.buffer = src
-			to_chat(user, "<span class='caution'>You download the data to the [W.name]'s buffer.</span>")
+			to_chat(user, "<span class='notice'>You download the data to the [W.name]'s buffer.</span>")
 		else
 			if(M.buffer && istype(M.buffer, /obj/machinery/teleport/station) && M.buffer != src)
 				if(linked_stations.len < efficiency)
 					linked_stations.Add(M.buffer)
 					M.buffer = null
-					to_chat(user, "<span class='caution'>You upload the data from the [W.name]'s buffer.</span>")
+					to_chat(user, "<span class='notice'>You upload the data from the [W.name]'s buffer.</span>")
 				else
 					to_chat(user, "<span class='alert'>This station can't hold more information, try to use better parts.</span>")
 		return
@@ -186,7 +186,7 @@
 	else if(W.tool_behaviour == TOOL_WIRECUTTER)
 		if(panel_open)
 			link_console_and_hub()
-			to_chat(user, "<span class='caution'>You reconnect the station to nearby machinery.</span>")
+			to_chat(user, "<span class='notice'>You reconnect the station to nearby machinery.</span>")
 			return
 	else
 		return ..()

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -54,7 +54,7 @@ AI MODULES
 				if(mylaw != "")
 					tot_laws++
 		if(tot_laws > CONFIG_GET(number/silicon_max_law_amount) && !bypass_law_amt_check)//allows certain boards to avoid this check, eg: reset
-			to_chat(user, "<span class='caution'>Not enough memory allocated to [law_datum.owner ? law_datum.owner : "the AI core"]'s law processor to handle this amount of laws.</span>")
+			to_chat(user, "<span class='alert'>Not enough memory allocated to [law_datum.owner ? law_datum.owner : "the AI core"]'s law processor to handle this amount of laws.</span>")
 			message_admins("[ADMIN_LOOKUPFLW(user)] tried to upload laws to [law_datum.owner ? ADMIN_LOOKUPFLW(law_datum.owner) : "an AI core"] that would exceed the law cap.")
 			overflow = TRUE
 

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -74,7 +74,7 @@
 		if(-INFINITY to RAD_LEVEL_NORMAL)
 			. += "<span class='notice'>Ambient radiation level count reports that all is well.</span>"
 		if(RAD_LEVEL_NORMAL + 1 to RAD_LEVEL_MODERATE)
-			. += "<span class='disarm'>Ambient radiation levels slightly above average.</span>"
+			. += "<span class='alert'>Ambient radiation levels slightly above average.</span>"
 		if(RAD_LEVEL_MODERATE + 1 to RAD_LEVEL_HIGH)
 			. += "<span class='warning'>Ambient radiation levels above average.</span>"
 		if(RAD_LEVEL_HIGH + 1 to RAD_LEVEL_VERY_HIGH)

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -147,7 +147,7 @@
 /obj/item/book/granter/spell/onlearned(mob/user)
 	..()
 	if(oneuse)
-		user.visible_message("<span class='caution'>[src] glows dark for a second!</span>")
+		user.visible_message("<span class='warning'>[src] glows dark for a second!</span>")
 
 /obj/item/book/granter/spell/fireball
 	spell = /obj/effect/proc_holder/spell/aimed/fireball
@@ -180,7 +180,7 @@
 
 /obj/item/book/granter/spell/smoke/recoil(mob/user)
 	..()
-	to_chat(user,"<span class='caution'>Your stomach rumbles...</span>")
+	to_chat(user,"<span class='warning'>Your stomach rumbles...</span>")
 	if(user.nutrition)
 		user.set_nutrition(200)
 		if(user.nutrition <= 0)

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -406,7 +406,7 @@
 	else if(href_list["Master"])
 		forced_ai = select_active_ai(usr)
 		if(!forced_ai)
-			to_chat(usr, "<span class='error'>No active AIs detected.</span>")
+			to_chat(usr, "<span class='alert'>No active AIs detected.</span>")
 
 	else if(href_list["Law"])
 		lawsync = !lawsync

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -57,7 +57,7 @@
 			if(!user.transferItemToLoc(F, src))
 				return
 			fireaxe = F
-			to_chat(user, "<span class='caution'>You place the [F.name] back in the [name].</span>")
+			to_chat(user, "<span class='notice'>You place the [F.name] back in the [name].</span>")
 			update_icon()
 			return
 		else if(!broken)
@@ -112,7 +112,7 @@
 		if(fireaxe)
 			user.put_in_hands(fireaxe)
 			fireaxe = null
-			to_chat(user, "<span class='caution'>You take the fire axe from the [name].</span>")
+			to_chat(user, "<span class='notice'>You take the fire axe from the [name].</span>")
 			src.add_fingerprint(user)
 			update_icon()
 			return
@@ -166,10 +166,10 @@
 		add_overlay("glass_raised")
 
 /obj/structure/fireaxecabinet/proc/toggle_lock(mob/user)
-	to_chat(user, "<span class='caution'>Resetting circuitry...</span>")
+	to_chat(user, "<span class='notice'>Resetting circuitry...</span>")
 	playsound(src, 'sound/machines/locktoggle.ogg', 50, TRUE)
 	if(do_after(user, 20, target = src))
-		to_chat(user, "<span class='caution'>You [locked ? "disable" : "re-enable"] the locking modules.</span>")
+		to_chat(user, "<span class='notice'>You [locked ? "disable" : "re-enable"] the locking modules.</span>")
 		locked = !locked
 		update_icon()
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -113,7 +113,7 @@
 	else //caused by emp/remote signal
 		M.log_message("was [targeted? "flashed(targeted)" : "flashed(AOE)"]",LOG_ATTACK)
 	if(generic_message && M != user)
-		to_chat(M, "<span class='disarm'>[src] emits a blinding light!</span>")
+		to_chat(M, "<span class='danger'>[src] emits a blinding light!</span>")
 	if(targeted)
 		if(M.flash_act(1, 1))
 			if(M.confused < power)
@@ -121,14 +121,14 @@
 				M.confused += min(power, diff)
 			if(user)
 				terrible_conversion_proc(M, user)
-				visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")
+				visible_message("<span class='danger'>[user] blinds [M] with the flash!</span>")
 				to_chat(user, "<span class='danger'>You blind [M] with the flash!</span>")
 				to_chat(M, "<span class='userdanger'>[user] blinds you with the flash!</span>")
 			else
 				to_chat(M, "<span class='userdanger'>You are blinded by [src]!</span>")
 			M.Paralyze(rand(80,120))
 		else if(user)
-			visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")
+			visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>")
 			to_chat(user, "<span class='warning'>You fail to blind [M] with the flash!</span>")
 			to_chat(M, "<span class='danger'>[user] fails to blind you with the flash!</span>")
 		else
@@ -152,10 +152,10 @@
 		var/diff = 5 * CONFUSION_STACK_MAX_MULTIPLIER - M.confused
 		R.confused += min(5, diff)
 		R.flash_act(affect_silicon = 1)
-		user.visible_message("<span class='disarm'>[user] overloads [R]'s sensors with the flash!</span>", "<span class='danger'>You overload [R]'s sensors with the flash!</span>")
+		user.visible_message("<span class='warning'>[user] overloads [R]'s sensors with the flash!</span>", "<span class='danger'>You overload [R]'s sensors with the flash!</span>")
 		return TRUE
 
-	user.visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>", "<span class='warning'>You fail to blind [M] with the flash!</span>")
+	user.visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>", "<span class='warning'>You fail to blind [M] with the flash!</span>")
 
 /obj/item/assembly/flash/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(holder)
@@ -266,14 +266,14 @@
 	else //caused by emp/remote signal
 		M.log_message("was [targeted? "hypno-flashed(targeted)" : "hypno-flashed(AOE)"]",LOG_ATTACK)
 	if(generic_message && M != user)
-		to_chat(M, "<span class='disarm'>[src] emits a soothing light...</span>")
+		to_chat(M, "<span class='notice'>[src] emits a soothing light...</span>")
 	if(targeted)
 		if(M.flash_act(1, 1))
 			var/hypnosis = FALSE
 			if(M.hypnosis_vulnerable())
 				hypnosis = TRUE
 			if(user)
-				user.visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>", "<span class='danger'>You hypno-flash [M]!</span>")
+				user.visible_message("<span class='danger'>[user] blinds [M] with the flash!</span>", "<span class='danger'>You hypno-flash [M]!</span>")
 
 			if(!hypnosis)
 				to_chat(M, "<span class='notice'>The light makes you feel oddly relaxed...</span>")
@@ -285,7 +285,7 @@
 				M.apply_status_effect(/datum/status_effect/trance, 200, TRUE)
 
 		else if(user)
-			user.visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>", "<span class='warning'>You fail to hypno-flash [M]!</span>")
+			user.visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>", "<span class='warning'>You fail to hypno-flash [M]!</span>")
 		else
 			to_chat(M, "<span class='danger'>[src] fails to blind you!</span>")
 

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -94,7 +94,7 @@
 			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
 			return
 		var/mob/living/pushed_mob = user.pulling
-		visible_message("<span class='warner'>[user] stuffs [pushed_mob] into [src]!</span>")
+		visible_message("<span class='warning'>[user] stuffs [pushed_mob] into [src]!</span>")
 		pushed_mob.forceMove(src)
 		user.stop_pulling()
 		return

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -297,11 +297,6 @@ em						{font-style: normal;	font-weight: bold;}
 h1.alert, h2.alert		{color: #000000;}
 
 .emote					{					font-style: italic;}
-.selecteddna			{color: #ffffff;	background-color: #001B1B}
-
-.attack					{color: #e01c1c;}
-.disarm					{color: #b42525;}
-.passive				{color: #a00f0f;}
 
 .userdanger				{color: #c51e1e;	font-weight: bold;	font-size: 185%;}
 .danger					{color: #c51e1e;}
@@ -324,9 +319,8 @@ h1.alert, h2.alert		{color: #000000;}
 .red					{color: #FF0000}
 .blue					{color: #215cff}
 .nicegreen				{color: #059223;}
-.shadowling				{color: #8e8a99;}
-.cult					{color: #aa1c1c;}
 
+.cult					{color: #aa1c1c;}
 .cultitalic				{color: #aa1c1c;	font-style: italic;}
 .cultbold				{color: #aa1c1c;	font-style: italic;	font-weight: bold;}
 .cultboldtalic			{color: #aa1c1c;	font-weight: bold;	font-size: 185%;}
@@ -346,37 +340,15 @@ h1.alert, h2.alert		{color: #000000;}
 .revenminor				{color: #823abb}
 .revenwarning			{color: #760fbb;	font-style: italic;}
 .revendanger			{color: #760fbb;	font-weight: bold;	font-size: 185%;}
-.umbra					{color: #7c00e6;}
-.umbra_emphasis			{color: #7c00e6;	font-weight: bold;	font-style: italic;}
-.umbra_large			{color: #7c00e6;	font-size: 185%;	font-weight: bold;	font-style: italic;}
 
 .deconversion_message	{color: #a947ff;	font-size: 185%;	font-style: italic;}
 
-.nezbere_large			{color: #42474D;	font-size: 185%;	font-weight: bold;	font-style: italic;}
-.nezbere				{color: #42474D;	font-weight: bold;	font-style: italic;}
-.nezbere_small			{color: #42474D;}
-.sevtug_large			{color: #AF0AAF;	font-size: 185%;	font-weight: bold;	font-style: italic;}
-.sevtug					{color: #AF0AAF;	font-weight: bold;	font-style: italic;}
-.sevtug_small			{color: #AF0AAF;}
-.inathneq_large			{color: #1E8CE1;	font-size: 185%;	font-weight: bold;	font-style: italic;}
-.inathneq				{color: #1E8CE1;	font-weight: bold;	font-style: italic;}
-.inathneq_small			{color: #1E8CE1;}
-.nzcrentr_large			{color: #DAAA18;	font-size: 185%;	font-weight: bold;	font-style: italic;}
-.nzcrentr				{color: #DAAA18;	font-weight: bold;	font-style: italic;}
-.nzcrentr_small			{color: #DAAA18;}
-.neovgre_large			{color: #6E001A;	font-size: 185%;	font-weight: bold;	font-style: italic;}
-.neovgre				{color: #6E001A;	font-weight: bold;	font-style: italic;}
-.neovgre_small			{color: #6E001A;}
-
-.newscaster				{color: #c05d5d;}
 .ghostalert				{color: #6600ff;	font-style: italic;	font-weight: bold;}
 
 .alien					{color: #855d85;}
 .noticealien			{color: #059223;}
 .alertalien				{color: #059223;	font-weight: bold;}
 .changeling				{color: #059223;	font-style: italic;}
-.alertsyndie			{color: #FF0000;	font-size: 24px;	font-weight: bold;}
-.assimilator			{color: #059223;	font-size: 125%;	font-weight: bold;}
 .alertsyndie			{color: #FF0000;	font-size: 185%;	font-weight: bold;}
 
 .spider					{color: #8800ff;	font-weight: bold;	font-size: 185%;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -294,11 +294,6 @@ em						{font-style: normal;	font-weight: bold;}
 h1.alert, h2.alert		{color: #000000;}
 
 .emote					{					font-style: italic;}
-.selecteddna			{color: #ffffff;	background-color: #001B1B}
-
-.attack					{color: #ff0000;}
-.disarm					{color: #990000;}
-.passive				{color: #660000;}
 
 .userdanger				{color: #ff0000;	font-weight: bold;	font-size: 185%;}
 .danger					{color: #ff0000;}
@@ -321,9 +316,8 @@ h1.alert, h2.alert		{color: #000000;}
 .red					{color: #FF0000}
 .blue					{color: #0000FF}
 .nicegreen				{color: #14a833;}
-.shadowling				{color: #3b2769;}
-.cult					{color: #960000;}
 
+.cult					{color: #960000;}
 .cultitalic				{color: #960000;	font-style: italic;}
 .cultbold				{color: #960000;	font-style: italic;	font-weight: bold;}
 .cultboldtalic			{color: #960000;	font-weight: bold;	font-size: 185%;}
@@ -343,36 +337,9 @@ h1.alert, h2.alert		{color: #000000;}
 .revenminor				{color: #823abb}
 .revenwarning			{color: #760fbb;	font-style: italic;}
 .revendanger			{color: #760fbb;	font-weight: bold;	font-size: 185%;}
-.umbra					{color: #5000A0;}
-.umbra_emphasis			{color: #5000A0;	font-weight: bold;	font-style: italic;}
-.umbra_large			{color: #5000A0;	font-size: 185%;	font-weight: bold;	font-style: italic;}
 
 .deconversion_message	{color: #5000A0;	font-size: 185%;	font-style: italic;}
 
-.brass					{color: #BE8700;}
-.heavy_brass			{color: #BE8700;	font-weight: bold;	font-style: italic;}
-.large_brass			{color: #BE8700;	font-size: 185%;}
-.big_brass				{color: #BE8700;	font-size: 185%;	font-weight: bold;	font-style: italic;}
-.ratvar					{color: #BE8700;	font-size: 370%;	font-weight: bold;	font-style: italic;}
-.alloy					{color: #42474D;}
-.heavy_alloy			{color: #42474D;	font-weight: bold;	font-style: italic;}
-.nezbere_large			{color: #42474D;	font-size: 185%;	font-weight: bold; font-style: italic;}
-.nezbere				{color: #42474D;	font-weight: bold;	font-style: italic;}
-.nezbere_small			{color: #42474D;}
-.sevtug_large			{color: #AF0AAF;	font-size: 185%;	font-weight: bold;	font-style: italic;}
-.sevtug					{color: #AF0AAF;	font-weight: bold;	font-style: italic;}
-.sevtug_small			{color: #AF0AAF;}
-.inathneq_large			{color: #1E8CE1;	font-size: 185%;	font-weight: bold;	font-style: italic;}
-.inathneq				{color: #1E8CE1;	font-weight: bold;	font-style: italic;}
-.inathneq_small			{color: #1E8CE1;}
-.nzcrentr_large			{color: #DAAA18;	font-size: 185%;	font-weight: bold;	font-style: italic;}
-.nzcrentr				{color: #DAAA18;	font-weight: bold;	font-style: italic;}
-.nzcrentr_small			{color: #DAAA18;}
-.neovgre_large			{color: #6E001A;	font-size: 185%;	font-weight: bold;	font-style: italic;}
-.neovgre				{color: #6E001A;	font-weight: bold;	font-style: italic;}
-.neovgre_small			{color: #6E001A;}
-
-.newscaster				{color: #800000;}
 .ghostalert				{color: #5c00e6;	font-style: italic;	font-weight: bold;}
 
 .alien					{color: #543354;}

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -71,11 +71,11 @@
 	var/hacked = FALSE //If we have laws to destroy the station
 	var/flavortext = \
 	"\n<big><span class='warning'>DO NOT INTERFERE WITH THE ROUND AS A DRONE OR YOU WILL BE DRONE BANNED</span></big>\n"+\
-	"<span class='notify'>Drones are a ghost role that are allowed to fix the station and build things. Interfering with the round as a drone is against the rules.</span>\n"+\
-	"<span class='notify'>Actions that constitute interference include, but are not limited to:</span>\n"+\
-	"<span class='notify'>     - Interacting with round critical objects (IDs, weapons, contraband, powersinks, bombs, etc.)</span>\n"+\
-	"<span class='notify'>     - Interacting with living beings (communication, attacking, healing, etc.)</span>\n"+\
-	"<span class='notify'>     - Interacting with non-living beings (dragging bodies, looting bodies, etc.)</span>\n"+\
+	"<span class='notice'>Drones are a ghost role that are allowed to fix the station and build things. Interfering with the round as a drone is against the rules.</span>\n"+\
+	"<span class='notice'>Actions that constitute interference include, but are not limited to:</span>\n"+\
+	"<span class='notice'>     - Interacting with round critical objects (IDs, weapons, contraband, powersinks, bombs, etc.)</span>\n"+\
+	"<span class='notice'>     - Interacting with living beings (communication, attacking, healing, etc.)</span>\n"+\
+	"<span class='notice'>     - Interacting with non-living beings (dragging bodies, looting bodies, etc.)</span>\n"+\
 	"<span class='warning'>These rules are at admin discretion and will be heavily enforced.</span>\n"+\
 	"<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>"
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -117,10 +117,10 @@
 	"3. Your goals are to actively build, maintain, repair, improve, and provide power to the best of your abilities within the facility that housed your activation."
 	flavortext = \
 	"\n<big><span class='warning'>DO NOT WILLINGLY LEAVE KOSMICHESKAYA STANTSIYA 13 (THE DERELICT)</span></big>\n"+\
-	"<span class='notify'>Derelict drones are a ghost role that is allowed to roam freely on KS13, with the main goal of repairing and improving it.</span>\n"+\
-	"<span class='notify'>Do not interfere with the round going on outside KS13.</span>\n"+\
-	"<span class='notify'>Actions that constitute interference include, but are not limited to:</span>\n"+\
-	"<span class='notify'>     - Going to the main station in search of materials.</span>\n"+\
-	"<span class='notify'>     - Interacting with non-drone players outside KS13, dead or alive.</span>\n"+\
+	"<span class='notice'>Derelict drones are a ghost role that is allowed to roam freely on KS13, with the main goal of repairing and improving it.</span>\n"+\
+	"<span class='notice'>Do not interfere with the round going on outside KS13.</span>\n"+\
+	"<span class='notice'>Actions that constitute interference include, but are not limited to:</span>\n"+\
+	"<span class='notice'>     - Going to the main station in search of materials.</span>\n"+\
+	"<span class='notice'>     - Interacting with non-drone players outside KS13, dead or alive.</span>\n"+\
 	"<span class='warning'>These rules are at admin discretion and will be heavily enforced.</span>\n"+\
 	"<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>"

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -80,7 +80,7 @@
 		return
 
 	if(!interface_control)
-		to_chat(usr, "<span class='error'>ERROR: Request timed out. Check wire contacts.</span>")
+		to_chat(usr, "<span class='alert'>ERROR: Request timed out. Check wire contacts.</span>")
 		return
 
 	if(href_list["close"])

--- a/code/modules/spells/spell_types/charge.dm
+++ b/code/modules/spells/spell_types/charge.dm
@@ -97,7 +97,7 @@
 		if(!charged_item)
 			to_chat(L, "<span class='notice'>You feel magical power surging through your hands, but the feeling rapidly fades...</span>")
 		else if(burnt_out)
-			to_chat(L, "<span class='caution'>[charged_item] doesn't seem to be reacting to the spell...</span>")
+			to_chat(L, "<span class='warning'>[charged_item] doesn't seem to be reacting to the spell!</span>")
 		else
 			playsound(get_turf(L), 'sound/magic/charge.ogg', 50, TRUE)
 			to_chat(L, "<span class='notice'>[charged_item] suddenly feels very warm!</span>")

--- a/code/modules/spells/spell_types/lichdom.dm
+++ b/code/modules/spells/spell_types/lichdom.dm
@@ -26,10 +26,10 @@
 		if(iscarbon(M))
 			hand_items = list(M.get_active_held_item(),M.get_inactive_held_item())
 		if(!hand_items.len)
-			to_chat(M, "<span class='caution'>You must hold an item you wish to make your phylactery...</span>")
+			to_chat(M, "<span class='warning'>You must hold an item you wish to make your phylactery!</span>")
 			return
 		if(!M.mind.hasSoul)
-			to_chat(user, "<span class='caution'>You do not possess a soul.</span>")
+			to_chat(user, "<span class='warning'>You do not possess a soul!</span>")
 			return
 
 		var/obj/item/marked_item

--- a/code/modules/spells/spell_types/summonitem.dm
+++ b/code/modules/spells/spell_types/summonitem.dm
@@ -36,9 +36,9 @@
 
 			if(!marked_item)
 				if(hand_items)
-					message = "<span class='caution'>You aren't holding anything that can be marked for recall.</span>"
+					message = "<span class='warning'>You aren't holding anything that can be marked for recall!</span>"
 				else
-					message = "<span class='notice'>You must hold the desired item in your hands to mark it for recall.</span>"
+					message = "<span class='warning'>You must hold the desired item in your hands to mark it for recall!</span>"
 
 		else if(marked_item && marked_item in hand_items) //unlinking item to the spell
 			message = "<span class='notice'>You remove the mark on [marked_item] to use elsewhere.</span>"
@@ -73,7 +73,7 @@
 						if(issilicon(M)) //Items in silicons warp the whole silicon
 							M.loc.visible_message("<span class='warning'>[M] suddenly disappears!</span>")
 							M.forceMove(L.loc)
-							M.loc.visible_message("<span class='caution'>[M] suddenly appears!</span>")
+							M.loc.visible_message("<span class='warning'>[M] suddenly appears!</span>")
 							item_to_retrieve = null
 							break
 						M.dropItemToGround(item_to_retrieve)
@@ -107,10 +107,10 @@
 				item_to_retrieve.loc.visible_message("<span class='warning'>The [item_to_retrieve.name] suddenly disappears!</span>")
 			if(!L.put_in_hands(item_to_retrieve))
 				item_to_retrieve.forceMove(L.drop_location())
-				item_to_retrieve.loc.visible_message("<span class='caution'>The [item_to_retrieve.name] suddenly appears!</span>")
+				item_to_retrieve.loc.visible_message("<span class='warning'>The [item_to_retrieve.name] suddenly appears!</span>")
 				playsound(get_turf(L), 'sound/magic/summonitems_generic.ogg', 50, TRUE)
 			else
-				item_to_retrieve.loc.visible_message("<span class='caution'>The [item_to_retrieve.name] suddenly appears in [L]'s hand!</span>")
+				item_to_retrieve.loc.visible_message("<span class='warning'>The [item_to_retrieve.name] suddenly appears in [L]'s hand!</span>")
 				playsound(get_turf(L), 'sound/magic/summonitems_generic.ogg', 50, TRUE)
 
 

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -35,7 +35,7 @@
 /datum/action/item_action/hands_free/activate_pill/Trigger()
 	if(!..())
 		return FALSE
-	to_chat(owner, "<span class='caution'>You grit your teeth and burst the implanted [target.name]!</span>")
+	to_chat(owner, "<span class='notice'>You grit your teeth and burst the implanted [target.name]!</span>")
 	log_combat(owner, null, "swallowed an implanted pill", target)
 	if(target.reagents.total_volume)
 		target.reagents.reaction(owner, INGEST)

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -59,11 +59,6 @@ em						{font-style: normal;	font-weight: bold;}
 h1.alert, h2.alert		{color: #000000;}
 
 .emote					{					font-style: italic;}
-.selecteddna			{color: #ffffff;	background-color: #001B1B}
-
-.attack					{color: #ff0000;}
-.disarm					{color: #990000;}
-.passive				{color: #660000;}
 
 .userdanger				{color: #ff0000;	font-weight: bold;	font-size: 3;}
 .danger					{color: #ff0000;}
@@ -83,7 +78,6 @@ h1.alert, h2.alert		{color: #000000;}
 .suicide				{color: #ff5050;	font-style: italic;}
 .green					{color: #03ff39;}
 .nicegreen				{color: #14a833;}
-.shadowling				{color: #3b2769;}
 .cult					{color: #960000;}
 .cultlarge				{color: #960000;	font-weight: bold;	font-size: 3;}
 .narsie					{color: #960000;	font-weight: bold;	font-size: 15;}
@@ -100,37 +94,15 @@ h1.alert, h2.alert		{color: #000000;}
 .revenminor				{color: #823abb}
 .revenwarning			{color: #760fbb;	font-style: italic;}
 .revendanger			{color: #760fbb;	font-weight: bold;	font-size: 3;}
-.umbra					{color: #5000A0;}
-.umbra_emphasis			{color: #5000A0;	font-weight: bold;	font-style: italic;}
-.umbra_large			{color: #5000A0;	font-size: 3;	font-weight: bold;	font-style: italic;}
 
 .deconversion_message	{color: #5000A0;	font-size: 3;	font-style: italic;}
 
-.nezbere_large			{color: #42474D;	font-size: 3;	font-weight: bold;	font-style: italic;}
-.nezbere				{color: #42474D;	font-weight: bold;	font-style: italic;}
-.nezbere_small			{color: #42474D;}
-.sevtug_large			{color: #AF0AAF;	font-size: 3;	font-weight: bold;	font-style: italic;}
-.sevtug					{color: #AF0AAF;	font-weight: bold;	font-style: italic;}
-.sevtug_small			{color: #AF0AAF;}
-.inathneq_large			{color: #1E8CE1;	font-size: 3;	font-weight: bold;	font-style: italic;}
-.inathneq				{color: #1E8CE1;	font-weight: bold;	font-style: italic;}
-.inathneq_small			{color: #1E8CE1;}
-.nzcrentr_large			{color: #DAAA18;	font-size: 3;	font-weight: bold;	font-style: italic;}
-.nzcrentr				{color: #DAAA18;	font-weight: bold;	font-style: italic;}
-.nzcrentr_small			{color: #DAAA18;}
-.neovgre_large			{color: #6E001A;	font-size: 3;	font-weight: bold;	font-style: italic;}
-.neovgre				{color: #6E001A;	font-weight: bold;	font-style: italic;}
-.neovgre_small			{color: #6E001A;}
-
-.newscaster				{color: #800000;}
 .ghostalert				{color: #5c00e6;	font-style: italic;	font-weight: bold;}
 
 .alien					{color: #543354;}
 .noticealien			{color: #00c000;}
 .alertalien				{color: #00c000;	font-weight: bold;}
 .changeling				{color: #800080;	font-style: italic;}
-.assimilator			{color: #800080;	font-size: 2 ;	font-weight: bold;}
-.bigassimilator			{color: #800080;	font-size: 4 ;	font-weight: bold;}
 
 .spider					{color: #4d004d;}
 


### PR DESCRIPTION
Removes all instances of 'caution', 'error' and 'notify', which were not defined in any .css-file.
I couldn't find any other spans that aren't defined. Let me know if there's any more.

Also removal the other way around: removing spans which were not used at all or extremely little. Tell me if I got something wrong, for example I tried searching "umbra" and couldn't find anything so I figured the span classes were unnecessary.


Btw I used this regex to find the undefined spans, it finds a line with "span class" but also doesn't have any of the big list below:
`^(?=.*?span class)((?!motd|italics|bold|prefix|ooc|adminobserverooc|adminooc|adminsay|admin|name|say|deadsay|binarysay|radio|yell|alert|emote|selecteddna|attack|disarm|passive|userdanger|danger|warning|announce|rose|info|notice|hear|unconscious|suicide|green|shadowling|cult|narsie|colossus|hierophant|purple|holoparasite|reven|umbra|deconversion|nezbere|sevtug|inathneq|nzcrentr|neovgre|newscaster|ghostalert|alien|changeling|assimilator|spider|interface|sans|papyrus|robot|command_headset|small|big|greentext|redtext|clown|his_grace|hypnophrase|phobia|icon|memo|abductor|mind_control|slime|drone|monkey|swarmer|resonate|brass|h[1-6]|good|average|bad|highlight|dark|linkon|linkoff|header).)*$`