### PR TITLE
Fixes changeling hivemind link

### DIFF
--- a/code/modules/antagonists/changeling/powers/linglink.dm
+++ b/code/modules/antagonists/changeling/powers/linglink.dm
@@ -57,14 +57,17 @@
 				target.mind.linglink = 1
 				target.say("[MODE_TOKEN_CHANGELING] AAAAARRRRGGGGGHHHHH!!")
 				to_chat(target, "<span class='changeling bold'>You can now communicate in the changeling hivemind, say \"[MODE_TOKEN_CHANGELING] message\" to communicate!</span>")
-				target.reagents.add_reagent(/datum/reagent/medicine/salbutamol, 40) // So they don't choke to death while you interrogate them
-				sleep(1800)
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]", "[i]"))
 		if(!do_mob(user, target, 20))
 			to_chat(user, "<span class='warning'>Our link with [target] has ended!</span>")
 			changeling.islinking = 0
 			target.mind.linglink = 0
 			return
+	
+	to_chat(user, "<span class='notice'>We must keep holding on to [target] to sustain the link. </span>")
+	while(user.pulling && user.grab_state == GRAB_KILL)
+		target.reagents.add_reagent(/datum/reagent/medicine/salbutamol, 1) // So they don't choke to death while you interrogate them
+		do_mob(user, target, 100, TRUE)
 
 	changeling.islinking = 0
 	target.mind.linglink = 0

--- a/code/modules/antagonists/changeling/powers/linglink.dm
+++ b/code/modules/antagonists/changeling/powers/linglink.dm
@@ -65,7 +65,7 @@
 			return
 	
 	to_chat(user, "<span class='notice'>We must keep holding on to [target] to sustain the link. </span>")
-	while(user.pulling && user.grab_state == GRAB_KILL)
+	while(user.pulling && user.grab_state >= GRAB_NECK)
 		target.reagents.add_reagent(/datum/reagent/medicine/salbutamol, 1) // So they don't choke to death while you interrogate them
 		do_mob(user, target, 100, TRUE)
 

--- a/code/modules/antagonists/changeling/powers/linglink.dm
+++ b/code/modules/antagonists/changeling/powers/linglink.dm
@@ -66,7 +66,7 @@
 	
 	to_chat(user, "<span class='notice'>We must keep holding on to [target] to sustain the link. </span>")
 	while(user.pulling && user.grab_state >= GRAB_NECK)
-		target.reagents.add_reagent(/datum/reagent/medicine/salbutamol, 1) // So they don't choke to death while you interrogate them
+		target.reagents.add_reagent(/datum/reagent/medicine/salbutamol, 0.5) // So they don't choke to death while you interrogate them
 		do_mob(user, target, 100, TRUE)
 
 	changeling.islinking = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently, changeling hivemind link is supposed to require you to keep holding onto your target for however long you want them to be able to talk on the hivemind. That's not working, so instead they get hivemind for three minutes until the sleep ends. Changes it to check again for the prereqs every 10 seconds instead, and not have an upper time limit since you seriously hamper yourself and this is mainly an RP feature anyway. Oh and you are able to slowly drag them along while doing this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #27163
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Hivemind Link now properly requires you to keep holding on to the target, and lasts indefinetely.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
