### PR TITLE
Arcades keep their radio, vending sound

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -81,18 +81,14 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		user.client.give_award(/datum/award/achievement/misc/pulse, user)
 		return
 
-	if(!contents.len)
-		var/prizeselect
-		if(prize_override)
-			prizeselect = pickweight(prize_override)
-		else
-			prizeselect = pickweight(GLOB.arcade_prize_pool)
-		new prizeselect(src)
-
-	var/atom/movable/the_prize = pick(contents)
+	var/prizeselect
+	if(prize_override)
+		prizeselect = pickweight(prize_override)
+	else
+		prizeselect = pickweight(GLOB.arcade_prize_pool)
+	var/atom/movable/the_prize = new prizeselect(get_turf(src))
+	playsound(src, 'sound/machines/machine_vend.ogg', 50, TRUE, extrarange = -3)
 	visible_message("<span class='notice'>[src] dispenses [the_prize]!</span>", "<span class='notice'>You hear a chime and a clunk.</span>")
-
-	the_prize.forceMove(get_turf(src))
 
 /obj/machinery/computer/arcade/emp_act(severity)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Since orion trails now have a radio for reporting unstable gamers, it kept getting ejected whenever someone won something. Theres no reason to put this in contents first anyway.
Also added the vending machine sound.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Orion trail will no longer give you a radio for winning. Arcades have vending sound.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
