### PR TITLE
Fixes special airlocks that don't have glass versions reverting to normal airlocks on completion if you added glass to the frame during construction.

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -216,6 +216,17 @@
 									G.use(2)
 									var/mineralassembly = text2path("/obj/structure/door_assembly/door_assembly_[M]")
 									var/obj/structure/door_assembly/MA = new mineralassembly(loc)
+
+									if(MA.noglass && glass) //in case the new door doesn't support glass. prevents the new one from reverting to a normal airlock after being constructed.
+										var/obj/item/stack/sheet/dropped_glass
+										if(heat_proof_finished)
+											dropped_glass = new /obj/item/stack/sheet/rglass(drop_location())
+											heat_proof_finished = FALSE
+										else
+											dropped_glass = new /obj/item/stack/sheet/glass(drop_location())
+										glass = FALSE
+										to_chat(user, "<span class='notice'>As you finish, a [dropped_glass.singular_name] falls out of [MA]'s frame.</span>")
+
 									transfer_assembly_vars(src, MA, TRUE)
 							else
 								to_chat(user, "<span class='warning'>You need at least two sheets add a mineral cover!</span>")


### PR DESCRIPTION
:cl: ShizCalev
fix: Special airlocks (ie mineral airlocks, high security doors, ect) that do not support glass windows will no longer revert to a normal airlock if you added glass to their frame prior to adding their special plating.
/:cl:

Fixes #36302