### PR TITLE
Fixes cyborg messaging on surgery cancel

### DIFF
--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -104,8 +104,7 @@
 			if(!close_tool)
 				to_chat(user, "<span class='warning'>You need to equip a cautery in an inactive slot to stop [M]'s surgery!</span>")
 				return
-
-		if((!close_tool || close_tool.tool_behaviour != required_tool_type) && !iscyborg(user)) // don't check tool type on cyborgs
+		else if(!close_tool || close_tool.tool_behaviour != required_tool_type)
 			to_chat(user, "<span class='warning'>You need to hold a [is_robotic ? "screwdriver" : "cautery"] in your inactive hand to stop [M]'s surgery!</span>")
 			return
 

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -83,27 +83,40 @@
 
 /proc/attempt_cancel_surgery(datum/surgery/S, obj/item/I, mob/living/M, mob/user)
 	var/selected_zone = user.zone_selected
+
 	if(S.status == 1)
 		M.surgeries -= S
 		user.visible_message("<span class='notice'>[user] removes [I] from [M]'s [parse_zone(selected_zone)].</span>", \
 			"<span class='notice'>You remove [I] from [M]'s [parse_zone(selected_zone)].</span>")
 		qdel(S)
-	else if(S.can_cancel)
+		return
+
+	if(S.can_cancel)
 		var/required_tool_type = TOOL_CAUTERY
 		var/obj/item/close_tool = user.get_inactive_held_item()
 		var/is_robotic = S.requires_bodypart_type == BODYPART_ROBOTIC
+
 		if(is_robotic)
 			required_tool_type = TOOL_SCREWDRIVER
-		if(close_tool && close_tool.tool_behaviour == required_tool_type || iscyborg(user))
-			if (ishuman(M))
-				var/mob/living/carbon/human/H = M
-				H.bleed_rate = max( (H.bleed_rate - 3), 0)
-			M.surgeries -= S
-			user.visible_message("<span class='notice'>[user] closes [M]'s [parse_zone(selected_zone)] with [close_tool] and removes [I].</span>", \
-				"<span class='notice'>You close [M]'s [parse_zone(selected_zone)] with [close_tool] and remove [I].</span>")
-			qdel(S)
-		else
+
+		if(iscyborg(user))
+			close_tool = locate(/obj/item/cautery) in user.held_items
+			if(!close_tool)
+				to_chat(user, "<span class='warning'>You need to equip a cautery in an inactive slot to stop [M]'s surgery!</span>")
+				return
+
+		if((!close_tool || close_tool.tool_behaviour != required_tool_type) && !iscyborg(user)) // don't check tool type on cyborgs
 			to_chat(user, "<span class='warning'>You need to hold a [is_robotic ? "screwdriver" : "cautery"] in your inactive hand to stop [M]'s surgery!</span>")
+			return
+
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			H.bleed_rate = max( (H.bleed_rate - 3), 0)
+		M.surgeries -= S
+		user.visible_message("<span class='notice'>[user] closes [M]'s [parse_zone(selected_zone)] with [close_tool] and removes [I].</span>", \
+			"<span class='notice'>You close [M]'s [parse_zone(selected_zone)] with [close_tool] and remove [I].</span>")
+		qdel(S)
+
 
 /proc/get_location_modifier(mob/M)
 	var/turf/T = get_turf(M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the surgery cancellation message when done by a borg and also adds a borg friendly message when not having the proper tool equipped. Medborgs are still able to use cautery to cancel augment surgery (as before), but this can be changed if it's not what we want.
Fixes #48565 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fix.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Thebleh
fix: Cyborgs now receive proper text feedback when attempting to cancel a surgery.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
