### PR TITLE
Gives non-antagonist combat-upgraded AI the ability to turn on your suit sensors. By force.

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -28,7 +28,7 @@
 	var/obj/item/clothing/under/U = H.w_uniform
 	if(!istype(U))
 		return 0
-	if(U.sensor_mode <= SENSOR_VITALS)
+	if(U.sensor_mode <= SENSOR_VITALS && !GLOB.force_sensors)
 		return 0
 	return 1
 
@@ -149,7 +149,6 @@
 			return "health-85"
 		else
 			return "health-100"
-	return "0"
 
 //HOOKS
 
@@ -302,7 +301,6 @@
 			return "crit"
 		else
 			return "dead"
-	return "dead"
 
 //Sillycone hooks
 /mob/living/silicon/proc/diag_hud_set_health()

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -130,8 +130,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			U = H.w_uniform
 
 			// Are the suit sensors on?
-			if (nanite_sensors || ((U.has_sensor > 0) && U.sensor_mode))
-				pos = H.z == 0 || (nanite_sensors || U.sensor_mode == SENSOR_COORDS) ? get_turf(H) : null
+			if (nanite_sensors || ((U.has_sensor > 0) && (U.sensor_mode || GLOB.force_sensors)))
+				pos = H.z == 0 || (GLOB.force_sensors || nanite_sensors || U.sensor_mode == SENSOR_COORDS) ? get_turf(H) : null
 
 				// Special case: If the mob is inside an object confirm the z-level on turf level.
 				if (H.z == 0 && (!pos || pos.z != z))
@@ -148,12 +148,12 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					assignment = ""
 					ijob = 80
 
-				if (nanite_sensors || U.sensor_mode >= SENSOR_LIVING)
+				if (GLOB.force_sensors || nanite_sensors || U.sensor_mode >= SENSOR_LIVING)
 					life_status = (!H.stat ? TRUE : FALSE)
 				else
 					life_status = null
 
-				if (nanite_sensors || U.sensor_mode >= SENSOR_VITALS)
+				if (GLOB.force_sensors || nanite_sensors || U.sensor_mode >= SENSOR_VITALS)
 					oxydam = round(H.getOxyLoss(),1)
 					toxdam = round(H.getToxLoss(),1)
 					burndam = round(H.getFireLoss(),1)
@@ -164,7 +164,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					burndam = null
 					brutedam = null
 
-				if (nanite_sensors || U.sensor_mode >= SENSOR_COORDS)
+				if (GLOB.force_sensors || nanite_sensors || U.sensor_mode >= SENSOR_COORDS)
 					if (!pos)
 						pos = get_turf(H)
 					area = get_area_name(H, TRUE)

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -95,8 +95,8 @@
 	if((H.z == 0 || H.z == here.z) && istype(H.w_uniform, /obj/item/clothing/under))
 		var/obj/item/clothing/under/U = H.w_uniform
 
-		// Suit sensors must be on maximum.
-		if(!U.has_sensor || (U.sensor_mode < SENSOR_COORDS && !ignore_suit_sensor_level))
+		// Suit sensors must be on maximum, or hacked.
+		if(!U.has_sensor || (U.sensor_mode < SENSOR_COORDS && (!ignore_suit_sensor_level || !GLOB.force_sensors)))
 			return FALSE
 
 		var/turf/there = get_turf(H)

--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -50,3 +50,27 @@
 	log_game("[key_name(user)] has upgraded [key_name(AI)] with a [src].")
 	message_admins("[ADMIN_LOOKUPFLW(user)] has upgraded [ADMIN_LOOKUPFLW(AI)] with a [src].")
 	qdel(src)
+
+
+//Forced Suit Sensors. If anyone adds more of these, you should probably make them subtypes, but two isn't enough to be worthwhile.
+/obj/item/suitsensors_upgrade
+	name = "suit sensors virus upgrade"
+	desc = "An illegal software package that will allow an artificial intelligence to distribute a virus to all sensor-enabled clothing, permanently enabling their vital sensors and tracking beacons."
+	icon = 'icons/obj/module.dmi'
+	icon_state = "datadisk3"
+
+/obj/item/suitsensors_upgrade/afterattack(mob/living/silicon/ai/AI, mob/user, proximity)
+	. = ..()
+	if(!proximity)
+		return
+	if(!istype(AI))
+		return
+	if(!GLOB.force_sensors)
+		GLOB.force_sensors = TRUE
+		to_chat(AI, "<span class='userdanger'>[user] has upgraded you with a suit sensor virus!</span>")
+		to_chat(AI, "Thanks to a powerful virus package, all suit sensors will be permanently enabled, allowing you to monitor the condition of the crew and track them.")
+	to_chat(user, "<span class='notice'>You upgrade [AI]. [src] is consumed in the process.</span>")
+	log_game("[key_name(user)] has upgraded [key_name(AI)] with a [src].")
+	message_admins("[ADMIN_LOOKUPFLW(user)] has upgraded [ADMIN_LOOKUPFLW(AI)] with a [src].")
+	qdel(src)
+

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -1,5 +1,6 @@
 #define DEFAULT_DOOMSDAY_TIMER 4500
 #define DOOMSDAY_ANNOUNCE_INTERVAL 600
+#define ANTAG_FREEZE 1 //Remove if the winter ever ends.
 
 GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		/obj/machinery/field/containment,
@@ -884,8 +885,13 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	unlock_text = "<span class='notice'>Viral payload distributed, all fabric-integrated lifesign monitors and tracking systems have been fully activated.</span>"
 	unlock_sound = 'sound/machines/defib_success.ogg'
 
-/datum/AI_Module/large/suit_sensors/upgrade()
-	GLOB.force_sensors = TRUE //It's easier and more efficient to set a global var that crew monitors check, than to iterate through every piece of clothing and change the sensor state.
+/datum/AI_Module/large/suit_sensors/upgrade(mob/living/silicon/ai/AI)
+	if(ANTAG_FREEZE && AI.mind.has_antag_datum(/datum/antagonist/traitor,TRUE)) //to avoid violating the permanent antag freeze
+		to_chat(owner, "<span class='notice'>Sorry! Syndicate-affiliated Artifical Intelligences are unable to use this right now!</span>")
+		var/datum/module_picker/M = AI.module_picker
+		M.processing_time += cost
+	else
+		GLOB.force_sensors = TRUE //It's easier and more efficient to set a global var that crew monitors check, than to iterate through every piece of clothing and change the sensor state.
 
 /datum/AI_Module/large/eavesdrop
 	module_name = "Enhanced Surveillance"
@@ -903,3 +909,4 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 
 #undef DEFAULT_DOOMSDAY_TIMER
 #undef DOOMSDAY_ANNOUNCE_INTERVAL
+#undef ANTAG_FREEZE

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -890,8 +890,8 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 /datum/AI_Module/large/suit_sensors/upgrade(mob/living/silicon/ai/AI)
 	if(ANTAG_FREEZE && AI.mind.has_antag_datum(/datum/antagonist/traitor,TRUE)) //to avoid violating the permanent antag freeze
 		to_chat(AI, "<span class='notice'>Sorry! Syndicate-affiliated Artifical Intelligences are unable to use this right now!</span>")
-		var/datum/module_picker/M = AI.malf_picker
-		M.processing_time += cost
+		var/datum/module_picker/module = AI.malf_picker
+		module.processing_time += cost
 	else
 		GLOB.force_sensors = TRUE //It's easier and more efficient to set a global var that crew monitors check, than to iterate through every piece of clothing and change the sensor state.
 

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -2,6 +2,8 @@
 #define DOOMSDAY_ANNOUNCE_INTERVAL 600
 #define ANTAG_FREEZE 1 //Remove if the winter ever ends.
 
+GLOBAL_VAR(force_sensors) // For forced suit sensors
+
 GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		/obj/machinery/field/containment,
 		/obj/machinery/power/supermatter_crystal,
@@ -887,8 +889,8 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 
 /datum/AI_Module/large/suit_sensors/upgrade(mob/living/silicon/ai/AI)
 	if(ANTAG_FREEZE && AI.mind.has_antag_datum(/datum/antagonist/traitor,TRUE)) //to avoid violating the permanent antag freeze
-		to_chat(owner, "<span class='notice'>Sorry! Syndicate-affiliated Artifical Intelligences are unable to use this right now!</span>")
-		var/datum/module_picker/M = AI.module_picker
+		to_chat(AI, "<span class='notice'>Sorry! Syndicate-affiliated Artifical Intelligences are unable to use this right now!</span>")
+		var/datum/module_picker/M = AI.malf_picker
 		M.processing_time += cost
 	else
 		GLOB.force_sensors = TRUE //It's easier and more efficient to set a global var that crew monitors check, than to iterate through every piece of clothing and change the sensor state.

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -873,6 +873,20 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 
 	unlock_text = replacetext(unlock_text, "CAMSUPGRADED", "<b>[upgraded_cameras]</b>") //This works, since unlock text is called after upgrade()
 
+//Hack Suit Sensors - sets all suit sensors on all clothing to max and prevents them from being turned off. Fairly obvious if anyone examines a jumpsuit or tries to change suit sensors.
+/datum/AI_Module/large/suit_sensors
+	module_name = "Hack Suit Sensors" //Announcement: "Suit Sensors!"
+	mod_pick_name = "suitsensors"
+	description = "Distribute a virus over the crew monitoring network, setting all suit sensors to max and preventing them from being turned off. The virus will also automatically infect any and all newly-created jumpsuits." //Announcement: "I wasn't asking."
+	one_purchase = TRUE
+	cost = 25 //Not quite omniscience, but it certainly helps!
+	upgrade = TRUE
+	unlock_text = "<span class='notice'>Viral payload distributed, all fabric-integrated lifesign monitors and tracking systems have been fully activated.</span>"
+	unlock_sound = 'sound/machines/defib_success.ogg'
+
+/datum/AI_Module/large/suit_sensors/upgrade()
+	GLOB.force_sensors = TRUE //It's easier and more efficient to set a global var that crew monitors check, than to iterate through every piece of clothing and change the sensor state.
+
 /datum/AI_Module/large/eavesdrop
 	module_name = "Enhanced Surveillance"
 	mod_pick_name = "eavesdrop"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -191,14 +191,14 @@ BLIND     // can't see anything
 		return
 	if (!can_use(M))
 		return
-	if(src.has_sensor == LOCKED_SENSORS)
-		to_chat(usr, "The controls are locked.")
-		return 0
 	if(src.has_sensor == BROKEN_SENSORS)
 		to_chat(usr, "The sensors have shorted out!")
 		return 0
 	if(src.has_sensor <= NO_SENSORS)
 		to_chat(usr, "This suit does not have any sensors.")
+		return 0
+	if(src.has_sensor == LOCKED_SENSORS || GLOB.force_sensors)
+		to_chat(usr, "The controls are locked.") //
 		return 0
 
 	var/list/modes = list("Off", "Binary vitals", "Exact vitals", "Tracking beacon")

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -164,7 +164,7 @@
 	if (has_sensor == BROKEN_SENSORS)
 		. += "Its sensors appear to be shorted out."
 	else if(has_sensor > NO_SENSORS)
-		If(GLOB.force_sensors)
+		if(GLOB.force_sensors)
 			. += "Its vital tracker and tracking beacon appear to be enabled, and seem to be malfunctioning." //hint hint
 		else
 			switch(sensor_mode)

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -61,7 +61,10 @@
 		sensor_mode = pick(SENSOR_OFF, SENSOR_OFF, SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS)
 		if(ismob(loc))
 			var/mob/M = loc
-			to_chat(M,"<span class='warning'>The sensors on the [src] change rapidly!</span>")
+			if(GLOB.force_sensors)
+				to_chat(M,"<span class='warning'>The sensors on the [src] flicker, but remain unchanged!</span>") //Technically changes, but sensor_mode is ignored anyway.
+			else
+				to_chat(M,"<span class='warning'>The sensors on the [src] change rapidly!</span>")
 
 /obj/item/clothing/under/equipped(mob/user, slot)
 	..()
@@ -161,15 +164,18 @@
 	if (has_sensor == BROKEN_SENSORS)
 		. += "Its sensors appear to be shorted out."
 	else if(has_sensor > NO_SENSORS)
-		switch(sensor_mode)
-			if(SENSOR_OFF)
-				. += "Its sensors appear to be disabled."
-			if(SENSOR_LIVING)
-				. += "Its binary life sensors appear to be enabled."
-			if(SENSOR_VITALS)
-				. += "Its vital tracker appears to be enabled."
-			if(SENSOR_COORDS)
-				. += "Its vital tracker and tracking beacon appear to be enabled."
+		If(GLOB.force_sensors)
+			. += "Its vital tracker and tracking beacon appear to be enabled, and seem to be malfunctioning." //hint hint
+		else
+			switch(sensor_mode)
+				if(SENSOR_OFF)
+					. += "Its sensors appear to be disabled."
+				if(SENSOR_LIVING)
+					. += "Its binary life sensors appear to be enabled."
+				if(SENSOR_VITALS)
+					. += "Its vital tracker appears to be enabled."
+				if(SENSOR_COORDS)
+					. += "Its vital tracker and tracking beacon appear to be enabled."
 	if(attached_accessory)
 		. += "\A [attached_accessory] is attached to it."
 

--- a/code/modules/research/designs/electronics_designs.dm
+++ b/code/modules/research/designs/electronics_designs.dm
@@ -33,6 +33,16 @@
 	category = list("Electronics")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/ai_suit_sensor_upgrade
+	name = "Suit Sensor Virus Software Update"
+	desc = "A software package that will allow an artificial intelligence to enable all suit sensors."
+	id = "ai_suit_sensor_upgrade"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 5000, /datum/material/glass = 5000, /datum/material/gold = 20000, /datum/material/silver = 20000, /datum/material/diamond = 10000, /datum/material/titanium = 20000)
+	build_path = /obj/item/suitsensors_upgrade
+	category = list("Electronics")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
 ///////////////////////////////////
 //////////Nanite Devices///////////
 ///////////////////////////////////

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1040,7 +1040,7 @@
 	display_name = "Illegal Technology"
 	description = "Dangerous research used to create dangerous objects."
 	prereq_ids = list("adv_engi", "adv_weaponry", "explosive_weapons")
-	design_ids = list("decloner", "borg_syndicate_module", "ai_cam_upgrade", "suppressor", "largecrossbow", "donksofttoyvendor", "donksoft_refill", "advanced_camera")
+	design_ids = list("decloner", "borg_syndicate_module", "ai_cam_upgrade", "ai_suit_sensor_upgrade", "suppressor", "largecrossbow", "donksofttoyvendor", "donksoft_refill", "advanced_camera")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 	hidden = TRUE


### PR DESCRIPTION
# Now with **ANTAG FREEZE COMPLIANCE**!



Combat-upgraded non-traitor AIs now have a ability that allows them to enable and lock-on all suit sensors, permanently.


The only way to disable them is to damage the jumpsuit itself or get a jumpsuit that doesn't have a sensor in the first place. Making new jumpsuits, using unworn jumpsuits, and such will not work; if it has sensors, they're always enabled.

There are obvious tells that the suit is hacked if you either examine the suit or try to change the setting, but otherwise it doesn't alert anyone on usage.

Costs 25 points, because it's about as, or more obvious than camera upgrades, and it only tells you where people are and if they're still alive, unlike cameras which let you see. Also, a Asimov Combat AI doesn't have all that much to spend points on anyway, so cost isn't super important.

Also adds a equivalent upgrade disk, which can be printed in science if they have unlocked illegal tech, just like the Surveillance upgrade disk,

:cl: 
Add: Growing frustration in the Artifical Intelligence Connectunity has led to the development of a virus that forcibly enables suit sensors. Nanotrasen has outlawed this virus and forbidden all AI from using it, but beware that many AI upgrades disks still have a copy of the virus!
/:cl: