### PR TITLE
Fixes check_contents blacklist check

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -82,7 +82,7 @@
 		var/needed_amount = R.reqs[requirement_path]
 		for(var/content_item_path in contents)
 			// Right path and not blacklisted
-			if(!ispath(content_item_path, requirement_path) || R.blacklist.Find(requirement_path))
+			if(!ispath(content_item_path, requirement_path) || R.blacklist.Find(content_item_path))
 				continue
 
 			needed_amount -= contents[content_item_path]


### PR DESCRIPTION

Fixes https://github.com/tgstation/tgstation/issues/48518
## Changelog
:cl:
fix: Fixed being able to craft with blacklisted items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
