### PR TITLE
Janitors start with holosigns again

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -511,7 +511,7 @@
 		/obj/item/flashlight,
 		/obj/item/reagent_containers/spray,
 		/obj/item/soap,
-		/obj/item/holosign_creator/janibarrier,
+		/obj/item/holosign_creator,
 		/obj/item/forcefield_projector,
 		/obj/item/key/janitor,
 		/obj/item/clothing/gloves,
@@ -524,7 +524,7 @@
 	new /obj/item/lightreplacer(src)
 	new /obj/item/reagent_containers/spray/cleaner(src)
 	new /obj/item/soap/nanotrasen(src)
-	new /obj/item/holosign_creator/janibarrier(src)
+	new /obj/item/holosign_creator(src)
 	new /obj/item/melee/flyswatter(src)
 
 /obj/item/storage/belt/bandolier

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -61,7 +61,7 @@
 	new /obj/item/flashlight(src)
 	for(var/i in 1 to 3)
 		new /obj/item/clothing/suit/caution(src)
-	new /obj/item/holosign_creator/janibarrier(src)
+	new /obj/item/holosign_creator(src)
 	new /obj/item/lightreplacer(src)
 	new /obj/item/soap(src)
 	new /obj/item/storage/bag/trash(src)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -62,7 +62,9 @@
 	if(mover.pass_flags & (PASSGLASS|PASSTABLE|PASSGRILLE))
 		return TRUE
 	if(iscarbon(mover))
-		var/mob/living/carbon/C = mover
+		var/mob/living/carbon/C = mover		
+		if(C.stat)	// Lets not prevent dragging unconscious/dead people.
+			return TRUE
 		if(allow_walk && C.m_intent == MOVE_INTENT_WALK)
 			return TRUE
 
@@ -75,6 +77,8 @@
 /obj/structure/holosign/barrier/wetsign/CanPass(atom/movable/mover, turf/target)
 	if(iscarbon(mover))
 		var/mob/living/carbon/C = mover
+		if(C.stat)	// Lets not prevent dragging unconscious/dead people.
+			return TRUE
 		if(allow_walk && C.m_intent != MOVE_INTENT_WALK)
 			return FALSE
 	return TRUE

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -54,17 +54,17 @@
 	pass_flags = LETPASSTHROW
 	density = TRUE
 	max_integrity = 20
-	var/allow_walk = 1 //can we pass through it on walk intent
+	var/allow_walk = TRUE //can we pass through it on walk intent
 
 /obj/structure/holosign/barrier/CanPass(atom/movable/mover, turf/target)
 	if(!density)
-		return 1
+		return TRUE
 	if(mover.pass_flags & (PASSGLASS|PASSTABLE|PASSGRILLE))
-		return 1
+		return TRUE
 	if(iscarbon(mover))
 		var/mob/living/carbon/C = mover
 		if(allow_walk && C.m_intent == MOVE_INTENT_WALK)
-			return 1
+			return TRUE
 
 /obj/structure/holosign/barrier/wetsign
 	name = "wet floor holobarrier"
@@ -73,9 +73,11 @@
 	icon_state = "holosign"
 
 /obj/structure/holosign/barrier/wetsign/CanPass(atom/movable/mover, turf/target)
-	if(istype(mover, /obj/vehicle/ridden/janicart))
-		return TRUE
-	return ..()
+	if(iscarbon(mover))
+		var/mob/living/carbon/C = mover
+		if(allow_walk && C.m_intent != MOVE_INTENT_WALK)
+			return FALSE
+	return TRUE
 
 /obj/structure/holosign/barrier/engineering
 	icon_state = "holosign_engi"
@@ -102,7 +104,7 @@
 	desc = "A fragile energy field that blocks movement. Excels at blocking lethal projectiles."
 	density = TRUE
 	max_integrity = 10
-	allow_walk = 0
+	allow_walk = FALSE
 
 /obj/structure/holosign/barrier/cyborg/bullet_act(obj/projectile/P)
 	take_damage((P.damage / 5) , BRUTE, "melee", 1)	//Doesn't really matter what damage flag it is.

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -246,7 +246,7 @@ Contains:
 	icon_state = "ert_janitor"
 	item_state = "ert_janitor"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/jani
-	allowed = list(/obj/item/storage/bag/trash, /obj/item/melee/flyswatter, /obj/item/mop, /obj/item/holosign_creator/janibarrier, /obj/item/reagent_containers/glass/bucket, /obj/item/reagent_containers/spray/chemsprayer/janitor)
+	allowed = list(/obj/item/storage/bag/trash, /obj/item/melee/flyswatter, /obj/item/mop, /obj/item/holosign_creator, /obj/item/reagent_containers/glass/bucket, /obj/item/reagent_containers/spray/chemsprayer/janitor)
 
 /obj/item/clothing/suit/space/eva
 	name = "EVA suit"

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -350,7 +350,7 @@
 	id = "holobarrier_jani"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000, /datum/material/silver = 1000)
-	build_path = /obj/structure/holosign/barrier/wetsign
+	build_path = /obj/item/holosign_creator/janibarrier
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -555,7 +555,7 @@
 	display_name = "Advanced Sanitation Technology"
 	description = "Clean things better, faster, stronger, and harder!"
 	prereq_ids = list("adv_engi")
-	design_ids = list("advmop", "buffer", "blutrash", "light_replacer", "spraybottle", "beartrap")
+	design_ids = list("holobarrier_jani", "advmop", "buffer", "blutrash", "light_replacer", "spraybottle", "beartrap")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -285,7 +285,7 @@
 					/obj/item/melee/flyswatter = 2,
 					/obj/item/flashlight = 2,
 					/obj/item/clothing/suit/caution = 6,
-					/obj/item/holosign_creator/janibarrier = 2,
+					/obj/item/holosign_creator = 2,
 					/obj/item/lightreplacer = 2,
 					/obj/item/soap/nanotrasen = 2,
 					/obj/item/storage/bag/trash = 2,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Slipping people in the hallways is a janitor staple, and the holo**barriers** kinda ruin that. Some people flat out avoid using them for this reason. This makes janitors start with the holo**sign** projector again.
The holobarrier projector will still be available from the service lathe after picking up the advanced sanitation tech. 
The holobarrier now only attempts to stop conscious carbons, so both silicons and anything else you might be pulling behind you is no longer stopped.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #46010
Fixes #41038
Slips are fun
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
tweak: Janitors once again start out with the holosign projectors. Holobarrier projectors now locked behind tech, printed at service lathe.
fix: Janitor holobarriers no longer block things, only conscious and running carbons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
