### PR TITLE
Border firelocks no longer crush mobs

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -37,6 +37,7 @@
 	var/poddoor = FALSE
 	var/unres_sides = 0 //Unrestricted sides. A bitflag for which direction (if any) can open the door with no access
 	var/safety_mode = FALSE ///Whether or not the airlock can be opened with bare hands while unpowered
+	var/no_crush = FALSE /// Whether or not the door can crush mobs when safe is FALSE.
 
 /obj/machinery/door/examine(mob/user)
 	. = ..()
@@ -165,7 +166,7 @@
 	. = ..()
 	if(.)
 		return
-	if(try_safety_unlock(user))	
+	if(try_safety_unlock(user))
 		return
 	return try_to_activate_door(user)
 
@@ -327,7 +328,7 @@
 	update_freelook_sight()
 	if(safe)
 		CheckForMobs()
-	else
+	else if(!no_crush)
 		crush()
 	return 1
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -326,11 +326,14 @@
 	operating = FALSE
 	air_update_turf(1)
 	update_freelook_sight()
-	if(safe)
+
+	if(!can_crush)
+		return TRUE
+	else if(safe)
 		CheckForMobs()
-	else if(can_crush)
+	else
 		crush()
-	return 1
+	return TRUE
 
 /obj/machinery/door/proc/CheckForMobs()
 	if(locate(/mob/living) in get_turf(src))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -37,7 +37,7 @@
 	var/poddoor = FALSE
 	var/unres_sides = 0 //Unrestricted sides. A bitflag for which direction (if any) can open the door with no access
 	var/safety_mode = FALSE ///Whether or not the airlock can be opened with bare hands while unpowered
-	var/no_crush = FALSE /// Whether or not the door can crush mobs when safe is FALSE.
+	var/can_crush = TRUE /// Whether or not the door can crush mobs.
 
 /obj/machinery/door/examine(mob/user)
 	. = ..()
@@ -328,7 +328,7 @@
 	update_freelook_sight()
 	if(safe)
 		CheckForMobs()
-	else if(!no_crush)
+	else if(can_crush)
 		crush()
 	return 1
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -329,7 +329,8 @@
 
 	if(!can_crush)
 		return TRUE
-	else if(safe)
+
+	if(safe)
 		CheckForMobs()
 	else
 		crush()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -216,7 +216,7 @@
 
 /obj/machinery/door/firedoor/border_only
 	icon = 'icons/obj/doors/edge_Doorfire.dmi'
-	no_crush = TRUE
+	can_crush = FALSE
 	flags_1 = ON_BORDER_1
 	CanAtmosPass = ATMOS_PASS_PROC
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -216,6 +216,7 @@
 
 /obj/machinery/door/firedoor/border_only
 	icon = 'icons/obj/doors/edge_Doorfire.dmi'
+	no_crush = TRUE
 	flags_1 = ON_BORDER_1
 	CanAtmosPass = ATMOS_PASS_PROC
 


### PR DESCRIPTION
## About The Pull Request
Stops border firelocks from crushing mobs and adds a `can_crush` variable to doors.

## Why It's Good For The Game
It makes no sense why border firelocks can crush mobs as they are border firelocks.

## Changelog
:cl:
tweak: Border firelocks no longer crush mobs.
/:cl:
