### PR TITLE
Metastation: Replaces most static maint loot with spawners

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3786,8 +3786,7 @@
 "ahU" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/table,
-/obj/item/stock_parts/manipulator,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ahV" = (
@@ -7482,17 +7481,13 @@
 /area/maintenance/starboard/fore)
 "ape" = (
 /obj/structure/rack,
-/obj/item/storage/belt{
-	desc = "Can hold quite a lot of stuff.";
-	name = "multi-belt"
-	},
 /obj/item/clothing/gloves/color/fyellow,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
 	name = "old sink";
 	pixel_y = 28
 	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "apf" = (
@@ -7669,13 +7664,10 @@
 /area/maintenance/port/fore)
 "apD" = (
 /obj/item/storage/box/lights/mixed,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "apE" = (
@@ -8584,8 +8576,7 @@
 /area/maintenance/starboard/fore)
 "arH" = (
 /obj/structure/rack,
-/obj/item/extinguisher,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arI" = (
@@ -8596,9 +8587,8 @@
 /area/maintenance/starboard/fore)
 "arJ" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/poncho,
-/obj/item/clothing/head/sombrero,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arK" = (
@@ -10611,7 +10601,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/item/storage/box/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "awB" = (
@@ -10746,7 +10736,7 @@
 /area/maintenance/port/fore)
 "awS" = (
 /obj/structure/closet/crate,
-/obj/item/coin/silver,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "awT" = (
@@ -13291,12 +13281,6 @@
 "aDb" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
-"aDc" = (
-/obj/structure/closet/crate,
-/obj/item/coin/silver,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aDh" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -15319,8 +15303,8 @@
 /area/crew_quarters/dorms)
 "aHV" = (
 /obj/structure/closet,
-/obj/item/storage/box/donkpockets,
 /obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aHX" = (
@@ -16391,9 +16375,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/item/wirecutters,
-/obj/item/weldingtool,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aKx" = (
@@ -16888,7 +16870,7 @@
 /area/crew_quarters/locker)
 "aLJ" = (
 /obj/structure/rack,
-/obj/item/stock_parts/matter_bin,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -18817,6 +18799,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
 /turf/open/floor/plasteel,
@@ -32453,9 +32436,8 @@
 	},
 /area/maintenance/starboard)
 "btu" = (
-/obj/item/storage/toolbox/emergency,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "btv" = (
@@ -35567,8 +35549,7 @@
 /area/crew_quarters/toilet/auxiliary)
 "bBq" = (
 /obj/structure/rack,
-/obj/item/flashlight,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bBr" = (
@@ -35975,6 +35956,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/item/storage/belt/utility,
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
@@ -39637,8 +39619,7 @@
 /area/maintenance/port)
 "bLd" = (
 /obj/structure/closet,
-/obj/item/clothing/shoes/jackboots,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bLe" = (
@@ -40059,6 +40040,7 @@
 /area/storage/tcom)
 "bLX" = (
 /obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -41683,6 +41665,7 @@
 "bPJ" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/horsehead,
+/obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bPK" = (
@@ -43160,8 +43143,8 @@
 /area/maintenance/port)
 "bTv" = (
 /obj/structure/rack,
-/obj/item/paper,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/item/paper,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bTw" = (
@@ -43824,9 +43807,9 @@
 /area/maintenance/port)
 "bUR" = (
 /obj/structure/closet,
-/obj/item/storage/box/donkpockets,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bUS" = (
@@ -44129,8 +44112,7 @@
 /area/maintenance/starboard)
 "bVE" = (
 /obj/structure/closet/crate,
-/obj/item/storage/belt/utility,
-/obj/item/stack/cable_coil,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bVF" = (
@@ -45015,7 +44997,7 @@
 /area/maintenance/port)
 "bXy" = (
 /obj/structure/closet,
-/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bXz" = (
@@ -45065,16 +45047,7 @@
 /area/maintenance/port)
 "bXH" = (
 /obj/structure/closet/crate,
-/obj/item/coin/silver,
-/obj/item/flashlight,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bXI" = (
-/obj/structure/closet,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/hemostat,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bXJ" = (
@@ -45536,8 +45509,8 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/item/storage/box/donkpockets,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bYQ" = (
@@ -47679,7 +47652,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cdk" = (
-/obj/item/trash/semki,
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cdl" = (
@@ -48676,11 +48649,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "cfC" = (
-/obj/item/trash/pistachios,
 /obj/structure/closet,
-/obj/item/stack/sheet/glass,
 /obj/item/extinguisher,
-/obj/item/storage/belt/utility,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cfD" = (
@@ -48690,6 +48661,7 @@
 "cfE" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/dropper,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cfF" = (
@@ -49739,23 +49711,20 @@
 /area/maintenance/starboard)
 "chC" = (
 /obj/structure/closet/crate,
-/obj/item/storage/belt/utility,
-/obj/item/stack/cable_coil,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "chD" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/item/cane,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "chE" = (
@@ -50954,17 +50923,16 @@
 /area/science/explab)
 "cku" = (
 /obj/structure/closet,
-/obj/item/storage/box/donkpockets,
 /obj/effect/spawner/lootdrop/maintenance/three,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "ckv" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/item/assembly/infra,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "ckw" = (
@@ -55643,18 +55611,14 @@
 /area/maintenance/port/aft)
 "cuh" = (
 /obj/structure/closet/crate,
-/obj/item/stack/cable_coil,
-/obj/item/grenade/chem_grenade,
-/obj/item/flashlight,
 /obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/maintenance/five,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cui" = (
 /obj/structure/closet/crate,
-/obj/item/coin/silver,
-/obj/item/reagent_containers/spray/weedspray,
 /obj/item/paper,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cuj" = (
@@ -56104,10 +56068,8 @@
 "cuY" = (
 /obj/structure/rack,
 /obj/item/extinguisher,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/mask/gas,
 /obj/item/storage/box/lights/mixed,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "cuZ" = (
@@ -56621,7 +56583,7 @@
 "cwn" = (
 /obj/structure/rack,
 /obj/item/flashlight/pen,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cwo" = (
@@ -57051,10 +57013,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
-"cxc" = (
-/obj/item/trash/chips,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cxd" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/landmark/blobstart,
@@ -61243,7 +61201,7 @@
 /area/science/mixing)
 "cGo" = (
 /obj/structure/closet/crate,
-/obj/item/clothing/mask/gas,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cGp" = (
@@ -62359,11 +62317,11 @@
 "cIh" = (
 /obj/structure/closet,
 /obj/item/storage/box/lights/mixed,
-/obj/item/flashlight,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/sign/warning/biohazard{
 	pixel_y = 32
 	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cIi" = (
@@ -62926,9 +62884,8 @@
 	},
 /obj/structure/closet/crate,
 /obj/item/clothing/gloves/color/fyellow,
-/obj/item/wrench,
-/obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/cable,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cJs" = (
@@ -62941,11 +62898,8 @@
 /area/maintenance/aft)
 "cJt" = (
 /obj/structure/rack,
-/obj/item/screwdriver{
-	pixel_y = 6
-	},
-/obj/item/crowbar,
 /obj/item/storage/pill_bottle,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cJu" = (
@@ -63285,9 +63239,8 @@
 /area/maintenance/starboard/aft)
 "cKa" = (
 /obj/structure/closet,
-/obj/item/clothing/glasses/science,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cKb" = (
@@ -64289,6 +64242,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "cMl" = (
@@ -64856,9 +64810,8 @@
 /area/maintenance/port/aft)
 "cNg" = (
 /obj/structure/rack,
-/obj/item/flashlight,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/light/small,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cNh" = (
@@ -65499,11 +65452,10 @@
 /area/hallway/secondary/exit/departure_lounge)
 "cOA" = (
 /obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cOB" = (
@@ -65844,8 +65796,7 @@
 /area/maintenance/starboard/aft)
 "cPz" = (
 /obj/structure/closet,
-/obj/item/flashlight,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cPA" = (
@@ -67549,6 +67500,7 @@
 /area/chapel/main)
 "cTp" = (
 /obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cTq" = (
@@ -69176,6 +69128,7 @@
 /area/maintenance/department/science/xenobiology)
 "ddi" = (
 /obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "ddj" = (
@@ -70172,15 +70125,13 @@
 	dir = 1
 	},
 /obj/structure/closet/crate,
-/obj/item/coin/silver,
-/obj/item/grenade/chem_grenade,
 /obj/item/storage/box/lights/mixed,
 /obj/item/watertank,
-/obj/item/storage/box/donkpockets,
 /obj/item/poster/random_contraband,
 /obj/item/poster/random_contraband,
 /obj/item/poster/random_contraband,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dhp" = (
@@ -70329,10 +70280,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "dhB" = (
-/obj/item/clothing/glasses/meson,
 /obj/structure/closet/crate,
 /obj/item/poster/random_contraband,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dhC" = (
@@ -71718,7 +71668,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dAh" = (
-/obj/item/storage/box,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dAn" = (
@@ -73359,8 +73309,7 @@
 /area/crew_quarters/kitchen)
 "hEP" = (
 /obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -73819,10 +73768,10 @@
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/item/storage/belt/utility,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
+/obj/item/storage/belt/utility,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "jYJ" = (
@@ -74018,10 +73967,10 @@
 /area/science/misc_lab/range)
 "kPN" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "kRO" = (
@@ -74280,6 +74229,10 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
+"lVD" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "lWY" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Server Room"
@@ -75093,13 +75046,11 @@
 /area/security/warden)
 "oXP" = (
 /obj/structure/closet/crate,
-/obj/item/crowbar/red,
-/obj/item/pen,
 /obj/item/flashlight/pen{
 	pixel_x = 4;
 	pixel_y = 3
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -75935,9 +75886,8 @@
 "sfQ" = (
 /obj/structure/closet,
 /obj/item/extinguisher,
-/obj/item/flashlight,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sfR" = (
@@ -76498,6 +76448,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"uYd" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "uYk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -76608,9 +76563,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "vAs" = (
-/obj/structure/rack,
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/item/wrench,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -76815,11 +76768,10 @@
 /area/security/prison)
 "wkM" = (
 /obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "wmt" = (
@@ -77265,6 +77217,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
+"yeM" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "yfM" = (
 /obj/machinery/vending/engivend,
 /obj/effect/turf_decal/delivery,
@@ -91012,7 +90971,7 @@ dne
 aip
 dne
 dst
-aDc
+awS
 dhE
 aRG
 aRG
@@ -95961,8 +95920,8 @@ cia
 cuh
 cvm
 cvl
-cxc
-cxR
+cdk
+uYd
 dux
 aaa
 aaa
@@ -96974,7 +96933,7 @@ dux
 dux
 dux
 dux
-cfD
+dyw
 dwb
 cic
 cia
@@ -97739,7 +97698,7 @@ bSB
 bPR
 bue
 div
-bXI
+bLd
 dux
 dux
 cbD
@@ -116239,7 +116198,7 @@ bNL
 bPh
 bKr
 bSd
-bPm
+yeM
 alq
 bVC
 bWY
@@ -117009,7 +116968,7 @@ bKr
 bKr
 bKr
 bKr
-apc
+lVD
 apc
 alq
 alq
@@ -117779,7 +117738,7 @@ bBt
 atm
 bLZ
 bPm
-apc
+lVD
 bSf
 apc
 bxc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It was time to do this a while ago, but better late than never. Removes most of the static toolbelt/flashlight/gas mask/tool spawns on metastation, replaces them with (in some cases more) maint spawners. No more running the predetermined gamer gear track, you'll actually have to sift through the loot if you want something nice.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Static maint loot is terrible for variety. Metastation is a serial offender in giving players too much guaranteed loot.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
balance: Metastation maint loot overhauled. Most static loot spawns have been replaced with random spawners instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
