### PR TITLE
Adds the ability to specify direction when calling generate_effect()

### DIFF
--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -56,16 +56,16 @@ would spawn and follow the beaker, even if it is carried or thrown.
 			return
 		INVOKE_ASYNC(src, .proc/generate_effect)
 
-/datum/effect_system/proc/generate_effect()
+/datum/effect_system/proc/generate_effect(var/direction = 0)
 	if(holder)
 		location = get_turf(holder)
 	var/obj/effect/E = new effect_type(location)
 	total_effects++
-	var/direction
-	if(cardinals)
-		direction = pick(GLOB.cardinals)
-	else
-		direction = pick(GLOB.alldirs)
+	if(!direction)
+		if(cardinals)
+			direction = pick(GLOB.cardinals)
+		else
+			direction = pick(GLOB.alldirs)
 	var/steps_amt = pick(1,2,3)
 	for(var/j in 1 to steps_amt)
 		sleep(5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As the title says. I'd like to use this in another PR I'm working on; the alternative seems to be re-writing the whole generate_effect() code inside the object that needs the effect.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Prevents the need to duplicate code just because an effect needs to follow a direction instead of being random.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Web edit, but I can't see this affecting any existing code.