### PR TITLE
Gets rid of space turf on meta

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -74238,18 +74238,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"kLK" = (
-/obj/machinery/airalarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "kMC" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -92086,7 +92074,7 @@ aaa
 aaa
 aaa
 aaa
-kLK
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
I miss mapdiffbot.

#47740 added an extra turf in space.