### PR TITLE
Max Payne and Problem Sleuth whiskeys

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -47,9 +47,24 @@
 	mood_change = -2
 	timeout = 4 MINUTES
 
-/datum/mood_event/depression
+/datum/mood_event/depression_minimal
+	description = "<span class='warning'>I feel a bit down.</span>\n"
+	mood_change = -10
+	timeout = 2 MINUTES
+
+/datum/mood_event/depression_mild
 	description = "<span class='warning'>I feel sad for no particular reason.</span>\n"
 	mood_change = -12
+	timeout = 2 MINUTES
+
+/datum/mood_event/depression_moderate
+	description = "<span class='warning'>I feel miserable.</span>\n"
+	mood_change = -14
+	timeout = 2 MINUTES
+
+/datum/mood_event/depression_severe
+	description = "<span class='warning'>I've lost all hope.</span>\n"
+	mood_change = -16
 	timeout = 2 MINUTES
 
 /datum/mood_event/shameful_suicide //suicide_acts that return SHAME, like sord

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -77,12 +77,12 @@
 	value = -1
 	gain_text = "<span class='danger'>You start feeling depressed.</span>"
 	lose_text = "<span class='notice'>You no longer feel depressed.</span>" //if only it were that easy!
-	medical_record_text = "Patient has a severe mood disorder, causing them to experience acute episodes of depression."
+	medical_record_text = "Patient has a mild mood disorder causing them to experience acute episodes of depression."
 	mood_quirk = TRUE
 
 /datum/quirk/depression/on_process()
 	if(prob(0.05))
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "depression", /datum/mood_event/depression)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "depression_mild", /datum/mood_event/depression_mild)
 
 /datum/quirk/family_heirloom
 	name = "Family Heirloom"

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -5,6 +5,11 @@
 //Bottles now knockdown and break when smashed on people's heads. - Giacom
 
 /obj/item/reagent_containers/food/drinks/bottle
+	name = "glass bottle"
+	desc = "This blank bottle is unyieldingly anonymous, offering no clues to its contents."
+	icon_state = "glassbottle"
+	fill_icon_thresholds = list(0, 10, 20, 30, 40, 50, 60, 70, 80, 90)
+	custom_price = 65
 	amount_per_transfer_from_this = 10
 	volume = 100
 	force = 15 //Smashing bottles over someone's head hurts.
@@ -16,6 +21,16 @@
 	isGlass = TRUE
 	foodtype = ALCOHOL
 
+/obj/item/reagent_containers/food/drinks/bottle/update_icon()
+	..()
+	add_overlay("[initial(icon_state)]shine")
+
+/obj/item/reagent_containers/food/drinks/bottle/small
+	name = "small glass bottle"
+	desc = "This blank bottle is unyieldingly anonymous, offering no clues to its contents."
+	icon_state = "glassbottlesmall"
+	volume = 50
+	custom_price = 55
 
 /obj/item/reagent_containers/food/drinks/bottle/smash(mob/living/target, mob/thrower, ranged = FALSE)
 	//Creates a shattering noise and replaces the bottle with a broken_bottle
@@ -147,6 +162,16 @@
 	desc = "A premium single-malt whiskey, gently matured inside the tunnels of a nuclear shelter. TUNNEL WHISKEY RULES."
 	icon_state = "whiskeybottle"
 	list_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 100)
+
+/obj/item/reagent_containers/food/drinks/bottle/kong
+	name = "Kong"
+	desc = "Makes You Go Ape!&#174;"
+	list_reagents = list(/datum/reagent/consumable/ethanol/whiskey/kong = 100)
+
+/obj/item/reagent_containers/food/drinks/bottle/candycornliquor
+	name = "candy corn liquor"
+	desc = "Like they drank in 2D speakeasies."
+	list_reagents = list(/datum/reagent/consumable/ethanol/whiskey/candycorn = 100)
 
 /obj/item/reagent_containers/food/drinks/bottle/vodka
 	name = "Tunguska triple distilled"
@@ -436,24 +461,6 @@
 	desc = "It is said that the ancient Applalacians used these stoneware jugs to capture lightning in a bottle."
 	icon_state = "moonshinebottle"
 	list_reagents = list(/datum/reagent/consumable/ethanol/moonshine = 100)
-
-/obj/item/reagent_containers/food/drinks/bottle/blank //Don't let players print these from a lathe, bottles should be obtained in mass from the bar only.
-	name = "glass bottle"
-	desc = "This blank bottle is unyieldingly anonymous, offering no clues to it's contents."
-	icon_state = "glassbottle"
-	fill_icon_thresholds = list(0, 10, 20, 30, 40, 50, 60, 70, 80, 90)
-	custom_price = 65
-
-/obj/item/reagent_containers/food/drinks/bottle/blank/update_icon()
-	..()
-	add_overlay("[initial(icon_state)]shine")
-
-/obj/item/reagent_containers/food/drinks/bottle/blank/small
-	name = "small glass bottle"
-	desc = "This small bottle is unyieldingly anonymous, offering no clues to it's contents."
-	icon_state = "glassbottlesmall"
-	volume = 50
-	custom_price = 55
 
 ////////////////////////// MOLOTOV ///////////////////////
 /obj/item/reagent_containers/food/drinks/bottle/molotov

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
@@ -17,7 +17,7 @@
 	name = "Moonshine Jug"
 	time = 30
 	reqs = list(
-		/obj/item/reagent_containers/food/drinks/bottle/blank = 1,
+		/obj/item/reagent_containers/food/drinks/bottle = 1,
 		/datum/reagent/consumable/ethanol/moonshine = 100
 	)
 	result = /obj/item/reagent_containers/food/drinks/bottle/moonshine
@@ -27,7 +27,7 @@
 	name = "Hooch Bottle"
 	time = 30
 	reqs = list(
-		/obj/item/reagent_containers/food/drinks/bottle/blank = 1,
+		/obj/item/reagent_containers/food/drinks/bottle = 1,
 		/obj/item/storage/box/papersack = 1,
 		/datum/reagent/consumable/ethanol/hooch = 100
 	)
@@ -38,7 +38,7 @@
 	name = "Blazaam Bottle"
 	time = 20
 	reqs = list(
-		/obj/item/reagent_containers/food/drinks/bottle/blank = 1,
+		/obj/item/reagent_containers/food/drinks/bottle = 1,
 		/datum/reagent/consumable/ethanol/blazaam = 100
 	)
 	result = /obj/item/reagent_containers/food/drinks/bottle/blazaam
@@ -48,7 +48,7 @@
 	name = "Champagne Bottle"
 	time = 30
 	reqs = list(
-		/obj/item/reagent_containers/food/drinks/bottle/blank = 1,
+		/obj/item/reagent_containers/food/drinks/bottle = 1,
 		/datum/reagent/consumable/ethanol/champagne = 100
 	)
 	result = /obj/item/reagent_containers/food/drinks/bottle/champagne
@@ -58,7 +58,7 @@
 	name = "Trappist Bottle"
 	time = 15
 	reqs = list(
-		/obj/item/reagent_containers/food/drinks/bottle/blank/small = 1,
+		/obj/item/reagent_containers/food/drinks/bottle/small = 1,
 		/datum/reagent/consumable/ethanol/trappist = 50
 	)
 	result = /obj/item/reagent_containers/food/drinks/bottle/trappist
@@ -68,7 +68,7 @@
 	name = "Goldschlager Bottle"
 	time = 30
 	reqs = list(
-		/obj/item/reagent_containers/food/drinks/bottle/blank = 1,
+		/obj/item/reagent_containers/food/drinks/bottle = 1,
 		/datum/reagent/consumable/ethanol/goldschlager = 100
 	)
 	result = /obj/item/reagent_containers/food/drinks/bottle/goldschlager
@@ -78,7 +78,7 @@
 	name = "Patron Bottle"
 	time = 30
 	reqs = list(
-		/obj/item/reagent_containers/food/drinks/bottle/blank = 1,
+		/obj/item/reagent_containers/food/drinks/bottle = 1,
 		/datum/reagent/consumable/ethanol/patron = 100
 	)
 	result = /obj/item/reagent_containers/food/drinks/bottle/patron
@@ -90,7 +90,7 @@
 	name = "Holy Water Flask"
 	time = 30
 	reqs = list(
-		/obj/item/reagent_containers/food/drinks/bottle/blank = 1,
+		/obj/item/reagent_containers/food/drinks/bottle = 1,
 		/datum/reagent/water/holywater = 100
 	)
 	result = /obj/item/reagent_containers/food/drinks/bottle/holywater
@@ -102,7 +102,7 @@
 	name = "Nothing Bottle"
 	time = 30
 	reqs = list(
-		/obj/item/reagent_containers/food/drinks/bottle/blank = 1,
+		/obj/item/reagent_containers/food/drinks/bottle = 1,
 		/datum/reagent/consumable/nothing = 100
 	)
 	result = /obj/item/reagent_containers/food/drinks/bottle/bottleofnothing
@@ -114,3 +114,22 @@
 	time = 10
 	reqs = list(/obj/item/stack/sheet/cardboard = 1)
 	category = CAT_DRINK
+
+/datum/crafting_recipe/candycornliquor
+	name = "candy corn liquor"
+	result = /obj/item/reagent_containers/food/drinks/bottle/candycornliquor
+	time = 30
+	reqs = list(/datum/reagent/consumable/ethanol/whiskey = 100,
+				/obj/item/reagent_containers/food/snacks/candy_corn = 1,
+				/obj/item/reagent_containers/food/drinks/bottle = 1)
+	category = CAT_DRINK
+
+/datum/crafting_recipe/kong
+	name = "Kong"
+	result = /obj/item/reagent_containers/food/drinks/bottle/kong
+	time = 30
+	reqs = list(/datum/reagent/consumable/ethanol/whiskey = 100,
+				/obj/item/reagent_containers/food/snacks/monkeycube = 1,
+				/obj/item/reagent_containers/food/drinks/bottle = 1)
+	category = CAT_DRINK
+

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -143,6 +143,56 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "The silky, smokey whiskey goodness inside the glass makes the drink look very classy."
 	shot_glass_icon_state = "shotglassbrown"
 
+/datum/reagent/consumable/ethanol/whiskey/kong
+	name = "Kong"
+	description = "Makes You Go Ape!&#174;"
+	color = "#332100" // rgb: 51, 33, 0
+	addiction_threshold = 15
+	taste_description = "the grip of a giant ape"
+	glass_name = "glass of Kong"
+	glass_desc = "Makes You Go Ape!&#174;"
+
+/datum/reagent/consumable/ethanol/whiskey/kong/addiction_act_stage1(mob/living/M)
+	if(prob(5))
+		to_chat(M, "<span class='notice'>You've made so many mistakes.</span>")
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "depression_minimal", /datum/mood_event/depression_minimal)
+	..()
+
+/datum/reagent/consumable/ethanol/whiskey/kong/addiction_act_stage2(mob/living/M)
+	if(prob(5))
+		to_chat(M, "<span class='notice'>No matter what you do, people will always get hurt.</span>")
+	SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "depression_minimal", /datum/mood_event/depression_minimal)
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "depression_mild", /datum/mood_event/depression_mild)
+	..()
+
+/datum/reagent/consumable/ethanol/whiskey/kong/addiction_act_stage3(mob/living/M)
+	if(prob(5))
+		to_chat(M, "<span class='notice'>You've lost so many people.</span>")
+	SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "depression_mild", /datum/mood_event/depression_mild)
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "depression_moderate", /datum/mood_event/depression_moderate)
+	..()
+
+/datum/reagent/consumable/ethanol/whiskey/kong/addiction_act_stage4(mob/living/M)
+	if(prob(5))
+		to_chat(M, "<span class='notice'>Just lie down and die.</span>")
+	SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "depression_moderate", /datum/mood_event/depression_moderate)
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "depression_severe", /datum/mood_event/depression_severe)
+	..()
+
+/datum/reagent/consumable/ethanol/whiskey/candycorn
+	name = "candy corn liquor"
+	description = "Like they drank in 2D speakeasies."
+	color = "#ccb800" // rgb: 204, 184, 0
+	taste_description = "pancake syrup"
+	glass_name = "glass of candy corn liquor"
+	glass_desc = "Good for your Imagination."
+	var/hal_amt = 4
+
+/datum/reagent/consumable/ethanol/whiskey/candycorn/on_mob_life(mob/living/carbon/M)
+	if(prob(10))
+		M.hallucination += hal_amt //conscious dreamers can be treasurers to their own currency
+	..()
+
 /datum/reagent/consumable/ethanol/thirteenloko
 	name = "Thirteen Loko"
 	description = "A potent mixture of caffeine and alcohol."

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -32,8 +32,8 @@
 					/obj/item/reagent_containers/food/drinks/bottle/grappa = 5,
 					/obj/item/reagent_containers/food/drinks/bottle/sake = 5,
 					/obj/item/reagent_containers/food/drinks/bottle/applejack = 5,
-					/obj/item/reagent_containers/food/drinks/bottle/blank = 15,
-					/obj/item/reagent_containers/food/drinks/bottle/blank/small = 15
+					/obj/item/reagent_containers/food/drinks/bottle = 15,
+					/obj/item/reagent_containers/food/drinks/bottle/small = 15
 					)
 	contraband = list(/obj/item/reagent_containers/food/drinks/mug/tea = 12,
 					 /obj/item/reagent_containers/food/drinks/bottle/fernet = 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Adds Kong and candy corn liquor. Kong is addictive, and makes you more depressed the more you withdraw.  Candy corn liquormakes you hallucinate. Both are crafted.
- Adds four different severities of depression. These are only used by Kong, but could be added to the depression quirk in future
- Merges the blank bottle from #47696 with the prototype bottle. I don't have bottle sprites for these drinks and changing this means this and other new drinks don't need them (it's preferable they do though obviously -- I hope someone will see these in-game and sprite for them, especially Kong given it's so iconic)
- Updated bottle crafting recipes and boozeomat to use the new bottle typepaths

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Players might appreciate the references. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
add: Adds Kong and candy corn whiskey. Craftable with whiskey, a bottle and either a piece of candy corn or a monkey cube
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->