### PR TITLE
Adds the Wood Datum Material, giving it to items made from wood.

### DIFF
--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -11,6 +11,6 @@
 /obj/item/weaponcrafting/stock
 	name = "rifle stock"
 	desc = "A classic rifle stock that doubles as a grip, roughly carved out of wood."
-	custom_materials = list(/datum/material/wood = 12000)
+	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 6)
 	icon = 'icons/obj/improvised.dmi'
 	icon_state = "riflestock"

--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -11,5 +11,6 @@
 /obj/item/weaponcrafting/stock
 	name = "rifle stock"
 	desc = "A classic rifle stock that doubles as a grip, roughly carved out of wood."
+	custom_materials = list(/datum/material/wood = 12000)
 	icon = 'icons/obj/improvised.dmi'
 	icon_state = "riflestock"

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -200,17 +200,15 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	beauty_modifier = 0.1
 	armor_modifiers = list("melee" = 1.1, "bullet" = 1.1, "laser" = 0.4, "energy" = 0.4, "bomb" = 1, "bio" = 0.2, "rad" = 0, "fire" = 0, "acid" = 0.3)
 
-/datum/material/wood/on_applied_obj(atom/source, amount, material_flags)
+/datum/material/wood/on_applied_obj(obj/source, amount, material_flags)
 	. = ..()
-	if(istype(source, /obj/item))
-		var/obj/item/wooden = source
-		wooden.resistance_flags |= FLAMMABLE
+	var/obj/item/wooden = source
+	wooden.resistance_flags |= FLAMMABLE
 
-/datum/material/wood/on_removed_obj(atom/source, material_flags)
+/datum/material/wood/on_removed_obj(obj/source, material_flags)
 	. = ..()
-	if(istype(source, /obj/item))
-		var/obj/item/wooden = source
-		wooden.resistance_flags &= ~FLAMMABLE
+	var/obj/item/wooden = source
+	wooden.resistance_flags &= ~FLAMMABLE
 
 ///Stronk force increase
 /datum/material/adamantine

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -205,18 +205,12 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	if(istype(source, /obj/item))
 		var/obj/item/wooden = source
 		wooden.resistance_flags |= FLAMMABLE
-		if(istype(wooden, /obj/item/melee))
-			var/obj/item/melee/wooden_stick = wooden
-			wooden_stick.force = 2
 
 /datum/material/wood/on_removed_obj(atom/source, material_flags)
 	. = ..()
 	if(istype(source, /obj/item))
 		var/obj/item/wooden = source
 		wooden.resistance_flags &= ~FLAMMABLE
-		if(istype(wooden, /obj/item/melee))
-			var/obj/item/melee/wooden_stick = wooden
-			wooden_stick.force = initial(wooden_stick.force)
 
 ///Stronk force increase
 /datum/material/adamantine

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -203,13 +203,13 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 /datum/material/wood/on_applied_obj(obj/source, amount, material_flags)
 	. = ..()
 	if(material_flags & MATERIAL_AFFECT_STATISTICS)
-		var/obj/item/wooden = source
+		var/obj/wooden = source
 		wooden.resistance_flags |= FLAMMABLE
 
 /datum/material/wood/on_removed_obj(obj/source, material_flags)
 	. = ..()
 	if(material_flags & MATERIAL_AFFECT_STATISTICS)
-		var/obj/item/wooden = source
+		var/obj/wooden = source
 		wooden.resistance_flags &= ~FLAMMABLE
 
 ///Stronk force increase

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -189,6 +189,35 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	strength_modifier = 0.8
 	value_per_unit = 0.025
 
+/datum/material/wood
+	name = "wood"
+	id = "wood"
+	desc = "Flexible, durable, but flamable. Hard to come across in space."
+	color = "#bb8e53"
+	strength_modifier = 0.5
+	categories = list(MAT_CATEGORY_RIGID = TRUE)
+	value_per_unit = 0.06
+	beauty_modifier = 0.1
+	armor_modifiers = list("melee" = 1.1, "bullet" = 1.1, "laser" = 0.4, "energy" = 0.4, "bomb" = 1, "bio" = 0.2, "rad" = 0, "fire" = 0, "acid" = 0.3)
+
+/datum/material/wood/on_applied_obj(atom/source, amount, material_flags)
+	. = ..()
+	if(istype(source, /obj/item))
+		var/obj/item/wooden = source
+		wooden.resistance_flags |= FLAMMABLE
+		if(istype(wooden, /obj/item/melee))
+			var/obj/item/melee/wooden_stick = wooden
+			wooden_stick.force = 2
+
+/datum/material/wood/on_removed_obj(atom/source, material_flags)
+	. = ..()
+	if(istype(source, /obj/item))
+		var/obj/item/wooden = source
+		wooden.resistance_flags &= ~FLAMMABLE
+		if(istype(wooden, /obj/item/melee))
+			var/obj/item/melee/wooden_stick = wooden
+			wooden_stick.force = initial(wooden_stick.force)
+
 ///Stronk force increase
 /datum/material/adamantine
 	name = "adamantine"

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -202,13 +202,15 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/wood/on_applied_obj(obj/source, amount, material_flags)
 	. = ..()
-	var/obj/item/wooden = source
-	wooden.resistance_flags |= FLAMMABLE
+	if(material_flags & MATERIAL_AFFECT_STATISTICS)
+		var/obj/item/wooden = source
+		wooden.resistance_flags |= FLAMMABLE
 
 /datum/material/wood/on_removed_obj(obj/source, material_flags)
 	. = ..()
-	var/obj/item/wooden = source
-	wooden.resistance_flags &= ~FLAMMABLE
+	if(material_flags & MATERIAL_AFFECT_STATISTICS)
+		var/obj/item/wooden = source
+		wooden.resistance_flags &= ~FLAMMABLE
 
 ///Stronk force increase
 /datum/material/adamantine

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -62,7 +62,8 @@
 	/datum/material/runite,
 	/datum/material/plastic,
 	/datum/material/adamantine,
-	/datum/material/mythril
+	/datum/material/mythril,
+	/datum/material/wood
 	), 0, TRUE, null, null, CALLBACK(src, .proc/AfterMaterialInsert))
 	. = ..()
 
@@ -145,8 +146,8 @@
 		flick("autolathe_r",src)//plays glass insertion animation by default otherwise
 	else
 		flick("autolathe_o",src)//plays metal insertion animation
-			
-				
+
+
 		use_power(min(1000, amount_inserted / 100))
 	updateUsrDialog()
 

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -101,7 +101,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	name = "firebrand"
 	desc = "An unlit firebrand. It makes you wonder why it's not just called a stick."
 	smoketime = 20 //40 seconds
-	custom_materials = list(/datum/material/wood = 2000)
+	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT)
 	grind_results = list(/datum/reagent/carbon = 2)
 
 /obj/item/match/firebrand/Initialize()

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -101,6 +101,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	name = "firebrand"
 	desc = "An unlit firebrand. It makes you wonder why it's not just called a stick."
 	smoketime = 20 //40 seconds
+	custom_materials = list(/datum/material/wood = 2000)
 	grind_results = list(/datum/reagent/carbon = 2)
 
 /obj/item/match/firebrand/Initialize()

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -215,7 +215,7 @@
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 7
-	custom_materials = list(/datum/material/wood = 3000)
+	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 1.5)
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	custom_price = 200

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -215,6 +215,7 @@
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 7
+	custom_materials = list(/datum/material/wood = 3000)
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	custom_price = 200

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -108,7 +108,7 @@
 	item_state = "buckler"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
-	custom_materials = null
+	custom_materials = list(/datum/material/wood = 20000)
 	resistance_flags = FLAMMABLE
 	block_chance = 30
 	transparent = FALSE

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -108,7 +108,7 @@
 	item_state = "buckler"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
-	custom_materials = list(/datum/material/wood = 20000)
+	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 10)
 	resistance_flags = FLAMMABLE
 	block_chance = 30
 	transparent = FALSE

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -225,11 +225,13 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	icon_state = "sheet-wood"
 	item_state = "sheet-wood"
 	icon = 'icons/obj/stack_objects.dmi'
+	custom_materials = list(/datum/material/wood=MINERAL_MATERIAL_AMOUNT)
 	sheettype = "wood"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/sheet/mineral/wood
 	novariants = TRUE
+	material_type = /datum/material/wood
 	grind_results = list(/datum/reagent/cellulose = 20) //no lignocellulose or lignin reagents yet,
 
 /obj/item/stack/sheet/mineral/wood/get_main_recipes()

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -556,6 +556,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 10
 	throwforce = 12
 	attack_verb = list("beat", "smacked")
+	custom_materials = list(/datum/material/wood = 7000)
 	w_class = WEIGHT_CLASS_HUGE
 	var/homerun_ready = 0
 	var/homerun_able = 0

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -556,7 +556,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 10
 	throwforce = 12
 	attack_verb = list("beat", "smacked")
-	custom_materials = list(/datum/material/wood = 7000)
+	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 3.5)
 	w_class = WEIGHT_CLASS_HUGE
 	var/homerun_ready = 0
 	var/homerun_able = 0

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -11,6 +11,7 @@
 	desc = "Stylish dark wood."
 	icon_state = "wood"
 	floor_tile = /obj/item/stack/tile/wood
+	custom_materials = list(/datum/material/wood = 500)
 	broken_states = list("wood-broken", "wood-broken2", "wood-broken3", "wood-broken4", "wood-broken5", "wood-broken6", "wood-broken7")
 	footstep = FOOTSTEP_WOOD
 	barefootstep = FOOTSTEP_WOOD_BAREFOOT

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -11,7 +11,7 @@
 	desc = "Stylish dark wood."
 	icon_state = "wood"
 	floor_tile = /obj/item/stack/tile/wood
-	custom_materials = list(/datum/material/wood = 500)
+	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 0.25)
 	broken_states = list("wood-broken", "wood-broken2", "wood-broken3", "wood-broken4", "wood-broken5", "wood-broken6", "wood-broken7")
 	footstep = FOOTSTEP_WOOD
 	barefootstep = FOOTSTEP_WOOD_BAREFOOT

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -190,6 +190,7 @@
 	desc = "A creepy wooden mask. Surprisingly expressive for a poorly carved bit of wood."
 	icon_state = "tiki_eyebrow"
 	item_state = "tiki_eyebrow"
+	custom_materials = list(/datum/material/wood = 2500)
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
 	actions_types = list(/datum/action/item_action/adjust)

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -190,7 +190,7 @@
 	desc = "A creepy wooden mask. Surprisingly expressive for a poorly carved bit of wood."
 	icon_state = "tiki_eyebrow"
 	item_state = "tiki_eyebrow"
-	custom_materials = list(/datum/material/wood = 2500)
+	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 1.25)
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
 	actions_types = list(/datum/action/item_action/adjust)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -29,7 +29,7 @@
 	desc = "A pair of rather plain wooden sandals."
 	name = "sandals"
 	icon_state = "wizard"
-	custom_materials = list(/datum/material/wood = 1000)
+	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 0.5)
 	strip_delay = 5
 	equip_delay_other = 50
 	permeability_coefficient = 0.9

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -29,6 +29,7 @@
 	desc = "A pair of rather plain wooden sandals."
 	name = "sandals"
 	icon_state = "wizard"
+	custom_materials = list(/datum/material/wood = 1000)
 	strip_delay = 5
 	equip_delay_other = 50
 	permeability_coefficient = 0.9

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -71,7 +71,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("slashed", "sliced", "bashed", "clawed")
 	hitsound = null
-	custom_materials = null
+	custom_materials = list(/datum/material/wood = 3000)
 	flags_1 = NONE
 	resistance_flags = FLAMMABLE
 

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -71,7 +71,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("slashed", "sliced", "bashed", "clawed")
 	hitsound = null
-	custom_materials = list(/datum/material/wood = 3000)
+	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 1.5)
 	flags_1 = NONE
 	resistance_flags = FLAMMABLE
 

--- a/code/modules/photography/photos/frame.dm
+++ b/code/modules/photography/photos/frame.dm
@@ -4,7 +4,7 @@
 	name = "picture frame"
 	desc = "The perfect showcase for your favorite deathtrap memories."
 	icon = 'icons/obj/decals.dmi'
-	custom_materials = null
+	custom_materials = list(/datum/material/wood = 800)
 	flags_1 = 0
 	icon_state = "frame-empty"
 	result_path = /obj/structure/sign/picture_frame

--- a/code/modules/photography/photos/frame.dm
+++ b/code/modules/photography/photos/frame.dm
@@ -4,7 +4,7 @@
 	name = "picture frame"
 	desc = "The perfect showcase for your favorite deathtrap memories."
 	icon = 'icons/obj/decals.dmi'
-	custom_materials = list(/datum/material/wood = 800)
+	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 0.5)
 	flags_1 = 0
 	icon_state = "frame-empty"
 	result_path = /obj/structure/sign/picture_frame

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -245,7 +245,7 @@
 	name = "wooden bucket"
 	icon_state = "woodbucket"
 	item_state = "woodbucket"
-	custom_materials = null
+	custom_materials = list(/datum/material/wood = 4500)
 	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 50)
 	resistance_flags = FLAMMABLE
 
@@ -301,6 +301,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30, 50, 100)
 	volume = 100
+	custom_materials = list(/datum/material/wood = 2000)
 	reagent_flags = OPENCONTAINER
 	spillable = TRUE
 	var/obj/item/grinded

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -245,7 +245,7 @@
 	name = "wooden bucket"
 	icon_state = "woodbucket"
 	item_state = "woodbucket"
-	custom_materials = list(/datum/material/wood = 4500)
+	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 2)
 	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 50)
 	resistance_flags = FLAMMABLE
 
@@ -301,7 +301,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30, 50, 100)
 	volume = 100
-	custom_materials = list(/datum/material/wood = 2000)
+	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT)
 	reagent_flags = OPENCONTAINER
 	spillable = TRUE
 	var/obj/item/grinded


### PR DESCRIPTION

## About The Pull Request

We have plenty of wooden items on-station at the moment anyway, so there's no real issue with expanding datum materials for these. I don't know if biomass was originally supposed to be wood or not, but I imagine that's supposed to be more like "plant matter" than anything else, so I went with this.

Anything made out of wood automatically becomes flamable, and by default wooden materials have weaker melee damage if it's affected by datum mats, to work more in line with being ["fake weapons"](https://www.youtube.com/watch?v=x5-JVvCrGC8).

## Why It's Good For The Game

Expands Datum Mats, making wood recyclable to a degree, and makes wood behave more like "wood".

## Changelog
:cl:
tweak: Wood is now a datum material, and behaves like other datum materials.
/:cl:
