### PR TITLE
Adds a flag for bespoke elements

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -16,8 +16,11 @@
 /// Return value to cancel attaching
 #define ELEMENT_INCOMPATIBLE 1
 
-/// /datum/element flags
+// /datum/element flags
+/// Causes the detach proc to be called when the host object is being deleted 
 #define ELEMENT_DETACH		(1 << 0)
+/// Getting an existing element uses some attach arguments as part of the id
+#define ELEMENT_BESPOKE		(1 << 1)
 
 // How multiple components of the exact same type are handled in the same datum
 /// old component is deleted (default)

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -19,7 +19,10 @@
 // /datum/element flags
 /// Causes the detach proc to be called when the host object is being deleted 
 #define ELEMENT_DETACH		(1 << 0)
-/// Getting an existing element uses some attach arguments as part of the id
+/**
+  * Only elements created with the same arguments given after `id_arg_index` share an element instance
+  * The arguments are the same when the text and number values are the same and all other values have the same ref
+  */
 #define ELEMENT_BESPOKE		(1 << 1)
 
 // How multiple components of the exact same type are handled in the same datum

--- a/code/controllers/subsystem/dcs.dm
+++ b/code/controllers/subsystem/dcs.dm
@@ -7,10 +7,22 @@ PROCESSING_SUBSYSTEM_DEF(dcs)
 /datum/controller/subsystem/processing/dcs/Recover()
 	comp_lookup = SSdcs.comp_lookup
 
-/datum/controller/subsystem/processing/dcs/proc/GetElement(eletype)
-	. = elements_by_type[eletype]
+/datum/controller/subsystem/processing/dcs/proc/GetElement(datum/element/eletype, ...)
+	var/element_id = eletype
+	
+	if(initial(eletype.element_flags) & ELEMENT_BESPOKE)
+		var/list/fullid = list("[eletype]")
+		for(var/i in initial(eletype.id_arg_index) to length(args))
+			var/argument = args[i]
+			if(istext(argument) || isnum(argument))
+				fullid += "[argument]"
+			else
+				fullid += "[REF(argument)]"
+		element_id = fullid.Join("&")
+			
+	. = elements_by_type[element_id]
 	if(.)
 		return
 	if(!ispath(eletype, /datum/element))
 		CRASH("Attempted to instantiate [eletype] as a /datum/element")
-	. = elements_by_type[eletype] = new eletype
+	. = elements_by_type[element_id] = new eletype

--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -7,6 +7,12 @@
 /datum/element
 	/// Option flags for element behaviour
 	var/element_flags = NONE
+	/**
+	  * The index of the first attach argument to consider for duplicate elements
+	  * Is only used when flags contains ELEMENT_BESPOKE
+	  * This is infinity so you must explicitly set this
+	  */
+	var/id_arg_index = INFINITY
 
 /// Activates the functionality defined by the element on the given target datum
 /datum/element/proc/Attach(datum/target)
@@ -31,12 +37,15 @@
 
 /// Finds the singleton for the element type given and attaches it to src
 /datum/proc/AddElement(eletype, ...)
-	var/datum/element/ele = SSdcs.GetElement(eletype)
+	var/datum/element/ele = SSdcs.GetElement(arglist(args))
 	args[1] = src
 	if(ele.Attach(arglist(args)) == ELEMENT_INCOMPATIBLE)
 		CRASH("Incompatible [eletype] assigned to a [type]! args: [json_encode(args)]")
 
-/// Finds the singleton for the element type given and detaches it from src
-/datum/proc/RemoveElement(eletype)
-	var/datum/element/ele = SSdcs.GetElement(eletype)
+/**
+  * Finds the singleton for the element type given and detaches it from src
+  * You only need additional arguments beyond the type if you're using ELEMENT_BESPOKE
+  */
+/datum/proc/RemoveElement(eletype, ...)
+	var/datum/element/ele = SSdcs.GetElement(arglist(args))
 	ele.Detach(src)

--- a/code/datums/elements/firestacker.dm
+++ b/code/datums/elements/firestacker.dm
@@ -2,30 +2,30 @@
   * Can be applied to /atom/movable subtypes to make them apply fire stacks to things they hit
   */
 /datum/element/firestacker
-	element_flags = ELEMENT_DETACH
-	/// A list in format {atom/movable/owner, number}
-	/// Used to keep track of movables which want to apply a different number of fire stacks than default
-	var/list/amount_by_owner = list()
+	element_flags = ELEMENT_BESPOKE
+	id_arg_index = 2
+	/// How many firestacks to apply per hit
+	var/amount
 
 /datum/element/firestacker/Attach(datum/target, amount)
 	. = ..()
+	
 	if(!ismovableatom(target))
 		return ELEMENT_INCOMPATIBLE
+	
+	src.amount = amount
+	
 	RegisterSignal(target, COMSIG_MOVABLE_IMPACT, .proc/impact, override = TRUE)
 	if(isitem(target))
 		RegisterSignal(target, COMSIG_ITEM_ATTACK, .proc/item_attack, override = TRUE)
 		RegisterSignal(target, COMSIG_ITEM_ATTACK_SELF, .proc/item_attack_self, override = TRUE)
 
-	if(amount) // If amount is not given we default to 1 and don't need to save it here
-		amount_by_owner[target] = amount
-
 /datum/element/firestacker/Detach(datum/source, force)
 	. = ..()
 	UnregisterSignal(source, list(COMSIG_MOVABLE_IMPACT, COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_SELF))
-	amount_by_owner -= source
 
 /datum/element/firestacker/proc/stack_on(datum/owner, mob/living/target)
-	target.adjust_fire_stacks(amount_by_owner[owner] || 1)
+	target.adjust_fire_stacks(amount)
 
 /datum/element/firestacker/proc/impact(datum/source, atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(isliving(hit_atom))

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -99,12 +99,12 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 /datum/material/plasma/on_applied(atom/source, amount, material_flags)
 	. = ..()
 	if(ismovableatom(source))
-		source.AddElement(/datum/element/firestacker)
+		source.AddElement(/datum/element/firestacker, 1)
 		source.AddComponent(/datum/component/explodable, 0, 0, amount / 2500, amount / 1250)
 
 /datum/material/plasma/on_removed(atom/source, material_flags)
 	. = ..()
-	source.RemoveElement(/datum/element/firestacker)
+	source.RemoveElement(/datum/element/firestacker, 1)
 	qdel(source.GetComponent(/datum/component/explodable))
 
 ///Can cause bluespace effects on use. (Teleportation) (Not yet implemented)


### PR DESCRIPTION
This muddies the water a bit in what elements are but basically this allows for multiple of the same kind of element to exist for particular usecases. The elements created in this way are still shared but only with other things that applied the same element with the same relevant args.

I switched the firestacker element to use this as an example. Now instead of keeping track of host objects which want a different firestack count it makes a new element automatically with the different stack amount.

This should cut down on vars used to keep track of objects in elements and allow for some more complex behavior.

I'm not fully satisfied with the implementation here but this should be good for now. Expect more prs when I've learned where the pain points are at.
