### PR TITLE
Fixes Kilo teleporter airlock access

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -15140,8 +15140,8 @@
 "axm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
-	name = "Teleport Access";
-	req_access_txt = "17;19"
+	name = "Teleporter Access";
+	req_one_access_txt = "17;19"
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
@@ -42746,7 +42746,7 @@
 "bkW" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "teleshutter";
-	name = "Teleport Access Shutter"
+	name = "Teleporter Access Shutter"
 	},
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
@@ -62442,7 +62442,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/command{
-	name = "Teleport Access";
+	name = "Teleporter Access";
 	req_one_access_txt = "17;19"
 	},
 /turf/open/floor/plasteel/dark,
@@ -63302,7 +63302,7 @@
 "bOZ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "command maintenance";
-	req_access_txt = "17;19"
+	req_one_access_txt = "17;19"
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,


### PR DESCRIPTION
Kilo's front/maint teleporter airlocks were using `req_access_txt` instead of the correct `req_one_access_txt` that only checks for either access.

## Changelog
:cl: Denton
fix: Kilostation's teleporter airlocks now use the correct access check.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
