### PR TITLE
Adds a solo abductor option to traitor panel

### DIFF
--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -30,6 +30,10 @@
 	landmark_type = /obj/effect/landmark/abductor/scientist
 	greet_text = "Use your experimental console and surgical equipment to monitor your agent and experiment upon abducted humans."
 	show_in_antagpanel = TRUE
+	
+/datum/antagonist/abductor/scientist/onemanteam
+	name = "Abductor Solo"
+	outfit = /datum/outfit/abductor/scientist/onemanteam
 
 /datum/antagonist/abductor/create_team(datum/team/abductor_team/new_team)
 	if(!new_team)

--- a/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
@@ -63,7 +63,7 @@
 	belt = /obj/item/storage/belt/military/abductor/full
 
 	backpack_contents = list(
-	/obj/item/abductor/gizmo = 1
+	/obj/item/abductor/gizmo = 1,
 	/obj/item/gun/energy/alien = 1,
 	/obj/item/abductor/silencer = 1
 	)

--- a/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
@@ -54,3 +54,16 @@
 	if(!visualsOnly)
 		var/obj/item/implant/abductor/beamplant = new /obj/item/implant/abductor(H)
 		beamplant.implant(H)
+
+/datum/outfit/abductor/scientist/onemanteam
+	name = "Abductor Scientist (w/ agent gear)"
+	head = /obj/item/clothing/head/helmet/abductor
+	suit = /obj/item/clothing/suit/armor/abductor/vest
+	suit_store = /obj/item/abductor/baton
+	belt = /obj/item/storage/belt/military/abductor/full
+
+	backpack_contents = list(
+	/obj/item/abductor/gizmo = 1
+	/obj/item/gun/energy/alien = 1,
+	/obj/item/abductor/silencer = 1
+	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## About The Pull Request
For when admins tc trade for solo abductor, makes it a bit easier on them. 

If anything else is missing from traitor panel, now's your time.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Happy admins, happy life.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
admin: Admins can now pick solo abductor in traitor panel.
/:cl: