### PR TITLE
Fixes false positive quirk cap trigger

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1098,7 +1098,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						return
 					all_quirks -= quirk
 				else
-					if(GetPositiveQuirkCount() >= MAX_QUIRKS)
+					var/is_positive_quirk = SSquirks.quirk_points[quirk] > 0
+					if(is_positive_quirk && GetPositiveQuirkCount() >= MAX_QUIRKS)
 						to_chat(user, "<span class='warning'>You can't have more than [MAX_QUIRKS] positive quirks!</span>")
 						return
 					if(balance - value < 0)


### PR DESCRIPTION
## About The Pull Request

Fixes #48375

## Why It's Good For The Game

Capping total quirks was never the intention here.

## Changelog
:cl:
fix: You are no longer prevented from selecting more neutral/negative quirks once you have reached the limit of 6 positive ones.
/:cl: