### PR TITLE
Dynamic revolution fixes, delayed ruleset improvements.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -496,7 +496,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		stack_trace("The starting rule \"[starting_rule.name]\" failed to pre_execute.")
 	return FALSE
 
-/// Mainly here to facilitate delayed rulesets. All rules roundstart rulesets are executed with a timered callback to this proc.
+/// Mainly here to facilitate delayed rulesets. All roundstart rulesets are executed with a timered callback to this proc.
 /datum/game_mode/dynamic/proc/execute_roundstart_rule(sent_rule)
 	var/datum/dynamic_ruleset/rule = sent_rule
 	if(rule.execute())
@@ -589,7 +589,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			log_game("DYNAMIC: The ruleset [new_rule.name] couldn't be executed due to lack of elligible players.")
 	return FALSE
 
-/// Mainly here to facilitate delayed rulesets. All rules midround/latejoin rulesets are executed with a timered callback to this proc.
+/// Mainly here to facilitate delayed rulesets. All midround/latejoin rulesets are executed with a timered callback to this proc.
 /datum/game_mode/dynamic/proc/execute_midround_latejoin_rule(sent_rule)
 	var/datum/dynamic_ruleset/rule = sent_rule
 	if (rule.execute())

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -373,7 +373,8 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 				rule.status = RULESET_FAILED // Doesnt trigger anything, but for consistency
 				rule.clean_up()	// Refund threat, delete teams and so on.
 				stack_trace("The starting rule \"[rule.name]\" failed to execute.")
-			rule.status = RULESET_STARTED
+			else
+				rule.status = RULESET_STARTED
 		if(rule.persistent)
 			current_rules += rule
 	..()
@@ -620,9 +621,9 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		update_playercounts()
 
 	for (var/datum/dynamic_ruleset/rule in current_rules)
-		if(rule.status == RULESET_WAITING) // Ruleset hasnt started yet, probably delayed start.
+		if(rule.status == RULESET_WAITING) // Ruleset hasn't executed yet, probably delayed start.
 			continue
-		if(rule.status == RULESET_FAILED) // Ruleset failed to start. Clean up time.
+		if(rule.status == RULESET_FAILED) // Ruleset has failed to execute. Clean up time.
 			rule.clean_up()
 			current_rules -= rule
 			executed_rules -= rule

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -61,7 +61,7 @@
 	/// Reference to the mode, use this instead of SSticker.mode.
 	var/datum/game_mode/dynamic/mode = null
 	/// If a role is to be considered another for the purpose of banning.
-	var/antag_flag_override = null 
+	var/antag_flag_override = null
 	/// If a ruleset type which is in this list has been executed, then the ruleset will not be executed.
 	var/list/blocking_rules = list()
 	/// The minimum amount of players required for the rule to be considered. 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -75,6 +75,11 @@
 	var/list/antag_cap = list()
 	/// Base probability used in scaling. The higher it is, the more likely to scale. Kept as a var to allow for config editing._SendSignal(sigtype, list/arguments)
 	var/base_prob = 60
+	/// Rulesets with delays set this var during execute. Prevents early processing.
+	var/status
+	/// Delay for when execute will get called from the time of post_setup (roundstart) or process (midround/latejoin).
+	/// Make sure your ruleset works with execute being called during the game when using this, and that the clean_up proc reverts it properly in case of faliure.
+	var/delay = 0
 
 
 /datum/dynamic_ruleset/New()
@@ -91,9 +96,6 @@
 
 /datum/dynamic_ruleset/roundstart // One or more of those drafted at roundstart
 	ruletype = "Roundstart"
-	/// Delay for when execute will get called from the time of post_setup.
-	/// Make sure your ruleset works with execute being called during the game when using this.
-	var/delay = 0
 
 // Can be drafted when a player joins the server
 /datum/dynamic_ruleset/latejoin
@@ -123,6 +125,13 @@
 	if(scaling_cost && scaling_cost <= remaining_threat_level) // Only attempts to scale the modes with a scaling cost explicitly set. 
 		var/new_prob
 		var/pop_to_antags = (mode.antags_rolled + (antag_cap[indice_pop] * (scaled_times + 1))) / mode.roundstart_pop_ready
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+		remaining_threat_level -= cost
+>>>>>>> 0a3a12215ac... scaling calculation again.
+=======
+>>>>>>> 7dd42bf4282... scaling exits earlier of not threat left
 		log_game("DYNAMIC: [name] roundstart ruleset attempting to scale up with [extra_rulesets] rulesets waiting and [remaining_threat_level] threat remaining.")
 		for(var/i in 1 to 3) //Can scale a max of 3 times
 			if(remaining_threat_level >= scaling_cost && pop_to_antags < 0.25)
@@ -161,6 +170,11 @@
 	if (required_candidates > candidates.len)		
 		return FALSE
 	return TRUE
+
+/// Runs from gamemode process() if ruleset fails to start, like delayed rulesets not getting valid candidates.
+/// This one only handles refunding the threat, override in ruleset to clean up the rest.
+/datum/dynamic_ruleset/proc/clean_up()
+	mode.refund_threat(cost + (scaled_times * scaling_cost))
 
 /// Gets weight of the ruleset
 /// Note that this decreases weight if repeatable is TRUE and repeatable_weight_decrease is higher than 0

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -75,7 +75,7 @@
 	var/list/antag_cap = list()
 	/// Base probability used in scaling. The higher it is, the more likely to scale. Kept as a var to allow for config editing._SendSignal(sigtype, list/arguments)
 	var/base_prob = 60
-	/// Rulesets with delays set this var during execute. Prevents early processing.
+	/// Used in rulesets with a delay set. Should be updated during execute to reflect its success.
 	var/status
 	/// Delay for when execute will get called from the time of post_setup (roundstart) or process (midround/latejoin).
 	/// Make sure your ruleset works with execute being called during the game when using this, and that the clean_up proc reverts it properly in case of faliure.
@@ -125,13 +125,6 @@
 	if(scaling_cost && scaling_cost <= remaining_threat_level) // Only attempts to scale the modes with a scaling cost explicitly set. 
 		var/new_prob
 		var/pop_to_antags = (mode.antags_rolled + (antag_cap[indice_pop] * (scaled_times + 1))) / mode.roundstart_pop_ready
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-		remaining_threat_level -= cost
->>>>>>> 0a3a12215ac... scaling calculation again.
-=======
->>>>>>> 7dd42bf4282... scaling exits earlier of not threat left
 		log_game("DYNAMIC: [name] roundstart ruleset attempting to scale up with [extra_rulesets] rulesets waiting and [remaining_threat_level] threat remaining.")
 		for(var/i in 1 to 3) //Can scale a max of 3 times
 			if(remaining_threat_level >= scaling_cost && pop_to_antags < 0.25)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -168,6 +168,7 @@
 /// This one only handles refunding the threat, override in ruleset to clean up the rest.
 /datum/dynamic_ruleset/proc/clean_up()
 	mode.refund_threat(cost + (scaled_times * scaling_cost))
+	mode.threat_log += "[worldtime2text()]: [ruletype] [name] refunded [cost + (scaled_times * scaling_cost)]"
 
 /// Gets weight of the ruleset
 /// Note that this decreases weight if repeatable is TRUE and repeatable_weight_decrease is higher than 0

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -75,8 +75,6 @@
 	var/list/antag_cap = list()
 	/// Base probability used in scaling. The higher it is, the more likely to scale. Kept as a var to allow for config editing._SendSignal(sigtype, list/arguments)
 	var/base_prob = 60
-	/// Used in rulesets with a delay set. Should be updated during execute to reflect its success.
-	var/status
 	/// Delay for when execute will get called from the time of post_setup (roundstart) or process (midround/latejoin).
 	/// Make sure your ruleset works with execute being called during the game when using this, and that the clean_up proc reverts it properly in case of faliure.
 	var/delay = 0

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -86,6 +86,7 @@
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 2
+	delay = 1 MINUTES	// Prevents rule start while head is offstation.
 	cost = 20
 	requirements = list(101,101,70,40,30,20,20,20,20,20)
 	high_population_requirement = 50
@@ -106,19 +107,27 @@
 	return (head_check >= required_heads_of_staff)
 
 /datum/dynamic_ruleset/latejoin/provocateur/execute()
-	var/mob/M = pick(candidates)
-	assigned += M.mind
-	M.mind.special_role = antag_flag
-	revolution = new()
-	var/datum/antagonist/rev/head/new_head = new()
-	new_head.give_flash = TRUE
-	new_head.give_hud = TRUE
-	new_head.remove_clumsy = TRUE
-	new_head = M.mind.add_antag_datum(new_head, revolution)
-	revolution.update_objectives()
-	revolution.update_heads()
-	SSshuttle.registerHostileEnvironment(src)
-	return TRUE
+	status = RULESET_FAILED
+	var/mob/M = pick(candidates)	// This should contain a single player, but in case.
+	if(check_eligible(M.mind))	// Didnt die/run off z-level/get implanted since leaving shuttle.
+		assigned += M.mind
+		M.mind.special_role = antag_flag
+		revolution = new()
+		var/datum/antagonist/rev/head/new_head = new()
+		new_head.give_flash = TRUE
+		new_head.give_hud = TRUE
+		new_head.remove_clumsy = TRUE
+		new_head = M.mind.add_antag_datum(new_head, revolution)
+		revolution.update_objectives()
+		revolution.update_heads()
+		SSshuttle.registerHostileEnvironment(src)
+		status = RULESET_STARTED
+		return TRUE
+	else
+		log_game("DYNAMIC: [ruletype] [name] discarded [M.name] from head revolutionary due to ineligibility.")
+		log_game("DYNAMIC: [ruletype] [name] failed to get any eligible headrevs. Refunding [cost] threat.")
+		status = RULESET_FAILED
+		return FALSE
 
 /datum/dynamic_ruleset/latejoin/provocateur/rule_process()
 	if(check_rev_victory())
@@ -128,10 +137,10 @@
 		finished = STATION_VICTORY
 		SSshuttle.clearHostileEnvironment(src)
 		priority_announce("It appears the mutiny has been quelled. Please return yourself and your colleagues to work. \
-			We have remotely blacklisted them from your cloning software to prevent accidental cloning.", null, 'sound/ai/attention.ogg', null, "Central Command Loyalty Monitoring Division")
+			We have remotely blacklisted the head revolutionaries from your cloning software to prevent accidental cloning.", null, 'sound/ai/attention.ogg', null, "Central Command Loyalty Monitoring Division")
 		for(var/datum/mind/M in revolution.members)	// Remove antag datums and prevent headrev cloning then restarting rebellions.
 			if(M.has_antag_datum(/datum/antagonist/rev/head))
-				var/datum/antagonist/rev/R = M.has_antag_datum(/datum/antagonist/rev/head)
+				var/datum/antagonist/rev/head/R = M.has_antag_datum(/datum/antagonist/rev/head)
 				R.remove_revolutionary(FALSE, "gamemode")
 				var/mob/living/carbon/C = M.current
 				C.makeUncloneable()
@@ -140,6 +149,12 @@
 				R.remove_revolutionary(FALSE, "gamemode")
 		return RULESET_STOP_PROCESSING
 
+/// Checks for revhead loss conditions and other antag datums.
+/datum/dynamic_ruleset/latejoin/provocateur/proc/check_eligible(var/datum/mind/M)
+	var/turf/T = get_turf(M.current)
+	if(!considered_afk(M) && considered_alive(M) && is_station_level(T.z) && !M.antag_datums?.len && !HAS_TRAIT(M, TRAIT_MINDSHIELD))
+		return TRUE
+	return FALSE
 
 /datum/dynamic_ruleset/latejoin/provocateur/check_finished()
 	if(finished == REVOLUTION_VICTORY)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -107,7 +107,6 @@
 	return (head_check >= required_heads_of_staff)
 
 /datum/dynamic_ruleset/latejoin/provocateur/execute()
-	status = RULESET_FAILED
 	var/mob/M = pick(candidates)	// This should contain a single player, but in case.
 	if(check_eligible(M.mind))	// Didnt die/run off z-level/get implanted since leaving shuttle.
 		assigned += M.mind
@@ -121,7 +120,6 @@
 		revolution.update_objectives()
 		revolution.update_heads()
 		SSshuttle.registerHostileEnvironment(src)
-		status = RULESET_STARTED
 		return TRUE
 	else
 		log_game("DYNAMIC: [ruletype] [name] discarded [M.name] from head revolutionary due to ineligibility.")

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -135,8 +135,7 @@
 		SSshuttle.clearHostileEnvironment(src)
 		priority_announce("It appears the mutiny has been quelled. Please return yourself and your colleagues to work. \
 			We have remotely blacklisted the head revolutionaries from your cloning software to prevent accidental cloning.", null, 'sound/ai/attention.ogg', null, "Central Command Loyalty Monitoring Division")
-		revolution.ex_headrevs = get_antag_minds(/datum/antagonist/rev/head, TRUE)
-		revolution.ex_revs = get_antag_minds(/datum/antagonist/rev, TRUE)
+		revolution.save_members()
 		for(var/datum/mind/M in revolution.members)	// Remove antag datums and prevents podcloned or exiled headrevs restarting rebellions.
 			if(M.has_antag_datum(/datum/antagonist/rev/head))
 				var/datum/antagonist/rev/head/R = M.has_antag_datum(/datum/antagonist/rev/head)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -135,12 +135,15 @@
 		SSshuttle.clearHostileEnvironment(src)
 		priority_announce("It appears the mutiny has been quelled. Please return yourself and your colleagues to work. \
 			We have remotely blacklisted the head revolutionaries from your cloning software to prevent accidental cloning.", null, 'sound/ai/attention.ogg', null, "Central Command Loyalty Monitoring Division")
-		for(var/datum/mind/M in revolution.members)	// Remove antag datums and prevent headrev cloning then restarting rebellions.
+		revolution.ex_headrevs = get_antag_minds(/datum/antagonist/rev/head, TRUE)
+		revolution.ex_revs = get_antag_minds(/datum/antagonist/rev, TRUE)
+		for(var/datum/mind/M in revolution.members)	// Remove antag datums and prevents podcloned or exiled headrevs restarting rebellions.
 			if(M.has_antag_datum(/datum/antagonist/rev/head))
 				var/datum/antagonist/rev/head/R = M.has_antag_datum(/datum/antagonist/rev/head)
 				R.remove_revolutionary(FALSE, "gamemode")
 				var/mob/living/carbon/C = M.current
-				C.makeUncloneable()
+				if(C.stat == DEAD)
+					C.makeUncloneable()
 			if(M.has_antag_datum(/datum/antagonist/rev))
 				var/datum/antagonist/rev/R = M.has_antag_datum(/datum/antagonist/rev)
 				R.remove_revolutionary(FALSE, "gamemode")

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -126,7 +126,6 @@
 	else
 		log_game("DYNAMIC: [ruletype] [name] discarded [M.name] from head revolutionary due to ineligibility.")
 		log_game("DYNAMIC: [ruletype] [name] failed to get any eligible headrevs. Refunding [cost] threat.")
-		status = RULESET_FAILED
 		return FALSE
 
 /datum/dynamic_ruleset/latejoin/provocateur/rule_process()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -168,7 +168,7 @@
 	name = "Syndicate Sleeper Agent"
 	antag_datum = /datum/antagonist/traitor
 	antag_flag = ROLE_TRAITOR
-	protected_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
+	protected_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	restricted_roles = list("Cyborg", "AI", "Positronic Brain")
 	required_candidates = 1
 	weight = 7

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -407,12 +407,15 @@
 		SSshuttle.clearHostileEnvironment(src)
 		priority_announce("It appears the mutiny has been quelled. Please return yourself and your incapacitated colleagues to work. \
 			We have remotely blacklisted the head revolutionaries from your cloning software to prevent accidental cloning.", null, 'sound/ai/attention.ogg', null, "Central Command Loyalty Monitoring Division")
-		for(var/datum/mind/M in revolution.members)	// Remove antag datums and prevent podcloned/exiled heads restarting rebellions.
+		revolution.ex_headrevs = get_antag_minds(/datum/antagonist/rev/head, TRUE)
+		revolution.ex_revs = get_antag_minds(/datum/antagonist/rev, TRUE)
+		for(var/datum/mind/M in revolution.members)	// Remove antag datums and prevents podcloned or exiled headrevs restarting rebellions.
 			if(M.has_antag_datum(/datum/antagonist/rev/head))
 				var/datum/antagonist/rev/head/R = M.has_antag_datum(/datum/antagonist/rev/head)
 				R.remove_revolutionary(FALSE, "gamemode")
 				var/mob/living/carbon/C = M.current
-				C.makeUncloneable()
+				if(C.stat == DEAD)
+					C.makeUncloneable()
 			if(M.has_antag_datum(/datum/antagonist/rev))
 				var/datum/antagonist/rev/R = M.has_antag_datum(/datum/antagonist/rev)
 				R.remove_revolutionary(FALSE, "gamemode")

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -407,8 +407,7 @@
 		SSshuttle.clearHostileEnvironment(src)
 		priority_announce("It appears the mutiny has been quelled. Please return yourself and your incapacitated colleagues to work. \
 			We have remotely blacklisted the head revolutionaries from your cloning software to prevent accidental cloning.", null, 'sound/ai/attention.ogg', null, "Central Command Loyalty Monitoring Division")
-		revolution.ex_headrevs = get_antag_minds(/datum/antagonist/rev/head, TRUE)
-		revolution.ex_revs = get_antag_minds(/datum/antagonist/rev, TRUE)
+		revolution.save_members()
 		for(var/datum/mind/M in revolution.members)	// Remove antag datums and prevents podcloned or exiled headrevs restarting rebellions.
 			if(M.has_antag_datum(/datum/antagonist/rev/head))
 				var/datum/antagonist/rev/head/R = M.has_antag_datum(/datum/antagonist/rev/head)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -371,6 +371,7 @@
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/revs/execute()
+	status = RULESET_FAILED
 	var/success = TRUE
 	revolution = new()
 	for(var/datum/mind/M in assigned)
@@ -391,13 +392,13 @@
 		revolution.update_objectives()
 		revolution.update_heads()
 		SSshuttle.registerHostileEnvironment(src)
+		status = RULESET_STARTED
 		return TRUE
-	// If the mode failed to get any antags, deletes the team, stops processing and refunds the cost. Oh boy, its midround/latejoin time.
-	qdel(revolution)
-	mode.refund_threat(cost)	// Maybe force latejoin revs instead in future.
-	mode.current_rules -= src
-	mode.executed_rules -= src
 	return FALSE
+
+/datum/dynamic_ruleset/roundstart/revs/clean_up()
+	qdel(revolution)
+	..()
 
 /datum/dynamic_ruleset/roundstart/revs/rule_process()
 	if(check_rev_victory())
@@ -406,11 +407,11 @@
 	else if (check_heads_victory())
 		finished = STATION_VICTORY
 		SSshuttle.clearHostileEnvironment(src)
-		priority_announce("It appears the mutiny has been quelled. Please return yourself and your colleagues to work. \
-			We have remotely blacklisted them from your cloning software to prevent accidental cloning.", null, 'sound/ai/attention.ogg', null, "Central Command Loyalty Monitoring Division")
-		for(var/datum/mind/M in revolution.members)	// Remove antag datums and prevent headrev cloning then restarting rebellions.
+		priority_announce("It appears the mutiny has been quelled. Please return yourself and your incapacitated colleagues to work. \
+			We have remotely blacklisted the head revolutionaries from your cloning software to prevent accidental cloning.", null, 'sound/ai/attention.ogg', null, "Central Command Loyalty Monitoring Division")
+		for(var/datum/mind/M in revolution.members)	// Remove antag datums and prevent podcloned/exiled heads restarting rebellions.
 			if(M.has_antag_datum(/datum/antagonist/rev/head))
-				var/datum/antagonist/rev/R = M.has_antag_datum(/datum/antagonist/rev/head)
+				var/datum/antagonist/rev/head/R = M.has_antag_datum(/datum/antagonist/rev/head)
 				R.remove_revolutionary(FALSE, "gamemode")
 				var/mob/living/carbon/C = M.current
 				C.makeUncloneable()
@@ -422,7 +423,7 @@
 /// Checks for revhead loss conditions and other antag datums.
 /datum/dynamic_ruleset/roundstart/revs/proc/check_eligible(var/datum/mind/M)
 	var/turf/T = get_turf(M.current)
-	if(!considered_afk(M) && considered_alive(M) && is_station_level(T.z) && !M.antag_datums?.len)
+	if(!considered_afk(M) && considered_alive(M) && is_station_level(T.z) && !M.antag_datums?.len && !HAS_TRAIT(M, TRAIT_MINDSHIELD))
 		return TRUE
 	return FALSE
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -371,7 +371,6 @@
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/revs/execute()
-	status = RULESET_FAILED
 	var/success = TRUE
 	revolution = new()
 	for(var/datum/mind/M in assigned)
@@ -392,7 +391,6 @@
 		revolution.update_objectives()
 		revolution.update_heads()
 		SSshuttle.registerHostileEnvironment(src)
-		status = RULESET_STARTED
 		return TRUE
 	return FALSE
 

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -310,6 +310,9 @@
 
 	addtimer(CALLBACK(src,.proc/update_heads),HEAD_UPDATE_PERIOD,TIMER_UNIQUE)
 
+/datum/team/revolution/proc/save_members()
+	ex_headrevs = get_antag_minds(/datum/antagonist/rev/head, TRUE)
+	ex_revs = get_antag_minds(/datum/antagonist/rev, TRUE)
 
 /datum/team/revolution/roundend_report()
 	if(!members.len && !ex_headrevs.len)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -212,7 +212,7 @@
 		owner.current.visible_message("<span class='deconversion_message'>[owner.current] looks like [owner.current.p_theyve()] just remembered [owner.current.p_their()] real allegiance!</span>", null, null, null, owner.current)
 		to_chat(owner, "<span class ='deconversion_message bold'>You have given up your cause of overthrowing the command staff. You are no longer a Head Revolutionary.</span>")
 	else if(issilicon(owner.current))
-		owner.current.visible_message("<span class='deconversion_message'>The frame beeps contentedly, suppressing the illoyal personality traits from the MMI before initalizing it.</span>", null, null, null, owner.current)
+		owner.current.visible_message("<span class='deconversion_message'>The frame beeps contentedly, suppressing the disloyal personality traits from the MMI before initalizing it.</span>", null, null, null, owner.current)
 		to_chat(owner, "<span class='userdanger'>The frame's firmware detects and suppresses your unwanted personality traits! You feel more content with the leadership around these parts.</span>")
 
 //blunt trauma deconversions call this through species.dm spec_attacked_by()

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -207,6 +207,14 @@
 		owner.current.visible_message("<span class='deconversion_message'>The frame beeps contentedly, purging the hostile memory engram from the MMI before initalizing it.</span>", null, null, null, owner.current)
 		to_chat(owner, "<span class='userdanger'>The frame's firmware detects and deletes your neural reprogramming! You remember nothing but the name of the one who flashed you.</span>")
 
+/datum/antagonist/rev/head/farewell()
+	if((ishuman(owner.current) || ismonkey(owner.current)) && owner.current.stat != DEAD )
+		owner.current.visible_message("<span class='deconversion_message'>[owner.current] looks like [owner.current.p_theyve()] just remembered [owner.current.p_their()] real allegiance!</span>", null, null, null, owner.current)
+		to_chat(owner, "<span class ='deconversion_message bold'>You have given up your cause of overthrowing the command staff. You are no longer a Head Revolutionary.</span>")
+	else if(issilicon(owner.current))
+		owner.current.visible_message("<span class='deconversion_message'>The frame beeps contentedly, suppressing the illoyal personality traits from the MMI before initalizing it.</span>", null, null, null, owner.current)
+		to_chat(owner, "<span class='userdanger'>The frame's firmware detects and suppresses your unwanted personality traits! You feel more content with the leadership around these parts.</span>")
+
 //blunt trauma deconversions call this through species.dm spec_attacked_by()
 /datum/antagonist/rev/proc/remove_revolutionary(borged, deconverter)
 	log_attack("[key_name(owner.current)] has been deconverted from the revolution by [key_name(deconverter)]!")

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -220,7 +220,7 @@
 
 //blunt trauma deconversions call this through species.dm spec_attacked_by()
 /datum/antagonist/rev/proc/remove_revolutionary(borged, deconverter)
-	log_attack("[key_name(owner.current)] has been deconverted from the revolution by [key_name(deconverter)]!")
+	log_attack("[key_name(owner.current)] has been deconverted from the revolution by [ismob(deconverter) ? key_name(deconverter) : deconverter]!")
 	if(borged)
 		message_admins("[ADMIN_LOOKUPFLW(owner.current)] has been borged while being a [name]")
 	owner.special_role = null
@@ -228,6 +228,10 @@
 		var/mob/living/carbon/C = owner.current
 		C.Unconscious(100)
 	owner.remove_antag_datum(type)
+
+/datum/antagonist/rev/head/remove_revolutionary(borged,deconverter)
+	if(borged || deconverter == "gamemode")
+		. = ..()
 
 /datum/antagonist/rev/head/equip_rev()
 	var/mob/living/carbon/H = owner.current

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -208,9 +208,12 @@
 		to_chat(owner, "<span class='userdanger'>The frame's firmware detects and deletes your neural reprogramming! You remember nothing but the name of the one who flashed you.</span>")
 
 /datum/antagonist/rev/head/farewell()
-	if((ishuman(owner.current) || ismonkey(owner.current)) && owner.current.stat != DEAD )
-		owner.current.visible_message("<span class='deconversion_message'>[owner.current] looks like [owner.current.p_theyve()] just remembered [owner.current.p_their()] real allegiance!</span>", null, null, null, owner.current)
-		to_chat(owner, "<span class ='deconversion_message bold'>You have given up your cause of overthrowing the command staff. You are no longer a Head Revolutionary.</span>")
+	if((ishuman(owner.current) || ismonkey(owner.current)))
+		if(owner.current.stat != DEAD)
+			owner.current.visible_message("<span class='deconversion_message'>[owner.current] looks like [owner.current.p_theyve()] just remembered [owner.current.p_their()] real allegiance!</span>", null, null, null, owner.current)
+			to_chat(owner, "<span class ='deconversion_message bold'>You have given up your cause of overthrowing the command staff. You are no longer a Head Revolutionary.</span>")
+		else
+			to_chat(owner, "<span class ='deconversion_message bold'>The sweet release of death. You are no longer a Head Revolutionary.</span>")
 	else if(issilicon(owner.current))
 		owner.current.visible_message("<span class='deconversion_message'>The frame beeps contentedly, suppressing the disloyal personality traits from the MMI before initalizing it.</span>", null, null, null, owner.current)
 		to_chat(owner, "<span class='userdanger'>The frame's firmware detects and suppresses your unwanted personality traits! You feel more content with the leadership around these parts.</span>")
@@ -225,11 +228,6 @@
 		var/mob/living/carbon/C = owner.current
 		C.Unconscious(100)
 	owner.remove_antag_datum(type)
-
-/datum/antagonist/rev/head/remove_revolutionary(borged,deconverter)
-	if(!borged)
-		return
-	. = ..()
 
 /datum/antagonist/rev/head/equip_rev()
 	var/mob/living/carbon/H = owner.current
@@ -261,6 +259,8 @@
 /datum/team/revolution
 	name = "Revolution"
 	var/max_headrevs = 3
+	var/list/ex_headrevs = list() // Dynamic removes revs on loss, used to keep a list for the roundend report.
+	var/list/ex_revs = list()
 
 /datum/team/revolution/proc/update_objectives(initial = FALSE)
 	var/untracked_heads = SSjob.get_all_heads()
@@ -312,7 +312,7 @@
 
 
 /datum/team/revolution/roundend_report()
-	if(!members.len)
+	if(!members.len && !ex_headrevs.len)
 		return
 
 	var/list/result = list()
@@ -332,8 +332,18 @@
 
 
 	var/list/targets = list()
-	var/list/datum/mind/headrevs = get_antag_minds(/datum/antagonist/rev/head)
-	var/list/datum/mind/revs = get_antag_minds(/datum/antagonist/rev,TRUE)
+	var/list/datum/mind/headrevs
+	var/list/datum/mind/revs
+	if(ex_headrevs.len)
+		headrevs = ex_headrevs
+	else
+		headrevs = get_antag_minds(/datum/antagonist/rev/head, TRUE)
+
+	if(ex_revs.len)
+		revs = ex_revs
+	else
+		revs = get_antag_minds(/datum/antagonist/rev, TRUE)
+
 	if(headrevs.len)
 		var/list/headrev_part = list()
 		headrev_part += "<span class='header'>The head revolutionaries were:</span>"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1520,7 +1520,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 					if(H.mind && H.stat == CONSCIOUS && H != user && prob(I.force + ((100 - H.health) * 0.5))) // rev deconversion through blunt trauma.
 						var/datum/antagonist/rev/rev = H.mind.has_antag_datum(/datum/antagonist/rev)
-						if(rev)
+						if(rev && !istype(rev, /datum/antagonist/rev/head))
 							rev.remove_revolutionary(FALSE, user)
 
 				if(bloody)	//Apply blood

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1520,7 +1520,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 					if(H.mind && H.stat == CONSCIOUS && H != user && prob(I.force + ((100 - H.health) * 0.5))) // rev deconversion through blunt trauma.
 						var/datum/antagonist/rev/rev = H.mind.has_antag_datum(/datum/antagonist/rev)
-						if(rev && !istype(rev, /datum/antagonist/rev/head))
+						if(rev)
 							rev.remove_revolutionary(FALSE, user)
 
 				if(bloody)	//Apply blood


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
More revolution fixes. Now checks for mindshield before assigning headrev and has more fitting farewell messages for headrevs that get exiled/borged into a rev loss.
Midround and latejoin rulesets now supports delayed start. 
Delayed rulesets will no longer start processing until they have been started in execute.
Latejoin revs should no longer lose if they start on offstation shuttle.
Refund and cleanup of delayed rulesets that failed to execute now handled on process.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Dynamic: Latejoin revs is now slightly delayed, will no longer lose instantly if on offstation arrivals shuttle.
fix: Dynamic: Clarified some ic messages for revolution.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
