### PR TITLE
Uncurses Polycircuit Stack Marginally.

### DIFF
--- a/code/game/objects/items/devices/polycircuit.dm
+++ b/code/game/objects/items/devices/polycircuit.dm
@@ -13,15 +13,20 @@
 
 /obj/item/stack/circuit_stack/attack_hand(mob/user)
 	var/mob/living/carbon/human/H = user
-	if(!user.get_inactive_held_item() == src)
+	if(user.get_inactive_held_item() != src)
 		return ..()
 	else
 		if(zero_amount())
 			return
-		chosen_circuit = input("What type of circuit would you like to remove?", "Choose a Circuit Type", chosen_circuit) in list("airlock","firelock","fire alarm","air alarm","APC")
+		if(user.get_inactive_held_item() != src)
+			return
+		chosen_circuit = input("What type of circuit would you like to remove?", "Choose a Circuit Type", chosen_circuit) in list("airlock","firelock","fire alarm","air alarm","APC","cancel")
 		if(zero_amount())
 			return
 		switch(chosen_circuit)
+			if("cancel")
+				to_chat(user, "<span class='notice'>You wisely avoid putting your hands anywhere near [src].</span>")
+				return
 			if("airlock")
 				circuit_type = /obj/item/electronics/airlock
 			if("firelock")

--- a/code/game/objects/items/devices/polycircuit.dm
+++ b/code/game/objects/items/devices/polycircuit.dm
@@ -46,12 +46,15 @@
 			use(1)
 			if(!amount)
 				to_chat(user, "<span class='notice'>You navigate the sharp edges of circuitry and remove the last board.</span>")
+				return
 			else
 				to_chat(user, "<span class='notice'>You navigate the sharp edges of circuitry and remove a single board from [src]</span>")
+				return
 		else
 			H.apply_damage(15, BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 			to_chat(user, "<span class='warning'>You give yourself a wicked cut on [src]'s many sharp corners and edges!</span>")
-		..()
+			return
+		return
 
 /obj/item/stack/circuit_stack/full
 	amount = 8

--- a/code/game/objects/items/devices/polycircuit.dm
+++ b/code/game/objects/items/devices/polycircuit.dm
@@ -18,7 +18,7 @@
 	else
 		if(zero_amount())
 			return
-		if(user.get_inactive_held_item() != src)
+		if(loc != user)
 			return
 		chosen_circuit = input("What type of circuit would you like to remove?", "Choose a Circuit Type", chosen_circuit) in list("airlock","firelock","fire alarm","air alarm","APC","cancel")
 		if(zero_amount())

--- a/code/game/objects/items/devices/polycircuit.dm
+++ b/code/game/objects/items/devices/polycircuit.dm
@@ -18,10 +18,10 @@
 	else
 		if(zero_amount())
 			return
-		if(loc != user)
-			return
 		chosen_circuit = input("What type of circuit would you like to remove?", "Choose a Circuit Type", chosen_circuit) in list("airlock","firelock","fire alarm","air alarm","APC","cancel")
 		if(zero_amount())
+			return
+		if(loc != user)
 			return
 		switch(chosen_circuit)
 			if("cancel")


### PR DESCRIPTION
## About The Pull Request

Fixes #48420 hopefully. Circuit stack now has a cancel button in the switch menu, as well as a distance check, so that if you just leave it alone it won't start sticking to your arms and teleporting all around the house like a chucky rip off.

## Why It's Good For The Game

Fixes a bug

## Changelog
:cl:
fix: The Polycircuit Stack item no longer leaps through space and time until a circuit is removed.
/:cl: