### PR TITLE
Reverts felinid interaction with cocoa

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -91,22 +91,6 @@
 		else
 			tail.Remove(H)
 
-/datum/species/human/felinid/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/M)
-	.=..()
-	if(chem.type == /datum/reagent/consumable/coco || chem.type == /datum/reagent/consumable/hot_coco || chem.type ==/datum/reagent/consumable/milk/chocolate_milk)
-		if(prob(20))
-			M.adjust_disgust(20)
-		if(prob(5))
-			M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>")
-		if(prob(10))
-			var/sick_message = pick("Your insides revolt at the presence of lethal chocolate!", "You feel nyauseous.", "You're nya't feeling so good.","You feel like your insides are melting.","You feel illsies.")
-			to_chat(M, "<span class='notice'>[sick_message]</span>")
-		if(prob(35))
-			var/obj/item/organ/guts = pick(M.internal_organs)
-			guts.applyOrganDamage(15)
-		return FALSE
-
-
 /proc/mass_purrbation()
 	for(var/M in GLOB.mob_list)
 		if(ishuman(M))


### PR DESCRIPTION
# Why It's Good For The Game
Redditors are bad for the game, if we can cause some of them to leave, the game will be improved immensely.

Further more this reaction was added during the felinid freeze and should not have been merged by maintainers in the first place.

I was willing to let it slide, but it has now become a problem for me.

## Changelog
:cl: oranges
del: Felinids no longer react to cocoa
/:cl:
