### PR TITLE
Modifies the Mechfab to use the Ore Silo

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -94943,6 +94943,8 @@
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
 /turf/open/floor/plating,
 /area/science/research/abandoned)
 "duq" = (
@@ -94955,11 +94957,12 @@
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dur" = (
-/obj/machinery/mecha_part_fabricator,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/mechfab,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dus" = (
@@ -94968,6 +94971,7 @@
 /obj/item/stock_parts/micro_laser,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
+/obj/item/stock_parts/manipulator,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dut" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -94943,8 +94943,6 @@
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
 /turf/open/floor/plating,
 /area/science/research/abandoned)
 "duq" = (
@@ -94961,8 +94959,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/frame/machine,
-/obj/item/circuitboard/machine/mechfab,
+/obj/machinery/mecha_part_fabricator/maint{
+	name = "forgotten exosuit fabricator"
+	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dus" = (
@@ -94971,7 +94970,6 @@
 /obj/item/stock_parts/micro_laser,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
-/obj/item/stock_parts/manipulator,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dut" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -46447,6 +46447,7 @@
 	charge = 100;
 	maxcharge = 15000
 	},
+/obj/item/circuitboard/machine/mechfab,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bYK" = (
@@ -47862,10 +47863,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cby" = (
-/obj/machinery/mecha_part_fabricator{
-	name = "counterfeit exosuit fabricator";
-	req_access = null
-	},
+/obj/structure/frame/machine,
+/obj/item/stack/sheet/glass,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/matter_bin,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cbz" = (
@@ -49083,6 +49086,7 @@
 	},
 /obj/item/hand_labeler,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/item/stack/cable_coil,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ceq" = (
@@ -63783,10 +63787,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cJf" = (
-/obj/effect/landmark/carpspawn,
-/turf/open/space/basic,
-/area/space)
 "cJg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/bedsheet/medical,
@@ -73824,6 +73824,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"gGX" = (
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/space)
 "gHh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance,
@@ -118195,7 +118199,7 @@ aaf
 aaa
 aaa
 aaa
-cJf
+gGX
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -47863,12 +47863,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cby" = (
-/obj/structure/frame/machine,
-/obj/item/stack/sheet/glass,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/matter_bin,
+/obj/machinery/mecha_part_fabricator/maint{
+	name = "forgotten exosuit fabricator"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cbz" = (
@@ -73824,10 +73821,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"gGX" = (
-/obj/effect/landmark/carpspawn,
-/turf/open/space/basic,
-/area/space)
 "gHh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance,
@@ -75919,6 +75912,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"tIk" = (
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/space)
 "tKc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable,
@@ -118199,7 +118196,7 @@ aaf
 aaa
 aaa
 aaa
-gGX
+tIk
 aaa
 aaa
 aaa

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -17,7 +17,7 @@ handles linking back and forth.
 	var/local_size = INFINITY
 	var/start_linked = TRUE
 
-/datum/component/remote_materials/Initialize(category, mapload, allow_standalone = TRUE, force_connect = FALSE, start_linked = TRUE)
+/datum/component/remote_materials/Initialize(category, mapload, allow_standalone = TRUE, force_connect = FALSE, )
 	if (!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -28,7 +28,7 @@ handles linking back and forth.
 	RegisterSignal(parent, COMSIG_ATOM_MULTITOOL_ACT, .proc/OnMultitool)
 
 	var/turf/T = get_turf(parent)
-	if (start_linked && (force_connect || (mapload && is_station_level(T.z))))
+	if ((force_connect || (mapload && is_station_level(T.z))))
 		addtimer(CALLBACK(src, .proc/LateInitialize))
 	else if (allow_standalone)
 		_MakeLocal()

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -16,7 +16,7 @@ handles linking back and forth.
 	var/allow_standalone
 	var/local_size = INFINITY
 
-/datum/component/remote_materials/Initialize(category, mapload, allow_standalone = TRUE, force_connect = FALSE, )
+/datum/component/remote_materials/Initialize(category, mapload, allow_standalone = TRUE, force_connect = FALSE)
 	if (!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -15,7 +15,6 @@ handles linking back and forth.
 	var/category
 	var/allow_standalone
 	var/local_size = INFINITY
-	var/start_linked = TRUE
 
 /datum/component/remote_materials/Initialize(category, mapload, allow_standalone = TRUE, force_connect = FALSE, )
 	if (!isatom(parent))
@@ -28,7 +27,7 @@ handles linking back and forth.
 	RegisterSignal(parent, COMSIG_ATOM_MULTITOOL_ACT, .proc/OnMultitool)
 
 	var/turf/T = get_turf(parent)
-	if ((force_connect || (mapload && is_station_level(T.z))))
+	if (force_connect || (mapload && is_station_level(T.z)))
 		addtimer(CALLBACK(src, .proc/LateInitialize))
 	else if (allow_standalone)
 		_MakeLocal()
@@ -74,12 +73,6 @@ handles linking back and forth.
 	mat_container = null
 	if (allow_standalone)
 		_MakeLocal()
-
-// Used to start something on the map that isn't automatically connected ie mechfabs in maintenance
-/datum/component/remote_materials/proc/Disconnect()
-	if(silo)
-		silo.connected -= src
-		disconnect_from(silo)
 
 /datum/component/remote_materials/proc/OnAttackBy(datum/source, obj/item/I, mob/user)
 	if (silo && istype(I, /obj/item/stack))

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -15,8 +15,9 @@ handles linking back and forth.
 	var/category
 	var/allow_standalone
 	var/local_size = INFINITY
+	var/start_linked = TRUE
 
-/datum/component/remote_materials/Initialize(category, mapload, allow_standalone = TRUE, force_connect = FALSE)
+/datum/component/remote_materials/Initialize(category, mapload, allow_standalone = TRUE, force_connect = FALSE, start_linked = TRUE)
 	if (!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -27,7 +28,7 @@ handles linking back and forth.
 	RegisterSignal(parent, COMSIG_ATOM_MULTITOOL_ACT, .proc/OnMultitool)
 
 	var/turf/T = get_turf(parent)
-	if (force_connect || (mapload && is_station_level(T.z)))
+	if (start_linked && (force_connect || (mapload && is_station_level(T.z))))
 		addtimer(CALLBACK(src, .proc/LateInitialize))
 	else if (allow_standalone)
 		_MakeLocal()
@@ -73,6 +74,12 @@ handles linking back and forth.
 	mat_container = null
 	if (allow_standalone)
 		_MakeLocal()
+
+// Used to start something on the map that isn't automatically connected ie mechfabs in maintenance
+/datum/component/remote_materials/proc/Disconnect()
+	if(silo)
+		silo.connected -= src
+		disconnect_from(silo)
 
 /datum/component/remote_materials/proc/OnAttackBy(datum/source, obj/item/I, mob/user)
 	if (silo && istype(I, /obj/item/stack))

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -19,6 +19,7 @@
 	var/processing_queue = 0
 	var/screen = "main"
 	var/temp
+	var/datum/component/remote_materials/rmat
 	var/list/part_sets = list(
 								"Cyborg",
 								"Ripley",
@@ -34,13 +35,10 @@
 								"Misc"
 								)
 
-/obj/machinery/mecha_part_fabricator/Initialize()
-    var/datum/component/material_container/materials = AddComponent(/datum/component/material_container,
-     list(/datum/material/iron, /datum/material/glass, /datum/material/silver, /datum/material/gold, /datum/material/diamond, /datum/material/plasma, /datum/material/uranium, /datum/material/bananium, /datum/material/titanium, /datum/material/bluespace), 0,
-        TRUE, /obj/item/stack, CALLBACK(src, .proc/is_insertion_ready), CALLBACK(src, .proc/AfterMaterialInsert))
-    materials.precise_insertion = TRUE
-    stored_research = new
-    return ..()
+/obj/machinery/mecha_part_fabricator/Initialize(mapload)
+	stored_research = new
+	rmat = AddComponent(/datum/component/remote_materials, "mechfab", mapload)
+	return ..()
 
 /obj/machinery/mecha_part_fabricator/RefreshParts()
 	var/T = 0
@@ -48,8 +46,7 @@
 	//maximum stocking amount (default 300000, 600000 at T4)
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 		T += M.rating
-	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
-	materials.max_amount = (200000 + (T*50000))
+		rmat.set_local_size((200000 + (T*50000)))
 
 	//resources adjustment coefficient (1 -> 0.85 -> 0.7 -> 0.55)
 	T = 1.15
@@ -65,9 +62,8 @@
 
 /obj/machinery/mecha_part_fabricator/examine(mob/user)
 	. = ..()
-	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 	if(in_range(user, src) || isobserver(user))
-		. += "<span class='notice'>The status display reads: Storing up to <b>[materials.max_amount]</b> material units.<br>Material consumption at <b>[component_coeff*100]%</b>.<br>Build time reduced by <b>[100-time_coeff*100]%</b>.</span>"
+		. += "<span class='notice'>The status display reads: Storing up to <b>[rmat.local_size]</b> material units.<br>Material consumption at <b>[component_coeff*100]%</b>.<br>Build time reduced by <b>[100-time_coeff*100]%</b>.<span>"
 
 /obj/machinery/mecha_part_fabricator/emag_act()
 	if(obj_flags & EMAGGED)
@@ -81,7 +77,6 @@
 	say("User DB corrupted \[Code 0x00FA\]. Truncating data structure...")
 	sleep(30)
 	say("User DB truncated. Please contact your Nanotrasen system operator for future assistance.")
-
 
 /obj/machinery/mecha_part_fabricator/proc/output_parts_list(set_name)
 	var/output = ""
@@ -111,17 +106,21 @@
 
 /obj/machinery/mecha_part_fabricator/proc/output_available_resources()
 	var/output
-	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
-	for(var/mat_id in materials.materials)
-		var/datum/material/M = mat_id
-		var/amount = materials.materials[mat_id]
-		output += "<span class=\"res_name\">[M.name]: </span>[amount] cm&sup3;"
-		if(amount >= MINERAL_MATERIAL_AMOUNT)
-			output += "<span style='font-size:80%;'>- Remove \[<a href='?src=[REF(src)];remove_mat=1;material=[REF(mat_id)]'>1</a>\]"
-			if(amount >= (MINERAL_MATERIAL_AMOUNT * 10))
-				output += " | \[<a href='?src=[REF(src)];remove_mat=10;material=[REF(M)]'>10</a>\]"
-			output += " | \[<a href='?src=[REF(src)];remove_mat=50;material=[REF(M)]'>All</a>\]</span>"
-		output += "<br/>"
+	var/datum/component/material_container/materials = rmat.mat_container
+
+	if(materials)
+		for(var/mat_id in materials.materials)
+			var/datum/material/M = mat_id
+			var/amount = materials.materials[mat_id]
+			output += "<span class=\"res_name\">[M.name]: </span>[amount] cm&sup3;"
+			if(amount >= MINERAL_MATERIAL_AMOUNT)
+				output += "<span style='font-size:80%;'>- Remove \[<a href='?src=[REF(src)];remove_mat=1;material=materials.materials[mat_id]'>1</a>\]"
+				if(amount >= (MINERAL_MATERIAL_AMOUNT * 10))
+					output += " | \[<a href='?src=[REF(src)];remove_mat=10;material=materials.materials[mat_id]'>10</a>\]"
+				output += " | \[<a href='?src=[REF(src)];remove_mat=50;material=materials.materials[mat_id]'>All</a>\]</span>"
+			output += "<br>"
+	else
+		output += "<font color='red'>No material storage connected, please contact the quartermaster.</font><br>"
 	return output
 
 /obj/machinery/mecha_part_fabricator/proc/get_resources_w_coeff(datum/design/D)
@@ -134,7 +133,7 @@
 /obj/machinery/mecha_part_fabricator/proc/check_resources(datum/design/D)
 	if(D.reagents_list.len) // No reagents storage - no reagent designs.
 		return FALSE
-	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
+	var/datum/component/material_container/materials = rmat.mat_container
 	if(materials.has_materials(get_resources_w_coeff(D)))
 		return TRUE
 	return FALSE
@@ -144,8 +143,21 @@
 	desc = "It's building \a [initial(D.name)]."
 	var/list/res_coef = get_resources_w_coeff(D)
 
-	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
+	var/datum/component/material_container/materials = rmat.mat_container
+	if (!materials)
+		say("No access to material storage, please contact the quartermaster.")
+		return 0
+	if (rmat.on_hold())
+		say("Mineral access is on hold, please contact the quartermaster.")
+		return 0
+	if(!check_resources(D))
+		say("Not enough resources. Queue processing stopped.")
+		temp = {"<span class='alert'>Not enough resources to build next part.</span><br>
+					<a href='?src=[REF(src)];process_queue=1'>Try again</a> | <a href='?src=[REF(src)];clear_temp=1'>Return</a><a>"}
+		return FALSE
 	materials.use_materials(res_coef)
+	rmat.silo_log(src, "built", -1, "[D.name]", res_coef)
+
 	add_overlay("fab-active")
 	use_power = ACTIVE_POWER_USE
 	updateUsrDialog()
@@ -201,13 +213,10 @@
 	while(D)
 		if(stat&(NOPOWER|BROKEN))
 			return FALSE
-		if(!check_resources(D))
-			say("Not enough resources. Queue processing stopped.")
-			temp = {"<span class='alert'>Not enough resources to build next part.</span><br>
-						<a href='?src=[REF(src)];process_queue=1'>Try again</a> | <a href='?src=[REF(src)];clear_temp=1'>Return</a><a>"}
+		if(build_part(D))
+			remove_from_queue(1)
+		else
 			return FALSE
-		remove_from_queue(1)
-		build_part(D)
 		D = listgetindex(queue, 1)
 	say("Queue processing finished successfully.")
 
@@ -397,10 +406,19 @@
 	process_queue()
 	processing_queue = 0
 
-/obj/machinery/mecha_part_fabricator/on_deconstruction()
-	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
-	materials.retrieve_all()
-	..()
+/obj/machinery/mecha_part_fabricator/proc/eject_sheets(eject_sheet, eject_amt)
+	var/datum/component/material_container/mat_container = rmat.mat_container
+	if (!mat_container)
+		say("No access to material storage, please contact the quartermaster.")
+		return 0
+	if (rmat.on_hold())
+		say("Mineral access is on hold, please contact the quartermaster.")
+		return 0
+	var/count = mat_container.retrieve_sheets(text2num(eject_amt), eject_sheet, drop_location())
+	var/list/matlist = list()
+	matlist[eject_sheet] = text2num(eject_amt)
+	rmat.silo_log(src, "ejected", -count, "sheets", matlist)
+	return count
 
 /obj/machinery/mecha_part_fabricator/proc/AfterMaterialInsert(item_inserted, id_inserted, amount_inserted)
 	var/datum/material/M = id_inserted

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -46,7 +46,7 @@
 	//maximum stocking amount (default 300000, 600000 at T4)
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 		T += M.rating
-			rmat.set_local_size((200000 + (T*50000)))
+		rmat.set_local_size((200000 + (T*50000)))
 
 	//resources adjustment coefficient (1 -> 0.85 -> 0.7 -> 0.55)
 	T = 1.15

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -38,7 +38,8 @@
 
 /obj/machinery/mecha_part_fabricator/Initialize(mapload)
 	stored_research = new
-	rmat = AddComponent(/datum/component/remote_materials, "mechfab", mapload, start_linked = link_on_init )
+	rmat = AddComponent(/datum/component/remote_materials, "mechfab", mapload && link_on_init)
+	RefreshParts() //Recalculating local material sizes if the fab isn't linked
 	return ..()
 
 /obj/machinery/mecha_part_fabricator/RefreshParts()
@@ -47,7 +48,7 @@
 	//maximum stocking amount (default 300000, 600000 at T4)
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 		T += M.rating
-		rmat.set_local_size((200000 + (T*50000)))
+	rmat.set_local_size((200000 + (T*50000)))
 
 	//resources adjustment coefficient (1 -> 0.85 -> 0.7 -> 0.55)
 	T = 1.15

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -18,6 +18,7 @@
 	var/list/queue = list()
 	var/processing_queue = 0
 	var/screen = "main"
+	var/link_on_init = TRUE
 	var/temp
 	var/datum/component/remote_materials/rmat
 	var/list/part_sets = list(
@@ -37,7 +38,7 @@
 
 /obj/machinery/mecha_part_fabricator/Initialize(mapload)
 	stored_research = new
-	rmat = AddComponent(/datum/component/remote_materials, "mechfab", mapload)
+	rmat = AddComponent(/datum/component/remote_materials, "mechfab", mapload, start_linked = link_on_init )
 	return ..()
 
 /obj/machinery/mecha_part_fabricator/RefreshParts()
@@ -118,7 +119,7 @@
 				output += "<span style='font-size:80%;'>- Remove \[<a href='?src=[REF(src)];remove_mat=1;material=[ref]'>1</a>\]"
 				if(amount >= (MINERAL_MATERIAL_AMOUNT * 10))
 					output += " | \[<a href='?src=[REF(src)];remove_mat=10;material=[ref]'>10</a>\]"
-				output += " | \[<a href='?src=[REF(src)];remove_mat=50;material=[ref]'>All</a>\]</span>"
+				output += " | \[<a href='?src=[REF(src)];remove_mat=50;material=[ref]'>50</a>\]</span>"
 			output += "<br>"
 	else
 		output += "<font color='red'>No material storage connected, please contact the quartermaster.</font><br>"
@@ -443,3 +444,6 @@
 		return FALSE
 
 	return TRUE
+
+/obj/machinery/mecha_part_fabricator/maint
+	link_on_init = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I have wanted this for ages. The Mechfab will now pull from the Ore Silo as opposed to having to manually put materials inside. Ported from Yogstation, big ups to @alexkar598 for taking the time to figure this out on their end and make my life a lot easier and to @kriskog and @AnturK for testing and assistance in making it work with our materials datum.

## Why It's Good For The Game

I spent more time on this than I will ever save walking to R&D for materials and walking back and it's totally worth it

## Changelog
:cl:
add: Modifications have been made to the Mech Fabricator to allow it to withdraw and deposit to the ore silo (Thanks to alexkar598 from Yogstation for the code!)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
