### PR TITLE
Jet air use fix and trails.

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -52,6 +52,8 @@
 
 
 /obj/item/tank/jetpack/proc/turn_on(mob/user)
+	if(!allow_thrust(0.01))
+		return
 	on = TRUE
 	icon_state = "[initial(icon_state)]-on"
 	ion_trail.start()

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -13,11 +13,11 @@
 
 	// Do we have a jetpack implant (and is it on)?
 	var/obj/item/organ/cyberimp/chest/thrusters/T = getorganslot(ORGAN_SLOT_THRUSTERS)
-	if(istype(T) && movement_dir && T.allow_thrust(0.01))
+	if(istype(T) && movement_dir && T.on)
 		return 1
 
 	var/obj/item/tank/jetpack/J = get_jetpack()
-	if(istype(J) && (movement_dir || J.stabilizers) && J.allow_thrust(0.01, src))
+	if(istype(J) && (movement_dir || J.stabilizers) && J.on)
 		return 1
 
 /mob/living/carbon/Move(NewLoc, direct)

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -132,6 +132,7 @@
 	. = ..()
 	if(!ion_trail)
 		ion_trail = new
+	ion_trail.auto_process = FALSE
 	ion_trail.set_up(M)
 
 /obj/item/organ/cyberimp/chest/thrusters/Remove(mob/living/carbon/M, special = 0)
@@ -152,12 +153,14 @@
 		if(allow_thrust(0.01))
 			ion_trail.start()
 			RegisterSignal(owner, COMSIG_MOVABLE_MOVED, .proc/move_react)
+			RegisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE, .proc/pre_move_react)
 			owner.add_movespeed_modifier(MOVESPEED_ID_CYBER_THRUSTER, priority=100, multiplicative_slowdown=-0.5, movetypes=FLOATING, conflict=MOVE_CONFLICT_JETPACK)
 			if(!silent)
 				to_chat(owner, "<span class='notice'>You turn your thrusters set on.</span>")
 	else
 		ion_trail.stop()
 		UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
+		UnregisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE)
 		owner.remove_movespeed_modifier(MOVESPEED_ID_CYBER_THRUSTER)
 		if(!silent)
 			to_chat(owner, "<span class='notice'>You turn your thrusters set off.</span>")
@@ -174,7 +177,13 @@
 		A.UpdateButtonIcon()
 
 /obj/item/organ/cyberimp/chest/thrusters/proc/move_react()
-	allow_thrust(0.01)
+	if(length(owner.client.keys_held & owner.client.movement_keys))
+		if(!isturf(owner.loc) || has_gravity(owner) || pulledby || throwing)
+			return
+		allow_thrust(0.01)
+
+/obj/item/organ/cyberimp/chest/thrusters/proc/pre_move_react()
+	ion_trail.oldposition = get_turf(src)
 
 /obj/item/organ/cyberimp/chest/thrusters/proc/allow_thrust(num)
 	if(!on || !owner)
@@ -193,6 +202,7 @@
 	// (just in case someone would ever use this implant system to make cyber-alien ops with jetpacks and taser arms)
 	if(owner.getPlasma() >= num*100)
 		owner.adjustPlasma(-num*100)
+		ion_trail.generate_effect()
 		return 1
 
 	// Priority 3: use internals tank.
@@ -201,6 +211,7 @@
 		var/datum/gas_mixture/removed = I.air_contents.remove(num)
 		if(removed.total_moles() > 0.005)
 			T.assume_air(removed)
+			ion_trail.generate_effect()
 			return 1
 		else
 			T.assume_air(removed)


### PR DESCRIPTION
## About The Pull Request
Remove continuous jet air using.
Remove jet air usung from carbon/Process_Spacemove and fix it in jet move_react.

## Why It's Good For The Game
Trails from nothing confuses.

Bugs is bad.
Jet that use air on every move and in gravity is bad.
fix #48661

## Changelog
:cl:
tweak: Jets make trails only on thrust
fix: jets use air only on thrust
/:cl:
