### PR TITLE
Electronic firing pins are now printable at a hacked autolathe.

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1060,7 +1060,7 @@
 	materials = list(/datum/material/plastic = 1000)
 	build_path = /obj/item/storage/box/plastic
 	category = list("initial", "Misc")
-	
+
 /datum/design/firing_pin
 	name = "Electronic Firing Pin"
 	id = "firing_pin"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1060,3 +1060,11 @@
 	materials = list(/datum/material/plastic = 1000)
 	build_path = /obj/item/storage/box/plastic
 	category = list("initial", "Misc")
+	
+/datum/design/firing_pin
+	name = "Electronic Firing Pin"
+	id = "firing_pin"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500)
+	build_path = /obj/item/firing_pin
+	category = list("hacked", "Security")


### PR DESCRIPTION


## About The Pull Request
You can now craft basic firing pins under the security section of a hacked autolathe for 2000 metal and 500 glass.

## Why It's Good For The Game

There is currently no way to make normal firing pins and they can not be removed from guns without them breaking. Many weapons do not come pre-equipped with a firing pin when they are printed, requiring whoever wants to use that gun to acquire a mindshield implant and a mindshield firing pin.


## Changelog
:cl:
add: Electronic firing pins are now printable at a hacked autolathe.
/:cl:


