### PR TITLE
Fix the newline problem in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,9 @@
 [*]
-insert_final_newline = true
 indent_style = tab
 indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
 
 [*.yml]
 indent_style = space


### PR DESCRIPTION
With current editor config, if you have trailing whitespace on final new line, it doesn't get trimmed, and no extra newline gets added, which breaks linters.

Whitespace trimming is good overall. And an additional "utf-8" enforcement.

Webedit kung-fu.

**P.S.** I could've also added an LF enforcement, but maybe next time.