### PR TITLE
Fixes wand recharge

### DIFF
--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -63,8 +63,11 @@
 
 
 /obj/item/gun/magic/process()
+	if (charges >= max_charges)
+		charge_tick = 0
+		return
 	charge_tick++
-	if(charge_tick < recharge_rate || charges >= max_charges)
+	if(charge_tick < recharge_rate)
 		return 0
 	charge_tick = 0
 	charges++


### PR DESCRIPTION
## About The Pull Request

Self-charging wands were able to hold one extra charge by allowing the recharge counter to increase indefinitely when the number of charges reached the maximum number of charges.

## Why It's Good For The Game

Makes the wands actually hold the number of charges they are meant to. Patches a counter that grows without bound unintentionally.

## Changelog
:cl:
fix: Fixed wand recharge to prevent recharge counter increasing when full
/:cl:
