### PR TITLE
Adds new direct mob sound admin verb

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -105,6 +105,7 @@
 	body += "<A href='?_src_=holder;[HrefToken()];traitor=[REF(M)]'>Traitor panel</A> | "
 	body += "<A href='?_src_=holder;[HrefToken()];narrateto=[REF(M)]'>Narrate to</A> | "
 	body += "<A href='?_src_=holder;[HrefToken()];subtlemessage=[REF(M)]'>Subtle message</A> | "
+	body += "<A href='?_src_=holder;[HrefToken()];playsoundto=[REF(M)]'>Play sound to</A> | "
 	body += "<A href='?_src_=holder;[HrefToken()];languagemenu=[REF(M)]'>Language Menu</A>"
 
 	if (M.client)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -79,7 +79,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(/client/proc/unban_panel, /client/proc/ban_panel, /client/proc/stickybanpanel))
 GLOBAL_PROTECT(admin_verbs_ban)
-GLOBAL_LIST_INIT(admin_verbs_sounds, list(/client/proc/play_local_sound, /client/proc/play_local_mob_sound, /client/proc/play_sound, /client/proc/set_round_end_sound))
+GLOBAL_LIST_INIT(admin_verbs_sounds, list(/client/proc/play_local_sound, /client/proc/play_direct_mob_sound, /client/proc/play_sound, /client/proc/set_round_end_sound))
 GLOBAL_PROTECT(admin_verbs_sounds)
 GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/cmd_admin_dress,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -79,7 +79,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(/client/proc/unban_panel, /client/proc/ban_panel, /client/proc/stickybanpanel))
 GLOBAL_PROTECT(admin_verbs_ban)
-GLOBAL_LIST_INIT(admin_verbs_sounds, list(/client/proc/play_local_sound, /client/proc/play_sound, /client/proc/set_round_end_sound))
+GLOBAL_LIST_INIT(admin_verbs_sounds, list(/client/proc/play_local_sound, /client/proc/play_local_mob_sound, /client/proc/play_sound, /client/proc/set_round_end_sound))
 GLOBAL_PROTECT(admin_verbs_sounds)
 GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/cmd_admin_dress,

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1501,8 +1501,9 @@
 			return
 
 		var/mob/M = locate(href_list["playsoundto"])
-		var/S = input("Select a file", "file",) as sound
-		usr.client.play_direct_mob_sound(S, M)
+		var/S = input("", "Select a sound file",) as null|sound
+		if(S)
+			usr.client.play_direct_mob_sound(S, M)
 
 	else if(href_list["individuallog"])
 		if(!check_rights(R_ADMIN))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1496,6 +1496,14 @@
 		var/mob/M = locate(href_list["subtlemessage"])
 		usr.client.cmd_admin_subtle_message(M)
 
+	else if(href_list["playsoundto"])
+		if(!check_rights(R_SOUND))
+			return
+
+		var/mob/M = locate(href_list["playsoundto"])
+		var/S = input("Select a file", "file",) as sound
+		usr.client.play_direct_mob_sound(S, M)
+
 	else if(href_list["individuallog"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -52,21 +52,18 @@
 	playsound(get_turf(src.mob), S, 50, FALSE, FALSE)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Local Sound") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/proc/play_local_mob_sound(S as sound)
+/client/proc/play_direct_mob_sound(S as sound, mob/M)
 	set category = "Fun"
-	set name = "Play Local Mob Sound"
+	set name = "Play Direct Mob Sound"
 	if(!check_rights(R_SOUND))
 		return
 
-	var/mob/target = input(usr, "Choose a mob to play the sound to.", "Play Mob Sound") as null|anything in sortNames(GLOB.player_list)
-	var/vol = input(usr, "What volume would you like the sound to play at?",, 50) as null|num
-	if(!vol)
-		return
-	vol = CLAMP(vol, 1, 100)
-	log_admin("[key_name(src)] played a local mob sound [S] to [target].")
-	message_admins("[key_name_admin(src)] played a local mob sound [S] to [ADMIN_LOOKUPFLW(target)].")
-	target.playsound_local(get_turf(target), S, vol, FALSE, pressure_affected = FALSE)
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Local Mob Sound") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	if(!M)
+		M = input(usr, "Choose a mob to play the sound to. Only they will hear it.", "Play Mob Sound") as null|anything in sortNames(GLOB.player_list)
+	log_admin("[key_name(src)] played a direct mob sound [S] to [M].")
+	message_admins("[key_name_admin(src)] played a direct mob sound [S] to [ADMIN_LOOKUPFLW(M)].")
+	SEND_SOUND(M, S)
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Direct Mob Sound") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/play_web_sound()
 	set category = "Fun"

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -60,6 +60,8 @@
 
 	if(!M)
 		M = input(usr, "Choose a mob to play the sound to. Only they will hear it.", "Play Mob Sound") as null|anything in sortNames(GLOB.player_list)
+	if(!M || QDELETED(M))
+		return
 	log_admin("[key_name(src)] played a direct mob sound [S] to [M].")
 	message_admins("[key_name_admin(src)] played a direct mob sound [S] to [ADMIN_LOOKUPFLW(M)].")
 	SEND_SOUND(M, S)

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -52,6 +52,22 @@
 	playsound(get_turf(src.mob), S, 50, FALSE, FALSE)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Local Sound") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/play_local_mob_sound(S as sound)
+	set category = "Fun"
+	set name = "Play Local Mob Sound"
+	if(!check_rights(R_SOUND))
+		return
+
+	var/mob/target = input(usr, "Choose a mob to play the sound to.", "Play Mob Sound") as null|anything in sortNames(GLOB.player_list)
+	var/vol = input(usr, "What volume would you like the sound to play at?",, 50) as null|num
+	if(!vol)
+		return
+	vol = CLAMP(vol, 1, 100)
+	log_admin("[key_name(src)] played a local mob sound [S] to [target].")
+	message_admins("[key_name_admin(src)] played a local mob sound [S] to [ADMIN_LOOKUPFLW(target)].")
+	target.playsound_local(get_turf(target), S, vol, FALSE, pressure_affected = FALSE)
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Local Mob Sound") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /client/proc/play_web_sound()
 	set category = "Fun"
 	set name = "Play Internet Sound"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the "Play Direct Mob Sound" for (b)admins to enjoy. Pick a sound and a mob, and only the chosen mob will hear it. Button also available in the player panel.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Happy admins happy life
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
admin: New sound verb, Play Direct Mob Sound. Can also be found in the player panel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
