### PR TITLE
Fixes partial sentences when examining a radioactive object at a distance

### DIFF
--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -65,13 +65,12 @@
 		out += "The air around [master] feels warm"
 		switch(strength)
 			if(RAD_AMOUNT_LOW to RAD_AMOUNT_MEDIUM)
-				out += "[out ? " and it " : "[master] "]feels weird to look at."
+				out += "[out ? " and it " : "[master] "]feels weird to look at"
 			if(RAD_AMOUNT_MEDIUM to RAD_AMOUNT_HIGH)
-				out += "[out ? " and it " : "[master] "]seems to be glowing a bit."
+				out += "[out ? " and it " : "[master] "]seems to be glowing a bit"
 			if(RAD_AMOUNT_HIGH to INFINITY) //At this level the object can contaminate other objects
-				out += "[out ? " and it " : "[master] "]hurts to look at."
-			else
-				out += "."
+				out += "[out ? " and it " : "[master] "]hurts to look at"
+		out += "."
 		to_chat(user, out.Join())
 
 /datum/component/radioactive/proc/rad_attack(datum/source, atom/movable/target, mob/living/user)

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -63,16 +63,16 @@
 	var/list/out = list()
 	if(get_dist(master, user) <= 1)
 		out += "The air around [master] feels warm"
-	switch(strength)
-		if(RAD_AMOUNT_LOW to RAD_AMOUNT_MEDIUM)
-			out += "[out ? " and it " : "[master] "]feels weird to look at."
-		if(RAD_AMOUNT_MEDIUM to RAD_AMOUNT_HIGH)
-			out += "[out ? " and it " : "[master] "]seems to be glowing a bit."
-		if(RAD_AMOUNT_HIGH to INFINITY) //At this level the object can contaminate other objects
-			out += "[out ? " and it " : "[master] "]hurts to look at."
-		else
-			out += "."
-	to_chat(user, out.Join())
+		switch(strength)
+			if(RAD_AMOUNT_LOW to RAD_AMOUNT_MEDIUM)
+				out += "[out ? " and it " : "[master] "]feels weird to look at."
+			if(RAD_AMOUNT_MEDIUM to RAD_AMOUNT_HIGH)
+				out += "[out ? " and it " : "[master] "]seems to be glowing a bit."
+			if(RAD_AMOUNT_HIGH to INFINITY) //At this level the object can contaminate other objects
+				out += "[out ? " and it " : "[master] "]hurts to look at."
+			else
+				out += "."
+		to_chat(user, out.Join())
 
 /datum/component/radioactive/proc/rad_attack(datum/source, atom/movable/target, mob/living/user)
 	radiation_pulse(parent, strength/20)

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -63,15 +63,16 @@
 	var/list/out = list()
 	if(get_dist(master, user) <= 1)
 		out += "The air around [master] feels warm"
-		switch(strength)
-			if(RAD_AMOUNT_LOW to RAD_AMOUNT_MEDIUM)
-				out += "[out ? " and it " : "[master] "]feels weird to look at"
-			if(RAD_AMOUNT_MEDIUM to RAD_AMOUNT_HIGH)
-				out += "[out ? " and it " : "[master] "]seems to be glowing a bit"
-			if(RAD_AMOUNT_HIGH to INFINITY) //At this level the object can contaminate other objects
-				out += "[out ? " and it " : "[master] "]hurts to look at"
-		out += "."
-		to_chat(user, out.Join())
+	switch(strength)
+		if(RAD_AMOUNT_LOW to RAD_AMOUNT_MEDIUM)
+			out += "[length(out) ? " and it " : "[master] "]feels weird to look at."
+		if(RAD_AMOUNT_MEDIUM to RAD_AMOUNT_HIGH)
+			out += "[length(out) ? " and it " : "[master] "]seems to be glowing a bit."
+		if(RAD_AMOUNT_HIGH to INFINITY) //At this level the object can contaminate other objects
+			out += "[length(out) ? " and it " : "[master] "]hurts to look at."
+		else
+			out += "."
+	to_chat(user, out.Join())
 
 /datum/component/radioactive/proc/rad_attack(datum/source, atom/movable/target, mob/living/user)
 	radiation_pulse(parent, strength/20)


### PR DESCRIPTION
Currently, examining a radioactive object at a distance looks like this:
![image](https://user-images.githubusercontent.com/16315400/69006764-ee8c2280-0901-11ea-908a-9f0cba79e71b.png)

And the message works as intended up close:
![image](https://user-images.githubusercontent.com/16315400/69006773-0b285a80-0902-11ea-86ee-b26cc1a6b1d4.png)

This fixes it so you don't get that sentence fragment at a distance.