### PR TITLE
More ways for ethereals to charge

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -787,6 +787,49 @@
 	. = ..()
 	if(.)
 		return
+
+	var/mob/living/carbon/human/H = user
+	if(istype(H))
+		var/datum/species/ethereal/eth_species = H.dna?.species
+		if(istype(eth_species) && H.a_intent == INTENT_HARM)
+			if(cell.charge <= (cell.maxcharge / 2)) // if charge is under 50% you shouldnt drain it
+				to_chat(H, "<span class='warning'>The APC doesn't have much power, you probably shouldn't drain any.</span>")
+				return
+			var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+			if(stomach.crystal_charge > 95)
+				to_chat(H, "<span class='warning'>Your charge is full!</span>")
+				return
+			to_chat(H, "<span class='notice'>You start channeling some power through the APC into your body.</span>")
+			if(do_after(user, 75, target = src))
+				if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > 95))
+					return
+				if(istype(stomach))
+					to_chat(H, "<span class='notice'>You receive some charge from the APC.</span>")
+					stomach.adjust_charge(10)
+					cell.charge -= 10
+				else
+					to_chat(H, "<span class='warning'>You can't receive charge from the APC!</span>")
+			return
+		if(istype(eth_species) && H.a_intent == INTENT_GRAB)
+			if(cell.charge == cell.maxcharge)
+				to_chat(H, "<span class='warning'>The APC is full!</span>")
+				return
+			var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+			if(stomach.crystal_charge < 10)
+				to_chat(H, "<span class='warning'>Your charge is too low!</span>")
+				return
+			to_chat(H, "<span class='notice'>You start channeling power through your body into the APC.</span>")
+			if(do_after(user, 75, target = src))
+				if(cell.charge == cell.maxcharge || (stomach.crystal_charge < 10))
+					return
+				if(istype(stomach))
+					to_chat(H, "<span class='notice'>You transfer some power to the APC.</span>")
+					stomach.adjust_charge(-10)
+					cell.charge += 10
+				else
+					to_chat(H, "<span class='warning'>You can't transfer power to the APC!</span>")
+			return
+
 	if(opened && (!issilicon(user)))
 		if(cell)
 			user.visible_message("<span class='notice'>[user] removes \the [cell] from [src]!</span>", "<span class='notice'>You remove \the [cell].</span>")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -788,20 +788,19 @@
 	if(.)
 		return
 
-	var/mob/living/carbon/human/H = user
-	if(istype(H))
-		var/datum/species/ethereal/eth_species = H.dna?.species
-		if(istype(eth_species) && H.a_intent == INTENT_HARM)
+	if(isethereal(user))
+		var/mob/living/carbon/human/H = user
+		if(H.a_intent == INTENT_HARM)
 			if(cell.charge <= (cell.maxcharge / 2)) // if charge is under 50% you shouldnt drain it
 				to_chat(H, "<span class='warning'>The APC doesn't have much power, you probably shouldn't drain any.</span>")
 				return
 			var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
-			if(stomach.crystal_charge > 95)
+			if(stomach.crystal_charge > 145)
 				to_chat(H, "<span class='warning'>Your charge is full!</span>")
 				return
 			to_chat(H, "<span class='notice'>You start channeling some power through the APC into your body.</span>")
 			if(do_after(user, 75, target = src))
-				if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > 95))
+				if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > 145))
 					return
 				if(istype(stomach))
 					to_chat(H, "<span class='notice'>You receive some charge from the APC.</span>")
@@ -810,7 +809,7 @@
 				else
 					to_chat(H, "<span class='warning'>You can't receive charge from the APC!</span>")
 			return
-		if(istype(eth_species) && H.a_intent == INTENT_GRAB)
+		if(H.a_intent == INTENT_GRAB)
 			if(cell.charge == cell.maxcharge)
 				to_chat(H, "<span class='warning'>The APC is full!</span>")
 				return

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -148,6 +148,30 @@
 				if(prob(25))
 					corrupt()
 
+/obj/item/stock_parts/cell/attack_self(mob/user)
+	var/mob/living/carbon/human/H = user
+	if(istype(H))
+		var/datum/species/ethereal/eth_species = H.dna?.species
+		if(istype(eth_species))
+			if(charge < 25)
+				to_chat(H, "<span class='warning'>The [src] doesn't have enough power!</span>")
+				return
+			var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+			if(stomach.crystal_charge > 96)
+				to_chat(H, "<span class='warning'>Your charge is full!</span>")
+				return
+			to_chat(H, "<span class='notice'>You clumsily channel power through the [src] and into your body, wasting some in the process.</span>")
+			if(do_after(user, 5, target = src))
+				if((charge < 25) || (stomach.crystal_charge > 96))
+					return
+				if(istype(stomach))
+					to_chat(H, "<span class='notice'>You receive some charge from the [src].</span>")
+					stomach.adjust_charge(3)
+					charge -= 100 //you waste way more than you receive, so that ethereals cant just steal one cell and forget about hunger
+				else
+					to_chat(H, "<span class='warning'>You can't receive charge from the [src]!</span>")
+			return
+
 
 /obj/item/stock_parts/cell/blob_act(obj/structure/blob/B)
 	ex_act(EXPLODE_DEVASTATE)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -149,28 +149,26 @@
 					corrupt()
 
 /obj/item/stock_parts/cell/attack_self(mob/user)
-	var/mob/living/carbon/human/H = user
-	if(istype(H))
-		var/datum/species/ethereal/eth_species = H.dna?.species
-		if(istype(eth_species))
-			if(charge < 25)
-				to_chat(H, "<span class='warning'>The [src] doesn't have enough power!</span>")
-				return
-			var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
-			if(stomach.crystal_charge > 96)
-				to_chat(H, "<span class='warning'>Your charge is full!</span>")
-				return
-			to_chat(H, "<span class='notice'>You clumsily channel power through the [src] and into your body, wasting some in the process.</span>")
-			if(do_after(user, 5, target = src))
-				if((charge < 25) || (stomach.crystal_charge > 96))
-					return
-				if(istype(stomach))
-					to_chat(H, "<span class='notice'>You receive some charge from the [src].</span>")
-					stomach.adjust_charge(3)
-					charge -= 100 //you waste way more than you receive, so that ethereals cant just steal one cell and forget about hunger
-				else
-					to_chat(H, "<span class='warning'>You can't receive charge from the [src]!</span>")
+	if(isethereal(user))
+		var/mob/living/carbon/human/H = user
+		if(charge < 100)
+			to_chat(H, "<span class='warning'>The [src] doesn't have enough power!</span>")
 			return
+		var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+		if(stomach.crystal_charge > 146)
+			to_chat(H, "<span class='warning'>Your charge is full!</span>")
+			return
+		to_chat(H, "<span class='notice'>You clumsily channel power through the [src] and into your body, wasting some in the process.</span>")
+		if(do_after(user, 5, target = src))
+			if((charge < 100) || (stomach.crystal_charge > 146))
+				return
+			if(istype(stomach))
+				to_chat(H, "<span class='notice'>You receive some charge from the [src].</span>")
+				stomach.adjust_charge(3)
+				charge -= 100 //you waste way more than you receive, so that ethereals cant just steal one cell and forget about hunger
+			else
+				to_chat(H, "<span class='warning'>You can't receive charge from the [src]!</span>")
+		return
 
 
 /obj/item/stock_parts/cell/blob_act(obj/structure/blob/B)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -293,7 +293,7 @@
 
 	if(start_with_cell && !no_emergency)
 		cell = new/obj/item/stock_parts/cell/emergency_light(src)
-	
+
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/light/LateInitialize()
@@ -643,7 +643,7 @@
 					var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 					if(istype(stomach))
 						to_chat(H, "<span class='notice'>You receive some charge from the [fitting].</span>")
-						stomach.adjust_charge(5)
+						stomach.adjust_charge(2)
 					else
 						to_chat(H, "<span class='warning'>You can't receive charge from the [fitting]!</span>")
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ethereals can now charge through APCs and powercells! Use harm intent with an empty hand as an ethereal on an APC, and you will steal some charge from it (Note: you can't drain an APC past 50%). If you use grab intent on an APC, you will transfer your own charge into it. Simply click a powercell when its in your hand and you'll drain some power from it. To keep this balanced, you waste way more energy from the powercell than you actually receive. 

You also now get less energy from light sources. 

## Why It's Good For The Game

More ways to charge is good! Makes playing Ethereal more fun. 

## Changelog
:cl:
add: You can now charge through APC's and Energy Cells as an Ethereal! Click an APC on harm intent to drain its energy, or on grab intent to give it your own energy! Click the energy cell while its in your hand to siphon its energy. 
balance: You now receive less charge from light as an Ethereal. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

@Qustinnus oked this.

Later I wanna add some more to ethereals while also making these continuous do afters (or rather he wants to - but I'll probably get around to it sooner). 
