### PR TITLE
Updates the Author from "McFlurry" to "Fury McFlurry"

### DIFF
--- a/html/changelogs/AutoChangeLog-pr-48129.yml
+++ b/html/changelogs/AutoChangeLog-pr-48129.yml
@@ -1,4 +1,4 @@
-author: "McFlurry"
+author: "Fury McFlurry"
 delete-after: True
 changes: 
   - imageadd: "Adds three new moth wings and markings!"


### PR DESCRIPTION
Updates the Author from "McFlurry" to "Fury McFlurry"

As my pr had the following 
**:cl:Fury McFlurry**

which only picked up the McFlurry part not the Fury part.

My excuses for having to make a pull request, next time I will simply use **:cl: Fury McFlurry**
