### PR TITLE
Moves "Observe" verb to ghost category

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -797,7 +797,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/verb/observe()
 	set name = "Observe"
-	set category = "OOC"
+	set category = "Ghost"
 
 	var/list/creatures = getpois()
 


### PR DESCRIPTION
I honestly thought this verb was removed because I couldn't find it anywhere, turns out it was in OOC category.

It should probably be moved to Ghost category, because Ghost category is all about observing and has all the other verbs for following mobs and other info and such.

For those who don't know it, Observe lets you view things from the perspective of another player, showing you their HUD and such.

:cl: 
Tweak: Moved the "Observe" verb to ghost tab
/:cl: