### PR TITLE
[WIP] Pointing is now an actual emote that is logged.

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -155,5 +155,5 @@
 
 	if(isliving(user))
 		var/mob/living/L = user
-		if(HAS_TRAIT(L, TRAIT_EMOTEMUTE))
+		if(HAS_TRAIT(L, TRAIT_EMOTEMUTE) || HAS_TRAIT(src, TRAIT_DEATHCOMA))
 			return FALSE

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,11 +1,11 @@
 //The code execution of the emote datum is located at code/datums/emotes.dm
 /mob/proc/emote(act, m_type = null, message = null, intentional = FALSE)
-	act = lowertext(act)
 	var/param = message
 	var/custom_param = findchar(act, " ")
 	if(custom_param)
 		param = copytext(act, custom_param + 1, length(act) + 1)
 		act = copytext(act, 1, custom_param)
+	act = lowertext(act)
 
 	var/list/key_emotes = GLOB.emote_list[act]
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -378,13 +378,10 @@
 
 //same as above
 /mob/living/pointed(atom/A as mob|obj|turf in view(client.view, src))
-	if(incapacitated())
-		return FALSE
-	if(HAS_TRAIT(src, TRAIT_DEATHCOMA))
-		return FALSE
 	if(!..())
 		return FALSE
-	visible_message("<span class='name'>[src]</span> points at [A].", "<span class='notice'>You point at [A].</span>")
+	var/paramfudge = "\the [A]"
+	src.emote("point [paramfudge]")
 	return TRUE
 
 /mob/living/verb/succumb(whispered as null)


### PR DESCRIPTION
## About The Pull Request

Pointing uses the actual emote system rather than having snowflake duplicate code. Notably this means they show up in emote logs. (Specifically, the actual pointing emote logged, but the click/hotkey to point did not, i.e. the one anyone ever used.)

Futzed with some other stuff to make this work, hopefully not in a manner breaking shit.

## Why It's Good For The Game

A code improvement, plus pointing not being logged has caused some issues in bans/complaints like this: https://tgstation13.org/phpBB/viewtopic.php?f=23&t=24625

Logging not tested but should work

## Changelog
:cl: bandit
admin: Pointing is logged now, in Emote Logs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
