### PR TITLE
Fixes all explicit occurrences of rand() being used incorrectly.

### DIFF
--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -188,7 +188,7 @@
 	holder.icon_state = "nanites[nanite_percent]"
 
 /datum/component/nanites/proc/on_emp(datum/source, severity)
-	nanite_volume *= (rand(0.60, 0.90))		//Lose 10-40% of nanites
+	nanite_volume *= (rand(60, 90) * 0.01)		//Lose 10-40% of nanites
 	adjust_nanites(null, -(rand(5, 50)))		//Lose 5-50 flat nanite volume
 	if(prob(40/severity))
 		cloud_id = 0
@@ -197,7 +197,7 @@
 		NP.on_emp(severity)
 
 /datum/component/nanites/proc/on_shock(datum/source, shock_damage)
-	nanite_volume *= (rand(0.45, 0.80))		//Lose 20-55% of nanites
+	nanite_volume *= (rand(45, 80) * 0.01)		//Lose 20-55% of nanites
 	adjust_nanites(null, -(rand(5, 50)))			//Lose 5-50 flat nanite volume
 	for(var/X in programs)
 		var/datum/nanite_program/NP = X

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -494,7 +494,7 @@
 
 /obj/machinery/clonepod/proc/horrifyingsound()
 	for(var/i in 1 to 5)
-		playsound(src,pick('sound/hallucinations/growl1.ogg','sound/hallucinations/growl2.ogg','sound/hallucinations/growl3.ogg'), 100, rand(0.95,1.05))
+		playsound(src,pick('sound/hallucinations/growl1.ogg','sound/hallucinations/growl2.ogg','sound/hallucinations/growl3.ogg'), 100, (rand(95,105) * 0.01))
 		sleep(1)
 	sleep(10)
 	playsound(src,'sound/hallucinations/wail.ogg', 100, TRUE)

--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -18,12 +18,12 @@
 /mob/living/carbon/human/Unconscious(amount, updating = 1, ignore_canstun = 0)
 	amount = dna.species.spec_stun(src,amount)
 	if(HAS_TRAIT(src, TRAIT_HEAVY_SLEEPER))
-		amount *= rand(1.25, 1.3)
+		amount *= (rand(125, 130) * 0.01)
 	return ..()
 
 /mob/living/carbon/human/Sleeping(amount, updating = 1, ignore_canstun = 0)
 	if(HAS_TRAIT(src, TRAIT_HEAVY_SLEEPER))
-		amount *= rand(1.25, 1.3)
+		amount *= (rand(125, 130) * 0.01)
 	return ..()
 
 /mob/living/carbon/human/cure_husk(list/sources)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -496,7 +496,7 @@
 			if(has_power() && (W.flags_1 & CONDUCT_1))
 				do_sparks(3, TRUE, src)
 				if (prob(75))
-					electrocute_mob(user, get_area(src), src, rand(0.7,1.0), TRUE)
+					electrocute_mob(user, get_area(src), src, (rand(7,10) * 0.1), TRUE)
 	else
 		return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a select few places where the rand proc is used to get a random number from a range. People would write rand(0.25, 0.75) and expect it to return a number between 0.25 and 0.75 but that is not how it works. The number would be rounded/changed to 0 or 1. Fixes a bunch of minor crap.
resolves #48704
heavy sleeper trait
weird cloning sound thing
lightbulb shock siemens_coeff not randomly 0

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: the bluespace randomness generator is no longer being used incorrectly
fix: nanites getting removed all at once when you get shocked, heavy sleeping being really random if it actually increases the time you sleep, the scary cloning sound (???), and lightbulbs randomly pretending you have insulated gloves are all fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
