### PR TITLE
Dead Goliath Broodmothers no longer spawns tentacles while dead.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -45,34 +45,34 @@
 								/datum/action/innate/elite_attack/spawn_children,
 								/datum/action/innate/elite_attack/rage,
 								/datum/action/innate/elite_attack/call_children)
-	
+
 	var/rand_tent = 0
 	var/list/mob/living/simple_animal/hostile/asteroid/elite/broodmother_child/children_list = list()
-	
+
 /datum/action/innate/elite_attack/tentacle_patch
 	name = "Tentacle Patch"
 	button_icon_state = "tentacle_patch"
 	chosen_message = "<span class='boldwarning'>You are now attacking with a patch of tentacles.</span>"
 	chosen_attack_num = TENTACLE_PATCH
-	
+
 /datum/action/innate/elite_attack/spawn_children
 	name = "Spawn Children"
 	button_icon_state = "spawn_children"
 	chosen_message = "<span class='boldwarning'>You will spawn two children at your location to assist you in combat.  You can have up to 8.</span>"
 	chosen_attack_num = SPAWN_CHILDREN
-	
+
 /datum/action/innate/elite_attack/rage
 	name = "Rage"
 	button_icon_state = "rage"
 	chosen_message = "<span class='boldwarning'>You will temporarily increase your movement speed.</span>"
 	chosen_attack_num = RAGE
-	
+
 /datum/action/innate/elite_attack/call_children
 	name = "Call Children"
 	button_icon_state = "call_children"
 	chosen_message = "<span class='boldwarning'>You will summon your children to your location.</span>"
 	chosen_attack_num = CALL_CHILDREN
-	
+
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother/OpenFire()
 	if(client)
 		switch(chosen_attack)
@@ -95,9 +95,11 @@
 			rage()
 		if(CALL_CHILDREN)
 			call_children()
-		
+
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother/Life()
-	. = ..()	
+	. = ..()
+	if(!.) //Checks if they are dead as a rock.
+		return
 	if(health < maxHealth * 0.5 && rand_tent < world.time)
 		rand_tent = world.time + 30
 		var/tentacle_amount = 5
@@ -107,16 +109,16 @@
 		for(var/i in 1 to tentacle_amount)
 			var/turf/t = pick_n_take(tentacle_loc)
 			new /obj/effect/temp_visual/goliath_tentacle/broodmother(t, src)
-	
-/mob/living/simple_animal/hostile/asteroid/elite/broodmother/proc/tentacle_patch(var/target)	
+
+/mob/living/simple_animal/hostile/asteroid/elite/broodmother/proc/tentacle_patch(var/target)
 	ranged_cooldown = world.time + 15
 	var/tturf = get_turf(target)
 	if(!isturf(tturf))
 		return
 	visible_message("<span class='warning'>[src] digs its tentacles under [target]!</span>")
 	new /obj/effect/temp_visual/goliath_tentacle/broodmother/patch(tturf, src)
-		
-/mob/living/simple_animal/hostile/asteroid/elite/broodmother/proc/spawn_children(var/target)	
+
+/mob/living/simple_animal/hostile/asteroid/elite/broodmother/proc/spawn_children(var/target)
 	ranged_cooldown = world.time + 40
 	visible_message("<span class='boldwarning'>The ground churns behind [src]!</span>")
 	for(var/i in 1 to 2)
@@ -137,12 +139,12 @@
 	set_varspeed(0)
 	move_to_delay = 3
 	addtimer(CALLBACK(src, .proc/reset_rage), 65)
-	
+
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother/proc/reset_rage()
 	color = "#FFFFFF"
 	set_varspeed(2)
 	move_to_delay = 5
-	
+
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother/proc/call_children()
 	ranged_cooldown = world.time + 60
 	visible_message("<span class='warning'>The ground shakes near [src]!</span>")
@@ -153,8 +155,8 @@
 		if(T)
 			child.forceMove(T)
 			playsound(src, 'sound/effects/bamf.ogg', 100, 1)
-		
-//The goliath's children.  Pretty weak, simple mobs which are able to put a single tentacle under their target when at range.		
+
+//The goliath's children.  Pretty weak, simple mobs which are able to put a single tentacle under their target when at range.
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother_child
 	name = "baby goliath"
 	desc = "A young goliath recently born from it's mother.  While they hatch from eggs, said eggs are incubated in the mother until they are ready to be born."
@@ -181,7 +183,7 @@
 	deathmessage = "falls to the ground."
 	status_flags = CANPUSH
 	var/mob/living/simple_animal/hostile/asteroid/elite/broodmother/mother = null
-	
+
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother_child/OpenFire(target)
 	ranged_cooldown = world.time + 40
 	var/tturf = get_turf(target)
@@ -190,7 +192,7 @@
 	if(get_dist(src, target) <= 7)//Screen range check, so it can't attack people off-screen
 		visible_message("<span class='warning'>[src] digs one of its tentacles under [target]!</span>")
 		new /obj/effect/temp_visual/goliath_tentacle/broodmother(tturf, src)
-	
+
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother_child/death()
 	. = ..()
 	if(mother != null)
@@ -198,7 +200,7 @@
 	visible_message("<span class='warning'>[src] explodes!</span>")
 	explosion(get_turf(loc),0,0,0,flame_range = 3, adminlog = FALSE)
 	gib()
-	
+
 //Tentacles have less stun time compared to regular variant, to balance being able to use them much more often.  Also, 10 more damage.
 /obj/effect/temp_visual/goliath_tentacle/broodmother/trip()
 	var/latched = FALSE
@@ -214,7 +216,7 @@
 	else
 		deltimer(timerid)
 		timerid = addtimer(CALLBACK(src, .proc/retract), 10, TIMER_STOPPABLE)
-		
+
 /obj/effect/temp_visual/goliath_tentacle/broodmother/patch/Initialize(mapload, new_spawner)
 	. = ..()
 	var/tentacle_locs = spiral_range_turfs(1, get_turf(src))
@@ -225,7 +227,7 @@
 		var/turf/T = get_step(get_turf(src), i)
 		T = get_step(T, i)
 		new /obj/effect/temp_visual/goliath_tentacle/broodmother(T, spawner)
-			
+
 // Broodmother's loot: Broodmother Tongue
 /obj/item/crusher_trophy/broodmother_tongue
 	name = "broodmother tongue"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR simply makes it so a dead Goliath Broodmother no longer spawns tentacles all around them constantly.

Fixes #47933 

(Side note, while I agree with removing the empty useless tabs. That wasn't my doing.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It sucks being hit by them even when the broodmother died.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Dead Goliath Broodmother no longer constantly spawns tentacles around them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
