### PR TITLE
Mining Skill is Now Exclusive To Dedicated Mining Tools, Not Weapons That Double As Mining Tools.

### DIFF
--- a/code/datums/skills/mining.dm
+++ b/code/datums/skills/mining.dm
@@ -5,16 +5,16 @@
 /datum/skill/mining/get_skill_speed_modifier(level)
 	switch(level)
 		if(SKILL_LEVEL_NONE)
-			return 1.3
-		if(SKILL_LEVEL_NOVICE)
-			return 1.2
-		if(SKILL_LEVEL_APPRENTICE)
-			return 1.1
-		if(SKILL_LEVEL_JOURNEYMAN)
 			return 1
-		if(SKILL_LEVEL_EXPERT)
+		if(SKILL_LEVEL_NOVICE)
+			return 0.95
+		if(SKILL_LEVEL_APPRENTICE)
 			return 0.9
-		if(SKILL_LEVEL_MASTER)
+		if(SKILL_LEVEL_JOURNEYMAN)
+			return 0.85
+		if(SKILL_LEVEL_EXPERT)
 			return 0.75
+		if(SKILL_LEVEL_MASTER)
+			return 0.65
 		if(SKILL_LEVEL_LEGENDARY)
 			return 0.5

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -551,7 +551,7 @@
 		to_chat(usr, "<span class='warning'>The rock seems to be too strong to destroy. Maybe I can break it once I become a master miner.</span>")
 
 
-/turf/closed/mineral/strong/gets_drilled(user, give_exp = TRUE)
+/turf/closed/mineral/strong/gets_drilled(mob/user)
 	drop_ores()
 	var/flags = NONE
 	if(defer_change) // TODO: make the defer change var a var for any changeturf flag
@@ -559,7 +559,9 @@
 	ScrapeAway(flags=flags)
 	addtimer(CALLBACK(src, .proc/AfterChange), 1, TIMER_UNIQUE)
 	playsound(src, 'sound/effects/break_stone.ogg', 50, TRUE) //beautiful destruction
-	user.mind.adjust_experience(/datum/skill/mining, 100) //yay!
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.mind.adjust_experience(/datum/skill/mining, 100) //yay!
 
 /turf/closed/mineral/strong/proc/drop_ores()
 	if(prob(10))

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -552,6 +552,11 @@
 
 
 /turf/closed/mineral/strong/gets_drilled(mob/user)
+	if(!ishuman(user))
+		return // see attackby
+	var/mob/living/carbon/human/H = user
+	if(!(H.mind.get_skill_level(/datum/skill/mining) >= SKILL_LEVEL_MASTER))
+		return
 	drop_ores()
 	var/flags = NONE
 	if(defer_change) // TODO: make the defer change var a var for any changeturf flag
@@ -559,9 +564,7 @@
 	ScrapeAway(flags=flags)
 	addtimer(CALLBACK(src, .proc/AfterChange), 1, TIMER_UNIQUE)
 	playsound(src, 'sound/effects/break_stone.ogg', 50, TRUE) //beautiful destruction
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		H.mind.adjust_experience(/datum/skill/mining, 100) //yay!
+	H.mind.adjust_experience(/datum/skill/mining, 100) //yay!
 
 /turf/closed/mineral/strong/proc/drop_ores()
 	if(prob(10))

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -64,12 +64,12 @@
 		if(I.use_tool(src, user, 40, volume=50))
 			if(ismineralturf(src))
 				to_chat(user, "<span class='notice'>You finish cutting into the rock.</span>")
-				gets_drilled(user)
+				gets_drilled(user, TRUE)
 				SSblackbox.record_feedback("tally", "pick_used_mining", 1, I.type)
 	else
 		return attack_hand(user)
 
-/turf/closed/mineral/proc/gets_drilled(user, give_exp = TRUE)
+/turf/closed/mineral/proc/gets_drilled(user, give_exp = FALSE)
 	if (mineralType && (mineralAmt > 0))
 		new mineralType(src, mineralAmt)
 		SSblackbox.record_feedback("tally", "ore_mined", mineralAmt, mineralType)
@@ -126,12 +126,12 @@
 	switch(severity)
 		if(3)
 			if (prob(75))
-				gets_drilled(null, 1)
+				gets_drilled(null, FALSE)
 		if(2)
 			if (prob(90))
-				gets_drilled(null, 1)
+				gets_drilled(null, FALSE)
 		if(1)
-			gets_drilled(null, 1)
+			gets_drilled(null, FALSE)
 	return
 
 /turf/closed/mineral/Spread(turf/T)
@@ -545,13 +545,13 @@
 		to_chat(usr, "<span class='warning'>Only a more advanced species could break a rock such as this one!</span>")
 		return FALSE
 	var/mob/living/carbon/human/H = user
-	if(H.mind.get_skill_level(/datum/skill/mining) >= SKILL_LEVEL_LEGENDARY)
+	if(H.mind.get_skill_level(/datum/skill/mining) >= SKILL_LEVEL_MASTER)
 		. = ..()
 	else
 		to_chat(usr, "<span class='warning'>The rock seems to be too strong to destroy. Maybe I can break it once I become a master miner.</span>")
 
 
-/turf/closed/mineral/strong/gets_drilled(user)
+/turf/closed/mineral/strong/gets_drilled(user, give_exp = TRUE)
 	drop_ores()
 	var/flags = NONE
 	if(defer_change) // TODO: make the defer change var a var for any changeturf flag
@@ -559,6 +559,7 @@
 	ScrapeAway(flags=flags)
 	addtimer(CALLBACK(src, .proc/AfterChange), 1, TIMER_UNIQUE)
 	playsound(src, 'sound/effects/break_stone.ogg', 50, TRUE) //beautiful destruction
+	H.mind.adjust_experience(/datum/skill/mining, 100) //yay!
 
 /turf/closed/mineral/strong/proc/drop_ores()
 	if(prob(10))

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -559,7 +559,7 @@
 	ScrapeAway(flags=flags)
 	addtimer(CALLBACK(src, .proc/AfterChange), 1, TIMER_UNIQUE)
 	playsound(src, 'sound/effects/break_stone.ogg', 50, TRUE) //beautiful destruction
-	H.mind.adjust_experience(/datum/skill/mining, 100) //yay!
+	user.mind.adjust_experience(/datum/skill/mining, 100) //yay!
 
 /turf/closed/mineral/strong/proc/drop_ores()
 	if(prob(10))

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -134,13 +134,6 @@
 		carried = 1
 
 	deltimer(recharge_timerid)
-	
-	var/skill_modifier = 1
-	if(ishuman(holder))
-		var/mob/living/carbon/human/H = holder
-		if(H.mind)
-			skill_modifier = H.mind.get_skill_speed_modifier(/datum/skill/mining)
-
 	recharge_timerid = addtimer(CALLBACK(src, .proc/reload), recharge_time * carried * skill_modifier, TIMER_STOPPABLE)
 
 /obj/item/gun/energy/kinetic_accelerator/emp_act(severity)

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -134,7 +134,7 @@
 		carried = 1
 
 	deltimer(recharge_timerid)
-	recharge_timerid = addtimer(CALLBACK(src, .proc/reload), recharge_time * carried * skill_modifier, TIMER_STOPPABLE)
+	recharge_timerid = addtimer(CALLBACK(src, .proc/reload), recharge_time * carried, TIMER_STOPPABLE)
 
 /obj/item/gun/energy/kinetic_accelerator/emp_act(severity)
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
closes #47521

## About The Pull Request
Mining skill was more of a concept run of skills. Why I do like the skill system, I think mining definitely needed some tweaks to further it into the reward mechanic I wanted it to be and not so much a combat-oriented one.

As such I've removed it from the "futuristic" type of tools and set it to classical tools such as pickaxes and drills.

You will also only receive XP from mining in this matter. No Hierophant staff shenanigans or bombing to raise mining. Only getting down and dirty with a dedicated tool will boost the skill!

Since it no longer affects weapons like the KA, I have now change the skill shifts similarly to how I used the medical skill.

  | Old | New | % Difference
-- | -- | -- | --
Noob | 1.30 | 1.00 (no penalty/boost) | 0.26
Novice | 1.20 | 0.95 | 0.23
Appr | 1.10 | 0.90 | 0.20
Journey | 1.00 (no penalty/boost) | 0.85 | 0.16
Exp | 0.90 | 0.75 | 0.18
Master | 0.75 | 0.65 | 0.14
Legend | 0.50 | 0.50 | 0.00

Minorly, I've also made it so it takes only a Master level to hit the mythril rock since it's more difficult to level (i'm assuming cheesing was accounted for).

Basically, I took my approach used with the medical skill and applied it to mining.

Also i'm not seeing where miners get free XP. I don't think they do since I ran through the code, but if you see it let me know since I was planning on taking that out here as well.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The mining skill was nearly doubling as a combat skill, and I think it was negatively impacting the game and hurting the reputation of the system. 

Doing it this way brings it more in line with the traditional sense of skilling/mining as well as help stop wacky stuff like "mining makes you a better bowman" or "mining helps you kill bosses" or "nuking lavaland makes you a better miner that can shoot bows faster and kill bosses more rapidly".

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Miningby
balance: Mining skill only affects tools like pickaxe/drill, and the skill can only be gained by using such tools
balance: Mining tools have been returned to their previous speed, and mining skill boosts this speed further. Previously mining skill lowered the speed and brought it back to normal after reaching certain levels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
