### PR TITLE
Decreases time for PAI do use doorjack from 50 seconds to 20 seconds

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -135,7 +135,7 @@
 
 /mob/living/silicon/pai/proc/process_hack()
 	if(cable && cable.machine && istype(cable.machine, /obj/machinery/door) && cable.machine == hackdoor && get_dist(src, hackdoor) <= 1)
-		hackprogress = CLAMP(hackprogress + 4, 0, 100)
+		hackprogress = CLAMP(hackprogress + 10, 0, 100)
 	else
 		temp = "Door Jack: Connection to airlock has been lost. Hack aborted."
 		hackprogress = 0


### PR DESCRIPTION
## About The Pull Request

This small code change simply changes the amount of progress that is added per tick of door hacking time. As of current, each tick adds 4%, where this changes it to add 10% progress. All in all, this changes the time to hack a door from 50 seconds to 20 seconds.

## Why It's Good For The Game

As of Current version, hacking a door for a PAI takes 50 seconds to open one door. Doing so also alerts the AI that someone is hacking the door at the location of the door being opened. Even a somewhat experienced player is capable of fully hacking a door from scratch in under 30 seconds.(Assuming using Multitool with electric/no shock) On top of this, once the combination of wires is known, it is possible to open a door in <10 seconds. All of this without alerting the AI or any non looker to their location or doing

This pull request would make PAI's somewhat more valuable as a late-round tool, when materials may be scarce, and the only way forward is hacking a door. While a fully equipped player may take only a few seconds to open a door, a PAI would need to take nearly a full minute to open the door.
This change may encourage people to take PAI's as somewhat of a backup or a safety net. If you only need one door, a PAI might be faster than manual, but always slower than 2-3 doors.


Please discuss if this is too much of a buff.

**TL/DR: Doorjack WAAAAAY to slow.**
## Changelog
:cl:
balance: Decreased time to hack a door as PAI by 30 seconds.
/:cl:

