### PR TITLE
Refactors embedding as an element, adds toy throwing stars and sticky tape!

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -135,6 +135,11 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define EMBED_THROWSPEED_THRESHOLD				4	//The minimum value of an item's throw_speed for it to embed (Unless it has embedded_ignore_throwspeed_threshold set to 1)
 #define EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER 8	//Coefficient of multiplication for the damage the item does when removed without a surgery (this*item.w_class)
 #define EMBEDDED_UNSAFE_REMOVAL_TIME			30	//A Time in ticks, total removal time = (this*item.w_class)
+#define EMBEDDED_JOSTLE_CHANCE					5	//Chance for embedded objects to cause pain every time they move (jostle)
+#define EMBEDDED_JOSTLE_PAIN_MULTIPLIER			1	//Coefficient of multiplication for the damage the item does while
+#define EMBEDDED_PAIN_STAM_PCT					0.0	//This percentage of all pain will be dealt as stam damage rather than brute (0-1)
+
+#define EMBED_HARMLESS arglist(list("pain_mult" = 0, "jostle_pain_mult" = 0, "ignore_throwspeed_threshold" = TRUE))
 
 //Gun weapon weight
 #define WEAPON_LIGHT 1

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -168,7 +168,7 @@
 #define COMSIG_MOVABLE_UNCROSSED "movable_uncrossed"            //from base of atom/movable/Uncrossed(): (/atom/movable)
 #define COMSIG_MOVABLE_BUMP "movable_bump"						//from base of atom/movable/Bump(): (/atom)
 #define COMSIG_MOVABLE_IMPACT "movable_impact"					//from base of atom/movable/throw_impact(): (/atom/hit_atom, /datum/thrownthing/throwingdatum)
-#define COMSIG_MOVABLE_IMPACT_ZONE "item_impact_zone"			//from base of mob/living/hitby(): (mob/living/target, hit_zone)
+#define COMSIG_MOVABLE_IMPACT_ZONE "item_impact_zone"			//from base of mob/living/hitby(): (mob/living/target, hit_zone, datum/thrownthing/throwingdatum)
 #define COMSIG_MOVABLE_BUCKLE "buckle"							//from base of atom/movable/buckle_mob(): (mob, force)
 #define COMSIG_MOVABLE_UNBUCKLE "unbuckle"						//from base of atom/movable/unbuckle_mob(): (mob, force)
 #define COMSIG_MOVABLE_PRE_THROW "movable_pre_throw"			//from base of atom/movable/throw_at(): (list/args)
@@ -278,7 +278,8 @@
 	#define COMPONENT_BLOCK_MARK_RETRIEVAL 1
 #define COMSIG_ITEM_HIT_REACT "item_hit_react"					//from base of obj/item/hit_reaction(): (list/args)
 #define COMSIG_ITEM_WEARERCROSSED "wearer_crossed"                //called on item when crossed by something (): (/atom/movable, mob/living/crossed)
-
+#define COMSIG_ITEM_EMBED_REMOVING_RIP "item_embed_removing"		// called on item when a human tries to rip out this embedded item (/obj/item, mob/living/carbon/human/target, /obj/item/bodypart/L)
+#define COMSIG_ITEM_EMBED_REMOVE_SURGERY "item_embed_remove_surgery"	// called on item from /datum/surgery_step/remove_object/success (/obj/item, mob/living/carbon/human/target, /obj/item/bodypart/L)
 // /obj/item/clothing signals
 #define COMSIG_SHOES_STEP_ACTION "shoes_step_action"			//from base of obj/item/clothing/shoes/proc/step_action(): ()
 

--- a/code/datums/elements/embed.dm
+++ b/code/datums/elements/embed.dm
@@ -1,0 +1,190 @@
+/datum/element/embed
+	element_flags = ELEMENT_BESPOKE
+	var/list/active_embeds = list()
+
+	var/embed_chance
+	var/fall_chance
+	var/pain_chance
+	var/pain_mult //The coefficient of multiplication for the damage this item does while embedded (this*w_class)
+	var/fall_pain_mult //The coefficient of multiplication for the damage this item does when falling out of a limb (this*w_class)
+	var/impact_pain_mult //The coefficient of multiplication for the damage this item does when first embedded (this*w_class)
+	var/rip_pain_mult //The coefficient of multiplication for the damage removing this without surgery causes (this*w_class)
+	var/rip_time //A time in ticks, multiplied by the w_class.
+	var/ignore_throwspeed_threshold //if we don't give a damn about EMBED_THROWSPEED_THRESHOLD
+	var/jostle_chance //Chance to cause pain every time the victim moves (1/2 chance if they're walking or crawling)
+	var/jostle_pain_mult //The coefficient of multiplication for the damage when jostle damage is applied (this*w_class)
+	var/pain_stam_pct //Percentage of all pain damage dealt as stamina instead of brute (none by default)
+
+	var/harmless = FALSE
+
+/datum/element/embed/New()
+	. = ..()
+	START_PROCESSING(SSdcs, src)
+
+/datum/element/embed/Attach(obj/item/target,
+	embed_chance = EMBED_CHANCE,
+    fall_chance = EMBEDDED_ITEM_FALLOUT,
+    pain_chance = EMBEDDED_PAIN_CHANCE,
+    pain_mult = EMBEDDED_PAIN_MULTIPLIER,
+    fall_pain_mult = EMBEDDED_FALL_PAIN_MULTIPLIER,
+    impact_pain_mult = EMBEDDED_IMPACT_PAIN_MULTIPLIER,
+    rip_pain_mult = EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER,
+    rip_time = EMBEDDED_UNSAFE_REMOVAL_TIME,
+    ignore_throwspeed_threshold = FALSE,
+	jostle_chance = EMBEDDED_JOSTLE_CHANCE,
+	jostle_pain_mult = EMBEDDED_JOSTLE_PAIN_MULTIPLIER,
+	pain_stam_pct = EMBEDDED_PAIN_STAM_PCT)
+
+	. = ..()
+
+	if(!isitem(target))
+		return ELEMENT_INCOMPATIBLE
+
+	src.embed_chance = embed_chance
+	src.fall_chance = fall_chance
+	src.pain_chance = pain_chance
+	src.pain_mult = pain_mult
+	src.fall_pain_mult = fall_pain_mult
+	src.impact_pain_mult = impact_pain_mult
+	src.rip_pain_mult = rip_pain_mult
+	src.rip_time = rip_time
+	src.ignore_throwspeed_threshold = ignore_throwspeed_threshold
+	src.jostle_chance = jostle_chance
+	src.jostle_pain_mult = jostle_pain_mult
+	src.pain_stam_pct = pain_stam_pct
+
+	harmless = (pain_mult == 0 && jostle_pain_mult == 0)
+
+
+	RegisterSignal(target, COMSIG_MOVABLE_IMPACT_ZONE, .proc/embed_check)
+	RegisterSignal(target, COMSIG_ITEM_EMBED_REMOVING_RIP, .proc/rip_out)
+	RegisterSignal(target, COMSIG_ITEM_EMBED_REMOVE_SURGERY, .proc/safe_remove)
+	RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/byeee)
+
+/datum/element/embed/Detach(obj/item/target)
+	. = ..()
+
+	if(target in active_embeds)
+		active_embeds -= target
+
+	UnregisterSignal(target, COMSIG_MOVABLE_IMPACT_ZONE)
+	UnregisterSignal(target, COMSIG_ITEM_EMBED_REMOVING_RIP)
+	UnregisterSignal(target, COMSIG_ITEM_EMBED_REMOVE_SURGERY)
+	UnregisterSignal(target, COMSIG_PARENT_QDELETING)
+
+/datum/element/embed/proc/byeee(obj/item/weapon)
+	if(weapon in active_embeds)
+		active_embeds -= weapon
+
+/datum/element/embed/proc/jostle_check(mob/living/carbon/human/victim)
+	for(var/obj/item/bodypart/L in victim.bodyparts)
+		for(var/obj/item/weapon in L.embedded_objects)
+
+			if(!harmless)
+				var/chance = jostle_chance
+				if(victim.m_intent == MOVE_INTENT_WALK || victim.lying)
+					chance *= 0.5
+
+				if(prob(chance))
+					var/damage = weapon.w_class * jostle_pain_mult
+					L.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage)
+					to_chat(victim, "<span class='userdanger'>[weapon] embedded in your [L.name] jostles and stings!</span>")
+
+/datum/element/embed/proc/embed_check(obj/item/weapon, mob/living/carbon/human/victim, hit_zone, datum/thrownthing/throwingdatum)
+	if(!istype(victim))
+		return
+
+	if(((throwingdatum ? throwingdatum.speed : weapon.throw_speed) >= EMBED_THROWSPEED_THRESHOLD) || ignore_throwspeed_threshold)
+		if(prob(embed_chance) && !HAS_TRAIT(victim, TRAIT_PIERCEIMMUNE))
+
+			var/obj/item/bodypart/L = pick(victim.bodyparts)
+			weapon.embedded_in = L // on the inside... on the inside...
+			L.embedded_objects |= weapon
+			weapon.forceMove(victim)
+			active_embeds += weapon
+
+			if(weapon.is_embed_harmless())
+				victim.visible_message("<span class='danger'>[weapon] sticks to [victim]'s [L.name]!</span>","<span class='userdanger'>[weapon] sticks to your [L.name]!</span>")
+			else
+				victim.visible_message("<span class='danger'>[weapon] embeds itself in [victim]'s [L.name]!</span>","<span class='userdanger'>[weapon] embeds itself in your [L.name]!</span>")
+				victim.throw_alert("embeddedobject", /obj/screen/alert/embeddedobject)
+				playsound(victim,'sound/weapons/bladeslice.ogg', 40)
+				weapon.add_mob_blood(victim)//it embedded itself in you, of course it's bloody!
+
+				var/damage = weapon.w_class * impact_pain_mult
+				L.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage)
+
+				SEND_SIGNAL(victim, COMSIG_ADD_MOOD_EVENT, "embedded", /datum/mood_event/embedded)
+				RegisterSignal(victim, COMSIG_MOVABLE_MOVED, .proc/jostle_check)
+
+			return TRUE
+
+/datum/element/embed/proc/fall_out(obj/item/weapon, mob/living/carbon/human/victim)
+	var/obj/item/bodypart/L = weapon.embedded_in
+
+	if(harmless)
+		victim.visible_message("<span class='danger'>[weapon] falls off of [victim.name]'s [L.name]!</span>","<span class='userdanger'>[weapon] falls off of your [L.name]!</span>")
+	else
+		var/damage = weapon.w_class * fall_pain_mult
+		L.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage)
+		victim.visible_message("<span class='danger'>[weapon] falls out of [victim.name]'s [L.name]!</span>","<span class='userdanger'>[weapon] falls out of your [L.name]!</span>")
+
+	safe_remove(weapon, victim, L)
+	weapon.forceMove(victim.drop_location())
+
+/datum/element/embed/proc/rip_out(obj/item/weapon, mob/living/carbon/human/victim, obj/item/bodypart/L)
+	var/time_taken = rip_time * weapon.w_class
+
+	victim.visible_message("<span class='warning'>[victim] attempts to remove [weapon] from [victim.p_their()] [L.name].</span>","<span class='notice'>You attempt to remove [weapon] from your [L.name]... (It will take [DisplayTimeText(time_taken)].)</span>")
+	if(do_after(victim, time_taken, needhand = 1, target = victim))
+		if(!weapon || !L || weapon.loc != victim || !(weapon in L.embedded_objects))
+			active_embeds -= weapon
+			if(!victim.has_embedded_objects())
+				UnregisterSignal(victim, COMSIG_MOVABLE_MOVED)
+			return
+
+		if(weapon.is_embed_harmless())
+			victim.visible_message("<span class='notice'>[victim] successfully unsticks [weapon] from [victim.p_their()] [L.name]!</span>", "<span class='notice'>You successfully unstick [weapon] from your [L.name].</span>")
+		else
+			var/damage = weapon.w_class * rip_pain_mult
+			L.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage) //It hurts to rip it out, get surgery you dingus.
+			victim.emote("scream")
+			victim.visible_message("<span class='notice'>[victim] successfully rips [weapon] out of [victim.p_their()] [L.name]!</span>", "<span class='notice'>You successfully remove [weapon] from your [L.name].</span>")
+
+		safe_remove(weapon, victim, L)
+		victim.put_in_hands(weapon)
+
+/datum/element/embed/proc/safe_remove(obj/item/weapon, mob/living/carbon/human/victim, obj/item/bodypart/L)
+	L.embedded_objects -= weapon
+	weapon.embedded_in = null
+	weapon.forceMove(get_turf(victim))
+	active_embeds -= weapon
+
+	if(!victim.has_embedded_objects())
+		victim.clear_alert("embeddedobject")
+		UnregisterSignal(victim, COMSIG_MOVABLE_MOVED)
+		SEND_SIGNAL(victim, COMSIG_CLEAR_MOOD_EVENT, "embedded")
+
+/datum/element/embed/process()
+	for(var/obj/item/weapon in active_embeds)
+		var/obj/item/bodypart/L = weapon.embedded_in
+		var/mob/living/carbon/human/victim = L.owner
+
+		if(!victim || !L) // in case the victim and/or their limbs exploded (say, due to a sticky bomb)
+			active_embeds -= weapon
+			if(victim && !victim.has_embedded_objects())
+				UnregisterSignal(victim, COMSIG_MOVABLE_MOVED)
+			weapon.embedded_in = null
+			weapon.forceMove(get_turf(weapon))
+			continue
+
+		if(victim.stat == DEAD)
+			continue
+
+		if(!harmless && prob(pain_chance))
+			var/damage = weapon.w_class * pain_mult
+			L.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage)
+			to_chat(victim, "<span class='userdanger'>[weapon] embedded in your [L.name] hurts!</span>")
+
+		if(prob(fall_chance))
+			fall_out(weapon, victim)

--- a/code/datums/elements/embed.dm
+++ b/code/datums/elements/embed.dm
@@ -1,6 +1,7 @@
 /datum/element/embed
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_DETACH
 	var/list/active_embeds = list()
+	id_arg_index = 2
 
 	var/embed_chance
 	var/fall_chance
@@ -21,37 +22,37 @@
 	. = ..()
 	START_PROCESSING(SSdcs, src)
 
-/datum/element/embed/Attach(obj/item/target,
-	embed_chance = EMBED_CHANCE,
-    fall_chance = EMBEDDED_ITEM_FALLOUT,
-    pain_chance = EMBEDDED_PAIN_CHANCE,
-    pain_mult = EMBEDDED_PAIN_MULTIPLIER,
-    fall_pain_mult = EMBEDDED_FALL_PAIN_MULTIPLIER,
-    impact_pain_mult = EMBEDDED_IMPACT_PAIN_MULTIPLIER,
-    rip_pain_mult = EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER,
-    rip_time = EMBEDDED_UNSAFE_REMOVAL_TIME,
-    ignore_throwspeed_threshold = FALSE,
-	jostle_chance = EMBEDDED_JOSTLE_CHANCE,
-	jostle_pain_mult = EMBEDDED_JOSTLE_PAIN_MULTIPLIER,
-	pain_stam_pct = EMBEDDED_PAIN_STAM_PCT)
+/datum/element/embed/Attach(datum/target,
+	embed_chance,
+    fall_chance,
+    pain_chance,
+    pain_mult,
+    fall_pain_mult,
+    impact_pain_mult,
+    rip_pain_mult,
+    rip_time,
+    ignore_throwspeed_threshold,
+	jostle_chance,
+	jostle_pain_mult,
+	pain_stam_pct)
 
 	. = ..()
 
 	if(!isitem(target))
 		return ELEMENT_INCOMPATIBLE
 
-	src.embed_chance = embed_chance
-	src.fall_chance = fall_chance
-	src.pain_chance = pain_chance
-	src.pain_mult = pain_mult
-	src.fall_pain_mult = fall_pain_mult
-	src.impact_pain_mult = impact_pain_mult
-	src.rip_pain_mult = rip_pain_mult
-	src.rip_time = rip_time
-	src.ignore_throwspeed_threshold = ignore_throwspeed_threshold
-	src.jostle_chance = jostle_chance
-	src.jostle_pain_mult = jostle_pain_mult
-	src.pain_stam_pct = pain_stam_pct
+	src.embed_chance = (!isnull(embed_chance) ? embed_chance : EMBED_CHANCE)
+	src.fall_chance = (!isnull(fall_chance) ? fall_chance : EMBEDDED_ITEM_FALLOUT)
+	src.pain_chance = (!isnull(pain_chance) ? pain_chance : EMBEDDED_PAIN_CHANCE)
+	src.pain_mult = (!isnull(pain_mult) ? pain_mult : EMBEDDED_PAIN_MULTIPLIER)
+	src.fall_pain_mult = (!isnull(fall_pain_mult) ? fall_pain_mult : EMBEDDED_FALL_PAIN_MULTIPLIER)
+	src.impact_pain_mult = (!isnull(impact_pain_mult) ? impact_pain_mult : EMBEDDED_IMPACT_PAIN_MULTIPLIER)
+	src.rip_pain_mult = (!isnull(rip_pain_mult) ? rip_pain_mult : EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER)
+	src.rip_time = (!isnull(rip_time) ? rip_time : EMBEDDED_UNSAFE_REMOVAL_TIME)
+	src.ignore_throwspeed_threshold = (!isnull(ignore_throwspeed_threshold) ? ignore_throwspeed_threshold : FALSE)
+	src.jostle_chance = (!isnull(jostle_chance) ? jostle_chance : EMBEDDED_JOSTLE_CHANCE)
+	src.jostle_pain_mult = (!isnull(jostle_pain_mult) ? jostle_pain_mult : EMBEDDED_JOSTLE_PAIN_MULTIPLIER)
+	src.pain_stam_pct = (!isnull(pain_stam_pct) ? pain_stam_pct : EMBEDDED_PAIN_STAM_PCT)
 
 	harmless = (pain_mult == 0 && jostle_pain_mult == 0)
 
@@ -59,7 +60,6 @@
 	RegisterSignal(target, COMSIG_MOVABLE_IMPACT_ZONE, .proc/embed_check)
 	RegisterSignal(target, COMSIG_ITEM_EMBED_REMOVING_RIP, .proc/rip_out)
 	RegisterSignal(target, COMSIG_ITEM_EMBED_REMOVE_SURGERY, .proc/safe_remove)
-	RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/byeee)
 
 /datum/element/embed/Detach(obj/item/target)
 	. = ..()
@@ -70,11 +70,6 @@
 	UnregisterSignal(target, COMSIG_MOVABLE_IMPACT_ZONE)
 	UnregisterSignal(target, COMSIG_ITEM_EMBED_REMOVING_RIP)
 	UnregisterSignal(target, COMSIG_ITEM_EMBED_REMOVE_SURGERY)
-	UnregisterSignal(target, COMSIG_PARENT_QDELETING)
-
-/datum/element/embed/proc/byeee(obj/item/weapon)
-	if(weapon in active_embeds)
-		active_embeds -= weapon
 
 /datum/element/embed/proc/jostle_check(mob/living/carbon/human/victim)
 	for(var/obj/item/bodypart/L in victim.bodyparts)

--- a/code/datums/embedding_behavior.dm
+++ b/code/datums/embedding_behavior.dm
@@ -1,58 +1,73 @@
-#define EMBEDID "embed-[embed_chance]-[embedded_fall_chance]-[embedded_pain_chance]-[embedded_pain_multiplier]-[embedded_fall_pain_multiplier]-[embedded_impact_pain_multiplier]-[embedded_unsafe_removal_pain_multiplier]-[embedded_unsafe_removal_time]-[embedded_ignore_throwspeed_threshold]"
+#define EMBEDID "embed-[embed_chance]-[fall_chance]-[pain_chance]-[pain_mult]-[fall_pain_mult]-[impact_pain_mult]-[rip_pain_mult]-[rip_time]-[ignore_throwspeed_threshold]-[jostle_chance]-[jostle_pain_mult]-[pain_stam_pct]"
 
 /proc/getEmbeddingBehavior(embed_chance = EMBED_CHANCE,
-                  embedded_fall_chance = EMBEDDED_ITEM_FALLOUT,
-                  embedded_pain_chance = EMBEDDED_PAIN_CHANCE,
-                  embedded_pain_multiplier = EMBEDDED_PAIN_MULTIPLIER,
-                  embedded_fall_pain_multiplier = EMBEDDED_FALL_PAIN_MULTIPLIER,
-                  embedded_impact_pain_multiplier = EMBEDDED_IMPACT_PAIN_MULTIPLIER,
-                  embedded_unsafe_removal_pain_multiplier = EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER,
-                  embedded_unsafe_removal_time = EMBEDDED_UNSAFE_REMOVAL_TIME,
-                  embedded_ignore_throwspeed_threshold = FALSE)
+                  fall_chance = EMBEDDED_ITEM_FALLOUT,
+                  pain_chance = EMBEDDED_PAIN_CHANCE,
+                  pain_mult = EMBEDDED_PAIN_MULTIPLIER,
+                  fall_pain_mult = EMBEDDED_FALL_PAIN_MULTIPLIER,
+                  impact_pain_mult = EMBEDDED_IMPACT_PAIN_MULTIPLIER,
+                  rip_pain_mult = EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER,
+                  rip_time = EMBEDDED_UNSAFE_REMOVAL_TIME,
+                  ignore_throwspeed_threshold = FALSE,
+				  jostle_chance = EMBEDDED_JOSTLE_CHANCE,
+				  jostle_pain_mult = EMBEDDED_JOSTLE_PAIN_MULTIPLIER,
+				  pain_stam_pct = EMBEDDED_PAIN_STAM_PCT)
   . = locate(EMBEDID)
   if (!.)
-    . = new /datum/embedding_behavior(embed_chance, embedded_fall_chance, embedded_pain_chance, embedded_pain_multiplier, embedded_fall_pain_multiplier, embedded_impact_pain_multiplier, embedded_unsafe_removal_pain_multiplier, embedded_unsafe_removal_time, embedded_ignore_throwspeed_threshold)
+    . = new /datum/embedding_behavior(embed_chance, fall_chance, pain_chance, pain_mult, fall_pain_mult, impact_pain_mult, rip_pain_mult, rip_time, ignore_throwspeed_threshold, jostle_chance, jostle_pain_mult, pain_stam_pct)
 
 /datum/embedding_behavior
   var/embed_chance
-  var/embedded_fall_chance
-  var/embedded_pain_chance
-  var/embedded_pain_multiplier //The coefficient of multiplication for the damage this item does while embedded (this*w_class)
-  var/embedded_fall_pain_multiplier //The coefficient of multiplication for the damage this item does when falling out of a limb (this*w_class)
-  var/embedded_impact_pain_multiplier //The coefficient of multiplication for the damage this item does when first embedded (this*w_class)
-  var/embedded_unsafe_removal_pain_multiplier //The coefficient of multiplication for the damage removing this without surgery causes (this*w_class)
-  var/embedded_unsafe_removal_time //A time in ticks, multiplied by the w_class.
-  var/embedded_ignore_throwspeed_threshold //if we don't give a damn about EMBED_THROWSPEED_THRESHOLD
+  var/fall_chance
+  var/pain_chance
+  var/pain_mult //The coefficient of multiplication for the damage this item does while embedded (this*w_class)
+  var/fall_pain_mult //The coefficient of multiplication for the damage this item does when falling out of a limb (this*w_class)
+  var/impact_pain_mult //The coefficient of multiplication for the damage this item does when first embedded (this*w_class)
+  var/rip_pain_mult //The coefficient of multiplication for the damage removing this without surgery causes (this*w_class)
+  var/rip_time //A time in ticks, multiplied by the w_class.
+  var/ignore_throwspeed_threshold //if we don't give a damn about EMBED_THROWSPEED_THRESHOLD
+  var/jostle_chance //Chance to cause pain every time the victim moves (1/2 chance if they're walking or crawling)
+  var/jostle_pain_mult //The coefficient of multiplication for the damage when jostle damage is applied (this*w_class)
+  var/pain_stam_pct //Percentage of all pain damage dealt as stamina instead of brute (none by default)
 
 /datum/embedding_behavior/New(embed_chance = EMBED_CHANCE,
-                  embedded_fall_chance = EMBEDDED_ITEM_FALLOUT,
-                  embedded_pain_chance = EMBEDDED_PAIN_CHANCE,
-                  embedded_pain_multiplier = EMBEDDED_PAIN_MULTIPLIER,
-                  embedded_fall_pain_multiplier = EMBEDDED_FALL_PAIN_MULTIPLIER,
-                  embedded_impact_pain_multiplier = EMBEDDED_IMPACT_PAIN_MULTIPLIER,
-                  embedded_unsafe_removal_pain_multiplier = EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER,
-                  embedded_unsafe_removal_time = EMBEDDED_UNSAFE_REMOVAL_TIME,
-                  embedded_ignore_throwspeed_threshold = FALSE)
+                  fall_chance = EMBEDDED_ITEM_FALLOUT,
+                  pain_chance = EMBEDDED_PAIN_CHANCE,
+                  pain_mult = EMBEDDED_PAIN_MULTIPLIER,
+                  fall_pain_mult = EMBEDDED_FALL_PAIN_MULTIPLIER,
+                  impact_pain_mult = EMBEDDED_IMPACT_PAIN_MULTIPLIER,
+                  rip_pain_mult = EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER,
+                  rip_time = EMBEDDED_UNSAFE_REMOVAL_TIME,
+                  ignore_throwspeed_threshold = FALSE,
+				  jostle_chance = EMBEDDED_JOSTLE_CHANCE,
+				  jostle_pain_mult = EMBEDDED_JOSTLE_PAIN_MULTIPLIER,
+				  pain_stam_pct = EMBEDDED_PAIN_STAM_PCT)
   src.embed_chance = embed_chance
-  src.embedded_fall_chance = embedded_fall_chance
-  src.embedded_pain_chance = embedded_pain_chance
-  src.embedded_pain_multiplier = embedded_pain_multiplier
-  src.embedded_fall_pain_multiplier = embedded_fall_pain_multiplier
-  src.embedded_impact_pain_multiplier = embedded_impact_pain_multiplier
-  src.embedded_unsafe_removal_pain_multiplier = embedded_unsafe_removal_pain_multiplier
-  src.embedded_unsafe_removal_time = embedded_unsafe_removal_time
-  src.embedded_ignore_throwspeed_threshold = embedded_ignore_throwspeed_threshold
+  src.fall_chance = fall_chance
+  src.pain_chance = pain_chance
+  src.pain_mult = pain_mult
+  src.fall_pain_mult = fall_pain_mult
+  src.impact_pain_mult = impact_pain_mult
+  src.rip_pain_mult = rip_pain_mult
+  src.rip_time = rip_time
+  src.ignore_throwspeed_threshold = ignore_throwspeed_threshold
+  src.jostle_chance = jostle_chance
+  src.jostle_pain_mult = jostle_pain_mult
+  src.pain_stam_pct = pain_stam_pct
   tag = EMBEDID
 
-/datum/embedding_behavior/proc/setRating(embed_chance, embedded_fall_chance, embedded_pain_chance, embedded_pain_multiplier, embedded_fall_pain_multiplier, embedded_impact_pain_multiplier, embedded_unsafe_removal_pain_multiplier, embedded_unsafe_removal_time, embedded_ignore_throwspeed_threshold)
+/datum/embedding_behavior/proc/setRating(embed_chance, fall_chance, pain_chance, pain_mult, fall_pain_mult, impact_pain_mult, rip_pain_mult, rip_time, ignore_throwspeed_threshold)
   return getEmbeddingBehavior((isnull(embed_chance) ? src.embed_chance : embed_chance),\
-                  (isnull(embedded_fall_chance) ? src.embedded_fall_chance : embedded_fall_chance),\
-                  (isnull(embedded_pain_chance) ? src.embedded_pain_chance : embedded_pain_chance),\
-                  (isnull(embedded_pain_multiplier) ? src.embedded_pain_multiplier : embedded_pain_multiplier),\
-                  (isnull(embedded_fall_pain_multiplier) ? src.embedded_fall_pain_multiplier : embedded_fall_pain_multiplier),\
-                  (isnull(embedded_impact_pain_multiplier) ? src.embedded_impact_pain_multiplier : embedded_impact_pain_multiplier),\
-                  (isnull(embedded_unsafe_removal_pain_multiplier) ? src.embedded_unsafe_removal_pain_multiplier : embedded_unsafe_removal_pain_multiplier),\
-                  (isnull(embedded_unsafe_removal_time) ? src.embedded_unsafe_removal_time : embedded_unsafe_removal_time),\
-                  (isnull(embedded_ignore_throwspeed_threshold) ? src.embedded_ignore_throwspeed_threshold : embedded_ignore_throwspeed_threshold))
+                  (isnull(fall_chance) ? src.fall_chance : fall_chance),\
+                  (isnull(pain_chance) ? src.pain_chance : pain_chance),\
+                  (isnull(pain_mult) ? src.pain_mult : pain_mult),\
+                  (isnull(fall_pain_mult) ? src.fall_pain_mult : fall_pain_mult),\
+                  (isnull(impact_pain_mult) ? src.impact_pain_mult : impact_pain_mult),\
+                  (isnull(rip_pain_mult) ? src.rip_pain_mult : rip_pain_mult),\
+                  (isnull(rip_time) ? src.rip_time : rip_time),\
+                  (isnull(ignore_throwspeed_threshold) ? src.ignore_throwspeed_threshold : ignore_throwspeed_threshold),\
+                  (isnull(jostle_chance) ? src.jostle_chance : jostle_chance),\
+                  (isnull(jostle_pain_mult) ? src.jostle_pain_mult : jostle_pain_mult),\
+                  (isnull(pain_stam_pct) ? src.pain_stam_pct : pain_stam_pct))
 
 #undef EMBEDID

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -85,7 +85,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER //the icon to indicate this object is being dragged
 
-	var/datum/embedding_behavior/embedding
+	var/list/embedding
 
 	var/embedded_in
 
@@ -151,11 +151,12 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(damtype == "brute")
 			hitsound = "swing_hit"
 
-	if(embedding)
-		var/list/t = list("eletype" = /datum/element/embed)
-		t += embedding
-		testing(t)
-		AddElement(arglist(t))
+	if(embedding != null)
+		var/list/temp = embedding.Copy()
+		temp.Insert(1, /datum/element/embed)
+		for(var/i in temp)
+			testing("[i] | [temp[i]]")
+		AddElement(arglist(temp))
 		/*if(islist(embedding))
 			embedding = getEmbeddingBehavior(arglist(embedding))
 		else if(!istype(embedding, /datum/embedding_behavior))
@@ -864,11 +865,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	return owner.dropItemToGround(src)
 
 /obj/item/proc/is_embed_harmless()
-<<<<<<< HEAD
-	if(embedding)
-		return (embedding.pain_mult == 0 && embedding.jostle_pain_mult == 0)
-=======
 	return FALSE
 	//if(embedding)
 		//return (embedding.pain_mult == 0 && embedding.jostle_pain_mult == 0)
->>>>>>> embeddead

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -87,6 +87,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	var/datum/embedding_behavior/embedding
 
+	var/embedded_in
+
 	var/flags_cover = 0 //for flags such as GLASSESCOVERSEYES
 	var/heat = 0
 	///All items with sharpness of IS_SHARP or higher will automatically get the butchering component.
@@ -149,12 +151,16 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(damtype == "brute")
 			hitsound = "swing_hit"
 
-	if (!embedding)
-		embedding = getEmbeddingBehavior()
-	else if (islist(embedding))
-		embedding = getEmbeddingBehavior(arglist(embedding))
-	else if (!istype(embedding, /datum/embedding_behavior))
-		stack_trace("Invalid type [embedding.type] found in .embedding during /obj/item Initialize()")
+	if(embedding)
+		var/list/t = list("eletype" = /datum/element/embed)
+		t += embedding
+		testing(t)
+		AddElement(arglist(t))
+		/*if(islist(embedding))
+			embedding = getEmbeddingBehavior(arglist(embedding))
+		else if(!istype(embedding, /datum/embedding_behavior))
+			stack_trace("Invalid type [embedding.type] found in .embedding during /obj/item Initialize()")
+		*/
 
 	if(sharpness) //give sharp objects butchering functionality, for consistency
 		AddComponent(/datum/component/butchering, 80 * toolspeed)
@@ -856,3 +862,13 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 /obj/item/proc/doStrip(mob/stripper, mob/owner)
 	return owner.dropItemToGround(src)
+
+/obj/item/proc/is_embed_harmless()
+<<<<<<< HEAD
+	if(embedding)
+		return (embedding.pain_mult == 0 && embedding.jostle_pain_mult == 0)
+=======
+	return FALSE
+	//if(embedding)
+		//return (embedding.pain_mult == 0 && embedding.jostle_pain_mult == 0)
+>>>>>>> embeddead

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -100,7 +100,7 @@
 			var/obj/item/I = AM
 			I.throw_speed = max(1, (I.throw_speed - 3))
 			I.throw_range = max(1, (I.throw_range - 3))
-			I.embedding = I.embedding.setRating(embed_chance = 0)
+			//I.embedding = I.embedding.setRating(embed_chance = 0)
 		else if(istype(AM, /mob/living))
 			plastic_overlay.layer = FLOAT_LAYER
 

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -157,7 +157,7 @@
 	name = "combat knife"
 	icon_state = "buckknife"
 	desc = "A military combat utility survival knife."
-	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 65, "embedded_fall_chance" = 10, "embedded_ignore_throwspeed_threshold" = TRUE)
+	embedding = list("pain_mult" = 4, "embed_chance" = 65, "fall_chance" = 10, "ignore_throwspeed_threshold" = TRUE)
 	force = 20
 	throwforce = 20
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "cut")
@@ -166,7 +166,7 @@
 /obj/item/kitchen/knife/combat/survival
 	name = "survival knife"
 	icon_state = "survivalknife"
-	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 35, "embedded_fall_chance" = 10)
+	embedding = list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 10)
 	desc = "A hunting grade survival knife."
 	force = 15
 	throwforce = 15
@@ -179,7 +179,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	desc = "A sharpened bone. The bare minimum in survival."
-	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 35, "embedded_fall_chance" = 10)
+	embedding = list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 10)
 	force = 15
 	throwforce = 15
 	custom_materials = null

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -99,7 +99,7 @@
 	throw_speed = 3
 	throw_range = 5
 	sharpness = IS_SHARP
-	embedding = list("embed_chance" = 75, "embedded_impact_pain_multiplier" = 10)
+	embedding = list("embed_chance" = 75, "impact_pain_mult" = 10)
 	armour_penetration = 35
 	block_chance = 50
 

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	max_amount = 50
 	attack_verb = list("hit", "bludgeoned", "whacked")
 	hitsound = 'sound/weapons/gun/general/grenade_launch.ogg'
+	embedding = list()
 	novariants = TRUE
 
 /obj/item/stack/rods/suicide_act(mob/living/carbon/user)

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -253,6 +253,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	sharpness = IS_SHARP
 	var/icon_prefix
 	var/obj/item/stack/sheet/weld_material = /obj/item/stack/sheet/glass
+	embedding = list("embed_chance" = 65)
 
 
 /obj/item/shard/suicide_act(mob/user)

--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -130,3 +130,33 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 3
 	throw_range = 5
+
+
+/obj/item/stack/sticky_tape
+	name = "sticky tape"
+	singular_name = "sticky tape"
+	desc = "Used for sticking things to people."
+	icon = 'icons/obj/stack_objects.dmi'
+	icon_state = "deliveryPaper"
+	var/prefix = "sticky"
+	item_flags = NOBLUDGEON
+	amount = 5
+	max_amount = 5
+	resistance_flags = FLAMMABLE
+	grind_results = list(/datum/reagent/cellulose = 5)
+
+
+/obj/item/stack/sticky_tape/afterattack(obj/item/I, mob/living/user)
+	. = ..()
+	if(I.embedding)
+		to_chat(user, "<span class='warning'>[I] is already able to stick inside someone!</span>")
+		return
+
+	user.visible_message("<span class='notice'>[user] begins wrapping [I] with [src].</span>", "<span class='notice'>You begin wrapping [I] with [src].</span>")
+
+	if(do_after(user, 30, target=I))
+		I.embedding = getEmbeddingBehavior(EMBED_HARMLESS)
+		I.AddElement(/datum/element/embed)
+
+	I.name = "[prefix] [I.name]"
+	update_icon()

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -453,7 +453,7 @@
 	force_wielded = 18
 	throwforce = 20
 	throw_speed = 4
-	embedding = list("embedded_impact_pain_multiplier" = 3)
+	embedding = list("impact_pain_mult" = 3)
 	armour_penetration = 10
 	custom_materials = list(/datum/material/iron=1150, /datum/material/glass=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -280,11 +280,27 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 2
 	throwforce = 20 //20 + 2 (WEIGHT_CLASS_SMALL) * 4 (EMBEDDED_IMPACT_PAIN_MULTIPLIER) = 28 damage on hit due to guaranteed embedding
 	throw_speed = 4
-	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 100, "embedded_fall_chance" = 0)
+	embedding = list("pain_mult" = 4, "embed_chance" = 100, "fall_chance" = 0)
+
+
 	w_class = WEIGHT_CLASS_SMALL
 	sharpness = IS_SHARP
 	custom_materials = list(/datum/material/iron=500, /datum/material/glass=500)
 	resistance_flags = FIRE_PROOF
+
+/obj/item/throwing_star/stamina
+	name = "shock throwing star"
+	desc = "An aerodynamic disc designed to cause excruciating pain when stuck inside fleeing targets, hopefully without causing fatal harm."
+	throwforce = 5
+	embedding = list("pain_chance" = 5, "embed_chance" = 100, "fall_chance" = 0, "jostle_chance" = 10, "pain_stam_pct" = 0.8, "jostle_pain_mult" = 3)
+
+/obj/item/throwing_star/toy
+	name = "toy throwing star"
+	desc = "An aerodynamic disc strapped with adhesive for sticking to people, good for playing pranks and getting yourself killed by security."
+	sharpness = IS_BLUNT
+	force = 0
+	throwforce = 0
+	embedding = list("pain_mult" = 0, "jostle_pain_mult" = 0, "embed_chance" = 100, "fall_chance" = 0)
 
 /obj/item/throwing_star/magspear
 	name = "magnetic spear"
@@ -295,7 +311,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 10
 	throw_range = 0 //throwing these invalidates the speargun
 	attack_verb = list("stabbed", "ripped", "gored", "impaled")
-	embedding = list("embedded_pain_multiplier" = 8, "embed_chance" = 100, "embedded_fall_chance" = 0, "embedded_impact_pain_multiplier" = 15) //55 damage+embed on hit
+	embedding = list("pain_mult" = 8, "embed_chance" = 100, "fall_chance" = 0, "impact_pain_mult" = 15) //55 damage+embed on hit
 
 /obj/item/switchblade
 	name = "switchblade"

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -80,7 +80,9 @@
 
 			//We want an accurate reading of .len
 			listclearnulls(BP.embedded_objects)
-			temp_bleed += 0.5*BP.embedded_objects.len
+			for(var/obj/item/embeddies in BP.embedded_objects)
+				if(!embeddies.is_embed_harmless())
+					temp_bleed += 0.5
 
 			if(brutedamage >= 20)
 				temp_bleed += (brutedamage * 0.013)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -136,7 +136,10 @@
 			disabled += BP
 		missing -= BP.body_zone
 		for(var/obj/item/I in BP.embedded_objects)
-			msg += "<B>[t_He] [t_has] \a [icon2html(I, user)] [I] embedded in [t_his] [BP.name]!</B>\n"
+			if(I.is_embed_harmless())
+				msg += "<B>[t_He] [t_has] \a [icon2html(I, user)] [I] stuck to [t_his] [BP.name]!</B>\n"
+			else
+				msg += "<B>[t_He] [t_has] \a [icon2html(I, user)] [I] embedded in [t_his] [BP.name]!</B>\n"
 
 	for(var/X in disabled)
 		var/obj/item/bodypart/BP = X

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -213,20 +213,7 @@
 		var/obj/item/I = locate(href_list["embedded_object"]) in L.embedded_objects
 		if(!I || I.loc != src) //no item, no limb, or item is not in limb or in the person anymore
 			return
-		var/time_taken = I.embedding.embedded_unsafe_removal_time*I.w_class
-		usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [usr.p_their()] [L.name].</span>","<span class='notice'>You attempt to remove [I] from your [L.name]... (It will take [DisplayTimeText(time_taken)].)</span>")
-		if(do_after(usr, time_taken, needhand = 1, target = src))
-			if(!I || !L || I.loc != src || !(I in L.embedded_objects))
-				return
-			L.embedded_objects -= I
-			L.receive_damage(I.embedding.embedded_unsafe_removal_pain_multiplier*I.w_class)//It hurts to rip it out, get surgery you dingus.
-			I.forceMove(get_turf(src))
-			usr.put_in_hands(I)
-			usr.emote("scream")
-			usr.visible_message("<span class='notice'>[usr] successfully rips [I] out of [usr.p_their()] [L.name]!</span>", "<span class='notice'>You successfully remove [I] from your [L.name].</span>")
-			if(!has_embedded_objects())
-				clear_alert("embeddedobject")
-				SEND_SIGNAL(usr, COMSIG_CLEAR_MOOD_EVENT, "embedded")
+		SEND_SIGNAL(I, COMSIG_ITEM_EMBED_REMOVING_RIP, src, L)
 		return
 
 	if(href_list["item"]) //canUseTopic check for this is handled by mob/Topic()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -140,20 +140,6 @@
 		hitpush = FALSE
 		skipcatch = TRUE
 		blocked = TRUE
-	else if(I)
-		if(((throwingdatum ? throwingdatum.speed : I.throw_speed) >= EMBED_THROWSPEED_THRESHOLD) || I.embedding.embedded_ignore_throwspeed_threshold)
-			if(can_embed(I))
-				if(prob(I.embedding.embed_chance) && !HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
-					throw_alert("embeddedobject", /obj/screen/alert/embeddedobject)
-					var/obj/item/bodypart/L = pick(bodyparts)
-					L.embedded_objects |= I
-					I.add_mob_blood(src)//it embedded itself in you, of course it's bloody!
-					I.forceMove(src)
-					L.receive_damage(I.w_class*I.embedding.embedded_impact_pain_multiplier)
-					visible_message("<span class='danger'>[I] embeds itself in [src]'s [L.name]!</span>","<span class='userdanger'>[I] embeds itself in your [L.name]!</span>")
-					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "embedded", /datum/mood_event/embedded)
-					hitpush = FALSE
-					skipcatch = TRUE //can't catch the now embedded item
 
 	return ..()
 
@@ -744,7 +730,10 @@
 		to_chat(src, "\t <span class='[no_damage ? "notice" : "warning"]'>Your [LB.name][isdisabled][self_aware ? " has " : " is "][status].</span>")
 
 		for(var/obj/item/I in LB.embedded_objects)
-			to_chat(src, "\t <a href='?src=[REF(src)];embedded_object=[REF(I)];embedded_limb=[REF(LB)]' class='warning'>There is \a [I] embedded in your [LB.name]!</a>")
+			if(I.is_embed_harmless())
+				to_chat(src, "\t <a href='?src=[REF(src)];embedded_object=[REF(I)];embedded_limb=[REF(LB)]' class='warning'>There is \a [I] stuck to your [LB.name]!</a>")
+			else
+				to_chat(src, "\t <a href='?src=[REF(src)];embedded_object=[REF(I)];embedded_limb=[REF(LB)]' class='warning'>There is \a [I] embedded in your [LB.name]!</a>")
 
 	for(var/t in missing)
 		to_chat(src, "<span class='boldannounce'>Your [parse_zone(t)] is missing!</span>")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -39,10 +39,6 @@
 			handle_heart()
 			handle_liver()
 
-		if(stat != DEAD)
-			//Stuff jammed in your limbs hurts
-			handle_embedded_objects()
-
 		dna.species.spec_life(src) // for mutantraces
 
 	//Update our name based on whether our face is obscured/disfigured
@@ -284,24 +280,6 @@
 		if(CH.clothing_flags & BLOCK_GAS_SMOKE_EFFECT)
 			return TRUE
 	return ..()
-
-
-/mob/living/carbon/human/proc/handle_embedded_objects()
-	for(var/X in bodyparts)
-		var/obj/item/bodypart/BP = X
-		for(var/obj/item/I in BP.embedded_objects)
-			if(prob(I.embedding.embedded_pain_chance))
-				BP.receive_damage(I.w_class*I.embedding.embedded_pain_multiplier)
-				to_chat(src, "<span class='userdanger'>[I] embedded in your [BP.name] hurts!</span>")
-
-			if(prob(I.embedding.embedded_fall_chance))
-				BP.receive_damage(I.w_class*I.embedding.embedded_fall_pain_multiplier)
-				BP.embedded_objects -= I
-				I.forceMove(drop_location())
-				visible_message("<span class='danger'>[I] falls out of [name]'s [BP.name]!</span>","<span class='userdanger'>[I] falls out of your [BP.name]!</span>")
-				if(!has_embedded_objects())
-					clear_alert("embeddedobject")
-					SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "embedded")
 
 /mob/living/carbon/human/proc/handle_heart()
 	var/we_breath = !HAS_TRAIT_FROM(src, TRAIT_NOBREATH, SPECIES_TRAIT)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -69,7 +69,11 @@
 		var/obj/item/I = AM
 		var/zone = ran_zone(BODY_ZONE_CHEST, 65)//Hits a random part of the body, geared towards the chest
 		var/dtype = BRUTE
-		SEND_SIGNAL(I, COMSIG_MOVABLE_IMPACT_ZONE, src, zone)
+		var/nosell_hit = SEND_SIGNAL(I, COMSIG_MOVABLE_IMPACT_ZONE, src, zone, throwingdatum) // TODO: find a better way to handle hitpush and skipcatch for humans
+		if(nosell_hit)
+			skipcatch = TRUE
+			hitpush = FALSE
+
 		dtype = I.damtype
 		if(!blocked)
 			visible_message("<span class='danger'>[src] is hit by [I]!</span>", \

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
@@ -15,4 +15,4 @@
 /obj/item/throwing_star/ninja
 	name = "ninja throwing star"
 	throwforce = 30
-	embedding = list("embedded_pain_multiplier" = 6, "embed_chance" = 100, "embedded_fall_chance" = 0)
+	embedding = list("pain_mult" = 6, "embed_chance" = 100, "fall_chance" = 0)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -27,6 +27,7 @@
 	var/colour = "black"	//what colour the ink is!
 	var/degrees = 0
 	var/font = PEN_FONT
+	embedding = list()
 
 /obj/item/pen/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is scribbling numbers all over [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit sudoku...</span>")
@@ -88,6 +89,7 @@
 						"Black and Silver" = "pen-fountain-b",
 						"Command Blue" = "pen-fountain-cb"
 						)
+	embedding = list("embed_chance" = 75)
 
 /obj/item/pen/fountain/captain/Initialize()
 	. = ..()

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -202,7 +202,7 @@
 		w_class = initial(w_class)
 		name = initial(name)
 		hitsound = initial(hitsound)
-		embedding = embedding.setRating(embed_chance = EMBED_CHANCE)
+		//embedding = embedding.setRating(embed_chance = EMBED_CHANCE)
 		throwforce = initial(throwforce)
 		playsound(user, 'sound/weapons/saberoff.ogg', 5, TRUE)
 		to_chat(user, "<span class='warning'>[src] can now be concealed.</span>")
@@ -213,7 +213,7 @@
 		w_class = WEIGHT_CLASS_NORMAL
 		name = "energy dagger"
 		hitsound = 'sound/weapons/blade1.ogg'
-		embedding = embedding.setRating(embed_chance = 100) //rule of cool
+		//embedding = embedding.setRating(embed_chance = 100) //rule of cool
 		throwforce = 35
 		playsound(user, 'sound/weapons/saberon.ogg', 5, TRUE)
 		to_chat(user, "<span class='warning'>[src] is now active.</span>")

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -150,11 +150,13 @@
 	clear_alert("embeddedobject")
 	SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "embedded")
 
-/mob/living/carbon/proc/has_embedded_objects()
+/mob/living/carbon/proc/has_embedded_objects(include_harmless=FALSE)
 	. = 0
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/L = X
 		for(var/obj/item/I in L.embedded_objects)
+			if(!include_harmless && I.is_embed_harmless())
+				continue
 			return 1
 
 

--- a/code/modules/surgery/remove_embedded_object.dm
+++ b/code/modules/surgery/remove_embedded_object.dm
@@ -29,11 +29,7 @@
 			var/objects = 0
 			for(var/obj/item/I in L.embedded_objects)
 				objects++
-				I.forceMove(get_turf(H))
-				L.embedded_objects -= I
-			if(!H.has_embedded_objects())
-				H.clear_alert("embeddedobject")
-				SEND_SIGNAL(H, COMSIG_CLEAR_MOOD_EVENT, "embedded")
+				SEND_SIGNAL(I, COMSIG_ITEM_EMBED_REMOVE_SURGERY, target, L)
 
 			if(objects > 0)
 				display_results(user, target, "<span class='notice'>You successfully remove [objects] objects from [H]'s [L.name].</span>",

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -63,7 +63,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/purchase_message_cooldown
 	///Last mob to shop with us
 	var/last_shopper
-
+	var/tilted = FALSE
 
 	/**
 	  * List of products this machine sells
@@ -400,7 +400,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 				else
 					to_chat(user, "<span class='warning'>There's nothing to restock!</span>")
 			return
-	if(compartmentLoadAccessCheck(user))
+	if(compartmentLoadAccessCheck(user) && user.a_intent != "harm")
 		if(canLoadItem(I))
 			loadingAttempt(I,user)
 			updateUsrDialog() //can't put this on the proc above because we spam it below
@@ -423,9 +423,64 @@ GLOBAL_LIST_EMPTY(vending_products)
 			if(loaded)
 				to_chat(user, "<span class='notice'>You insert [loaded] dishes into [src]'s compartment.</span>")
 				updateUsrDialog()
-
 	else
-		..()
+		. = ..()
+		if(I.force && !tilted)
+			switch(rand(1, 100))
+				if(1 to 5)
+					freebie(user, 3)
+				if(6 to 15)
+					freebie(user, 2)
+				if(16 to 26)
+					freebie(user, 1)
+				if(81 to 100)
+					tilt(user)
+
+/obj/machinery/vending/proc/freebie(mob/fatty, freebies)
+	src.visible_message("<span class='notice'>\The [src] yields [freebies > 1 ? "several free goodies" : "a free goody"]!</span>")
+
+	for(var/i=0, i<freebies, i++)
+		playsound(src, 'sound/machines/machine_vend.ogg', 50, TRUE, extrarange = -3)
+		for(var/datum/data/vending_product/R in shuffle(product_records))
+
+			if(R.amount <= 0) //Try to use a record that actually has something to dump.
+				continue
+			var/dump_path = R.product_path
+			if(!dump_path)
+				continue
+
+			R.amount--
+			new dump_path(get_turf(src))
+			break
+
+/obj/machinery/vending/proc/tilt(mob/fatty)
+	src.visible_message("<span class='danger'>\The [src] tips over!</span>")
+	tilted = TRUE
+	anchored = FALSE
+
+	for(var/mob/living/L in get_turf(fatty))
+		L.Paralyze(60)
+		L.emote("scream")
+		playsound(L, 'sound/effects/blobattack.ogg', 40, TRUE)
+		playsound(L, 'sound/effects/splat.ogg', 50, TRUE)
+		L.visible_message("<span class='danger'>[L] is crushed by \the [src]!</span>", \
+			"<span class='userdanger'>You are crushed by \the [src]!</span>")
+		L.apply_damage(90, forced=TRUE, spread_damage=TRUE)
+
+	var/matrix/M = matrix()
+	M.Turn(pick(90, 270))
+	src.transform = M
+
+	src.throw_at(get_turf(fatty), 2, 2, spin=FALSE)
+
+/obj/machinery/vending/proc/untilt(mob/user)
+	user.visible_message("<span class='notice'>[user] rights /the [src].", \
+		"<span class='notice'>You right \the [src].")
+	tilted = FALSE
+
+	var/matrix/M = matrix()
+	M.Turn(0)
+	src.transform = M
 
 /obj/machinery/vending/proc/loadingAttempt(obj/item/I, mob/user)
 	. = TRUE
@@ -500,6 +555,13 @@ GLOBAL_LIST_EMPTY(vending_products)
 	if(seconds_electrified && !(stat & NOPOWER))
 		if(shock(user, 100))
 			return
+
+	if(tilted)
+		to_chat(user, "<span class='notice'>You begin righting \the [src].")
+		if(do_after(user, 50, target=src))
+			untilt(user)
+		return
+
 	return ..()
 
 /obj/machinery/vending/ui_interact(mob/user)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -512,6 +512,7 @@
 #include "code\datums\elements\cleaning.dm"
 #include "code\datums\elements\digitalcamo.dm"
 #include "code\datums\elements\earhealing.dm"
+#include "code\datums\elements\embed.dm"
 #include "code\datums\elements\firestacker.dm"
 #include "code\datums\elements\selfknockback.dm"
 #include "code\datums\elements\snail_crawl.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR moves as much embedding code out of human/carbon code and into a central element handler as I could. Originally it was gonna be a component, but then I realized the state variables could just be left in the weapon or target, and figured it might make a good case for an element! Honestly I didn't really plan this out and maybe this would have worked better as a subsystem, but oh well! Here we are!

Also adds new functionality for embeds: jostling, and stamina share. Every time a mob with an embed moves, they have a chance to jostle the embedded object and cause pain! I envision this being used with the other new feature, embed stamina share, which diverts a percentage of any embedding damage from brute to stamina. For example, I include a "shock throwing star" that has a 15% jostle rate but deals 80% of its damage to stamina, which would be useful for security in chases. Unlike weapons like disablers, stunbatons, and bolas, the shock throwing star is more useful the more the target tries to run rather than immediately, adding extra layers of depth.



ALSO in more fun news, adds support for harmless embeds! Adds a toy throwing star that does no damage and is fluffed as sticking _to_ the target, rather than _in_ them.

[![dreamseeker_2019-11-18_01-06-33.png](https://i.imgur.com/EgmThqI.png)](https://i.imgur.com/EgmThqI.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Centralizes most embedding code without exploding the memory footprint of embedding. Adds new functionality to embedding.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
add: Adds harmless toy throwing stars that you can throw at the HoS and get killed for as if they were real! Fun for all!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
