### PR TITLE
Fixes refugee hunter shuttle destinations, gives space cops EVA suits

### DIFF
--- a/_maps/shuttles/hunter_russian.dmm
+++ b/_maps/shuttles/hunter_russian.dmm
@@ -152,7 +152,7 @@
 "E" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/hunter{
 	dir = 8;
-	jumpto_ports = list("huntership_home" = 1);
+	jumpto_ports = list("huntership_home" = 1, "whiteship_home" = 1, "syndicate_nw" = 1);
 	view_range = 12;
 	x_offset = 0;
 	y_offset = 3

--- a/_maps/shuttles/hunter_russian.dmm
+++ b/_maps/shuttles/hunter_russian.dmm
@@ -152,8 +152,6 @@
 "E" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/hunter{
 	dir = 8;
-	jumpto_ports = list("huntership_home" = 1, "whiteship_home" = 1, "syndicate_nw" = 1);
-	view_range = 12;
 	x_offset = 0;
 	y_offset = 3
 	},

--- a/_maps/shuttles/hunter_space_cop.dmm
+++ b/_maps/shuttles/hunter_space_cop.dmm
@@ -2,7 +2,6 @@
 "aa" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/hunter{
 	dir = 8;
-	jumpto_ports = list("huntership_home" = 1, "whiteship_home" = 1, "syndicate_nw" = 1);
 	view_range = 7;
 	x_offset = 6
 	},
@@ -65,7 +64,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/hunter)
 "aj" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate/eva,
 /obj/effect/turf_decal/box,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/hunter)

--- a/_maps/shuttles/hunter_space_cop.dmm
+++ b/_maps/shuttles/hunter_space_cop.dmm
@@ -2,7 +2,7 @@
 "aa" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/hunter{
 	dir = 8;
-	jumpto_ports = list("huntership_home" = 1);
+	jumpto_ports = list("huntership_home" = 1, "whiteship_home" = 1, "syndicate_nw" = 1);
 	view_range = 7;
 	x_offset = 6
 	},

--- a/code/modules/antagonists/fugitive/fugitive_ship.dm
+++ b/code/modules/antagonists/fugitive/fugitive_ship.dm
@@ -35,7 +35,7 @@
 /obj/machinery/computer/shuttle/hunter
 	name = "shuttle console"
 	shuttleId = "huntership"
-	possible_destinations = "huntership_away;huntership_home;huntership_custom"
+	possible_destinations = "huntership_home;huntership_custom;whiteship_home"
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/hunter
 	name = "shuttle navigation computer"

--- a/code/modules/antagonists/fugitive/fugitive_ship.dm
+++ b/code/modules/antagonists/fugitive/fugitive_ship.dm
@@ -35,7 +35,7 @@
 /obj/machinery/computer/shuttle/hunter
 	name = "shuttle console"
 	shuttleId = "huntership"
-	possible_destinations = "huntership_home;huntership_custom;whiteship_home"
+	possible_destinations = "huntership_home;huntership_custom;whiteship_home;syndicate_nw"
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/hunter
 	name = "shuttle navigation computer"
@@ -44,3 +44,19 @@
 	lock_override = CAMERA_LOCK_STATION
 	shuttlePortId = "huntership_custom"
 	see_hidden = FALSE
+	jumpto_ports = list("huntership_home" = 1, "whiteship_home" = 1, "syndicate_nw" = 1)
+	view_range = 12
+
+/obj/structure/closet/crate/eva
+	name = "EVA crate"
+
+/obj/structure/closet/crate/eva/PopulateContents()
+	..()
+	for(var/i in 1 to 3)
+		new /obj/item/clothing/suit/space/eva(src)
+	for(var/i in 1 to 3)
+		new /obj/item/clothing/head/helmet/space/eva(src)
+	for(var/i in 1 to 3)
+		new /obj/item/clothing/mask/breath(src)
+	for(var/i in 1 to 3)
+		new /obj/item/tank/internals/oxygen(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds missing destinations for refugee hunter shuttles and removes the unused huntership_away destination. syndicate_nw is a backup destination in case the white ship dock is occupied by the public mining shuttle or white ship.

I also added two EVA crates to the space cop shuttle since they're the only refugee hunters without space suits.
Closes: #45156
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl: Denton
fix: Added missing destinations for refugee hunter shuttles.
tweak: Added two EVA crates to the space cop shuttle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
