### PR TITLE
Fixes the sugar sack icon

### DIFF
--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -25,7 +25,7 @@
 	 /datum/reagent/consumable/sodiumchloride = list("icon_state" = "saltshakersmall", "item_state" = "", "icon_empty" = "emptyshaker", "name" = "salt shaker", "desc" = "Salt. From dead crew, presumably."),
 	 /datum/reagent/consumable/soymilk = list("icon_state" = "soymilk", "item_state" = "carton", "icon_empty" = "", "name" = "soy milk", "desc" = "It's soy milk. White and nutritious goodness!"),
 	 /datum/reagent/consumable/soysauce = list("icon_state" = "soysauce", "item_state" = "", "icon_empty" = "", "name" = "soy sauce bottle", "desc" = "A salty soy-based flavoring."),
-	 /datum/reagent/consumable/sugar = list("icon_state" = "rice", "item_state" = "flour", "icon_empty" = "", "name" = "sugar sack", "desc" = "Tasty spacey sugar!"),
+	 /datum/reagent/consumable/sugar = list("icon_state" = "sugar", "item_state" = "flour", "icon_empty" = "", "name" = "sugar sack", "desc" = "Tasty spacey sugar!"),
 	 /datum/reagent/consumable/ketchup = list("icon_state" = "ketchup", "item_state" = "", "icon_empty" = "", "name" = "ketchup bottle", "desc" = "You feel more American already."),
 	 /datum/reagent/consumable/capsaicin = list("icon_state" = "hotsauce", "item_state" = "", "icon_empty" = "", "name" = "hotsauce bottle", "desc" = "You can almost TASTE the stomach ulcers!"),
 	 /datum/reagent/consumable/frostoil = list("icon_state" = "coldsauce", "item_state" = "", "icon_empty" = "", "name" = "coldsauce bottle", "desc" = "Leaves the tongue numb from its passage."),
@@ -137,7 +137,7 @@
 /obj/item/reagent_containers/food/condiment/sugar
 	name = "sugar sack"
 	desc = "Tasty spacey sugar!"
-	icon_state = "rice"
+	icon_state = "sugar"
 	item_state = "flour"
 	list_reagents = list(/datum/reagent/consumable/sugar = 50)
 


### PR DESCRIPTION
## About The Pull Request
Fixes the sugar sack icon so it stops looking the same as the rice sack. 

Before:
![191206 1508 29 Rice and sugar before aaah](https://user-images.githubusercontent.com/46400996/70344176-58d91880-1859-11ea-90b3-35b67eecd13e.png)

After:
![191206 1531 59 Rice and sugar after aaah](https://user-images.githubusercontent.com/46400996/70344192-5d9dcc80-1859-11ea-9af3-758f8f029b40.png)


## Why It's Good For The Game
For some reason we are using the rice sack icon for the sugar sack. As some may have noticed (from wiki) there already existed a seemingly unused icon for the sugar sack. Being able to tell rice and sugar apart easier should be a quality of life improvement for cooks and cakehat knights alike. 

## Changelog
:cl:Angust
fix: fixed the sugar sack to stop looking like the rice sack
/:cl:
