### PR TITLE
make hardsuit helmets repairable

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -116,6 +116,11 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	..()
 
+/obj/item/clothing/suit/space/hardsuit/examine(mob/user)
+	. = ..()
+	if(!helmet && helmettype)
+		. += "<span class'notice'> The helmet on [src] seems to be malfunctioning. It may be repairable with a welder.</span>"
+
 /obj/item/clothing/suit/space/hardsuit/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/tank/jetpack/suit))
 		if(jetpack)
@@ -142,6 +147,18 @@
 		jetpack = null
 		to_chat(user, "<span class='notice'>You successfully remove the jetpack from [src].</span>")
 		return
+	else if(I.tool_behaviour == TOOL_WELDER && helmettype)
+		if(src == user.get_item_by_slot(ITEM_SLOT_OCLOTHING))
+			to_chat(user, "<span class='warning'> You cannot repair the helmet of [src] while wearing it.</span>")
+			return
+		if(helmet)
+			to_chat(user, "<span class='warning'> The helmet of [src] does not require repairs.</span>")
+			return
+		if(!I.tool_start_check(user))
+			return
+		if(I.use_tool(src, user, 100, 10, 100))
+			helmet = new helmettype(src)
+			to_chat(user, "<span class='notice'> You have successfully repaired [src]'s helmet.</span>")
 	return ..()
 
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -155,7 +155,7 @@
 			to_chat(user, "<span class='warning'>The helmet of [src] does not require a new bulb.</span>")
 			return
 		var/obj/item/light/L = I
-		if(L.status != LIGHT_OK)
+		if(L.status)
 			to_chat(user, "<span class='warning'>This bulb is too damaged to use as a replacement!</span>")
 			return
 		if(do_after(user, 50, 1, src))

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -119,7 +119,7 @@
 /obj/item/clothing/suit/space/hardsuit/examine(mob/user)
 	. = ..()
 	if(!helmet && helmettype)
-		. += "<span class'notice'> The helmet on [src] seems to be malfunctioning. It may be repairable with a welder.</span>"
+		. += "<span class='notice'> The helmet on [src] seems to be malfunctioning. It may be repairable with a welder.</span>"
 
 /obj/item/clothing/suit/space/hardsuit/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/tank/jetpack/suit))

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -119,7 +119,7 @@
 /obj/item/clothing/suit/space/hardsuit/examine(mob/user)
 	. = ..()
 	if(!helmet && helmettype)
-		. += "<span class='notice'> The helmet on [src] seems to be malfunctioning. It may be repairable with a welder.</span>"
+		. += "<span class='notice'> The helmet on [src] seems to be malfunctioning. It's light bulb needs to be replaced.</span>"
 
 /obj/item/clothing/suit/space/hardsuit/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/tank/jetpack/suit))
@@ -147,18 +147,22 @@
 		jetpack = null
 		to_chat(user, "<span class='notice'>You successfully remove the jetpack from [src].</span>")
 		return
-	else if(I.tool_behaviour == TOOL_WELDER && helmettype)
+	else if(istype(I, /obj/item/light) && helmettype)
 		if(src == user.get_item_by_slot(ITEM_SLOT_OCLOTHING))
-			to_chat(user, "<span class='warning'> You cannot repair the helmet of [src] while wearing it.</span>")
+			to_chat(user, "<span class='warning'>You cannot replace the bulb in the helmet of [src] while wearing it.</span>")
 			return
 		if(helmet)
-			to_chat(user, "<span class='warning'> The helmet of [src] does not require repairs.</span>")
+			to_chat(user, "<span class='warning'>The helmet of [src] does not require a new bulb.</span>")
 			return
-		if(!I.tool_start_check(user))
+		var/obj/item/light/L = I
+		if(L.status != LIGHT_OK)
+			to_chat(user, "<span class='warning'>This bulb is too damaged to use as a replacement!</span>")
 			return
-		if(I.use_tool(src, user, 100, 10, 100))
+		if(do_after(user, 50, 1, src))
+			qdel(I)
 			helmet = new helmettype(src)
-			to_chat(user, "<span class='notice'> You have successfully repaired [src]'s helmet.</span>")
+			to_chat(user, "<span class='notice'>You have successfully repaired [src]'s helmet.</span>")
+			new /obj/item/light/bulb/broken(get_turf(src))
 	return ..()
 
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -162,7 +162,7 @@
 			qdel(I)
 			helmet = new helmettype(src)
 			to_chat(user, "<span class='notice'>You have successfully repaired [src]'s helmet.</span>")
-			new /obj/item/light/bulb/broken(get_turf(src))
+			new /obj/item/light/bulb/broken(drop_location())
 	return ..()
 
 

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -184,7 +184,7 @@
 	if(!helmettype)
 		return
 	if(!helmet)
-		to_chat(H, "<span class='warning'> The helmet seems to be damaged! You can try to repair it with a welder. </span>")
+		to_chat(H, "<span class='warning'> The helmet's lightbulb seems to be damaged! You'll need a replacement bulb.</span>")
 		return
 	if(!suittoggled)
 		if(ishuman(src.loc))

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -184,6 +184,7 @@
 	if(!helmettype)
 		return
 	if(!helmet)
+		to_chat(H, "<span class='warning'> The helmet seems to be damaged! You can try to repair it with a welder. </span>")
 		return
 	if(!suittoggled)
 		if(ishuman(src.loc))

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -184,7 +184,7 @@
 	if(!helmettype)
 		return
 	if(!helmet)
-		to_chat(H, "<span class='warning'> The helmet's lightbulb seems to be damaged! You'll need a replacement bulb.</span>")
+		to_chat(H, "<span class='warning'>The helmet's lightbulb seems to be damaged! You'll need a replacement bulb.</span>")
 		return
 	if(!suittoggled)
 		if(ishuman(src.loc))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a way to repair an hardsuit helmet if it somehow gets damaged like by an nightmare light eater
relevant issue: #48770
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows you to repair your hardsuit rather than needing to replace it entirely due to being hit by a light eater once
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: hardsuit helmets are now repairable by using a lightbulb on the hardsuit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
