### PR TITLE
Generic Gas Tanks now show up in Engie/Cargo protolathes like they're supposed to

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -279,6 +279,7 @@
 	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/tank/internals/generic
 	category = list("initial","Misc","Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
 
 /datum/design/metal
 	name = "Metal"


### PR DESCRIPTION
Emergency gas tanks, extended gas tanks, and plasma air tanks can be made in the Protolathes, but for some reason Generic ones (the grey ones) can't be. Fixes that, easy peasy

## Changelog
:cl:
fix: Generic Gas Tanks (the grey ones) can now be built in the Engineering and Cargo Protolathes like they're supposed to.
/:cl:
