### PR TITLE
fix crafting ui breaking when knowing desserts

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -413,7 +413,13 @@
 /obj/item/book/granter/crafting_recipe/cooking_sweets_101
 	name = "Cooking Desserts 101"
 	desc = "A cook book that teaches you some more of the newest desserts. AI approved, and a best seller on Honkplanet."
-	crafting_recipe_types = list(/datum/crafting_recipe/food/mimetart, /datum/crafting_recipe/food/berrytart, /datum/crafting_recipe/food/cocolavatart, /datum/crafting_recipe/food/clowncake, /datum/crafting_recipe/food/vanillacake)
+	crafting_recipe_types = list(
+		/datum/crafting_recipe/food/mimetart,
+		/datum/crafting_recipe/food/berrytart,
+		/datum/crafting_recipe/food/cocolavatart,
+		/datum/crafting_recipe/food/clowncake,
+		/datum/crafting_recipe/food/vanillacake
+	)
 	icon_state = "cooking_learing_sweets"
 	oneuse = FALSE
 	remarks = list("So that is how icing is made!", "Placing fruit on top? How simple...", "Huh layering cake seems harder then this...", "This book smells like candy", "A clown must have made this page, or they forgot to spell check it before printing...", "Wait, a way to cook slime to be safe?")

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pie.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pie.dm
@@ -165,6 +165,7 @@
 	        /obj/item/slime_extract = 1 //The reason you dont know how to make it!
 	        )
 	result = /obj/item/reagent_containers/food/snacks/pie/cocolavatart
+	subcategory = CAT_PIE
 
 /datum/crafting_recipe/food/blumpkinpie
 	name = "Blumpkin pie"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If something doesn't have a subcategory when it's on a category with subcategories it breaks things hard. I should probably add some checking for this but the checking would be fairly complicated.

Fixes #47612

## Changelog
:cl:
fix: Learning to bake cakes doesn't break the entire crafting ui anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
