### PR TITLE
Moves "Cancel Camera View" verb to ghost tab

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -580,7 +580,7 @@
   */
 /mob/verb/cancel_camera()
 	set name = "Cancel Camera View"
-	set category = "OOC"
+	set category = "Ghost"
 	reset_perspective(null)
 	unset_machine()
 


### PR DESCRIPTION
This PR moves the "Cancel Camera View" verb to the ghost tab, like in #48258
Fixes: #48435

## Changelog
:cl:
tweak: Moved the "Cancel Camera View" verb to the ghost tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
