### PR TITLE
Adds a new changeling chemical, which can cure a majority of traumas, to Anatomic Panacea.

### DIFF
--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -30,6 +30,7 @@
 	user.reagents.add_reagent(/datum/reagent/medicine/pen_acid, 20)
 	user.reagents.add_reagent(/datum/reagent/medicine/antihol, 10)
 	user.reagents.add_reagent(/datum/reagent/medicine/mannitol, 25)
+	user.reagents.add_reagent(/datum/reagent/medicine/changelingpanacea, 10)
 
 	if(isliving(user))
 		var/mob/living/L = user

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1040,6 +1040,16 @@
 	..()
 	return TRUE
 
+/datum/reagent/medicine/changelingpanacea
+	name = "Changeling Panacea"
+	description = "Cures all but the most magical and permanent brain traumas."
+	color = "#C8A5DC"
+	can_synth = FALSE
+
+/datum/reagent/medicine/changelingpanacea/on_mob_life(mob/living/carbon/M)
+	M.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
+	..()
+
 /datum/reagent/medicine/corazone
 	// Heart attack code will not do damage if corazone is present
 	// because it's SPACE MAGIC ASPIRIN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds a new changeling chemical, called Changeling Panacea, which can cure all traumas up to lobotomy-level, but does not work on neither magical nor permanent traumas(tiers 4 and 5 respectively). Since this is also a rather strong chemical, its can_synth has be set to FALSE. Would not be ideal of botany gets it via RNG.

Naturally, this chemical is also added to the changeling power of Anatomic Panacea so changelings actually has a way to cure the actually curable variety of traumas without either having to go get neurine, brain surgery, or a lobotomy, none of which would make much sense for an alien capable of near-perfect biological manipulation down to the cellular level.

Fixes #44067 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As stated above. Currently changelings, to cure one of the curable varieties of traumas, either has to drink neurine, undergo brain surgery, or get a lobotomy. Which is not to sensible for what they are, and because they can already heal their brain of actual physical damage.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Changelings are now able to cure themselves of most traumas via Anatomic Panacea, except magical and permanent traumas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
