### PR TITLE
Wayfinder quick fixes

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -42,3 +42,6 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	if(badquirk)
 		cli.prefs.save_character()
 
+	// Assign wayfinding pinpointer granting quirk if they're new
+	if(cli.calc_exp_type(EXP_TYPE_CREW) < 20 HOURS && !user.has_quirk(/datum/quirk/needswayfinder))
+		user.add_quirk(/datum/quirk/needswayfinder, TRUE)

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -42,6 +42,3 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	if(badquirk)
 		cli.prefs.save_character()
 
-	// Assign wayfinding pinpointer granting quirk if they're new
-	if(cli.calc_exp_type(EXP_TYPE_LIVING) < 1200 && !user.has_quirk(/datum/quirk/needswayfinder))
-		user.add_quirk(/datum/quirk/needswayfinder, TRUE)

--- a/code/game/objects/items/wayfinding.dm
+++ b/code/game/objects/items/wayfinding.dm
@@ -6,7 +6,7 @@
 	density = FALSE
 	layer = HIGH_OBJ_LAYER
 	var/list/obj/item/pinpointer/wayfinding/pinpointers = list()
-	var/spawn_cooldown = 1200 //deciseconds per person to spawn another pinpointer
+	var/spawn_cooldown = 6000 //deciseconds per person to spawn another pinpointer
 
 /obj/machinery/pinpointer_dispenser/attack_hand(mob/living/carbon/user)
 	if(world.time < pinpointers[user.real_name])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There are too many wayfinding pinpointers lying around. https://github.com/tgstation/tgstation/pull/48616 will take a while to be reviewed and approved. 

In the meantime, this simply fixes the bugged code causing everyone to spawn with the pinpointers and increases the cooldown to dispense another from 2 to 10 minutes. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less unused pinpointers littering the station. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
fix: You should no longer spawn with a pinpointer you don't want
tweak: Pinpointer dispenser cooldown increased to 10 minutes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author in-game. -->
<!-- You can use multiple of the same prefix (they're only used for the icon in-game) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->