### PR TITLE
you can only slice aggressive grabs or higher now

### DIFF
--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -32,7 +32,7 @@
 
 	if(ishuman(M) && source.force && source.get_sharpness())
 		var/mob/living/carbon/human/H = M
-		if((H.health <= H.crit_threshold || (user.pulling == H && user.grab_state >= GRAB_NECK) || H.IsSleeping()) && user.zone_selected == BODY_ZONE_HEAD) // Only sleeping, neck grabbed, or crit, can be sliced.
+		if((user.pulling == H && user.grab_state >= GRAB_NECK) && user.zone_selected == BODY_ZONE_HEAD) // Only neck grabbed can be sliced.
 			if(H.has_status_effect(/datum/status_effect/neck_slice))
 				user.show_message("<span class='warning'>[H]'s neck has already been already cut, you can't make the bleeding any worse!</span>", MSG_VISUAL, \
 								"<span class='warning'>Their neck has already been already cut, you can't make the bleeding any worse!</span>")

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -32,7 +32,7 @@
 
 	if(ishuman(M) && source.force && source.get_sharpness())
 		var/mob/living/carbon/human/H = M
-		if((user.pulling == H && user.grab_state >= GRAB_NECK) && user.zone_selected == BODY_ZONE_HEAD) // Only neck grabbed can be sliced.
+		if((user.pulling == H && user.grab_state >= GRAB_AGGRESSIVE) && user.zone_selected == BODY_ZONE_HEAD) // Only neck grabbed can be sliced.
 			if(H.has_status_effect(/datum/status_effect/neck_slice))
 				user.show_message("<span class='warning'>[H]'s neck has already been already cut, you can't make the bleeding any worse!</span>", MSG_VISUAL, \
 								"<span class='warning'>Their neck has already been already cut, you can't make the bleeding any worse!</span>")

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -32,7 +32,7 @@
 
 	if(ishuman(M) && source.force && source.get_sharpness())
 		var/mob/living/carbon/human/H = M
-		if((user.pulling == H && user.grab_state >= GRAB_AGGRESSIVE) && user.zone_selected == BODY_ZONE_HEAD) // Only neck grabbed can be sliced.
+		if((user.pulling == H && user.grab_state >= GRAB_AGGRESSIVE) && user.zone_selected == BODY_ZONE_HEAD) // Only aggressive grabbed can be sliced.
 			if(H.has_status_effect(/datum/status_effect/neck_slice))
 				user.show_message("<span class='warning'>[H]'s neck has already been already cut, you can't make the bleeding any worse!</span>", MSG_VISUAL, \
 								"<span class='warning'>Their neck has already been already cut, you can't make the bleeding any worse!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
you can no longer neck slice people that are sleeping/critical/dead
you can now neck slice starting with aggressive grabs instead of neck grabs

## Why It's Good For The Game

its annoying as fuck to be aiming for the head while killing someone with a sharp weapon, they fall into crit and now you gotta switch to chest instead of just keeping stabbing because theres a timer on you killing someone
it also works on dead people and fucks you up when you try to behead someone
you could argue about sleeping but if someones asleep you can just neck grab them and do the neck slice they cant move

## Changelog
:cl:
tweak: neck slices no longer work on critical/dead/sleeping people, but they now require just an aggressive grab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
