### PR TITLE
Adds a cooldown to the deathgasp emote

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -79,7 +79,7 @@
 	message_larva = "lets out a sickly hiss of air and falls limply to the floor..."
 	message_monkey = "lets out a faint chimper as it collapses and stops moving..."
 	message_simple =  "stops moving..."
-	cooldown = 150
+	cooldown = (15 SECONDS)
 	stat_allowed = UNCONSCIOUS
 
 /datum/emote/living/deathgasp/run_emote(mob/user, params, type_override, intentional)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -87,12 +87,17 @@
 		message_simple = S.deathmessage
 	. = ..()
 	message_simple = initial(message_simple)
+
 	if(. && user.deathsound)
 		if(isliving(user))
 			var/mob/living/L = user
+			var/cooldown = world.time
+			if(cooldown > world.time)
+				return //Still does the deathgasp but sound can't be spammed now
 			if(!L.can_speak_vocal() || L.oxyloss >= 50)
 				return //stop the sound if oxyloss too high/cant speak
 		playsound(user, user.deathsound, 200, TRUE, TRUE)
+		cooldown = world.time + 300 //30 seconds
 
 /datum/emote/living/drool
 	key = "drool"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -79,6 +79,7 @@
 	message_larva = "lets out a sickly hiss of air and falls limply to the floor..."
 	message_monkey = "lets out a faint chimper as it collapses and stops moving..."
 	message_simple =  "stops moving..."
+	cooldown = 150
 	stat_allowed = UNCONSCIOUS
 
 /datum/emote/living/deathgasp/run_emote(mob/user, params, type_override, intentional)
@@ -91,13 +92,9 @@
 	if(. && user.deathsound)
 		if(isliving(user))
 			var/mob/living/L = user
-			var/cooldown = world.time
-			if(cooldown > world.time)
-				return //Still does the deathgasp but sound can't be spammed now
 			if(!L.can_speak_vocal() || L.oxyloss >= 50)
 				return //stop the sound if oxyloss too high/cant speak
 		playsound(user, user.deathsound, 200, TRUE, TRUE)
-		cooldown = world.time + 300 //30 seconds
 
 /datum/emote/living/drool
 	key = "drool"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Yeah, yeah, I hate fun. The borg deathgasp sound is the most irritating thing in the universe. ~~30~~ 15 seconds but I'm super open to reducing it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
TARS shudders violently for a moment before falling still, its eyes slowly darkening.
TARS shudders violently for a moment before falling still, its eyes slowly darkening.
TARS shudders violently for a moment before falling still, its eyes slowly darkening.
TARS shudders violently for a moment before falling still, its eyes slowly darkening.
TARS shudders violently for a moment before falling still, its eyes slowly darkening.
TARS shudders violently for a moment before falling still, its eyes slowly darkening.
TARS shudders violently for a moment before falling still, its eyes slowly darkening.
TARS shudders violently for a moment before falling still, its eyes slowly darkening.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Adds a cooldown to the Deathgasp emote
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
