### PR TITLE
Puts encryption keys in hand when removed

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -287,14 +287,12 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 				SSradio.remove_object(src, GLOB.radiochannels[ch_name])
 				secure_radio_connections[ch_name] = null
 
-			var/turf/T = user.drop_location()
-			if(T)
-				if(keyslot)
-					keyslot.forceMove(T)
-					keyslot = null
-				if(keyslot2)
-					keyslot2.forceMove(T)
-					keyslot2 = null
+			if(keyslot)
+				user.put_in_hands(keyslot)
+				keyslot = null
+			if(keyslot2)
+				user.put_in_hands(keyslot2)
+				keyslot2 = null
 
 			recalculateChannels()
 			to_chat(user, "<span class='notice'>You pop out the encryption keys in the headset.</span>")


### PR DESCRIPTION
oops this wasn't supposed to be deleted
Puts encryption keys in the user's hand if the user has a free hand.

## Why It's Good For The Game
It's a quality of life improvement that saves time.

## Changelog
:cl:
tweak: Makes encryption keys be put in the hands of the user when able instead of being dropped on the floor when removed from headsets
/:cl:
