### PR TITLE
Gives medkit pills their own unique colors

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -242,20 +242,20 @@
 /obj/item/reagent_containers/pill/potassiodide
 	name = "potassium iodide pill"
 	desc = "Used to reduce low radiation damage very effectively."
-	icon_state = "pill9"
+	icon_state = "pill11"
 	list_reagents = list(/datum/reagent/medicine/potass_iodide = 15)
 	rename_with_volume = TRUE
 
 /obj/item/reagent_containers/pill/trophazole
 	name = "trophazole pill"
 	desc = "Used to treat brute damage of minor and moderate severity.The carving in the pill says 'Eat before ingesting'."
-	icon_state = "pill9"
+	icon_state = "pill12"
 	list_reagents = list(/datum/reagent/medicine/trophazole = 15)
 	rename_with_volume = TRUE
 
 /obj/item/reagent_containers/pill/iron
 	name = "iron pill"
 	desc = "Used to reduce bloodloss slowly."
-	icon_state = "pill9"
+	icon_state = "pill8"
 	list_reagents = list(/datum/reagent/iron = 30)
 	rename_with_volume = TRUE


### PR DESCRIPTION
## About The Pull Request

Makes trophazole pills red, potassium iodide pills light green, and iron pills light blue instead of having them all be white.

## Why It's Good For The Game

Lets you distinguish between the different pill types without having to examine them.

## Changelog
:cl: Bumtickley00
tweak: Pills found in medkits now have their own unique colors
/:cl: