### PR TITLE
Modifies caramel recipe to require water

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -79,8 +79,8 @@
 /datum/chemical_reaction/caramel
 	name = "Caramel"
 	id = /datum/reagent/consumable/caramel
-	results = list(/datum/reagent/consumable/caramel = 1)
-	required_reagents = list(/datum/reagent/consumable/sugar = 1)
+	results = list(/datum/reagent/consumable/caramel = 5)
+	required_reagents = list(/datum/reagent/consumable/sugar = 5, /datum/reagent/water = 1)
 	required_temp = 413.15
 	mob_react = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Modifies the recipe for caramel to require water.
The new recipe calls for 5 parts Sugar and 1 part Water, resulting in 5u caramel.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The overtly simple recipe for caramel is really frustrating for chemists, particularly those working complex ChemFactory setups or making smoke grenades, as all sugar becomes caramel at 413.15K and then carbon at 483.15K.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: paulgatto
tweak: The recipe for Caramel now requires 5 parts Sugar and 1 part Water, resulting in 5 units of Caramel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
