### PR TITLE
Malf AIs can now enable your suit sensors for you. By force.

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -28,7 +28,7 @@
 	var/obj/item/clothing/under/U = H.w_uniform
 	if(!istype(U))
 		return 0
-	if(U.sensor_mode <= SENSOR_VITALS)
+	if(U.sensor_mode <= SENSOR_VITALS && !GLOB.force_sensors)
 		return 0
 	return 1
 
@@ -149,7 +149,6 @@
 			return "health-85"
 		else
 			return "health-100"
-	return "0"
 
 //HOOKS
 
@@ -302,7 +301,6 @@
 			return "crit"
 		else
 			return "dead"
-	return "dead"
 
 //Sillycone hooks
 /mob/living/silicon/proc/diag_hud_set_health()

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -130,8 +130,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			U = H.w_uniform
 
 			// Are the suit sensors on?
-			if (nanite_sensors || ((U.has_sensor > 0) && U.sensor_mode))
-				pos = H.z == 0 || (nanite_sensors || U.sensor_mode == SENSOR_COORDS) ? get_turf(H) : null
+			if (nanite_sensors || ((U.has_sensor > 0) && (U.sensor_mode || GLOB.force_sensors)))
+				pos = H.z == 0 || (GLOB.force_sensors || nanite_sensors || U.sensor_mode == SENSOR_COORDS) ? get_turf(H) : null
 
 				// Special case: If the mob is inside an object confirm the z-level on turf level.
 				if (H.z == 0 && (!pos || pos.z != z))
@@ -148,12 +148,12 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					assignment = ""
 					ijob = 80
 
-				if (nanite_sensors || U.sensor_mode >= SENSOR_LIVING)
+				if (GLOB.force_sensors || nanite_sensors || U.sensor_mode >= SENSOR_LIVING)
 					life_status = (!H.stat ? TRUE : FALSE)
 				else
 					life_status = null
 
-				if (nanite_sensors || U.sensor_mode >= SENSOR_VITALS)
+				if (GLOB.force_sensors || nanite_sensors || U.sensor_mode >= SENSOR_VITALS)
 					oxydam = round(H.getOxyLoss(),1)
 					toxdam = round(H.getToxLoss(),1)
 					burndam = round(H.getFireLoss(),1)
@@ -164,7 +164,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					burndam = null
 					brutedam = null
 
-				if (nanite_sensors || U.sensor_mode >= SENSOR_COORDS)
+				if (GLOB.force_sensors || nanite_sensors || U.sensor_mode >= SENSOR_COORDS)
 					if (!pos)
 						pos = get_turf(H)
 					area = get_area_name(H, TRUE)

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -95,8 +95,8 @@
 	if((H.z == 0 || H.z == here.z) && istype(H.w_uniform, /obj/item/clothing/under))
 		var/obj/item/clothing/under/U = H.w_uniform
 
-		// Suit sensors must be on maximum.
-		if(!U.has_sensor || (U.sensor_mode < SENSOR_COORDS && !ignore_suit_sensor_level))
+		// Suit sensors must be on maximum, or hacked.
+		if(!U.has_sensor || (U.sensor_mode < SENSOR_COORDS && (!ignore_suit_sensor_level || !GLOB.force_sensors)))
 			return FALSE
 
 		var/turf/there = get_turf(H)

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -873,6 +873,20 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 
 	unlock_text = replacetext(unlock_text, "CAMSUPGRADED", "<b>[upgraded_cameras]</b>") //This works, since unlock text is called after upgrade()
 
+//Hack Suit Sensors - sets all suit sensors on all clothing to max and prevents them from being turned off. Fairly obvious if anyone examines a jumpsuit or tries to change suit sensors.
+/datum/AI_Module/large/suit_sensors
+	module_name = "Hack Suit Sensors" //Announcement: "Suit Sensors!"
+	mod_pick_name = "suitsensors"
+	description = "Distribute a virus over the crew monitoring network, setting all suit sensors to max and preventing them from being turned off. The virus will also automatically infect any and all newly-created jumpsuits." //Announcement: "I wasn't asking."
+	one_purchase = TRUE
+	cost = 25 //Not quite omniscience, but it certainly helps!
+	upgrade = TRUE
+	unlock_text = "<span class='notice'>Viral payload distributed, all fabric-integrated lifesign monitors and tracking systems have been fully activated.</span>"
+	unlock_sound = 'sound/machines/defib_success.ogg'
+
+/datum/AI_Module/large/suit_sensors/upgrade()
+	GLOB.force_sensors = TRUE //It's easier and more efficient to set a global var that crew monitors check, than to iterate through every piece of clothing and change the sensor state.
+
 /datum/AI_Module/large/eavesdrop
 	module_name = "Enhanced Surveillance"
 	mod_pick_name = "eavesdrop"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -191,14 +191,14 @@ BLIND     // can't see anything
 		return
 	if (!can_use(M))
 		return
-	if(src.has_sensor == LOCKED_SENSORS)
-		to_chat(usr, "The controls are locked.")
-		return 0
 	if(src.has_sensor == BROKEN_SENSORS)
 		to_chat(usr, "The sensors have shorted out!")
 		return 0
 	if(src.has_sensor <= NO_SENSORS)
 		to_chat(usr, "This suit does not have any sensors.")
+		return 0
+	if(src.has_sensor == LOCKED_SENSORS || GLOB.force_sensors)
+		to_chat(usr, "The controls are locked.") //
 		return 0
 
 	var/list/modes = list("Off", "Binary vitals", "Exact vitals", "Tracking beacon")

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -61,7 +61,10 @@
 		sensor_mode = pick(SENSOR_OFF, SENSOR_OFF, SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS)
 		if(ismob(loc))
 			var/mob/M = loc
-			to_chat(M,"<span class='warning'>The sensors on the [src] change rapidly!</span>")
+			if(GLOB.force_sensors)
+				to_chat(M,"<span class='warning'>The sensors on the [src] flicker, but remain unchanged!</span>") //Technically changes, but sensor_mode is ignored anyway.
+			else
+				to_chat(M,"<span class='warning'>The sensors on the [src] change rapidly!</span>")
 
 /obj/item/clothing/under/equipped(mob/user, slot)
 	..()
@@ -161,15 +164,18 @@
 	if (has_sensor == BROKEN_SENSORS)
 		. += "Its sensors appear to be shorted out."
 	else if(has_sensor > NO_SENSORS)
-		switch(sensor_mode)
-			if(SENSOR_OFF)
-				. += "Its sensors appear to be disabled."
-			if(SENSOR_LIVING)
-				. += "Its binary life sensors appear to be enabled."
-			if(SENSOR_VITALS)
-				. += "Its vital tracker appears to be enabled."
-			if(SENSOR_COORDS)
-				. += "Its vital tracker and tracking beacon appear to be enabled."
+		If(GLOB.force_sensors)
+			. += "Its vital tracker and tracking beacon appear to be enabled, and seem to be malfunctioning." //hint hint
+		else
+			switch(sensor_mode)
+				if(SENSOR_OFF)
+					. += "Its sensors appear to be disabled."
+				if(SENSOR_LIVING)
+					. += "Its binary life sensors appear to be enabled."
+				if(SENSOR_VITALS)
+					. += "Its vital tracker appears to be enabled."
+				if(SENSOR_COORDS)
+					. += "Its vital tracker and tracking beacon appear to be enabled."
 	if(attached_accessory)
 		. += "\A [attached_accessory] is attached to it."
 


### PR DESCRIPTION
Malf AIs now have a ability that allows them to enable and lock-on all suit sensors, permanently.


The only way to disable them is to damage the jumpsuit itself or get a jumpsuit that doesn't have a sensor in the first place. Making new jumpsuits, using unworn jumpsuits, and such will not work; if it has sensors, they're always enabled.

There are obvious tells that the suit is hacked if you either examine the suit or try to change the setting, but otherwise it doesn't alert anyone on usage.

Costs 25 points, because it's about as, or more obvious than camera upgrades, and it only tells you where people are and if they're still alive, unlike cameras which let you see.

:cl: 
Add: Growing frustration in the Artifical Intelligence Connectunity has led to the development of a virus that forcibly enables suit sensors. Nanotrasen has outlawed this virus and forbidden all AI from using it, but beware of any malfunctioning units taking advantage of this!
/:cl: