### PR TITLE
Adds air tank to seed vault ruin, replaces active turfs

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -365,7 +365,6 @@
 "aY" = (
 /obj/effect/decal/cleanable/food/plant_smudge,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	icon_state = "vent_map_on-2";
 	dir = 1
 	},
 /turf/open/floor/vault,
@@ -647,7 +646,6 @@
 /area/ruin/powered/seedvault)
 "oR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "pipe11-2";
 	dir = 10
 	},
 /turf/open/floor/plasteel/freezer,
@@ -676,7 +674,6 @@
 "Eu" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -688,14 +685,12 @@
 /area/ruin/powered/seedvault)
 "PH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "Uz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	icon_state = "vent_map_on-2";
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -142,6 +142,7 @@
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/green/filled/end,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered/seedvault)
 "ax" = (
@@ -230,6 +231,7 @@
 /area/ruin/powered/seedvault)
 "aH" = (
 /obj/machinery/door/airlock/vault,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "aI" = (
@@ -362,6 +364,10 @@
 /area/ruin/powered/seedvault)
 "aY" = (
 /obj/effect/decal/cleanable/food/plant_smudge,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	icon_state = "vent_map_on-2";
+	dir = 1
+	},
 /turf/open/floor/vault,
 /area/ruin/powered/seedvault)
 "aZ" = (
@@ -506,13 +512,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/floor/plating/grass/lavaland,
 /area/ruin/powered/seedvault)
 "bn" = (
 /obj/structure/window/spawner/east,
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
+/turf/open/floor/plating/grass/lavaland,
 /area/ruin/powered/seedvault)
 "bo" = (
 /obj/machinery/chem_master/condimaster,
@@ -551,19 +557,19 @@
 "br" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
+/turf/open/floor/plating/grass/lavaland,
 /area/ruin/powered/seedvault)
 "bs" = (
 /obj/structure/window/spawner/east,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/grass,
+/turf/open/floor/plating/grass/lavaland,
 /area/ruin/powered/seedvault)
 "bt" = (
 /obj/structure/window/spawner,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
+/turf/open/floor/plating/grass/lavaland,
 /area/ruin/powered/seedvault)
 "bu" = (
 /obj/structure/window/spawner/east,
@@ -571,7 +577,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/grass,
+/turf/open/floor/plating/grass/lavaland,
 /area/ruin/powered/seedvault)
 "bv" = (
 /obj/machinery/light,
@@ -633,6 +639,71 @@
 "bD" = (
 /turf/closed/wall/r_wall,
 /area/lavaland/surface/outdoors)
+"ca" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
+"oR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	icon_state = "pipe11-2";
+	dir = 10
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
+"pW" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
+"qQ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
+"sv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/vault,
+/area/ruin/powered/seedvault)
+"Bb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
+"DA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/mineral/titanium/blue,
+/area/ruin/powered/seedvault)
+"Eu" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	icon_state = "pipe11-2";
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
+"KF" = (
+/obj/machinery/door/airlock/titanium,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/vault,
+/area/ruin/powered/seedvault)
+"PH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	icon_state = "pipe11-2";
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
+"Uz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	icon_state = "vent_map_on-2";
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/ruin/powered/seedvault)
+"Vn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
 
 (1,1,1) = {"
 aa
@@ -706,7 +777,7 @@ ac
 ak
 ah
 ac
-ah
+ca
 ac
 ac
 ac
@@ -728,7 +799,7 @@ ac
 ap
 ah
 as
-ah
+PH
 aQ
 av
 al
@@ -748,9 +819,9 @@ aa
 aa
 ac
 ap
-ah
-ah
-ah
+Vn
+Bb
+qQ
 ah
 av
 am
@@ -772,7 +843,7 @@ ac
 aq
 ah
 ac
-ah
+PH
 aU
 ac
 ac
@@ -794,7 +865,7 @@ ac
 ac
 ac
 ac
-ah
+PH
 ah
 aS
 ac
@@ -816,7 +887,7 @@ ac
 ar
 at
 az
-ah
+PH
 ah
 aT
 ac
@@ -838,7 +909,7 @@ ad
 al
 al
 al
-ah
+PH
 ah
 al
 aC
@@ -858,16 +929,16 @@ ac
 ac
 ae
 al
-ah
-ah
-ah
-ah
-ah
-ah
+Vn
+Bb
+pW
+Bb
+Bb
+Bb
 aH
-ah
-bb
-aN
+Bb
+DA
+Uz
 aV
 aW
 be
@@ -882,7 +953,7 @@ af
 am
 al
 al
-ah
+PH
 ah
 al
 aD
@@ -904,7 +975,7 @@ ac
 ac
 aw
 al
-ah
+PH
 ah
 aF
 ac
@@ -926,7 +997,7 @@ ag
 an
 al
 al
-ah
+PH
 ah
 ah
 au
@@ -946,9 +1017,9 @@ aa
 ac
 ai
 al
-ah
-ah
-ah
+Vn
+Bb
+qQ
 ah
 aF
 ac
@@ -970,7 +1041,7 @@ aj
 al
 al
 al
-aU
+Eu
 ac
 ac
 ac
@@ -992,7 +1063,7 @@ ac
 ao
 al
 al
-ah
+PH
 ac
 aX
 aE
@@ -1014,10 +1085,10 @@ ac
 ac
 ax
 aJ
-ah
-au
-aA
-aA
+oR
+KF
+sv
+sv
 aY
 aM
 ac


### PR DESCRIPTION
It's #48603 except with an air tank + air alarm and vents instead of tiny fans

Closes: #48603
Fixes: #48508

## Changelog
:cl: Denton
tweak: Added an air tank and vents to the seed vault lavaland ruin
fix: Fixed active turfs in the seed vault lavaland ruin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
