### PR TITLE
add test for changelings

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1852,3 +1852,19 @@
 	color = "#9C5A19"
 	taste_description = "bananas"
 	can_synth = TRUE
+
+/datum/reagent/lingmus_test
+	name = "Lingmus Test"
+	description = "Test on blood"
+	color = "#3293a8"
+	taste_description = "science"
+
+/datum/reagent/lingmus_test_positive
+	name = "Positive Lingmus Test"
+	description = "changeling caught!"
+	color = "#6b0606"
+
+/datum/reagent/lingmus_test_negative
+	name = "Negative Lingmus Test"
+	description = "No changeling here!"
+	color = "#05f2db"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -642,3 +642,38 @@
 /datum/chemical_reaction/slime_extractification/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
 	new /obj/item/slime_extract/grey(location)
+
+/datum/chemical_reaction/lingmus_test
+	name = "Lingmus test"
+	id = /datum/reagent/lingmus_test
+	results = list(/datum/reagent/lingmus_test = 5)
+	required_reagents = list(/datum/reagent/consumable/ethanol/changelingsting = 5, /datum/reagent/phenol = 5, /datum/reagent/toxin/carpotoxin = 2)
+
+
+/datum/chemical_reaction/changeling_reaction
+	name = "Lingmus reaction"
+	id = "Lingmus reaction"
+	required_reagents = list( /datum/reagent/water = 5, /datum/reagent/lingmus_test = 5)
+	required_catalysts = list(/datum/reagent/blood = 10)
+
+
+/datum/chemical_reaction/changeling_reaction/on_reaction(datum/reagents/holder)
+	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in holder.reagent_list
+
+	if (B && B.data)
+		var/datum/reagent/iron/I = locate(/datum/reagent/iron) in holder.reagent_list
+		var/datum/reagent/toxin/acid/A = locate(/datum/reagent/toxin/acid) in holder.reagent_list
+		var/datum/mind/M = B.data["mind"]
+		// Iron causes a false negative and suplhuric acid causes false positive
+		if (A || (M && M.has_antag_datum(/datum/antagonist/changeling) && !I))
+			holder.add_reagent(/datum/reagent/lingmus_test_positive, 20)
+		else 
+			holder.add_reagent(/datum/reagent/lingmus_test_negative, 20)
+		if (I)
+			holder.remove_reagent(/datum/reagent/iron, I.volume)
+		if (A)
+			holder.remove_reagent(/datum/reagent/toxin/acid, A.volume)
+		holder.remove_reagent(/datum/reagent/blood, B.volume)
+	
+	
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new test for changelings: chemists can create a lingmus test (get it?) created by 5u changeling sting, 5u phenol, 2u carpotoxin.
5u lingmus test + 5u water + 10u of blood will either reveal a light blue liquid (a negative test) or a dark red liquid (ling confirmed)
But watch out! a sneaky chemist can add iron to ensure the test will always show as negative or add sulphuric acid to ensure the test will resolve as positive.

## Why It's Good For The Game

There's always been a bit of a gap for confirming lings which I find annoying as security, often I'll just have to shuttle gib them and hope it was the right thing to do.
Hopefully this adds this functionality but without making it too easy. I've tried to balance the recipe so it's not so hard that it will never be used but not so easy it will be used on everyone not just suspects. Especially since you can't trust it due to potential sabotage. Please feel free to suggest other alternative recipes.




## Changelog
:cl: Wineallwine
add: the lingmus test to test changeling blood. Created with 5u changeling sting, 5u phenol and 2u carpotoxin, mixing blood and water will reveal if someone is a changeling. But watch out! a sneaky chemist can falsify the results with iron or sulphuric acid!

/:cl:

