### PR TITLE
Lowers Nitric Acid Toxpower

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -807,7 +807,7 @@
 	name = "Nitric acid"
 	description = "Nitric acid is an extremely corrosive chemical substance that violently reacts with living organic tissue."
 	color = "#5050FF"
-	toxpwr = 6
+	toxpwr = 2
 	acidpwr = 5.0
 
 /datum/reagent/toxin/acid/nitracid/on_mob_life(mob/living/carbon/M)


### PR DESCRIPTION
gives nitric acid a toxpwr of 2

## About The Pull Request

gives nitric acid a toxpwr of 2, leaving it on par with fluacid. i can lower this if that's needed

## Why It's Good For The Game

stops the syringe gun from being the most powerful gun in the game

## Changelog
:cl: tmtmtl30
balance: nitric acid no longer has the corrosive capability of an armor-piercing sniper bullet
/:cl: