### PR TITLE
Adds logging for airlock bolting

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1498,10 +1498,10 @@
 			to_chat(user, "<span class='warning'>The door has no power - you can't raise the door bolts.</span>")
 		else
 			unbolt()
-			log_combat(user, src, unbolted)
+			log_combat(user, src, "unbolted")
 	else
 		bolt()
-		log_combat(user, src, bolted)
+		log_combat(user, src, "bolted")
 
 /obj/machinery/door/airlock/proc/toggle_emergency(mob/user)
 	if(!user_allowed(user))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1498,8 +1498,10 @@
 			to_chat(user, "<span class='warning'>The door has no power - you can't raise the door bolts.</span>")
 		else
 			unbolt()
+			log_combat(user, src, unbolted)
 	else
 		bolt()
+		log_combat(user, src, bolted)
 
 /obj/machinery/door/airlock/proc/toggle_emergency(mob/user)
 	if(!user_allowed(user))


### PR DESCRIPTION
This PR adds airlock bolt/unbolt logging to the combat log.

## Changelog
:cl: Denton
admin: Added airlock bolt/unbolt logging to the combat log.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
