### PR TITLE
Fixes shock propagation, adds it to fireman carry

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -220,19 +220,21 @@
 	. = ..()
 	if(!.)
 		return
-	//Pulling
-	if(iscarbon(pulling) && !(flags & SHOCK_ILLUSION) && source != pulling)
-		var/mob/living/carbon/C = pulling
-		C.electrocute_act(shock_damage*0.75, src, 1, flags)
-	if(iscarbon(pulledby) && !(flags & SHOCK_ILLUSION) && source != pulledby)
-		var/mob/living/carbon/C = pulledby
-		C.electrocute_act(shock_damage*0.75, src, 1, flags)
-	if(iscarbon(buckled) && !(flags & SHOCK_ILLUSION) && source != buckled)
-		var/mob/living/carbon/C = buckled
-		C.electrocute_act(shock_damage*0.75, src, 1, flags)
-	for(var/thing in buckled_mobs)
-		if(iscarbon(thing) && !(flags & SHOCK_ILLUSION) && source != thing)
-			var/mob/living/carbon/C = thing
+	//Propagation through pulling, fireman carry
+	if(!(flags & SHOCK_ILLUSION))
+		var/list/shocking_queue = list()
+		if(iscarbon(pulling) && source != pulling)
+			shocking_queue += pulling
+		if(iscarbon(pulledby) && source != pulledby)
+			shocking_queue += pulledby
+		if(iscarbon(buckled) && source != buckled)
+			shocking_queue += buckled
+		for(var/thing in buckled_mobs)
+			if(iscarbon(thing) && source != thing)
+				shocking_queue += thing
+		//Found our victims, now lets shock them all
+		for(var/victim in shocking_queue)
+			var/mob/living/carbon/C = victim
 			C.electrocute_act(shock_damage*0.75, src, 1, flags)
 	//Stun
 	var/should_stun = (!(flags & SHOCK_TESLA) || siemens_coeff > 0.5) && !(flags & SHOCK_NOSTUN)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -234,7 +234,6 @@
 		if(iscarbon(thing) && !(flags & SHOCK_ILLUSION) && source != thing)
 			var/mob/living/carbon/C = thing
 			C.electrocute_act(shock_damage*0.75, src, 1, flags)
-
 	//Stun
 	var/should_stun = (!(flags & SHOCK_TESLA) || siemens_coeff > 0.5) && !(flags & SHOCK_NOSTUN)
 	if(should_stun)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -223,10 +223,18 @@
 	//Pulling
 	if(iscarbon(pulling) && !(flags & SHOCK_ILLUSION) && source != pulling)
 		var/mob/living/carbon/C = pulling
-		C.electrocute_act(shock_damage*0.75, src, flags)
+		C.electrocute_act(shock_damage*0.75, src, 1, flags)
 	if(iscarbon(pulledby) && !(flags & SHOCK_ILLUSION) && source != pulledby)
 		var/mob/living/carbon/C = pulledby
-		C.electrocute_act(shock_damage*0.75, src, flags)
+		C.electrocute_act(shock_damage*0.75, src, 1, flags)
+	if(iscarbon(buckled) && !(flags & SHOCK_ILLUSION) && source != buckled)
+		var/mob/living/carbon/C = buckled
+		C.electrocute_act(shock_damage*0.75, src, 1, flags)
+	for(var/thing in buckled_mobs)
+		if(iscarbon(thing) && !(flags & SHOCK_ILLUSION) && source != thing)
+			var/mob/living/carbon/C = thing
+			C.electrocute_act(shock_damage*0.75, src, 1, flags)
+
 	//Stun
 	var/should_stun = (!(flags & SHOCK_TESLA) || siemens_coeff > 0.5) && !(flags & SHOCK_NOSTUN)
 	if(should_stun)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -229,9 +229,9 @@
 			shocking_queue += pulledby
 		if(iscarbon(buckled) && source != buckled)
 			shocking_queue += buckled
-		for(var/thing in buckled_mobs)
-			if(iscarbon(thing) && source != thing)
-				shocking_queue += thing
+		for(var/mob/living/carbon/carried in buckled_mobs)
+			if(source != carried)
+				shocking_queue += carried
 		//Found our victims, now lets shock them all
 		for(var/victim in shocking_queue)
 			var/mob/living/carbon/C = victim


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The electrocute_act refactor made the shock propagating stop working, this fixes that. Also adds it to fireman carry, belatedly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Shocks are fun. More shocks are more fun.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Fixed shock propagation.
add: Adds shock propagation to fireman carry.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
