### PR TITLE
Breath interacts with body temperature

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -41,11 +41,10 @@
 #define CELL_VOLUME				2500
 
 /// liters in a normal breath
-#define BREATH_VOLUME				0.5
+#define BREATH_VOLUME			0.5
 /// Amount of air to take a from a tile
-#define BREATH_PERCENTAGE			(BREATH_VOLUME/CELL_VOLUME)
-// Your breath is a few degrees less than body temperature
-#define BREATH_TEMPERATURE_OFFSET	4
+#define BREATH_PERCENTAGE		(BREATH_VOLUME/CELL_VOLUME)
+
 
 //EXCITED GROUPS
 /// number of FULL air controller ticks before an excited group breaks down (averages gas contents across turfs)

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -44,7 +44,7 @@
 #define BREATH_VOLUME				0.5
 /// Amount of air to take a from a tile
 #define BREATH_PERCENTAGE			(BREATH_VOLUME/CELL_VOLUME)
-// Your breath is a few degrees less then body temperatur
+// Your breath is a few degrees less than body temperature
 #define BREATH_TEMPERATURE_OFFSET	4
 
 //EXCITED GROUPS

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -39,10 +39,13 @@
 #define MOLES_N2STANDARD		(MOLES_CELLSTANDARD*N2STANDARD)
 /// liters in a cell
 #define CELL_VOLUME				2500
+
 /// liters in a normal breath
-#define BREATH_VOLUME			0.5
+#define BREATH_VOLUME				0.5
 /// Amount of air to take a from a tile
-#define BREATH_PERCENTAGE		(BREATH_VOLUME/CELL_VOLUME)
+#define BREATH_PERCENTAGE			(BREATH_VOLUME/CELL_VOLUME)
+// Your breath is a few degrees less then body temperatur
+#define BREATH_TEMPERATURE_OFFSET	4
 
 //EXCITED GROUPS
 /// number of FULL air controller ticks before an excited group breaks down (averages gas contents across turfs)
@@ -72,7 +75,7 @@
 #define WALL_HEAT_TRANSFER_COEFFICIENT		0.0
 #define OPEN_HEAT_TRANSFER_COEFFICIENT		0.4
 /// a hack for now
-#define WINDOW_HEAT_TRANSFER_COEFFICIENT	0.1	
+#define WINDOW_HEAT_TRANSFER_COEFFICIENT	0.1
 /// a hack to help make vacuums "cold", sacrificing realism for gameplay
 #define HEAT_CAPACITY_VACUUM				7000
 
@@ -104,7 +107,7 @@
 
 // Pressure limits.
 /// This determins at what pressure the ultra-high pressure red icon is displayed. (This one is set as a constant)
-#define HAZARD_HIGH_PRESSURE				550	
+#define HAZARD_HIGH_PRESSURE				550
 /// This determins when the orange pressure icon is displayed (it is 0.7 * HAZARD_HIGH_PRESSURE)
 #define WARNING_HIGH_PRESSURE				325
 /// This is when the gray low pressure icon is displayed. (it is 2.5 * HAZARD_LOW_PRESSURE)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -285,13 +285,9 @@
 			else
 				SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
 
-
 	//Clear all moods if no miasma at all
 	else
 		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
-
-
-
 
 	breath.garbage_collect()
 
@@ -302,7 +298,13 @@
 
 //Fourth and final link in a breath chain
 /mob/living/carbon/proc/handle_breath_temperature(datum/gas_mixture/breath)
-	return
+	// the air you breath out should match your body tempurature
+	if(bodytemperature > breath.temperature)
+		// raise the tempurature of our breath to just below body temp
+		breath.temperature = bodytemperature - BREATH_TEMPERATURE_OFFSET
+	else
+		// the air is hot so we need to lower the air temp
+		breath.temperature = bodytemperature + BREATH_TEMPERATURE_OFFSET
 
 /mob/living/carbon/proc/get_breath_from_internal(volume_needed)
 	if(internal)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -298,13 +298,8 @@
 
 //Fourth and final link in a breath chain
 /mob/living/carbon/proc/handle_breath_temperature(datum/gas_mixture/breath)
-	// The air you breath out should about match your body temperature
-	if(bodytemperature > breath.temperature)
-		// Raise the temperature of our breath to just below body temp
-		breath.temperature = bodytemperature - BREATH_TEMPERATURE_OFFSET
-	else
-		// The air is hotter than out body so we need to lower the air temp
-		breath.temperature = bodytemperature + BREATH_TEMPERATURE_OFFSET
+	// The air you breath out should match your body temperature
+	breath.temperature = bodytemperature
 
 /mob/living/carbon/proc/get_breath_from_internal(volume_needed)
 	if(internal)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -298,12 +298,12 @@
 
 //Fourth and final link in a breath chain
 /mob/living/carbon/proc/handle_breath_temperature(datum/gas_mixture/breath)
-	// the air you breath out should match your body tempurature
+	// The air you breath out should about match your body temperature
 	if(bodytemperature > breath.temperature)
-		// raise the tempurature of our breath to just below body temp
+		// Raise the temperature of our breath to just below body temp
 		breath.temperature = bodytemperature - BREATH_TEMPERATURE_OFFSET
 	else
-		// the air is hot so we need to lower the air temp
+		// The air is hotter than out body so we need to lower the air temp
 		breath.temperature = bodytemperature + BREATH_TEMPERATURE_OFFSET
 
 /mob/living/carbon/proc/get_breath_from_internal(volume_needed)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -298,7 +298,7 @@
 
 //Fourth and final link in a breath chain
 /mob/living/carbon/proc/handle_breath_temperature(datum/gas_mixture/breath)
-	// The air you breath out should match your body temperature
+	// The air you breathe out should match your body temperature
 	breath.temperature = bodytemperature
 
 /mob/living/carbon/proc/get_breath_from_internal(volume_needed)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -65,6 +65,8 @@
 			if(1000 to INFINITY)
 				adjustFireLoss(8)
 
+	. = ..() // interact with body heat after dealing with the hot air
+
 /mob/living/carbon/monkey/handle_environment(datum/gas_mixture/environment)
 	if(!environment)
 		return

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -388,12 +388,12 @@
 			if(prob(20))
 				to_chat(H, "<span class='warning'>You feel [hot_message] in your [name]!</span>")
 
-	// the air you breath out should match your body tempurature
+	// The air you breath out should about match your body temperature
 	if(H.bodytemperature > breath.temperature)
-		// raise the tempurature of our breath to just below body temp
+		// Raise the temperature of our breath to just below body temp
 		breath.temperature = H.bodytemperature - BREATH_TEMPERATURE_OFFSET
 	else
-		// the air is hot so we need to lower the air temp
+		// The air is hotter than out body so we need to lower the air temp
 		breath.temperature = H.bodytemperature + BREATH_TEMPERATURE_OFFSET
 
 /obj/item/organ/lungs/on_life()

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -388,13 +388,8 @@
 			if(prob(20))
 				to_chat(H, "<span class='warning'>You feel [hot_message] in your [name]!</span>")
 
-	// The air you breath out should about match your body temperature
-	if(H.bodytemperature > breath.temperature)
-		// Raise the temperature of our breath to just below body temp
-		breath.temperature = H.bodytemperature - BREATH_TEMPERATURE_OFFSET
-	else
-		// The air is hotter than out body so we need to lower the air temp
-		breath.temperature = H.bodytemperature + BREATH_TEMPERATURE_OFFSET
+	// The air you breath out should match your body temperature
+	breath.temperature = H.bodytemperature
 
 /obj/item/organ/lungs/on_life()
 	..()

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -388,6 +388,14 @@
 			if(prob(20))
 				to_chat(H, "<span class='warning'>You feel [hot_message] in your [name]!</span>")
 
+	// the air you breath out should match your body tempurature
+	if(H.bodytemperature > breath.temperature)
+		// raise the tempurature of our breath to just below body temp
+		breath.temperature = H.bodytemperature - BREATH_TEMPERATURE_OFFSET
+	else
+		// the air is hot so we need to lower the air temp
+		breath.temperature = H.bodytemperature + BREATH_TEMPERATURE_OFFSET
+
 /obj/item/organ/lungs/on_life()
 	..()
 	if((!failed) && ((organ_flags & ORGAN_FAILING)))

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -388,7 +388,7 @@
 			if(prob(20))
 				to_chat(H, "<span class='warning'>You feel [hot_message] in your [name]!</span>")
 
-	// The air you breath out should match your body temperature
+	// The air you breathe out should match your body temperature
 	breath.temperature = H.bodytemperature
 
 /obj/item/organ/lungs/on_life()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Your breath out now interacts with your body temperature.
Breath out will now be your body temperature with an offset as it never quite matches.
This has a minor effect on the station temp, but a 3x3 room of monkeys cannot even heat it up 1c over 10 min. and atmos is plumped to manage heat.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More atmo interactions.
The proc existed for this but was left empty.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Your breath out now interacts with your body temperature.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
