### PR TITLE
[WIP] Replaces Syndicate thrown weapons in gambling drop table with toy versions

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1980,7 +1980,6 @@
 	req_access_txt = "3"
 	},
 /obj/effect/spawner/lootdrop/maintenance/three,
-/obj/effect/spawner/lootdrop/armory_contraband/metastation,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -50842,11 +50841,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"chY" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "chZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -73332,6 +73326,11 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
+"dSE" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "dVT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -74124,6 +74123,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"izt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iAj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -74211,12 +74217,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
-"jnW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
 "jrE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -74288,14 +74288,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"jUe" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "jUk" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -74307,6 +74299,16 @@
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
+/area/maintenance/port/aft)
+"kcn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "kcI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -74599,10 +74601,6 @@
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"lKu" = (
-/obj/effect/landmark/carpspawn,
-/turf/open/space/basic,
-/area/space)
 "lMz" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -74889,13 +74887,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"njJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "nnV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -75551,6 +75542,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/vacant_room/commissary)
+"qGl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "qJB" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
@@ -75790,13 +75787,6 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
 /area/medical/chemistry)
-"sof" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "svg" = (
 /obj/structure/lattice,
 /obj/structure/girder/reinforced,
@@ -76303,16 +76293,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"wdc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "wdq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -76378,6 +76358,13 @@
 "wtq" = (
 /turf/closed/wall,
 /area/maintenance/aft/secondary)
+"wtE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "wxc" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
@@ -76404,6 +76391,10 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
+"wBA" = (
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/space)
 "wFH" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/cable,
@@ -76470,6 +76461,14 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
+"wPW" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "wQA" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
@@ -76525,6 +76524,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"xrV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "xse" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -76648,13 +76654,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine/cult,
 /area/library)
-"ycH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "ydn" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -89705,7 +89704,7 @@ tSO
 diI
 dux
 uYL
-jnW
+qGl
 dux
 dux
 dux
@@ -90451,9 +90450,9 @@ bJq
 bKX
 bbL
 bbL
-ycH
+xrV
 bbL
-chY
+dSE
 nfn
 aob
 aob
@@ -91505,7 +91504,7 @@ cmB
 hwW
 cga
 luh
-sof
+izt
 fvT
 uOc
 cwh
@@ -94075,7 +94074,7 @@ mtp
 vQt
 cga
 oXP
-jUe
+wPW
 dux
 dux
 dux
@@ -94332,7 +94331,7 @@ cga
 cga
 cga
 ceu
-jUe
+wPW
 bXE
 dvq
 dux
@@ -94588,8 +94587,8 @@ fFJ
 csi
 chZ
 chZ
-wdc
-njJ
+kcn
+wtE
 ceu
 dux
 dux
@@ -118246,7 +118245,7 @@ aaf
 aaa
 aaa
 aaa
-lKu
+wBA
 aaa
 aaa
 aaa

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -40,29 +40,28 @@
 				/obj/item/gun/ballistic/automatic/pistol = 8,
 				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
 				/obj/item/gun/ballistic/revolver/mateba,
-				/obj/item/gun/ballistic/automatic/pistol/deagle
+				/obj/item/gun/ballistic/automatic/pistol/deagle,
 				)
 
 /obj/effect/spawner/lootdrop/armory_contraband/metastation
 	loot = list(/obj/item/gun/ballistic/automatic/pistol = 5,
 				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
 				/obj/item/gun/ballistic/revolver/mateba,
-				/obj/item/gun/ballistic/automatic/pistol/deagle,
-				/obj/item/storage/box/syndie_kit/throwing_weapons = 3)
+				/obj/item/gun/ballistic/automatic/pistol/deagle)
 
 /obj/effect/spawner/lootdrop/armory_contraband/donutstation
 	loot = list(/obj/item/grenade/clusterbuster/teargas = 5,
 				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
 				/obj/item/bikehorn/golden,
-				/obj/item/grenade/clusterbuster,
-				/obj/item/storage/box/syndie_kit/throwing_weapons = 3)
+				/obj/item/grenade/clusterbuster)
 
 /obj/effect/spawner/lootdrop/gambling
 	name = "gambling valuables spawner"
 	loot = list(
 				/obj/item/gun/ballistic/revolver/russian = 5,
-				/obj/item/storage/box/syndie_kit/throwing_weapons = 1,
-				/obj/item/toy/cards/deck/syndicate = 2
+				/obj/item/coin/gold = 1,
+				/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka = 1,
+				/obj/item/toy/cards/deck = 2
 				)
 
 /obj/effect/spawner/lootdrop/grille_or_trash

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -58,8 +58,8 @@
 /obj/effect/spawner/lootdrop/gambling
 	name = "gambling valuables spawner"
 	loot = list(
-				/obj/item/gun/ballistic/revolver/russian = 5,
-				/obj/item/clothing/head/ushanka = 4,
+				/obj/item/gun/ballistic/revolver/russian = 4,
+				/obj/item/storage/box/toythrown = 4,
 				/obj/item/coin/gold = 1,
 				/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka = 1,
 				/obj/item/toy/cards/deck = 2

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -40,7 +40,7 @@
 				/obj/item/gun/ballistic/automatic/pistol = 8,
 				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
 				/obj/item/gun/ballistic/revolver/mateba,
-				/obj/item/gun/ballistic/automatic/pistol/deagle,
+				/obj/item/gun/ballistic/automatic/pistol/deagle
 				)
 
 /obj/effect/spawner/lootdrop/armory_contraband/metastation
@@ -59,6 +59,7 @@
 	name = "gambling valuables spawner"
 	loot = list(
 				/obj/item/gun/ballistic/revolver/russian = 5,
+				/obj/item/clothing/head/ushanka = 4,
 				/obj/item/coin/gold = 1,
 				/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka = 1,
 				/obj/item/toy/cards/deck = 2

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -345,6 +345,13 @@
 		C.Knockdown(knockdown)
 		playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 
+/obj/item/restraints/legcuffs/bola/toy
+	name = "toy bola"
+	desc = "A bola made of hollow plastic balls and rubber tubing. It doesn't look like it'd be very effective..."
+	icon_state = "bola"
+	breakouttime = 1 //honk
+	slowdown = 4
+
 /obj/item/restraints/legcuffs/bola/tactical//traitor variant
 	name = "reinforced bola"
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -376,6 +376,7 @@ GLOBAL_LIST_INIT(cardboard_recipes, list (														\
 	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg),				\
 	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5),					\
+	new/datum/stack_recipe("dangerous materials box", /obj/item/storage/box/danger),			\
 	null,																						\
 
 	new/datum/stack_recipe("pizza box", /obj/item/pizzabox),									\

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1085,6 +1085,11 @@
 		/obj/item/stock_parts/matter_bin = 3)
 	generate_items_inside(items_inside,src)
 
+/obj/item/storage/box/danger
+	name = "dangerous materials box"
+	desc = "A box intended to hold dangerous materials. Looks kind of suspicious, though you're not sure why."
+	icon_state = "syndiebox"
+
 /obj/item/storage/box/stockparts/deluxe
 	name = "box of deluxe stock parts"
 	desc = "Contains a variety of deluxe stock parts."

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1090,6 +1090,19 @@
 	desc = "A box intended to hold dangerous materials. Looks kind of suspicious, though you're not sure why."
 	icon_state = "syndiebox"
 
+/obj/item/storage/box/toythrown
+	name = "DonkSoft Thrown Weapons Kit"
+	desc = "Set of harmless thrown weapons manufacturered by DonkSoft."
+	icon_state = "syndiebox"
+	
+/obj/item/storage/box/toythrown/PopulateContents()
+	var/static/items_inside = list(
+		/obj/item/throwing_star/plastic = 4,
+		/obj/item/restraints/legcuffs/bola/toy = 2,
+		/obj/item/toy/cards/deck = 1)
+	generate_items_inside(items_inside,src)
+	
+
 /obj/item/storage/box/stockparts/deluxe
 	name = "box of deluxe stock parts"
 	desc = "Contains a variety of deluxe stock parts."

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -297,6 +297,17 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	attack_verb = list("stabbed", "ripped", "gored", "impaled")
 	embedding = list("embedded_pain_multiplier" = 8, "embed_chance" = 100, "embedded_fall_chance" = 0, "embedded_impact_pain_multiplier" = 15) //55 damage+embed on hit
 
+/obj/item/throwing_star/plastic
+	name = "plastic throwing star"
+	desc = "A plastic replica of a ninja's signature weapon. Perfect for the aspiring shinobi. Still looks pretty sharp..."
+	icon_state = "throwingstar"
+	force = 2
+	throwforce = 0
+	embedding = list("embedded_pain_multiplier" = 0, "embed_chance" = 100, "embedded_fall_chance" = 100)
+	//visible_message("<span class='danger'>[I] sticks itself to [src]'s [L.name]!</span>","<span class='userdanger'>[I] sticks itself to your [L.name]!</span>")
+	custom_materials = list(/datum/material/plastic=500)
+
+
 /obj/item/switchblade
 	name = "switchblade"
 	icon_state = "switchblade"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -213,20 +213,31 @@
 		var/obj/item/I = locate(href_list["embedded_object"]) in L.embedded_objects
 		if(!I || I.loc != src) //no item, no limb, or item is not in limb or in the person anymore
 			return
-		var/time_taken = I.embedding.embedded_unsafe_removal_time*I.w_class
-		usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [usr.p_their()] [L.name].</span>","<span class='notice'>You attempt to remove [I] from your [L.name]... (It will take [DisplayTimeText(time_taken)].)</span>")
-		if(do_after(usr, time_taken, needhand = 1, target = src))
-			if(!I || !L || I.loc != src || !(I in L.embedded_objects))
-				return
-			L.embedded_objects -= I
-			L.receive_damage(I.embedding.embedded_unsafe_removal_pain_multiplier*I.w_class)//It hurts to rip it out, get surgery you dingus.
-			I.forceMove(get_turf(src))
-			usr.put_in_hands(I)
-			usr.emote("scream")
-			usr.visible_message("<span class='notice'>[usr] successfully rips [I] out of [usr.p_their()] [L.name]!</span>", "<span class='notice'>You successfully remove [I] from your [L.name].</span>")
-			if(!has_embedded_objects())
-				clear_alert("embeddedobject")
-				SEND_SIGNAL(usr, COMSIG_CLEAR_MOOD_EVENT, "embedded")
+		if(istype(I, /obj/item/throwing_star/plastic))
+			var/time_taken = 5*I.w_class
+			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [usr.p_their()] [L.name].</span>","<span class='notice'>You attempt to remove [I] from your [L.name]... (It will take [DisplayTimeText(time_taken)].)</span>")
+			if(do_after(usr, time_taken, needhand = 1, target = src))
+				if(!I || !L || I.loc != src || !(I in L.embedded_objects))
+					return
+				L.embedded_objects -= I
+				I.forceMove(get_turf(src))
+				usr.put_in_hands(I)
+				usr.visible_message("<span class='notice'>[usr] successfully pulls [I] off of [usr.p_their()] [L.name]!</span>", "<span class='notice'>You successfully pull [I] off of your [L.name].</span>")
+		else
+			var/time_taken = I.embedding.embedded_unsafe_removal_time*I.w_class
+			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [usr.p_their()] [L.name].</span>","<span class='notice'>You attempt to remove [I] from your [L.name]... (It will take [DisplayTimeText(time_taken)].)</span>")
+			if(do_after(usr, time_taken, needhand = 1, target = src))
+				if(!I || !L || I.loc != src || !(I in L.embedded_objects))
+					return
+				L.embedded_objects -= I
+				L.receive_damage(I.embedding.embedded_unsafe_removal_pain_multiplier*I.w_class)//It hurts to rip it out, get surgery you dingus.
+				I.forceMove(get_turf(src))
+				usr.put_in_hands(I)
+				usr.emote("scream")
+				usr.visible_message("<span class='notice'>[usr] successfully rips [I] out of [usr.p_their()] [L.name]!</span>", "<span class='notice'>You successfully remove [I] from your [L.name].</span>")
+				if(!has_embedded_objects())
+					clear_alert("embeddedobject")
+					SEND_SIGNAL(usr, COMSIG_CLEAR_MOOD_EVENT, "embedded")
 		return
 
 	if(href_list["item"]) //canUseTopic check for this is handled by mob/Topic()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -140,6 +140,15 @@
 		hitpush = FALSE
 		skipcatch = TRUE
 		blocked = TRUE
+	if(istype(AM, /obj/item/throwing_star/plastic))
+		I = AM
+		var/obj/item/bodypart/L = pick(bodyparts)
+		L.embedded_objects |= I
+		I.forceMove(src)
+		L.receive_damage(I.w_class*I.embedding.embedded_impact_pain_multiplier)
+		visible_message("<span class='danger'>[I] sticks itself to [src]'s [L.name]!</span>","<span class='userdanger'>[I] sticks itself to your [L.name]!</span>")
+		hitpush = FALSE
+		skipcatch = TRUE
 	else if(I)
 		if(((throwingdatum ? throwingdatum.speed : I.throw_speed) >= EMBED_THROWSPEED_THRESHOLD) || I.embedding.embedded_ignore_throwspeed_threshold)
 			if(can_embed(I))
@@ -744,7 +753,10 @@
 		to_chat(src, "\t <span class='[no_damage ? "notice" : "warning"]'>Your [LB.name][isdisabled][self_aware ? " has " : " is "][status].</span>")
 
 		for(var/obj/item/I in LB.embedded_objects)
-			to_chat(src, "\t <a href='?src=[REF(src)];embedded_object=[REF(I)];embedded_limb=[REF(LB)]' class='warning'>There is \a [I] embedded in your [LB.name]!</a>")
+			if(istype(I, /obj/item/throwing_star/plastic))
+				to_chat(src, "\t <a href='?src=[REF(src)];embedded_object=[REF(I)];embedded_limb=[REF(LB)]' class='warning'>There is \a [I] stuck on your [LB.name]!</a>")
+			else
+				to_chat(src, "\t <a href='?src=[REF(src)];embedded_object=[REF(I)];embedded_limb=[REF(LB)]' class='warning'>There is \a [I] embedded in your [LB.name]!</a>")
 
 	for(var/t in missing)
 		to_chat(src, "<span class='boldannounce'>Your [parse_zone(t)] is missing!</span>")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -293,15 +293,20 @@
 			if(prob(I.embedding.embedded_pain_chance))
 				BP.receive_damage(I.w_class*I.embedding.embedded_pain_multiplier)
 				to_chat(src, "<span class='userdanger'>[I] embedded in your [BP.name] hurts!</span>")
-
+				
 			if(prob(I.embedding.embedded_fall_chance))
-				BP.receive_damage(I.w_class*I.embedding.embedded_fall_pain_multiplier)
-				BP.embedded_objects -= I
-				I.forceMove(drop_location())
-				visible_message("<span class='danger'>[I] falls out of [name]'s [BP.name]!</span>","<span class='userdanger'>[I] falls out of your [BP.name]!</span>")
-				if(!has_embedded_objects())
-					clear_alert("embeddedobject")
-					SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "embedded")
+				if(istype(I, /obj/item/throwing_star/plastic))
+					BP.embedded_objects -= I
+					I.forceMove(drop_location())
+					visible_message("<span class='danger'>[I] falls off of [name]'s [BP.name]!</span>","<span class='userdanger'>[I] falls off of your [BP.name]!</span>")
+				else 
+					BP.receive_damage(I.w_class*I.embedding.embedded_fall_pain_multiplier)
+					BP.embedded_objects -= I
+					I.forceMove(drop_location())
+					visible_message("<span class='danger'>[I] falls out of [name]'s [BP.name]!</span>","<span class='userdanger'>[I] falls out of your [BP.name]!</span>")
+					if(!has_embedded_objects())
+						clear_alert("embeddedobject")
+						SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "embedded")
 
 /mob/living/carbon/human/proc/handle_heart()
 	var/we_breath = !HAS_TRAIT_FROM(src, TRAIT_NOBREATH, SPECIES_TRAIT)


### PR DESCRIPTION
Fixes #47792, change is because this makes it far too easy to research illegal tech on the rounds it spawns in.

Instead, I replaced them with toy versions of the throwing stars and bola. The stars will still embed but do zero damage, do not make you bleed, and can be removed easily. The bola will still slow you but has an incredibly short removal time.

Also added a way to craft the syndicate bundle boxes by request.

I also removed the contraband gun spawner from the armory, as it doesn't seem very useful aside from "HoP/Captain that wants to validhunt". I might revert this if it proves to be controversial enough.

## Changelog
:cl:
add: You can now craft a dangerous items box (the box Syndicate bundles come in) using one sheet of cardboard.
add: DonkSoft has introduced a new line of thrown weapons!
balance: Syndicate items can no longer drop from the "Gambling items" or "Armory contraband" loot tables.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
