### PR TITLE
makes jousting actually possible

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -468,14 +468,11 @@
 /obj/item/twohanded/spear/Initialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 70) //decent in a pinch, but pretty bad.
+	AddComponent(/datum/component/jousting)
 
 /obj/item/twohanded/spear/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] begins to sword-swallow \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return BRUTELOSS
-
-/obj/item/twohanded/spear/Initialize()
-	. = ..()
-	AddComponent(/datum/component/jousting)
 
 /obj/item/twohanded/spear/update_icon()
 	icon_state = "[icon_prefix][wielded]"


### PR DESCRIPTION
## About The Pull Request

borg jousting was in for about 3 months but then butchering was moved to a component and that added the dual Initialize() proc, which stopped the jousting component from being added to the spear and making the entire component completely useless. i was going to add secway / janicart jousting but i realized this component already existed and didn't work so this took precedence. two things to disclose: 1. i haven't tested this since it requires some pretty niche conditions 2. this probably works with fireman carrying which might be a little busted maybe

## Why It's Good For The Game

fixes a feature that was added two years ago and hasn't worked for nearly as long

## Changelog
:cl:
fix: Nanotransen cyborgs have recovered from butchering-induced trauma and are now able to joust again.
/:cl: