### PR TITLE
Simple mob alerts

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -20,7 +20,7 @@ SUBSYSTEM_DEF(minor_mapping)
 			M = new(proposed_turf)
 		else
 			M.forceMove(proposed_turf)
-		if(M.environment_is_safe())
+		if(M.environment_air_is_safe())
 			num_mice -= 1
 			M = null
 

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -149,9 +149,12 @@
 /mob/living/simple_animal/hostile/alien/handle_temperature_damage()
 	if(bodytemperature < minbodytemp)
 		adjustBruteLoss(2)
+		throw_alert("temp", /obj/screen/alert/cold, 1)
 	else if(bodytemperature > maxbodytemp)
 		adjustBruteLoss(20)
-
+		throw_alert("temp", /obj/screen/alert/hot, 3)
+	else
+		clear_alert("temp")
 
 /mob/living/simple_animal/hostile/alien/maid
 	name = "lusty xenomorph maid"

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -546,8 +546,12 @@
 /mob/living/simple_animal/hostile/poison/giant_spider/handle_temperature_damage()
 	if(bodytemperature < minbodytemp)
 		adjustBruteLoss(20)
+		throw_alert("temp", /obj/screen/alert/cold, 3)
 	else if(bodytemperature > maxbodytemp)
 		adjustBruteLoss(20)
+		throw_alert("temp", /obj/screen/alert/hot, 3)
+	else
+		clear_alert("temp")
 
 #undef SPIDER_IDLE
 #undef SPINNING_WEB

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -67,5 +67,9 @@
 /mob/living/simple_animal/hostile/asteroid/handle_temperature_damage()
 	if(bodytemperature < minbodytemp)
 		adjustBruteLoss(2)
+		throw_alert("temp", /obj/screen/alert/cold, 1)
 	else if(bodytemperature > maxbodytemp)
 		adjustBruteLoss(20)
+		throw_alert("temp", /obj/screen/alert/hot, 3)
+	else
+		clear_alert("temp")

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -40,8 +40,12 @@
 /mob/living/simple_animal/hostile/retaliate/clown/handle_temperature_damage()
 	if(bodytemperature < minbodytemp)
 		adjustBruteLoss(10)
+		throw_alert("temp", /obj/screen/alert/cold, 2)
 	else if(bodytemperature > maxbodytemp)
 		adjustBruteLoss(15)
+		throw_alert("temp", /obj/screen/alert/hot, 3)
+	else
+		clear_alert("temp")
 
 /mob/living/simple_animal/hostile/retaliate/clown/attack_hand(mob/living/carbon/human/M)
 	..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -270,12 +270,10 @@
 					else
 						emote("me", 2, pick(emote_hear))
 
-
-/mob/living/simple_animal/proc/environment_is_safe(datum/gas_mixture/environment, check_temp = FALSE)
+/mob/living/simple_animal/proc/environment_air_is_safe()
 	. = TRUE
 
 	if(pulledby && pulledby.grab_state >= GRAB_KILL && atmos_requirements["min_oxy"])
-		throw_alert("not_enough_oxy", /obj/screen/alert/not_enough_oxy)
 		. = FALSE //getting choked
 
 	if(isturf(loc) && isopenturf(loc))
@@ -292,47 +290,30 @@
 			ST.air.garbage_collect()
 
 			if(atmos_requirements["min_oxy"] && oxy < atmos_requirements["min_oxy"])
-				throw_alert("not_enough_oxy", /obj/screen/alert/not_enough_oxy)
 				. = FALSE
 			else if(atmos_requirements["max_oxy"] && oxy > atmos_requirements["max_oxy"])
-				throw_alert("too_much_oxy", /obj/screen/alert/too_much_oxy)
 				. = FALSE
 			else if(atmos_requirements["min_tox"] && tox < atmos_requirements["min_tox"])
-				throw_alert("not_enough_tox", /obj/screen/alert/not_enough_tox)
 				. = FALSE
 			else if(atmos_requirements["max_tox"] && tox > atmos_requirements["max_tox"])
-				throw_alert("too_much_tox", /obj/screen/alert/too_much_tox)
 				. = FALSE
 			else if(atmos_requirements["min_n2"] && n2 < atmos_requirements["min_n2"])
-				throw_alert("not_enough_nitro", /obj/screen/alert/not_enough_nitro)
 				. = FALSE
 			else if(atmos_requirements["max_n2"] && n2 > atmos_requirements["max_n2"])
-				throw_alert("too_much_nitro", /obj/screen/alert/too_much_nitro)
 				. = FALSE
 			else if(atmos_requirements["min_co2"] && co2 < atmos_requirements["min_co2"])
-				throw_alert("not_enough_co2", /obj/screen/alert/not_enough_co2)
 				. = FALSE
 			else if(atmos_requirements["max_co2"] && co2 > atmos_requirements["max_co2"])
-				throw_alert("too_much_co2", /obj/screen/alert/too_much_co2)
 				. = FALSE
 		else
-			if(atmos_requirements["min_oxy"])
-				throw_alert("not_enough_oxy", /obj/screen/alert/not_enough_oxy)
-				. = FALSE
-			else if(atmos_requirements["min_tox"])
-				throw_alert("not_enough_tox", /obj/screen/alert/not_enough_tox)
-				. = FALSE
-			else if(atmos_requirements["min_n2"])
-				throw_alert("not_enough_nitro", /obj/screen/alert/not_enough_nitro)
-				. = FALSE
-			else if(atmos_requirements["min_co2"])
-				throw_alert("not_enough_co2", /obj/screen/alert/not_enough_co2)
+			if(atmos_requirements["min_oxy"] || atmos_requirements["min_tox"] || atmos_requirements["min_n2"] || atmos_requirements["min_co2"])
 				. = FALSE
 
-	if(check_temp)
-		var/areatemp = get_temperature(environment)
-		if((areatemp < minbodytemp) || (areatemp > maxbodytemp))
-			. = FALSE
+/mob/living/simple_animal/proc/environment_temperature_is_safe(datum/gas_mixture/environment)
+	. = TRUE
+	var/areatemp = get_temperature(environment)
+	if((areatemp < minbodytemp) || (areatemp > maxbodytemp))
+		. = FALSE
 
 /mob/living/simple_animal/handle_environment(datum/gas_mixture/environment)
 	var/atom/A = loc
@@ -343,15 +324,15 @@
 			diff = diff / 5
 			adjust_bodytemperature(diff)
 
-	if(!environment_is_safe(environment))
+	if(!environment_air_is_safe())
 		adjustHealth(unsuitable_atmos_damage)
+		throw_alert("not_enough_oxy", /obj/screen/alert/not_enough_oxy)
+	else
+		clear_alert("not_enough_oxy")
 
 	handle_temperature_damage()
 
 /mob/living/simple_animal/proc/handle_temperature_damage()
-	if(!unsuitable_atmos_damage)
-		return
-
 	if(bodytemperature < minbodytemp)
 		adjustHealth(unsuitable_atmos_damage)
 		switch(unsuitable_atmos_damage)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -326,7 +326,8 @@
 
 	if(!environment_air_is_safe())
 		adjustHealth(unsuitable_atmos_damage)
-		throw_alert("not_enough_oxy", /obj/screen/alert/not_enough_oxy)
+		if(unsuitable_atmos_damage > 0)
+			throw_alert("not_enough_oxy", /obj/screen/alert/not_enough_oxy)
 	else
 		clear_alert("not_enough_oxy")
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -275,10 +275,11 @@
 	. = TRUE
 
 	if(pulledby && pulledby.grab_state >= GRAB_KILL && atmos_requirements["min_oxy"])
+		throw_alert("not_enough_oxy", /obj/screen/alert/not_enough_oxy)
 		. = FALSE //getting choked
 
-	if(isturf(src.loc) && isopenturf(src.loc))
-		var/turf/open/ST = src.loc
+	if(isturf(loc) && isopenturf(loc))
+		var/turf/open/ST = loc
 		if(ST.air)
 			var/ST_gases = ST.air.gases
 			ST.air.assert_gases(arglist(GLOB.hardcoded_gases))
@@ -291,23 +292,41 @@
 			ST.air.garbage_collect()
 
 			if(atmos_requirements["min_oxy"] && oxy < atmos_requirements["min_oxy"])
+				throw_alert("not_enough_oxy", /obj/screen/alert/not_enough_oxy)
 				. = FALSE
 			else if(atmos_requirements["max_oxy"] && oxy > atmos_requirements["max_oxy"])
+				throw_alert("too_much_oxy", /obj/screen/alert/too_much_oxy)
 				. = FALSE
 			else if(atmos_requirements["min_tox"] && tox < atmos_requirements["min_tox"])
+				throw_alert("not_enough_tox", /obj/screen/alert/not_enough_tox)
 				. = FALSE
 			else if(atmos_requirements["max_tox"] && tox > atmos_requirements["max_tox"])
+				throw_alert("too_much_tox", /obj/screen/alert/too_much_tox)
 				. = FALSE
 			else if(atmos_requirements["min_n2"] && n2 < atmos_requirements["min_n2"])
+				throw_alert("not_enough_nitro", /obj/screen/alert/not_enough_nitro)
 				. = FALSE
 			else if(atmos_requirements["max_n2"] && n2 > atmos_requirements["max_n2"])
+				throw_alert("too_much_nitro", /obj/screen/alert/too_much_nitro)
 				. = FALSE
 			else if(atmos_requirements["min_co2"] && co2 < atmos_requirements["min_co2"])
+				throw_alert("not_enough_co2", /obj/screen/alert/not_enough_co2)
 				. = FALSE
 			else if(atmos_requirements["max_co2"] && co2 > atmos_requirements["max_co2"])
+				throw_alert("too_much_co2", /obj/screen/alert/too_much_co2)
 				. = FALSE
 		else
-			if(atmos_requirements["min_oxy"] || atmos_requirements["min_tox"] || atmos_requirements["min_n2"] || atmos_requirements["min_co2"])
+			if(atmos_requirements["min_oxy"])
+				throw_alert("not_enough_oxy", /obj/screen/alert/not_enough_oxy)
+				. = FALSE
+			else if(atmos_requirements["min_tox"])
+				throw_alert("not_enough_tox", /obj/screen/alert/not_enough_tox)
+				. = FALSE
+			else if(atmos_requirements["min_n2"])
+				throw_alert("not_enough_nitro", /obj/screen/alert/not_enough_nitro)
+				. = FALSE
+			else if(atmos_requirements["min_co2"])
+				throw_alert("not_enough_co2", /obj/screen/alert/not_enough_co2)
 				. = FALSE
 
 	if(check_temp)
@@ -315,12 +334,11 @@
 		if((areatemp < minbodytemp) || (areatemp > maxbodytemp))
 			. = FALSE
 
-
 /mob/living/simple_animal/handle_environment(datum/gas_mixture/environment)
-	var/atom/A = src.loc
+	var/atom/A = loc
 	if(isturf(A))
 		var/areatemp = get_temperature(environment)
-		if( abs(areatemp - bodytemperature) > 5)
+		if(abs(areatemp - bodytemperature) > 5)
 			var/diff = areatemp - bodytemperature
 			diff = diff / 5
 			adjust_bodytemperature(diff)
@@ -331,8 +349,29 @@
 	handle_temperature_damage()
 
 /mob/living/simple_animal/proc/handle_temperature_damage()
-	if((bodytemperature < minbodytemp) || (bodytemperature > maxbodytemp))
+	if(!unsuitable_atmos_damage)
+		return
+
+	if(bodytemperature < minbodytemp)
 		adjustHealth(unsuitable_atmos_damage)
+		switch(unsuitable_atmos_damage)
+			if(1 to 5)
+				throw_alert("temp", /obj/screen/alert/cold, 1)
+			if(5 to 10)
+				throw_alert("temp", /obj/screen/alert/cold, 2)
+			if(10 to INFINITY)
+				throw_alert("temp", /obj/screen/alert/cold, 3)
+	else if(bodytemperature > maxbodytemp)
+		adjustHealth(unsuitable_atmos_damage)
+		switch(unsuitable_atmos_damage)
+			if(1 to 5)
+				throw_alert("temp", /obj/screen/alert/hot, 1)
+			if(5 to 10)
+				throw_alert("temp", /obj/screen/alert/hot, 2)
+			if(10 to INFINITY)
+				throw_alert("temp", /obj/screen/alert/hot, 3)
+	else
+		clear_alert("temp")
 
 /mob/living/simple_animal/gib()
 	if(butcher_results || guaranteed_butcher_results)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Simple mobs will now receive two new alerts about being in too hot/cold envinronment and about being in an unbreathable area. They will receive these alerts only if they are being damaged by them, as otherwise player playing as them could have no idea what is killing him.

**Example image:**

![Alerts](https://user-images.githubusercontent.com/43862960/71861316-35beb480-30f6-11ea-8bc5-be199f0128f5.png)

Fixes #48280
Fixes #37820

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Better experience playing as a simple mob.

## Changelog
:cl: Arkatos
add: Simple mobs will now receive an alert about being in too hot/cold environment.
add: Simple mobs will now receive an alert about choking to death.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
