### PR TITLE
Actual issue fix this time: Anatomic Panacea now also cures brain traumas.

### DIFF
--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/panacea
 	name = "Anatomic Panacea"
-	desc = "Expels impurifications from our form; curing diseases, removing parasites, sobering us, purging toxins and radiation, and resetting our genetic code completely. Costs 20 chemicals."
+	desc = "Expels impurifications from our form; curing diseases, removing parasites, sobering us, purging toxins and radiation, curing traumas and brain damage, and resetting our genetic code completely. Costs 20 chemicals."
 	helptext = "Can be used while unconscious."
 	button_icon_state = "panacea"
 	chemical_cost = 20
@@ -30,6 +30,10 @@
 	user.reagents.add_reagent(/datum/reagent/medicine/pen_acid, 20)
 	user.reagents.add_reagent(/datum/reagent/medicine/antihol, 10)
 	user.reagents.add_reagent(/datum/reagent/medicine/mannitol, 25)
+
+	if(iscarbon(user))
+		var/mob/living/carbon/C = user
+		C.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
 
 	if(isliving(user))
 		var/mob/living/L = user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This time Anatomic Panacea itself cures brain traumas, at the very least up to lobotomy level brain traumas that is. Magical and Permanent brain traumas(tier 4 and tier 5 brain traumas) remains beyond their reach even now. Tested and it does seem to work, though I would appreciate it if someone else could double check.

Side note: It also updates the description of Anatomic Panacea.

This time it should be an acceptable issue fix due to not adding a new changeling chemical.

Fixes #44067 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently changelings, to cure one of the curable varieties of traumas, either has to drink neurine, undergo brain surgery, or get a lobotomy. Which is not to sensible for what they are, and because they can already heal their brain of actual physical damage.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Changelings are now able to cure themselves of most traumas via Anatomic Panacea, except magical and permanent traumas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
