### PR TITLE
Adds cell deletion handling for stunbatons

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -16,7 +16,7 @@
 
 	var/cooldown = (2.5 SECONDS)
 	var/stunforce = (5 SECONDS)
-	var/status = 0
+	var/turned_on = FALSE
 	var/obj/item/stock_parts/cell/cell
 	var/hitcost = 1000
 	var/throw_hit_chance = 35
@@ -38,10 +38,24 @@
 			cell = new preload_cell_type(src)
 	update_icon()
 
+
+/obj/item/melee/baton/Destroy()
+	if(cell)
+		QDEL_NULL(cell)
+	return ..()
+
+/obj/item/melee/baton/handle_atom_del(atom/A)
+	if(A == cell)
+		cell = null
+		turned_on = FALSE
+		update_icon()
+	return ..()
+
+
 /obj/item/melee/baton/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	..()
 	//Only mob/living types have stun handling
-	if(status && prob(throw_hit_chance) && iscarbon(hit_atom))
+	if(turned_on && prob(throw_hit_chance) && iscarbon(hit_atom))
 		baton_effect(hit_atom)
 
 /obj/item/melee/baton/loaded //this one starts with a cell pre-installed.
@@ -52,15 +66,15 @@
 		//Note this value returned is significant, as it will determine
 		//if a stun is applied or not
 		. = cell.use(chrgdeductamt)
-		if(status && cell.charge < hitcost)
+		if(turned_on && cell.charge < hitcost)
 			//we're below minimum, turn off
-			status = 0
+			turned_on = FALSE
 			update_icon()
-			playsound(loc, "sparks", 75, TRUE, -1)
+			playsound(src, "sparks", 75, TRUE, -1)
 
 
 /obj/item/melee/baton/update_icon()
-	if(status)
+	if(turned_on)
 		icon_state = "[initial(icon_state)]_active"
 	else if(!cell)
 		icon_state = "[initial(icon_state)]_nocell"
@@ -95,18 +109,18 @@
 			cell.forceMove(get_turf(src))
 			cell = null
 			to_chat(user, "<span class='notice'>You remove the cell from [src].</span>")
-			status = 0
+			turned_on = FALSE
 			update_icon()
 	else
 		return ..()
 
 /obj/item/melee/baton/attack_self(mob/user)
 	if(cell && cell.charge > hitcost)
-		status = !status
-		to_chat(user, "<span class='notice'>[src] is now [status ? "on" : "off"].</span>")
-		playsound(loc, "sparks", 75, TRUE, -1)
+		turned_on = !turned_on
+		to_chat(user, "<span class='notice'>[src] is now [turned_on ? "on" : "off"].</span>")
+		playsound(src, "sparks", 75, TRUE, -1)
 	else
-		status = 0
+		turned_on = FALSE
 		if(!cell)
 			to_chat(user, "<span class='warning'>[src] does not have a power source!</span>")
 		else
@@ -115,7 +129,7 @@
 	add_fingerprint(user)
 
 /obj/item/melee/baton/attack(mob/M, mob/living/carbon/human/user)
-	if(status && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
+	if(turned_on && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 		user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
 							"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
 		user.Knockdown(stunforce*3)
@@ -133,7 +147,7 @@
 			return
 
 	if(user.a_intent != INTENT_HARM)
-		if(status)
+		if(turned_on)
 			if(cooldown_check <= world.time)
 				if(baton_effect(M, user))
 					user.do_attack_animation(M)
@@ -144,7 +158,7 @@
 			M.visible_message("<span class='warning'>[user] has prodded [M] with [src]. Luckily it was off.</span>", \
 							"<span class='warning'>[user] has prodded you with [src]. Luckily it was off</span>")
 	else
-		if(status)
+		if(turned_on)
 			if(cooldown_check <= world.time)
 				baton_effect(M, user)
 		..()
@@ -155,14 +169,14 @@
 		var/mob/living/carbon/human/H = L
 		if(H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK)) //No message; check_shields() handles that
 			playsound(L, 'sound/weapons/genhit.ogg', 50, TRUE)
-			return 0
+			return FALSE
 	if(iscyborg(loc))
 		var/mob/living/silicon/robot/R = loc
 		if(!R || !R.cell || !R.cell.use(hitcost))
-			return 0
+			return FALSE
 	else
 		if(!deductcharge(hitcost))
-			return 0
+			return FALSE
 
 	/// After a target is hit, we do a chunk of stamina damage, along with other effects.
 	/// After a period of time, we then check to see what stun duration we give.
@@ -181,7 +195,7 @@
 								"<span class='userdanger'>[user] has stunned you with [src]!</span>")
 		log_combat(user, L, "stunned")
 
-	playsound(loc, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
+	playsound(src, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
 
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
@@ -230,3 +244,9 @@
 /obj/item/melee/baton/cattleprod/baton_effect()
 	if(sparkler.activate())
 		..()
+
+/obj/item/melee/baton/cattleprod/Destroy()
+	if(sparkler)
+		QDEL_NULL(sparkler)
+	return ..()
+

--- a/code/game/objects/items/teleprod.dm
+++ b/code/game/objects/items/teleprod.dm
@@ -8,7 +8,7 @@
 
 /obj/item/melee/baton/cattleprod/teleprod/attack(mob/living/carbon/M, mob/living/carbon/user)//handles making things teleport when hit
 	..()
-	if(status && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
+	if(turned_on && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 		user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
 							"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
 		if(do_teleport(user, get_turf(user), 50, channel = TELEPORT_CHANNEL_BLUESPACE))//honk honk
@@ -21,7 +21,7 @@
 			deductcharge(hitcost/4)
 		return
 	else
-		if(status)
+		if(turned_on)
 			if(!istype(M) && M.anchored)
 				return .
 			else

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -303,7 +303,7 @@
 	if(istype(O, /obj/item/melee/baton))
 		var/obj/item/melee/baton/B = O
 		if(B.cell)
-			if(B.cell.charge > 0 && B.status == 1)
+			if(B.cell.charge > 0 && B.turned_on)
 				flick("baton_active", src)
 				var/stunforce = B.stunforce
 				user.Paralyze(stunforce)

--- a/code/modules/surgery/advanced/revival.dm
+++ b/code/modules/surgery/advanced/revival.dm
@@ -40,7 +40,7 @@
 			return FALSE
 	if(istype(tool, /obj/item/melee/baton))
 		var/obj/item/melee/baton/B = tool
-		if(!B.status)
+		if(!B.turned_on)
 			to_chat(user, "<span class='warning'>[B] needs to be active!</span>")
 			return FALSE
 	if(istype(tool, /obj/item/gun/energy))


### PR DESCRIPTION
Partially resolves the issues in #48020 where the cell's deletion wasn't being handled correctly.

Also renamed the `status` var to `turned_on` to make it a bit more intuitive to read.