### PR TITLE
Nanite public chambers can swap Cloud IDs on existing nanites

### DIFF
--- a/code/modules/research/nanites/public_chamber.dm
+++ b/code/modules/research/nanites/public_chamber.dm
@@ -60,6 +60,31 @@
 		log_combat(attacker, occupant, "injected", null, "with nanites via [src]")
 	occupant.AddComponent(/datum/component/nanites, 75, cloud_id)
 
+/obj/machinery/public_nanite_chamber/proc/change_cloud(mob/living/attacker)
+	if(stat & (NOPOWER|BROKEN))
+		return
+	if((stat & MAINT) || panel_open)
+		return
+	if(!occupant || busy)
+		return
+
+	var/locked_state = locked
+	locked = TRUE
+
+	set_busy(TRUE, "[initial(icon_state)]_raising")
+	addtimer(CALLBACK(src, .proc/set_busy, TRUE, "[initial(icon_state)]_active"),20)
+	addtimer(CALLBACK(src, .proc/set_busy, TRUE, "[initial(icon_state)]_falling"),40)
+	addtimer(CALLBACK(src, .proc/complete_cloud_change, locked_state, attacker),60)
+
+/obj/machinery/public_nanite_chamber/proc/complete_cloud_change(locked_state, mob/living/attacker)
+	locked = locked_state
+	set_busy(FALSE)
+	if(!occupant)
+		return
+	if(attacker)
+		occupant.investigate_log("had their nanite cloud ID changed into [cloud_id] by [key_name(attacker)] using [src] at [AREACOORD(src)].", INVESTIGATE_NANITES)
+	SEND_SIGNAL(occupant, COMSIG_NANITE_SET_CLOUD, cloud_id)
+
 /obj/machinery/public_nanite_chamber/update_icon()
 	cut_overlays()
 
@@ -135,6 +160,9 @@
 	if(occupant)
 		var/mob/living/L = occupant
 		if(SEND_SIGNAL(L, COMSIG_HAS_NANITES))
+			var/datum/component/nanites/nanites = L.GetComponent(/datum/component/nanites)
+			if(nanites && nanites.cloud_id != cloud_id)
+				change_cloud(attacker)
 			return
 		if(L.mob_biotypes & (MOB_ORGANIC | MOB_UNDEAD))
 			inject_nanites(attacker)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title says it all, really.

I have a few more plans concerning cloud IDs, like assigning them internal and public names, but i'll have to wait until the UI rework is done to implement them.

## Why It's Good For The Game

Makes multiple public cloud IDs more viable without having to manually swap them with the lab Nanite Chamber.

## Changelog
:cl: XDTM
add: Nanite public chambers can now swap Cloud IDs on existing nanites.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
