### PR TITLE
Adds deadmin/readmin keybindings

### DIFF
--- a/code/datums/keybinding/admin.dm
+++ b/code/datums/keybinding/admin.dm
@@ -72,3 +72,23 @@
 /datum/keybinding/admin/deadsay/down(client/user)
 	user.get_dead_say()
 	return TRUE
+
+/datum/keybinding/admin/deadmin
+	hotkey_keys = list("Unbound")
+	name = "deadmin"
+	full_name = "Deadmin"
+	description = "Shed your admin powers"
+
+/datum/keybinding/admin/deadmin/down(client/user)
+	user.deadmin()
+	return TRUE
+
+/datum/keybinding/admin/readmin
+	hotkey_keys = list("Unbound")
+	name = "readmin"
+	full_name = "Readmin"
+	description = "Regain your admin powers"
+
+/datum/keybinding/admin/readmin/down(client/user)
+	user.readmin()
+	return TRUE


### PR DESCRIPTION
This PR adds deadmin/readmin keybindings. They're unbound by default, so admins will have to assign keys to them.

## Changelog
:cl: Denton
admin: Added deadmin/readmin keybindings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
