### PR TITLE
Dice bags spawn the special die in the bag

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -358,16 +358,3 @@
 				/obj/item/circuitboard/computer/apc_control,
 				/obj/item/circuitboard/computer/robotics
 				)
-/obj/effect/spawner/lootdrop/special_die
-	name = "special die spawner"
-	loot = list(
-				/obj/item/dice/d1 = 1,
-				/obj/item/dice/d2 = 1,
-				/obj/item/dice/fudge = 1,
-				/obj/item/dice/d6/space = 1,
-				/obj/item/dice/d00 = 1,
-				/obj/item/dice/eightbd20 = 1,
-				/obj/item/dice/fourdd6 = 1,
-				/obj/item/dice/d100 = 1
-				)
-

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -5,15 +5,26 @@
 	desc = "Contains all the luck you'll ever need."
 	icon = 'icons/obj/dice.dmi'
 	icon_state = "dicebag"
+	var/list/special_die = list(
+				/obj/item/dice/d1 = 1,
+				/obj/item/dice/d2 = 1,
+				/obj/item/dice/fudge = 1,
+				/obj/item/dice/d6/space = 1,
+				/obj/item/dice/d00 = 1,
+				/obj/item/dice/eightbd20 = 1,
+				/obj/item/dice/fourdd6 = 1,
+				/obj/item/dice/d100 = 1
+				)
 
 /obj/item/storage/pill_bottle/dice/PopulateContents()
-	new /obj/effect/spawner/lootdrop/special_die(src)
 	new /obj/item/dice/d4(src)
 	new /obj/item/dice/d6(src)
 	new /obj/item/dice/d8(src)
 	new /obj/item/dice/d10(src)
 	new /obj/item/dice/d12(src)
 	new /obj/item/dice/d20(src)
+	var/picked = pick(special_die)
+	new picked(src)
 
 /obj/item/storage/pill_bottle/dice/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is gambling with death! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -6,14 +6,14 @@
 	icon = 'icons/obj/dice.dmi'
 	icon_state = "dicebag"
 	var/list/special_die = list(
-				/obj/item/dice/d1 = 1,
-				/obj/item/dice/d2 = 1,
-				/obj/item/dice/fudge = 1,
-				/obj/item/dice/d6/space = 1,
-				/obj/item/dice/d00 = 1,
-				/obj/item/dice/eightbd20 = 1,
-				/obj/item/dice/fourdd6 = 1,
-				/obj/item/dice/d100 = 1
+				/obj/item/dice/d1,
+				/obj/item/dice/d2,
+				/obj/item/dice/fudge,
+				/obj/item/dice/d6/space,
+				/obj/item/dice/d00,
+				/obj/item/dice/eightbd20,
+				/obj/item/dice/fourdd6,
+				/obj/item/dice/d100
 				)
 
 /obj/item/storage/pill_bottle/dice/PopulateContents()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Old code had a lootdrop spawner spawn in the bag, then drop its load on the turf.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skgolol
fix: Bag of dice now has a special die INSIDE the bag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
