### PR TITLE
 Adds a hypnotic flashbang to the uplink 

### DIFF
--- a/code/game/objects/items/grenades/hypno.dm
+++ b/code/game/objects/items/grenades/hypno.dm
@@ -1,0 +1,66 @@
+/obj/item/grenade/hypnotic
+	name = "flashbang"
+	desc = "A modified flashbang which uses hypnotic flashes and mind-altering soundwaves to induce an instant trance upon detonation."
+	icon_state = "flashbang"
+	item_state = "flashbang"
+	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
+	var/flashbang_range = 7
+
+/obj/item/grenade/hypnotic/prime()
+	update_mob()
+	var/flashbang_turf = get_turf(src)
+	if(!flashbang_turf)
+		return
+	do_sparks(rand(5, 9), FALSE, src)
+	playsound(flashbang_turf, 'sound/effects/screech.ogg', 100, TRUE, 8, 0.9)
+	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_PURPLE, (flashbang_range + 2), 4, 2)
+	for(var/mob/living/M in get_hearers_in_view(flashbang_range, flashbang_turf))
+		bang(get_turf(M), M)
+	qdel(src)
+
+/obj/item/grenade/hypnotic/proc/bang(turf/T, mob/living/M)
+	if(M.stat == DEAD)	//They're dead!
+		return
+	var/distance = max(0,get_dist(get_turf(src),T))
+
+	//Bang
+	var/hypno_sound = FALSE
+
+	//Hearing protection check
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		var/list/reflist = list(1)
+		SEND_SIGNAL(C, COMSIG_CARBON_SOUNDBANG, reflist)
+		var/intensity = reflist[1]
+		var/ear_safety = C.get_ear_protection()
+		var/effect_amount = intensity - ear_safety
+		if(effect_amount > 0)
+			hypno_sound = TRUE
+
+	if(!distance || loc == M || loc == M.loc)
+		M.Paralyze(10)
+		M.Knockdown(100)
+		to_chat(M, "<span class='hypnophrase'>The sound echoes in your brain...</span>")
+		M.hallucination += 50
+	else
+		if(distance <= 1)
+			M.Paralyze(5)
+			M.Knockdown(30)
+		if(hypno_sound)
+			to_chat(M, "<span class='hypnophrase'>The sound echoes in your brain...</span>")
+			M.hallucination += 50
+
+	//Flash
+	if(M.flash_act(affect_silicon = 1))
+		M.Paralyze(max(10/max(1,distance), 5))
+		M.Knockdown(max(100/max(1,distance), 40))
+		if(iscarbon(M))
+			var/mob/living/carbon/C = M
+			if(C.hypnosis_vulnerable()) //The sound causes the necessary conditions unless the target has mindshield or hearing protection
+				C.apply_status_effect(/datum/status_effect/trance, 100, TRUE)
+			else
+				to_chat(C, "<span class='hypnophrase'>The light is so pretty...</span>")
+				C.confused += min(C.confused + 10, 20)
+				C.dizziness += min(C.dizziness + 10, 20)
+				C.drowsyness += min(C.drowsyness + 10, 20)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -276,7 +276,7 @@
 				user.visible_message("<span class='danger'>[user] blinds [M] with the flash!</span>", "<span class='danger'>You hypno-flash [M]!</span>")
 
 			if(!hypnosis)
-				to_chat(M, "<span class='notice'>The light makes you feel oddly relaxed...</span>")
+				to_chat(M, "<span class='hypnophrase'>The light makes you feel oddly relaxed...</span>")
 				M.confused += min(M.confused + 10, 20)
 				M.dizziness += min(M.dizziness + 10, 20)
 				M.drowsyness += min(M.drowsyness + 10, 20)

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -368,7 +368,7 @@ h1.alert, h2.alert		{color: #000000;}
 .redtext				{color: #c51e1e;	font-size: 185%;}
 .clown					{color: #ff70c1;	font-size: 160%;	font-family: "Comic Sans MS", cursive, sans-serif;	font-weight: bold;}
 .his_grace				{color: #15D512;	font-family: "Courier New", cursive, sans-serif;	font-style: italic;}
-.hypnophrase			{color: #202020;	font-weight: bold;	animation: hypnocolor 1500ms infinite;}
+.hypnophrase			{color: #202020;	font-weight: bold;	animation: hypnocolor 1500ms infinite; animation-direction: alternate;}
 @keyframes hypnocolor {
 	0%		{color: #202020;}
 	25%		{color: #4b02ac;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -365,7 +365,7 @@ h1.alert, h2.alert		{color: #000000;}
 .redtext				{color: #FF0000;	font-size: 185%;}
 .clown					{color: #FF69Bf;	font-size: 160%; font-family: "Comic Sans MS", cursive, sans-serif;	font-weight: bold;}
 .his_grace				{color: #15D512;	font-family: "Courier New", cursive, sans-serif;	font-style: italic;}
-.hypnophrase			{color: #0d0d0d;	font-weight: bold;	animation: hypnocolor 1500ms infinite;}
+.hypnophrase			{color: #0d0d0d;	font-weight: bold;	animation: hypnocolor 1500ms infinite; animation-direction: alternate;}
 @keyframes hypnocolor {
 	0%		{color: #0d0d0d;}
 	25%		{color: #410194;}

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1362,6 +1362,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/assembly/flash/hypnotic
 	cost = 7
 
+/datum/uplink_item/device_tools/hypnotic_grenade
+	name = "Hypnotic Grenade"
+	desc = "A modified flashbang grenade able to hypnotize targets. The sound portion of the flashbang causes hallucinations, and will allow the flash to induce a hypnotic trance to viewers."
+	item = /obj/item/grenade/hypnotic
+	cost = 6
+
 /datum/uplink_item/device_tools/medgun
 	name = "Medbeam Gun"
 	desc = "A wonder of Syndicate engineering, the Medbeam gun, or Medi-Gun enables a medic to keep his fellow \

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -121,7 +121,7 @@ h1.alert, h2.alert		{color: #000000;}
 .redtext				{color: #FF0000;	font-size: 3;}
 .clown					{color: #FF69Bf;	font-size: 3;	font-family: "Comic Sans MS", cursive, sans-serif;	font-weight: bold;}
 .his_grace				{color: #15D512;	font-family: "Courier New", cursive, sans-serif;	font-style: italic;}
-.hypnophrase			{color: #3bb5d3;	font-weight: bold;	animation: hypnocolor 1500ms infinite;}
+.hypnophrase			{color: #3bb5d3;	font-weight: bold;	animation: hypnocolor 1500ms infinite; animation-direction: alternate;}
 	@keyframes hypnocolor {
 		0%		{color: #0d0d0d;}
 		25%		{color: #410194;}

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -987,6 +987,7 @@
 #include "code\game\objects\items\grenades\flashbang.dm"
 #include "code\game\objects\items\grenades\ghettobomb.dm"
 #include "code\game\objects\items\grenades\grenade.dm"
+#include "code\game\objects\items\grenades\hypno.dm"
 #include "code\game\objects\items\grenades\plastic.dm"
 #include "code\game\objects\items\grenades\smokebomb.dm"
 #include "code\game\objects\items\grenades\spawnergrenade.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

_Note: i coded this and completely forgot about antag freeze until i finished it. I'm opening the PR just in case it's acceptable, but i can also remove the uplink part and wait until the freeze is over if necessary._

Adds a hypnotic flashbang, disguised as a regular flashbang, to the traitor/nuke op uplink. Pretty much an AoE one-use hypnotic flash, but it doesn't require weakening the targets as long as they can be affected by the sound of the grenade, since it causes minor hallucinations.

Tweaked the hypnophrase text span to make it smoother.

## Why It's Good For The Game

While the effect is the same as the flash, the use case is much different. Since the odds of some other message setting off the trance first is much higher if you're targeting a room of unsuspecting, radio-having people, it's not as reliable as using the flash covertly in isolated locations, but it's still effective as a chaos-maker, and will often result in a roomful of people sharing a hypnosis phrase.
Which can lead to interesting situations if, for example, you end up with a gang of people following Poly's latest words.

Effectively this is a chaos-making tool, even while being non-lethal and non-destructive. Possibly a better choice for nuke ops than traitors.

I also expect some people to manage to hypnotize themselves with these, which i see as a definite plus.

## Changelog
:cl:
add: Added a hypnotic flashbang to the uplink for 6 TC. It can hypnotize people much like a hypnoflash, and the sound will automatically make victims vulnerable to the trance.
tweak: Hypnotic text now changes color more smoothly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
