### PR TITLE
Disconnect port aft solar control's SMES input from the main power line on MetaStation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -43811,11 +43811,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"bUP" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "bUQ" = (
 /obj/item/cigbutt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -44258,7 +44253,6 @@
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
 "bVQ" = (
-/obj/structure/cable,
 /obj/machinery/light/small{
 	brightness = 3;
 	dir = 8
@@ -44995,6 +44989,10 @@
 "bXu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/machinery/power/terminal{
+	icon_state = "term";
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "bXv" = (
@@ -45002,6 +45000,7 @@
 	pixel_x = 32
 	},
 /obj/structure/cable,
+/obj/machinery/power/smes,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -74627,9 +74626,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ntG" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -91603,7 +91599,7 @@ cga
 nPC
 uqB
 bTp
-bUP
+vhx
 ntG
 bXv
 bYC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Relocates and rewires the SMES on Port Aft (south west) solar control on MetaStation
This SMES is currently wired directly into the main power lines (check out its power input, it's drawing from the engine room SMES by default) and also connects the solars straight into the main power line.
Relocated the SMES, generated new wire terminal directional, SMES is now fed only by the local solar array and outputs into the main grid.
Local APC still fed by main power line.  Tested total supply on the lines at various points before and after wiring the array.

This is my first map change so please give it a check; the final diff looks reasonable though.  Particularly I don't understand layering, but the map compiles and plays as I'd expect in the altered area.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency, perhaps some deeper reasoning behind the power grid.  The other 3 solar controls are wired up to run solars->SMES-> main grid, but this one room basically just wires them all together directly.
Prevents engineers from asking questions about the wiring of this room :D
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: iain0
fix: MetaStation Port Aft Solar Control SMES input isolated from main power line, like all other solar control rooms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
