### PR TITLE
Fixes dynamic rev ruleset going bonkers when first assigned is invalid.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -384,7 +384,7 @@
 		else
 			assigned -= M
 			log_game("DYNAMIC: [ruletype] [name] discarded [M.name] from head revolutionary due to ineligibility.")
-		if(!revolution.members.len)
+		if(!revolution.members.len && !assigned.len)
 			success = FALSE
 			log_game("DYNAMIC: [ruletype] [name] failed to get any eligible headrevs. Refunding [cost] threat.")
 	if(success)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -371,7 +371,6 @@
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/revs/execute()
-	var/success = TRUE
 	revolution = new()
 	for(var/datum/mind/M in assigned)
 		GLOB.pre_setup_antags -= M
@@ -384,14 +383,12 @@
 		else
 			assigned -= M
 			log_game("DYNAMIC: [ruletype] [name] discarded [M.name] from head revolutionary due to ineligibility.")
-		if(!revolution.members.len && !assigned.len)
-			success = FALSE
-			log_game("DYNAMIC: [ruletype] [name] failed to get any eligible headrevs. Refunding [cost] threat.")
-	if(success)
+	if(revolution.members.len)
 		revolution.update_objectives()
 		revolution.update_heads()
 		SSshuttle.registerHostileEnvironment(src)
 		return TRUE
+	log_game("DYNAMIC: [ruletype] [name] failed to get any eligible headrevs. Refunding [cost] threat.")
 	return FALSE
 
 /datum/dynamic_ruleset/roundstart/revs/clean_up()


### PR DESCRIPTION
## About The Pull Request
Basically the revolution ruleset in dynamic continues to create other assigned revheads after refunding and unsuccessfully executing, then it removes the revolution team and the existing revhead datums now create new teams. Ending up with two to three new revolution teams.

## Why It's Good For The Game
Bug fixes are good.

## Changelog
:cl:
fix: Dynamic revolution ruleset no longer makes multiple revolution teams when first assigned revhead is invalid.
/:cl: