### PR TITLE
Fixes explosion runtime.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -405,7 +405,8 @@
 			if(bomb_armor < EXPLODE_GIB_THRESHOLD) //gibs the mob if their bomb armor is lower than EXPLODE_GIB_THRESHOLD
 				for(var/I in contents)
 					var/atom/A = I
-					A.ex_act(severity)
+					if(!QDELETED(A))
+						A.ex_act(severity)
 				gib()
 				return
 			else


### PR DESCRIPTION
Scenario A:
Human equipment blown up and qdeled, human pushed by pressure into neighbouring tile, ex act on human.
Scenerio B:
Human blown up in explosion epicenter. And of course that awful epicenter code does it twice.
