### PR TITLE
Fixes contractor tablet

### DIFF
--- a/code/modules/antagonists/traitor/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/syndicate_contract.dm
@@ -2,6 +2,7 @@
 	var/id = 0
 	var/status = CONTRACT_STATUS_INACTIVE
 	var/datum/objective/contract/contract = new()
+	var/target_rank
 	var/ransom = 0
 	var/payout_type = null
 
@@ -15,6 +16,12 @@
 
 /datum/syndicate_contract/proc/generate(blacklist)
 	contract.find_target(null, blacklist)
+	
+	var/datum/data/record/record = find_record("name", contract.target.name, GLOB.data_core.general)
+	if (record)
+		target_rank = record.fields["rank"]
+	else 
+		target_rank = "Unknown"
 
 	if (payout_type == CONTRACT_PAYOUT_LARGE)
 		contract.payout_bonus = rand(9,13)

--- a/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
@@ -152,17 +152,9 @@
 			))
 
 		for (var/datum/syndicate_contract/contract in traitor_data.contractor_hub.assigned_contracts)
-			var/target_rank = ""
-			if (contract.contract.target)
-				var/datum/data/record/record = find_record("name", contract.contract.target.current.real_name, GLOB.data_core.general)
-				if (record)
-					target_rank = record.fields["rank"]
-				else 
-					target_rank = "Unknown"
-
 			data["contracts"] += list(list(
 				"target" = contract.contract.target,
-				"target_rank" = target_rank,
+				"target_rank" = contract.target_rank,
 				"payout" = contract.contract.payout,
 				"payout_bonus" = contract.contract.payout_bonus,
 				"dropoff" = contract.contract.dropoff,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Contractor tablet kept updating the targets ranks from target.current.real_name, meaning if any of the targets' bodies were destroyed (gibber, cremator, bomb) it runtimed in ui_data and broke the program. It now only sets rank once on contract creation instead.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #47547
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Contractor tablet should no longer break randomly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
