### PR TITLE
Corazone renamed to Higadrite, adds replacement chemical for abductors and fixes heart disease

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -54,7 +54,7 @@
 										/datum/reagent/phenol, /datum/reagent/medicine/inacusiate, /datum/reagent/medicine/oculine, /datum/reagent/medicine/antihol
 									),
 									list(	// level 7
-										/datum/reagent/medicine/leporazine, /datum/reagent/toxin/mindbreaker, /datum/reagent/medicine/corazone
+										/datum/reagent/medicine/leporazine, /datum/reagent/toxin/mindbreaker, /datum/reagent/medicine/higadrite
 									),
 									list(	// level 8
 										/datum/reagent/pax, /datum/reagent/drug/happiness, /datum/reagent/medicine/ephedrine

--- a/code/datums/diseases/heart_failure.dm
+++ b/code/datums/diseases/heart_failure.dm
@@ -59,7 +59,7 @@
 						"<span class='userdanger'>You feel a terrible pain in your chest, as if your heart has stopped!</span>")
 				H.adjustStaminaLoss(60)
 				H.set_heartattack(TRUE)
-				H.reagents.add_reagent(/datum/reagent/medicine/penthrite, 3) // To give the victim a final chance to shock their heart before losing consciousness
+				H.reagents.add_reagent(/datum/reagent/medicine/C2/penthrite, 3) // To give the victim a final chance to shock their heart before losing consciousness
 				cure()
 	else
 		cure()

--- a/code/datums/diseases/heart_failure.dm
+++ b/code/datums/diseases/heart_failure.dm
@@ -3,7 +3,7 @@
 	name = "Myocardial Infarction"
 	max_stages = 5
 	stage_prob = 2
-	cure_text = "Heart replacement surgery to cure. Defibrillation (or as a last resort, uncontrolled electric shocking) may also be effective after the onset of cardiac arrest. Corazone can also mitigate cardiac arrest."
+	cure_text = "Heart replacement surgery to cure. Defibrillation (or as a last resort, uncontrolled electric shocking) may also be effective after the onset of cardiac arrest. Penthrite can also mitigate cardiac arrest."
 	agent = "Shitty Heart"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	permeability_mod = 1
@@ -59,7 +59,7 @@
 						"<span class='userdanger'>You feel a terrible pain in your chest, as if your heart has stopped!</span>")
 				H.adjustStaminaLoss(60)
 				H.set_heartattack(TRUE)
-				H.reagents.add_reagent(/datum/reagent/medicine/corazone, 3) // To give the victim a final chance to shock their heart before losing consciousness
+				H.reagents.add_reagent(/datum/reagent/medicine/penthrite, 3) // To give the victim a final chance to shock their heart before losing consciousness
 				cure()
 	else
 		cure()

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -799,7 +799,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	icon_state = "bed"
 	can_buckle = 1
 
-	var/static/list/injected_reagents = list(/datum/reagent/medicine/corazone)
+	var/static/list/injected_reagents = list(/datum/reagent/medicine/cordiolis_hepatico)
 
 /obj/structure/table/optable/abductor/Crossed(atom/movable/AM)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -346,12 +346,12 @@
 
 /******ORGAN HEALING******/
 /*Suffix: -rite*/
-	//replaces corazone's heart stabilization
 /datum/reagent/medicine/C2/penthrite
 	name = "Penthrite"
 	description = "An explosive compound used to stabilize heart conditions. May interfere with stomach acid!"
 	color = "#F5F5F5"
 	self_consuming = TRUE
+
 /datum/reagent/medicine/C2/penthrite/on_mob_add(mob/living/M)
 	. = ..()
 	ADD_TRAIT(M, TRAIT_STABLEHEART, type)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1049,20 +1049,36 @@
 	..()
 	return TRUE
 
-/datum/reagent/medicine/corazone
-	//Corazone no longer stops heart attacks. look into C2 penthrite.
-	name = "Corazone"
-	description = "A medication used to treat pain, fever, and inflammation, along with failing livers."
-	color = "#F49797"
+/datum/reagent/medicine/higadrite
+	name = "Higadrite"
+	description = "A medication utilized to treat ailing livers."
+	color = "#FF3542"
 	self_consuming = TRUE
 
-/datum/reagent/medicine/corazone/on_mob_add(mob/living/M)
+/datum/reagent/medicine/higadrite/on_mob_add(mob/living/M)
 	..()
 	ADD_TRAIT(M, TRAIT_STABLELIVER, type)
 
-/datum/reagent/medicine/corazone/on_mob_end_metabolize(mob/living/M)
-	REMOVE_TRAIT(M, TRAIT_STABLELIVER, type)
+/datum/reagent/medicine/higadrite/on_mob_end_metabolize(mob/living/M)
 	..()
+	REMOVE_TRAIT(M, TRAIT_STABLELIVER, type)
+
+
+/datum/reagent/medicine/cordiolis_hepatico
+	name = "Cordiolis Hepatico"
+	description = "A strange, pitch-black reagent that seems to absorb all light. Effects unknown."
+	color = "#000000"
+	self_consuming = TRUE
+
+/datum/reagent/medicine/higadrite/on_mob_add(mob/living/M)
+	..()
+	ADD_TRAIT(M, TRAIT_STABLELIVER, type)
+	ADD_TRAIT(M, TRAIT_STABLEHEART, type)
+
+/datum/reagent/medicine/higadrite/on_mob_end_metabolize(mob/living/M)
+	..()
+	REMOVE_TRAIT(M, TRAIT_STABLEHEART, type)
+	REMOVE_TRAIT(M, TRAIT_STABLELIVER, type)
 
 /datum/reagent/medicine/muscle_stimulant
 	name = "Muscle Stimulant"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1063,7 +1063,6 @@
 	..()
 	REMOVE_TRAIT(M, TRAIT_STABLELIVER, type)
 
-
 /datum/reagent/medicine/cordiolis_hepatico
 	name = "Cordiolis Hepatico"
 	description = "A strange, pitch-black reagent that seems to absorb all light. Effects unknown."

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1069,12 +1069,12 @@
 	color = "#000000"
 	self_consuming = TRUE
 
-/datum/reagent/medicine/higadrite/on_mob_add(mob/living/M)
+/datum/reagent/medicine/cordiolis_hepatico/on_mob_add(mob/living/M)
 	..()
 	ADD_TRAIT(M, TRAIT_STABLELIVER, type)
 	ADD_TRAIT(M, TRAIT_STABLEHEART, type)
 
-/datum/reagent/medicine/higadrite/on_mob_end_metabolize(mob/living/M)
+/datum/reagent/medicine/cordiolis_hepatico/on_mob_end_metabolize(mob/living/M)
 	..()
 	REMOVE_TRAIT(M, TRAIT_STABLEHEART, type)
 	REMOVE_TRAIT(M, TRAIT_STABLELIVER, type)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -187,10 +187,10 @@
 	results = list(/datum/reagent/medicine/regen_jelly = 2)
 	required_reagents = list(/datum/reagent/medicine/omnizine = 1, /datum/reagent/toxin/slimejelly = 1)
 
-/datum/chemical_reaction/corazone
-	name = "Corazone"
-	id = /datum/reagent/medicine/corazone
-	results = list(/datum/reagent/medicine/corazone = 3)
+/datum/chemical_reaction/higadrite
+	name = "Higadrite"
+	id = /datum/reagent/medicine/higadrite
+	results = list(/datum/reagent/medicine/higadrite = 3)
 	required_reagents = list(/datum/reagent/phenol = 2, /datum/reagent/lithium = 1)
 
 /datum/chemical_reaction/morphine


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Renames Corazone to Higadrite, as #47536 made it only stabilize the liver, and Corazone is spanish for heart.
Fixes Miocardial Infarction's flavor text that says Corazone is a cure, and it adding Corazone to your bloodstream even though it no longer stabilizes the heart.
Adds a new reagent, Cordiolis Hepatico. Acts as old Corazone, only injectable ingame with an abductor surgery table.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As a spanish dialect speaker, corazone being named the same hurts my corazon. This will make it clearer that it's different for everyone attempting to make old corazone, and helps understand what it is a bit more clearly if you have a bilingual bonus.
Fixing heart disease not being properly updated is obviously beneficial.
Abductor table had a heart and liver stabilizing chemical being constantly injected into the victim/patient, so now it has that again.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: As corazone no longer stabilizes the heart, It's been renamed to Higadrite.
fix: Fixes heart disease telling you to utilize corazone, and injecting you with it during its final stages. It now injects Penthrite.
fix: Abductor surgery table injects a replacement chemical for old Corazone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
