### PR TITLE
Close storage window on any backpack move.

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -180,10 +180,11 @@
 		next += slave.parent
 
 /datum/component/storage/proc/on_move()
-	var/atom/A = parent
-	for(var/mob/living/L in can_see_contents())
-		if(!L.CanReach(A))
-			hide_from(L)
+	//var/atom/A = parent
+	//for(var/mob/living/L in can_see_contents())
+	//	if(!L.CanReach(A))
+	//		hide_from(L)
+	close_all()
 
 /datum/component/storage/proc/attack_self(datum/source, mob/M)
 	if(locked)


### PR DESCRIPTION
## About The Pull Request

Close storage window when you put it somewhere.
Easiest and guaranteed way to fix 43766 but have some disadvantages.
Now you can't have open storage window of pulled bag on move.

## Why It's Good For The Game

fixes #43766

## Changelog
:cl:
fix: folded bluespace bodybag issues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
