### PR TITLE
Wizard Gamemode now ends when all wizards and wizard apprentices are dead

### DIFF
--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -45,7 +45,7 @@
 
 
 /datum/game_mode/wizard/are_special_antags_dead()
-	for(var/datum/mind/wizard in wizards)
+	for(var/datum/mind/wizard in wizards | apprentices)
 		if(isliving(wizard.current) && wizard.current.stat!=DEAD)
 			return FALSE
 
@@ -63,6 +63,9 @@
 	. = ..()
 	if(.)
 		finished = TRUE
+	else if(gamemode_ready && are_special_antags_dead() && !CONFIG_GET(keyed_list/continuous)[config_tag])
+		finished = TRUE
+		. = TRUE
 
 /datum/game_mode/wizard/set_round_result()
 	..()


### PR DESCRIPTION
## About The Pull Request
This adds wizard apprentices to the check for special antagonists in wizard, and now checks if those special antagonists are dead. If the gamemode is not continuous (config option where rounds continue even if antags die) then the round will end ignoring all other antags.

## Why It's Good For The Game
This is meant to be a short and kind of fun based mode in my opinion, so when it delays for lengthy amounts of time due to survivalists or other side antagonists, it tarnishes the original purpose and needlessly drags out a round that should be short and simple.

[permission](https://i.imgur.com/MdY0eF7.png)

## Changelog
:cl: Joe Berrbyson
tweak: The Wizard Gamemode now immediately ends when the main wizard and wizard apprentice antagonists die.
/:cl: