### PR TITLE
Removes extra COMSIG_MOVABLE_HEAR signal for mobs

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -242,7 +242,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	// Recompose message for AI hrefs, language incomprehension.
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode)
-	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)
 
 	show_message(message, MSG_AUDIBLE, deaf_message, deaf_type)
 	return message


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
COMSIG_MOVABLE_HEAR is sent by both /atom/movable/Hear() and /mob/living/Hear(), but the hear for mob's inherits from movable anyway, so the signal was sending twice for mobs. 

https://github.com/tgstation/tgstation/blob/c38a7a3bb59259953562de6a5e05d9d898941585/code/game/say.dm#L32
https://github.com/tgstation/tgstation/blob/8cfe0f6467a2b7ca815a61e3f37ab10879d168ee/code/modules/mob/living/say.dm#L245
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
consistency
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
