### PR TITLE
Plumbing-surgery (meta) & Medbay-viro (delta) connection is no longer considered maintenance.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -90758,9 +90758,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"dlT" = (
-/turf/closed/wall,
-/area/maintenance/department/medical)
 "dlU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -103873,7 +103870,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dLk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -103886,7 +103883,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dLl" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -103894,7 +103891,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dLm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -104693,7 +104690,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dMQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -104707,7 +104704,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dMR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -104719,7 +104716,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dMS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -105231,7 +105228,7 @@
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dNV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -105240,7 +105237,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dNW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/green,
@@ -105248,7 +105245,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dNX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -105700,14 +105697,14 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dOJ" = (
 /obj/machinery/light/small,
 /obj/machinery/iv_drip,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/white,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dOK" = (
 /obj/item/stack/cable_coil,
 /obj/structure/lattice/catwalk,
@@ -105996,11 +105993,11 @@
 /area/hallway/primary/aft)
 "dPm" = (
 /turf/closed/wall/r_wall,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dPn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dPo" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -106035,7 +106032,7 @@
 /obj/structure/sign/warning/biohazard,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "dPq" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
@@ -114754,12 +114751,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"jdT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/department/medical)
 "jeu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -116739,7 +116730,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
-/area/maintenance/department/medical)
+/area/medical/medbay/central)
 "vJu" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Nanite Lab Maintenance";
@@ -162786,10 +162777,10 @@ dtK
 dtK
 dtK
 dtK
-jdT
+dhs
 dMO
-dlT
-dlT
+cPy
+cPy
 dPm
 dPq
 dPq
@@ -163814,10 +163805,10 @@ mYs
 dEb
 dEb
 cPy
-jdT
+dhs
 dMS
-dlT
-dlT
+cPy
+cPy
 dPm
 dPq
 dQX

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -58946,7 +58946,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/area/medical/chemistry)
 "cBs" = (
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -73012,7 +73012,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/area/medical/chemistry)
 "fMA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -73687,7 +73687,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/area/medical/chemistry)
 "jnW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -74101,7 +74101,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/area/medical/chemistry)
 "lci" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/yellow,
@@ -74283,7 +74283,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/area/medical/chemistry)
 "lWY" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Server Room"
@@ -74927,7 +74927,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/area/medical/chemistry)
 "owR" = (
 /turf/closed/wall,
 /area/engine/storage_shared)
@@ -75055,10 +75055,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
-"oPU" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall,
-/area/maintenance/port/aft)
 "oRL" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -75082,7 +75078,7 @@
 	},
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/area/medical/chemistry)
 "oVO" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -75690,7 +75686,7 @@
 	req_access_txt = null
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/area/medical/chemistry)
 "roZ" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -76910,7 +76906,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/area/medical/chemistry)
 "wBp" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -94674,7 +94670,7 @@ cdd
 dux
 cfC
 fWc
-oPU
+snr
 ovU
 jkQ
 fJl
@@ -94931,7 +94927,7 @@ cde
 dux
 dux
 cdc
-dux
+cga
 oSw
 jkQ
 lVu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #48462 
This caused the shown areas to not be affected by the radiation storm event, which didn't quite seem right.
Unsure if this was intended or not, but before this it wasn't consistent between maps. Figured I may as well learn a bit about mapping by doing an easy change, too.
Previously:
![](https://user-images.githubusercontent.com/52540478/71565872-0e217980-2a70-11ea-860e-b536e684c398.PNG)
![](https://user-images.githubusercontent.com/52540478/71566476-2fd12f80-2a75-11ea-88ef-91535c222ce1.PNG)
Now:
![image](https://user-images.githubusercontent.com/52540478/71610578-71cea400-2b4f-11ea-9b96-b41a4e13146c.png)
![image](https://user-images.githubusercontent.com/52540478/71610594-8d39af00-2b4f-11ea-9454-5b060aa52d0d.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency between maps. For example, this is viro on meta (unchanged):
![](https://user-images.githubusercontent.com/52540478/71610495-ca517180-2b4e-11ea-808e-3ab73539965e.PNG)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Plumbing-surgery connection on Meta is now not considered maintenance.
tweak: Viro-medbay connection on Delta is now not considered maintenance.
rscdel: Nanotrasen has removed expensive maintenance-exclusive radiation shields in specific areas on two of their research stations. 
/:cl:
