### PR TITLE
Xenomorph embryos no longer proccess in dead hosts

### DIFF
--- a/code/game/objects/items/body_egg.dm
+++ b/code/game/objects/items/body_egg.dm
@@ -29,12 +29,6 @@
 		INVOKE_ASYNC(src, .proc/RemoveInfectionImages, owner)
 	..()
 
-/obj/item/organ/body_egg/on_death()
-	. = ..()
-	if(!owner)
-		return
-	egg_process()
-
 /obj/item/organ/body_egg/on_life()
 	. = ..()
 	egg_process()


### PR DESCRIPTION
This gives xenomorphs a reason to keep alive hosts, until they burst, so aliens wont be no longer encouraged to kill their host once infected, which is just unfun gameplay
:cl:
balance: Xenomorph embryos no longer grow in dead hosts.
/:cl:
