### PR TITLE
Adds everything that's needed for SDQL varedit macros

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -214,6 +214,11 @@
 /proc/_step_away(ref, trg, max)
 	step_away(ref, trg, max)
 
+/proc/_file(name)
+	return file(name)
+
+/proc/_icon()
+
 /proc/_has_trait(datum/thing,trait)
 	return HAS_TRAIT(thing,trait)
 

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -217,8 +217,6 @@
 /proc/_file(name)
 	return file(name)
 
-/proc/_icon()
-
 /proc/_has_trait(datum/thing,trait)
 	return HAS_TRAIT(thing,trait)
 

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -26,7 +26,8 @@
 	var/total_count_reset = 0
 	///Internal counter for clients sending external (IRC/Discord) relay messages via ahelp to prevent spamming. Set to a number every time an admin reply is sent, decremented for every client send.
 	var/externalreplyamount = 0
-
+	///You should use this to store the result of SDQL queries. This exists for saveable VAREDITS.
+	var/list/sdql_stored_datums
 		/////////
 		//OTHER//
 		/////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Everything as in: An empty variable and a file() wrapper.

Alright listen up jannies. I've had enough of your shitty varedits that you add into the codebase. Go write a SDQL thing instead.
Syntax is cancerous but I will consider writing a thing that converts .json into SDQL if there is enough demand.

Here's an example on how you would write such a thing:

```
UPDATE /mob IN usr MAP client SET sdql_stored_datums = [global._new(/mob/living/simple_animal/hostile/retaliate , [null])];
UPDATE /mob IN (@[/mob IN usr MAP client MAP sdql_stored_datums])[1] SET icon_state = "honkhulk", icon = global._file("icons/mob/clown_mobs.dmi");
CALL forceMove(usr.loc) ON /mob IN (@[/mob IN usr MAP client MAP sdql_stored_datums])[1];
UPDATE /mob/living/simple_animal/hostile/retaliate IN usr MAP client SET sdql_stored_datums = 0
```
^This spawns a clownhulk, for the most part (some vars are not implemented) allowing us to remove that typepath from the code

Please stop merging varedits now that is 100% possible spawn them en'masse after you written like 40 lines of text at most. Not like performance matters for adminbuse anyways.


Again, .json converter might come soon if there is demand.
