### PR TITLE
New MOB_SIZE define & Megafauna Fix

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -25,6 +25,7 @@
 #define MOB_SIZE_SMALL 1
 #define MOB_SIZE_HUMAN 2
 #define MOB_SIZE_LARGE 3
+#define MOB_SIZE_IMPOSSIBLE 4
 
 //Ventcrawling defines
 #define VENTCRAWLER_NONE   0

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -25,7 +25,7 @@
 #define MOB_SIZE_SMALL 1
 #define MOB_SIZE_HUMAN 2
 #define MOB_SIZE_LARGE 3
-#define MOB_SIZE_IMPOSSIBLE 4
+#define MOB_SIZE_HUGE 4 // Use this for things you don't want bluespace body-bagged
 
 //Ventcrawling defines
 #define VENTCRAWLER_NONE   0

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -25,7 +25,7 @@
 	move_force = MOVE_FORCE_OVERPOWERING
 	move_resist = MOVE_FORCE_OVERPOWERING
 	pull_force = MOVE_FORCE_OVERPOWERING
-	mob_size = MOB_SIZE_IMPOSSIBLE
+	mob_size = MOB_SIZE_HUGE
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -25,7 +25,7 @@
 	move_force = MOVE_FORCE_OVERPOWERING
 	move_resist = MOVE_FORCE_OVERPOWERING
 	pull_force = MOVE_FORCE_OVERPOWERING
-	mob_size = MOB_SIZE_LARGE
+	mob_size = MOB_SIZE_IMPOSSIBLE
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1


### PR DESCRIPTION
## About The Pull Request
Adds a `MOB_SIZE_HUGE` define to `code/__DEFINES/mobs.dm` and changes `MOB_SIZE_LARGE` to `MOB_SIZE_HUGEE` in megafauna.dm

## Why It's Good For The Game
Adds a define that would mainly be used to avoid having mobs/simplemobs put in thing such as bluespace body bags and/or other such things that allow `MOB_SIZE_LARGE` into it.

Also fixes #47832 

## Changelog
:cl:Vondiech
fix: You can no longer put megafauna into bluespace body bags.
/:cl: