### PR TITLE
Lowers minimum mole count for BZ formation

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -374,8 +374,8 @@
 
 /datum/gas_reaction/bzformation/init_reqs()
 	min_requirements = list(
-		/datum/gas/nitrous_oxide = 10,
-		/datum/gas/plasma = 10
+		/datum/gas/nitrous_oxide = 1,
+		/datum/gas/plasma = 2
 	)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lowers the minimum mole count for BZ formation from 20 moles (10 moles nitrous and plasma) to 3 moles (2 moles plasma, 1 mole nitrous).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cramming 20 moles (30 for optimal formation) of gas into less than 10kPa requires multiple fully upgraded freezers to obtain a tangible amount of BZ. For something as goofy as drug gas, I don’t see why it’s so hard to make. Sure it has the niche use of fighting changelings, but they can just use internals. Cargo can sell it, but they can sell tritium too, and for just as much credits.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Lowered the minimum mole count of BZ formation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
