### PR TITLE
Bolted AIs now have TRAIT_NO_TELEPORT while bolted, and their move resist is MOVE_FORCE_OVERPOWERING

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -18,7 +18,6 @@
 	icon = 'icons/mob/ai.dmi'
 	icon_state = "ai"
 	move_resist = MOVE_FORCE_VERY_STRONG
-	anchored = TRUE
 	density = TRUE
 	mobility_flags = ALL
 	status_flags = CANSTUN|CANPUSH
@@ -105,6 +104,7 @@
 		new/obj/structure/AIcore/deactivated(loc) //New empty terminal.
 		return INITIALIZE_HINT_QDEL //Delete AI.
 
+	anchored = TRUE
 	if(L && istype(L, /datum/ai_laws))
 		laws = L
 		laws.associate(src)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -17,7 +17,7 @@
 	real_name = "AI"
 	icon = 'icons/mob/ai.dmi'
 	icon_state = "ai"
-	move_resist = MOVE_FORCE_VERY_STRONG
+	move_resist = MOVE_FORCE_OVERPOWERING
 	density = TRUE
 	mobility_flags = ALL
 	status_flags = CANSTUN|CANPUSH
@@ -104,7 +104,7 @@
 		new/obj/structure/AIcore/deactivated(loc) //New empty terminal.
 		return INITIALIZE_HINT_QDEL //Delete AI.
 
-	anchored = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TELEPORT, src)
 	if(L && istype(L, /datum/ai_laws))
 		laws = L
 		laws.associate(src)
@@ -340,14 +340,16 @@
 			return
 		battery = battery - 50
 		to_chat(src, "<span class='notice'>You route power from your backup battery to move the bolts.</span>")
-	if(move_resist == MOVE_FORCE_VERY_STRONG)
-		anchored = FALSE
+	var/is_anchored = FALSE
+	if(move_resist == MOVE_FORCE_OVERPOWERING)
 		move_resist = MOVE_FORCE_NORMAL
+		REMOVE_TRAIT(src, TRAIT_NO_TELEPORT, src)
 	else
-		anchored = TRUE
-		move_resist = MOVE_FORCE_VERY_STRONG
+		is_anchored = TRUE
+		move_resist = MOVE_FORCE_OVERPOWERING
+		ADD_TRAIT(src, TRAIT_NO_TELEPORT, src)
 
-	to_chat(src, "<b>You are now [anchored ? "" : "un"]anchored.</b>")
+	to_chat(src, "<b>You are now [is_anchored ? "" : "un"]anchored.</b>")
 	// the message in the [] will change depending whether or not the AI is anchored
 
 /mob/living/silicon/ai/update_mobility() //If the AI dies, mobs won't go through it anymore

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -18,6 +18,7 @@
 	icon = 'icons/mob/ai.dmi'
 	icon_state = "ai"
 	move_resist = MOVE_FORCE_VERY_STRONG
+	anchored = TRUE
 	density = TRUE
 	mobility_flags = ALL
 	status_flags = CANSTUN|CANPUSH
@@ -339,14 +340,14 @@
 			return
 		battery = battery - 50
 		to_chat(src, "<span class='notice'>You route power from your backup battery to move the bolts.</span>")
-	var/is_anchored = FALSE
 	if(move_resist == MOVE_FORCE_VERY_STRONG)
+		anchored = FALSE
 		move_resist = MOVE_FORCE_NORMAL
 	else
-		is_anchored = TRUE
+		anchored = TRUE
 		move_resist = MOVE_FORCE_VERY_STRONG
 
-	to_chat(src, "<b>You are now [is_anchored ? "" : "un"]anchored.</b>")
+	to_chat(src, "<b>You are now [anchored ? "" : "un"]anchored.</b>")
 	// the message in the [] will change depending whether or not the AI is anchored
 
 /mob/living/silicon/ai/update_mobility() //If the AI dies, mobs won't go through it anymore


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does as the title says.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Keeps the launchpad from teleporting AIs, and the new move resist should stop shuttles from knocking them loose.

Specifically, fixes #47331 

Does not change interactions such as dragging the AI (or being unable to when they're bolted).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Bolted AIs can no longer be teleported by launchpads.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
