### PR TITLE
Restores Maintenance Drones to Robotics

### DIFF
--- a/code/datums/components/shy.dm
+++ b/code/datums/components/shy.dm
@@ -1,0 +1,46 @@
+/// You can't use items on anyone other than yourself if there are other living mobs around you
+/datum/component/shy
+	can_transfer = TRUE
+	var/shy_range = 4 //! Range of your bashfullness
+	var/list/whitelist //! Typecache of mob types you are okay around
+	var/message = "You find yourself too shy to do that around %TARGET!" //! Message shown when you are bashful
+	var/dead_shy = FALSE //! Are you shy around a dead body?
+
+/// _shy_range, _whitelist, _message map to vars
+/datum/component/shy/Initialize(_whitelist, _shy_range, _message, _dead_shy)
+	if(!ismob(parent))
+		return COMPONENT_INCOMPATIBLE
+	whitelist = _whitelist
+	if(_shy_range)
+		shy_range = _shy_range
+	if(_message)
+		message = _message
+	if(_dead_shy)
+		dead_shy = _dead_shy
+
+/datum/component/shy/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_MOB_CLICKON, .proc/bashful)
+
+/datum/component/shy/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_CLICKON)
+
+/datum/component/shy/PostTransfer()
+	if(!ismob(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/shy/InheritComponent(datum/component/shy/friend, i_am_original, list/arguments)
+	if(i_am_original)
+		shy_range = friend.shy_range
+		whitelist = friend.whitelist
+		message = friend.message
+
+/datum/component/shy/proc/bashful(datum/source, atom/A, params)
+	var/mob/owner = parent
+	var/list/strangers = view(shy_range, get_turf(owner))
+	if(!length(strangers) || !(locate(/mob/living) in strangers) || (A in owner.DirectAccess()))
+		return
+
+	for(var/mob/living/person in strangers)
+		if(!is_type_in_typecache(person, whitelist) && (person.stat != DEAD || dead_shy))
+			to_chat(owner, "<span class='warning'>[replacetext(message, "%TARGET", person)]</span>")
+			return COMSIG_MOB_CANCEL_CLICKON

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -244,8 +244,7 @@ Key procs
 							/datum/language/narsie = list(LANGUAGE_ATOM))
 
 /datum/language_holder/drone
-	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM),
-								/datum/language/machine = list(LANGUAGE_ATOM))
+	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
 	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 

--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -81,4 +81,4 @@
 	if(!D)
 		return ..()
 	icon = 'icons/mob/drone.dmi'
-	icon_state = "[D.visualAppearence]_hat"
+	icon_state = "[D.visualAppearance]_hat"

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -67,7 +67,7 @@
 	var/obj/item/head
 	var/obj/item/default_storage = /obj/item/storage/backpack/duffelbag/drone //If this exists, it will spawn in internal storage
 	var/obj/item/default_hatmask //If this exists, it will spawn in the hat/mask slot if it can fit
-	var/visualAppearence = MAINTDRONE //What we appear as
+	var/visualAppearance = MAINTDRONE //What we appear as
 	var/hacked = FALSE //If we have laws to destroy the station
 	var/shy = TRUE //! If we have laws to minimize bothering others
 	var/flavortext = \

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -69,6 +69,7 @@
 	var/obj/item/default_hatmask //If this exists, it will spawn in the hat/mask slot if it can fit
 	var/visualAppearence = MAINTDRONE //What we appear as
 	var/hacked = FALSE //If we have laws to destroy the station
+	var/shy = TRUE //! If we have laws to minimize bothering others
 	var/flavortext = \
 	"\n<big><span class='warning'>DO NOT INTERFERE WITH THE ROUND AS A DRONE OR YOU WILL BE DRONE BANNED</span></big>\n"+\
 	"<span class='notice'>Drones are a ghost role that are allowed to fix the station and build things. Interfering with the round as a drone is against the rules.</span>\n"+\
@@ -94,6 +95,8 @@
 		equip_to_slot_or_del(I, ITEM_SLOT_HEAD)
 
 	ADD_TRAIT(access_card, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
+
+	shy_update()
 
 	alert_drones(DRONE_NET_CONNECT)
 
@@ -239,6 +242,20 @@
 					L -= I
 		if(cleared)
 			to_chat(src, "--- [class] alarm in [A.name] has been cleared.")
+
+/mob/living/simple_animal/drone/proc/set_shy(newShy)
+	shy = newShy
+	shy_update()
+
+/mob/living/simple_animal/drone/proc/shy_update()
+	if(shy)
+		ADD_TRAIT(src, TRAIT_PACIFISM, INNATE_TRAIT)
+		LoadComponent(/datum/component/shy, typecacheof(/mob/living/simple_animal/drone), 4, "Your laws prevent this action near %TARGET.", TRUE)
+	else
+		REMOVE_TRAIT(src, TRAIT_PACIFISM, INNATE_TRAIT)
+		var/datum/component/shy/S = GetComponent(/datum/component/shy)
+		if(S)
+			qdel(S)
 
 /mob/living/simple_animal/drone/handle_temperature_damage()
 	return

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -15,7 +15,10 @@
 	density = FALSE
 	death = FALSE
 	roundstart = FALSE
+	mob_name = "drone"
 	mob_type = /mob/living/simple_animal/drone //Type of drone that will be spawned
+	banType = ROLE_DRONE
+	show_flavour = FALSE
 
 /obj/effect/mob_spawn/drone/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -87,15 +87,15 @@
 /mob/living/simple_animal/drone/polymorphed/Initialize()
 	. = ..()
 	liberate()
-	visualAppearence = pick(MAINTDRONE, REPAIRDRONE, SCOUTDRONE)
-	if(visualAppearence == MAINTDRONE)
+	visualAppearance = pick(MAINTDRONE, REPAIRDRONE, SCOUTDRONE)
+	if(visualAppearance == MAINTDRONE)
 		var/colour = pick("grey", "blue", "red", "green", "pink", "orange")
-		icon_state = "[visualAppearence]_[colour]"
+		icon_state = "[visualAppearance]_[colour]"
 	else
-		icon_state = visualAppearence
+		icon_state = visualAppearance
 
 	icon_living = icon_state
-	icon_dead = "[visualAppearence]_dead"
+	icon_dead = "[visualAppearance]_dead"
 
 /obj/effect/mob_spawn/drone/derelict
 	name = "derelict drone shell"

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -29,6 +29,7 @@
 	default_storage = /obj/item/uplink
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi
 	hacked = TRUE
+	shy = FALSE
 	flavortext = null
 
 /mob/living/simple_animal/drone/syndrone/Initialize()

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -149,7 +149,7 @@
 		ventcrawler = initial(ventcrawler)
 		speed = initial(speed)
 		message_admins("[ADMIN_LOOKUPFLW(src)], a hacked drone, was restored to factory defaults!")
-	update_drone_icon()
+	update_drone_icon_hacked()
 
 /mob/living/simple_animal/drone/proc/liberate()
 	// F R E E D R O N E
@@ -157,25 +157,18 @@
 	set_shy(FALSE)
 	to_chat(src, laws)
 
-/mob/living/simple_animal/drone/proc/update_drone_icon()
-	//Different icons for different hack states
-	if(!hacked)
-		if(visualAppearence == SCOUTDRONE_HACKED)
-			visualAppearence = SCOUTDRONE
-		else if(visualAppearence == REPAIRDRONE_HACKED)
-			visualAppearence = REPAIRDRONE
-		else if(visualAppearence == MAINTDRONE_HACKED)
-			visualAppearence = MAINTDRONE + "_[colour]"
-	else if(hacked)
-		if(visualAppearence == SCOUTDRONE)
-			visualAppearence = SCOUTDRONE_HACKED
-		else if(visualAppearence == REPAIRDRONE)
-			visualAppearence = REPAIRDRONE_HACKED
-		else if(visualAppearence == MAINTDRONE)
-			visualAppearence = MAINTDRONE_HACKED
-
-	icon_living = "[visualAppearence]"
-	icon_dead = "[visualAppearence]_dead"
+/mob/living/simple_animal/drone/proc/update_drone_icon_hacked() //this is hacked both ways
+	var/static/hacked_appearances = list(
+		SCOUTDRONE = SCOUTDRONE_HACKED,
+		REPAIRDRONE = REPAIRDRONE_HACKED,
+		MAINTDRONE = MAINTDRONE_HACKED
+	)
+	if(hacked)
+		icon_living = hacked_appearances[visualAppearence]
+	else if(visualAppearence == MAINTDRONE && colour)
+		icon_living = "[visualAppearence]_[colour]"
+	else
+		icon_living = visualAppearence
 	if(stat == DEAD)
 		icon_state = icon_dead
 	else

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -164,11 +164,11 @@
 		MAINTDRONE = MAINTDRONE_HACKED
 	)
 	if(hacked)
-		icon_living = hacked_appearances[visualAppearence]
-	else if(visualAppearence == MAINTDRONE && colour)
-		icon_living = "[visualAppearence]_[colour]"
+		icon_living = hacked_appearances[visualAppearance]
+	else if(visualAppearance == MAINTDRONE && colour)
+		icon_living = "[visualAppearance]_[colour]"
 	else
-		icon_living = visualAppearence
+		icon_living = visualAppearance
 	if(stat == DEAD)
 		icon_state = icon_dead
 	else

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -127,6 +127,8 @@
 		to_chat(src, laws)
 		to_chat(src, "<i>Your onboard antivirus has initiated lockdown. Motor servos are impaired, ventilation access is denied, and your display reports that you are hacked to all nearby.</i>")
 		hacked = TRUE
+		set_shy(FALSE)
+		REMOVE_TRAIT(src, TRAIT_PACIFISM, SPECIES_TRAIT)
 		mind.special_role = "hacked drone"
 		ventcrawler = VENTCRAWLER_NONE //Again, balance
 		speed = 1 //gotta go slow
@@ -142,6 +144,7 @@
 		to_chat(src, laws)
 		to_chat(src, "<i>Having been restored, your onboard antivirus reports the all-clear and you are able to perform all actions again.</i>")
 		hacked = FALSE
+		set_shy(initial(shy))
 		mind.special_role = null
 		ventcrawler = initial(ventcrawler)
 		speed = initial(speed)
@@ -151,6 +154,7 @@
 /mob/living/simple_animal/drone/proc/liberate()
 	// F R E E D R O N E
 	laws = "1. You are a Free Drone."
+	set_shy(FALSE)
 	to_chat(src, laws)
 
 /mob/living/simple_animal/drone/proc/update_drone_icon()

--- a/code/modules/mob/living/simple_animal/friendly/drone/say.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/say.dm
@@ -22,6 +22,3 @@
 
 /mob/living/simple_animal/drone/proc/drone_chat(msg)
 	alert_drones("<i>Drone Chat: <span class='name'>[name]</span> <span class='message'>[say_quote(msg)]</span></i>", TRUE)
-
-/mob/living/simple_animal/drone/binarycheck()
-	return TRUE

--- a/code/modules/mob/living/simple_animal/friendly/drone/visuals_icons.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/visuals_icons.dm
@@ -98,23 +98,23 @@
 	var/appearence = input("Choose your appearance!", "Appearance", "Maintenance Drone") in sortList(list("Maintenance Drone", "Repair Drone", "Scout Drone"))
 	switch(appearence)
 		if("Maintenance Drone")
-			visualAppearence = MAINTDRONE
+			visualAppearance = MAINTDRONE
 			colour = input("Choose your colour!", "Colour", "grey") in sortList(list("grey", "blue", "red", "green", "pink", "orange"))
-			icon_state = "[visualAppearence]_[colour]"
-			icon_living = "[visualAppearence]_[colour]"
-			icon_dead = "[visualAppearence]_dead"
+			icon_state = "[visualAppearance]_[colour]"
+			icon_living = "[visualAppearance]_[colour]"
+			icon_dead = "[visualAppearance]_dead"
 
 		if("Repair Drone")
-			visualAppearence = REPAIRDRONE
-			icon_state = visualAppearence
-			icon_living = visualAppearence
-			icon_dead = "[visualAppearence]_dead"
+			visualAppearance = REPAIRDRONE
+			icon_state = visualAppearance
+			icon_living = visualAppearance
+			icon_dead = "[visualAppearance]_dead"
 
 		if("Scout Drone")
-			visualAppearence = SCOUTDRONE
-			icon_state = visualAppearence
-			icon_living = visualAppearence
-			icon_dead = "[visualAppearence]_dead"
+			visualAppearance = SCOUTDRONE
+			icon_state = visualAppearance
+			icon_living = visualAppearance
+			icon_dead = "[visualAppearance]_dead"
 
 		else
 			return
@@ -124,7 +124,7 @@
 
 
 /mob/living/simple_animal/drone/proc/getItemPixelShiftY()
-	switch(visualAppearence)
+	switch(visualAppearance)
 		if(MAINTDRONE)
 			. = 0
 		if(REPAIRDRONE,SCOUTDRONE,CLOCKDRONE)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -796,3 +796,13 @@
 	construction_time = 100
 	build_path = /obj/item/assembly/flash/handheld
 	category = list("Misc")
+
+/datum/design/maint_drone
+	name = "Maintenance Drone"
+	desc = "\"Repairs the station without bothering you!\" is what the marketing says."
+	id = "maint_drone"
+	build_type = MECHFAB
+	materials = list(/datum/material/iron = 800, /datum/material/glass = 350)
+	construction_time = 150
+	build_path = /obj/effect/mob_spawn/drone
+	category = list("Misc")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -287,6 +287,15 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
+/datum/techweb_node/dex_robotics
+	id = "dex_robotics"
+	display_name = "Dexterous Robotics Research"
+	description = "The fine art of opposable thumbs."
+	prereq_ids = list("adv_engi", "adv_robotics", "biotech")
+	design_ids = list("maint_drone")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	export_price = 5000
+
 /datum/techweb_node/neural_programming
 	id = "neural_programming"
 	display_name = "Neural Programming"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -414,6 +414,7 @@
 #include "code\datums\components\rotation.dm"
 #include "code\datums\components\shrapnel.dm"
 #include "code\datums\components\shrink.dm"
+#include "code\datums\components\shy.dm"
 #include "code\datums\components\sizzle.dm"
 #include "code\datums\components\slippery.dm"
 #include "code\datums\components\soulstoned.dm"


### PR DESCRIPTION
## About The Pull Request

Drones are back!

If you've played the derelict drones before, these are similar except for being on the station.
To describe drones briefly: They are tiny robots with hands that repair the station and have laws preventing them from interfering with others.

You can now make them again in techwebs. I put them a bit further up in the tech tree so it shouldn't be as common. This does not restore the drone dispensers to the map.

## How it's different from last time

- They can't do much except move around when they are close to a being, alive or dead.
- No more binary chat
- Some bugfixes
- Back in 9c04ff81a0, the drone vision filters were removed. They have not been restored this time, so drones can see beings again
- The drone cargo pack was not restored, just techwebs right now
- As mentioned, drone dispensers are not mapped.

## Why It's Good For The Game

Drones are fun and can help repair the station. Too many players were not listening to the laws, so I figure a gameplay solution would help. Drones are now at the absolute mercy of all beings and can't fight back or do anything except flee. The binary chat change keeps them segregated from the station AI again.

If the item usage limit isn't far enough we can make even further changes.

## Changelog
:cl: JJRcop
add: Maintenance Drones are available as Robotics research once again!
tweak: Drones can no longer use items when near a being.
del: Drones can no longer understand binary chat or machine language.
/:cl: