### PR TITLE
E.X.P.E.R.I-Mentor Overhaul Part the First: Research Notes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -26871,6 +26871,7 @@
 	},
 /obj/item/folder/white,
 /obj/item/pen,
+/obj/item/relic,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "brt" = (
@@ -49850,6 +49851,7 @@
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/book/manual/wiki/experimentor,
+/obj/item/relic,
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -92878,6 +92878,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/item/relic,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "dqk" = (
@@ -103169,6 +103170,7 @@
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = -32
 	},
+/obj/item/relic,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dJY" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -1503,6 +1503,7 @@
 "adJ" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/experimentor,
+/obj/item/relic,
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
@@ -36363,6 +36364,7 @@
 /obj/item/circuitboard/computer/arcade/battle,
 /obj/item/circuitboard/machine/microwave,
 /obj/item/book/manual/wiki/research_and_development,
+/obj/item/relic,
 /turf/open/floor/plating,
 /area/science/research)
 "bRC" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -7478,9 +7478,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/item/relic,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "alP" = (
@@ -44275,6 +44273,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/item/relic,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bnf" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -46893,6 +46893,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/item/relic,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cav" = (
@@ -75875,6 +75876,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"tEg" = (
+/obj/item/relic,
+/turf/open/floor/engine,
+/area/science/explab)
 "tFJ" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -111553,7 +111558,7 @@ ceZ
 cgq
 chy
 ciU
-chx
+tEg
 clU
 cmT
 con

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -26064,6 +26064,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/relic,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpn" = (

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -84,6 +84,10 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/toy/crayon/spraycan = 1,
 		) = 1,
 
+	list(//strange objects
+		/obj/item/relic = 5,
+		) = 1,
+
 	list(//equipment
 		/obj/item/clothing/mask/gas = 1,
 		/obj/item/radio/headset = 1,
@@ -198,7 +202,7 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		list(//medical chems
 			/obj/item/reagent_containers/glass/bottle/multiver = 1,
 			/obj/item/reagent_containers/syringe/convermol = 1,
-			) = 1, 
+			) = 1,
 		list(//drinks
 			/obj/item/reagent_containers/food/drinks/bottle/vodka = 1,
 			/obj/item/reagent_containers/food/drinks/soda_cans/grey_bull = 1,
@@ -215,11 +219,7 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/storage/box/donkpockets = 1,
 		/obj/item/reagent_containers/food/snacks/monkeycube = 1,
 		) = 1,
-
-	list(//strange objects
-		/obj/item/relic = 1,
-		) = 1,
-	))
+))
 
 GLOBAL_LIST_INIT(oddity_loot, list(//oddity: strange or crazy items
 	//keeping commented out until there are more, otherwise the same ones may appear too often

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -30,7 +30,7 @@ SUBSYSTEM_DEF(research)
 	var/list/errored_datums = list()
 	var/list/point_types = list()				//typecache style type = TRUE list
 	//----------------------------------------------
-	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 54.3)
+	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 53.3)
 	var/multiserver_calculation = FALSE
 	var/last_income
 	//^^^^^^^^ ALL OF THESE ARE PER SECOND! ^^^^^^^^

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -30,7 +30,7 @@ SUBSYSTEM_DEF(research)
 	var/list/errored_datums = list()
 	var/list/point_types = list()				//typecache style type = TRUE list
 	//----------------------------------------------
-	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 53.3)
+	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 52.3)
 	var/multiserver_calculation = FALSE
 	var/last_income
 	//^^^^^^^^ ALL OF THESE ARE PER SECOND! ^^^^^^^^

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -523,15 +523,19 @@
 			investigate_log("Experimentor has drained power from its APC", INVESTIGATE_EXPERIMENTOR)
 		if(globalMalf == 99)
 			visible_message("<span class='warning'>[src] begins to glow and vibrate. It's going to blow!")
-			sleep(50)
-			explosion(src, 1, 5, 10, 5, 1)
+			addtimer(CALLBACK(src, .proc/boom), 50)
 		if(globalMalf == 100)
 			visible_message("<span class='warning'>[src] begins to glow and vibrate. It's going to blow!")
-			sleep(50)
-			playsound(src, 'sound/items/bikehorn.ogg', 500)
-			new /obj/item/grown/bananapeel(loc)
+			addtimer(CALLBACK(src, .proc/honk), 50)
 
 	addtimer(CALLBACK(src, .proc/reset_exp), resetTime)
+
+/obj/machinery/rnd/experimentor/proc/boom()
+	explosion(src, 1, 5, 10, 5, 1)
+
+/obj/machinery/rnd/experimentor/proc/honk()
+	playsound(src, 'sound/items/bikehorn.ogg', 500)
+	new /obj/item/grown/bananapeel(loc)
 
 /obj/machinery/rnd/experimentor/proc/reset_exp()
 	update_icon()

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -241,7 +241,7 @@
 	smoke.start()
 
 
-/obj/machinery/rnd/experimentor/proc/experiment(exp,obj/item/exp_on)
+/obj/machinery/rnd/experimentor/proc/experiment(exp,obj/item/exp_on, mob/user)
 	recentlyExperimented = 1
 	icon_state = "h_lathe_wloop"
 	var/chosenchem
@@ -466,7 +466,7 @@
 		ejectItem(TRUE)
 	////////////////////////////////////////////////////////////////////////////////////////////////
 	if(exp == FAIL)
-		var/a = pick("rumbles","shakes","vibrates","shudders")
+		var/a = pick("rumbles","shakes","vibrates","shudders","honks")
 		var/b = pick("crushes","spins","viscerates","smashes","insults")
 		visible_message("<span class='warning'>[exp_on] [a], and [b], the experiment was a failure.</span>")
 
@@ -475,8 +475,8 @@
 		playsound(src, 'sound/effects/supermatter.ogg', 50, 3, -1)
 		var/obj/item/relic/R = loaded_item
 		if (!R.revealed)
-			var/points = rand(2500,2750) // discovery reward
-			SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points))
+			var/points = rand(3500,3750) // discovery reward
+			new /obj/item/research_notes(drop_location(src), points, "experimentation")
 			visible_message("<span class='notice'> This discovery netted [points] points for research.</span>")
 		R.reveal()
 		investigate_log("Experimentor has revealed a relic with <span class='danger'>[R.realProc]</span> effect.", INVESTIGATE_EXPERIMENTOR)
@@ -517,10 +517,19 @@
 				new /mob/living/simple_animal/pet/cat(loc)
 				investigate_log("Experimentor failed to steal runtime, and instead spawned a new cat.", INVESTIGATE_EXPERIMENTOR)
 			ejectItem(TRUE)
-		if(globalMalf > 76)
+		if(globalMalf > 76 && globalMalf < 98)
 			visible_message("<span class='warning'>[src] begins to smoke and hiss, shaking violently!</span>")
 			use_power(500000)
 			investigate_log("Experimentor has drained power from its APC", INVESTIGATE_EXPERIMENTOR)
+		if(globalMalf == 99)
+			visible_message("<span class='warning'>[src] begins to glow and vibrate. It's going to blow!")
+			sleep(50)
+			explosion(src, 1, 5, 10, 5, 1)
+		if(globalMalf == 100)
+			visible_message("<span class='warning'>[src] begins to glow and vibrate. It's going to blow!")
+			sleep(50)
+			playsound(src, 'sound/items/bikehorn.ogg', 500)
+			new /obj/item/grown/bananapeel(loc)
 
 	addtimer(CALLBACK(src, .proc/reset_exp), resetTime)
 
@@ -557,7 +566,7 @@
 
 /obj/item/relic
 	name = "strange object"
-	desc = "What mysteries could this hold?"
+	desc = "What mysteries could this hold? Maybe Research & Development could find out."
 	icon = 'icons/obj/assemblies.dmi'
 	var/realName = "defined object"
 	var/revealed = FALSE
@@ -589,7 +598,7 @@
 			call(src,realProc)(user)
 			addtimer(CALLBACK(src, .proc/cd), cooldownMax)
 	else
-		to_chat(user, "<span class='notice'>You aren't quite sure what to do with this yet.</span>")
+		to_chat(user, "<span class='notice'>You aren't quite sure what this is. Maybe R&D knows what to do with it?</span>")
 
 /obj/item/relic/proc/cd()
 	cooldown = FALSE

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -241,7 +241,7 @@
 	smoke.start()
 
 
-/obj/machinery/rnd/experimentor/proc/experiment(exp,obj/item/exp_on, mob/user)
+/obj/machinery/rnd/experimentor/proc/experiment(exp,obj/item/exp_on)
 	recentlyExperimented = 1
 	icon_state = "h_lathe_wloop"
 	var/chosenchem


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I was kind of surprised with my last PR to see people want to keep this thing around. I've always preferred refactor instead of remove, so screw it. Let's refactor.

Strange Objects now have a description that actually tell players what to do with it - a not-so-subtle hint to take the damn thing to R&D. After putting it in the machine and running discover, you'll get research notes that can be fed into the R&D console for anywhere from 3,500 to 3,750 points, up from 2,500 to 2,750. As a result of this being buffed, **overall passive point generation has been reduced by 2/s, a net loss of 7,200 over an hour**. To offset this, I've added two guaranteed Strange Object spawns on each map, one of which is in the experimentation lab, the other somewhere nearby in science.

I also added a few new 'bad thing' reactions for normal experimentation. There's a less than one percent chance it just completely fucking explodes. Odds are you'll never see this, but it does make things inherently dangerous, if only a little.

Todo in part 2: Increase the number of Strange Objects that spawn on the station, either come up with a way for normal experimentation to grant low amounts of research or have a chance to create a Strange Object, and add (relatively low!) failure chance to the Discovery experiment.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less passive, more active. I believe we eventually need to only be generating a small amount to start with, but have every department in Science contribute to points over time. Whether it's Roboticists creating cyborgs that can make points, geneticists getting research notes by getting powers or dissection, toxins getting points for different mixes and sizes of bombs, or XB getting points for submitting a wide array of cores, the end game here is for everything in science to, one way or another, contribute to the tech web.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Due to its age, the E.X.P.E.R.I-Mentor might be prone to exploding in very, very rare scenarios. Please take care in its use.
tweak: Increased the amount of research gained for discovering a strange object's true nature.
tweak: The E.X.P.E.R.I-Mentor will now produce research notes instead of feeding points directly into the server.
tweak: Strange objects have a more informational examine string.
balance: Reduced the overall amount of passive research generation by a small amount.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
