### PR TITLE
Barmaid/Bardrone godmode tweak

### DIFF
--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -146,13 +146,8 @@
 /mob/living/simple_animal/drone/snowflake/bardrone/Initialize()
 	. = ..()
 	access_card.access |= ACCESS_CENT_BAR
-
-/mob/living/simple_animal/drone/snowflake/bardrone/Life(seconds, times_fired)
-	. = ..()
-	if(istype(get_area(loc), /area/shuttle/escape))
-		status_flags |= GODMODE
-	else
-		status_flags &= ~GODMODE
+	RegisterSignal(src, COMSIG_ENTER_AREA, .proc/check_barstaff_godmode)
+	check_barstaff_godmode()
 
 /mob/living/simple_animal/hostile/alien/maid/barmaid
 	gold_core_spawnable = NO_SPAWN
@@ -171,17 +166,18 @@
 	access_card.access = C.get_access()
 	access_card.access |= ACCESS_CENT_BAR
 	ADD_TRAIT(access_card, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
-
-/mob/living/simple_animal/hostile/alien/maid/barmaid/Life()
-	. = ..()
-	if(istype(get_area(loc), /area/shuttle/escape))
-		status_flags |= GODMODE
-	else
-		status_flags &= ~GODMODE
+	RegisterSignal(src, COMSIG_ENTER_AREA, .proc/check_barstaff_godmode)
+	check_barstaff_godmode()
 
 /mob/living/simple_animal/hostile/alien/maid/barmaid/Destroy()
 	qdel(access_card)
 	. = ..()
+
+/mob/living/simple_animal/proc/check_barstaff_godmode()
+	if(istype(get_area(loc), /area/shuttle/escape))
+		status_flags |= GODMODE
+	else
+		status_flags &= ~GODMODE
 
 // Bar table, a wooden table that kicks you in a direction if you're not
 // barstaff (defined as someone who was a roundstart bartender or someone

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -130,17 +130,16 @@
 /obj/structure/table/abductor/wabbajack/right
 	desc = "It wakes so you may sleep."
 
-// Bar staff, GODMODE mobs that just want to make sure people have drinks
+// Bar staff, GODMODE mobs(as long as they stay in the shuttle) that just want to make sure people have drinks
 // and a good time.
 
 /mob/living/simple_animal/drone/snowflake/bardrone
 	name = "Bardrone"
-	desc = "A barkeeping drone, an indestructible robot built to tend bars."
+	desc = "A barkeeping drone, a robot built to tend bars."
 	hacked = TRUE
 	laws = "1. Serve drinks.\n\
 		2. Talk to patrons.\n\
 		3. Don't get messed up in their affairs."
-	status_flags = GODMODE // Please don't punch the barkeeper
 	unique_name = FALSE // disables the (123) number suffix
 	initial_language_holder = /datum/language_holder/universal
 
@@ -148,12 +147,18 @@
 	. = ..()
 	access_card.access |= ACCESS_CENT_BAR
 
+/mob/living/simple_animal/drone/snowflake/bardrone/Life(seconds, times_fired)
+	. = ..()
+	if(istype(get_area(loc), /area/shuttle/escape))
+		status_flags |= GODMODE
+	else
+		status_flags &= ~GODMODE
+
 /mob/living/simple_animal/hostile/alien/maid/barmaid
 	gold_core_spawnable = NO_SPAWN
 	name = "Barmaid"
 	desc = "A barmaid, a maiden found in a bar."
 	pass_flags = PASSTABLE
-	status_flags = GODMODE
 	unique_name = FALSE
 	AIStatus = AI_OFF
 	stop_automated_movement = TRUE
@@ -166,6 +171,13 @@
 	access_card.access = C.get_access()
 	access_card.access |= ACCESS_CENT_BAR
 	ADD_TRAIT(access_card, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
+
+/mob/living/simple_animal/hostile/alien/maid/barmaid/Life()
+	. = ..()
+	if(istype(get_area(loc), /area/shuttle/escape))
+		status_flags |= GODMODE
+	else
+		status_flags &= ~GODMODE
 
 /mob/living/simple_animal/hostile/alien/maid/barmaid/Destroy()
 	qdel(access_card)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Barmaids and Bardrones are now only invincible if they are inside escape shuttle. If they step out of it, they lose their godmode and can be killed. Stepping inside escape shuttle again will restore godmode status.

Fixes #35868

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Less administrative burden. Problematic Barmaids/Bardrones will get easily slapped out of existence if they step out of shuttle and cause issues.

## Changelog
:cl: Arkatos
tweak: Barmaids and Bardrones are now only invincible if they inside escape shuttle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
