### PR TITLE
[s] Fixes a material dupe bug

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -225,6 +225,8 @@
 		if(O)
 			O.setDir(usr.dir)
 		use(R.req_amount * multiplier)
+		for(var/i in custom_materials)
+			custom_materials[i] = amount * mats_per_stack
 	
 		if(R.applies_mats && custom_materials && custom_materials.len)
 			var/list/used_materials = list()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -413,6 +413,8 @@
 	if(!use(amount, TRUE, FALSE))
 		return FALSE
 	var/obj/item/stack/F = new type(user? user : drop_location(), amount, FALSE)
+	for(var/i in F.custom_materials)
+		custom_materials[i] -= F.custom_materials[i]
 	. = F
 	F.copy_evidences(src)
 	if(user)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -225,8 +225,6 @@
 		if(O)
 			O.setDir(usr.dir)
 		use(R.req_amount * multiplier)
-		for(var/i in custom_materials)
-			custom_materials[i] = amount * mats_per_stack
 	
 		if(R.applies_mats && custom_materials && custom_materials.len)
 			var/list/used_materials = list()
@@ -317,6 +315,8 @@
 	amount -= used
 	if(check)
 		zero_amount()
+	for(var/i in custom_materials)
+		custom_materials[i] = amount * mats_per_stack
 	update_icon()
 	update_weight()
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Splitting a stack of materials in-hand wasn't updating the custom_materials list of the old stack. The result is that while you may have a stack of metal that _says_ it's only 5 sheets, it could have 100000 units of iron (or 50 sheets worth) listed in its custom_materials. Since machines now read the custom_materials list, sticking this bugged stack of mats into a machine effectively duplicated the materials.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dupe bug bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
