### PR TITLE
Removes paralysis on meathook, rebalances damage

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -412,6 +412,7 @@
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	pass_flags = PASSTABLE
 	damage = 20
+	stamina = 20
 	armour_penetration = 60
 	damage_type = BRUTE
 	hitsound = 'sound/effects/splat.ogg'
@@ -450,8 +451,8 @@
 	projectile_type = /obj/projectile/hook/bounty
 
 /obj/projectile/hook/bounty
-	damage_type = STAMINA
-	damage = 40
+	damage = 0
+	stamina = 40
 
 //Immortality Talisman
 /obj/item/immortality_talisman

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -417,6 +417,7 @@
 	damage_type = BRUTE
 	hitsound = 'sound/effects/splat.ogg'
 	var/chain
+	var/knockdown_time_carbon = (0.5 SECONDS)
 
 /obj/projectile/hook/fire(setAngle)
 	if(firer)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -411,11 +411,10 @@
 	icon_state = "hook"
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	pass_flags = PASSTABLE
-	damage = 25
-	armour_penetration = 100
+	damage = 20
+	armour_penetration = 60
 	damage_type = BRUTE
 	hitsound = 'sound/effects/splat.ogg'
-	paralyze = 30
 	var/chain
 
 /obj/projectile/hook/fire(setAngle)
@@ -451,8 +450,8 @@
 	projectile_type = /obj/projectile/hook/bounty
 
 /obj/projectile/hook/bounty
-	damage = 0
-	paralyze = 20
+	damage_type = STAMINA
+	damage = 40
 
 //Immortality Talisman
 /obj/item/immortality_talisman
@@ -1034,8 +1033,6 @@
 	var/list/da_list = list()
 	for(var/I in GLOB.alive_mob_list & GLOB.player_list)
 		var/mob/living/L = I
-		if(is_centcom_level(L.z))
-			continue
 		da_list[L.real_name] = L
 
 	var/choice = input(user,"Who do you want dead?","Choose Your Victim") as null|anything in sortList(da_list)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -417,7 +417,7 @@
 	damage_type = BRUTE
 	hitsound = 'sound/effects/splat.ogg'
 	var/chain
-	var/knockdown_time_carbon = (0.5 SECONDS)
+	var/knockdown_time = (0.5 SECONDS)
 
 /obj/projectile/hook/fire(setAngle)
 	if(firer)
@@ -433,6 +433,10 @@
 			return
 		A.visible_message("<span class='danger'>[A] is snagged by [firer]'s hook!</span>")
 		new /datum/forced_movement(A, get_turf(firer), 5, TRUE)
+		if (isliving(target))
+			var/mob/living/fresh_meat = target
+			fresh_meat.Knockdown(knockdown_time)
+			return
 		//TODO: keep the chain beamed to A
 		//TODO: needs a callback to delete the chain
 


### PR DESCRIPTION
## About The Pull Request
Removes the stun on the hook to bring it in line with other weapons losing their stun. Reduces the brute damage, adds stamina damage.

## Why It's Good For The Game
Paralyze as a weapon mechanic is no longer supported, this brings the hook in line with other modern stamina-damage weapons. It also brings the hook's armor penetration down to something closer to an armor piercing rifle round, rather than being an absolutely perfect armor penetrator.

:cl:
balance: Removes hitstun on meathook
balance: Changes meathook's damage from 25 brute at 100 armor penetration to 20 brute, 20 stamina at 60 armor penetration
balance: Changes the bounty hunter's meathook to do 40 stamina damage instead of a stun, adds a half-second knockdown.
/:cl: