### PR TITLE
Round time starts counting from round-start, not world-start

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -697,9 +697,9 @@
 		stat(null, "Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]")
 		stat(null, "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]")
 		if (SSticker.round_start_time)
-				stat(null, "Round Time: [gameTimestamp("hh:mm:ss", (world.time - SSticker.round_start_time))]")
+			stat(null, "Round Time: [gameTimestamp("hh:mm:ss", (world.time - SSticker.round_start_time))]")
 		else
-				stat(null, "Lobby Time: [gameTimestamp("hh:mm:ss", 0)]")
+			stat(null, "Lobby Time: [gameTimestamp("hh:mm:ss", 0)]")
 		stat(null, "Station Time: [station_time_timestamp()]")
 		stat(null, "Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)")
 		if(SSshuttle.emergency)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -696,7 +696,10 @@
 			stat(null, "Next Map: [cached.map_name]")
 		stat(null, "Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]")
 		stat(null, "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]")
-		stat(null, "Round Time: [gameTimestamp("hh:mm:ss", (world.time - SSticker.round_start_time))]")
+		if (SSticker.round_start_time)
+				stat(null, "Round Time: [gameTimestamp("hh:mm:ss", (world.time - SSticker.round_start_time))]")
+		else
+				stat(null, "Lobby Time: [gameTimestamp("hh:mm:ss", 0)]")
 		stat(null, "Station Time: [station_time_timestamp()]")
 		stat(null, "Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)")
 		if(SSshuttle.emergency)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -696,7 +696,7 @@
 			stat(null, "Next Map: [cached.map_name]")
 		stat(null, "Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]")
 		stat(null, "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]")
-		stat(null, "Round Time: [worldtime2text()]")
+		stat(null, "Round Time: [gameTimestamp("hh:mm:ss", (world.time - SSticker.round_start_time))]")
 		stat(null, "Station Time: [station_time_timestamp()]")
 		stat(null, "Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)")
 		if(SSshuttle.emergency)


### PR DESCRIPTION
It always irked me a bit that the timer is about 3 minutes fast because it includes the startup period. It means that people get times for things wrong a lot because they don't know that it's fast, and today I saw a admin give a 5 minute warning and then start a carp meme 2 minutes into the round instead of 5 minutes (probably) because of it.


A minor detail that's off is that the timer will still count up while in startup, and then reset back to zero when the shift starts. I'm not sure how to avoid that in a efficient manner, but it's not a huge deal either way.


:cl: 
tweak: An intern at Nanotrasen noticed that their shift timer was running about 3 minutes fast, misleading employees about how long they had been clocked in. The timer has been fixed, and anyone who clocked out early has had their pay docked.
/:cl:

edit: With approval from MSO and assurances from other people that this isn't going to do diddly squat to performance compared to checking every carbon for alien organs every tick, the timer now says "lobby time" in the lobby.