### PR TITLE
Adds a new server restart option: regular restart with a custom delay time

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -472,7 +472,7 @@
 				if("Regular Restart (with delay)")
 					var/delay = input("What delay should the restart have (in seconds)?", "Restart Delay", 5) as num|null
 					if(!delay)
-						delay = 1
+						return FALSE
 					SSticker.Reboot(init_by, "admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]", delay * 10)
 				if("Hard Restart (No Delay, No Feeback Reason)")
 					to_chat(world, "World reboot - [init_by]")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -451,7 +451,7 @@
 	if (!usr.client.holder)
 		return
 
-	var/list/options = list("Regular Restart", "Hard Restart (No Delay/Feeback Reason)", "Hardest Restart (No actions, just reboot)")
+	var/list/options = list("Regular Restart", "Regular Restart (with delay)", "Hard Restart (No Delay/Feeback Reason)", "Hardest Restart (No actions, just reboot)")
 	if(world.TgsAvailable())
 		options += "Server Restart (Kill and restart DD)";
 
@@ -469,6 +469,11 @@
 			switch(result)
 				if("Regular Restart")
 					SSticker.Reboot(init_by, "admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]", 10)
+				if("Regular Restart (with delay)")
+					var/delay = input("What delay should the restart have (in seconds)?", "Restart Delay", 5) as num|null
+					if(!delay)
+						delay = 1
+					SSticker.Reboot(init_by, "admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]", delay * 10)
 				if("Hard Restart (No Delay, No Feeback Reason)")
 					to_chat(world, "World reboot - [init_by]")
 					world.Reboot()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As per title. Handy for when you're doing a lot of compiling and restarting. You can tell DM to compile and set your restart to roughly the same time. Then your server will restart as DM is done compiling.

The default is 5 seconds but this is an arbitrary value.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
![restart](https://user-images.githubusercontent.com/42044220/69092628-71040780-0a12-11ea-9400-997ca531cda4.png)
![delay](https://user-images.githubusercontent.com/42044220/69092639-75302500-0a12-11ea-9f2c-08b610477f67.png)

## Changelog
:cl:
add: Adds a new server restart option: regular restart with a custom delay time that the user can specify
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
