### PR TITLE
Radiation Collectors can now be upgraded

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -48,9 +48,9 @@
 	return anchored
 
 /obj/machinery/power/rad_collector/RefreshParts()
-	var/coefficient
-	var/efficiency
-	var/miningrate
+	var/coefficient = 0
+	var/efficiency = 0
+	var/miningrate = 0
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 		coefficient += 2/3+M.rating/3
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -62,7 +62,7 @@
 	drainratio = 1/(coefficient*miningrate)
 	mining_conversion_rate = efficiency*miningrate*RAD_COLLECTOR_MINING_CONVERSION_RATE
 
-/obj/machinery/power/rad_collector/
+/obj/machinery/power/rad_collector/Initialize()
 	. = ..()
 	RefreshParts()
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -57,10 +57,14 @@
 		miningrate += 2/3+C.rating/3
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		efficiency += 4/3-M.rating/3
-	collector_efficiency == efficiency*RAD_COLLECTOR_EFFICIENCY
-	collector_coefficient == coefficient*RAD_COLLECTOR_COEFFICIENT
-	drainratio == 1/(coefficient*miningrate)
-	mining_conversion_rate == efficiency*miningrate*RAD_COLLECTOR_MINING_CONVERSION_RATE
+	collector_efficiency = efficiency*RAD_COLLECTOR_EFFICIENCY
+	collector_coefficient = coefficient*RAD_COLLECTOR_COEFFICIENT
+	drainratio = 1/(coefficient*miningrate)
+	mining_conversion_rate = efficiency*miningrate*RAD_COLLECTOR_MINING_CONVERSION_RATE
+
+/obj/machinery/power/rad_collector/
+	. = ..()
+	RefreshParts()
 
 /obj/machinery/power/rad_collector/process()
 	if(!loaded_tank)


### PR DESCRIPTION
Radiation collectors can now be upgraded. Technically, they could already be upgraded, but improved parts didn't give any benefit.

The effects with fully upgraded parts are:
1: 2x power output.
2: No minimum radiation pulse strength to generate power (also boosts power output compared to unupgraded, depending on the radiation pulse strength).
3: 4x research and money output in research mode.
4: 1/4th as much gas drain in research mode.

This ought to give more incentive for actually using rad collectors for research, and also makes memes like uranium floor engines possible with upgraded collectors.

If people think anything needs to be tweaked up or down, I'm open to suggestions.

:cl: 
tweak: Nanotrasen has updated the firmware used by radiation collectors, they can now make use of upgraded parts to improve performance.
/:cl: