### PR TITLE
Readds map diversity

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -233,7 +233,7 @@ SUBSYSTEM_DEF(mapping)
 	station_start = world.maxz + 1
 	INIT_ANNOUNCE("Loading [config.map_name]...")
 	LoadGroup(FailedZs, "Station", config.map_path, config.map_file, config.traits, ZTRAITS_STATION)
- 
+
 	if(SSdbcore.Connect())
 		var/datum/DBQuery/query_round_map_name = SSdbcore.NewQuery("UPDATE [format_table_name("round")] SET map_name = '[config.map_name]' WHERE id = [GLOB.round_id]")
 		query_round_map_name.Execute()
@@ -266,7 +266,7 @@ SUBSYSTEM_DEF(mapping)
 		fdel("_maps/custom/[config.map_file]")
 		// And as the file is now removed set the next map to default.
 		next_map_config = load_map_config(default_to_box = TRUE)
-	
+
 GLOBAL_LIST_EMPTY(the_station_areas)
 
 /datum/controller/subsystem/mapping/proc/generate_station_area_list()
@@ -285,9 +285,8 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 
 /datum/controller/subsystem/mapping/proc/maprotate()
 	if(map_voted)
-		map_voted = FALSE
 		return
-	
+
 	var/players = GLOB.clients.len
 	var/list/mapvotes = list()
 	//count votes

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -1,4 +1,5 @@
 #define FILE_ANTAG_REP "data/AntagReputation.json"
+#define FILE_RECENT_MAPS "data/RecentMaps.json"
 
 SUBSYSTEM_DEF(persistence)
 	name = "Persistence"
@@ -107,10 +108,10 @@ SUBSYSTEM_DEF(persistence)
 	saved_modes = json["data"]
 
 /datum/controller/subsystem/persistence/proc/LoadRecentMaps()
-	var/json_file = file("data/RecentMaps.json")
-	if(!fexists(json_file))
+	var/map_sav = FILE_RECENT_MAPS
+	if(!fexists(FILE_RECENT_MAPS))
 		return
-	var/list/json = json_decode(file2text(json_file))
+	var/list/json = json_decode(file2text(map_sav))
 	if(!json)
 		return
 	saved_maps = json["data"]

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -286,7 +286,7 @@ SUBSYSTEM_DEF(persistence)
 /datum/controller/subsystem/persistence/proc/CollectMaps()
 	saved_maps[2] = saved_maps[1]
 	saved_maps[1] = SSmapping.config.map_name
-	var/json_file = file("data/RecentMaps.json")
+	var/json_file = file(FILE_RECENT_MAPS)
 	var/list/file_data = list()
 	file_data["data"] = saved_maps
 	fdel(json_file)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -198,7 +198,7 @@ SUBSYSTEM_DEF(vote)
 					for(var/name in SSpersistence.saved_maps)
 						if(VM.map_name == name)
 							run++
-					if(run >= 2)	//If run twice in the last three (including current) as of time of writing, disable map for voting.
+					if(run >= 2 || !VM.votable)	//If run twice in the last three (including current) as of time of writing, disable map for voting.
 						continue
 					choices.Add(VM.map_name)
 			if("custom")

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -74,12 +74,12 @@ SUBSYSTEM_DEF(vote)
 			else if(mode == "map")
 				for (var/non_voter_ckey in non_voters)
 					var/client/C = non_voters[non_voter_ckey]
-					if(C.prefs.preferred_map)
+					if(C.prefs.preferred_map && choices[C.prefs.preferred_map]) //No votes if the map isnt in the vote.
 						var/preferred_map = C.prefs.preferred_map
 						choices[preferred_map] += 1
 						greatest_votes = max(greatest_votes, choices[preferred_map])
-					else if(global.config.defaultmap)
-						var/default_map = global.config.defaultmap.map_name
+					else if(config.defaultmap && choices[config.defaultmap]) //No votes if the map isnt in the vote.
+						var/default_map = config.defaultmap.map_name
 						choices[default_map] += 1
 						greatest_votes = max(greatest_votes, choices[default_map])
 	//get all options with that many votes and return them in a list

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -121,27 +121,27 @@ SUBSYSTEM_DEF(vote)
 
 /datum/controller/subsystem/vote/proc/result()
 	. = announce_result()
-	var/restart = 0
+	var/restart = FALSE
 	if(.)
 		switch(mode)
 			if("restart")
 				if(. == "Restart Round")
-					restart = 1
+					restart = TRUE
 			if("gamemode")
 				if(GLOB.master_mode != .)
 					SSticker.save_mode(.)
 					if(SSticker.HasRoundStarted())
-						restart = 1
+						restart = TRUE
 					else
 						GLOB.master_mode = .
 			if("map")
 				SSmapping.changemap(global.config.maplist[.])
 				SSmapping.map_voted = TRUE
 	if(restart)
-		var/active_admins = 0
+		var/active_admins = FALSE
 		for(var/client/C in GLOB.admins)
 			if(!C.is_afk() && check_rights_for(C, R_SERVER))
-				active_admins = 1
+				active_admins = TRUE
 				break
 		if(!active_admins)
 			SSticker.Reboot("Restart vote successful.", "restart vote")
@@ -154,30 +154,31 @@ SUBSYSTEM_DEF(vote)
 /datum/controller/subsystem/vote/proc/submit_vote(vote)
 	if(mode)
 		if(CONFIG_GET(flag/no_dead_vote) && usr.stat == DEAD && !usr.client.holder)
-			return 0
+			return FALSE
 		if(!(usr.ckey in voted))
 			if(vote && 1<=vote && vote<=choices.len)
 				voted += usr.ckey
 				choices[choices[vote]]++	//check this
 				return vote
-	return 0
+	return FALSE
 
 /datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key)
+	var/admin = FALSE
+	var/ckey = ckey(initiator_key)
+	if(GLOB.admin_datums[ckey])
+		admin = TRUE
+
 	if(!mode)
 		if(started_time)
 			var/next_allowed_time = (started_time + CONFIG_GET(number/vote_delay))
 			if(mode)
 				to_chat(usr, "<span class='warning'>There is already a vote in progress! please wait for it to finish.</span>")
-				return 0
+				return FALSE
 
-			var/admin = FALSE
-			var/ckey = ckey(initiator_key)
-			if(GLOB.admin_datums[ckey])
-				admin = TRUE
 
 			if(next_allowed_time > world.time && !admin)
 				to_chat(usr, "<span class='warning'>A vote was initiated recently, you must wait [DisplayTimeText(next_allowed_time-world.time)] before a new vote can be started!</span>")
-				return 0
+				return FALSE
 
 		reset()
 		switch(vote_type)
@@ -186,22 +187,31 @@ SUBSYSTEM_DEF(vote)
 			if("gamemode")
 				choices.Add(config.votable_modes)
 			if("map")
-				for(var/map in global.config.maplist)
+				if(!admin && SSmapping.map_voted)
+					to_chat(usr, "<span class='warning'>The next map has already been selected.</span>")
+					return FALSE
+				for(var/map in config.maplist)
 					var/datum/map_config/VM = config.maplist[map]
-					if(!VM.votable)
+					var/run = 0
+					if(VM.map_name == SSmapping.config.map_name)
+						run++
+					for(var/name in SSpersistence.saved_maps)
+						if(VM.map_name == name)
+							run++
+					if(run >= 2)	//If run twice in the last three (including current) as of time of writing, disable map for voting.
 						continue
 					choices.Add(VM.map_name)
 			if("custom")
 				question = stripped_input(usr,"What is the vote for?")
 				if(!question)
-					return 0
+					return FALSE
 				for(var/i=1,i<=10,i++)
 					var/option = capitalize(stripped_input(usr,"Please enter an option or hit cancel to finish"))
 					if(!option || mode || !usr.client)
 						break
 					choices.Add(option)
 			else
-				return 0
+				return FALSE
 		mode = vote_type
 		initiator = initiator_key
 		started_time = world.time
@@ -220,18 +230,18 @@ SUBSYSTEM_DEF(vote)
 			C.player_details.player_actions += V
 			V.Grant(C.mob)
 			generated_actions += V
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /datum/controller/subsystem/vote/proc/interface(client/C)
 	if(!C)
 		return
-	var/admin = 0
-	var/trialmin = 0
+	var/admin = FALSE
+	var/trialmin = FALSE
 	if(C.holder)
-		admin = 1
+		admin = TRUE
 		if(check_rights_for(C, R_ADMIN))
-			trialmin = 1
+			trialmin = TRUE
 	voting |= C
 
 	if(mode)
@@ -291,11 +301,11 @@ SUBSYSTEM_DEF(vote)
 	if(!usr || !usr.client)
 		return	//not necessary but meh...just in-case somebody does something stupid
 
-	var/trialmin = 0
+	var/trialmin = FALSE
 	if(usr.client.holder)
 		if(check_rights_for(usr.client, R_ADMIN))
-			trialmin = 1
-	
+			trialmin = TRUE
+
 	switch(href_list["vote"])
 		if("close")
 			voting -= usr.client
@@ -357,7 +367,7 @@ SUBSYSTEM_DEF(vote)
 		Remove(owner)
 
 /datum/action/vote/IsAvailable()
-	return 1
+	return TRUE
 
 /datum/action/vote/proc/remove_from_client()
 	if(!owner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes map vote to only allow for changing the next map once per round, and adds map tracking of the last two rounds to SSPersistence. Map votes will no longer include maps that have been chosen twice in the last three rounds, including current. 

In practice, this means maps like Metastation which have a ridiculous play rate (>95%) should land at a maximum of 50% play rate if votes control the map choice all the time. Map rotation choice is not affected by this, but will be unable to change away from voted map.

To satisfy my curiosity I grabbed some map distribution data from our logs.
https://cdn.discordapp.com/attachments/326831214667235328/661007980032163845/unknown.png
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We have way too little played map diversity, and it is hurting both our replayability and the state of our map pool. This should hopefully also get people working on our other maps again so we don't end up with a ton of unused outdated maps.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
tweak: Map vote now only allows one map vote/rotation per round. Maps that have been played twice in the last three rounds including current are not available for voting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
