### PR TITLE
Adds the Energy Shotgun to the techweb system

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -60,6 +60,15 @@
 	desc = "A laser gun equipped with a refraction kit that spreads bolts."
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter, /obj/item/ammo_casing/energy/laser)
 
+/obj/item/gun/energy/laser/scatter/security
+	name = "energy shotgun"
+	icon_state = "lasercannon"
+	item_state = "laser"
+	desc = "A laser cannon modified to fire scatter shots. Can switch between lethal and disabler shots."
+	shaded_charge = 0
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter/disabler, /obj/item/ammo_casing/energy/laser/scatter)
+	pin = null
+
 /obj/item/gun/energy/laser/scatter/shotty
 	name = "energy shotgun"
 	icon = 'icons/obj/guns/projectile.dmi'

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -134,6 +134,16 @@
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
+/datum/design/scatterlaser
+	name = "Energy Shotgun"
+	desc = "A laser cannon modified to fire scatter shots. Can switch between lethal and disabler shots."
+	id = "scatterlaser"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 10000, /datum/material/glass = 5000, /datum/material/diamond = 5000, /datum/material/gold = 5000)
+	build_path = /obj/item/gun/energy/laser/scatter/security
+	category = list("Weapons")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
 /datum/design/decloner
 	name = "Decloner"
 	desc = "Your opponent will bubble into a messy pile of goop."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -655,7 +655,7 @@
 	display_name = "Beam Weaponry"
 	description = "Various basic beam weapons"
 	prereq_ids = list("adv_weaponry")
-	design_ids = list("temp_gun", "xray_laser")
+	design_ids = list("temp_gun", "xray_laser", "scatterlaser")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Christ, something like five years ago @sirbayer added a scatter laser function that looks bomb as hell and seems pretty damn cool. There's also a shotgun already _in_ the code, but it's used in a pretty small place and it uses electrodes, so... Yeah. This works as a better alternative that can actually be used without being hilariously broken. Can switch between firing 3 spread Disabler shots or 5 spread Laser pellets. Working on getting a custom sprite for it, but right now it uses the laser cannon sprite.

It's located in the "Beam Weapons" techweb node, along with the Temperature Gun and X-ray Laser.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We could use some more interesting weapons in this node. Nobody uses the temperature gun because it sucks and the x-ray laser got nerfed against blob so it never gets printed now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the Energy Shotgun. Capable of firing lethal and disabler shots in a wide spread. Requires the Beam Weapons research node.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
