### PR TITLE
The Janitor Strikes Back: Scrubbing (Cleaning) Skill / `remove_any` proc granularity change

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -22,3 +22,7 @@
 
 // Gets the reference for the skill type that was given
 #define GetSkillRef(A) (SSskills.all_skills[A])
+
+//number defines
+#define CLEAN_SKILL_BEAUTY_ADJUSTMENT	15//It's a denominator so no 0. Higher number = less cleaning xp per cleanable
+#define CLEAN_SKILL_GENERIC_WASH_XP	1.5//Value. Higher number = more XP when cleaning non-cleanables (walls/floors/lips)

--- a/code/datums/skills/cleaning.dm
+++ b/code/datums/skills/cleaning.dm
@@ -1,4 +1,4 @@
 /datum/skill/cleaning
 	name = "Scrubbing"
 	desc = "It’s not who I am underneath, but what I mop up that defines me."
-	modifiers = list(SKILL_SPEED_MODIFIER = list(1.15, 1.05, 1, 0.9, 0.75, 0.5, 0.36))
+	modifiers = list(SKILL_SPEED_MODIFIER = list(1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.36))

--- a/code/datums/skills/cleaning.dm
+++ b/code/datums/skills/cleaning.dm
@@ -1,4 +1,4 @@
 /datum/skill/cleaning
 	name = "Scrubbing"
 	desc = "It’s not who I am underneath, but what I mop up that defines me."
-	modifiers = list(SKILL_SPEED_MODIFIER = list(1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.36))
+	modifiers = list(SKILL_SPEED_MODIFIER = list(1.15, 1.05, 1, 0.9, 0.75, 0.5, 0.36))

--- a/code/datums/skills/cleaning.dm
+++ b/code/datums/skills/cleaning.dm
@@ -1,4 +1,4 @@
 /datum/skill/cleaning
-	name = "Cleaning"
+	name = "Scrubbing"
 	desc = "It’s not who I am underneath, but what I mop up that defines me."
 	modifiers = list(SKILL_SPEED_MODIFIER = list(1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.36))

--- a/code/datums/skills/cleaning.dm
+++ b/code/datums/skills/cleaning.dm
@@ -1,0 +1,4 @@
+/datum/skill/cleaning
+	name = "Cleaning"
+	desc = "It’s not who I am underneath, but what I mop up that defines me."
+	modifiers = list(SKILL_SPEED_MODIFIER = list(1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.36))

--- a/code/datums/skills/cleaning.dm
+++ b/code/datums/skills/cleaning.dm
@@ -1,4 +1,4 @@
 /datum/skill/cleaning
 	name = "Scrubbing"
 	desc = "It’s not who I am underneath, but what I mop up that defines me."
-	modifiers = list(SKILL_SPEED_MODIFIER = list(1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.36))
+	modifiers = list(SKILL_SPEED_MODIFIER = list(1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.36)) //speed also touches probability in using up a soap's charge

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -91,7 +91,7 @@
 	. = ..()
 	if(!proximity || !check_allowed_items(target))
 		return
-	var/clean_speedies = src.cleanspeed * min(user.mind.get_skill_modifier(/datum/skill/cleaning, SKILL_SPEED_MODIFIER)+0.1,1) //less scaling for soapies
+	var/clean_speedies = cleanspeed * min(user.mind.get_skill_modifier(/datum/skill/cleaning, SKILL_SPEED_MODIFIER)+0.1,1) //less scaling for soapies
 	//I couldn't feasibly  fix the overlay bugs caused by cleaning items we are wearing.
 	//So this is a workaround. This also makes more sense from an IC standpoint. ~Carn
 	if(user.client && ((target in user.client.screen) && !user.is_holding(target)))

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -80,7 +80,9 @@
 	return (TOXLOSS)
 
 /obj/item/soap/proc/decreaseUses(mob/user)
-	uses--
+	var/skillcheck = user.mind.get_skill_modifier(/datum/skill/cleaning, SKILL_SPEED_MODIFIER)
+	if(prob(skillcheck*100)) //higher level = more uses assuming RNG is nice
+		uses--
 	if(uses <= 0)
 		to_chat(user, "<span class='warning'>[src] crumbles into tiny bits!</span>")
 		qdel(src)
@@ -89,39 +91,47 @@
 	. = ..()
 	if(!proximity || !check_allowed_items(target))
 		return
+	var/clean_speedies = src.cleanspeed * min(user.mind.get_skill_modifier(/datum/skill/cleaning, SKILL_SPEED_MODIFIER)+0.1,1) //less scaling for soapies
 	//I couldn't feasibly  fix the overlay bugs caused by cleaning items we are wearing.
 	//So this is a workaround. This also makes more sense from an IC standpoint. ~Carn
 	if(user.client && ((target in user.client.screen) && !user.is_holding(target)))
 		to_chat(user, "<span class='warning'>You need to take that [target.name] off before cleaning it!</span>")
 	else if(istype(target, /obj/effect/decal/cleanable))
 		user.visible_message("<span class='notice'>[user] begins to scrub \the [target.name] out with [src].</span>", "<span class='warning'>You begin to scrub \the [target.name] out with [src]...</span>")
-		if(do_after(user, src.cleanspeed, target = target))
+		if(do_after(user, clean_speedies, target = target))
 			to_chat(user, "<span class='notice'>You scrub \the [target.name] out.</span>")
+			var/obj/effect/decal/cleanable/cleanies = target
+			user?.mind.adjust_experience(/datum/skill/cleaning, max(round(cleanies.beauty/CLEAN_SKILL_BEAUTY_ADJUSTMENT),0)) //again, intentional that this does NOT round but mops do.
 			qdel(target)
 			decreaseUses(user)
 
 	else if(ishuman(target) && user.zone_selected == BODY_ZONE_PRECISE_MOUTH)
 		var/mob/living/carbon/human/H = user
 		user.visible_message("<span class='warning'>\the [user] washes \the [target]'s mouth out with [src.name]!</span>", "<span class='notice'>You wash \the [target]'s mouth out with [src.name]!</span>") //washes mouth out with soap sounds better than 'the soap' here			if(user.zone_selected == "mouth")
+		if(H.lip_style)
+			user?.mind.adjust_experience(/datum/skill/cleaning, CLEAN_SKILL_GENERIC_WASH_XP)
 		H.lip_style = null //removes lipstick
 		H.update_body()
 		decreaseUses(user)
 		return
 	else if(istype(target, /obj/structure/window))
 		user.visible_message("<span class='notice'>[user] begins to clean \the [target.name] with [src]...</span>", "<span class='notice'>You begin to clean \the [target.name] with [src]...</span>")
-		if(do_after(user, src.cleanspeed, target = target))
+		if(do_after(user, clean_speedies, target = target))
 			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
 			target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 			target.set_opacity(initial(target.opacity))
+			user?.mind.adjust_experience(/datum/skill/cleaning, CLEAN_SKILL_GENERIC_WASH_XP)
 			decreaseUses(user)
 	else
 		user.visible_message("<span class='notice'>[user] begins to clean \the [target.name] with [src]...</span>", "<span class='notice'>You begin to clean \the [target.name] with [src]...</span>")
-		if(do_after(user, src.cleanspeed, target = target))
+		if(do_after(user, clean_speedies, target = target))
 			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
 			for(var/obj/effect/decal/cleanable/C in target)
+				user?.mind.adjust_experience(/datum/skill/cleaning, round(C.beauty/CLEAN_SKILL_BEAUTY_ADJUSTMENT))
 				qdel(C)
 			target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 			SEND_SIGNAL(target, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
+			user?.mind.adjust_experience(/datum/skill/cleaning, CLEAN_SKILL_GENERIC_WASH_XP)
 			decreaseUses(user)
 	return
 

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -24,14 +24,19 @@
 	create_reagents(mopcap)
 
 
-/obj/item/mop/proc/clean(turf/A)
+/obj/item/mop/proc/clean(turf/A, mob/living/cleaner)
 	if(reagents.has_reagent(/datum/reagent/water, 1) || reagents.has_reagent(/datum/reagent/water/holywater, 1) || reagents.has_reagent(/datum/reagent/consumable/ethanol/vodka, 1) || reagents.has_reagent(/datum/reagent/space_cleaner, 1))
 		SEND_SIGNAL(A, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
 		for(var/obj/effect/O in A)
 			if(is_cleanable(O))
+				var/obj/effect/decal/cleanable/C = O
+				cleaner?.mind.adjust_experience(/datum/skill/cleaning, max(round(C.beauty/CLEAN_SKILL_BEAUTY_ADJUSTMENT,1),0)) //it is intentional that the mop rounds xp but soap does not, USE THE SACRED TOOL
 				qdel(O)
 	reagents.reaction(A, TOUCH, 10)	//Needed for proper floor wetting.
-	reagents.remove_any(1)			//reaction() doesn't use up the reagents
+	var/val2remove = 1
+	if(cleaner?.mind)
+		val2remove = round(cleaner.mind.get_skill_modifier(/datum/skill/cleaning, SKILL_SPEED_MODIFIER),0.1)
+	reagents.remove_any(val2remove)			//reaction() doesn't use up the reagents
 
 
 /obj/item/mop/afterattack(atom/A, mob/user, proximity)
@@ -39,7 +44,7 @@
 	if(!proximity)
 		return
 
-	if(reagents.total_volume < 1)
+	if(reagents.total_volume < 0.1)
 		to_chat(user, "<span class='warning'>Your mop is dry!</span>")
 		return
 
@@ -50,10 +55,10 @@
 
 	if(T)
 		user.visible_message("<span class='notice'>[user] begins to clean \the [T] with [src].</span>", "<span class='notice'>You begin to clean \the [T] with [src]...</span>")
-
-		if(do_after(user, src.mopspeed, target = T))
+		var/clean_speedies = user.mind.get_skill_modifier(/datum/skill/cleaning, SKILL_SPEED_MODIFIER)
+		if(do_after(user, src.mopspeed*clean_speedies, target = T))
 			to_chat(user, "<span class='notice'>You finish mopping.</span>")
-			clean(T)
+			clean(T, user)
 
 
 /obj/effect/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -56,7 +56,7 @@
 	if(T)
 		user.visible_message("<span class='notice'>[user] begins to clean \the [T] with [src].</span>", "<span class='notice'>You begin to clean \the [T] with [src]...</span>")
 		var/clean_speedies = user.mind.get_skill_modifier(/datum/skill/cleaning, SKILL_SPEED_MODIFIER)
-		if(do_after(user, src.mopspeed*clean_speedies, target = T))
+		if(do_after(user, mopspeed*clean_speedies, target = T))
 			to_chat(user, "<span class='notice'>You finish mopping.</span>")
 			clean(T, user)
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -104,6 +104,7 @@
 	var/list/cached_reagents = reagent_list
 	var/total_transfered = 0
 	var/current_list_element = 1
+	var/initial_list_length = cached_reagents.len //stored here because removing can cause some reagents to be deleted, ergo length change.
 
 	current_list_element = rand(1, cached_reagents.len)
 
@@ -117,14 +118,16 @@
 			current_list_element = 1
 
 		var/datum/reagent/R = cached_reagents[current_list_element]
-		remove_reagent(R.type, 1)
+		var/remove_amt = min(amount-total_transfered,round(amount/rand(2,initial_list_length),round(amount/10,0.01))) //double round to keep it at a somewhat even spread relative to amount without getting funky numbers.
+		//min ensures we don't go over amount.
+		remove_reagent(R.type, remove_amt)
 
 		current_list_element++
-		total_transfered++
+		total_transfered += remove_amt
 		update_total()
 
 	handle_reactions()
-	return total_transfered
+	return total_transfered //this should be amount unless the loop is prematurely broken, in which case it'll be lower. It shouldn't ever go OVER amount.
 
 /datum/reagents/proc/remove_all(amount = 1)
 	var/list/cached_reagents = reagent_list

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -576,6 +576,7 @@
 #include "code\datums\ruins\lavaland.dm"
 #include "code\datums\ruins\space.dm"
 #include "code\datums\skills\_skill.dm"
+#include "code\datums\skills\cleaning.dm"
 #include "code\datums\skills\medical.dm"
 #include "code\datums\skills\mining.dm"
 #include "code\datums\status_effects\buffs.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the ~~cleaning~~ scrubbing skill. Clean up items with a mop/soap for...

- Mop: Less reagent used per swipe, Faster Mopping
- Soap: More Uses*, Faster Soaping

*RNG permitting

Also changes how `remove_any` works so it can accept numbers smaller than 1 and jumble reagent loss a bit more when dealing with lower values. I mainly tested through the janitor mop so other interactions may be "unintended", but I'd argue for the better 😏 

consequently fixes an odd portion of remove_any where you could have more removed than the amount you asked it to remove since it was expecting integers.

I decided to make the mop slightly better than the soap since the soap is more convert and smaller weight.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's a fun skill and being able to brag about being a legendary janitor ~~and showing off your skillcape~~ is a fun story to tell.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Mopby
add: The Cleaning Skill
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
