### PR TITLE
You can now directly add trash inside a bag hooked on the pimpin ride.

### DIFF
--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -52,6 +52,10 @@
 		to_chat(user, "<span class='notice'>You upgrade [src] with the floor buffer.</span>")
 		AddElement(/datum/element/cleaning)
 		update_icon()
+	else if(istype(I, /obj/item/key/janitor))
+		..()
+	else if(mybag)
+		mybag.attackby(I, user)
 	else
 		return ..()
 


### PR DESCRIPTION
## About The Pull Request

You can directly add trash inside a trashbag hooked into a janicart but for the pimpin ride you had to remove the bag, put the trash inside the bag and hook it again, by copying the code from the janicart you can now do the same to the pimpin ride.
Also added a extra line to prioritize placing the pimpin key on the ride instead of the trashbag.
## Why It's Good For The Game

Makes using the pimpin ride more convenient for janitors.

## Changelog
:cl:
add: The pimpin ride hook now holds the trashbag open for easier trash disposal.
/:cl: