### PR TITLE
[WIP] Makes action buttons bindable to empty hand usage

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -39,6 +39,9 @@
 		return ..()
 
 /obj/screen/movable/action_button/Click(location,control,params)
+	if(!can_use(usr))
+		return
+
 	var/list/modifiers = params2list(params)
 	if(modifiers["middle"])
 		if(ismob(usr))

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -43,7 +43,8 @@
 	if(modifiers["middle"])
 		if(ismob(usr))
 			var/mob/M = usr
-			if(M.get_active_action())
+			if(M.get_active_action() == linked_action)
+				M.put_action_in_active_hand(null)
 				return
 			M.put_action_in_active_hand(linked_action)
 			return

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -39,10 +39,14 @@
 		return ..()
 
 /obj/screen/movable/action_button/Click(location,control,params)
-	if (!can_use(usr))
-		return
-
 	var/list/modifiers = params2list(params)
+	if(modifiers["middle"])
+		if(ismob(usr))
+			var/mob/M = usr
+			if(M.get_active_action())
+				return
+			M.put_action_in_active_hand(linked_action)
+			return
 	if(modifiers["shift"])
 		if(locked)
 			to_chat(usr, "<span class='warning'>Action button \"[name]\" is locked, unlock it first.</span>")
@@ -78,7 +82,7 @@
 /obj/screen/movable/action_button/hide_toggle/Initialize()
 	. = ..()
 	var/static/list/icon_cache = list()
-	
+
 	var/cache_key = "[hide_icon][hide_state]"
 	hide_appearance = icon_cache[cache_key]
 	if(!hide_appearance)

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -76,6 +76,9 @@
 	if(M)
 		if(M.client)
 			M.client.screen -= button
+		for(var/datum/action/A in M.held_actions)
+			if(A == src)
+				M.put_action_in_hand(null, M.get_held_index_of_action(A))
 		M.actions -= src
 		M.update_action_buttons()
 	owner = null

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -30,6 +30,21 @@
 		return held_items[i]
 	return FALSE
 
+/mob/proc/get_active_action()
+	return(get_action_for_held_index(active_hand_index))
+
+/mob/proc/get_action_for_held_index(i)
+	if(i > 0 && i <= held_items.len)
+		return held_actions[i]
+	return FALSE
+
+/mob/proc/put_action_in_hand(datum/action/A, hand_index)
+	if(hand_index == null)
+		return FALSE
+	held_actions[hand_index] = A
+
+/mob/proc/put_action_in_active_hand(datum/action/A)
+	return put_action_in_hand(A, active_hand_index)
 
 //Odd = left. Even = right
 /mob/proc/held_index_to_dir(i)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -46,6 +46,9 @@
 /mob/proc/put_action_in_active_hand(datum/action/A)
 	return put_action_in_hand(A, active_hand_index)
 
+/mob/proc/get_held_index_of_action(datum/action/A)
+	return held_actions.Find(A)
+
 //Odd = left. Even = right
 /mob/proc/held_index_to_dir(i)
 	if(!(i % 2))

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -6,6 +6,7 @@
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ANTAG_HUD,GLAND_HUD,NANITE_HUD,DIAG_NANITE_FULL_HUD)
 	has_limbs = 1
 	held_items = list(null, null)
+	held_actions = list(null, null)
 	var/list/internal_organs		= list()	//List of /obj/item/organ in the mob. They don't go in the contents for some reason I don't want to know.
 	var/list/internal_organs_slot= list() //Same as above, but stores "slot ID" - "organ" pairs for easy access.
 	var/silent = FALSE 		//Can't talk. Value goes down every life proc. //NOTE TO FUTURE CODERS: DO NOT INITIALIZE NUMERICAL VARS AS NULL OR I WILL MURDER YOU.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -504,6 +504,10 @@
 	if(I)
 		I.attack_self(src)
 		update_inv_hands()
+		return
+	var/datum/action/A = held_actions[active_hand_index]
+	if(A)
+		A.Trigger()
 
 /**
   * Get the notes of this mob

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -125,6 +125,8 @@
 	  * get_active_held_item() instead, because OOP
 	  */
 	var/list/held_items = list()
+	///Actions assigned to hands to use in hand if hand is empty
+	var/list/held_actions = list()
 
 	//HUD things
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows players to on-the-fly bind different actions to "use in hand" with an empty hands. This is done by middle clicking the action button with the hand you wish to put the action in. There is currently no way to see what action is in what hand, which I will work on next. Making this PR early because I am very aware that this could be an ungraceful solution.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This should streamline some action-oriented stuff, like spellcasting and toolset implants.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Middle clicking an action button binds it to a hand. "Use in hand" an empty hand to trigger its bound action.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
