### PR TITLE
Dark mode chat color tweaks

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -274,9 +274,9 @@ em						{font-style: normal;	font-weight: bold;}
 
 .say					{}
 .deadsay				{color: #e2c1ff}
-.binarysay				{color: #20c20e;	background-color: #000000;	display: block;}
-.binarysay a			{color: #00ff00;}
-.binarysay a:active, .binarysay a:visited {color: #88ff88;}
+.binarysay				{color: #200ec2;	background-color: #e6e6e6;	display: block;}
+.binarysay a			{color: #0000ee;}
+.binarysay a:active, .binarysay a:visited {color: #551a8b;}
 .radio					{color: #1ecc43;}
 .sciradio				{color: #c68cfa;}
 .comradio				{color: #5177ff;}

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -279,7 +279,7 @@ em						{font-style: normal;	font-weight: bold;}
 .binarysay a:active, .binarysay a:visited {color: #88ff88;}
 .radio					{color: #1ecc43;}
 .sciradio				{color: #c68cfa;}
-.comradio				{color: #5177ff;}
+.comradio				{color: #fcdf03;}
 .secradio				{color: #dd3535;}
 .medradio				{color: #57b8f0;}
 .engradio				{color: #f37746;}

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -274,7 +274,7 @@ em						{font-style: normal;	font-weight: bold;}
 
 .say					{}
 .deadsay				{color: #e2c1ff}
-.binarysay				{color: #1e90ff;	background-color: #000000;	display: block;}
+.binarysay				{color: #1e90ff;}
 .binarysay a			{color: #00ff00;}
 .binarysay a:active, .binarysay a:visited {color: #88ff88;}
 .radio					{color: #1ecc43;}

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -274,9 +274,9 @@ em						{font-style: normal;	font-weight: bold;}
 
 .say					{}
 .deadsay				{color: #e2c1ff}
-.binarysay				{color: #200ec2;	background-color: #e6e6e6;	display: block;}
-.binarysay a			{color: #0000ee;}
-.binarysay a:active, .binarysay a:visited {color: #551a8b;}
+.binarysay				{color: #1e90ff;	background-color: #000000;	display: block;}
+.binarysay a			{color: #00ff00;}
+.binarysay a:active, .binarysay a:visited {color: #88ff88;}
 .radio					{color: #1ecc43;}
 .sciradio				{color: #c68cfa;}
 .comradio				{color: #5177ff;}


### PR DESCRIPTION
  Changes binary chat colors in dark mode.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR tweaks the binary chat colors in dark mode to be more distinct from common, from green to blue. This does not change the colors for light mode, they are still the same as they were. As a result, the dark mode color for command has been changed from blue to gold, being more consistent with light mode. @Hopefully, Borgs won't get locked down for missing an order form an AI in the sea of green text anymore.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Black text background in dark mode is dumb.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

tweak: Changed the binary dark mode chat color to be more distinct from common, from green to blue.
tweak: Changed the command dark mode chat color to be more consistent with light mode, from blue to gold.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
