### PR TITLE
Makes the medical belt able to hold spray bottles and amputation shears.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -170,7 +170,9 @@
 		/obj/item/pinpointer/crew,
 		/obj/item/holosign_creator/medical,
 		/obj/item/construction/plumbing,
-		/obj/item/plunger
+		/obj/item/plunger,
+		/obj/item/reagent_containers/spray,
+		/obj/item/shears
 		))
 
 /obj/item/storage/belt/medical/paramedic/PopulateContents()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Spray bottles and all subtypes now fit in the medical belt.

The amputation shears now also fit in the medical belt.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Spray bottles are now used in medicine for administering rhigoxane and can also be used an an easy method of delivering alcoholic drinks for the purpose of surgical sterility.

The amputation shears, being a surgical tool is something players expect to be able to carry in their belt.

This slight buff to the medical belt is warranted, as many doctors tend to replace it with the compact defib pretty early(or carry both, but that is a problem for another PR). 

This change also makes it easier to ditch your backpack for a back slot item.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: spray bottles and amputation shears now fit in the medical belt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
