### PR TITLE
Borg spin-launch nerf alternate

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -47,7 +47,7 @@
 		if(iscyborg(user) && user.has_buckled_mobs())
 			var/mob/living/silicon/robot/R = user
 			var/datum/component/riding/riding_datum = R.GetComponent(/datum/component/riding)
-			if(riding_datum)
+			if(riding_datum && R.launchable)
 				for(var/mob/M in R.buckled_mobs)
 					riding_datum.force_dismount(M)
 			else

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -86,6 +86,7 @@
 	can_buckle = TRUE
 	buckle_lying = FALSE
 	var/static/list/can_ride_typecache = typecacheof(/mob/living/carbon/human)
+	var/launchable = FALSE //flag for if the mob can be launched via spinning
 
 /mob/living/silicon/robot/get_cell()
 	return cell
@@ -1160,7 +1161,12 @@
 		else
 			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [M.p_their()] hands are full!</span>")
 		return
+	addtimer(CALLBACK(src, /mob/living/silicon/robot/proc/set_launchable), 2 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 	. = ..(M, force, check_loc)
+
+/mob/living/silicon/robot/proc/set_launchable()
+	if(buckled_mobs.len)
+		launchable = TRUE
 
 /mob/living/silicon/robot/unbuckle_mob(mob/user, force=FALSE)
 	if(iscarbon(user))
@@ -1168,6 +1174,7 @@
 		if(istype(riding_datum))
 			riding_datum.unequip_buckle_inhands(user)
 			riding_datum.restore_position(user)
+	launchable = FALSE
 	. = ..(user)
 
 /mob/living/silicon/robot/proc/TryConnectToAI()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a timer of two seconds that a human (or similar mob) must sit on a borg before they can be launched off. Should the borg spin before the two seconds has passed, the human is simply unbucked, and left standing where the borg was when it spun.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Alt to #47851. That PR includes a nerf to the utility of buckling (as in, the ability to get a human out of danger quick). This PR functionally achieves the same goal (making borg spin-stuns not an instant ability) without also nerfing the non-combat uses of buckling.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Borgs debuckling people from themselves by spinning can no longer stun if the person has been riding for less than two seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
