### PR TITLE
Ling clothes delete properly on dismember

### DIFF
--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -9,6 +9,7 @@
 
 /obj/item/clothing/glasses/changeling
 	name = "flesh"
+	item_flags = DROPDEL
 
 /obj/item/clothing/glasses/changeling/Initialize()
 	. = ..()
@@ -24,6 +25,7 @@
 
 /obj/item/clothing/under/changeling
 	name = "flesh"
+	item_flags = DROPDEL
 
 /obj/item/clothing/under/changeling/Initialize()
 	. = ..()
@@ -40,6 +42,7 @@
 /obj/item/clothing/suit/changeling
 	name = "flesh"
 	allowed = list(/obj/item/changeling)
+	item_flags = DROPDEL
 
 /obj/item/clothing/suit/changeling/Initialize()
 	. = ..()
@@ -55,6 +58,7 @@
 
 /obj/item/clothing/head/changeling
 	name = "flesh"
+	item_flags = DROPDEL
 
 /obj/item/clothing/head/changeling/Initialize()
 	. = ..()
@@ -70,6 +74,7 @@
 
 /obj/item/clothing/shoes/changeling
 	name = "flesh"
+	item_flags = DROPDEL
 
 /obj/item/clothing/shoes/changeling/Initialize()
 	. = ..()
@@ -85,6 +90,7 @@
 
 /obj/item/clothing/gloves/changeling
 	name = "flesh"
+	item_flags = DROPDEL
 
 /obj/item/clothing/gloves/changeling/Initialize()
 	. = ..()
@@ -100,6 +106,7 @@
 
 /obj/item/clothing/mask/changeling
 	name = "flesh"
+	item_flags = DROPDEL
 
 /obj/item/clothing/mask/changeling/Initialize()
 	. = ..()
@@ -117,6 +124,7 @@
 	name = "flesh"
 	slot_flags = ALL
 	allowed = list(/obj/item/changeling)
+	item_flags = DROPDEL
 
 /obj/item/changeling/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Avoids dropping fake nodrop clothes on dismemberment.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Fake changeling clothes no longer drop on dismember.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
