### PR TITLE
Adds a new space ruin with ultra-powerful healing cocktail

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldbar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldbar.dmm
@@ -1,0 +1,72 @@
+"a" = (/turf/open/space/basic,/area/space)
+"b" = (/obj/structure/lattice,/turf/open/space/basic,/area/space)
+"c" = (/obj/item/stack/rods,/turf/open/space/basic,/area/space)
+"d" = (/obj/structure/reagent_dispensers/beerkeg,/turf/open/space/basic,/area/space)
+"e" = (/obj/item/broken_bottle,/turf/open/space/basic,/area/space)
+"f" = (/turf/closed/wall,/area/ruin/unpowered)
+"g" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plating,/area/ruin/unpowered)
+"h" = (/obj/structure/grille/broken,/obj/effect/decal/cleanable/glass,/turf/open/floor/plating,/area/ruin/unpowered)
+"i" = (/obj/structure/sign/poster/random,/turf/closed/wall,/area/ruin/unpowered)
+"j" = (/obj/structure/sign/barsign,/turf/closed/wall,/area/ruin/unpowered)
+"l" = (/turf/closed/wall/rust,/area/ruin/unpowered)
+"m" = (/obj/structure/table,/obj/machinery/chem_dispenser/drinks/beer,/turf/open/floor/plasteel/cafeteria,/area/ruin/unpowered)
+"n" = (/obj/machinery/vending/boozeomat,/turf/open/floor/plasteel/cafeteria,/area/ruin/unpowered)
+"o" = (/turf/open/floor/plasteel/cafeteria,/area/ruin/unpowered)
+"p" = (/obj/structure/closet/secure_closet/bar,/turf/open/floor/plasteel/cafeteria,/area/ruin/unpowered)
+"q" = (/obj/effect/decal/remains/human,/obj/item/gun/ballistic/shotgun/doublebarrel,/turf/open/floor/plasteel/cafeteria,/area/ruin/unpowered)
+"r" = (/obj/machinery/door/airlock/freezer,/turf/open/floor/plasteel/freezer,/area/ruin/unpowered)
+"s" = (/turf/open/floor/plasteel/freezer,/area/ruin/unpowered)
+"t" = (/obj/structure/closet/crate/freezer,/obj/effect/decal/cleanable/cobweb/cobweb2,/turf/open/floor/plasteel/freezer,/area/ruin/unpowered)
+"u" = (/obj/item/ammo_casing/shotgun/beanbag,/turf/open/floor/plasteel/cafeteria,/area/ruin/unpowered)
+"v" = (/obj/effect/decal/cleanable/glass,/turf/open/floor/plasteel/cafeteria,/area/ruin/unpowered)
+"w" = (/obj/effect/decal/cleanable/blood/old,/turf/open/floor/plasteel/cafeteria,/area/ruin/unpowered)
+"x" = (/obj/effect/decal/cleanable/food/egg_smudge,/turf/open/floor/plasteel/freezer,/area/ruin/unpowered)
+"y" = (/obj/structure/kitchenspike,/turf/open/floor/plasteel/freezer,/area/ruin/unpowered)
+"z" = (/obj/machinery/door/window/southleft,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"A" = (/obj/structure/table/reinforced,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"B" = (/obj/structure/table/reinforced,/obj/item/reagent_containers/food/drinks/bottle/vodka/special,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"C" = (/obj/effect/decal/cleanable/blood/gibs/old,/turf/open/floor/plasteel/freezer,/area/ruin/unpowered)
+"D" = (/obj/effect/decal/remains/human,/obj/item/gun/ballistic/revolver/russian,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"E" = (/obj/effect/spawner/structure/window/reinforced,/turf/closed/wall,/area/ruin/unpowered)
+"F" = (/obj/effect/decal/cleanable/blood/old,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"G" = (/obj/item/chair/stool/bar,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"H" = (/obj/structure/chair/stool/bar,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"I" = (/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"J" = (/obj/structure/closet/secure_closet/freezer/fridge,/turf/open/floor/plasteel/freezer,/area/ruin/unpowered)
+"K" = (/obj/structure/grille,/turf/open/floor/plating,/area/ruin/unpowered)
+"L" = (/obj/item/reagent_containers/food/drinks/beer/light,/turf/open/space/basic,/area/space)
+"M" = (/obj/machinery/atmospherics/components/unary/vent_pump,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"N" = (/obj/effect/decal/cleanable/glass,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"O" = (/obj/machinery/light/broken{dir = 4},/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"P" = (/obj/item/chair/stool/bar,/turf/open/space/basic,/area/space)
+"Q" = (/obj/machinery/portable_atmospherics/canister/oxygen,/turf/open/space/basic,/area/space)
+"R" = (/obj/item/ammo_casing/shotgun/beanbag,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"S" = (/obj/structure/girder,/turf/open/floor/plating,/area/ruin/unpowered)
+"T" = (/obj/machinery/atmospherics/pipe/simple,/obj/effect/decal/cleanable/glass,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"U" = (/obj/machinery/light/broken,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"V" = (/obj/structure/reagent_dispensers/water_cooler,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"W" = (/obj/machinery/vending/cigarette,/turf/open/floor/plasteel/checker,/area/ruin/unpowered)
+"X" = (/obj/machinery/atmospherics/pipe/simple,/turf/open/floor/plating,/area/ruin/unpowered)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaaaaaaaa
+aaeaaaabaaaaaabaaaaa
+aaaaacaaaadaabbaaaaa
+aaaaaaaaaaabaabaaaca
+aabaaffghijffffllaba
+aabbblmnopqorsstfbba
+aaabaloouvowrxsyiaba
+aaaaafzAAAABfsCsfbba
+aaabaEFGHIHOfsJJfabb
+aaabbKMNDRFIfSfflaaa
+aaLaahTIIUVWfabaaaaa
+aaaaaSXhKliflabbaaaa
+aaaaaaaaabaaaaaaaaaa
+aaabaaaabbaaaaaaaaca
+aaaaaaPaabbaaaaaaaaa
+aaaaaaaaaaaaaaabaaaa
+aaaacaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaQaaaaaaaa
+aaaaaaaaaaaaaaaaaaaa
+"}

--- a/_maps/RandomRuins/SpaceRuins/oldbar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldbar.dmm
@@ -8,6 +8,7 @@
 "h" = (/obj/structure/grille/broken,/obj/effect/decal/cleanable/glass,/turf/open/floor/plating,/area/ruin/unpowered)
 "i" = (/obj/structure/sign/poster/random,/turf/closed/wall,/area/ruin/unpowered)
 "j" = (/obj/structure/sign/barsign,/turf/closed/wall,/area/ruin/unpowered)
+"k" = (/obj/machinery/power/apc{name = "Booze-Stained APC"; pixel_x = 0; pixel_y = -9; step_y = 0},/turf/closed/wall,/area/ruin/unpowered)
 "l" = (/turf/closed/wall/rust,/area/ruin/unpowered)
 "m" = (/obj/structure/table,/obj/machinery/chem_dispenser/drinks/beer,/turf/open/floor/plasteel/cafeteria,/area/ruin/unpowered)
 "n" = (/obj/machinery/vending/boozeomat,/turf/open/floor/plasteel/cafeteria,/area/ruin/unpowered)
@@ -53,7 +54,7 @@ aaaaaaaaaaaaaaaaaaaa
 aaeaaaabaaaaaabaaaaa
 aaaaacaaaadaabbaaaaa
 aaaaaaaaaaabaabaaaca
-aabaaffghijffffllaba
+aabaaffghijfffkllaba
 aabbblmnopqorsstfbba
 aaabaloouvowrxsyiaba
 aaaaafzAAAABfsCsfbba

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -293,3 +293,9 @@
 	suffix = "clericden.dmm"
 	name = "Cleric's Den"
 	description = "Once part of a larger monastery, this holy order of long dead clerics practiced far less non-violence than they preached. Appears to have been untouched by looters, however. Odd."
+
+/datum/map_template/ruin/space/oldbar
+	id = "oldbar"
+	suffix = "oldbar.dmm"
+	name = "Misplaced Bar"
+	description = "An ancient-looking bar, floating through space. The entire ruin smells faintly of vodka."

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -164,7 +164,7 @@
 	name = "Strange vodka"
 	desc = "It's an odd mixture of an extremely strong alcohol, apparently originating in ancient Russia many, many years ago. It has a label -- '3,000% Alcohol, 2% Experimental Drugs!'"
 	icon_state = "badminka"
-	list_reagents = list(/datum/reagent/medicine/adminordrazine/strangevodka = 2, /datum/reagent/medicine/omnizine = 48, /datum/reagent/consumable/ethanol/vodka = 50)
+	list_reagents = list(/datum/reagent/medicine/adminordrazine/strangevodka = 0.2, /datum/reagent/medicine/omnizine = 49.8, /datum/reagent/consumable/ethanol/vodka = 50)
 
 /obj/item/reagent_containers/food/drinks/bottle/tequila
 	name = "Caccavo guaranteed quality tequila"

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -160,6 +160,12 @@
 	icon_state = "badminka"
 	list_reagents = list(/datum/reagent/consumable/ethanol/vodka = 100)
 
+/obj/item/reagent_containers/food/drinks/bottle/vodka/special
+	name = "Strange vodka"
+	desc = "It's an odd mixture of an extremely strong alcohol, apparently originating in ancient Russia many, many years ago. It has a label -- '3,000% Alcohol, 2% Experimental Drugs!'"
+	icon_state = "badminka"
+	list_reagents = list(/datum/reagent/medicine/adminordrazine/strangevodka = 2, /datum/reagent/medicine/omnizine = 48, /datum/reagent/consumable/ethanol/vodka = 50)
+
 /obj/item/reagent_containers/food/drinks/bottle/tequila
 	name = "Caccavo guaranteed quality tequila"
 	desc = "Made from premium petroleum distillates, pure thalidomide and other fine quality ingredients!"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -78,6 +78,12 @@
 	description = "Rare and experimental particles, that apparently swap the user's body with one from an alternate dimension where it's completely healthy."
 	taste_description = "science"
 
+/datum/reagent/medicine/adminordrazine/strangevodka
+	name = "Strange Vodka"
+	description = "An ancient mixture of extremely strong and rare reagents. Has the power to rapidly repair any and all wounds, at the cost of getting the user very, very drunk."
+	taste_description = "the motherland"
+	var/boozepwr = 200
+
 /datum/reagent/medicine/synaptizine
 	name = "Synaptizine"
 	description = "Increases resistance to stuns as well as reducing drowsiness and hallucinations."

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -82,7 +82,7 @@
 	name = "Strange Vodka"
 	description = "An ancient mixture of extremely strong and rare reagents. Has the power to rapidly repair any and all wounds, at the cost of getting the user very, very drunk."
 	taste_description = "the motherland"
-	var/boozepwr = 200
+	var/boozepwr = 20000
 
 /datum/reagent/medicine/synaptizine
 	name = "Synaptizine"


### PR DESCRIPTION
**THE WHAT**
Adds the Misplaced Bar space ruin, an ancient bar torn straight off whatever it used to be connected to. While being relatively safe to traverse (no enemies to fight) due to it's small size, it has a small amount of useful items to offer -- a lot of booze, a double-barreled shotgun, a russian revolver... and an uber-powerful healing cocktail. This cocktail contains a mix of 49.8% Omnizine (downing the entire cocktail without stopping will OD an average person on Omnizine, watch out!), 50% Normal Vodka, and 0.2% Strange Vodka. This 0.2 units of Strange Vodka have the ability to completely heal anyone who drinks it nigh-instantly, at the cost of them getting very, very, very, very drunk. ( 20000 Booze Power, two hundred times the strength of Hooch ) This also has only a sliver of this unreplicable miracle drug, so use it wisely!

The Misplaced Bar;
![image](https://user-images.githubusercontent.com/46986487/69469959-a20d7080-0d61-11ea-9908-6b2ba720740c.png)


**THE HOW**
Made a little bar .dmm, which I tossed into the SpaceRuins folder. A new addition to the ruins list in 'space.dm' makes the ruin actually spawn in-game -- it's not guaranteed to spawn every round, though.

**THE WHY**
Most space ruins are completely useless, let's be real. There's no reason to go space exploring unless you're looking for the white ship, or didn't roll antag like you wanted. This ruin gives just a little more incentive for folks to go spacing, or just acts as a neat reward for folks who happen to be floating about.

:cl:
add: Added the Misplaced Bar, a space ruin with russian origins
add: Added Strange Vodka, a miracle drug that can only be found on the Misplaced Bar
/:cl:
