### PR TITLE
Radioactive contamination rework(/severe nerf)

### DIFF
--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -48,7 +48,7 @@ Ask ninjanomnom if they're around
 // contamination_strength = 	(strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT
 #define RAD_MINIMUM_CONTAMINATION 350				// How strong does a radiation wave have to be to contaminate objects
 #define RAD_CONTAMINATION_CHANCE_COEFFICIENT 0.01	// Higher means higher strength scaling contamination chance
-#define RAD_CONTAMINATION_STR_COEFFICIENT 0.25		// Higher means higher strength scaling contamination strength
+#define RAD_CONTAMINATION_STR_COEFFICIENT 0.3		// Higher means higher strength scaling contamination strength
 #define RAD_DISTANCE_COEFFICIENT 1					// Lower means further rad spread
 
 #define RAD_HALF_LIFE 90							// The half-life of contaminated objects

--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -49,8 +49,8 @@
 	if(strength<RAD_BACKGROUND_RADIATION)
 		qdel(src)
 		return
-	var/last_radiation_amount = radiate(atoms, FLOOR(min(strength,remaining_contam), 1))
-	remaining_contam = max(0,remaining_contam-last_radiation_amount)
+	var/last_contam_amount = radiate(atoms, strength)
+	remaining_contam = max(0,remaining_contam-last_contam_amount)
 	check_obstructions(atoms) // reduce our overall strength if there are radiation insulators
 
 /datum/radiation_wave/proc/get_rad_atoms()
@@ -112,14 +112,14 @@
 			/obj/item/implant,
 			/obj/singularity
 			))
-		if(!can_contaminate || blacklisted[thing.type])
+		if(!can_contaminate || !can_contam || blacklisted[thing.type])
 			continue
 		if(CHECK_BITFIELD(thing.rad_flags, RAD_NO_CONTAMINATE) || SEND_SIGNAL(thing, COMSIG_ATOM_RAD_CONTAMINATING, strength) & COMPONENT_BLOCK_CONTAMINATION)
 			continue
 		contam_atoms += thing
 	var/did_contam = 0
-	if(length(can_contam))
-		var/rad_strength = ((strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT)/contam_atoms.len
+	if(length(contam_atoms) && prob(50+steps*10)) // the prob lets it carry a bit further
+		var/rad_strength = min((strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT,remaining_contam)/contam_atoms.len
 		for(var/k in 1 to contam_atoms.len)
 			var/atom/thing = contam_atoms[k]
 			thing.AddComponent(/datum/component/radioactive, rad_strength, source)

--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -49,10 +49,8 @@
 	if(strength<RAD_BACKGROUND_RADIATION)
 		qdel(src)
 		return
-
-	if(radiate(atoms, FLOOR(min(strength,remaining_contam), 1)))
-		//oof ow ouch
-		remaining_contam = max(0,remaining_contam-((min(strength,remaining_contam)-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT))
+	var/last_radiation_amount = radiate(atoms, FLOOR(min(strength,remaining_contam), 1))
+	remaining_contam = max(0,remaining_contam-last_radiation_amount)
 	check_obstructions(atoms) // reduce our overall strength if there are radiation insulators
 
 /datum/radiation_wave/proc/get_rad_atoms()
@@ -119,11 +117,11 @@
 		if(CHECK_BITFIELD(thing.rad_flags, RAD_NO_CONTAMINATE) || SEND_SIGNAL(thing, COMSIG_ATOM_RAD_CONTAMINATING, strength) & COMPONENT_BLOCK_CONTAMINATION)
 			continue
 		contam_atoms += thing
-	var/did_contam = FALSE
+	var/did_contam = 0
 	if(length(can_contam))
 		var/rad_strength = ((strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT)/contam_atoms.len
 		for(var/k in 1 to contam_atoms.len)
 			var/atom/thing = contam_atoms[k]
 			thing.AddComponent(/datum/component/radioactive, rad_strength, source)
-			did_contam = TRUE
+			did_contam += rad_strength
 	return did_contam

--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -3,6 +3,7 @@
 	var/turf/master_turf //The center of the wave
 	var/steps=0 //How far we've moved
 	var/intensity //How strong it was originaly
+	var/remaining_contam //How much contaminated material it still has
 	var/range_modifier //Higher than 1 makes it drop off faster, 0.5 makes it drop off half etc
 	var/move_dir //The direction of movement
 	var/list/__dirs //The directions to the side of the wave, stored for easy looping
@@ -20,6 +21,7 @@
 	__dirs+=turn(dir, -90)
 
 	intensity = _intensity
+	remaining_contam = intensity
 	range_modifier = _range_modifier
 	can_contaminate = _can_contaminate
 
@@ -48,8 +50,9 @@
 		qdel(src)
 		return
 
-	radiate(atoms, FLOOR(strength, 1))
-
+	if(radiate(atoms, FLOOR(min(strength,remaining_contam), 1)))
+		//oof ow ouch
+		remaining_contam = max(0,remaining_contam-((min(strength,remaining_contam)-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT))
 	check_obstructions(atoms) // reduce our overall strength if there are radiation insulators
 
 /datum/radiation_wave/proc/get_rad_atoms()
@@ -91,7 +94,8 @@
 			intensity *= (1-((1-thing.rad_insulation)/width))
 
 /datum/radiation_wave/proc/radiate(list/atoms, strength)
-	var/contamination_chance = (strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_CHANCE_COEFFICIENT * min(1, 1/(steps*range_modifier))
+	var/can_contam = strength >= RAD_MINIMUM_CONTAMINATION
+	var/list/contam_atoms = list()
 	for(var/k in 1 to atoms.len)
 		var/atom/thing = atoms[k]
 		if(!thing)
@@ -112,8 +116,14 @@
 			))
 		if(!can_contaminate || blacklisted[thing.type])
 			continue
-		if(prob(contamination_chance)) // Only stronk rads get to have little baby rads
-			if(SEND_SIGNAL(thing, COMSIG_ATOM_RAD_CONTAMINATING, strength) & COMPONENT_BLOCK_CONTAMINATION)
-				continue
-			var/rad_strength = (strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT
+		if(CHECK_BITFIELD(thing.rad_flags, RAD_NO_CONTAMINATE) || SEND_SIGNAL(thing, COMSIG_ATOM_RAD_CONTAMINATING, strength) & COMPONENT_BLOCK_CONTAMINATION)
+			continue
+		contam_atoms += thing
+	var/did_contam = FALSE
+	if(length(can_contam))
+		var/rad_strength = ((strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT)/contam_atoms.len
+		for(var/k in 1 to contam_atoms.len)
+			var/atom/thing = contam_atoms[k]
 			thing.AddComponent(/datum/component/radioactive, rad_strength, source)
+			did_contam = TRUE
+	return did_contam


### PR DESCRIPTION
## About The Pull Request

Makes it so that a single radiation pulse has a limited amount of radioactive contamination, so it won't end up somehow creating more radiation than it started with. 

## Why It's Good For The Game

The most salient point I saw against the removal of cloning is that radiation will just *ruin* people without being able to kill-and-clone. However, this is not an argument against the removal of cloning: this is an argument against the current state of radioactive contamination. Naturally, I already made a fix for this elsewhere, so I'm porting it.

**I recommend making radiation more dangerous to individual mobs and maybe even make sources of radiation stronger in general to follow up on this.** I haven't paid enough attention to how good this is on Citadel where it's been running for a while, and it may be way too weak.

## Changelog
:cl: Putnam
balance: Radioactive contamination is no longer an infinitely recursing death spiral whose only solution is death or lying under a shower for a literal hour.
/:cl: