### PR TITLE
Abandoned crates now roll loot upon opening

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -21,6 +21,8 @@
 		code += dig
 		digits -= dig  //there are never matching digits in the answer
 
+/obj/structure/closet/crate/secure/loot/open(mob/living/user)
+
 	var/loot = rand(1,100) //100 different crates with varying chances of spawning
 	switch(loot)
 		if(1 to 5) //5% chance
@@ -141,6 +143,8 @@
 		if(100)
 			new /obj/item/melee/skateboard/hoverboard(src)
 
+			new /obj/item/clothing/head/bearpelt(src)
+	. = ..()
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/structure/closet/crate/secure/loot/attack_hand(mob/user)
 	if(locked)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This will do what it says on the tin to fix some minor issues with certain contents of these crates, namely one possible drop causing the crates to explode prematurely.

## Why It's Good For The Game

E

## Changelog
:cl:
fix: Abandoned crates now roll their loot upon being opened
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
