### PR TITLE
[s]Ghosts can no longer interact with pirate equipment.

### DIFF
--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -129,6 +129,8 @@
 	START_PROCESSING(SSobj,src)
 
 /obj/machinery/shuttle_scrambler/interact(mob/user)
+	if (ismob(user) && !isliving(user))
+		return
 	if(!active)
 		if(alert(user, "Turning the scrambler on will make the shuttle trackable by GPS. Are you sure you want to do it?", "Scrambler", "Yes", "Cancel") == "Cancel")
 			return
@@ -211,6 +213,8 @@
 	var/next_use = 0
 
 /obj/machinery/loot_locator/interact(mob/user)
+	if (ismob(user) && !isliving(user))
+		return
 	if(world.time <= next_use)
 		to_chat(user,"<span class='warning'>[src] is recharging.</span>")
 		return


### PR DESCRIPTION
## About The Pull Request

Adds a ghost check to pirate equipment. Fixes https://github.com/tgstation/tgstation/issues/47441.

## Why It's Good For The Game

fixes the sisyphean ghost interact bugs

## Changelog
:cl: bandit
fix: Ghost pirates stealing credits have been exorcised back to the Flying Dutchman where they belong.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
