### PR TITLE
Re-adds Paramedic spawn landmarks to Boxstation

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -27295,6 +27295,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsz" = (
@@ -34683,6 +34684,7 @@
 /area/medical/medbay/central)
 "bLX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bLY" = (
@@ -49590,6 +49592,10 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"fGg" = (
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "fGF" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
@@ -90052,7 +90058,7 @@ bAs
 bvj
 bCL
 bxO
-bDR
+fGg
 bDR
 bIk
 bJC


### PR DESCRIPTION
Some walnut removed the paramedic spawn landmarks on Box, which according to a Reddit user causes them to spawn in random station areas (like the AI chamber).
This also indicates that `SendToLateJoin(living_mob)` might be broken, but I haven't tested that so far.

This should be merged quickly as it can fuck up rounds for Paramedics on Box.

## Changelog
:cl: Denton
fix: Boxstation: Roundstart Paramedics now properly start in medbay.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
