### PR TITLE
Alters immovable rod announcement text

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -27,7 +27,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	announceWhen = 5
 
 /datum/round_event/immovable_rod/announce(fake)
-	priority_announce("Unknown object detected on collision course with the station.", "General Alert")
+	priority_announce("Unknown high-density object detected on collision co-- What the fuck was that?!", "General Alert")
 
 /datum/round_event/immovable_rod/start()
 	var/datum/round_event_control/immovable_rod/C = control

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -27,7 +27,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	announceWhen = 5
 
 /datum/round_event/immovable_rod/announce(fake)
-	priority_announce("What the fuck was that?!", "General Alert")
+	priority_announce("Unknown object detected on collision course with the station.", "General Alert")
 
 /datum/round_event/immovable_rod/start()
 	var/datum/round_event_control/immovable_rod/C = control


### PR DESCRIPTION
:cl: Flavor and Immersion Committee
tweak: Immovable Rod warning announcement is no longer entirely as immersion breaking.
/:cl:

~~I know it's a piece of our heritage... but times change, and I think we all have to accept that the previous announcement is a little bit too silly and immersion breaking.~~

~~(Sorry to all who this change saddens)~~


Should be *slightly* more immersive now, without anything being sacrificed.