### PR TITLE
Hardcode tgui script name in git hook installer

### DIFF
--- a/tgui-next/bin/tgui
+++ b/tgui-next/bin/tgui
@@ -83,7 +83,7 @@ task-install-git-hooks() {
   git_root="$(git rev-parse --show-toplevel)"
   git_base_dir="${base_dir/${git_root}/.}"
   git config --replace-all merge.tgui-merge-bundle.driver \
-    "${git_base_dir}/${0} --merge=bundle %O %A %B %L"
+    "${git_base_dir}/bin/tgui --merge=bundle %O %A %B %L"
   echo "tgui: Merge drivers have been successfully installed!"
 }
 


### PR DESCRIPTION
## About The Pull Request

Subject. This fixes git hooks since `$0` is unreliable.

Not critical, but hooks won't work without this fix.
