### PR TITLE
[s]Adds the Booze and Soda Synthesizer to Plumbing.

### DIFF
--- a/code/modules/plumbing/plumbers/synthesizer.dm
+++ b/code/modules/plumbing/plumbers/synthesizer.dm
@@ -118,3 +118,60 @@
 		r_overlay.color = "#FFFFFF"
 
 	overlays += r_overlay
+
+/obj/machinery/plumbing/synthesizer/booze
+	name = "booze synthesizer"
+	desc = "For the chemistry major who couldn't quite find work in the field."
+	dispensable_reagents = list(
+		/datum/reagent/consumable/ethanol/beer,
+		/datum/reagent/consumable/ethanol/kahlua,
+		/datum/reagent/consumable/ethanol/whiskey,
+		/datum/reagent/consumable/ethanol/wine,
+		/datum/reagent/consumable/ethanol/vodka,
+		/datum/reagent/consumable/ethanol/gin,
+		/datum/reagent/consumable/ethanol/rum,
+		/datum/reagent/consumable/ethanol/tequila,
+		/datum/reagent/consumable/ethanol/vermouth,
+		/datum/reagent/consumable/ethanol/cognac,
+		/datum/reagent/consumable/ethanol/ale,
+		/datum/reagent/consumable/ethanol/absinthe,
+		/datum/reagent/consumable/ethanol/hcider,
+		/datum/reagent/consumable/ethanol/creme_de_menthe,
+		/datum/reagent/consumable/ethanol/creme_de_cacao,
+		/datum/reagent/consumable/ethanol/triple_sec,
+		/datum/reagent/consumable/ethanol/sake,
+		/datum/reagent/consumable/ethanol/applejack,
+		/datum/reagent/consumable/ethanol/thirteenloko,
+		/datum/reagent/consumable/ethanol/whiskey_cola,
+		/datum/reagent/consumable/ethanol/atomicbomb,
+		/datum/reagent/consumable/ethanol/fernet,
+		/datum/reagent/consumable/ethanol
+	)
+
+/obj/machinery/plumbing/synthesizer/soda
+	name = "soda synthesizer"
+	desc = "For the chemistry major who couldn't quite find work in the field, and then still couldn't find work as a bartender."
+	dispensable_reagents = list(
+		/datum/reagent/water,
+		/datum/reagent/consumable/ice,
+		/datum/reagent/consumable/coffee,
+		/datum/reagent/consumable/cream,
+		/datum/reagent/consumable/tea,
+		/datum/reagent/consumable/icetea,
+		/datum/reagent/consumable/space_cola,
+		/datum/reagent/consumable/spacemountainwind,
+		/datum/reagent/consumable/dr_gibb,
+		/datum/reagent/consumable/space_up,
+		/datum/reagent/consumable/tonic,
+		/datum/reagent/consumable/sodawater,
+		/datum/reagent/consumable/lemon_lime,
+		/datum/reagent/consumable/pwr_game,
+		/datum/reagent/consumable/shamblers,
+		/datum/reagent/consumable/sugar,
+		/datum/reagent/consumable/orangejuice,
+		/datum/reagent/consumable/grenadine,
+		/datum/reagent/consumable/limejuice,
+		/datum/reagent/consumable/tomatojuice,
+		/datum/reagent/consumable/lemonjuice,
+		/datum/reagent/consumable/menthol
+	)


### PR DESCRIPTION

## About The Pull Request
Adds the Booze and Soda Synthesizer to the plumbing tool.
![dreamseeker_TGMiu84wcj](https://user-images.githubusercontent.com/4081722/69688129-0427e780-107a-11ea-9d3a-163feb7089f5.png)
![jdUCfP7RSs](https://user-images.githubusercontent.com/4081722/69688132-05591480-107a-11ea-8f74-c47bfdd34201.png)
![dreamseeker_I9H6bvrOJA](https://user-images.githubusercontent.com/4081722/69688133-068a4180-107a-11ea-8cf9-2cff608a46f7.png)
![tgEp5br7Up](https://user-images.githubusercontent.com/4081722/69688134-0722d800-107a-11ea-90f1-a5614b09b422.png)


## Why It's Good For The Game
Building plumbing automation to make your favorite brews is always a good time, and can be used to get fancy medicinal effects(or poison effects) to your pills.

## Changelog
:cl: Iamgoofball
add: Added the Booze and Soda synthezisers to Plumbing.
experimental: It's good to be back.
/:cl: