### PR TITLE
Attempt to get the autobuild action finally working

### DIFF
--- a/.github/workflows/autobuild_tgui.yml
+++ b/.github/workflows/autobuild_tgui.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Push Artifacts
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_MASTER_KEY }}


### PR DESCRIPTION
As title, uses an all access key instead of the generic actions access one to hopefully have proper perms on the master branch