### PR TITLE
Deleting a reagent removes it from the addiction list if present

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -543,8 +543,10 @@
 					R.metabolizing = FALSE
 					R.on_mob_end_metabolize(M)
 				R.on_mob_delete(M)
-			qdel(R)
+			//Clear from relevant lists
+			addiction_list -= R
 			reagent_list -= R
+			qdel(R)
 			update_total()
 			if(my_atom)
 				my_atom.on_reagent_change(DEL_REAGENT)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -71,6 +71,8 @@
 
 /datum/reagents/Destroy()
 	. = ..()
+	//We're about to delete all reagents, so lets cleanup
+	addiction_list.Cut()
 	var/list/cached_reagents = reagent_list
 	for(var/reagent in cached_reagents)
 		var/datum/reagent/R = reagent


### PR DESCRIPTION
This prevents nulls in the addiction list that lead to later runtimes
when trying to heal/clear addictions on users