### PR TITLE
Make fire alarm monitoring work at the area level

### DIFF
--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -72,15 +72,23 @@
 /datum/computer_file/program/alarm_monitor/proc/cancelAlarm(class, area/A, obj/origin)
 	var/list/L = alarms[class]
 	var/cleared = 0
+	var/arealevelalarm = 0 // set to 1 for alarms that set/clear whole areas
+	if (class=="Fire")
+		arealevelalarm = 1
 	for (var/I in L)
 		if (I == A.name)
-			var/list/alarm = L[I]
-			var/list/srcs  = alarm[3]
-			if (origin in srcs)
-				srcs -= origin
-			if (srcs.len == 0)
+			if (arealevelalarm == 0) // the traditional behaviour
+				var/list/alarm = L[I]
+				var/list/srcs  = alarm[3]
+				if (origin in srcs)
+					srcs -= origin
+				if (srcs.len == 0)
+					cleared = 1
+					L -= I
+			else
+				L -= I // wipe the instances entirely
 				cleared = 1
-				L -= I
+
 
 	update_alarm_display()
 	return !cleared

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -72,12 +72,12 @@
 /datum/computer_file/program/alarm_monitor/proc/cancelAlarm(class, area/A, obj/origin)
 	var/list/L = alarms[class]
 	var/cleared = 0
-	var/arealevelalarm = 0 // set to 1 for alarms that set/clear whole areas
+	var/arealevelalarm = FALSE // set to TRUE for alarms that set/clear whole areas
 	if (class=="Fire")
-		arealevelalarm = 1
+		arealevelalarm = TRUE
 	for (var/I in L)
 		if (I == A.name)
-			if (arealevelalarm == 0) // the traditional behaviour
+			if (!arealevelalarm) // the traditional behaviour
 				var/list/alarm = L[I]
 				var/list/srcs  = alarm[3]
 				if (origin in srcs)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the Alarm Monitoring program on tablets/consoles/computers to clear fire alarms for the area rather than individual alarms when a fire alarm is cleared.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently fire alarms can become stuck "on" in the monitoring program if the alarms are cancelled from a different fire alarm, or the originating fire alarm is destroyed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: iain0
fix: Alarm Monitoring program changed to avoid always-on unclearable fire alarms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Fixes #48421