### PR TITLE
pie throwing skill affects cream pies (alt to #47765)

### DIFF
--- a/code/datums/components/creamed.dm
+++ b/code/datums/components/creamed.dm
@@ -74,7 +74,7 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 /datum/component/creamed/proc/cream()
 	if(iscarbon(parent))
 		var/mob/living/C = parent
-		if(C.client && thrower && thrower.mind) //making sure the target (C)  isnt afk
+		if(C.client && !qdeleted(thrower)) //making sure the target (C)  isnt afk
 			SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "creampie", /datum/mood_event/creampie)
 			var/experience_given = 30
 			if(HAS_TRAIT(C.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
@@ -82,7 +82,7 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 			if(already_creamed)
 				experience_given *= 0.1
 			thrower.mind.adjust_experience(/datum/skill/pie_throwing, experience_given)
-		if(stun && thrower)
+		if(stun && !qdeleted(thrower))
 			var/skillmod = thrower.mind.get_skill_speed_modifier(/datum/skill/pie_throwing)
 			if(skillmod > 25)// journeyman level or higher
 				C.Paralyze(skillmod) //splat!

--- a/code/datums/components/creamed.dm
+++ b/code/datums/components/creamed.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 
 	var/mutable_appearance/creamface
 
-/datum/component/creamed/Initialize()
+/datum/component/creamed/Initialize(_thrower)//
 	if(!is_type_in_typecache(parent, GLOB.creamable))
 		return COMPONENT_INCOMPATIBLE
 
@@ -36,6 +36,14 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 
 	var/atom/A = parent
 	A.add_overlay(creamface)
+	//
+	if(_thrower)
+		thrower = _thrower
+	var/experience_given = 30
+				experience_given *= 0.1
+			if(HAS_TRAIT(L.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
+				experience_given *= 3
+			H.mind.adjust_experience(/datum/skill/pie_throwing, experience_given)
 
 /datum/component/creamed/Destroy(force, silent)
 	var/atom/A = parent
@@ -53,9 +61,9 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 
 /datum/component/creamed/UnregisterFromParent()
 	UnregisterSignal(parent, list(
-		COMSIG_COMPONENT_CLEAN_ACT, 
+		COMSIG_COMPONENT_CLEAN_ACT,
 		COMSIG_COMPONENT_CLEAN_FACE_ACT))
-	
+
 ///Callback to remove pieface
 /datum/component/creamed/proc/clean_up(datum/source, strength)
 	if(strength >= CLEAN_WEAK)

--- a/code/datums/components/creamed.dm
+++ b/code/datums/components/creamed.dm
@@ -74,7 +74,7 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 /datum/component/creamed/proc/cream()
 	if(iscarbon(parent))
 		var/mob/living/C = parent
-		if(C.client && !qdeleted(thrower)) //making sure the target (C)  isnt afk
+		if(C.client && thrower && thrower.mind) //making sure the target (C)  isnt afk
 			SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "creampie", /datum/mood_event/creampie)
 			var/experience_given = 30
 			if(HAS_TRAIT(C.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
@@ -82,7 +82,7 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 			if(already_creamed)
 				experience_given *= 0.1
 			thrower.mind.adjust_experience(/datum/skill/pie_throwing, experience_given)
-		if(stun && !qdeleted(thrower))
+		if(stun && thrower)
 			var/skillmod = thrower.mind.get_skill_speed_modifier(/datum/skill/pie_throwing)
 			if(skillmod > 25)// journeyman level or higher
 				C.Paralyze(skillmod) //splat!

--- a/code/datums/components/creamed.dm
+++ b/code/datums/components/creamed.dm
@@ -13,12 +13,21 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
 	var/mutable_appearance/creamface
+	var/already_creamed = FALSE
+	var/mob/living/carbon/thrower
+	var/stun = FALSE
 
-/datum/component/creamed/Initialize(_thrower)//
+
+/datum/component/creamed/Initialize(_thrower, _stun)
 	if(!is_type_in_typecache(parent, GLOB.creamable))
 		return COMPONENT_INCOMPATIBLE
-
+	if(_thrower)
+		thrower = _thrower
+	if(_stun)
+		stun = _stun
 	creamface = mutable_appearance('icons/effects/creampie.dmi')
+
+	cream()
 
 	if(ishuman(parent))
 		var/mob/living/carbon/human/H = parent
@@ -26,7 +35,6 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 			creamface.icon_state = "creampie_lizard"
 		else
 			creamface.icon_state = "creampie_human"
-		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "creampie", /datum/mood_event/creampie)
 	else if(ismonkey(parent))
 		creamface.icon_state = "creampie_monkey"
 	else if(iscorgi(parent))
@@ -34,16 +42,9 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 	else if(isAI(parent))
 		creamface.icon_state = "creampie_ai"
 
+
 	var/atom/A = parent
 	A.add_overlay(creamface)
-	//
-	if(_thrower)
-		thrower = _thrower
-	var/experience_given = 30
-				experience_given *= 0.1
-			if(HAS_TRAIT(L.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-				experience_given *= 3
-			H.mind.adjust_experience(/datum/skill/pie_throwing, experience_given)
 
 /datum/component/creamed/Destroy(force, silent)
 	var/atom/A = parent
@@ -68,3 +69,30 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 /datum/component/creamed/proc/clean_up(datum/source, strength)
 	if(strength >= CLEAN_WEAK)
 		qdel(src)
+
+///proc that manages xp and pie stun
+/datum/component/creamed/proc/cream()
+	if(iscarbon(parent))
+		var/mob/living/C = parent
+		if(C.client && thrower && thrower.mind) //making sure the target (C)  isnt afk
+			SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "creampie", /datum/mood_event/creampie)
+			var/experience_given = 30
+			if(HAS_TRAIT(C.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
+				experience_given *= 3
+			if(already_creamed)
+				experience_given *= 0.1
+			thrower.mind.adjust_experience(/datum/skill/pie_throwing, experience_given)
+		if(stun && thrower)
+			var/skillmod = thrower.mind.get_skill_speed_modifier(/datum/skill/pie_throwing)
+			if(skillmod > 25)// journeyman level or higher
+				C.Paralyze(skillmod) //splat!
+			else
+				C.Knockdown(skillmod) //splish!
+			C.adjust_blurriness(1)
+		C.visible_message("<span class='warning'>[C] is creamed by a pie!</span>", "<span class='userdanger'>You've been creamed by a pie!</span>")
+		playsound(C, "desceration", 50, TRUE)
+
+/datum/component/creamed/InheritComponent(datum/newcomp, orig, list/arglist)
+	. = ..()
+	already_creamed = TRUE
+	cream()

--- a/code/datums/skills/pie_throwing.dm
+++ b/code/datums/skills/pie_throwing.dm
@@ -1,5 +1,5 @@
 /datum/skill/pie_throwing
-	name = "Pie Throwing"
+	name = "pie throwing"
 	desc = "Clowning tecniques."
 
 /datum/skill/pie_throwing/get_skill_speed_modifier(level)
@@ -11,10 +11,10 @@
 		if(SKILL_LEVEL_APPRENTICE)
 			return 20
 		if(SKILL_LEVEL_JOURNEYMAN)
-			return 30
+			return 25
 		if(SKILL_LEVEL_EXPERT)
-			return 40
+			return 30
 		if(SKILL_LEVEL_MASTER)
-			return 50
+			return 35
 		if(SKILL_LEVEL_LEGENDARY)
-			return 60
+			return 50

--- a/code/datums/skills/pie_throwing.dm
+++ b/code/datums/skills/pie_throwing.dm
@@ -7,14 +7,14 @@
 		if(SKILL_LEVEL_NONE)
 			return 0
 		if(SKILL_LEVEL_NOVICE)
-			return 0
+			return 10
 		if(SKILL_LEVEL_APPRENTICE)
-			return 1
+			return 20
 		if(SKILL_LEVEL_JOURNEYMAN)
-			return 2
+			return 30
 		if(SKILL_LEVEL_EXPERT)
-			return 3
+			return 40
 		if(SKILL_LEVEL_MASTER)
-			return 4
+			return 50
 		if(SKILL_LEVEL_LEGENDARY)
-			return 5
+			return 60

--- a/code/datums/skills/pie_throwing.dm
+++ b/code/datums/skills/pie_throwing.dm
@@ -1,0 +1,20 @@
+/datum/skill/pie_throwing
+	name = "Pie Throwing"
+	desc = "Clowning tecniques."
+
+/datum/skill/pie_throwing/get_skill_speed_modifier(level)
+	switch(level)
+		if(SKILL_LEVEL_NONE)
+			return 0
+		if(SKILL_LEVEL_NOVICE)
+			return 0
+		if(SKILL_LEVEL_APPRENTICE)
+			return 1
+		if(SKILL_LEVEL_JOURNEYMAN)
+			return 2
+		if(SKILL_LEVEL_EXPERT)
+			return 3
+		if(SKILL_LEVEL_MASTER)
+			return 4
+		if(SKILL_LEVEL_LEGENDARY)
+			return 5

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -293,7 +293,7 @@
 /obj/item/pneumatic_cannon/pie/selfcharge
 	automatic = TRUE
 	selfcharge = TRUE
-	charge_type = /obj/item/reagent_containers/food/snacks/pie/cream/syndicate
+	charge_type = /obj/item/reagent_containers/food/snacks/pie/cream
 	maxWeightClass = 60	//20 pies.
 
 /obj/item/pneumatic_cannon/pie/selfcharge/cyborg

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -293,7 +293,7 @@
 /obj/item/pneumatic_cannon/pie/selfcharge
 	automatic = TRUE
 	selfcharge = TRUE
-	charge_type = /obj/item/reagent_containers/food/snacks/pie/cream
+	charge_type = /obj/item/reagent_containers/food/snacks/pie/cream/syndicate
 	maxWeightClass = 60	//20 pies.
 
 /obj/item/pneumatic_cannon/pie/selfcharge/cyborg

--- a/code/modules/food_and_drinks/food/snacks_pie.dm
+++ b/code/modules/food_and_drinks/food/snacks_pie.dm
@@ -28,14 +28,12 @@
 	tastes = list("pie" = 1)
 	foodtype = GRAIN | DAIRY | SUGAR
 	var/stunning = TRUE
-	var/experience_given = 10
-	var/experience_mod = 1
 
 /obj/item/reagent_containers/food/snacks/pie/cream/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
 	if(!.) //if we're not being caught
 		if(ishuman(throwingdatum.thrower))
-			var/mob/living/carbon/human/H
+			var/mob/living/carbon/human/H = throwingdatum.thrower
 			splat(hit_atom,H)
 		else
 			splat(hit_atom)
@@ -47,31 +45,30 @@
 	new/obj/effect/decal/cleanable/food/pie_smudge(T)
 	if(reagents && reagents.total_volume)
 		reagents.reaction(hit_atom, TOUCH)
+	if(isliving(hit_atom))
+		var/mob/living/L = hit_atom
+		if(L.mind && H)
+			var/experience_given = 15
+			if(HAS_TRAIT(L.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
+				experience_given *= 3
+			if(L.GetComponents(/datum/component/creamed))
+				experience_given *= 0.3
+			H.mind.adjust_experience(/datum/skill/pie_throwing, experience_given)
+		if(stunning && H)
+			var/skillmod = H.mind.get_skill_speed_modifier(/datum/skill/pie_throwing)
+			if(skillmod > 30)
+				L.Paralyze(skillmod) //splat!
+			else
+				L.Stun(skillmod) //splish!
+		L.adjust_blurriness(1)
+		L.visible_message("<span class='warning'>[L] is creamed by [src]!</span>", "<span class='userdanger'>You've been creamed by [src]!</span>")
+		playsound(L, "desceration", 50, TRUE)
 	if(is_type_in_typecache(hit_atom, GLOB.creamable))
 		hit_atom.AddComponent(/datum/component/creamed, src)
-	if(!isliving(hit_atom))
-		qdel(src)
-		return
-	var/mob/living/L = hit_atom
-	if(L.mind)
-		if(HAS_TRAIT(L.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-			experience_mod = 3
-		else
-			experience_mod = 1
-		H.mind.adjust_experience(/datum/skill/pie_throwing, experience_given * experience_mod)
-	if(stunning)
-		var/skillmod = H.mind.get_skill_speed_modifier(/datum/skill/pie_throwing)
-		L.Paralyze(skillmod * 10) //splat!
-	L.adjust_blurriness(1)
-	L.visible_message("<span class='warning'>[L] is creamed by [src]!</span>", "<span class='userdanger'>You've been creamed by [src]!</span>")
-	playsound(L, "desceration", 50, TRUE)
 	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/pie/cream/nostun
 	stunning = FALSE
-
-/obj/item/reagent_containers/food/snacks/pie/cream/syndicate
-	experience_given = 2
 
 /obj/item/reagent_containers/food/snacks/pie/berryclafoutis
 	name = "berry clafoutis"

--- a/code/modules/food_and_drinks/food/snacks_pie.dm
+++ b/code/modules/food_and_drinks/food/snacks_pie.dm
@@ -38,7 +38,7 @@
 		else
 			splat(hit_atom)
 
-/obj/item/reagent_containers/food/snacks/pie/cream/proc/splat(atom/movable/hit_atom, mob/living/carbon/human/H)
+/obj/item/reagent_containers/food/snacks/pie/cream/proc/splat(atom/movable/hit_atom, mob/living/carbon/human/H = null)
 	if(isliving(loc)) //someone caught us!
 		return
 	var/turf/T = get_turf(hit_atom)
@@ -47,16 +47,16 @@
 		reagents.reaction(hit_atom, TOUCH)
 	if(isliving(hit_atom))
 		var/mob/living/L = hit_atom
-		if(L.mind && H)
-			var/experience_given = 15
+		if(L.client && H)
+			var/experience_given = 30
+			if(L.GetComponent(/datum/component/creamed))
+				experience_given *= 0.1
 			if(HAS_TRAIT(L.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 				experience_given *= 3
-			if(L.GetComponents(/datum/component/creamed))
-				experience_given *= 0.3
 			H.mind.adjust_experience(/datum/skill/pie_throwing, experience_given)
 		if(stunning && H)
 			var/skillmod = H.mind.get_skill_speed_modifier(/datum/skill/pie_throwing)
-			if(skillmod > 30)
+			if(skillmod > 25)// journeyman level or higher
 				L.Paralyze(skillmod) //splat!
 			else
 				L.Stun(skillmod) //splish!

--- a/code/modules/food_and_drinks/food/snacks_pie.dm
+++ b/code/modules/food_and_drinks/food/snacks_pie.dm
@@ -28,32 +28,50 @@
 	tastes = list("pie" = 1)
 	foodtype = GRAIN | DAIRY | SUGAR
 	var/stunning = TRUE
+	var/experience_given = 10
+	var/experience_mod = 1
 
 /obj/item/reagent_containers/food/snacks/pie/cream/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
 	if(!.) //if we're not being caught
-		splat(hit_atom)
+		if(ishuman(throwingdatum.thrower))
+			var/mob/living/carbon/human/H
+			splat(hit_atom,H)
+		else
+			splat(hit_atom)
 
-/obj/item/reagent_containers/food/snacks/pie/cream/proc/splat(atom/movable/hit_atom)
+/obj/item/reagent_containers/food/snacks/pie/cream/proc/splat(atom/movable/hit_atom, mob/living/carbon/human/H)
 	if(isliving(loc)) //someone caught us!
 		return
 	var/turf/T = get_turf(hit_atom)
 	new/obj/effect/decal/cleanable/food/pie_smudge(T)
 	if(reagents && reagents.total_volume)
 		reagents.reaction(hit_atom, TOUCH)
-	if(isliving(hit_atom))
-		var/mob/living/L = hit_atom
-		if(stunning)
-			L.Paralyze(20) //splat!
-		L.adjust_blurriness(1)
-		L.visible_message("<span class='warning'>[L] is creamed by [src]!</span>", "<span class='userdanger'>You've been creamed by [src]!</span>")
-		playsound(L, "desceration", 50, TRUE)
 	if(is_type_in_typecache(hit_atom, GLOB.creamable))
 		hit_atom.AddComponent(/datum/component/creamed, src)
+	if(!isliving(hit_atom))
+		qdel(src)
+		return
+	var/mob/living/L = hit_atom
+	if(L.mind)
+		if(HAS_TRAIT(L.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
+			experience_mod = 3
+		else
+			experience_mod = 1
+		H.mind.adjust_experience(/datum/skill/pie_throwing, experience_given * experience_mod)
+	if(stunning)
+		var/skillmod = H.mind.get_skill_speed_modifier(/datum/skill/pie_throwing)
+		L.Paralyze(skillmod * 10) //splat!
+	L.adjust_blurriness(1)
+	L.visible_message("<span class='warning'>[L] is creamed by [src]!</span>", "<span class='userdanger'>You've been creamed by [src]!</span>")
+	playsound(L, "desceration", 50, TRUE)
 	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/pie/cream/nostun
 	stunning = FALSE
+
+/obj/item/reagent_containers/food/snacks/pie/cream/syndicate
+	experience_given = 2
 
 /obj/item/reagent_containers/food/snacks/pie/berryclafoutis
 	name = "berry clafoutis"

--- a/code/modules/food_and_drinks/food/snacks_pie.dm
+++ b/code/modules/food_and_drinks/food/snacks_pie.dm
@@ -45,27 +45,8 @@
 	new/obj/effect/decal/cleanable/food/pie_smudge(T)
 	if(reagents && reagents.total_volume)
 		reagents.reaction(hit_atom, TOUCH)
-	if(isliving(hit_atom))
-		var/mob/living/L = hit_atom
-		if(L.client && H)
-			L.AddComponent(/datum/component/creamed, src)
-			var/experience_given = 30//moved to component
-			if(L.GetComponent(/datum/component/creamed))
-				experience_given *= 0.1
-			if(HAS_TRAIT(L.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-				experience_given *= 3
-			H.mind.adjust_experience(/datum/skill/pie_throwing, experience_given)
-		if(stunning && H)
-			var/skillmod = H.mind.get_skill_speed_modifier(/datum/skill/pie_throwing)
-			if(skillmod > 25)// journeyman level or higher
-				L.Paralyze(skillmod) //splat!
-			else
-				L.Stun(skillmod) //splish!
-		L.adjust_blurriness(1)
-		L.visible_message("<span class='warning'>[L] is creamed by [src]!</span>", "<span class='userdanger'>You've been creamed by [src]!</span>")
-		playsound(L, "desceration", 50, TRUE)
-	else if(is_type_in_typecache(hit_atom, GLOB.creamable))
-		hit_atom.AddComponent(/datum/component/creamed, src)
+	if(is_type_in_typecache(hit_atom, GLOB.creamable))
+		hit_atom.AddComponent(/datum/component/creamed, H, stunning)
 	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/pie/cream/nostun

--- a/code/modules/food_and_drinks/food/snacks_pie.dm
+++ b/code/modules/food_and_drinks/food/snacks_pie.dm
@@ -48,7 +48,8 @@
 	if(isliving(hit_atom))
 		var/mob/living/L = hit_atom
 		if(L.client && H)
-			var/experience_given = 30
+			L.AddComponent(/datum/component/creamed, src)
+			var/experience_given = 30//moved to component
 			if(L.GetComponent(/datum/component/creamed))
 				experience_given *= 0.1
 			if(HAS_TRAIT(L.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
@@ -63,7 +64,7 @@
 		L.adjust_blurriness(1)
 		L.visible_message("<span class='warning'>[L] is creamed by [src]!</span>", "<span class='userdanger'>You've been creamed by [src]!</span>")
 		playsound(L, "desceration", 50, TRUE)
-	if(is_type_in_typecache(hit_atom, GLOB.creamable))
+	else if(is_type_in_typecache(hit_atom, GLOB.creamable))
 		hit_atom.AddComponent(/datum/component/creamed, src)
 	qdel(src)
 

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -47,7 +47,7 @@
 	duffelbag = /obj/item/storage/backpack/duffelbag/clown //strangely has a duffel
 
 	box = /obj/item/storage/box/hug/survival
-	
+
 	chameleon_extras = /obj/item/stamp/clown
 
 /datum/outfit/job/clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -59,3 +59,4 @@
 	H.dna.add_mutation(CLOWNMUT)
 	for(var/datum/mutation/human/clumsy/M in H.dna.mutations)
 		M.mutadone_proof = TRUE
+	H.mind.adjust_experience(/datum/skill/pie_throwing, 1000) // clown college

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -59,4 +59,5 @@
 	H.dna.add_mutation(CLOWNMUT)
 	for(var/datum/mutation/human/clumsy/M in H.dna.mutations)
 		M.mutadone_proof = TRUE
-	H.mind.adjust_experience(/datum/skill/pie_throwing, 1000) // clown college
+	if(H.mind)
+		H.mind.adjust_experience(/datum/skill/pie_throwing, 1000) // clown college

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -47,6 +47,7 @@
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak(null))
 		H.mind.miming = 1
+		H.mind.adjust_experience(/datum/skill/pie_throwing, 500) // mime college
 
 /obj/item/book/mimery
 	name = "Guide to Dank Mimery"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -563,6 +563,7 @@
 #include "code\datums\ruins\space.dm"
 #include "code\datums\skills\_skill.dm"
 #include "code\datums\skills\mining.dm"
+#include "code\datums\skills\pie_throwing.dm"
 #include "code\datums\status_effects\buffs.dm"
 #include "code\datums\status_effects\debuffs.dm"
 #include "code\datums\status_effects\gas.dm"


### PR DESCRIPTION
:cl:
balance: pies stun is affected by your clown skills (clowns start with higher skill mimes with slight less skill)
/:cl:

you get 3x bonus xp for creampiying security
you only get xp from people with mind (not cata or braindead)
creampiying someone already creampiyed gives you 0.1x modifier
max skill is at  100 * people creampiyed

levels:
0 nothing
1 1s softstun
2 2s softstun
3 3s hardstun
4 4 hardstun
5 5 hardstun
6 6 hardstun

(*) numbers arent definitive and proof of concept