### PR TITLE
Removes one of the Air Alarms from the Armory

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -26462,10 +26462,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "bgB" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -54583,7 +54579,6 @@
 /area/science/genetics)
 "crW" = (
 /obj/structure/bed/roller,
-/mob/living/carbon/monkey,
 /obj/machinery/door/window/westleft{
 	base_state = "right";
 	dir = 1;
@@ -54592,6 +54587,7 @@
 	pixel_y = 2;
 	req_access_txt = "9"
 	},
+/mob/living/carbon/monkey,
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
 "crZ" = (


### PR DESCRIPTION
## About The Pull Request
Removes one of the previously two air alarms from the armory
![dreammaker_2020-01-04_13-45-08](https://user-images.githubusercontent.com/17747087/71765870-d6945080-2ef9-11ea-8be8-68beb24097ed.png)

## Why It's Good For The Game
Because ~~aeth is a silly peanut~~ no room needs more then a single air alarm.

## Changelog
:cl: Vondiech
tweak: The armory now no longer has 2 air alarms
/:cl: