### PR TITLE
Minor space zoo ruin fixes/tweaks

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -3,11 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "ab" = (
-/obj/machinery/power/shieldwallgen{
-	active = 2;
-	anchored = 1;
-	power = 1
-	},
+/obj/machinery/power/shieldwallgen/anchored,
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
@@ -153,11 +149,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/abandonedzoo)
 "aE" = (
-/obj/machinery/power/shieldwallgen{
-	active = 2;
-	anchored = 1;
-	power = 1
-	},
+/obj/machinery/power/shieldwallgen/anchored,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
@@ -248,7 +240,6 @@
 /obj/machinery/power/apc/unlocked{
 	dir = 8;
 	environ = 0;
-	equipment = 0;
 	lighting = 0;
 	name = "Worn-out APC";
 	pixel_x = -25
@@ -367,11 +358,8 @@
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bf" = (
-/obj/machinery/power/smes/magical{
-	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit.";
-	name = "power storage unit"
-	},
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bg" = (
@@ -435,13 +423,13 @@
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bs" = (
-/obj/machinery/power/shieldwallgen,
 /obj/structure/cable,
+/obj/machinery/power/shieldwallgen/anchored,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
 "bt" = (
-/obj/machinery/power/shieldwallgen,
 /obj/structure/cable,
+/obj/machinery/power/shieldwallgen/anchored,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
 "bu" = (
@@ -496,6 +484,7 @@
 /area/ruin/space/has_grav/abandonedzoo)
 "bD" = (
 /obj/item/clothing/mask/facehugger/dead,
+/obj/structure/alien/weeds,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
 "bE" = (
@@ -654,7 +643,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
 "wF" = (
 /obj/machinery/door/airlock/hatch{
@@ -690,6 +679,11 @@
 "KN" = (
 /turf/template_noop,
 /area/space/nearstation)
+"Ng" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds/node,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/abandonedzoo)
 
 (1,1,1) = {"
 ab
@@ -979,7 +973,7 @@ bl
 at
 ac
 bB
-bB
+Ng
 bD
 bH
 ac
@@ -1002,7 +996,7 @@ ac
 bC
 bH
 bH
-bX
+bB
 bT
 aa
 "}
@@ -1022,7 +1016,7 @@ aL
 aD
 bD
 bB
-bX
+Ng
 bO
 bU
 bW
@@ -1043,7 +1037,7 @@ aQ
 ac
 bB
 bB
-bX
+bB
 bX
 bP
 aa

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -225,8 +225,6 @@
 	active_power_usage = 50
 	max_integrity = 300
 	var/active = FALSE
-	var/power = 0
-	var/maximum_stored_power = 500
 	var/locked = TRUE
 	var/shield_range = 8
 	var/obj/structure/cable/attached // the attached cable
@@ -235,6 +233,9 @@
 	name = "xenobiology shield wall generator"
 	desc = "A shield generator meant for use in xenobiology."
 	req_access = list(ACCESS_XENOBIOLOGY)
+
+/obj/machinery/power/shieldwallgen/anchored
+	anchored = TRUE
 
 /obj/machinery/power/shieldwallgen/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Fixed shield wall generators in the ruin attempting to spawn powered
* Each time this ruin spawns, there is pointless spam in game.log about how the shield wall gens depower at roundstart. Generators with `active = ACTIVE_SETUPFIELDS` still switch off roundstart, so unless someone knows an easy solution it's better to just properly leave them switched off.
* Fixed the tile with the pried up floor tile; now it's plain plating instead of a floor tile on top of another floor tile
* Replaces the magical infinite charge SMES with a regular one
* Removes two unused shield wall gen vars
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes log spam and adds immersion(tm)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
fix: Fixed shield wall generators in the abandoned space zoo ruin attempting to spawn powered
tweak: Replaced the magical infinite charge SMES in the abandoned space zoo ruin with a regular one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
