### PR TITLE
borg buckle nerf

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1161,7 +1161,7 @@
 			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [M.p_their()] hands are full!</span>")
 		return
 	M.visible_message("<span class='boldwarning'>[M] is being loaded onto [src]!</span>")//if you have better flavor text for this by all means change it
-	if(do_after(src, 20, target = M))
+	if(do_after(src, 5, target = M))
 		. = ..(M, force, check_loc)
 
 /mob/living/silicon/robot/unbuckle_mob(mob/user, force=FALSE)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1160,7 +1160,9 @@
 		else
 			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [M.p_their()] hands are full!</span>")
 		return
-	. = ..(M, force, check_loc)
+	M.visible_message("<span class='boldwarning'>[M] is being loaded onto [src]!</span>")//if you have better flavor text for this by all means change it
+	if(do_after(src, 20, target = M))
+		. = ..(M, force, check_loc)
 
 /mob/living/silicon/robot/unbuckle_mob(mob/user, force=FALSE)
 	if(iscarbon(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

borg buckle has a do_after now

## Why It's Good For The Game
ever since the drag changes, borgs have been able to indefinitely chain spinstuns, prior to that they were balanced and difficult to pull off. with the recent emote binding, it has hit a whole new level of being simple to do. you can just drive-by buckle people if they're next to you for any period of time. The core of the issue is being able to instantly buckle people to yourself, which is why im choosing to not go a solution regarding emote binding or removing the ability to self-buckle altogether. Spinstuns will still be deadly if the target is unaware, as you'll still be able to infinite chainstun after they get stunned once. I believe this is the best solution for the above reasons.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: borgs buckling humans to themselves takes 0.5 seconds instead of being instant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
