### PR TITLE
Medical Kiosk runtime fix

### DIFF
--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -81,16 +81,18 @@
 	return ..()
 
 /obj/machinery/medical_kiosk/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
+	if(!ishuman(user))
+		to_chat(user, "<span class='warning'>[src] is unable to interface with non-humanoids!</span>")
+		return
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "medical_kiosk", name, 600, 500, master_ui, state)
 		ui.open()
 		scan_active = FALSE
 		icon_state = "kiosk_off"
-	if(ishuman(user))
-		RefreshParts()
-		H = user
-		C = H.get_idcard(TRUE)
+	RefreshParts()
+	H = user
+	C = H.get_idcard(TRUE)
 
 /obj/machinery/medical_kiosk/ui_data(mob/living/carbon/human/user)
 	var/list/data = list()


### PR DESCRIPTION
The kiosk expects the user to be human and presents their health status to the user. 

```
[2019-11-13 04:01:00.695] runtime error: undefined proc or verb /mob/living/silicon/robot/get traumas().
 - 
 - proc name: ui data (/obj/machinery/medical_kiosk/ui_data)
 -   source file: medical_kiosk.dm,116
 -   usr: SYNTHia (/mob/living/silicon/robot)
 -   src: the medical kiosk (/obj/machinery/medical_kiosk)
 -   usr.loc: the floor (100,112,2) (/turf/open/floor/plasteel/white/side)
 -   src.loc: the floor (99,111,2) (/turf/open/floor/plasteel/white)
 -   call stack:
 - the medical kiosk (/obj/machinery/medical_kiosk): ui data(SYNTHia (/mob/living/silicon/robot))
 - /datum/tgui (/datum/tgui): open()
 - the medical kiosk (/obj/machinery/medical_kiosk): ui interact(SYNTHia (/mob/living/silicon/robot), "main", /datum/tgui (/datum/tgui), 0, null, /datum/ui_state/default (/datum/ui_state/default))
 - the medical kiosk (/obj/machinery/medical_kiosk): interact(SYNTHia (/mob/living/silicon/robot), null)
 - the medical kiosk (/obj/machinery/medical_kiosk): interact(SYNTHia (/mob/living/silicon/robot), null)
 - the medical kiosk (/obj/machinery/medical_kiosk):  try interact(SYNTHia (/mob/living/silicon/robot))
 - the medical kiosk (/obj/machinery/medical_kiosk):  try interact(SYNTHia (/mob/living/silicon/robot))
 - the medical kiosk (/obj/machinery/medical_kiosk): attack robot(SYNTHia (/mob/living/silicon/robot))
 - SYNTHia (/mob/living/silicon/robot): ClickOn(the medical kiosk (/obj/machinery/medical_kiosk), "icon-x=15;icon-y=17;left=1;scr...")
 - the medical kiosk (/obj/machinery/medical_kiosk): Click(the floor (99,111,2) (/turf/open/floor/plasteel/white), "mapwindow.map", "icon-x=15;icon-y=17;left=1;scr...")
 - A Big D (/client): Click(the medical kiosk (/obj/machinery/medical_kiosk), the floor (99,111,2) (/turf/open/floor/plasteel/white), "mapwindow.map", "icon-x=15;icon-y=17;left=1;scr...")
 - 
```