### PR TITLE
Caltrop / glass / lightbulb crossing fixes

### DIFF
--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -15,10 +15,6 @@
 	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED), .proc/Crossed)
 
 /datum/component/caltrop/proc/Crossed(datum/source, atom/movable/AM)
-	var/atom/A = parent
-	if(!A.has_gravity())
-		return
-
 	if(!prob(probability))
 		return
 
@@ -28,6 +24,12 @@
 			return
 
 		if((flags & CALTROP_IGNORE_WALKERS) && H.m_intent == MOVE_INTENT_WALK)
+			return
+
+		//move these next two down a level if you add more mobs to this.
+		if(H.is_flying() || H.is_floating()) //check if they are able to pass over us
+			return							//gravity checking only our parent would prevent us from triggering they're using magboots / other gravity assisting items that would cause them to still touch us.
+		if(H.buckled) //if they're buckled to something, that something should be checked instead.
 			return
 
 		var/picked_def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
@@ -42,15 +44,13 @@
 		if(!(flags & CALTROP_BYPASS_SHOES) && (H.shoes || feetCover))
 			return
 
-		if((H.movement_type & FLYING) || H.buckled)
-			return
-
 		var/damage = rand(min_damage, max_damage)
 		if(HAS_TRAIT(H, TRAIT_LIGHT_STEP))
 			damage *= 0.75
 		H.apply_damage(damage, BRUTE, picked_def_zone)
 
 		if(cooldown < world.time - 10) //cooldown to avoid message spam.
+			var/atom/A = parent
 			if(!H.incapacitated(ignore_restraints = TRUE))
 				H.visible_message("<span class='danger'>[H] steps on [A].</span>", \
 						"<span class='userdanger'>You step on [A]!</span>")

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -331,8 +331,8 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	return TRUE
 
 /obj/item/shard/Crossed(mob/living/L)
-	if(istype(L) && has_gravity(loc))
-		playsound(loc, 'sound/effects/glass_step.ogg', HAS_TRAIT(L, TRAIT_LIGHT_STEP) ? 30 : 50, TRUE)
+	if(istype(L) && !(L.is_flying() || L.is_floating() || L.buckled))
+		playsound(src, 'sound/effects/glass_step.ogg', HAS_TRAIT(L, TRAIT_LIGHT_STEP) ? 30 : 50, TRUE)
 	return ..()
 
 /obj/item/shard/plasma

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -504,11 +504,13 @@
 		return FALSE
 
 ///Is the mob a flying mob
-/mob/proc/is_flying(mob/M = src)
-	if(M.movement_type & FLYING)
-		return 1
-	else
-		return 0
+/mob/proc/is_flying()
+	return (movement_type & FLYING)
+
+///Is the mob a floating mob
+/mob/proc/is_floating()
+	return (movement_type & FLOATING)
+
 
 ///Clicks a random nearby mob with the source from this mob
 /mob/proc/click_random_mob()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -293,7 +293,7 @@
 
 	if(start_with_cell && !no_emergency)
 		cell = new/obj/item/stock_parts/cell/emergency_light(src)
-	
+
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/light/LateInitialize()
@@ -833,8 +833,8 @@
 
 /obj/item/light/Crossed(mob/living/L)
 	. = ..()
-	if(istype(L) && has_gravity(loc))
-		playsound(loc, 'sound/effects/glass_step.ogg', HAS_TRAIT(L, TRAIT_LIGHT_STEP) ? 30 : 50, TRUE)
+	if(istype(L) && !(L.is_flying() || L.is_floating() || L.buckled))
+		playsound(src, 'sound/effects/glass_step.ogg', HAS_TRAIT(L, TRAIT_LIGHT_STEP) ? 30 : 50, TRUE)
 		if(status == LIGHT_BURNED || status == LIGHT_OK)
 			shatter()
 


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed humans stepping on and getting hurt by glass shards when they're thrown past them.
fix: Fixed humans stepping on, getting hurt by, and shattering lightbulbs when they're thrown past them.
fix: Fixed lightbulbs shattering when a buckled mob passes over them.
fix: Fixed lightbulbs shattering when a flying mob (including revenants) flies over them.
fix: Fixed glass shards and light bulbs playing sounds when a flying mob (including revenants) flies over them.
fix: Fixed lightbulbs and glass shards not triggering their effects in low gravity when a human wearing activated magboots walks over them.
fix: Fixed glass shards and lightbulbs playing stepping sounds when a buckled mob passes over them.
/:cl:

Fixes #48249