### PR TITLE
Fixes Structures and Coin Press UIs being usable by ghosts

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -39,7 +39,7 @@
 		structureclimber.visible_message("<span class='warning'>[structureclimber] has been knocked off [src].", "You're knocked off [src]!", "You see [structureclimber] get knocked off [src].</span>")
 
 /obj/structure/ui_act(action, params)
-	..()
+	. = ..()
 	add_fingerprint(usr)
 
 /obj/structure/MouseDrop_T(atom/movable/O, mob/user)

--- a/code/modules/mining/mint.dm
+++ b/code/modules/mining/mint.dm
@@ -104,6 +104,10 @@
 	return data;
 
 /obj/machinery/mineral/mint/ui_act(action, params, datum/tgui/ui)
+
+	if(..())
+		return
+
 	switch(action)
 		if ("startpress")
 			if (!processing)

--- a/code/modules/mining/mint.dm
+++ b/code/modules/mining/mint.dm
@@ -37,7 +37,7 @@
 /obj/machinery/mineral/mint/process()
 	var/turf/T = get_step(src, input_dir)
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
-	
+
 	for(var/obj/item/stack/O in T)
 		var/inserted = materials.insert_item(O)
 		if(inserted)
@@ -59,7 +59,7 @@
 				for(var/coin_to_make in 1 to 5)
 					create_coins()
 					produced_coins++
-			else 
+			else
 				var/found_new = FALSE
 				for(var/datum/material/inserted_material in materials.materials)
 					var/amount = materials.get_material_amount(inserted_material)
@@ -67,7 +67,7 @@
 					if(amount)
 						chosen = inserted_material
 						found_new = TRUE
-				
+
 				if(!found_new)
 					processing = FALSE
 	else
@@ -86,7 +86,7 @@
 
 	for(var/datum/material/inserted_material in materials.materials)
 		var/amount = materials.get_material_amount(inserted_material)
-		
+
 		if(!amount)
 			continue
 
@@ -105,7 +105,8 @@
 
 /obj/machinery/mineral/mint/ui_act(action, params, datum/tgui/ui)
 
-	if(..())
+	. = ..()
+	if(.)
 		return
 
 	switch(action)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Structure types were always usable by ghosts, gone unnoticed due to there being only 2 of them with ui_act(). This fixes that and the Coin Press as well.

Fixes #48224
Fixes #48513

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug Fix, no metaing.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Thebleh
fix: Tank Dispensers, Ore Boxes and Coin Presses are no longer usable by ghosts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
