### PR TITLE
Various ruin mapping fixes

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_elephant_graveyard.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_elephant_graveyard.dmm
@@ -53,11 +53,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
-"am" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating/asteroid/basalt/wasteland,
-/area/ruin/unpowered/elephant_graveyard)
 "an" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /obj/item/assembly/mousetrap,
@@ -366,7 +361,6 @@
 /area/ruin/unpowered/elephant_graveyard)
 "bw" = (
 /obj/structure/cable,
-/obj/structure/cable,
 /obj/machinery/power/floodlight,
 /turf/open/floor/plating/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
@@ -521,7 +515,6 @@
 /turf/open/floor/plating/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "cb" = (
-/obj/structure/cable,
 /obj/structure/cable,
 /obj/item/reagent_containers/glass/bottle/frostoil{
 	desc = "A small bottle. Contains cold sauce. There's a label on here: APPLY ON SEVERE BURNS.";
@@ -1258,7 +1251,7 @@ bf
 bf
 aE
 bf
-am
+al
 aq
 as
 az
@@ -1346,7 +1339,7 @@ al
 al
 al
 al
-am
+al
 al
 cA
 bf

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -1769,7 +1769,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white,
@@ -2047,7 +2046,6 @@
 /obj/machinery/light/small,
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
@@ -2069,6 +2067,7 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "fn" = (
@@ -3421,6 +3420,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "it" = (
@@ -3992,6 +3994,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "jt" = (
@@ -4167,7 +4172,6 @@
 /area/ruin/space/has_grav/ancientstation/proto)
 "jO" = (
 /obj/machinery/light/small/broken{
-	icon_state = "bulb-broken";
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
@@ -4331,7 +4335,6 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white,
@@ -4588,11 +4591,9 @@
 "kK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	icon_state = "pipe11-3";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -4605,7 +4606,6 @@
 /area/ruin/space/has_grav/ancientstation/atmo)
 "kL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	icon_state = "pipe11-3";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4687,7 +4687,6 @@
 "kW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "pipe11-2";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -5046,7 +5045,6 @@
 	pixel_x = -23
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
@@ -5403,7 +5401,6 @@
 /obj/item/tank/internals/oxygen,
 /obj/item/tank/internals/oxygen,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
@@ -5709,11 +5706,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "pipe11-2";
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	icon_state = "pipe11-3";
 	dir = 8
 	},
 /obj/item/stack/rods,
@@ -5756,7 +5751,6 @@
 "ny" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer3{
-	icon_state = "manifold-3";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -5770,7 +5764,6 @@
 "nz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	icon_state = "pipe11-3";
 	dir = 1
 	},
 /obj/machinery/firealarm{
@@ -5795,7 +5788,6 @@
 "nB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3{
-	icon_state = "connector_map-3";
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -5820,7 +5812,6 @@
 /obj/item/retractor,
 /obj/item/surgical_drapes,
 /obj/machinery/light/small/broken{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -5999,7 +5990,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "tracks";
 	dir = 1
 	},
 /mob/living/simple_animal/hostile/alien,
@@ -6052,7 +6042,6 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "tracks";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -6222,7 +6211,6 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light/small/broken{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -6255,7 +6243,6 @@
 /obj/structure/table,
 /obj/item/tank/internals/oxygen,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -6408,7 +6395,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
@@ -6646,7 +6632,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	icon_state = "inje_map-2";
 	dir = 8
 	},
 /obj/machinery/light/small{
@@ -6872,7 +6857,6 @@
 	name = "Plasma Canister Storage"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	icon_state = "pipe11-3";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -6998,7 +6982,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	icon_state = "pipe11-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7023,7 +7006,6 @@
 "DJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
@@ -7061,7 +7043,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3{
-	icon_state = "connector_map-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/airless,
@@ -7153,7 +7134,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "tracks";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7201,7 +7181,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	icon_state = "inje_map-2";
 	dir = 8
 	},
 /obj/machinery/light/small,
@@ -7225,7 +7204,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "tracks";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7261,7 +7239,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer3{
-	icon_state = "manifold-3";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -7489,7 +7466,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "tracks";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -7511,7 +7487,6 @@
 "Su" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -7588,7 +7563,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	icon_state = "pipe11-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7601,7 +7575,6 @@
 "Vm" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	icon_state = "pipe11-3";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -7699,7 +7672,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "tracks";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -7728,7 +7700,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "tracks";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7757,7 +7728,6 @@
 /area/ruin/space/has_grav/ancientstation/atmo)
 "Zg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	icon_state = "pipe11-3";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1462,7 +1462,7 @@
 /area/mine/living_quarters)
 "ed" = (
 /obj/machinery/camera{
-	c_tag = "Crew Area Hallway West";
+	c_tag = "Crew Area Hallway";
 	network = list("mine")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -4243,7 +4243,7 @@
 /area/mine/living_quarters)
 "YY" = (
 /obj/machinery/camera{
-	c_tag = "Crew Area";
+	c_tag = "Crew Area Hallway West";
 	dir = 1;
 	network = list("mine")
 	},

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -7883,11 +7883,12 @@
 "rB" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/weldingtool/experimental,
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/item/weldingtool/experimental,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "rC" = (

--- a/_maps/shuttles/ruin_caravan_victim.dmm
+++ b/_maps/shuttles/ruin_caravan_victim.dmm
@@ -230,6 +230,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter1)
 "lM" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes some ruin mapping issues, double cables, stray atmos pipes. Added a cable under a SMES terminal on CC since thats always going to scream about it.
Also gives StrongDMM and mapmerger a chance to clean some stuff up.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes map issues
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Various ruin mapping fixes. Stray pipes, double cables gone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
