### PR TITLE
pubby's monastery shuttle now also functions as a public mining shuttle

### DIFF
--- a/code/modules/shuttle/monastery.dm
+++ b/code/modules/shuttle/monastery.dm
@@ -3,5 +3,5 @@
 	desc = "Used to control the monastery shuttle."
 	circuit = /obj/item/circuitboard/computer/monastery_shuttle
 	shuttleId = "pod1"
-	possible_destinations = "monastery_shuttle_asteroid;monastery_shuttle_station"
+	possible_destinations = "monastery_shuttle_asteroid;monastery_shuttle_station;lavaland_common_away;landing_zone_dock;mining_public"
 	no_destination_swap = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

pubby monastery can now fly to places the lavaland public shuttle can (except the whiteship dock)

## Why It's Good For The Game

pubby does not have any escape pods except for the monastery shuttle and it doesnt have a public lavaland shuttle, its a multipurpose pod, now it can be used for mining

## Changelog
:cl:
tweak: the monastery shuttle can now be used as a mining shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
