### PR TITLE
Remove derelict apc from Derelict

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -3812,10 +3812,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/solar_control)
-"PQ" = (
-/obj/machinery/power/apc,
-/turf/template_noop,
-/area/template_noop)
 "PR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel/airless,
@@ -12723,7 +12719,7 @@ aa
 aa
 aa
 aa
-PQ
+aa
 aa
 aa
 aa


### PR DESCRIPTION
## About The Pull Request
There was a lone APC created in space on the derelict ruin by tgstation/tgstation#48295. Check your map diffs!

## Changelog
:cl: JJRcop
del: Errant APC in Derelict ruin was removed.
/:cl: