### PR TITLE
Adds maint oddities, small adjustments to loot tables

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -50,7 +50,6 @@ GLOBAL_LIST_INIT(trash_loot, list(//junk: useless, very easy to get, or ghetto c
 		/obj/item/reagent_containers/food/snacks/urinalcake = 1,
 
 		/obj/item/airlock_painter = 1,
-		/obj/item/pipe = 1,
 		/obj/item/rack_parts = 1,
 		/obj/item/clothing/mask/breath = 1,
 		/obj/item/shard = 1,
@@ -82,10 +81,6 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/mop = 1,
 		/obj/item/reagent_containers/glass/bucket = 1,
 		/obj/item/toy/crayon/spraycan = 1,
-		) = 1,
-
-	list(//strange objects
-		/obj/item/relic = 5,
 		) = 1,
 
 	list(//equipment
@@ -169,7 +164,7 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/grenade/iedcasing = 1,
 		/obj/item/melee/baton/cattleprod = 1,
 		/obj/item/throwing_star = 1,
-		) = 1,
+		) = 8,
 
 	list(//equipment
 		/obj/item/clothing/head/welding = 1,
@@ -184,14 +179,18 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/clothing/mask/muzzle = 1,
 		/obj/item/clothing/ears/earmuffs = 1,
 		/obj/item/clothing/gloves/color/black = 1,
-		) = 1,
+		) = 8,
+
+	list(//strange objects
+		/obj/item/relic = 5,
+		) = 8,
 
 	list(//construction and crafting
 		/obj/item/stock_parts/cell/high = 1,
 		/obj/item/stack/sheet/mineral/wood/fifty = 1,
 		/obj/item/beacon = 1,
 		/obj/item/weaponcrafting/receiver = 1,
-		) = 1,
+		) = 8,
 
 	list(//medical and chemicals
 		list(//basic healing items
@@ -212,7 +211,7 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 			/obj/item/watertank = 1,
 			/obj/item/watertank/janitor = 1,
 			) = 1,
-		) = 1,
+		) = 8,
 
 	list(//food
 		/obj/item/reagent_containers/food/snacks/canned/peaches/maint = 1,
@@ -223,15 +222,27 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 			/obj/item/storage/box/donkpockets/donkpocketpizza = 1,
 			/obj/item/storage/box/donkpockets/donkpocketberry = 1,
 			/obj/item/storage/box/donkpockets/donkpockethonk = 1,
-		) = 1,
+			) = 1,
 		/obj/item/reagent_containers/food/snacks/monkeycube = 1,
+		) = 8,
+
+	list(//fakeout items, keep this list at low relative weight
+		/obj/item/dice/d20 = 1,	//To balance out the stealth die of fates in oddities
+		/obj/item/clothing/shoes/jackboots = 1,
 		) = 1,
 ))
 
 GLOBAL_LIST_INIT(oddity_loot, list(//oddity: strange or crazy items
-	//keeping commented out until there are more, otherwise the same ones may appear too often
-	// /obj/effect/rune/teleport = 1,
-	"" = 1 //nothing, so loot spawner doesn't break while nothing else is here
+		/obj/effect/rune/teleport = 1,
+		/obj/item/clothing/gloves/color/yellow = 1,
+		/obj/item/clothing/head/helmet/abductor = 1,
+		/obj/item/clothing/head/helmet/justice =1,
+		/obj/item/clothing/suit/space/hardsuit/carp = 1,
+		/obj/item/dice/d20/fate/stealth/one_use = 1,	//Looks like a d20, keep the d20 in the uncommon pool.
+		/obj/item/dice/d20/fate/stealth/cursed = 1, 	//Only rolls 1
+		/obj/item/clothing/shoes/jackboots/fast = 1,
+		/obj/item/clothing/suit/armor/reactive/table = 1,
+		/obj/item/storage/box/donkpockets/donkpocketgondola = 1
 	))
 
 //Maintenance loot spawner pools

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -171,16 +171,8 @@
 	var/reusable = TRUE
 	var/used = FALSE
 
-/obj/item/dice/d20/fate/stealth
-	name = "d20"
-	desc = "A die with twenty sides. The preferred die to throw at the GM."
-
 /obj/item/dice/d20/fate/one_use
 	reusable = FALSE
-
-/obj/item/dice/d20/fate/one_use/stealth
-	name = "d20"
-	desc = "A die with twenty sides. The preferred die to throw at the GM."
 
 /obj/item/dice/d20/fate/cursed
 	name = "cursed Die of Fate"
@@ -189,6 +181,23 @@
 
 	rigged = DICE_TOTALLY_RIGGED
 	rigged_value = 1
+
+/obj/item/dice/d20/fate/cursed/one_use
+	reusable = FALSE
+
+/obj/item/dice/d20/fate/stealth
+	name = "d20"
+	desc = "A die with twenty sides. The preferred die to throw at the GM."
+
+/obj/item/dice/d20/fate/stealth/one_use
+	reusable = FALSE
+
+/obj/item/dice/d20/fate/stealth/cursed
+	rigged = DICE_TOTALLY_RIGGED
+	rigged_value = 1
+
+/obj/item/dice/d20/fate/stealth/cursed/one_use
+	reusable = FALSE
 
 /obj/item/dice/d20/fate/diceroll(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Finally makes use of the oddities list from #47646. These are very rare (1:10000) per maint loot spawn. This list is still a bit small, more specific items will hopefully be made and added as time goes on.
Repathed die of fate slightly, and added a stealth cursed version.
Reduced the overall amount of strange items, it was a bit high.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Provides some motivation to go digging through maint loot, and should hopefully make for some fun experiences.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
add: Maint loot table has been adjusted, may now contain some special stuff. Get hunting!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
