### PR TITLE
Update Travis to SpacemanDMM suite v1.1

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -23,4 +23,4 @@ export NODE_VERSION=12
 export PHP_VERSION=5.6
 
 # SpacemanDMM git tag
-export SPACEMAN_DMM_VERSION=suite-1.0
+export SPACEMAN_DMM_VERSION=suite-1.1


### PR DESCRIPTION
[Full changelog](https://github.com/SpaceManiac/SpacemanDMM/releases/tag/suite-1.1). Relevant fixes:

DM Language
- Attempt to parse strings as UTF-8 before falling back to Latin-1 (preparation for BYOND 513).

dmdoc
- Add a basic dark theme (by PJB).
- Fix `/*!` comments including the `!` in the output.

DreamChecker
- Handle `SHOULD_CALL_PARENT(TRUE)` and `FALSE` properly, rather than `1` and `0` only.
