### PR TITLE
(multiz) mechs can now go down (stairs)

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -4,7 +4,8 @@
 	icon = 'icons/mecha/mecha.dmi'
 	density = TRUE //Dense. To raise the heat.
 	opacity = 1 ///opaque. Menacing.
-	anchored = TRUE //no pulling around.
+	move_force = MOVE_FORCE_VERY_STRONG
+	move_resist = MOVE_FORCE_EXTREMELY_STRONG
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	layer = BELOW_MOB_LAYER//icon draw layer
 	infra_luminosity = 15 //byond implementation is bugged.
@@ -660,11 +661,11 @@
 					step(src,dir)
 		if(isobj(obstacle))
 			var/obj/O = obstacle
-			if(!O.anchored)
+			if(!O.anchored && O.move_resist <= move_force)
 				step(obstacle, dir)
 		else if(ismob(obstacle))
 			var/mob/M = obstacle
-			if(!M.anchored)
+			if(M.move_resist <= move_force)
 				step(obstacle, dir)
 
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -153,7 +153,7 @@
 		prev_turf.visible_message("<span class='danger'>[mov_name] falls through [prev_turf]!</span>")
 	if(flags & FALL_INTERCEPTED)
 		return
-	if(zFall(A, ++levels, src))
+	if(zFall(A, ++levels))
 		return FALSE
 	A.visible_message("<span class='danger'>[A] crashes into [src]!</span>")
 	A.onZImpact(src, levels)


### PR DESCRIPTION
## About The Pull Request
Converting mecha's anchored state to move force and resistance, and updating the required checks for pushing other objects and mobs away when bumping them with your big stompy mech.
Also removing an unnecessary argument from a `zFall()` call from `/turf/proc/zImpact` that I previously added by accident.

## Why It's Good For The Game
This will close #47604, hopefully without making mechas quirkier thanks to their high move_resist.
And prevents mechs from pushing certain mobs or objects they weren't supposed to.

## Changelog
:cl:
fix: Mechs can now go down (stairs)
fix: Mechs can't push (non-anchored) objects and mobs with move resistance greater than "very strong" anymore.
/:cl:

