### PR TITLE
Fixes personal crafting menus not working properly

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -395,7 +395,10 @@
 			if(!isnull(params["category"]))
 				cur_category = params["category"]
 			if(!isnull(params["subcategory"]))
-				cur_subcategory = params["subcategory"]
+				if(params["subcategory"] == "0")
+					cur_subcategory = ""
+				else
+					cur_subcategory = params["subcategory"]
 			. = TRUE
 
 /datum/component/personal_crafting/proc/build_recipe_data(datum/crafting_recipe/R)

--- a/tgui-next/packages/tgui/interfaces/PersonalCrafting.js
+++ b/tgui-next/packages/tgui/interfaces/PersonalCrafting.js
@@ -140,7 +140,7 @@ export const PersonalCrafting = props => {
               label={recipe.category}
               onClick={() => act(ref, 'set_category', {
                 category: recipe.category,
-                subcategory: recipe.firstSubcatName,
+                subcategory: recipe.firstSubcatName, // Backend expects "0" or "" to indicate no subcategory
               })}>
               {() => !recipe.hasSubcats && (
                 <CraftingList


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title

## Changelog
:cl:
fix: Personal crafting menus now work properly on categories without subcategories
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
