### PR TITLE
Removes extra APCs from Delta arrivals.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -114764,19 +114764,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
-"jfR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/power/apc,
-/obj/machinery/power/apc,
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "jjN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
@@ -151348,7 +151335,7 @@ aaa
 aaO
 aaO
 aaO
-jfR
+ajw
 ajV
 aky
 alm


### PR DESCRIPTION


## About The Pull Request
Removes extra APCs in Delta arrivals due to https://github.com/tgstation/tgstation/pull/48295

## Why It's Good For The Game

Only one APC per area.

## Changelog

del: Removes extra APCs in Delta arrivals.
/:cl:


