### PR TITLE
Cap Guns and Capgun Ammo can now be made in a hacked Autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -984,3 +984,19 @@
 	build_path = /obj/item/stack/ducts
 	category = list("initial", "Construction")
 	maxstack = 50
+
+/datum/design/toygun
+	name = "Cap Gun"
+	id = "toygun"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 100, /datum/material/glass = 50)
+	build_path = /obj/item/toy/gun
+	category = list("hacked", "Misc")
+
+/datum/design/capbox
+	name = "Box of Cap Gun Shots"
+	id = "capbox"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 20, /datum/material/glass = 5)
+	build_path = /obj/item/toy/ammo/gun
+	category = list("hacked", "Misc")


### PR DESCRIPTION
**THE WHAT**
Lets the Cap Gun item (looks exactly like a .357 revolver, but fires blanks) and spare ammunition for it be made in a hacked Autolathe, for all your pranking needs! Cap Gun can be made for 100 cm3 iron and 50 cm3 glass, and an extra box of caps (7 shots) can be made for 20 cm3 iron and 5 cm3 glass. 

[ This PR is not responsible for any beatings by security you may receive for building cap guns. ]

**THE HOW**
Literally tossing a few lines of code into 'autolathe_designs.dm' lets us make these items.

**THE WHY**
I found it odd that the few cap guns you could find on-station could be 'recycled' at an Autolathe, but are unable to be remade. Considering the amount of  _Fun!(tm)_ that could be had with a cap gun, I decided they should be able to be made. Also, in case you don't want to print out a new gun every time you run out of caps, you can print spare ammunition.

For when you want to pretend that you rolled traitor instead of rolling Clown. Again.

****
## Changelog
:cl:
add: Cap Guns and boxes of spare caps can be printed at hacked Autolathes
/:cl:


