### PR TITLE
Improves cinematic code

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -54,6 +54,9 @@
 #define COMSIG_GLOB_MOB_DEATH "!mob_death"
 /// global living say plug - use sparingly: (mob/speaker , message)
 #define COMSIG_GLOB_LIVING_SAY_SPECIAL "!say_special"
+/// called by datum/cinematic/play() : (datum/cinematic/new_cinematic)
+#define COMSIG_GLOB_PLAY_CINEMATIC "!play_cinematic"
+	#define COMPONENT_GLOB_BLOCK_CINEMATIC 1
 
 //////////////////////////////////////////////////////////////////
 

--- a/code/datums/cinematic.dm
+++ b/code/datums/cinematic.dm
@@ -1,5 +1,3 @@
-GLOBAL_LIST_EMPTY(cinematics)
-
 // Use to play cinematics.
 // Watcher can be world,mob, or a list of mobs
 // Blocks until sequence is done.
@@ -38,28 +36,32 @@ GLOBAL_LIST_EMPTY(cinematics)
 	var/stop_ooc = TRUE //Turns off ooc when played globally.
 
 /datum/cinematic/New()
-	GLOB.cinematics += src
 	screen = new(src)
 
 /datum/cinematic/Destroy()
-	GLOB.cinematics -= src
+	for(var/CC in watching)
+		if(!CC)
+			continue
+		var/client/C = CC
+		C.screen -= screen
 	QDEL_NULL(screen)
-	for(var/mob/M in locked)
+	QDEL_NULL(special_callback)
+	for(var/MM in locked)
+		if(!MM)
+			continue
+		var/mob/M = MM
 		M.notransform = FALSE
 	return ..()
 
 /datum/cinematic/proc/play(watchers)
-	//Check if you can actually play it (stop mob cinematics for global ones) and create screen objects
-	for(var/A in GLOB.cinematics)
-		var/datum/cinematic/C = A
-		if(C == src)
-			continue
-		if(C.is_global || !is_global)
-			return //Can't play two global or local cinematics at the same time
+	//Check if you can actually play it (stop mob cinematics for global ones)
+	if(SEND_GLOBAL_SIGNAL(COMSIG_GLOB_PLAY_CINEMATIC, src) & COMPONENT_GLOB_BLOCK_CINEMATIC)
+		return
 
-	//Close all open windows if global
-	if(is_global)
-		SStgui.close_all_uis()
+	//We are now playing this cinematic
+
+	//Handle what happens when a different cinematic tries to play over us
+	RegisterSignal(SSdcs, COMSIG_GLOB_PLAY_CINEMATIC, .proc/replacement_cinematic)
 
 	//Pause OOC
 	var/ooc_toggled = FALSE
@@ -67,20 +69,15 @@ GLOBAL_LIST_EMPTY(cinematics)
 		ooc_toggled = TRUE
 		toggle_ooc(FALSE)
 
-
-	for(var/mob/M in GLOB.mob_list)
-		if(M in watchers)
-			M.notransform = TRUE //Should this be done for non-global cinematics or even at all ?
-			locked += M
-			//Close watcher ui's
-			SStgui.close_user_uis(M)
-			if(M.client)
-				watching += M.client
-				M.client.screen += screen
-		else
-			if(is_global)
-				M.notransform = TRUE
-				locked += M
+	for(var/MM in watchers)
+		var/mob/M = MM
+		M.notransform = TRUE //Should this be done for non-global cinematics or even at all ?
+		locked += M
+		//Close watcher ui's
+		SStgui.close_user_uis(M)
+		if(M.client)
+			watching += M.client
+			M.client.screen += screen
 
 	//Actually play it
 	content()
@@ -110,6 +107,11 @@ GLOBAL_LIST_EMPTY(cinematics)
 //Actual cinematic goes in here
 /datum/cinematic/proc/content()
 	sleep(50)
+
+/datum/cinematic/proc/replacement_cinematic(datum/source, datum/cinematic/other)
+	if(!is_global && other.is_global) //Allow it to play if we're local and it's global
+		return 0
+	return COMPONENT_GLOB_BLOCK_CINEMATIC
 
 /datum/cinematic/nuke_win
 	id = CINEMATIC_NUKE_WIN


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the /obj/screen/cinematic that the cinematics use GC properly.
Adds a global signal for when a cinematic tries to play. Kills the global list of cinematics.
Makes cinematics no longer loop through the global mob list to make sure that each mob is in fact actually in the global mob list.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
