### PR TITLE
Fixes broken rad damage curve

### DIFF
--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -16,6 +16,11 @@ Ask ninjanomnom if they're around
 #define RAD_OVERDOSE_REDUCTION 0.000001				// Coefficient to the reduction in applied rads once the thing, usualy mob, has too much radiation
 													// WARNING: This number is highly sensitive to change, graph is first for best results
 #define RAD_BURN_THRESHOLD 1000						// Applied radiation must be over this to burn
+//Holy shit test after you tweak anything it's said like 6 times in here
+//You probably want to plot any tweaks you make so you can see the curves visually
+#define RAD_BURN_LOG_BASE 1.1
+#define RAD_BURN_LOG_GRADIENT 10000
+#define RAD_BURN_CURVE(X) log(1+((X-RAD_BURN_THRESHOLD)/RAD_BURN_LOG_GRADIENT))/log(RAD_BURN_LOG_BASE)
 
 #define RAD_MOB_SAFE 500							// How much stored radiation in a mob with no ill effects
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1038,7 +1038,7 @@
 	var/blocked = getarmor(null, "rad")
 
 	if(amount > RAD_BURN_THRESHOLD)
-		apply_damage(log(amount)*2, BURN, null, blocked)
+		apply_damage(RAD_BURN_CURVE(amount), BURN, null, blocked)
 
 	apply_effect((amount*RAD_MOB_COEFFICIENT)/max(1, (radiation**2)*RAD_OVERDOSE_REDUCTION), EFFECT_IRRADIATE, blocked)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes the rad_act damage curve changes from #46806 which broke low damage levels.  A new log curve is added, which starts out similar to the original linear scaling of rad strength to burn damage, but caps out at about 35 damage per pulse at the point where the old linear relationship would instahusk.

## Why It's Good For The Game

The old log curve from #46806 starts out from 14-15 damage per pulse, which means even a borg standing next to a boring round-start sm setup dies in under 15 seconds to rad burn damage.  This was obviously unintended as the original pr aim was a flat cap at 15 damage, with the old linear relationship before that cap, before getting bikeshedded into an untested log curve that was ultimately broken.

New log curve starts at 0 at RAD_BURN_THRESHOLD like the old and intended behaviour.

plots at https://imgur.com/a/fsh6VY9

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Tetr4
fix: SM radiation no longer kills you in 12 seconds without rad protection.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
