### PR TITLE
Adds immersion and realism to internals tank suicides

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -131,7 +131,7 @@
 		var/matrix/M = matrix()
 		M.Scale(2, 1.2)
 		animate(H, time = 40, transform = M, easing = SINE_EASING)
-		return MANUAL_SUICIDE_NONLETHAL
+		return MANUAL_SUICIDE
 	else
 		to_chat(user, "<span class='warning'>There isn't enough pressure in [src] to commit suicide with...</span>")
 	return SHAME

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -127,10 +127,7 @@
 	playsound(loc, 'sound/effects/spray.ogg', 10, TRUE, -3)
 	if(!QDELETED(H) && air_contents && air_contents.return_pressure() >= 1000)
 		ADD_TRAIT(H, TRAIT_DISFIGURED, TRAIT_GENERIC)
-		addtimer(CALLBACK(H, /mob/living/carbon/.proc/gib, null, null, TRUE, TRUE), 25)
-		var/matrix/M = matrix()
-		M.Scale(2, 1.2)
-		animate(H, time = 40, transform = M, easing = SINE_EASING)
+		H.inflate_gib()
 		return MANUAL_SUICIDE
 	else
 		to_chat(user, "<span class='warning'>There isn't enough pressure in [src] to commit suicide with...</span>")

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -125,21 +125,16 @@
 	var/mob/living/carbon/human/H = user
 	user.visible_message("<span class='suicide'>[user] is putting [src]'s valve to [user.p_their()] lips! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(loc, 'sound/effects/spray.ogg', 10, TRUE, -3)
-	if (!QDELETED(H) && air_contents && air_contents.return_pressure() >= 1000)
-		for(var/obj/item/W in H)
-			H.dropItemToGround(W)
-			if(prob(50))
-				step(W, pick(GLOB.alldirs))
+	if(!QDELETED(H) && air_contents && air_contents.return_pressure() >= 1000)
 		ADD_TRAIT(H, TRAIT_DISFIGURED, TRAIT_GENERIC)
-		H.bleed_rate = 5
-		H.gib_animation()
-		sleep(3)
-		H.adjustBruteLoss(1000) //to make the body super-bloody
-		H.spawn_gibs()
-		H.spill_organs()
-		H.spread_bodyparts()
-
-	return (BRUTELOSS)
+		addtimer(CALLBACK(H, /mob/living/carbon/.proc/gib, null, null, TRUE, TRUE), 25)
+		var/matrix/M = matrix()
+		M.Scale(2, 1.2)
+		animate(H, time = 40, transform = M, easing = SINE_EASING)
+		return MANUAL_SUICIDE_NONLETHAL
+	else
+		to_chat(user, "<span class='warning'>There isn't enough pressure in [src] to commit suicide with...</span>")
+	return SHAME
 
 /obj/item/tank/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -24,7 +24,7 @@
 	animate(src, time = 40, transform = M, easing = SINE_EASING)
 
 /mob/living/carbon/gib(no_brain, no_organs, no_bodyparts, safe_gib = FALSE)
-	if(safe_gib) // If you wan't to keep all the mob's items and not have them deleted
+	if(safe_gib) // If you want to keep all the mob's items and not have them deleted
 		for(var/obj/item/W in src)
 			dropItemToGround(W)
 			if(prob(50))

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -17,6 +17,12 @@
 	if(SSticker.mode)
 		SSticker.mode.check_win() //Calls the rounds wincheck, mainly for wizard, malf, and changeling now
 
+/mob/living/carbon/proc/inflate_gib() // Plays an animation that makes mobs appear to inflate before finally gibbing
+	addtimer(CALLBACK(src, .proc/gib, null, null, TRUE, TRUE), 25)
+	var/matrix/M = matrix()
+	M.Scale(1.8, 1.2)
+	animate(src, time = 40, transform = M, easing = SINE_EASING)
+
 /mob/living/carbon/gib(no_brain, no_organs, no_bodyparts, safe_gib = FALSE)
 	if(safe_gib) // If you wan't to keep all the mob's items and not have them deleted
 		for(var/obj/item/W in src)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -17,12 +17,17 @@
 	if(SSticker.mode)
 		SSticker.mode.check_win() //Calls the rounds wincheck, mainly for wizard, malf, and changeling now
 
-/mob/living/carbon/gib(no_brain, no_organs, no_bodyparts)
+/mob/living/carbon/gib(no_brain, no_organs, no_bodyparts, safe_gib = FALSE)
+	if(safe_gib) // If you wan't to keep all the mob's items and not have them deleted
+		for(var/obj/item/W in src)
+			dropItemToGround(W)
+			if(prob(50))
+				step(W, pick(GLOB.alldirs))
 	var/atom/Tsec = drop_location()
 	for(var/mob/M in src)
 		M.forceMove(Tsec)
 		visible_message("<span class='danger'>[M] bursts out of [src]!</span>")
-	..()
+	. = ..()
 
 /mob/living/carbon/spill_organs(no_brain, no_organs, no_bodyparts)
 	var/atom/Tsec = drop_location()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -143,7 +143,7 @@
 
 /datum/reagent/toxin/minttoxin/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_FAT))
-		M.gib()
+		M.inflate_gib()
 	return ..()
 
 /datum/reagent/toxin/carpotoxin


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When you suicide with an internals tank, normally you just fall over and gib immediately. Now you get to see people inflate from inhaling the gas in the tank before they explode. I can still tweak how it looks but this is what I have so far:

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

![GIF](https://user-images.githubusercontent.com/42044220/68607138-907cbc80-0475-11ea-9305-c66d6660bf4e.gif)


## Changelog
:cl:
tweak: When you suicide using an internals tank, you're character will now inflate, and grow in size before you gib.
code: Adds a safe_gib argument to the carbon gib proc. Allows you to specifiy if you want to preserve the items on the mob you're gibbing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
