### PR TITLE
[WIP] Removes the E.X.P.E.R.I-Mentor from all active maps in preparation for remapping on Meta

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -30464,10 +30464,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bAR" = (
-/obj/machinery/rnd/experimentor,
-/turf/open/floor/engine,
-/area/science/explab)
 "bAS" = (
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
@@ -49849,7 +49845,6 @@
 "ifv" = (
 /obj/structure/table,
 /obj/item/clipboard,
-/obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
@@ -50228,9 +50223,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "kxC" = (
-/obj/machinery/computer/rdconsole/experiment{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -101905,7 +101897,7 @@ bvO
 nbv
 bqe
 bzO
-bAR
+bzO
 bzO
 bqe
 uUy

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -92854,7 +92854,6 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/experimentor,
 /obj/item/healthanalyzer,
 /obj/machinery/light_switch{
 	pixel_x = -26
@@ -92900,9 +92899,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/computer/rdconsole/experiment{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -95007,11 +95003,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "duw" = (
-/turf/open/floor/engine,
-/area/science/explab)
-"dux" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
 /area/science/explab)
 "duy" = (
@@ -146043,7 +146034,7 @@ dou
 dqk
 drJ
 qVd
-dux
+duy
 dwe
 djA
 dzo

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -1489,7 +1489,6 @@
 	},
 /area/science/explab)
 "adH" = (
-/obj/machinery/computer/rdconsole/experiment,
 /turf/open/floor/plasteel/white/corner,
 /area/science/explab)
 "adI" = (
@@ -1502,7 +1501,6 @@
 /area/security/prison)
 "adJ" = (
 /obj/structure/table,
-/obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
@@ -19760,9 +19758,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "bcm" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/science/explab)
@@ -20468,8 +20463,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bef" = (
-/obj/machinery/rnd/experimentor,
 /obj/effect/landmark/blobstart,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/science/explab)
 "beg" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -16135,10 +16135,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "ayT" = (
-/obj/machinery/computer/rdconsole/experiment{
-	icon_state = "computer";
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -16251,21 +16247,16 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "aza" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery,
-/obj/item/folder/white,
-/obj/item/pen,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters";
 	name = "Chemistry Lobby Shutters"
 	},
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Chemistry Desk";
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
 	req_access_txt = "5; 33"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
 "azb" = (
 /obj/machinery/door/firedoor,
@@ -16943,15 +16934,15 @@
 "aAc" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
-/obj/item/folder/yellow,
+/obj/item/folder/white,
 /obj/item/pen,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters_2";
-	name = "Chemistry Hall Shutters"
+	id = "chemistry_shutters";
+	name = "Chemistry Lobby Shutters"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/window/northleft{
-	dir = 8;
+	dir = 2;
 	name = "Chemistry Desk";
 	req_access_txt = "5; 33"
 	},
@@ -26045,15 +26036,22 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/cryo)
 "aNZ" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters";
-	name = "Chemistry Lobby Shutters"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab";
 	req_access_txt = "5; 33"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
 "aOa" = (
@@ -32837,7 +32835,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "aXo" = (
-/obj/machinery/rnd/experimentor,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/science/explab)
@@ -34916,23 +34913,21 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bae" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/delivery,
+/obj/item/folder/yellow,
+/obj/item/pen,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemistry_shutters_2";
+	name = "Chemistry Hall Shutters"
 	},
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab";
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	name = "Chemistry Desk";
 	req_access_txt = "5; 33"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/medical/chemistry)
 "baf" = (
 /obj/effect/turf_decal/tile/red,
@@ -37548,7 +37543,6 @@
 /obj/item/folder{
 	pixel_x = -6
 	},
-/obj/item/book/manual/wiki/experimentor,
 /obj/item/pen,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -116533,7 +116527,7 @@ aNm
 aQb
 aNn
 aQV
-bae
+aNZ
 aRn
 aQW
 aQW
@@ -117560,7 +117554,7 @@ aSY
 aSY
 aYC
 aTv
-aNZ
+aza
 aUF
 bdO
 beA
@@ -118074,7 +118068,7 @@ aTA
 aVx
 aRZ
 aSl
-aza
+aAc
 aSw
 aRO
 baR
@@ -118592,7 +118586,7 @@ aQW
 aWx
 aQW
 aSg
-aAc
+bae
 aSg
 bAN
 bAN

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -50953,7 +50953,7 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "ciU" = (
-/obj/machinery/rnd/experimentor,
+/obj/item/target/syndicate,
 /turf/open/floor/engine,
 /area/science/explab)
 "ciV" = (
@@ -52676,15 +52676,33 @@
 /turf/open/floor/plasteel,
 /area/science/explab)
 "cmT" = (
-/obj/machinery/computer/rdconsole/experiment,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = 4
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel,
 /area/science/explab)
 "cmU" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
-/obj/item/book/manual/wiki/experimentor,
 /obj/effect/turf_decal/stripes/line,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/mask/gas,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/multitool{
+	pixel_x = 3
+	},
 /turf/open/floor/plasteel,
 /area/science/explab)
 "cmV" = (
@@ -53406,20 +53424,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "com" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_y = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -53437,15 +53443,6 @@
 "coo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/wrench,
-/obj/item/crowbar,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/science,
-/obj/item/multitool{
-	pixel_x = 3
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -54800,6 +54797,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/target/syndicate,
+/obj/item/target/syndicate,
+/obj/item/target/clown,
+/obj/item/target/clown,
+/obj/item/target/alien,
+/obj/item/target/alien,
+/obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/science/explab)
 "cqX" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -24862,10 +24862,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"blQ" = (
-/obj/machinery/rnd/experimentor,
-/turf/open/floor/engine,
-/area/science/explab)
 "blR" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/landmark/xeno_spawn,
@@ -24876,7 +24872,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/engine,
 /area/science/explab)
 "blX" = (
@@ -25001,9 +24996,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmt" = (
-/turf/open/floor/plasteel,
-/area/security/checkpoint/medical)
-"bmu" = (
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmv" = (
@@ -25806,11 +25798,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
-"boI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/medical/medbay/central)
 "boJ" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -26034,7 +26021,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpe" = (
-/obj/machinery/computer/rdconsole/experiment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -26936,19 +26922,6 @@
 	dir = 4
 	},
 /obj/machinery/computer/crew,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"brh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bri" = (
@@ -86394,7 +86367,7 @@ bim
 bjb
 bjY
 bli
-bmu
+bmt
 bnB
 boF
 bpO
@@ -86651,7 +86624,7 @@ bik
 bja
 bjZ
 blj
-bmu
+bmt
 bnC
 boG
 brg
@@ -87163,11 +87136,11 @@ aJI
 aDZ
 bik
 bjc
-boI
-boI
-boI
-boI
-boI
+boH
+boH
+boH
+boH
+boH
 bsG
 bri
 gfo
@@ -87424,7 +87397,7 @@ bkc
 bll
 bmw
 bkh
-boI
+boH
 bpR
 bri
 jWH
@@ -97701,7 +97674,7 @@ aEj
 aTx
 bjw
 bkz
-blQ
+bky
 bmW
 bnW
 bpe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I get the feeling this is gonna be a veeeeeeeery controversial change, despite very little use coming of the thing lately. All it really does is give you a small bit of research for clicking the correct button with a strange object. Unless we make those easier to find or up the research value (currently sitting around 3k points), this is pretty damn well useless, and taking up valuable space on Meta I plan on using for moving Xenobiology closer to the main station. Due to feature parity, if I remove it from one, it goes from all of them.

I made this as a separate PR so that I have options as to what can be done regarding whether or not the playerbase wants it gone. Note that this only removes it from maps - nothing prevents you from building it using the circuit printer.

## Why It's Good For The Game

It's using up valuable space we can use for other features and, despite being around for quite some time, never really fulfilled its purpose.

## Changelog
:cl:
del: The E.X.P.E.R.I-Mentor has been removed from all maps in preparation for a science mapping overhaul on Metastation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
