### PR TITLE
Aliens can now open blastdoors. Can also attack already open doors

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1224,21 +1224,23 @@
 		loseBackupPower()
 
 /obj/machinery/door/airlock/attack_alien(mob/living/carbon/alien/humanoid/user)
-	add_fingerprint(user)
 	if(isElectrified())
 		shock(user, 100) //Mmm, fried xeno!
 		return
 	if(!density) //Already open
-		return
+		return ..()
 	if(locked || welded) //Extremely generic, as aliens only understand the basics of how airlocks work.
+		if(user.a_intent == INTENT_HARM)
+			return ..()
 		to_chat(user, "<span class='warning'>[src] refuses to budge!</span>")
 		return
+	add_fingerprint(user)
 	user.visible_message("<span class='warning'>[user] begins prying open [src].</span>",\
 						"<span class='noticealien'>You begin digging your claws into [src] with all your might!</span>",\
 						"<span class='warning'>You hear groaning metal...</span>")
-	var/time_to_open = 5
+	var/time_to_open = 5 //half a second
 	if(hasPower())
-		time_to_open = 50 //Powered airlocks take longer to open, and are loud.
+		time_to_open = 5 SECONDS //Powered airlocks take longer to open, and are loud.
 		playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE)
 
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -93,4 +93,24 @@
 
 /obj/machinery/door/poddoor/try_to_crowbar(obj/item/I, mob/user)
 	if(stat & NOPOWER)
-		open(1)
+		open(TRUE)
+
+/obj/machinery/door/poddoor/attack_alien(mob/living/carbon/alien/humanoid/user)
+	if(density)
+		add_fingerprint(user)
+		user.visible_message("<span class='warning'>[user] begins prying open [src].</span>",\
+					"<span class='noticealien'>You begin digging your claws into [src] with all your might!</span>",\
+					"<span class='warning'>You hear groaning metal...</span>")
+		playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE)
+
+		var/time_to_open = 5 SECONDS
+		if(hasPower())
+			time_to_open = 15 SECONDS
+
+		if(do_after(user, time_to_open, TRUE, src))
+			if(density && !open(TRUE)) //The airlock is still closed, but something prevented it opening. (Another player noticed and bolted/welded the airlock in time!)
+				to_chat(user, "<span class='warning'>Despite your efforts, [src] managed to resist your attempts to open it!</span>")
+
+	else
+		return ..()
+


### PR DESCRIPTION
:cl: ShizCalev
fix: Aliens can now attempt to open closed blastdoors.
tweak: Aliens can now attack normal airlocks after they've been opened, or when using harm intent if they're locked / welded.
/:cl:

Fixes #48515