### PR TITLE
Assemblies installed on grenades now pre-prime, instead of detonating

### DIFF
--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -40,12 +40,12 @@
 /datum/wires/explosive/chem_grenade/explode()
 	var/obj/item/grenade/chem_grenade/G = holder
 	var/obj/item/assembly/assembly = get_attached(get_wire(1))
-	message_admins("\An [assembly] has pulsed a grenade, which was installed by [fingerprint].")
-	log_game("\An [assembly] has pulsed a grenade, which was installed by [fingerprint].")
+	message_admins("\An [assembly] has pulsed and preprimed a grenade, which was installed by [fingerprint].")
+	log_game("\An [assembly] has pulsed and preprimed a grenade, which was installed by [fingerprint].")
 	var/mob/M = get_mob_by_ckey(fingerprint)
 	var/turf/T = get_turf(M)	
 	G.log_grenade(M, T)
-	G.prime()
+	G.preprime()
 
 /datum/wires/explosive/chem_grenade/detach_assembly(color)
 	var/obj/item/assembly/S = get_attached(color)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Instantly blowing up a grenade is far too strong, and there are plenty of reasons why;
1. You can easily make a ghetto flash/bang grenade that instantly stuns people, leaving you unharmed and them down on the floor for a while.
2. You can take that last strat and apply it to a crap-ton of things: Super hellfoam with you in a suit and noslips, smoke with lexorin, meth and bath salts, and plenty of other reddit grenade recipes
3. You can leave maint surprises and drop primed proximity sensor gunpowder nades around.
4. The most obvious one: You can effortlessly kill anyone that's taken you down with it. Walk into maint, let cult stun-crit you, health sensor grenade instantly explodes taking both of you out. Or run up to any other antagonist, get stunbatoned or whatnot, the moment you lose, even in crit, whisper something and instantly take them down with you. 
You don't even need to be stunned yourself, you can just walk up to people and blow up. Needless to say this isn't fair, at most leave it to explosive lances as those have an obvious tell with their huge sprite.

There's a reason instant timer chem grenades don't exist, it's far too strong. Making you need to walk through a minor hoop to replicate the effect is barely any different, there's a reason syringe guns are limited. Reagents and chemistry are incredibly powerful and being able to ignore the in-built mechanics (lol piercing syringe and infinitely fabbable rapid syringe guns) roundstart is not good.
On suicide bombing, it's not risky whatsoever. You have nothing to lose and everything to gain, by blowing up whoever killed you. If you're smart you can even give botany some of your blood and it's truly riskfree.

By changing it to prepriming, instead of having to either face down every chemist (traitor or not) or chemistry powergamer by either hoping they don't have a suicide bomb or only killing them via ranged weapons, it instead rewards paying attention to audible cues and still lets those moments happen, via blowing up deaf and inattentive people.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Attachables now preprime the chemical grenade, they don't blow it up instantly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
