### PR TITLE
E.X.P.E.R.I-Mentor Overhaul Part 2: Strange Things

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -30,7 +30,7 @@ SUBSYSTEM_DEF(research)
 	var/list/errored_datums = list()
 	var/list/point_types = list()				//typecache style type = TRUE list
 	//----------------------------------------------
-	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 52.3)
+	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 51.3)
 	var/multiserver_calculation = FALSE
 	var/last_income
 	//^^^^^^^^ ALL OF THESE ARE PER SECOND! ^^^^^^^^

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -1,6 +1,7 @@
 //this is designed to replace the destructive analyzer
 
 //NEEDS MAJOR CODE CLEANUP
+//NO SHIT IT'S LIKE 20 NESTED IF STATEMENTS WHAT THE FUCK GUYS
 
 #define SCANTYPE_POKE 1
 #define SCANTYPE_IRRADIATE 2
@@ -15,6 +16,7 @@
 #define EFFECT_PROB_MEDIUM 50
 #define EFFECT_PROB_HIGH 75
 #define EFFECT_PROB_VERYHIGH 95
+#define EFFECT_PROB_RELICMAKE 50
 
 #define FAIL 8
 /obj/machinery/rnd/experimentor
@@ -251,7 +253,15 @@
 		visible_message("<span class='notice'>[src] prods at [exp_on] with mechanical arms.</span>")
 		if(prob(EFFECT_PROB_LOW) && criticalReaction)
 			visible_message("<span class='notice'>[exp_on] is gripped in just the right way, enhancing its focus.</span>")
+			var/points = rand(2500,3000)
+			visible_message("<span class='notice'>[src] spits out some research notes worth [points] points!")
+			new /obj/item/research_notes(drop_location(src), points, "experimentation")
+			ejectItem(TRUE)
 			badThingCoeff++
+		else if(prob(EFFECT_PROB_MEDIUM) && prob(EFFECT_PROB_RELICMAKE))
+			visible_message("<span class='notice'>[exp_on] is prodded into a new, strange shape!</span>")
+			new /obj/item/relic(drop_location(src))
+			ejectItem(TRUE)
 		else if(prob(EFFECT_PROB_VERYLOW-badThingCoeff))
 			visible_message("<span class='danger'>[src] malfunctions and destroys [exp_on], lashing its arms out at nearby people!</span>")
 			for(var/mob/living/m in oview(1, src))
@@ -278,6 +288,13 @@
 			cloneMode = TRUE
 			investigate_log("Experimentor has made a clone of [exp_on]", INVESTIGATE_EXPERIMENTOR)
 			ejectItem()
+			var/points = rand(2500,3000)
+			visible_message("<span class='notice'>[src] spits out some research notes worth [points] points!")
+			new /obj/item/research_notes(drop_location(src), points, "experimentation")
+		else if(prob(EFFECT_PROB_MEDIUM) && prob(EFFECT_PROB_RELICMAKE))
+			visible_message("<span class='notice'>[exp_on] mutates into a new, strange shape!</span>")
+			new /obj/item/relic(drop_location(src))
+			ejectItem(TRUE)
 		else if(prob(EFFECT_PROB_VERYLOW-badThingCoeff))
 			visible_message("<span class='danger'>[src] malfunctions, melting [exp_on] and leaking radiation!</span>")
 			radiation_pulse(src, 500)
@@ -306,6 +323,14 @@
 		if(prob(EFFECT_PROB_LOW) && criticalReaction)
 			visible_message("<span class='notice'>[exp_on] achieves the perfect mix!</span>")
 			new /obj/item/stack/sheet/mineral/plasma(get_turf(pick(oview(1,src))))
+			var/points = rand(2500,3000)
+			visible_message("<span class='notice'>[src] spits out some research notes worth [points] points!")
+			new /obj/item/research_notes(drop_location(src), points, "experimentation")
+			ejectItem(TRUE)
+		else if(prob(EFFECT_PROB_MEDIUM) && prob(EFFECT_PROB_RELICMAKE))
+			visible_message("<span class='notice'>[exp_on] reacts with the gas, changing into a new, strange shape!</span>")
+			new /obj/item/relic(drop_location(src))
+			ejectItem(TRUE)
 		else if(prob(EFFECT_PROB_VERYLOW-badThingCoeff))
 			visible_message("<span class='danger'>[src] destroys [exp_on], leaking dangerous gas!</span>")
 			chosenchem = pick(/datum/reagent/carbon,/datum/reagent/uranium/radium,/datum/reagent/toxin,/datum/reagent/consumable/condensedcapsaicin,/datum/reagent/drug/mushroomhallucinogen,/datum/reagent/drug/space_drugs,/datum/reagent/consumable/ethanol,/datum/reagent/consumable/ethanol/beepsky_smash)
@@ -354,6 +379,14 @@
 			C.name = "Cup of Suspicious Liquid"
 			C.desc = "It has a large hazard symbol printed on the side in fading ink."
 			investigate_log("Experimentor has made a cup of [chosenchem] coffee.", INVESTIGATE_EXPERIMENTOR)
+			var/points = rand(2500,3000)
+			visible_message("<span class='notice'>[src] spits out some research notes worth [points] points!")
+			new /obj/item/research_notes(drop_location(src), points, "experimentation")
+			ejectItem(TRUE)
+		else if(prob(EFFECT_PROB_MEDIUM) && prob(EFFECT_PROB_RELICMAKE))
+			visible_message("<span class='notice'>[exp_on] melts down into a new, strange shape!</span>")
+			new /obj/item/relic(drop_location(src))
+			ejectItem(TRUE)
 		else if(prob(EFFECT_PROB_VERYLOW-badThingCoeff))
 			var/turf/start = get_turf(src)
 			var/mob/M = locate(/mob/living) in view(src, 3)
@@ -403,6 +436,14 @@
 			C.name = "Cup of Suspicious Liquid"
 			C.desc = "It has a large hazard symbol printed on the side in fading ink."
 			investigate_log("Experimentor has made a cup of [chosenchem] coffee.", INVESTIGATE_EXPERIMENTOR)
+			var/points = rand(2500,3000)
+			visible_message("<span class='notice'>[src] spits out some research notes worth [points] points!")
+			new /obj/item/research_notes(drop_location(src), points, "experimentation")
+			ejectItem(TRUE)
+		else if(prob(EFFECT_PROB_MEDIUM) && prob(EFFECT_PROB_RELICMAKE))
+			visible_message("<span class='notice'>[exp_on]'s atoms align into a new, strange shape!</span>")
+			new /obj/item/relic(drop_location(src))
+			ejectItem(TRUE)
 		else if(prob(EFFECT_PROB_VERYLOW-badThingCoeff))
 			visible_message("<span class='danger'>[src] malfunctions, shattering [exp_on] and releasing a dangerous cloud of coolant!</span>")
 			var/datum/reagents/R = new/datum/reagents(50)
@@ -445,6 +486,9 @@
 		if(prob(EFFECT_PROB_LOW) && criticalReaction)
 			visible_message("<span class='warning'>[src]'s crushing mechanism slowly and smoothly descends, flattening the [exp_on]!</span>")
 			new /obj/item/stack/sheet/plasteel(get_turf(pick(oview(1,src))))
+			var/points = rand(3500,4000)
+			visible_message("<span class='notice'>[src] spits out some research notes worth [points] points!")
+			new /obj/item/research_notes(drop_location(src), points, "experimentation")
 		else if(prob(EFFECT_PROB_VERYLOW-badThingCoeff))
 			visible_message("<span class='danger'>[src]'s crusher goes way too many levels too high, crushing right through space-time!</span>")
 			playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE, -3)
@@ -475,9 +519,9 @@
 		playsound(src, 'sound/effects/supermatter.ogg', 50, 3, -1)
 		var/obj/item/relic/R = loaded_item
 		if (!R.revealed)
-			var/points = rand(3500,3750) // discovery reward
+			var/points = rand(500, 750) // discovery reward
 			new /obj/item/research_notes(drop_location(src), points, "experimentation")
-			visible_message("<span class='notice'> This discovery netted [points] points for research.</span>")
+			visible_message("<span class='notice'>The [src] spits out research notes worth [points] points!</span>")
 		R.reveal()
 		investigate_log("Experimentor has revealed a relic with <span class='danger'>[R.realProc]</span> effect.", INVESTIGATE_EXPERIMENTOR)
 		ejectItem()

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -37,6 +37,7 @@
 	var/list/valid_items = list() //valid items for special reactions like transforming
 	var/list/critical_items_typecache //items that can cause critical reactions
 	var/banned_typecache // items that won't be produced
+	requires_console = FALSE
 
 /obj/machinery/rnd/experimentor/proc/ConvertReqString2List(list/source_list)
 	var/list/temp_list = params2list(source_list)
@@ -126,8 +127,6 @@
 
 /obj/machinery/rnd/experimentor/ui_interact(mob/user)
 	var/list/dat = list("<center>")
-	if(!linked_console)
-		dat += "<b><a href='byond://?src=[REF(src)];function=search'>Scan for R&D Console</A></b>"
 	if(loaded_item)
 		dat += "<b>Loaded Item:</b> [loaded_item]"
 
@@ -177,10 +176,6 @@
 	if(href_list["close"])
 		usr << browse(null, "window=experimentor")
 		return
-	if(scantype == "search")
-		var/obj/machinery/computer/rdconsole/D = locate(/obj/machinery/computer/rdconsole) in oview(3,src)
-		if(D)
-			linked_console = D
 	else if(scantype == "eject")
 		ejectItem()
 	else if(scantype == "refresh")
@@ -200,11 +195,6 @@
 				dotype = matchReaction(process,scantype)
 			experiment(dotype,process)
 			use_power(750)
-			if(dotype != FAIL)
-				var/list/nodes = techweb_item_boost_check(process)
-				var/picked = pickweight(nodes)		//This should work.
-				if(linked_console)
-					linked_console.stored_research.boost_with_path(SSresearch.techweb_node_by_id(picked), process.type)
 	updateUsrDialog()
 
 /obj/machinery/rnd/experimentor/proc/matchReaction(matching,reaction)
@@ -479,10 +469,6 @@
 	////////////////////////////////////////////////////////////////////////////////////////////////
 	if(exp == SCANTYPE_OBLITERATE)
 		visible_message("<span class='warning'>[exp_on] activates the crushing mechanism, [exp_on] is destroyed!</span>")
-		if(linked_console.linked_lathe)
-			var/datum/component/material_container/linked_materials = linked_console.linked_lathe.GetComponent(/datum/component/material_container)
-			for(var/material in exp_on.custom_materials)
-				linked_materials.insert_amount_mat( min((linked_materials.max_amount - linked_materials.total_amount), (exp_on.custom_materials[material])), material)
 		if(prob(EFFECT_PROB_LOW) && criticalReaction)
 			visible_message("<span class='warning'>[src]'s crushing mechanism slowly and smoothly descends, flattening the [exp_on]!</span>")
 			new /obj/item/stack/sheet/plasteel(get_turf(pick(oview(1,src))))

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -159,7 +159,7 @@
 	else if(loaded_item)
 		dat += "<b>Loaded Item:</b> [loaded_item]"
 		if(is_type_in_typecache(loaded_item, critical_items_typecache))
-			dat += "<b>Advanced technolgy detected - chance of higher research point generation</b>"
+			dat += "<b>Advanced technology detected - chance of higher research point generation</b>"
 		if(is_type_in_typecache(loaded_item, already_researched))
 			dat += "<b>Technology has already been experimented on - no points will be awarded!</b>"
 		if(istype(loaded_item,/obj/item/relic))

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -89,7 +89,15 @@
 		/obj/item/stack/sheet,
 		/obj/item/reagent_containers/food,
 		/obj/item/reagent_containers/food/drinks,
-		/obj/item/research_notes
+		/obj/item/research_notes,
+		/obj/item/gun/energy/laser/captain,
+		/obj/item/gun/energy/e_gun/hos,
+		/obj/item/hand_tele,
+		/obj/item/tank/jetpack/oxygen/captain,
+		/obj/item/clothing/shoes/magboots/advance,
+		/obj/item/reagent_containers/hypospray/CMO,
+		/obj/item/clothing/suit/hooded/ablative,
+		/obj/item/clothing/suit/armor/reactive/teleport,
 	))
 
 	critical_items_typecache = typecacheof(list(
@@ -100,14 +108,6 @@
 		/obj/item/slime_extract,
 		/obj/item/onetankbomb,
 		/obj/item/transfer_valve,
-		/obj/item/gun/energy/laser/captain,
-		/obj/item/gun/energy/e_gun/hos,
-		/obj/item/hand_tele,
-		/obj/item/tank/jetpack/oxygen/captain,
-		/obj/item/clothing/shoes/magboots/advance,
-		/obj/item/reagent_containers/hypospray/CMO,
-		/obj/item/clothing/suit/hooded/ablative,
-		/obj/item/clothing/suit/armor/reactive/teleport,
 		/obj/item/gun/energy/e_gun/nuclear,
 		/obj/item/stock_parts/cell/hyper
 	))
@@ -153,7 +153,7 @@
 
 /obj/machinery/rnd/experimentor/ui_interact(mob/user)
 	var/list/dat = list("<center>")
-	if(banned_items[loaded_item.type])
+	if(is_type_in_typecache(loaded_item, banned_items))
 		dat += "<b>Item is not cleared for use in E.X.P.E.R.I-MENTOR. If you believe this is in error, please contact Nanotrasen Central Command."
 		dat += "<b><a href='byond://?src=[REF(src)];function=eject'>Eject</A>"
 	else if(loaded_item)

--- a/code/modules/surgery/experimental_dissection.dm
+++ b/code/modules/surgery/experimental_dissection.dm
@@ -1,4 +1,4 @@
-#define BASE_HUMAN_REWARD 500
+#define BASE_HUMAN_REWARD 750
 #define EXPDIS_FAIL_MSG "<span class='notice'>You dissect [target], but do not find anything particularly interesting.</span>"
 #define PUBLIC_TECHWEB_GAIN 0.6 //how many research points go directly into the main pool
 #define PRIVATE_TECHWEB_GAIN (1 - PUBLIC_TECHWEB_GAIN) //how many research points go directly into the main pool


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR shakes things up a bit from what I intended before as I noticed a few problems with it. **I'm still taking a look at how R&D is affected by my last PR, so this won't be ready for a hot minute.**

Almost any item has roughly a 50% chance of, upon successfully finding the right experiment, being destroyed and awarding anywhere from 300 to 500 points in the form of research notes. The only blacklisted items are ones critical to the round (namely the Nuke disk because I have _no idea_ how it would react), material sheets (probably not necessary but just in case) and food and drink (because that would just break it you silly!). Once an item has been experimented on, you can't experiment on that item again. Think the old 'deconstruct for techweb boosts' system - this keeps you from just printing like 50 multitools and using those. The machine will tell you if whatever you're experimenting on isn't going to give you points.

In addition to this, if the correct items are placed into the E.X.P.E.R.I-Mentor and analyzed, there's a small chance (35%) they will react in interesting, unexpected ways. These reactions produce different interactions depending on the experiment, however, all of them will also generate a high point bounty. These are worth 3,000 to 5000 for all _except for Irradiate_, which duplicates the item in question.

Why do this? I came up with a few ideas for how the machine should work:

- General method of producing a small number of points with a potential for a high payoff with the right items
- High risk/reward: you can make a fair bit of points with practically any item (with the chance of even more), though you run the risk of fucking things up for you or your team
- Should have interesting reactions other than just "hurts you" or "explodes"
- Should be easy to add and remove reactions over time

This is covering the first two points. It's hard to really, truly go nuts making points with the E.X.P.E.R.I-Mentor since doing so usually means you're going to blow yourself up early on (there's a karma mechanic attached - the more good things that happen, the higher the chance for catastrophic failure), but you run the chance of making a good chunk of points if you know how the machine works.

This comes with yet another passive reduction in points, reducing them by 3,600 per hour. This is a small techweb node, but odds are you'll make that back pretty quickly by focusing on this.

Also, to help out a bit, there's a minor buff to points for dissection because it was already pretty crap before. So there's more incentive to actually do something other than burger dead bodies.

What needs to happen before more iteration on the E.X.P.E.R.I-Mentor:
- Fuckin' refactor the whole thing. Whoever made this originally just made each experiment in a single giant proc of like 10 nested if statements. It's bad, it's poorly optimized, and it's probably why it's so goddamn buggy. Shit gotta go, but that's not a project I really have time for right now. That'll be part 3.
- Ideas for more interesting interactions. I love the stuff it does with the station pets and having it mess with the environment in the room is neat. All the others are some variation of "explode" or "hurt you and everything around it" and that's boring.
- Work out point values for upgrades.
- tgui-next the UI

After I finish these, we'll start looking at making XB generate points.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less passive, more active. Making it possible to generate strange objects gives a decent method of printing points for a very low price, though the risk gets higher the more it pays off. If you're lucky, you can earn more points than you get passively now. If not, you still shouldn't be completely fucked for the round.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The E.X.P.E.R.I-Mentor can now generate research points from almost any item. Items are destroyed on use, can't be used more than once, and certain items are blacklisted.
tweak: Point generation using the E.X.P.E.R.I-Mentor has been rebalanced. Most items will produce from 300-500, while specific high-tech items can produce up to 5,000(!)
tweak: Slightly reduced the amount of passively produced research points.
tweak: Slightly raised the amount of points gained for dissecting a body.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
