### PR TITLE
Revert "Removes felinid interaction with cocoa (#48066)"

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -91,6 +91,22 @@
 		else
 			tail.Remove(H)
 
+/datum/species/human/felinid/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/M)
+	.=..()
+	if(chem.type == /datum/reagent/consumable/coco || chem.type == /datum/reagent/consumable/hot_coco || chem.type ==/datum/reagent/consumable/milk/chocolate_milk)
+		if(prob(20))
+			M.adjust_disgust(20)
+		if(prob(5))
+			M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>")
+		if(prob(10))
+			var/sick_message = pick("Your insides revolt at the presence of lethal chocolate!", "You feel nyauseous.", "You're nya't feeling so good.","You feel like your insides are melting.","You feel illsies.")
+			to_chat(M, "<span class='notice'>[sick_message]</span>")
+		if(prob(35))
+			var/obj/item/organ/guts = pick(M.internal_organs)
+			guts.applyOrganDamage(15)
+		return FALSE
+
+
 /proc/mass_purrbation()
 	for(var/M in GLOB.mob_list)
 		if(ishuman(M))


### PR DESCRIPTION
This reverts commit 3179685149d3bc7b5836769fb427bf6720919b83.

## About The Pull Request

reverts a revert ok ese?

## Why It's Good For The Game

'get rid of the reditors' should not be a valid excuse to remove felinid interaction with cocoa and speedmerge it when it's your own PR
this'll probably be denied instantly and i'll get banned from the repo but it's worth a shot :>

## Changelog
:cl:
add: Makes felinids have a bad interaction with cocoa again.
/:cl:

