### PR TITLE
Kicking people to the side now stuns for a third of the remaining knockdown time.

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1348,7 +1348,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				shove_blocked = TRUE
 
 		if(target.IsKnockdown() && !target.IsParalyzed())
-			target.Paralyze(SHOVE_CHAIN_PARALYZE)
+			var/stun_cut = target.AmountKnockdown()/3
+			target.Paralyze(stun_cut)
 			target.visible_message("<span class='danger'>[user.name] kicks [target.name] onto their side!</span>",
 							"<span class='userdanger'>You're kicked onto your side by [user.name]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
 			to_chat(user, "<span class='danger'>You kick [target.name] onto their side!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Shove stuns are kind of OP as hell. I've heard headmins asked for it to be long enough to cuff people as a means to stop tiders going into departments, but this _kind of_ impacts other areas of the game? It's just way too long for a no-effort stun that allows you to hit someone with a toolbox 5 times for free before they can stand up (only to be shoved into the wall again).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Kicking people to the side now stuns for a third of the remaining knockdown time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
