### PR TITLE
Fixes medbay lobby vent pressure

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -76337,10 +76337,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)


### PR DESCRIPTION
## About The Pull Request
Changes the vent in Medbay lobby from a server vent to a normal vent

## Why It's Good For The Game
I accidentally used the wrong vent, causing too much pressure to come into the Medbay lobby unnecessarily.

## Changelog
:cl: Vondiech
fix: Metastation medical lobby vent no longer over-pressurizes the lobby room.
/:cl:
