### PR TITLE
Vampires maintain blood level over bat form

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -123,7 +123,7 @@
 
 /mob/living/carbon/Stat()
 	..()
-	if(statpanel("Status"))	
+	if(statpanel("Status"))
 		var/obj/item/organ/heart/vampire/darkheart = getorgan(/obj/item/organ/heart/vampire)
 		if(darkheart)
 			stat(null, "<span class='notice'>Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM].</span>")
@@ -141,4 +141,5 @@
 	invocation = "Squeak!"
 	charge_max = 50
 	cooldown_min = 50
+	convert_blood = TRUE
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -141,5 +141,4 @@
 	invocation = "Squeak!"
 	charge_max = 50
 	cooldown_min = 50
-	convert_blood = TRUE
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -14,6 +14,7 @@
 	var/revert_on_death = TRUE
 	var/die_with_shapeshifted_form = TRUE
 	var/convert_damage = TRUE //If you want to convert the caster's health to the shift, and vice versa.
+	var/convert_blood = FALSE //If you want to convert the caster's blood level to the shift, and vice versa.
 	var/convert_damage_type = BRUTE //Since simplemobs don't have advanced damagetypes, what to convert damage back into.
 
 	var/mob/living/shapeshift_type
@@ -101,7 +102,7 @@
 	desc = "Take on the shape a lesser ash drake."
 	invocation = "RAAAAAAAAWR!"
 	convert_damage = FALSE
-	
+
 
 	shapeshift_type = /mob/living/simple_animal/hostile/megafauna/dragon/lesser
 
@@ -131,6 +132,9 @@
 		var/damapply = damage_percent * shape.maxHealth;
 
 		shape.apply_damage(damapply, source.convert_damage_type, forced = TRUE);
+
+	if(source.convert_blood)
+		shape.blood_volume = stored.blood_volume;
 
 	slink = soullink(/datum/soullink/shapeshift, stored , shape)
 	slink.source = src
@@ -186,6 +190,8 @@
 		var/damapply = stored.maxHealth * damage_percent
 
 		stored.apply_damage(damapply, source.convert_damage_type, forced = TRUE)
+	if(source.convert_blood)
+		stored.blood_volume = shape.blood_volume;
 	qdel(shape)
 	qdel(src)
 

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -13,8 +13,7 @@
 
 	var/revert_on_death = TRUE
 	var/die_with_shapeshifted_form = TRUE
-	var/convert_damage = TRUE //If you want to convert the caster's health to the shift, and vice versa.
-	var/convert_blood = FALSE //If you want to convert the caster's blood level to the shift, and vice versa.
+	var/convert_damage = TRUE //If you want to convert the caster's health and blood to the shift, and vice versa.
 	var/convert_damage_type = BRUTE //Since simplemobs don't have advanced damagetypes, what to convert damage back into.
 
 	var/mob/living/shapeshift_type
@@ -132,8 +131,6 @@
 		var/damapply = damage_percent * shape.maxHealth;
 
 		shape.apply_damage(damapply, source.convert_damage_type, forced = TRUE);
-
-	if(source.convert_blood)
 		shape.blood_volume = stored.blood_volume;
 
 	slink = soullink(/datum/soullink/shapeshift, stored , shape)
@@ -190,7 +187,7 @@
 		var/damapply = stored.maxHealth * damage_percent
 
 		stored.apply_damage(damapply, source.convert_damage_type, forced = TRUE)
-	if(source.convert_blood)
+	if(source.convert_damage)
 		stored.blood_volume = shape.blood_volume;
 	qdel(shape)
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Vampires can no longer reset their blood level by shifting in and out of bat form.
Makes it trivial to toggle in the code for other shapeshifters.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Vampires should need blood to live. Fixes #47512 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Vampires maintain blood volume when shapeshifting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
