### PR TITLE
Fixes broken pipes in MetaStation aft maintenance

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -44812,7 +44812,6 @@
 	},
 /area/maintenance/solars/port/aft)
 "bUO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
 /obj/machinery/camera/autoname,
 /turf/open/floor/plating,
@@ -45274,7 +45273,7 @@
 "bVR" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
@@ -53144,6 +53143,9 @@
 	doorOpen = 'sound/effects/doorcreaky.ogg';
 	name = "The Gobetting Barmaid"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cnm" = (
@@ -57575,6 +57577,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cwj" = (
@@ -73409,6 +73414,9 @@
 /obj/structure/girder,
 /obj/structure/grille,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -73419,6 +73427,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"ewp" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "eyv" = (
 /obj/structure/grille/broken,
 /obj/structure/lattice,
@@ -73621,6 +73637,7 @@
 	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fwb" = (
@@ -73757,6 +73774,9 @@
 "glz" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
@@ -74204,6 +74224,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
+"jnX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jrE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -74211,6 +74238,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"jrQ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "jwW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/crew_quarters/fitness/recreation)
@@ -74462,6 +74494,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"kRs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "kSB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/trunk,
@@ -74509,6 +74548,9 @@
 	name = "Port Quarter Solar Access";
 	req_access_txt = "10"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "liQ" = (
@@ -74551,6 +74593,9 @@
 "luh" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "lwA" = (
@@ -74894,6 +74939,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "nwq" = (
@@ -75121,6 +75169,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"oCO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "oFI" = (
 /obj/machinery/door/window/eastright{
 	dir = 8;
@@ -75162,6 +75220,13 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
 /area/maintenance/port/aft)
+"oRm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "oRL" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -75213,6 +75278,9 @@
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -76195,6 +76263,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"vKK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "vKU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -89123,7 +89197,7 @@ cjt
 ckS
 ckP
 ckP
-bXE
+cdg
 ptP
 ckP
 ckP
@@ -89637,7 +89711,7 @@ tSO
 diI
 dux
 uYL
-ckP
+vKK
 dux
 dux
 dux
@@ -90383,9 +90457,9 @@ bJq
 bKX
 bbL
 bbL
-bPG
-bxT
-bSn
+oRm
+bbL
+jrQ
 nfn
 aob
 aob
@@ -90408,7 +90482,7 @@ gcu
 cmB
 tQS
 cga
-cbx
+nPC
 wkM
 bTn
 bUN
@@ -90665,7 +90739,7 @@ fwL
 cmB
 wij
 cga
-cbx
+nPC
 reI
 bTn
 bUO
@@ -90922,7 +90996,7 @@ fwL
 cmB
 wij
 cga
-cbx
+nPC
 uqB
 bTp
 bUP
@@ -91179,7 +91253,7 @@ gUb
 cmB
 wij
 snr
-cbx
+nPC
 dux
 bTn
 bTn
@@ -91437,9 +91511,9 @@ cmB
 hwW
 cga
 luh
-cbx
+jnX
 fvT
-cbx
+uOc
 cwh
 hEP
 dux
@@ -91694,7 +91768,7 @@ cmB
 jPu
 cga
 cxR
-cbx
+nPC
 ceu
 dyw
 bXE
@@ -91951,7 +92025,7 @@ kBT
 omB
 cga
 ceu
-cbx
+nPC
 dux
 dux
 ckN
@@ -92208,7 +92282,7 @@ tRO
 cga
 cga
 cLI
-cbx
+nPC
 dux
 anT
 aaf
@@ -92465,7 +92539,7 @@ fkj
 cga
 sfQ
 bXE
-cbx
+nPC
 ckN
 aaf
 aaa
@@ -92722,7 +92796,7 @@ xTm
 cga
 ceu
 dvt
-cbx
+nPC
 ckN
 aaf
 aaa
@@ -93236,7 +93310,7 @@ ndC
 xZy
 cga
 hdX
-cbx
+nPC
 ckN
 aaf
 aaa
@@ -93493,7 +93567,7 @@ wpK
 eSm
 cga
 ceu
-cbx
+nPC
 ckN
 aaf
 aaa
@@ -93750,7 +93824,7 @@ cmB
 cqt
 cga
 jNy
-cbx
+nPC
 dux
 aaf
 aaf
@@ -94007,7 +94081,7 @@ mtp
 vQt
 cga
 oXP
-luh
+ewp
 dux
 dux
 dux
@@ -94264,7 +94338,7 @@ cga
 cga
 cga
 ceu
-luh
+ewp
 bXE
 dvq
 dux
@@ -94520,8 +94594,8 @@ fFJ
 csi
 chZ
 chZ
-cvl
-cbx
+oCO
+kRs
 ceu
 dux
 dux


### PR DESCRIPTION
reconnects the port quarter solars and the abandoned bar to the air supply. They were deleted when the plumbing room was implemented

:cl:
fix: The abandoned bar and port quarter solars are now connected to the air supply
/:cl: