### PR TITLE
Fixes floodlights

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -57,7 +57,6 @@
 #define FLOODLIGHT_NEEDS_WIRES 0
 #define FLOODLIGHT_NEEDS_LIGHTS 1
 #define FLOODLIGHT_NEEDS_SECURING 2
-#define FLOODLIGHT_NEEDS_WRENCHING 3
 
 //other construction-related things
 

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -1,20 +1,15 @@
 
 /obj/structure/floodlight_frame
 	name = "floodlight frame"
-	desc = "A bare metal frame looking vaguely like a floodlight. Requires wrenching down."
+	desc = "A bare metal frame looking vaguely like a floodlight. Requires wiring."
 	max_integrity = 100
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "floodlight_c1"
 	density = TRUE
-	var/state = FLOODLIGHT_NEEDS_WRENCHING
+	var/state = FLOODLIGHT_NEEDS_WIRES
 
 /obj/structure/floodlight_frame/attackby(obj/item/O, mob/user, params)
-	if(O.tool_behaviour == TOOL_WRENCH && (state == FLOODLIGHT_NEEDS_WRENCHING))
-		to_chat(user, "<span class='notice'>You secure [src].</span>")
-		anchored = TRUE
-		state = FLOODLIGHT_NEEDS_WIRES
-		desc = "A bare metal frame looking vaguely like a floodlight. Requires wiring."
-	else if(istype(O, /obj/item/stack/cable_coil) && (state == FLOODLIGHT_NEEDS_WIRES))
+	if(istype(O, /obj/item/stack/cable_coil) && (state == FLOODLIGHT_NEEDS_WIRES))
 		var/obj/item/stack/S = O
 		if(S.use(5))
 			to_chat(user, "<span class='notice'>You wire [src].</span>")
@@ -22,19 +17,28 @@
 			desc = "A bare metal frame looking vaguely like a floodlight. Requires securing with a screwdriver."
 			icon_state = "floodlight_c2"
 			state = FLOODLIGHT_NEEDS_SECURING
-	else if(istype(O, /obj/item/light/tube) && (state == FLOODLIGHT_NEEDS_LIGHTS))
-		if(user.transferItemToLoc(O))
-			to_chat(user, "<span class='notice'>You put lights in [src].</span>")
-			new /obj/machinery/power/floodlight(src.loc)
-			qdel(src)
-	else if(O.tool_behaviour == TOOL_SCREWDRIVER && (state == FLOODLIGHT_NEEDS_SECURING))
+			return
+		else
+			to_chat(user, "You need 5 cables to wire [src].")
+			return
+	if(O.tool_behaviour == TOOL_SCREWDRIVER && (state == FLOODLIGHT_NEEDS_SECURING))
 		to_chat(user, "<span class='notice'>You fasten the wiring and electronics in [src].</span>")
 		name = "secured [name]"
-		desc = "A bare metal frame that looks like a floodlight. Requires light tubes."
+		desc = "A bare metal frame that looks like a floodlight. Requires a light tube to complete."
 		icon_state = "floodlight_c3"
 		state = FLOODLIGHT_NEEDS_LIGHTS
-	else
-		..()
+		return
+	if(istype(O, /obj/item/light/tube))
+		var/obj/item/light/tube/L = O
+		if(state == FLOODLIGHT_NEEDS_LIGHTS && L.status != 2) //Ready for a light tube, and not broken.
+			to_chat(user, "<span class='notice'>You put lights in [src].</span>")
+			new /obj/machinery/power/floodlight(loc)
+			qdel(src)
+			qdel(O)
+			return
+		else //A minute of silence for all the accidentally broken light tubes.
+			return
+	..()
 
 /obj/machinery/power/floodlight
 	name = "floodlight"
@@ -46,16 +50,20 @@
 	integrity_failure = 0.8
 	idle_power_usage = 100
 	active_power_usage = 1000
-	var/list/light_setting_list = list(0, 5, 10, 15)
-	var/light_power_coefficient = 300
-	var/setting = 1
+	anchored = FALSE
 	light_power = 1.75
+	var/list/light_setting_list = list(0, 5, 10, 15)
+	var/light_power_coefficient = 200
+	var/setting = 1
 
 /obj/machinery/power/floodlight/process()
-	if(avail(active_power_usage))
-		add_load(active_power_usage)
+	if(setting > 1)
+		if(avail(active_power_usage))
+			add_load(active_power_usage)
+		else
+			change_setting(1)
 	else
-		change_setting(1)
+		add_load(idle_power_usage)
 
 /obj/machinery/power/floodlight/proc/change_setting(val, mob/user)
 	if((val < 1) || (val > light_setting_list.len))
@@ -64,7 +72,7 @@
 	if(!avail(active_power_usage))
 		return change_setting(val - 1)
 	setting = val
-	set_light(light_setting_list[val])
+	set_light(light_setting_list[val], light_power)
 	var/setting_text = ""
 	if(val > 1)
 		icon_state = "[initial(icon_state)]_on"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Floodlights had a few issue that needed sorting out.
Construction has been rewritten slightly, frame no longer requires wrenching to complete. Wrenching is still necessary to connect the finished floodlight though. This used to require wrenching to complete, then unwrenching and wrenching again to hook to a powernet.
Light tubes will no longer get broken if you attempt to add them in the wrong step. The light tube step is now light replacer compatible.
Power use has been increased through the previously unused power coefficient var. It now consumes 100w (off), 1000w, 2000w, 3000w instead of 0w, 5w, 10w, 15w. It will additionally turn off properly if there is not enough power or the cable gets cut.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #43610
Fixes #40234
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Floodlights can no longer be run in wireless power mode.
fix: Floodlights now accept light tubes from light replacers.
fix: Floodlights now only requires a single wrenching after construction to connect.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
