### PR TITLE
Improve holiday station name picking

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -67,10 +67,11 @@ GLOBAL_VAR(command_name)
 		name = ""
 
 	// Prefix
-	for(var/holiday_name in SSevents.holidays)
-		if(holiday_name == "Friday the 13th")
-			random = 13
+	var/holiday_name = pick(SSevents.holidays)
+	if(holiday_name)
 		var/datum/holiday/holiday = SSevents.holidays[holiday_name]
+		if(istype(holiday), /datum/holiday/friday_thirteenth)
+			random = 13
 		name = holiday.getStationPrefix()
 		//get normal name
 	if(!name)

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -70,7 +70,7 @@ GLOBAL_VAR(command_name)
 	var/holiday_name = pick(SSevents.holidays)
 	if(holiday_name)
 		var/datum/holiday/holiday = SSevents.holidays[holiday_name]
-		if(istype(holiday, /datum/holiday/friday_thirteenth)
+		if(istype(holiday, /datum/holiday/friday_thirteenth))
 			random = 13
 		name = holiday.getStationPrefix()
 		//get normal name

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -70,7 +70,7 @@ GLOBAL_VAR(command_name)
 	var/holiday_name = pick(SSevents.holidays)
 	if(holiday_name)
 		var/datum/holiday/holiday = SSevents.holidays[holiday_name]
-		if(istype(holiday), /datum/holiday/friday_thirteenth)
+		if(istype(holiday, /datum/holiday/friday_thirteenth)
 			random = 13
 		name = holiday.getStationPrefix()
 		//get normal name


### PR DESCRIPTION
- Randomly pick an active holiday instead of using the last one.
- Remove hard-coded string lookup of Friday the 13th.

Sorry for the webedit, local repo refuses to push because of the actions stuff and I'm too lazy to fix it right now.

:cl:
fix: If multiple holidays are active, the station name may be derived from any of them instead of a single one.
/:cl: