### PR TITLE
Pubby mapping fixes

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -16259,21 +16259,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"aQA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aQB" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -81994,7 +81985,7 @@ aAL
 luM
 aAL
 aAL
-aQA
+aHE
 aAL
 aAL
 aTO

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -38644,7 +38644,7 @@
 	name = "Atmospherics Monitoring";
 	req_access_txt = "24"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/lobby)
 "bRs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{


### PR DESCRIPTION
## About The Pull Request

Fixes a disposal pipe in the west side of Pubby's main hall that throws out trash from a specific garbage can.
<table>
<tr>
    <td><center>OLD</center></td>
    <td><center>NEW</center></td>
</tr>
<tr>
    <td>
<img src="https://user-images.githubusercontent.com/2520037/72225741-edb8eb00-3556-11ea-9899-f2741a63fa68.png" width="300">
    </td>
    <td>
<img src="https://user-images.githubusercontent.com/2520037/72225749-02957e80-3557-11ea-95a8-927463108c2f.png" width="300">
    </td>
</tr>
</table>

Also adds a floor tile underneath the door from engi lobby to atmos.

## Why It's Good For The Game

Mapping fixes

## Changelog
:cl: FlufflyCthulu
fix: PubbyStation fixes
/:cl: