### PR TITLE
Christmas trees can no longer be cut down

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -56,8 +56,7 @@
 	desc = "A wondrous decorated Christmas tree."
 	icon_state = "pine_c"
 	icon_states = null
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //protected by the christmas spirit
-	flags_1 = NODECONSTRUCT_1
+	flags_1 = NODECONSTRUCT_1 //protected by the christmas spirit
 
 /obj/structure/flora/tree/pine/xmas/presents
 	icon_state = "pinepresents"

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -22,8 +22,6 @@
 				user.visible_message("<span class='notice'>[user] fells [src] with the [W].</span>","<span class='notice'>You fell [src] with the [W].</span>", "<span class='hear'>You hear the sound of a tree falling.</span>")
 				playsound(get_turf(src), 'sound/effects/meteorimpact.ogg', 100 , FALSE, FALSE)
 				user.log_message("cut down [src] at [AREACOORD(src)]", LOG_ATTACK)
-				if(istype(src, /obj/structure/flora/tree/pine/xmas))
-					message_admins("[ADMIN_LOOKUPFLW(user)][ADMIN_SMITE(user)] cut down [src] at [ADMIN_COORDJMP(src)]")
 				for(var/i=1 to log_amount)
 					new /obj/item/grown/log/tree(get_turf(src))
 				var/obj/structure/flora/stump/S = new(loc)
@@ -58,6 +56,8 @@
 	desc = "A wondrous decorated Christmas tree."
 	icon_state = "pine_c"
 	icon_states = null
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //protected by the christmas spirit
+	flags_1 = NODECONSTRUCT_1
 
 /obj/structure/flora/tree/pine/xmas/presents
 	icon_state = "pinepresents"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR stops christmas trees from getting cut down like regular trees.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a seasonal event and I don't see any value in having christmas trees cut down within a few seconds. They can still be destroyed if someone puts in enough effort, it'll just take a while due to the 150 base integrity.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
tweak: Christmas trees can no longer be cut down like regular trees. They can however still be destroyed with enough effort.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
