### PR TITLE
Revive proc tweaks

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -816,7 +816,7 @@
 		update_handcuffed()
 		if(reagents)
 			reagents.addiction_list = list()
-	cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
+		cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
 	..()
 	// heal ears after healing traits, since ears check TRAIT_DEAF trait
 	// when healing.

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -816,7 +816,7 @@
 		update_handcuffed()
 		if(reagents)
 			reagents.addiction_list = list()
-		cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
+	cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
 	..()
 	// heal ears after healing traits, since ears check TRAIT_DEAF trait
 	// when healing.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -515,10 +515,8 @@
 //Proc used to resuscitate a mob, for full_heal see fully_heal()
 /mob/living/proc/revive(full_heal = FALSE, admin_revive = FALSE)
 	SEND_SIGNAL(src, COMSIG_LIVING_REVIVE, full_heal, admin_revive)
-	if(full_heal && admin_revive)
-		fully_heal(admin_revive = TRUE)
 	if(full_heal)
-		fully_heal(admin_revive = FALSE)
+		fully_heal(admin_revive = admin_revive)
 	if(stat == DEAD && can_be_revived()) //in some cases you can't revive (e.g. no brain)
 		GLOB.dead_mob_list -= src
 		GLOB.alive_mob_list += src

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -515,8 +515,10 @@
 //Proc used to resuscitate a mob, for full_heal see fully_heal()
 /mob/living/proc/revive(full_heal = FALSE, admin_revive = FALSE)
 	SEND_SIGNAL(src, COMSIG_LIVING_REVIVE, full_heal, admin_revive)
-	if(full_heal)
+	if(full_heal && admin_revive)
 		fully_heal(admin_revive = TRUE)
+	if(full_heal)
+		fully_heal(admin_revive = FALSE)
 	if(stat == DEAD && can_be_revived()) //in some cases you can't revive (e.g. no brain)
 		GLOB.dead_mob_list -= src
 		GLOB.alive_mob_list += src

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -74,7 +74,7 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		if(L.mob_biotypes & MOB_UNDEAD) //negative energy heals the undead
-			user.revive(full_heal = TRUE, admin_revive = FALSE)
+			user.revive(full_heal = TRUE, admin_revive = TRUE)
 			to_chat(user, "<span class='notice'>You feel great!</span>")
 			return
 	to_chat(user, "<span class='warning'>You irradiate yourself with pure negative energy! \
@@ -116,7 +116,7 @@
 			</span>")
 			user.death(0)
 			return
-	user.revive(full_heal = TRUE, admin_revive = FALSE)
+	user.revive(full_heal = TRUE, admin_revive = TRUE)
 	to_chat(user, "<span class='notice'>You feel great!</span>")
 
 /obj/item/gun/magic/wand/resurrection/debug //for testing

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -23,7 +23,7 @@
 			if(L.mob_biotypes & MOB_UNDEAD) //negative energy heals the undead
 				if(L.hellbound && L.stat == DEAD)
 					return BULLET_ACT_BLOCK
-				if(L.revive(full_heal = TRUE, admin_revive = FALSE))
+				if(L.revive(full_heal = TRUE, admin_revive = TRUE))
 					L.grab_ghost(force = TRUE) // even suicides
 					to_chat(L, "<span class='notice'>You rise with a start, you're undead!!!</span>")
 				else if(L.stat != DEAD)
@@ -51,7 +51,7 @@
 		else
 			if(target.hellbound && target.stat == DEAD)
 				return BULLET_ACT_BLOCK
-			if(target.revive(full_heal = TRUE, admin_revive = FALSE))
+			if(target.revive(full_heal = TRUE, admin_revive = TRUE))
 				target.grab_ghost(force = TRUE) // even suicides
 				to_chat(target, "<span class='notice'>You rise with a start, you're alive!!!</span>")
 			else if(target.stat != DEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fun fact, `revive()` with full_heal = TRUE and admin_revive = FALSE still calls `fully_heal(admin_revive = TRUE)`.
This PR changes that; the limb/organ restoring and uncuffing part of admin_heal will only apply when the revive proc's admin_revive is set to TRUE. 
I've also adjusted wands of resurrection/healing bolts so that they still regenerate limbs as before.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
revive() with admin_revive = FALSE executing the admin_revive part is completely misleading and has lead to a bunch of items (for example xenobio crossbreeds) that "accidentally" admin heal instead of just completely healing a target.

That aside, revival code is spaghetti and could use a refactor for the sake of readability.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
code: revive() with admin_revive = FALSE no longer calls fully_heal(admin_revive = TRUE).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
