### PR TITLE
Moves Achievements to OOC Tab instead of reserved slot

### DIFF
--- a/code/datums/achievements/_achievement_data.dm
+++ b/code/datums/achievements/_achievement_data.dm
@@ -115,7 +115,7 @@
 	return ret_data
 
 /client/verb/checkachievements()
-	set category = "IC"
+	set category = "OOC"
 	set name = "Check achievements"
 	set desc = "See all of your achievements!"
 

--- a/code/datums/achievements/_achievement_data.dm
+++ b/code/datums/achievements/_achievement_data.dm
@@ -115,7 +115,7 @@
 	return ret_data
 
 /client/verb/checkachievements()
-	set category = "Personal"
+	set category = "IC"
 	set name = "Check achievements"
 	set desc = "See all of your achievements!"
 


### PR DESCRIPTION
Why: It wastes a tab and OOC should cover this already. These aren't character-bound anyways.

:cl: Cobby
tweak: Achievements are now moved to the OOC tab, effectively removing the personal tab
/:cl:

