### PR TITLE
Improve autobuild Github action

### DIFF
--- a/.github/workflows/autobuild_tgui.yml
+++ b/.github/workflows/autobuild_tgui.yml
@@ -18,18 +18,15 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-         node-version: '>=12.13'
-      - name: Get Dependencies
-        run: yarn install
-        working-directory: ./tgui-next
+          node-version: '>=12.13'
       - name: Build TGUI
-        run: yarn run build
+        run: bin/tgui --ci
         working-directory: ./tgui-next
       - name: Commit Artifacts
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "TGUI"
-          git commit -m "Automatic TGUI Rebuild [ci skip]" -a
+          git commit -m "Automatic TGUI Rebuild [ci skip]" -a || true
       - name: Push Artifacts
         uses: ad-m/github-push-action@master
         with:

--- a/tgui-next/bin/tgui
+++ b/tgui-next/bin/tgui
@@ -62,19 +62,6 @@ task-clean() {
   rm -f **/package-lock.json
 }
 
-## Validates current build against the build stored in git
-task-validate-build() {
-  cd "${base_dir}"
-  local diff
-  diff="$(git diff packages/tgui/public/tgui.bundle.*)"
-  if [[ -n ${diff} ]]; then
-    echo "Error: our build differs from the build committed into git."
-    echo "Please rebuild tgui."
-    exit 1
-  fi
-  echo "tgui: build is ok"
-}
-
 ## Installs merge drivers and git hooks
 task-install-git-hooks() {
   cd "${base_dir}"
@@ -123,7 +110,6 @@ if [[ ${1} == "--ci" ]]; then
   task-install
   task-eslint
   task-webpack --mode=production
-  task-validate-build
   exit 0
 fi
 

--- a/tools/travis/build_tgui.sh
+++ b/tools/travis/build_tgui.sh
@@ -21,5 +21,4 @@ node node_modules/gulp/bin/gulp.js --min
 
 echo "Building 'tgui-next'"
 cd "${base_dir}/tgui-next"
-bin/tgui --clean
-bin/tgui
+bin/tgui --ci


### PR DESCRIPTION
## About The Pull Request

- Use `bin/tgui --ci` to do the build instead of executing yarn scripts.
- Removed build validation from the `--ci` pipeline (RIP).
- Let `git commit` always return 0 even if there is nothing to commit.
