### PR TITLE
Laser eye shots hit your mask, glasses, or hat if they block your face

### DIFF
--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -101,13 +101,18 @@
 /datum/mutation/human/laser_eyes/proc/on_ranged_attack(mob/living/carbon/human/source, atom/target, mouseparams)
 	if(source.a_intent != INTENT_HARM)
 		return
-	to_chat(source, "<span class='warning'>You shoot with your laser eyes!</span>")
 	source.changeNext_move(CLICK_CD_RANGE)
 	var/obj/projectile/beam/laser_eyes/LE = new(source.loc)
 	LE.firer = source
 	LE.def_zone = ran_zone(source.zone_selected)
-	LE.preparePixelProjectile(target, source, mouseparams)
-	LE.fire()
+	source.newtonian_move(get_dir(target, source))
+	var/obj/item/blocker = source.is_eyes_covered()
+	if(blocker)
+		to_chat(source, "<span class='warning'>You shoot your [blocker] with your laser eyes!</span>")
+	else
+		LE.preparePixelProjectile(target, source, mouseparams)
+		to_chat(source, "<span class='warning'>You shoot with your laser eyes!</span>")
+	LE.fire(null, blocker)
 	playsound(source, 'sound/weapons/taser2.ogg', 75, TRUE)
 
 ///Projectile type used by laser eyes


### PR DESCRIPTION

## About The Pull Request

Laser eyes will hit shit between your eyes and the space in front of your eyes. This does break them, so be careful.
Also added a newtonian_move to shooting laser eyes so you can use them to move around in low grav. Since shooting them will break your hardsuit helmet, I'm not sure how often this will come up, but eyyyyyy.

## Why It's Good For The Game

Laser eyes is frankly a stupidly OP mutation and while this doesn't really make it balanced, it's a start.

## Changelog
:cl: MrPerson
add: Laser eyes will now hit your glasses, helmet, or mask if those things block your eyes. They'll take damage too, so you should take them off before shooting your eyes out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
