### PR TITLE
Holodeck buttons fix

### DIFF
--- a/code/modules/holodeck/area_copy.dm
+++ b/code/modules/holodeck/area_copy.dm
@@ -38,6 +38,9 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 		if(ismachinery(O))
 			var/obj/machinery/M = O
 			M.power_change()
+			if(istype(O, /obj/machinery/button))
+				var/obj/machinery/button/B = O
+				B.setup_device()
 
 	if(holoitem)
 		O.flags_1 |= HOLOGRAM_1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

When the holodeck area is copied on the station's holodeck, buttons are not properly linked to their internal controllers while still having been marked as initialized, resulting in unusuable buttons. This PR makes it so that buttons are re-linked to their controllers when the area is copied.

Fixes #46187

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Less bugs.

## Changelog
:cl: Arkatos
fix: Holodeck buttons now work properly. Fire the torpedos right away!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
