### PR TITLE
Adds a function to grant research points for slime extracts

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -75,3 +75,13 @@
 	)
 
 #define TECHWEB_BOMB_POINTCAP		50000 //Adjust as needed; Stops toxins from nullifying RND progression mechanics. Current Value Cap Radius: 100
+
+//research point values for slime extracts
+
+#define SLIME_RESEARCH_TIER_0 100
+#define SLIME_RESEARCH_TIER_1 500
+#define SLIME_RESEARCH_TIER_2 1000
+#define SLIME_RESEARCH_TIER_3 1500
+#define SLIME_RESEARCH_TIER_4 2000
+#define SLIME_RESEARCH_TIER_5 2500
+#define SLIME_RESEARCH_TIER_RAINBOW 5000

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -30,6 +30,7 @@ SUBSYSTEM_DEF(research)
 	)
 	var/list/errored_datums = list()
 	var/list/point_types = list()				//typecache style type = TRUE list
+	var/list/slime_already_researched = list() 	//Slime cores that have already been researched
 	//----------------------------------------------
 	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 52.3)
 	var/multiserver_calculation = FALSE

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -35,7 +35,6 @@
 	var/obj/item/slimepotion/slime/current_potion
 	var/max_slimes = 5
 	var/monkeys = 0
-	var/static/list/already_researched = list() //List of cores that've already been used for research
 
 	icon_screen = "slime_comp"
 	icon_keyboard = "rd_key"
@@ -172,15 +171,15 @@
 		return
 	else if(istype(O, /obj/item/slime_extract))
 		var/obj/item/slime_extract/E = O
-		if(!already_researched[E.type])
+		if(!SSresearch.slime_already_researched[E.type])
 			playsound(src, 'sound/machines/ping.ogg', 50, 3, -1)
-			visible_message("<span class='notice'>You insert the [E] into a slot on the [src]. It pings and prints out some research notes worth [E.research] points!</span>")
+			visible_message("<span class='notice'>You insert [E] into a slot on the [src]. It pings and prints out some research notes worth [E.research] points!</span>")
 			new /obj/item/research_notes(drop_location(src), E.research, "xenobiology")
-			already_researched[E.type] = TRUE
+			SSresearch.slime_already_researched[E.type] = TRUE
 			qdel(O)
 			return
 		else
-			visible_message("<span class='notice'>[src] buzzes and displays a message: Slime core already researched!")
+			visible_message("<span class='notice'>[src] buzzes and displays a message: Slime extract already researched!")
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 3, -1)
 			return
 	..()

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -172,18 +172,18 @@
 	else if(istype(O, /obj/item/slime_extract))
 		var/obj/item/slime_extract/E = O
 		if(!SSresearch.slime_already_researched[E.type])
-			if(E.research == null || E.research == 0)
+			if(!E.research)
 				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 3, -1)
 				visible_message("<span class='notice'>[src] buzzes and displays a message: Invalid extract! (You shouldn't be seeing this. If you are, tell someone.)</span>")
 				return
-			if(E.Uses == 0)
+			if(E.Uses <= 0)
 				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 3, -1)
 				visible_message("<span class='notice'>[src] buzzes and displays a message: Extract consumed - no research available.</span>")
 				return
 			else
 				playsound(src, 'sound/machines/ping.ogg', 50, 3, -1)
 				visible_message("<span class='notice'>You insert [E] into a slot on the [src]. It pings and prints out some research notes worth [E.research] points!</span>")
-				new /obj/item/research_notes(drop_location(src), E.research, "xenobiology")
+				new /obj/item/research_notes(drop_location(), E.research, "xenobiology")
 				SSresearch.slime_already_researched[E.type] = TRUE
 				qdel(O)
 				return

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -171,11 +171,12 @@
 		to_chat(user, "<span class='notice'>You load [O] in the console's potion slot[replaced ? ", replacing the one that was there before" : ""].</span>")
 		return
 	else if(istype(O, /obj/item/slime_extract))
-		if(!already_researched[O.type])
+		var/obj/item/slime_extract/E = O
+		if(!already_researched[E.type])
 			playsound(src, 'sound/machines/ping.ogg', 50, 3, -1)
-			visible_message("<span class='notice'>You insert the [O] into a slot on the [src]. It pings and prints out some research notes worth 1,000 points!</span>")
-			new /obj/item/research_notes(drop_location(src), 1000, "xenobiology")
-			already_researched[O.type] = TRUE
+			visible_message("<span class='notice'>You insert the [E] into a slot on the [src]. It pings and prints out some research notes worth [E.research] points!</span>")
+			new /obj/item/research_notes(drop_location(src), E.research, "xenobiology")
+			already_researched[E.type] = TRUE
 			qdel(O)
 			return
 		else

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -172,14 +172,23 @@
 	else if(istype(O, /obj/item/slime_extract))
 		var/obj/item/slime_extract/E = O
 		if(!SSresearch.slime_already_researched[E.type])
-			playsound(src, 'sound/machines/ping.ogg', 50, 3, -1)
-			visible_message("<span class='notice'>You insert [E] into a slot on the [src]. It pings and prints out some research notes worth [E.research] points!</span>")
-			new /obj/item/research_notes(drop_location(src), E.research, "xenobiology")
-			SSresearch.slime_already_researched[E.type] = TRUE
-			qdel(O)
-			return
+			if(E.research == null || E.research == 0)
+				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 3, -1)
+				visible_message("<span class='notice'>[src] buzzes and displays a message: Invalid extract! (You shouldn't be seeing this. If you are, tell someone.)</span>")
+				return
+			if(E.Uses == 0)
+				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 3, -1)
+				visible_message("<span class='notice'>[src] buzzes and displays a message: Extract consumed - no research available.</span>")
+				return
+			else
+				playsound(src, 'sound/machines/ping.ogg', 50, 3, -1)
+				visible_message("<span class='notice'>You insert [E] into a slot on the [src]. It pings and prints out some research notes worth [E.research] points!</span>")
+				new /obj/item/research_notes(drop_location(src), E.research, "xenobiology")
+				SSresearch.slime_already_researched[E.type] = TRUE
+				qdel(O)
+				return
 		else
-			visible_message("<span class='notice'>[src] buzzes and displays a message: Slime extract already researched!")
+			visible_message("<span class='notice'>[src] buzzes and displays a message: Slime extract already researched!</span>")
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 3, -1)
 			return
 	..()

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -35,6 +35,7 @@
 	var/obj/item/slimepotion/slime/current_potion
 	var/max_slimes = 5
 	var/monkeys = 0
+	var/static/list/already_researched = list() //List of cores that've already been used for research
 
 	icon_screen = "slime_comp"
 	icon_keyboard = "rd_key"
@@ -169,6 +170,18 @@
 		current_potion = O
 		to_chat(user, "<span class='notice'>You load [O] in the console's potion slot[replaced ? ", replacing the one that was there before" : ""].</span>")
 		return
+	else if(istype(O, /obj/item/slime_extract))
+		if(!already_researched[O.type])
+			playsound(src, 'sound/machines/ping.ogg', 50, 3, -1)
+			visible_message("<span class='notice'>You insert the [O] into a slot on the [src]. It pings and prints out some research notes worth 2,000 points!</span>")
+			new /obj/item/research_notes(drop_location(src), 2000, "xenobiology")
+			already_researched[O.type] = TRUE
+			qdel(O)
+			return
+		else
+			visible_message("<span class='notice'>[src] buzzes and displays a message: Slime core already researched!")
+			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 3, -1)
+			return
 	..()
 
 /obj/machinery/computer/camera_advanced/xenobio/multitool_act(mob/living/user, obj/item/multitool/I)

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -173,8 +173,8 @@
 	else if(istype(O, /obj/item/slime_extract))
 		if(!already_researched[O.type])
 			playsound(src, 'sound/machines/ping.ogg', 50, 3, -1)
-			visible_message("<span class='notice'>You insert the [O] into a slot on the [src]. It pings and prints out some research notes worth 2,000 points!</span>")
-			new /obj/item/research_notes(drop_location(src), 2000, "xenobiology")
+			visible_message("<span class='notice'>You insert the [O] into a slot on the [src]. It pings and prints out some research notes worth 1,000 points!</span>")
+			new /obj/item/research_notes(drop_location(src), 1000, "xenobiology")
 			already_researched[O.type] = TRUE
 			qdel(O)
 			return

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -1,13 +1,3 @@
-// Defines for research points //
-
-#define SLIME_TIER_0 100
-#define SLIME_TIER_1 500
-#define SLIME_TIER_2 1000
-#define SLIME_TIER_3 1500
-#define SLIME_TIER_4 2000
-#define SLIME_TIER_5 2500
-#define SLIME_TIER_RAINBOW 5000
-
 /// Slime Extracts ///
 
 /obj/item/slime_extract
@@ -90,7 +80,7 @@
 	icon_state = "grey slime extract"
 	effectmod = "reproductive"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
-	research = SLIME_TIER_0
+	research = SLIME_RESEARCH_TIER_0
 
 /obj/item/slime_extract/grey/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -116,7 +106,7 @@
 	icon_state = "gold slime extract"
 	effectmod = "symbiont"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
-	research = SLIME_TIER_4
+	research = SLIME_RESEARCH_TIER_4
 
 /obj/item/slime_extract/gold/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -146,7 +136,7 @@
 	icon_state = "silver slime extract"
 	effectmod = "consuming"
 	activate_reagents = list(/datum/reagent/toxin/plasma,/datum/reagent/water)
-	research = SLIME_TIER_2
+	research = SLIME_RESEARCH_TIER_2
 
 /obj/item/slime_extract/silver/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -172,7 +162,7 @@
 	icon_state = "metal slime extract"
 	effectmod = "industrial"
 	activate_reagents = list(/datum/reagent/toxin/plasma,/datum/reagent/water)
-	research = SLIME_TIER_1
+	research = SLIME_RESEARCH_TIER_1
 
 /obj/item/slime_extract/metal/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -197,7 +187,7 @@
 	icon_state = "purple slime extract"
 	effectmod = "regenerative"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma)
-	research = SLIME_TIER_1
+	research = SLIME_RESEARCH_TIER_1
 
 /obj/item/slime_extract/purple/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -217,7 +207,7 @@
 	icon_state = "dark purple slime extract"
 	effectmod = "self-sustaining"
 	activate_reagents = list(/datum/reagent/toxin/plasma)
-	research = SLIME_TIER_2
+	research = SLIME_RESEARCH_TIER_2
 
 /obj/item/slime_extract/darkpurple/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -241,7 +231,7 @@
 	icon_state = "orange slime extract"
 	effectmod = "burning"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
-	research = SLIME_TIER_1
+	research = SLIME_RESEARCH_TIER_1
 
 /obj/item/slime_extract/orange/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -262,7 +252,7 @@
 	icon_state = "yellow slime extract"
 	effectmod = "charged"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
-	research = SLIME_TIER_2
+	research = SLIME_RESEARCH_TIER_2
 
 /obj/item/slime_extract/yellow/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -286,7 +276,7 @@
 	icon_state = "red slime extract"
 	effectmod = "sanguine"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
-	research = SLIME_TIER_4
+	research = SLIME_RESEARCH_TIER_4
 
 /obj/item/slime_extract/red/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -307,7 +297,7 @@
 	icon_state = "blue slime extract"
 	effectmod = "stabilized"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
-	research = SLIME_TIER_1
+	research = SLIME_RESEARCH_TIER_1
 
 /obj/item/slime_extract/blue/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -328,7 +318,7 @@
 	icon_state = "dark blue slime extract"
 	effectmod = "chilling"
 	activate_reagents = list(/datum/reagent/toxin/plasma,/datum/reagent/water)
-	research = SLIME_TIER_2
+	research = SLIME_RESEARCH_TIER_2
 
 /obj/item/slime_extract/darkblue/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -352,7 +342,7 @@
 	icon_state = "pink slime extract"
 	effectmod = "gentle"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma)
-	research = SLIME_TIER_4
+	research = SLIME_RESEARCH_TIER_4
 
 /obj/item/slime_extract/pink/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -381,7 +371,7 @@
 	icon_state = "green slime extract"
 	effectmod = "mutative"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/uranium/radium)
-	research = SLIME_TIER_4
+	research = SLIME_RESEARCH_TIER_4
 
 /obj/item/slime_extract/green/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -406,7 +396,7 @@
 	icon_state = "light pink slime extract"
 	effectmod = "loyal"
 	activate_reagents = list(/datum/reagent/toxin/plasma)
-	research = SLIME_TIER_5
+	research = SLIME_RESEARCH_TIER_5
 
 /obj/item/slime_extract/lightpink/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -431,7 +421,7 @@
 	icon_state = "black slime extract"
 	effectmod = "transformative"
 	activate_reagents = list(/datum/reagent/toxin/plasma)
-	research = SLIME_TIER_5
+	research = SLIME_RESEARCH_TIER_5
 
 /obj/item/slime_extract/black/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -453,7 +443,7 @@
 	icon_state = "oil slime extract"
 	effectmod = "detonating"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma)
-	research = SLIME_TIER_5
+	research = SLIME_RESEARCH_TIER_5
 
 /obj/item/slime_extract/oil/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -477,7 +467,7 @@
 	icon_state = "adamantine slime extract"
 	effectmod = "crystalline"
 	activate_reagents = list(/datum/reagent/toxin/plasma)
-	research = SLIME_TIER_5
+	research = SLIME_RESEARCH_TIER_5
 
 /obj/item/slime_extract/adamantine/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -511,7 +501,7 @@
 	var/teleport_x = 0
 	var/teleport_y = 0
 	var/teleport_z = 0
-	research = SLIME_TIER_3
+	research = SLIME_RESEARCH_TIER_3
 
 /obj/item/slime_extract/bluespace/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -544,7 +534,7 @@
 	icon_state = "pyrite slime extract"
 	effectmod = "prismatic"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma)
-	research = SLIME_TIER_3
+	research = SLIME_RESEARCH_TIER_3
 
 /obj/item/slime_extract/pyrite/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -572,7 +562,7 @@
 	icon_state = "cerulean slime extract"
 	effectmod = "recurring"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma)
-	research = SLIME_TIER_3
+	research = SLIME_RESEARCH_TIER_3
 
 /obj/item/slime_extract/cerulean/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -593,7 +583,7 @@
 	icon_state = "sepia slime extract"
 	effectmod = "lengthened"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
-	research = SLIME_TIER_3
+	research = SLIME_RESEARCH_TIER_3
 
 /obj/item/slime_extract/sepia/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -616,7 +606,7 @@
 	icon_state = "rainbow slime extract"
 	effectmod = "hyperchromatic"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,"lesser plasma",/datum/reagent/toxin/slimejelly,"holy water and uranium") //Curse this snowflake reagent list.
-	research = SLIME_TIER_RAINBOW
+	research = SLIME_RESEARCH_TIER_RAINBOW
 
 /obj/item/slime_extract/rainbow/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -1,3 +1,13 @@
+// Defines for research points //
+
+#define SLIME_TIER_0 100
+#define SLIME_TIER_1 500
+#define SLIME_TIER_2 1000
+#define SLIME_TIER_3 1500
+#define SLIME_TIER_4 2000
+#define SLIME_TIER_5 2500
+#define SLIME_TIER_RAINBOW 5000
+
 /// Slime Extracts ///
 
 /obj/item/slime_extract
@@ -16,6 +26,7 @@
 	var/effectmod
 	var/list/activate_reagents = list() //Reagents required for activation
 	var/recurring = FALSE
+	var/research //Research point value
 
 /obj/item/slime_extract/examine(mob/user)
 	. = ..()
@@ -79,6 +90,7 @@
 	icon_state = "grey slime extract"
 	effectmod = "reproductive"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
+	research = SLIME_TIER_0
 
 /obj/item/slime_extract/grey/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -104,6 +116,7 @@
 	icon_state = "gold slime extract"
 	effectmod = "symbiont"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
+	research = SLIME_TIER_4
 
 /obj/item/slime_extract/gold/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -133,6 +146,7 @@
 	icon_state = "silver slime extract"
 	effectmod = "consuming"
 	activate_reagents = list(/datum/reagent/toxin/plasma,/datum/reagent/water)
+	research = SLIME_TIER_2
 
 /obj/item/slime_extract/silver/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -158,6 +172,7 @@
 	icon_state = "metal slime extract"
 	effectmod = "industrial"
 	activate_reagents = list(/datum/reagent/toxin/plasma,/datum/reagent/water)
+	research = SLIME_TIER_1
 
 /obj/item/slime_extract/metal/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -182,6 +197,7 @@
 	icon_state = "purple slime extract"
 	effectmod = "regenerative"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma)
+	research = SLIME_TIER_1
 
 /obj/item/slime_extract/purple/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -201,6 +217,7 @@
 	icon_state = "dark purple slime extract"
 	effectmod = "self-sustaining"
 	activate_reagents = list(/datum/reagent/toxin/plasma)
+	research = SLIME_TIER_2
 
 /obj/item/slime_extract/darkpurple/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -224,6 +241,7 @@
 	icon_state = "orange slime extract"
 	effectmod = "burning"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
+	research = SLIME_TIER_1
 
 /obj/item/slime_extract/orange/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -244,6 +262,7 @@
 	icon_state = "yellow slime extract"
 	effectmod = "charged"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
+	research = SLIME_TIER_2
 
 /obj/item/slime_extract/yellow/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -267,6 +286,7 @@
 	icon_state = "red slime extract"
 	effectmod = "sanguine"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
+	research = SLIME_TIER_4
 
 /obj/item/slime_extract/red/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -287,6 +307,7 @@
 	icon_state = "blue slime extract"
 	effectmod = "stabilized"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
+	research = SLIME_TIER_1
 
 /obj/item/slime_extract/blue/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -307,6 +328,7 @@
 	icon_state = "dark blue slime extract"
 	effectmod = "chilling"
 	activate_reagents = list(/datum/reagent/toxin/plasma,/datum/reagent/water)
+	research = SLIME_TIER_2
 
 /obj/item/slime_extract/darkblue/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -330,6 +352,7 @@
 	icon_state = "pink slime extract"
 	effectmod = "gentle"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma)
+	research = SLIME_TIER_4
 
 /obj/item/slime_extract/pink/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -358,6 +381,7 @@
 	icon_state = "green slime extract"
 	effectmod = "mutative"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/uranium/radium)
+	research = SLIME_TIER_4
 
 /obj/item/slime_extract/green/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -382,6 +406,7 @@
 	icon_state = "light pink slime extract"
 	effectmod = "loyal"
 	activate_reagents = list(/datum/reagent/toxin/plasma)
+	research = SLIME_TIER_5
 
 /obj/item/slime_extract/lightpink/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -406,6 +431,7 @@
 	icon_state = "black slime extract"
 	effectmod = "transformative"
 	activate_reagents = list(/datum/reagent/toxin/plasma)
+	research = SLIME_TIER_5
 
 /obj/item/slime_extract/black/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -427,6 +453,7 @@
 	icon_state = "oil slime extract"
 	effectmod = "detonating"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma)
+	research = SLIME_TIER_5
 
 /obj/item/slime_extract/oil/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -450,6 +477,7 @@
 	icon_state = "adamantine slime extract"
 	effectmod = "crystalline"
 	activate_reagents = list(/datum/reagent/toxin/plasma)
+	research = SLIME_TIER_5
 
 /obj/item/slime_extract/adamantine/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -483,6 +511,7 @@
 	var/teleport_x = 0
 	var/teleport_y = 0
 	var/teleport_z = 0
+	research = SLIME_TIER_3
 
 /obj/item/slime_extract/bluespace/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -515,6 +544,7 @@
 	icon_state = "pyrite slime extract"
 	effectmod = "prismatic"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma)
+	research = SLIME_TIER_3
 
 /obj/item/slime_extract/pyrite/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -542,6 +572,7 @@
 	icon_state = "cerulean slime extract"
 	effectmod = "recurring"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma)
+	research = SLIME_TIER_3
 
 /obj/item/slime_extract/cerulean/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -562,6 +593,7 @@
 	icon_state = "sepia slime extract"
 	effectmod = "lengthened"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
+	research = SLIME_TIER_3
 
 /obj/item/slime_extract/sepia/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)
@@ -584,6 +616,7 @@
 	icon_state = "rainbow slime extract"
 	effectmod = "hyperchromatic"
 	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,"lesser plasma",/datum/reagent/toxin/slimejelly,"holy water and uranium") //Curse this snowflake reagent list.
+	research = SLIME_TIER_RAINBOW
 
 /obj/item/slime_extract/rainbow/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Another part of the R&D rework - Xenobiologists can now spend a slime extract by feeding it to the slime camera console to get research points for the _first instance of that extract_. This consumes the core in the process. As an example: if you use a green extract, you can't use another one for points. This maxes out at a pretty big chunk of points, but most rounds don't see every breed of slimes bred, so I don't expect it to be a major issue.

The points are as follows for each slime:

Tier 0 = 100 (Grey)
Tier 1 = 500 (Orange, purple, blue, metal)
Tier 2 = 1000 (Yellow, dark purple, dark blue, silver)
Tier 3 = 1500 (Bluespace, sepia, cerulean, pyrite)
Tier 4 = 2000 (Red, green, pink, gold)
Tier 5 = 2500 (Oil, black, light pink, adamantine
Rainbow = 5000

## Why It's Good For The Game

Xenobiology has ways to contribute to the station as a whole but no way to actively contribute to research. This fixes that. This should also help make up for a lack of the Experimentor while I work on the Research Scanner.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the ability for Xenobiologists to spend slime extracts for research points. Only one of each extract can be used for points.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
