### PR TITLE
fixes modifier hotkeys and adds alternative move intent toggle

### DIFF
--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -57,7 +57,7 @@
 
 /datum/keybinding/mob/stop_pulling/down(client/user)
 	var/mob/M = user.mob
-	if (M.pulling)
+	if(!M.pulling)
 		to_chat(user, "<span class='notice'>You are not pulling anything.</span>")
 	else
 		M.stop_pulling()

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -162,6 +162,17 @@
 	M.toggle_move_intent()
 	return TRUE
 
+/datum/keybinding/mob/toggle_move_intent_alternative
+	key = "Unbound"
+	name = "toggle_move_intent_alt"
+	full_name = "press to cycle move intent"
+	description = "Pressing this cycle to the opposite move intent, does not cycle back"
+
+/datum/keybinding/mob/toggle_move_intent_alternative/down(client/user)
+	var/mob/M = user.mob
+	M.toggle_move_intent()
+	return TRUE
+
 /datum/keybinding/mob/target_head_cycle
 	key = "Numpad8"
 	name = "target_head_cycle"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -128,7 +128,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			S["facial_style_name"]	>> facial_hairstyle
 			
 	if(current_version < 27)
-		key_bindings = sanitize_islist(key_bindings, deepCopyList(GLOB.keybinding_list_by_key))
+		key_bindings = deepCopyList(GLOB.keybinding_list_by_key)
 		WRITE_FILE(S["key_bindings"], key_bindings)
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -129,10 +129,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			
 	if(current_version < 26)
 		key_bindings = sanitize_islist(key_bindings, deepCopyList(GLOB.keybinding_list_by_key))
-		key_bindings["T"] = list(1 = "say")
-		key_bindings["M"] = list(1 = "me")
-		key_bindings["O"] = list(1 = "ooc")
-		key_bindings["L"] = list(1 = "looc")
 		WRITE_FILE(S["key_bindings"], key_bindings)
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	26
+#define SAVEFILE_VERSION_MAX	27
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -127,7 +127,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		if(S["facial_style_name"])
 			S["facial_style_name"]	>> facial_hairstyle
 			
-	if(current_version < 26)
+	if(current_version < 27)
 		key_bindings = sanitize_islist(key_bindings, deepCopyList(GLOB.keybinding_list_by_key))
 		WRITE_FILE(S["key_bindings"], key_bindings)
 

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -3,7 +3,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 /client/verb/ooc_wrapper()
 	set hidden = TRUE
-	var/message = input("", "OOC") as text
+	var/message = input("", "OOC \"text\"") as null|text
 	ooc(message)
 	
 /client/verb/ooc(msg as text)

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -47,11 +47,12 @@
 
 	// Client-level keybindings are ones anyone should be able to do at any time
 	// Things like taking screenshots, hitting tab, and adminhelps.
-
 	var/AltMod = keys_held["Alt"] ? "Alt-" : ""
 	var/CtrlMod = keys_held["Ctrl"] ? "Ctrl-" : ""
 	var/ShiftMod = keys_held["Shift"] ? "Shift-" : ""
 	var/full_key = "[AltMod][CtrlMod][ShiftMod][_key]"
+	if(_key == "Alt" || _key == "Ctrl" || _key == "Shift") // only add modifiers if the key is not a modifier already
+		full_key = _key
 	var/keycount = 0
 	for(var/kb_name in prefs.key_bindings[full_key])
 		keycount++

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -11,8 +11,9 @@
 		say(message)
 
 /mob/verb/say_wrapper()
+	set name = ".Say"
 	set hidden = TRUE
-	var/message = input("", "Say") as text
+	var/message = input("", "Say \"text\"") as null|text
 	say_verb(message)
 	
 ///Whisper verb


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds an alternative move intent toggle that doesn't restore original intent after pressing, it starts unbound also fixes #47563

should also fix #47570 but its hard to test because I still couldn't reproduce
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->


## Changelog
:cl:
add: new button that truly toggles move intent
fix: hotkeys using Alt, Shift and Ctrl now work correctly
fix: pressing h will allow you to stop pulling now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
