### PR TITLE
Fixes speargun not embedding the magspears it fires.

### DIFF
--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -316,6 +316,7 @@
 	checktank = FALSE
 	range_multiplier = 3
 	throw_amount = 1
+	pressureSetting = 2
 	maxWeightClass = 2 //a single magspear
 	spin_item = FALSE
 	var/static/list/magspear_typecache = typecacheof(/obj/item/throwing_star/magspear)


### PR DESCRIPTION

## About The Pull Request

Fixes magspears not embedding when fired from speargun. Embedding compares the throw speed of the object to the embed threshold (4). The pneumatic cannon calculates the speed of the objects it throws as pressureSetting*2, since the default is 1, the magspear was firing magspears at 2 speed, which was not over or equal to the embed threshold, thus they did not embed. Fixes #46199 .

## Why It's Good For The Game
Fixes a bug. Spearguns work again!

## Changelog
:cl:
fix: Fixes magspears not embedding when fired from speargun.
/:cl:


