### PR TITLE
Keybindable emotes followup

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -153,7 +153,7 @@
 	return FALSE
 
 /mob/living/split_personality/emote(act, m_type = null, message = null, intentional = FALSE)
-	return
+	return FALSE
 
 ///////////////BRAINWASHING////////////////////
 

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -23,6 +23,7 @@
 	var/sound //Sound to play when emote is called
 	var/vary = FALSE	//used for the honk borg emote
 	var/only_forced_audio = FALSE //can only code call this event instead of the player.
+	var/cooldown = 0.8 SECONDS
 
 /datum/emote/New()
 	if (ispath(mob_type_allowed_typecache))
@@ -74,6 +75,17 @@
 		user.audible_message(msg)
 	else
 		user.visible_message(msg)
+
+/// For handling emote cooldown, return true to allow the emote to happen
+/datum/emote/proc/check_cooldown(mob/user, intentional)
+	if(!intentional)
+		return TRUE
+	if(user.emotes_used && user.emotes_used[src] + cooldown > world.time)
+		return FALSE
+	if(!user.emotes_used)
+		user.emotes_used = list()
+	user.emotes_used[src] = world.time
+	return TRUE
 
 /datum/emote/proc/get_sound(mob/living/user)
 	return sound //by default just return this var.

--- a/code/datums/keybinding/emote.dm
+++ b/code/datums/keybinding/emote.dm
@@ -12,4 +12,4 @@
 
 /datum/keybinding/emote/down(client/user)
 	. = ..()
-	user.mob.emote(emote_key)
+	return user.mob.emote(emote_key, intentional=TRUE)

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -24,4 +24,4 @@
 	return FALSE
 
 /mob/camera/emote(act, m_type=1, message = null, intentional = FALSE)
-	return
+	return FALSE

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -50,7 +50,8 @@
 				"<span class='notice'>[flippy_mcgee] attempts to do a flip and falls over, what a doofus!</span>",
 				"<span class='notice'>You attempt to do a flip while still off balance from the last flip and fall down!</span>"
 			)
-			flippy_mcgee.adjustBruteLoss(rand(0, 1))
+			if(prob(50))
+				flippy_mcgee.adjustBruteLoss(1)
 		else
 			flippy_mcgee.visible_message(
 				"<span class='notice'>[flippy_mcgee] stumbles a bit after their flip.</span>",

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -7,18 +7,22 @@
 		param = copytext(act, custom_param + 1, length(act) + 1)
 		act = copytext(act, 1, custom_param)
 
-
 	var/list/key_emotes = GLOB.emote_list[act]
 
 	if(!length(key_emotes))
 		if(intentional)
 			to_chat(src, "<span class='notice'>'[act]' emote does not exist. Say *help for a list.</span>")
-		return
+		return FALSE
+	var/silenced = FALSE
 	for(var/datum/emote/P in key_emotes)
+		if(!P.check_cooldown(src, intentional))
+			silenced = TRUE
+			continue
 		if(P.run_emote(src, param, m_type, intentional))
-			return
-	if(intentional)
+			return TRUE
+	if(intentional && !silenced)
 		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
+	return FALSE
 
 /datum/emote/flip
 	key = "flip"
@@ -31,6 +35,27 @@
 	. = ..()
 	if(.)
 		user.SpinAnimation(7,1)
+
+/datum/emote/flip/check_cooldown(mob/user, intentional)
+	. = ..()
+	if(.)
+		return
+	if(!can_run_emote(user, intentional=intentional))
+		return
+	if(isliving(user))
+		var/mob/living/flippy_mcgee = user
+		if(prob(20))
+			flippy_mcgee.Knockdown(1 SECONDS)
+			flippy_mcgee.visible_message(
+				"<span class='notice'>[flippy_mcgee] attempts to do a flip and falls over, what a doofus!</span>",
+				"<span class='notice'>You attempt to do a flip while still off balance from the last flip and fall down!</span>"
+			)
+			flippy_mcgee.adjustBruteLoss(rand(0, 1))
+		else
+			flippy_mcgee.visible_message(
+				"<span class='notice'>[flippy_mcgee] stumbles a bit after their flip.</span>",
+				"<span class='notice'>You stumble a bit from still being off balance from your last flip.</span>"
+			)
 
 /datum/emote/spin
 	key = "spin"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -358,8 +358,8 @@
 
 /mob/living/simple_animal/emote(act, m_type=1, message = null, intentional = FALSE)
 	if(stat)
-		return
-	. = ..()
+		return FALSE
+	return ..()
 
 /mob/living/simple_animal/proc/set_varspeed(var_value)
 	speed = var_value

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -205,3 +205,6 @@
 	var/bloody_hands = 0
 
 	var/datum/focus //What receives our keyboard inputs. src by default
+
+	/// Used for tracking last uses of emotes for cooldown purposes
+	var/list/emotes_used


### PR DESCRIPTION
I hope you had your fun with unrestricted emote keybinds while they lasted because here's the fun removal pr.

:cl: ninjanomnom
fix: Keybound emotes now count as intentional. This means emotes that don't play a sound when you type the emote also don't play a sound when you use the keybinding.
fix: Emotes can no longer be stacked on one key.
tweak: Emotes have been given cooldowns. Each emote has their own cooldown so you can still do your flip and scream.
tweak: You can fall over if you try to flip too much.
/:cl:

fixes #47831