### PR TITLE
Fixes cleanbot renaming, buffs emagged cleanbots w/ knives

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -35,6 +35,7 @@
 
 	var/obj/item/weapon
 	var/weapon_orig_force = 0
+	var/chosen_name
 
 	var/list/stolen_valor
 
@@ -56,8 +57,8 @@
 		user.transferItemToLoc(W, src)
 		weapon = W
 		weapon_orig_force = weapon.force
-		weapon.force = weapon.force / 2
-		icon_state = "cleanbot[on]"
+		if(!emagged)
+			weapon.force = weapon.force / 2
 		add_overlay(image(icon=weapon.lefthand_file,icon_state=weapon.item_state))
 
 /mob/living/simple_animal/bot/cleanbot/proc/update_titles()
@@ -71,7 +72,7 @@
 					commissioned = TRUE
 				break
 
-	working_title += initial(name)
+	working_title += chosen_name
 
 	for(var/suf in suffixes)
 		for(var/title in suf)
@@ -88,6 +89,8 @@
 
 /mob/living/simple_animal/bot/cleanbot/Initialize()
 	. = ..()
+
+	chosen_name = name
 	get_targets()
 	icon_state = "cleanbot[on]"
 
@@ -136,13 +139,12 @@
 		if(!istype(C))
 			return
 
-		weapon.attack(C, src)
-		C.Knockdown(20)
-
 		if(!(C.job in stolen_valor))
 			stolen_valor += C.job
 		update_titles()
-		return
+
+		weapon.attack(C, src)
+		C.Knockdown(20)
 
 /mob/living/simple_animal/bot/cleanbot/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/card/id)||istype(W, /obj/item/pda))
@@ -157,14 +159,16 @@
 			else
 				to_chat(user, "<span class='notice'>\The [src] doesn't seem to respect your authority.</span>")
 	else if(istype(W, /obj/item/kitchen/knife) && user.a_intent != INTENT_HARM)
-		to_chat(user, "<span class='notice'>You start attaching the [W] to \the [src]...</span>")
-		if(do_after(user, 40, target = src))
+		to_chat(user, "<span class='notice'>You start attaching \the [W] to \the [src]...</span>")
+		if(do_after(user, 25, target = src))
 			deputize(W, user)
 	else
 		return ..()
 
 /mob/living/simple_animal/bot/cleanbot/emag_act(mob/user)
 	..()
+	if(weapon)
+		weapon.force = weapon_orig_force
 	if(emagged == 2)
 		if(user)
 			to_chat(user, "<span class='danger'>[src] buzzes and beeps.</span>")

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -121,6 +121,8 @@
 
 /mob/living/simple_animal/bot/cleanbot/bot_reset()
 	..()
+	if(weapon && emagged == 2)
+		weapon.force = weapon_orig_force
 	ignore_list = list() //Allows the bot to clean targets it previously ignored due to being unreachable.
 	target = null
 	oldloc = null
@@ -167,9 +169,10 @@
 
 /mob/living/simple_animal/bot/cleanbot/emag_act(mob/user)
 	..()
-	if(weapon)
-		weapon.force = weapon_orig_force
+
 	if(emagged == 2)
+		if(weapon)
+			weapon.force = weapon_orig_force
 		if(user)
 			to_chat(user, "<span class='danger'>[src] buzzes and beeps.</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #47810 where cleanbots would fallback to the name "cleanbot" when deputized
Reduces time to attach knife from 4 seconds to 2.5 seconds (4 seconds was juuuuuuust long enough to let it move while you were attaching)
Emagged cleanbots will do full damage when they stab someone rather than half damage

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes knifebots more robust
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
balance: Cleanbots with knives will do full damage rather than half if emagged
fix: Cleanbots will no longer lose their name when given knives
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
