### PR TITLE
Examining lights too closely visually flashes you

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -293,7 +293,7 @@
 
 	if(start_with_cell && !no_emergency)
 		cell = new/obj/item/stock_parts/cell/emergency_light(src)
-	
+
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/light/LateInitialize()
@@ -433,6 +433,11 @@
 	switch(status)
 		if(LIGHT_OK)
 			. += "It is turned [on? "on" : "off"]."
+			if(on && iscarbon(user))
+				var/mob/living/carbon/C = user
+				if(Adjacent(C))
+					if(C.flash_act(visual = 1))
+						. += " It's really bright, too. Ow."
 		if(LIGHT_EMPTY)
 			. += "The [fitting] has been removed."
 		if(LIGHT_BURNED)


### PR DESCRIPTION
Split from https://github.com/tgstation/tgstation/pull/48180

inb4 >webedit, this was tested in the original PR and a web edit to remake the PR is just faster so 🤷‍♂ 

:cl:
add: Examining lights that are still on while you're too close is more realistic.
/:cl:
