### PR TITLE
Meta update to kitchen with shared biogenerator

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -40504,6 +40504,10 @@
 /area/hallway/primary/central)
 "bLI" = (
 /obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	name = "kitchen shutters";
+	id = "kitchenwindow"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "bLJ" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -40486,7 +40486,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bLH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
@@ -40532,7 +40531,9 @@
 	},
 /area/crew_quarters/kitchen)
 "bLL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -40541,12 +40542,18 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
 "bLN" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -41918,9 +41925,9 @@
 	},
 /area/crew_quarters/kitchen)
 "bOT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -42613,18 +42620,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bQC" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
 "bQD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -42633,12 +42639,10 @@
 	},
 /area/crew_quarters/kitchen)
 "bQF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -43102,6 +43106,7 @@
 /obj/machinery/button/door{
 	id = "kitchenhydro";
 	name = "Service Shutter Control";
+	pixel_x = 7;
 	pixel_y = -24;
 	req_access_txt = "28"
 	},
@@ -43112,6 +43117,7 @@
 /area/crew_quarters/kitchen)
 "bRS" = (
 /obj/machinery/deepfryer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bRT" = (
@@ -73062,7 +73068,7 @@
 /obj/machinery/button/door{
 	id = "kitchenwindow";
 	name = "Window Shutter Control";
-	pixel_x = 0;
+	pixel_x = -6;
 	pixel_y = -24;
 	req_access_txt = "28"
 	},
@@ -74302,11 +74308,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "kWu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "lal" = (
@@ -76263,6 +76269,7 @@
 	dir = 4
 	},
 /obj/machinery/deepfryer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -76521,6 +76528,14 @@
 /area/hallway/primary/port)
 "wyV" = (
 /obj/machinery/holopad,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
+"wzm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -111460,7 +111475,7 @@ bFk
 bwO
 woI
 bKj
-bLK
+wzm
 vuY
 bRS
 bQF

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -39083,25 +39083,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"bIr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bIs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bIt" = (
-/obj/machinery/newscaster{
-	pixel_x = -30
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+/turf/closed/wall,
+/area/crew_quarters/bar)
+"bIu" = (
+/obj/item/radio/intercom{
+	pixel_y = -28
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -39111,15 +39107,8 @@
 	desc = "A reminder of why we can't have nice things.";
 	name = "Potty the plant"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bIu" = (
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/machinery/newscaster{
+	pixel_x = -30
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -40508,28 +40497,16 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bLI" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/machinery/button/door{
-	id = "kitchenwindow";
-	name = "Window Shutter Control";
-	pixel_x = -26;
-	req_access_txt = "28"
-	},
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "bLJ" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /obj/machinery/button/door{
 	id = "kitchen";
 	name = "Kitchen Shutters Control";
@@ -40541,6 +40518,10 @@
 	pixel_x = 6;
 	pixel_y = 26
 	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bLK" = (
@@ -40550,17 +40531,19 @@
 /area/crew_quarters/kitchen)
 "bLL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
 "bLM" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -40588,6 +40571,10 @@
 /area/crew_quarters/kitchen)
 "bLP" = (
 /obj/structure/cable,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -41352,27 +41339,27 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNv" = (
-/obj/effect/spawner/structure/window,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/hallway/primary/central)
+"bNw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "kitchenwindow";
-	name = "kitchen shutters"
+	name = "kitchen shutters";
+	step_x = 0;
+	id = "kitchenwindow"
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/kitchen)
-"bNw" = (
-/obj/structure/rack,
-/obj/item/book/manual/chef_recipes{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/stack/packageWrap,
-/obj/item/storage/box/donkpockets,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -41380,14 +41367,6 @@
 "bNx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
-"bNy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -41913,15 +41892,21 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bOP" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "kitchenwindow";
-	name = "kitchen shutters"
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/hallway/primary/central)
 "bOQ" = (
-/obj/machinery/food_cart,
+/obj/machinery/door/poddoor/preopen{
+	name = "kitchen shutters";
+	step_x = 0;
+	id = "kitchenwindow"
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -41937,21 +41922,7 @@
 	},
 /area/crew_quarters/kitchen)
 "bOT" = (
-/obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
-"bOU" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
-"bOV" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -41961,9 +41932,19 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/storage/box/donkpockets,
+/obj/item/stack/packageWrap{
+	pixel_x = 6
+	},
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/item/book/manual/chef_recipes{
+	pixel_x = 2;
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -42634,16 +42615,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bQA" = (
-/obj/machinery/deepfryer,
-/obj/structure/cable,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "bQC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -42652,7 +42625,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -42661,7 +42633,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -42681,6 +42652,9 @@
 /area/crew_quarters/kitchen/coldroom)
 "bQJ" = (
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "bQN" = (
@@ -43104,21 +43078,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bRP" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/mint,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/kitchen";
-	name = "Kitchen APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "bRQ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker{
@@ -43131,14 +43090,13 @@
 /area/crew_quarters/kitchen)
 "bRR" = (
 /obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
 /obj/machinery/button/door{
 	id = "kitchenhydro";
 	name = "Service Shutter Control";
 	pixel_y = -24;
 	req_access_txt = "28"
 	},
+/obj/machinery/microwave,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -43164,6 +43122,17 @@
 	},
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
+/obj/structure/cable,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -7;
+	pixel_y = -3;
+	step_x = 0
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 6;
+	step_x = 0
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -43215,10 +43184,10 @@
 /obj/item/radio/intercom{
 	pixel_y = -29
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "bRY" = (
@@ -43237,6 +43206,9 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "bRZ" = (
@@ -43251,6 +43223,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/food_cart,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "bSa" = (
@@ -43600,10 +43573,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/hydroponics)
-"bSW" = (
-/obj/machinery/smartfridge,
-/turf/closed/wall,
 /area/hydroponics)
 "bSX" = (
 /obj/effect/turf_decal/stripes/line{
@@ -44110,10 +44079,6 @@
 /area/hallway/primary/central)
 "bUc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/sign/departments/botany{
-	pixel_x = 32;
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -44137,6 +44102,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/structure/sign/departments/botany{
+	pixel_x = 32;
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bUe" = (
@@ -44150,7 +44119,7 @@
 /obj/structure/noticeboard{
 	desc = "A board for pinning important notices upon. Probably helpful for keeping track of requests.";
 	name = "requests board";
-	pixel_y = 32
+	pixel_y = 28
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -45226,10 +45195,6 @@
 /area/hallway/primary/central)
 "bWG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -46493,13 +46458,16 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bZv" = (
-/obj/machinery/biogenerator,
 /obj/machinery/light_switch{
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/table/glass,
+/obj/item/clothing/accessory/armband/hydro,
+/obj/item/clothing/suit/apron,
+/obj/item/wrench,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bZw" = (
@@ -69929,11 +69897,6 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating/airless,
 /area/science/xenobiology)
-"ddE" = (
-/obj/effect/landmark/start/cook,
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "ddF" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
@@ -71309,9 +71272,16 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "dik" = (
-/obj/structure/sign/poster/official/random,
-/turf/closed/wall,
-/area/crew_quarters/kitchen)
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/hallway/primary/central)
 "dil" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -72777,7 +72747,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "dDe" = (
-/obj/effect/landmark/event_spawn,
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -73082,6 +73055,20 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"ecJ" = (
+/obj/machinery/button/door{
+	id = "kitchenwindow";
+	name = "Window Shutter Control";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access_txt = "28"
+	},
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "eew" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/drinks/bottle/vodka{
@@ -73513,6 +73500,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -73661,6 +73649,17 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"hBB" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/mint,
+/obj/item/storage/box/donkpockets,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "hEP" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -74079,6 +74078,21 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"jZS" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/hallway/primary/central)
 "kcI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/janitor,
@@ -74144,14 +74158,6 @@
 "krD" = (
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
-"kwI" = (
-/obj/item/wrench,
-/obj/item/clothing/suit/apron,
-/obj/item/clothing/accessory/armband/hydro,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "kwL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -74275,6 +74281,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"kWu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/deepfryer,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "lal" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -74373,6 +74387,20 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lyI" = (
+/obj/machinery/camera{
+	c_tag = "Kitchen";
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/kitchen";
+	name = "Kitchen APC";
+	pixel_y = -23
+	},
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "lzk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
@@ -74406,6 +74434,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lSe" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/hallway/primary/central)
 "lUr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -74570,6 +74606,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"mCX" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "mGS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -75122,6 +75162,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"peH" = (
+/obj/effect/landmark/start/cook,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "pgY" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -75257,7 +75302,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -75461,6 +75505,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"qVp" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "qZf" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -75558,6 +75612,11 @@
 "rAF" = (
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
+"rBy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/smartfridge,
+/turf/closed/wall,
+/area/hydroponics)
 "rBU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75580,6 +75639,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"rOP" = (
+/obj/structure/sign/poster/official/random,
+/turf/closed/wall,
+/area/crew_quarters/bar)
 "rQK" = (
 /obj/structure/chair{
 	dir = 4
@@ -75778,12 +75841,30 @@
 "sJW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/engine/break_room)
+"sKL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sLd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"sPc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sQe" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -76084,6 +76165,13 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"vaY" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/area/crew_quarters/kitchen/coldroom)
 "vgd" = (
 /obj/item/taperecorder,
 /obj/item/camera,
@@ -76120,6 +76208,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"vuY" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "vwi" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -76311,6 +76409,18 @@
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"woI" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "wpK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -76343,6 +76453,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"wyV" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "wAn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -108706,14 +108822,14 @@ bBQ
 bDz
 bFg
 bGV
-bGV
 bKc
+bSQ
 bLH
 bNt
 bOO
 bQz
 bRO
-bSQ
+sKL
 bUb
 bVb
 bWG
@@ -108963,9 +109079,9 @@ bBR
 bDA
 bFh
 bGW
-bIr
 aZa
 aWf
+sPc
 aWf
 aWf
 aWf
@@ -109220,8 +109336,8 @@ byw
 bDB
 bFi
 bGX
-bIs
 bKd
+bIs
 bIs
 bNu
 bIs
@@ -109477,14 +109593,14 @@ bBS
 bDC
 bFj
 bGY
-bmP
+rOP
 dik
-bKe
+lSe
 bNv
 bOP
 bOP
-bKe
-bSS
+lSe
+jZS
 bUd
 bVq
 bWJ
@@ -109739,8 +109855,8 @@ bKe
 bLI
 bNw
 bOQ
-bQA
-bRP
+bOQ
+bLI
 bST
 bUe
 bVr
@@ -109996,8 +110112,8 @@ bKe
 bLJ
 bNx
 bOR
-bLP
-bRQ
+bLK
+ecJ
 bST
 bUf
 bVs
@@ -110250,9 +110366,9 @@ bFk
 bGZ
 bBT
 bKf
-bLK
-bNy
-bOS
+bLN
+bNx
+wyV
 pVb
 bRR
 bST
@@ -110508,7 +110624,7 @@ bHb
 bMP
 bKg
 bLL
-bLL
+kWu
 bOT
 bQC
 bLK
@@ -110765,11 +110881,11 @@ bHc
 bIw
 bKh
 bLM
-bLK
-bOU
+hBB
+bOS
 bQD
-bRS
-oub
+lyI
+bST
 bUi
 bVu
 bWO
@@ -111023,7 +111139,7 @@ bBT
 bKi
 bLN
 dDe
-bOV
+bRQ
 bQD
 bRT
 bST
@@ -111276,14 +111392,14 @@ bBT
 bwO
 bFk
 bwO
-bBT
+woI
 bKj
 bLN
-bLK
-ddE
+vuY
+bRS
 bQF
 grA
-bSV
+rBy
 bUk
 bVv
 bWQ
@@ -111536,11 +111652,11 @@ dhT
 bmP
 bKe
 bLO
-bNB
-bNB
+qVp
+peH
 bNB
 bRU
-bSW
+bSV
 bUh
 bVw
 dDl
@@ -111797,8 +111913,8 @@ bNC
 bOW
 bQH
 bRV
-bST
-kwI
+mCX
+bUh
 bVx
 bWS
 bYi
@@ -112054,7 +112170,7 @@ bKe
 bKe
 bKe
 bRW
-bST
+oub
 bUm
 pgY
 bWT
@@ -112566,7 +112682,7 @@ bKm
 rUK
 bNE
 dbn
-dbn
+vaY
 bRY
 bST
 bUo
@@ -112825,9 +112941,9 @@ bNF
 bOZ
 bQJ
 bRZ
-rUK
-rUK
-rUK
+bST
+bST
+bST
 bST
 bST
 bST

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -39086,6 +39086,7 @@
 "bIs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bIt" = (
@@ -39889,7 +39890,6 @@
 	id = "kitchen";
 	name = "Serving Hatch"
 	},
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -40519,9 +40519,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bLK" = (
@@ -40531,9 +40529,6 @@
 /area/crew_quarters/kitchen)
 "bLL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -40542,25 +40537,17 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
 "bLN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
 "bLO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
@@ -41336,6 +41323,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNv" = (
@@ -41346,9 +41334,8 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41359,6 +41346,7 @@
 	id = "kitchenwindow"
 	},
 /obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -41372,8 +41360,10 @@
 	},
 /area/crew_quarters/kitchen)
 "bNB" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -41895,9 +41885,11 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side{
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bOQ" = (
 /obj/machinery/door/poddoor/preopen{
@@ -42615,12 +42607,18 @@
 /area/hallway/primary/central)
 "bQC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
 "bQD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -42630,6 +42628,9 @@
 "bQF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -42646,6 +42647,9 @@
 /area/crew_quarters/kitchen)
 "bQI" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "bQJ" = (
@@ -43101,17 +43105,7 @@
 /area/crew_quarters/kitchen)
 "bRS" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
 /obj/item/kitchen/rollingpin,
-/obj/machinery/camera{
-	c_tag = "Kitchen";
-	dir = 1
-	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bRT" = (
@@ -43121,14 +43115,6 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/structure/cable,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 6
-	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -43182,7 +43168,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
@@ -43202,9 +43188,6 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "bRZ" = (
@@ -44126,6 +44109,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bUh" = (
@@ -45806,8 +45790,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "bYc" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/structure/window/spawner/east,
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/grass,
 /area/hallway/primary/central)
 "bYd" = (
 /obj/machinery/door/firedoor,
@@ -45818,9 +45808,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bYe" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/paper/guides/jobs/hydroponics,
 /obj/machinery/requests_console{
@@ -71274,9 +71261,8 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dil" = (
 /obj/machinery/light/small{
@@ -73018,6 +73004,15 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
+"dVQ" = (
+/obj/structure/window/spawner/west,
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "dVT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -73120,6 +73115,17 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"eza" = (
+/obj/structure/window/spawner/west,
+/obj/structure/window/spawner/east,
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/floor/grass,
+/area/hallway/primary/central)
 "eAa" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -73508,6 +73514,14 @@
 	},
 /turf/open/floor/plating,
 /area/science/nanite)
+"gwH" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gAj" = (
 /obj/structure/closet/secure_closet/chemical{
 	pixel_x = -3
@@ -74085,9 +74099,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kcI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -74434,9 +74446,8 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lUr" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -74759,15 +74770,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"nvp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "nwq" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/sign/poster/contraband/random{
@@ -75307,6 +75309,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -75432,6 +75437,15 @@
 "qBq" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/hallway/secondary/entry)
+"qBD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "qBS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -75501,6 +75515,24 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"qOS" = (
+/obj/machinery/door/poddoor/preopen{
+	name = "kitchen shutters";
+	id = "kitchenwindow"
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "qUR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -75511,7 +75543,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "qVp" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -76173,7 +76204,7 @@
 "vaY" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
@@ -76248,6 +76279,14 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port)
+"vAE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "vDb" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
@@ -76292,6 +76331,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
+"vLs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "vLD" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -108838,7 +108886,7 @@ sKL
 bUb
 bVb
 bWG
-bSS
+dVQ
 bSS
 bSS
 bSS
@@ -109347,7 +109395,7 @@ bIs
 bNu
 bIs
 bIs
-bIs
+vLs
 bSR
 bUc
 bVp
@@ -109603,13 +109651,13 @@ dik
 lSe
 bNv
 bOP
-bOP
+gwH
 lSe
 jZS
 bUd
 bVq
 bWJ
-bYc
+eza
 bZs
 aWf
 ccr
@@ -109860,7 +109908,7 @@ bKe
 bLI
 bNw
 bOQ
-bOQ
+qOS
 bLI
 bST
 bUe
@@ -110115,9 +110163,9 @@ bHa
 bIu
 bKe
 bLJ
-bNx
-bOR
-bLK
+qBD
+peH
+vAE
 ecJ
 bST
 bUf
@@ -110371,7 +110419,7 @@ bFk
 bGZ
 bBT
 bKf
-bLN
+bLK
 bNx
 wyV
 pVb
@@ -111145,7 +111193,7 @@ bKi
 bLN
 dDe
 bRQ
-nvp
+bQD
 bRT
 bST
 bUj
@@ -111399,7 +111447,7 @@ bFk
 bwO
 woI
 bKj
-bLN
+bLK
 vuY
 bRS
 bQF
@@ -111658,7 +111706,7 @@ bmP
 bKe
 bLO
 qVp
-peH
+bOR
 bNB
 bRU
 bSV

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -41913,7 +41913,8 @@
 /area/crew_quarters/kitchen)
 "bOT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/deepfryer,
+/obj/structure/table,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -43104,8 +43105,7 @@
 	},
 /area/crew_quarters/kitchen)
 "bRS" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
+/obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bRT" = (
@@ -72733,6 +72733,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/item/book/manual/wiki/cooking_to_serve_man,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -74291,10 +74292,10 @@
 /area/maintenance/starboard/secondary)
 "kWu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/deepfryer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "lal" = (
@@ -76245,11 +76246,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "vuY" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -41347,6 +41347,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -41897,6 +41898,7 @@
 	id = "kitchenwindow"
 	},
 /obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -43531,6 +43533,7 @@
 	name = "Service Door";
 	req_one_access_txt = "35;28"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -43551,6 +43554,10 @@
 	req_one_access_txt = "30;35"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchenhydro";
+	name = "Service Shutter"
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bSX" = (
@@ -74616,6 +74623,7 @@
 /area/engine/storage_shared)
 "mCX" = (
 /obj/machinery/biogenerator,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "mGS" = (
@@ -75530,6 +75538,7 @@
 	pixel_x = 8;
 	pixel_y = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -41356,7 +41356,6 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	name = "kitchen shutters";
-	step_x = 0;
 	id = "kitchenwindow"
 	},
 /obj/structure/table/reinforced,
@@ -41903,7 +41902,6 @@
 "bOQ" = (
 /obj/machinery/door/poddoor/preopen{
 	name = "kitchen shutters";
-	step_x = 0;
 	id = "kitchenwindow"
 	},
 /obj/structure/table/reinforced,
@@ -43125,13 +43123,11 @@
 /obj/structure/cable,
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -7;
-	pixel_y = -3;
-	step_x = 0
+	pixel_y = -3
 	},
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -8;
-	pixel_y = 6;
-	step_x = 0
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -74763,6 +74763,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"nvp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "nwq" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/sign/poster/contraband/random{
@@ -111140,7 +111149,7 @@ bKi
 bLN
 dDe
 bRQ
-bQD
+nvp
 bRT
 bST
 bUj


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This was primarily to get the biogenerator in botany to be shared with the kitchen. That goal has been reached. The kitchen underwent some remodeling with this change. Seating was added to the hallway, and the layout of the room has been reworked.

![biogenerator shared v4](https://user-images.githubusercontent.com/6491940/70718882-ae2c8400-1cb6-11ea-9ef2-eccbcc142565.PNG)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The hallway seating has more people involved in hallway activities creating more interactions.
If you want to eat you do not have to enter the bar, if you do not like alcohol, or people are getting crazy in the bar. 
The line of the hall was pushed back for the Botany counter, and this keeps the nice visual flow.
Lets the Chefs interact with more people having a second window.
Give a nice prep table to the cooks, the old one was to small to work with, more so if you had two cooks.
The Biogenerator is the source of milf and stuff that the chefs need, they should have access to it. and it gives botany a reason to dump stuff in it constantly if they want more food.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Moved the Biogenerator to be shared with the kitchen
add: Hallway counter to the kitchen
tweak: Changed the layout of the kitchen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
