### PR TITLE
You do not lose the storage window on storage pickup.

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -764,6 +764,7 @@
 			show_to(user)
 
 /datum/component/storage/proc/signal_on_pickup(datum/source, mob/user)
+	update_actions()
 	for(var/mob/M in can_see_contents() - user)
 		close(M)
 

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -764,11 +764,8 @@
 			show_to(user)
 
 /datum/component/storage/proc/signal_on_pickup(datum/source, mob/user)
-	var/atom/A = parent
-	update_actions()
-	for(var/mob/M in range(1, A))
-		if(M.active_storage == src)
-			close(M)
+	for(var/mob/M in can_see_contents() - user)
+		close(M)
 
 /datum/component/storage/proc/signal_take_obj(datum/source, atom/movable/AM, new_loc, force = FALSE)
 	if(!(AM in real_location()))


### PR DESCRIPTION
## About The Pull Request

You do not lose the storage window on storage pickup.

## Why It's Good For The Game
Now storage window do not closes when you pickup the storage.
I see old realisation some strange and unoptimized.

## Changelog
:cl:
tweak: You do not lose the storage window on storage pickup.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
