### PR TITLE
Adds blacklist check for using crafting ingredients

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -87,7 +87,7 @@
 			return FALSE
 	return TRUE
 
-/datum/component/personal_crafting/proc/get_environment(mob/user, var/list/blacklist = null)
+/datum/component/personal_crafting/proc/get_environment(mob/user, list/blacklist = null)
 	. = list()
 	for(var/obj/item/I in user.held_items)
 		. += I

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -87,7 +87,7 @@
 			return FALSE
 	return TRUE
 
-/datum/component/personal_crafting/proc/get_environment(mob/user)
+/datum/component/personal_crafting/proc/get_environment(mob/user, var/list/blacklist = null)
 	. = list()
 	for(var/obj/item/I in user.held_items)
 		. += I
@@ -104,6 +104,10 @@
 				. += AM
 	for(var/slot in list(ITEM_SLOT_RPOCKET, ITEM_SLOT_LPOCKET))
 		. += user.get_item_by_slot(slot)
+	if(blacklist)
+		for(var/obj/B in .)
+			if(blacklist.Find(B.type))
+				. -= B
 
 /datum/component/personal_crafting/proc/get_surroundings(mob/user)
 	. = list()
@@ -214,7 +218,7 @@
 	main_loop:
 		for(var/A in R.reqs)
 			amt = R.reqs[A]
-			surroundings = get_environment(user)
+			surroundings = get_environment(user, R.blacklist)
 			surroundings -= Deletion
 			if(ispath(A, /datum/reagent))
 				var/datum/reagent/RG = new A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a check to get_environment when called by del_reqs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It prevents blacklisted items from being used when they are a subtype of a required item.
Fixes one of the issues in https://github.com/tgstation/tgstation/issues/47863
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed crafting items using blacklisted subtypes of required items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
