### PR TITLE
Fixes door locks in auxiliary bathrooms, APC placement in arrivals on Meta

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -31427,7 +31427,7 @@
 "bqh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
-	id_tag = "AuxToilet2";
+	id_tag = "AuxShower";
 	name = "Showers"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -75372,8 +75372,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/entry";
+	dir = 8;
 	name = "Arrivals APC";
-	pixel_x = -26
+	pixel_x = -26;
+	pixel_y = null
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -75374,8 +75374,7 @@
 	areastring = "/area/hallway/secondary/entry";
 	dir = 8;
 	name = "Arrivals APC";
-	pixel_x = -26;
-	pixel_y = null
+	pixel_x = -26
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #48016. Also took care of an APC placement issue in Arrivals next to the second dock.

## Changelog
:cl:
fix: The lock for the shower door in the auxiliary bathrooms now actually works.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
