### PR TITLE
Bureaucratic error event has new effects

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -14,10 +14,7 @@
 	var/list/jobs = SSjob.occupations.Copy()
 	jobs -= /datum/job/ai // AI doesnt really support latejoining with more than one total.
 	if(prob(50))	// Only allows latejoining as a single role. Add latejoin AI bluespace pods for fun later.
-		var/datum/job/old_overflow = SSjob.GetJob(SSjob.overflow_role)
-		old_overflow.total_positions = 0
-		var/datum/job/overflow = pick_n_take(jobs)
-		overflow.total_positions = -1	// Infinite, basically overflow without the unwanted effects.
+		SSjob.set_overflow_role(pick_n_take(jobs))	// Setting overflow replaces assistant overflow and ensures we always got a job slot open.
 		for(var/job in jobs)
 			var/datum/job/current = job
 			current.total_positions = 0

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -13,8 +13,11 @@
 /datum/round_event/bureaucratic_error/start()
 	var/list/jobs = SSjob.occupations.Copy()
 	jobs -= /datum/job/ai // AI doesnt really support latejoining with more than one total.
-	if(prob(50))	// Only allows latejoining as a single role. Add latejoin AI bluespace pods for fun later.
-		SSjob.set_overflow_role(pick_n_take(jobs))	// Setting overflow replaces assistant overflow and ensures we always got a job slot open.
+	if(prob(33))	// Only allows latejoining as a single role. Add latejoin AI bluespace pods for fun later.
+		var/datum/job/overflow = pick_n_take(jobs)
+		overflow.minimal_player_age = 0
+		overflow.exp_requirements = 0
+		SSjob.set_overflow_role(overflow.title)	// Ensures everyone can join as this role. Assistant will still be open.
 		for(var/job in jobs)
 			var/datum/job/current = job
 			current.total_positions = 0

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -11,4 +11,18 @@
 	priority_announce("A recent bureaucratic error in the Organic Resources Department may result in personnel shortages in some departments and redundant staffing in others.", "Paperwork Mishap Alert")
 
 /datum/round_event/bureaucratic_error/start()
-	SSjob.set_overflow_role(pick(get_all_jobs()))
+	var/list/jobs = SSjob.occupations.Copy()
+	jobs -= /datum/job/ai // AI doesnt really support latejoining with more than one total.
+	if(prob(50))	// Only allows latejoining as a single role. Add latejoin AI bluespace pods for fun later.
+		var/datum/job/old_overflow = SSjob.GetJob(SSjob.overflow_role)
+		old_overflow.total_positions = 0
+		var/datum/job/overflow = pick_n_take(jobs)
+		overflow.total_positions = -1	// Infinite, basically overflow without the unwanted effects.
+		for(var/job in jobs)
+			var/datum/job/current = job
+			current.total_positions = 0
+	else	// Adds/removes a random amount of job slots from all jobs.
+		for(var/job in jobs)
+			var/datum/job/current = job
+			var/ran = rand(-2,4)
+			current.total_positions = max(current.total_positions + ran, 0)

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -11,16 +11,19 @@
 	priority_announce("A recent bureaucratic error in the Organic Resources Department may result in personnel shortages in some departments and redundant staffing in others.", "Paperwork Mishap Alert")
 
 /datum/round_event/bureaucratic_error/start()
-	var/list/jobs = SSjob.occupations.Copy()
-	jobs -= /datum/job/ai // AI doesnt really support latejoining with more than one total.
+	var/list/jobs = SSjob.occupations.Copy()		
 	if(prob(33))	// Only allows latejoining as a single role. Add latejoin AI bluespace pods for fun later.
 		var/datum/job/overflow = pick_n_take(jobs)
 		SSjob.set_overflow_role(overflow.title)	// Ensures infinite slots as this role. Assistant will still be open for those that cant.
 		for(var/job in jobs)
 			var/datum/job/current = job
+			if(current.title == "AI") // AI currently doesnt support latejoining past one total.
+				continue
 			current.total_positions = 0
 	else	// Adds/removes a random amount of job slots from all jobs.
 		for(var/job in jobs)
 			var/datum/job/current = job
+			if(current.title == "AI") // AI currently doesnt support latejoining past one total.
+				continue
 			var/ran = rand(-2,4)
 			current.total_positions = max(current.total_positions + ran, 0)

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -15,9 +15,7 @@
 	jobs -= /datum/job/ai // AI doesnt really support latejoining with more than one total.
 	if(prob(33))	// Only allows latejoining as a single role. Add latejoin AI bluespace pods for fun later.
 		var/datum/job/overflow = pick_n_take(jobs)
-		overflow.minimal_player_age = 0
-		overflow.exp_requirements = 0
-		SSjob.set_overflow_role(overflow.title)	// Ensures everyone can join as this role. Assistant will still be open.
+		SSjob.set_overflow_role(overflow.title)	// Ensures infinite slots as this role. Assistant will still be open for those that cant.
 		for(var/job in jobs)
 			var/datum/job/current = job
 			current.total_positions = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bureacratic error event now has two possible outcomes. In the first, a single job is set to the new overflow role and the rest (except the old overflow) are set to 0. In the other, all jobs (except AI) have their available slots adjusted by a value between -2 and 4. 
Should cause some more chaos than currently, and fits better with the announcement flavor text. Diligent HoP's can correct the issue over time, though the 30 second cooldown between job management actions will try their patience.

When/if this is in, someone can go ahead and add latejoin AI drop-podding and adminbuse options.

Closes  #45999
This isnt actually fixed, but a result of the necessity of setting overflow role both in the old and new event.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Boring event made fun
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
tweak: Bureaucratic error event has new effects!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
