### PR TITLE
Alt clicking inside bag wont show turf tab

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -343,7 +343,7 @@
 /atom/proc/AltClick(mob/user)
 	SEND_SIGNAL(src, COMSIG_CLICK_ALT, user)
 	var/turf/T = get_turf(src)
-	if(T && isturf(loc) && user.TurfAdjacent(T))
+	if(T && (isturf(loc) || isturf(src)) && user.TurfAdjacent(T))
 		user.listed_turf = T
 		user.client.statpanel = T.name
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -343,7 +343,7 @@
 /atom/proc/AltClick(mob/user)
 	SEND_SIGNAL(src, COMSIG_CLICK_ALT, user)
 	var/turf/T = get_turf(src)
-	if(T && user.TurfAdjacent(T))
+	if(T && isturf(loc) && user.TurfAdjacent(T))
 		user.listed_turf = T
 		user.client.statpanel = T.name
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the turf view to only open for something that is a turf or is on the turf, and not inside something else like a bag. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents tabs switching all the time.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
tweak: Alt clicking will no longer show turf contents for items inside bags etc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
