### PR TITLE
Kilo Station mapping fixes

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -8294,7 +8294,6 @@
 "ans" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/xeno_spawn,
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/solar/port/fore)
 "ant" = (
@@ -9028,7 +9027,7 @@
 /area/lawoffice)
 "aoz" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/asteroid/airless,
+/turf/open/floor/plating/asteroid/lowpressure,
 /area/space/nearstation)
 "aoA" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -9507,7 +9506,7 @@
 /area/lawoffice)
 "apm" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/plating/asteroid/airless,
+/turf/open/floor/plating/asteroid/lowpressure,
 /area/space/nearstation)
 "apn" = (
 /obj/machinery/porta_turret/ai{
@@ -10968,7 +10967,7 @@
 "arz" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/tank/internals/emergency_oxygen/empty,
-/turf/open/floor/plating/asteroid/airless,
+/turf/open/floor/plating/asteroid/lowpressure,
 /area/space/nearstation)
 "arA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11376,7 +11375,6 @@
 "ase" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/xeno_spawn,
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/solar/starboard/fore)
 "asf" = (
@@ -12637,10 +12635,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/genetics)
-"auc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/bridge)
 "aud" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -12879,6 +12873,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/bridge)
 "auw" = (
@@ -14042,6 +14037,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/bridge)
 "awi" = (
@@ -20181,7 +20177,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/research)
 "aFZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -21359,7 +21354,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
 "aHR" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -24023,7 +24018,7 @@
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
 "aLY" = (
 /obj/effect/turf_decal/tile/red,
@@ -24842,13 +24837,6 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
-"aNe" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "aNf" = (
 /obj/structure/reflector/single/anchored{
@@ -29066,12 +29054,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/storage)
-"aTd" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/asteroid/airless{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/space/nearstation)
 "aTe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -30001,9 +29983,7 @@
 "aUq" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/plating/lowpressure,
 /area/maintenance/port)
 "aUr" = (
 /obj/effect/turf_decal/tile/purple{
@@ -30143,13 +30123,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/camera{
-	c_tag = "Recovery Room";
-	dir = 1;
-	name = "medical camera";
-	network = list("ss13","medical");
-	pixel_x = 32
-	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
 "aUB" = (
@@ -30166,6 +30139,12 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
+	},
+/obj/machinery/camera{
+	c_tag = "Recovery Room";
+	dir = 1;
+	name = "medical camera";
+	network = list("ss13","medical")
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/surgery)
@@ -34622,9 +34601,7 @@
 "baQ" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
-/turf/open/floor/plating/airless{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/plating/lowpressure,
 /area/maintenance/port)
 "baR" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -41215,7 +41192,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Departures Cargo Dock";
+	c_tag = "Arrivals Shuttle Dock";
 	dir = 4;
 	name = "shuttle camera"
 	},
@@ -52540,9 +52517,6 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
 	pixel_x = 38;
 	pixel_y = 6
@@ -62683,19 +62657,11 @@
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
-"bQb" = (
-/obj/structure/flora/rock,
-/turf/open/floor/plating/asteroid/airless{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/space/nearstation)
 "bQc" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/remains/xeno,
-/turf/open/floor/plating/asteroid/airless{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/plating/asteroid/lowpressure,
 /area/space/nearstation)
 "bQd" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -62761,9 +62727,7 @@
 /mob/living/simple_animal/hostile/asteroid/basilisk{
 	environment_smash = 0
 	},
-/turf/open/floor/plating/asteroid/airless{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/plating/asteroid/lowpressure,
 /area/space/nearstation)
 "bQh" = (
 /obj/machinery/door/airlock/maintenance{
@@ -62926,9 +62890,7 @@
 "bQq" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/limb,
-/turf/open/floor/plating/asteroid/airless{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/plating/asteroid/lowpressure,
 /area/space/nearstation)
 "bQr" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -63281,9 +63243,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/pickaxe,
-/turf/open/floor/plating/asteroid/airless{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/plating/asteroid/lowpressure,
 /area/space/nearstation)
 "bQO" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -63828,9 +63788,7 @@
 "bRy" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/plating/asteroid/airless{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/plating/asteroid/lowpressure,
 /area/space/nearstation)
 "bRz" = (
 /obj/effect/turf_decal/tile/purple{
@@ -63943,7 +63901,7 @@
 /area/hallway/primary/central)
 "bRJ" = (
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating/lowpressure,
 /area/maintenance/port)
 "bRK" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -70584,22 +70542,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cbD" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cbE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -75004,6 +74946,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ciU" = (
@@ -75547,6 +75490,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cjI" = (
@@ -79750,7 +79694,6 @@
 	pixel_x = 24;
 	req_one_access_txt = "10"
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cqF" = (
@@ -82514,7 +82457,6 @@
 "cuS" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/xeno_spawn,
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/solar/port/aft)
 "cuT" = (
@@ -86404,6 +86346,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cBk" = (
@@ -86512,6 +86455,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cBu" = (
@@ -86646,7 +86590,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cBK" = (
@@ -86854,7 +86797,6 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 30
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cCf" = (
@@ -87341,7 +87283,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cCR" = (
@@ -87473,6 +87414,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cDf" = (
@@ -87637,6 +87579,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cDv" = (
@@ -88112,7 +88055,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEr" = (
@@ -88365,7 +88307,6 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEL" = (
@@ -88613,6 +88554,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cFf" = (
@@ -88623,6 +88565,7 @@
 	dir = 1;
 	pixel_y = -26
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cFg" = (
@@ -89497,7 +89440,6 @@
 "cGG" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/xeno_spawn,
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/solar/starboard/aft)
 "cGH" = (
@@ -93465,7 +93407,7 @@
 "cNZ" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating/lowpressure,
 /area/space/nearstation)
 "cOb" = (
 /obj/structure/sign/warning/biohazard,
@@ -93653,7 +93595,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/turf/open/floor/plating/asteroid/airless,
+/turf/open/floor/plating/asteroid/lowpressure,
 /area/space/nearstation)
 "cQs" = (
 /obj/effect/turf_decal/tile/red,
@@ -93879,6 +93821,13 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"cYF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "dgX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -93888,11 +93837,26 @@
 /obj/machinery/navbeacon/wayfinding,
 /turf/open/floor/plasteel/dark,
 /area/storage/primary)
+"dvN" = (
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/space/nearstation)
 "fhz" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"llk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"ogA" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/lowpressure,
+/area/space/nearstation)
 "prO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
@@ -93919,6 +93883,18 @@
 /obj/machinery/navbeacon/wayfinding,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"qvq" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/space/nearstation)
+"rkn" = (
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating/asteroid/airless,
+/area/space/nearstation)
+"thU" = (
+/mob/living/simple_animal/hostile/asteroid/goliath,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/space/nearstation)
 "utx" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research{
@@ -93932,11 +93908,22 @@
 /obj/machinery/navbeacon/wayfinding,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"vQL" = (
+/turf/open/floor/plating/airless,
+/area/solar/starboard/aft)
+"wDI" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/space/nearstation)
 "xIs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/pinpointer_dispenser,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"ycp" = (
+/mob/living/simple_animal/hostile/asteroid/hivelord,
+/turf/open/floor/plating/asteroid/lowpressure,
+/area/space/nearstation)
 
 (1,1,1) = {"
 aaa
@@ -104650,7 +104637,7 @@ coS
 coS
 coS
 coS
-coT
+cCa
 coS
 coS
 coS
@@ -104861,7 +104848,7 @@ aeU
 aeu
 aeu
 aeu
-bKl
+wDI
 aeu
 aeu
 bUG
@@ -104907,7 +104894,7 @@ coT
 coT
 coT
 coT
-coT
+cCa
 coT
 coT
 coT
@@ -105164,7 +105151,7 @@ coS
 coS
 coS
 coS
-coT
+cCa
 coS
 coS
 coS
@@ -105352,7 +105339,7 @@ ahG
 ahG
 ahG
 ahG
-ahG
+cjl
 ahG
 ahG
 ahG
@@ -105373,7 +105360,7 @@ aUz
 aeU
 aeu
 aeu
-bKl
+wDI
 bQg
 aeu
 aeu
@@ -105421,7 +105408,7 @@ ckk
 aaa
 aaa
 ckk
-coT
+cCa
 ckk
 aaa
 aaa
@@ -105609,7 +105596,7 @@ ahF
 ahF
 ahF
 ahF
-ahG
+cjl
 ahF
 ahF
 ahF
@@ -105678,7 +105665,7 @@ coS
 coS
 coS
 ckj
-coT
+cCa
 ckj
 coS
 coS
@@ -105866,7 +105853,7 @@ ckk
 aaa
 aaa
 ckk
-ahG
+cjl
 ckk
 aaa
 aaa
@@ -105888,7 +105875,7 @@ aeu
 aeu
 aeu
 bQc
-aDQ
+dvN
 aeu
 aeu
 aeu
@@ -105934,9 +105921,9 @@ coT
 coT
 coT
 coT
-coT
+cCa
 cuS
-coT
+cCa
 coT
 coT
 cAm
@@ -106123,7 +106110,7 @@ ahF
 ahF
 ahF
 cFS
-ahG
+cjl
 ctE
 ahF
 ahF
@@ -106143,7 +106130,7 @@ aeU
 aeu
 aeu
 aeu
-aDQ
+dvN
 bQg
 aeu
 aeu
@@ -106192,7 +106179,7 @@ coS
 coS
 coS
 ckj
-coT
+cCa
 ckj
 coS
 coS
@@ -106379,9 +106366,9 @@ ahG
 ahG
 ahG
 ahG
-ahG
+cjl
 ans
-ahG
+cjl
 ahG
 ahG
 ahG
@@ -106401,8 +106388,8 @@ aeu
 aeu
 aeu
 aeu
-aDQ
-aDQ
+dvN
+dvN
 aeu
 aeu
 aeu
@@ -106449,7 +106436,7 @@ ckk
 aaa
 aaa
 ckk
-coT
+cCa
 ckk
 aaa
 aaa
@@ -106637,7 +106624,7 @@ ahF
 ahF
 ahF
 ctE
-ahG
+cjl
 ctE
 ahF
 ahF
@@ -106656,11 +106643,11 @@ aeu
 aeu
 aeu
 aeu
-aDQ
-bKl
+dvN
+wDI
 bQq
-bQb
-aDQ
+qvq
+dvN
 aeu
 aeu
 amA
@@ -106706,7 +106693,7 @@ coS
 coS
 coS
 coS
-coT
+cCa
 coS
 coS
 coS
@@ -106894,7 +106881,7 @@ ckk
 aaa
 aaa
 ckk
-ahG
+cjl
 ckk
 aaa
 aaa
@@ -106912,12 +106899,12 @@ aeu
 aeu
 aeu
 aeu
-bKl
-aDQ
-aDQ
-aDQ
-aDQ
-aDQ
+wDI
+dvN
+dvN
+dvN
+dvN
+dvN
 aeu
 aeu
 amR
@@ -106963,7 +106950,7 @@ coT
 coT
 coT
 coT
-coT
+cCa
 coT
 coT
 coT
@@ -107151,7 +107138,7 @@ ahF
 ahF
 ahF
 ahF
-ahG
+cjl
 ahF
 ahF
 ahF
@@ -107169,12 +107156,12 @@ aeu
 aeu
 aeu
 aeu
-aDQ
-aDQ
-aTd
-bKl
-aDQ
-aDQ
+dvN
+dvN
+aoz
+wDI
+dvN
+dvN
 aeu
 aeu
 amA
@@ -107220,7 +107207,7 @@ coS
 coS
 coS
 coS
-coT
+cCa
 coS
 coS
 coS
@@ -107408,7 +107395,7 @@ ahG
 ahG
 ahG
 ahG
-ahG
+cjl
 ahG
 ahG
 ahG
@@ -107427,10 +107414,10 @@ aeu
 aeu
 aeu
 aeu
-aDQ
-bQb
-aDQ
-aDQ
+dvN
+qvq
+dvN
+dvN
 amA
 amR
 amA
@@ -107477,7 +107464,7 @@ cmU
 cmU
 cmU
 aDS
-coT
+cCa
 bFI
 cmU
 cmU
@@ -107665,7 +107652,7 @@ ahF
 ahF
 ahF
 ahF
-ahG
+cjl
 ahF
 ahF
 ahF
@@ -107685,8 +107672,8 @@ aeu
 aeu
 aeu
 aeu
-aDQ
-aDQ
+dvN
+dvN
 aUq
 amA
 cug
@@ -107732,9 +107719,9 @@ aeU
 aeU
 aeU
 aeU
-aeU
+rkn
 aDS
-coT
+cCa
 bFI
 aeU
 coy
@@ -107922,7 +107909,7 @@ cmU
 cmU
 cmU
 aDS
-ahG
+cjl
 bFI
 cmU
 cmU
@@ -107943,7 +107930,7 @@ aeu
 aeu
 aeu
 aeu
-aDQ
+dvN
 baQ
 bdl
 beN
@@ -108179,9 +108166,9 @@ aeU
 coy
 aeU
 aDS
-ahG
+cjl
 bFI
-aeU
+rkn
 aeU
 aeU
 aeu
@@ -121372,7 +121359,7 @@ cIG
 bPG
 byz
 aFU
-aNe
+aFO
 cyP
 bKO
 coj
@@ -121596,7 +121583,7 @@ bOX
 cbi
 ceb
 ceS
-cbD
+cgk
 bZZ
 cao
 bEA
@@ -123381,7 +123368,7 @@ bEN
 bFu
 bHB
 aGG
-auc
+bMV
 atj
 atj
 bNI
@@ -124409,7 +124396,7 @@ bEP
 bFH
 atj
 aHU
-auc
+bMV
 atj
 atj
 bNL
@@ -128049,8 +128036,8 @@ cBs
 cBP
 cBi
 cCQ
-cBi
-cBi
+llk
+llk
 cEq
 aAQ
 axW
@@ -130873,7 +130860,7 @@ cAO
 cAV
 cBj
 cBt
-cCG
+cCd
 cCd
 cCG
 cDt
@@ -131134,7 +131121,7 @@ cCe
 cqE
 cDe
 cDu
-azw
+cYF
 cFf
 axa
 cki
@@ -134993,9 +134980,9 @@ aeu
 aeu
 aeU
 aDS
-cDr
+ctQ
 bFI
-aeU
+rkn
 coy
 aeU
 aeU
@@ -135250,7 +135237,7 @@ aeU
 aeU
 aUz
 aDS
-cDr
+ctQ
 bFI
 aeU
 aeU
@@ -135507,7 +135494,7 @@ cmU
 cmU
 cmU
 aDS
-cDr
+ctQ
 bFI
 cmU
 cmU
@@ -135764,7 +135751,7 @@ cDo
 cDo
 cDo
 cDo
-cDr
+ctQ
 cDo
 cDo
 cDo
@@ -136021,7 +136008,7 @@ cDr
 cDr
 cDr
 cDr
-cDr
+ctQ
 cDr
 cDr
 cDr
@@ -136278,7 +136265,7 @@ cDo
 cDo
 cDo
 cDo
-cDr
+ctQ
 cDo
 cDo
 cDo
@@ -136535,7 +136522,7 @@ ckk
 aaa
 aaa
 ckk
-cDr
+ctQ
 ckk
 aaa
 aaa
@@ -136792,7 +136779,7 @@ cDo
 cDo
 cDo
 ckA
-cDr
+ctQ
 ckA
 cDo
 cDo
@@ -137048,9 +137035,9 @@ cDr
 cDr
 cDr
 cDr
-cDr
+ctQ
 cGG
-cDr
+ctQ
 cDr
 cDr
 cDr
@@ -137306,7 +137293,7 @@ cDo
 cDo
 cDo
 ckA
-cDr
+ctQ
 ckA
 cDo
 cDo
@@ -137563,7 +137550,7 @@ ckk
 aaa
 aaa
 ckk
-cDr
+ctQ
 ckk
 aaa
 aaa
@@ -137820,7 +137807,7 @@ cDo
 cDo
 cDo
 cDo
-cDr
+ctQ
 cDo
 cDo
 cDo
@@ -138077,7 +138064,7 @@ cDr
 cFh
 cDr
 cDr
-cDr
+vQL
 cDr
 cDr
 cDr
@@ -138505,7 +138492,7 @@ aeU
 aUz
 coy
 aeU
-aeU
+rkn
 aDS
 ajH
 bFI
@@ -138764,7 +138751,7 @@ cmU
 cmU
 cmU
 aDS
-ajH
+cMU
 bFI
 cmU
 cmU
@@ -139021,7 +139008,7 @@ ajG
 ajG
 ajG
 ajG
-ajH
+cMU
 ajG
 ajG
 ajG
@@ -139278,7 +139265,7 @@ amb
 ajH
 ajH
 ajH
-ajH
+cMU
 ajH
 ajH
 ajH
@@ -139535,7 +139522,7 @@ ajG
 ajG
 ajG
 ajG
-ajH
+cMU
 ajG
 ajG
 ajG
@@ -139792,7 +139779,7 @@ ckk
 aaa
 aaa
 ckk
-ajH
+cMU
 ckk
 aaa
 aaa
@@ -140049,7 +140036,7 @@ ajG
 ajG
 ajG
 cLN
-ajH
+cMU
 cLN
 ajG
 ajG
@@ -140305,9 +140292,9 @@ ajH
 ajH
 ajH
 ajH
-ajH
+cMU
 ase
-ajH
+cMU
 ajH
 ajH
 ajH
@@ -140563,7 +140550,7 @@ ajG
 ajG
 ajG
 cLN
-ajH
+cMU
 cLN
 ajG
 ajG
@@ -140820,7 +140807,7 @@ ckk
 aaa
 aaa
 ckk
-ajH
+cMU
 ckk
 aaa
 aaa
@@ -141026,9 +141013,9 @@ aeu
 aeu
 aeu
 cPY
-cmU
-cmU
-cmU
+ogA
+ogA
+ogA
 aeu
 aeu
 aeu
@@ -141077,7 +141064,7 @@ ajG
 ajG
 ajG
 ajG
-ajH
+cMU
 ajG
 ajG
 ajG
@@ -141281,12 +141268,12 @@ aeu
 aeu
 aeu
 aap
-aeU
-aeU
-cmU
+dvN
+dvN
+ogA
 cNZ
-cmU
-aeU
+ogA
+dvN
 aeu
 aeu
 aeu
@@ -141334,7 +141321,7 @@ ajH
 ajH
 ajH
 ajH
-ajH
+cMU
 ajH
 ajH
 ajH
@@ -141538,12 +141525,12 @@ aeu
 aeu
 aeu
 aeu
-aeU
-aUz
-aeU
-coy
-aeU
-aeU
+dvN
+wDI
+dvN
+qvq
+dvN
+dvN
 aap
 aeu
 aeu
@@ -141794,13 +141781,13 @@ aeu
 aeu
 aeu
 aeu
-aeU
-aeU
-aeU
-cuj
-aeU
-aeU
-aeU
+dvN
+dvN
+dvN
+ycp
+dvN
+dvN
+dvN
 aeu
 aeu
 aeu
@@ -142050,13 +142037,13 @@ aeu
 aeu
 aeu
 aeu
-aeU
+dvN
 arz
-aeU
-aeU
-aeU
-aeU
-aUz
+dvN
+dvN
+dvN
+dvN
+wDI
 aeu
 aeu
 aeu
@@ -142306,13 +142293,13 @@ aeu
 aeu
 aeu
 aeu
-aeU
-aeU
-aeU
-aeU
+dvN
+dvN
+dvN
+dvN
 aoz
-aeU
-aeU
+dvN
+dvN
 aeu
 aeu
 aeu
@@ -142563,12 +142550,12 @@ aeu
 aeu
 aeu
 aeu
-aeU
-aeU
-aUz
+dvN
+dvN
+wDI
 apm
-aeU
-aeU
+dvN
+dvN
 aeu
 aeu
 aeu
@@ -142821,11 +142808,11 @@ aeu
 aeu
 aeu
 aeu
-aeU
-aeU
+dvN
+dvN
 aoz
 bQN
-aeU
+dvN
 aap
 aeu
 aeu
@@ -143079,9 +143066,9 @@ aeu
 aeu
 aap
 aoz
-cui
-aeU
-aeU
+thU
+dvN
+dvN
 aeu
 aeu
 aeu
@@ -143335,9 +143322,9 @@ aeu
 aeu
 aeu
 aeu
-aeU
-aeU
-aUz
+dvN
+dvN
+wDI
 aeu
 aeu
 aeu
@@ -143591,10 +143578,10 @@ aeu
 aeu
 aeu
 aeu
-aeU
+dvN
 bRy
-aeU
-aeU
+dvN
+dvN
 aeu
 aeu
 aeu
@@ -143848,8 +143835,8 @@ aeu
 aeu
 aeu
 aap
-aeU
-aeU
+dvN
+dvN
 aoz
 aap
 aeu
@@ -144106,7 +144093,7 @@ aeu
 aeu
 aeu
 aeu
-aeU
+dvN
 aeu
 aeu
 aeu

--- a/code/game/turfs/open/floor/plating/asteroid.dm
+++ b/code/game/turfs/open/floor/plating/asteroid.dm
@@ -122,7 +122,10 @@
 	baseturfs = /turf/open/lava/smooth/lava_land_surface
 
 
-
+/turf/open/floor/plating/asteroid/lowpressure
+	initial_gas_mix = OPENTURF_LOW_PRESSURE
+	baseturfs = /turf/open/floor/plating/asteroid/lowpressure
+	turf_type = /turf/open/floor/plating/asteroid/lowpressure
 
 /turf/open/floor/plating/asteroid/airless
 	initial_gas_mix = AIRLESS_ATMOS

--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -3,6 +3,10 @@
 	icon_state = "plating"
 	initial_gas_mix = AIRLESS_ATMOS
 
+/turf/open/floor/plating/lowpressure
+	initial_gas_mix = OPENTURF_LOW_PRESSURE
+	baseturfs = /turf/open/floor/plating/lowpressure
+
 /turf/open/floor/plating/abductor
 	name = "alien floor"
 	icon_state = "alienpod1"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Atomizing these per map to avoid merge conflict hell.
Some mapping fixes for Kilo Station. Not a whole lot of structural issues here, but discovered all four solars were wired at roundstart. Disconnected them and added cable coils.
Fixed some conflicting camera ids and a disconnected room, and a bunch of active turfs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mapping fixes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Various Kilo Station mapping fixes. Station connected caves are now properly low pressure.
balance: Kilo Station solars are no longer connected roundstart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
