### PR TITLE
Makes rezadone cure husking. (alt to #48717)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -199,6 +199,14 @@
 	..()
 	. = 1
 
+/datum/reagent/medicine/rezadone/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
+	. = ..()
+	if(iscarbon(M))
+		var/mob/living/carbon/patient = M
+		if(reac_volume >= 5 && HAS_TRAIT_FROM(patient, TRAIT_HUSK, "burn") && patient.getFireLoss() < 50) //One carp yields 12u rezadone.
+			patient.cure_husk("burn")
+			patient.visible_message("<span class='nicegreen'>[patient]'s body rapidly absorbs moisture from the enviroment, taking on a more healthy appearance.")
+
 /datum/reagent/medicine/spaceacillin
 	name = "Spaceacillin"
 	description = "Spaceacillin will prevent a patient from conventionally spreading any diseases they are currently infected with."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes rezadone unhusk burn victims. The body needs to be below 50 burn damage and at least 5u rezadone needs to be used(to prevent cheesing with 0.1u).

Alternative to and ~~closes~~ #48717

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Rezadone has long been an extremely marginal chem since there was no reason to make it when you you could just upgrade the cloner instead.

Which the impending cloning removal rezadone is looking more useless than ever, which is a shame.

In additon, @kriskog has opened a PR that makes synthflesh cure husking. I dislike that PR, because it trivializes husking by making it cureable with 0.1u of a round start chem.

This PR aims to solve all these issues by instead applying the dehusking property to rezadone and giving the chem a carefully chosen minimum volume for the dehusking to work.

One space carp can be used to make 12u rezadone(2.4 doses) and since medbay now has 2 EVA capable paramedics(in addtion to the CMO), rezadone should be easy to get.

This preserves husking as a real issue, but one that can be mitigated with a little bit of preparation.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: 5u+ rezadone now unhusks bodies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

cobby edit: removed closes
