### PR TITLE
Adds message cooldown to vomitgeese refusing to eat food.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goose.dm
@@ -35,6 +35,7 @@
 	var/icon_vomit_start = "vomit_start"
 	var/icon_vomit = "vomit"
 	var/icon_vomit_end = "vomit_end"
+	var/message_cooldown = 0
 
 /mob/living/simple_animal/hostile/retaliate/goose/handle_automated_movement()
 	. = ..()
@@ -81,7 +82,9 @@
 
 /mob/living/simple_animal/hostile/retaliate/goose/vomit/proc/feed(obj/item/reagent_containers/food/tasty)
 	if (contents.len > GOOSE_SATIATED)
-		visible_message("<span class='notice'>[src] looks too full to eat \the [tasty]!</span>")
+		if(message_cooldown < world.time)
+			visible_message("<span class='notice'>[src] looks too full to eat \the [tasty]!</span>")
+			message_cooldown = world.time + 5 SECONDS
 		return
 	if (tasty.foodtype & GROSS)
 		visible_message("<span class='notice'>[src] hungrily gobbles up \the [tasty]!</span>")
@@ -90,7 +93,9 @@
 		vomitCoefficient += 3
 		vomitTimeBonus += 2
 	else
-		visible_message("<span class='notice'>[src] refuses to eat \the [tasty].</span>")
+		if(message_cooldown < world.time)
+			visible_message("<span class='notice'>[src] refuses to eat \the [tasty].</span>")
+			message_cooldown = world.time + 5 SECONDS
 
 /mob/living/simple_animal/hostile/retaliate/goose/vomit/proc/vomit()
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
## About The Pull Request

Adds a cooldown to messages about the goose being too full to eat or refusing to eat food. Cooldowns are not added to the goose actually eating food, because that would actually affect the goose's behavior, where this just affects the spam level. 

Fixes https://github.com/tgstation/tgstation/issues/45030.

## Why It's Good For The Game

fixes yet another goose bug

## Changelog
:cl: bandit
fix: Vomitgeese no longer spam you when refusing to eat food.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
