### PR TITLE
Fixes Light Eater not overloading borg lamps.

### DIFF
--- a/code/__DEFINES/robots.dm
+++ b/code/__DEFINES/robots.dm
@@ -50,3 +50,5 @@
 #define ASSEMBLY_THIRD_STEP     2
 #define ASSEMBLY_FOURTH_STEP    3
 #define ASSEMBLY_FIFTH_STEP     4
+
+#define BORG_LAMP_CD_RESET -1 //special value to reset cyborg's lamp_cooldown

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -186,7 +186,7 @@
 
 		if(iscyborg(AM))
 			var/mob/living/silicon/robot/borg = AM
-			if(!borg.lamp_cooldown)
+			if(borg.lamp_intensity)
 				borg.update_headlamp(TRUE, INFINITY)
 				to_chat(borg, "<span class='danger'>Your headlamp is fried! You'll need a human to help replace it.</span>")
 		else

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -707,7 +707,7 @@
 	if(lamp_intensity && (turn_off || stat || low_power_mode))
 		to_chat(src, "<span class='danger'>Your headlamp has been deactivated.</span>")
 		lamp_intensity = 0
-		lamp_cooldown = world.time + cooldown
+		lamp_cooldown = BORG_LAMP_CD_RESET ? 0 : max(world.time + cooldown, lamp_cooldown)
 	else
 		set_light(lamp_intensity)
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -707,7 +707,7 @@
 	if(lamp_intensity && (turn_off || stat || low_power_mode))
 		to_chat(src, "<span class='danger'>Your headlamp has been deactivated.</span>")
 		lamp_intensity = 0
-		lamp_cooldown = BORG_LAMP_CD_RESET ? 0 : max(world.time + cooldown, lamp_cooldown)
+		lamp_cooldown = cooldown == BORG_LAMP_CD_RESET ? 0 : max(world.time + cooldown, lamp_cooldown)
 	else
 		set_light(lamp_intensity)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -221,7 +221,7 @@
 	R.setDir(SOUTH)
 	R.anchored = FALSE
 	R.notransform = FALSE
-	R.update_headlamp()
+	R.update_headlamp(FALSE, BORG_LAMP_CD_RESET)
 	R.notify_ai(NEW_MODULE)
 	if(R.hud_used)
 		R.hud_used.update_robot_modules_display()


### PR DESCRIPTION
## About The Pull Request
`lamp_cooldown` is one of those world.time tracking var, so a `!borg.lamp_cooldown` check would only be TRUE if the cyborg's lamp was never ever toggled.
Yes, the change does make it so the light eater won't fry unlit cyborg lamps, but that's just consistent with how the light eater normally interacts with items and more reliable than the current crapshot, so don't freeze me.

## Why It's Good For The Game
This will close #48078.

## Changelog
:cl:
fix: Fixes Light Eater not reliably overloading borg lamps most times.
/:cl:
