### PR TITLE
Nerfs the Drake Armor and Explorer's Suit Plate Upgrades

### DIFF
--- a/code/datums/components/armor_plate.dm
+++ b/code/datums/components/armor_plate.dm
@@ -2,7 +2,7 @@
 	var/amount = 0
 	var/maxamount = 3
 	var/upgrade_item = /obj/item/stack/sheet/animalhide/goliath_hide
-	var/datum/armor/added_armor = list("melee" = 10)
+	var/datum/armor/added_armor = list("melee" = 5)
 	var/upgrade_name
 
 /datum/component/armor_plate/Initialize(_maxamount,obj/item/_upgrade_item,datum/armor/_added_armor)

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -72,7 +72,7 @@
 	icon_state = "dragon"
 	desc = "A suit of armour fashioned from the remains of an ash drake."
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe, /obj/item/twohanded/spear)
-	armor = list("melee" = 70, "bullet" = 30, "laser" = 50, "energy" = 40, "bomb" = 70, "bio" = 60, "rad" = 50, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 50, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 70, "bio" = 60, "rad" = 50, "fire" = 100, "acid" = 100)
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/drake
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -84,7 +84,7 @@
 	name = "drake helm"
 	icon_state = "dragon"
 	desc = "The skull of a dragon."
-	armor = list("melee" = 70, "bullet" = 30, "laser" = 50, "energy" = 40, "bomb" = 70, "bio" = 60, "rad" = 50, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 50, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 70, "bio" = 60, "rad" = 50, "fire" = 100, "acid" = 100)
 	clothing_flags = SNUG_FIT
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT


### PR DESCRIPTION
## About The Pull Request

This PR nerfs the ash drake's melee armor from 70 to 50, and it's laser armor from 50 to 30.  It also nerfs the explorer's suit goliath plate upgrades from giving 10 melee resistance to 5 melee resistance.

## Why It's Good For The Game

The armor values on the drake armor and the fully-upgraded explorer suit were pretty high for something not difficult to obtain.  The main appealing feature of the drake armor should be ash resistance, not insane armor resistances.  The issues mainly manifested when miners came back to the station with armor that made them incredibly durable, especially so considering that they have access to medipens and legion cores that work perfectly fine station side.  These healing items also work well enough on Lavaland, and this change shouldn't really impact the balance of Lavaland except for those who abuse armor values to facetank.

## Changelog
:cl:
balance: Lack of veterinarians in their diet have weakened the defensive properties of an ash drake's scales when used for armor.  Miners have also reported that goliath scales prove not as effective when attached to their explorer suit.
/:cl: