### PR TITLE
Adding a disk to a DNA console removes the old disk

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -69,9 +69,9 @@
 		if(diskette)
 			diskette.forceMove(drop_location())
 			diskette = null
-		src.diskette = I
+		diskette = I
 		to_chat(user, "<span class='notice'>You insert [I].</span>")
-		src.updateUsrDialog()
+		updateUsrDialog()
 		return
 	if (istype(I, /obj/item/chromosome))
 		if(LAZYLEN(stored_chromosomes) < max_chromosomes)

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -64,13 +64,15 @@
 
 /obj/machinery/computer/scan_consolenew/attackby(obj/item/I, mob/user, params)
 	if (istype(I, /obj/item/disk/data)) //INSERT SOME DISKETTES
-		if (!src.diskette)
-			if (!user.transferItemToLoc(I,src))
-				return
-			src.diskette = I
-			to_chat(user, "<span class='notice'>You insert [I].</span>")
-			src.updateUsrDialog()
+		if (!user.transferItemToLoc(I,src))
 			return
+		if(diskette)
+			diskette.forceMove(drop_location())
+			diskette = null
+		src.diskette = I
+		to_chat(user, "<span class='notice'>You insert [I].</span>")
+		src.updateUsrDialog()
+		return
 	if (istype(I, /obj/item/chromosome))
 		if(LAZYLEN(stored_chromosomes) < max_chromosomes)
 			I.forceMove(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1790,6 +1790,7 @@
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_bread.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_burger.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_cake.dm"
+#include "code\modules\food_and_drinks\recipes\tablecraft\recipes_drink.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_egg.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_frozen.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_meat.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1790,7 +1790,6 @@
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_bread.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_burger.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_cake.dm"
-#include "code\modules\food_and_drinks\recipes\tablecraft\recipes_drink.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_egg.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_frozen.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_meat.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Inserting a disk into a genetics console pops out the old disk, like the botany gene modifier.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes swapping disks easier.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Adding a genetics disk to a dna console that already contains a disk will remove the old disk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
