### PR TITLE
fixes reaction chambers sometimes not waking up

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -28,6 +28,7 @@
 #define ADD_REAGENT		2	// reagent added
 #define REM_REAGENT		3	// reagent removed (may still exist)
 #define CLEAR_REAGENTS	4	// all reagents were cleared
+#define REACT_REAGENTS	5	// a reaction occured
 
 #define MIMEDRINK_SILENCE_DURATION 30  //ends up being 60 seconds given 1 tick every 2 seconds
 //used by chem masters and pill presses

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -516,6 +516,7 @@
 							ME2.name = "used slime extract"
 							ME2.desc = "This extract has been used up."
 
+			my_atom?.on_reagent_change(REACT_REAGENTS)
 			selected_reaction.on_reaction(src, multiplier)
 			reaction_occurred = 1
 


### PR DESCRIPTION
closes #47583 
Fixes a case where on_reagent_change wouldnt get called on the changing of reagents.

:cl:
fix: Reaction chambers now don't break after certain reactions, like meat creation.
/:cl: