### PR TITLE
Actually adds the RSF sprite to the Rapid Service Fabricator

### DIFF
--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -70,6 +70,7 @@ RSF
 		var/mob/living/silicon/robot/R = user
 		if(!R.cell || R.cell.charge < 200)
 			to_chat(user, "<span class='warning'>You do not have enough power to use [src].</span>")
+			icon_state = "rsf_empty"
 			return
 	else if (matter < 1)
 		to_chat(user, "<span class='warning'>\The [src] doesn't have enough matter left.</span>")

--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -7,7 +7,7 @@ RSF
 	name = "\improper Rapid-Service-Fabricator"
 	desc = "A device used to rapidly deploy service items."
 	icon = 'icons/obj/tools.dmi'
-	icon_state = "rcd"
+	icon_state = "rsf"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	opacity = 0
@@ -35,6 +35,7 @@ RSF
 		matter += 10
 		playsound(src.loc, 'sound/machines/click.ogg', 10, TRUE)
 		to_chat(user, "<span class='notice'>The RSF now holds [matter]/30 fabrication-units.</span>")
+		icon_state = "rsf"
 	else
 		return ..()
 
@@ -72,6 +73,7 @@ RSF
 			return
 	else if (matter < 1)
 		to_chat(user, "<span class='warning'>\The [src] doesn't have enough matter left.</span>")
+		icon_state = "rsf_empty"
 		return
 
 	var/turf/T = get_turf(A)


### PR DESCRIPTION
## About The Pull Request

I made this a few months ago, but planned on implementing it in a PR after a different refactor PR for it was in the works. That PR got closed it seems, and I uhhh, "totally intentionally" realized about 10 minutes ago that these got merged in with a different PR. Whoops!
In any case, this attaches the new RSF sprite with the actual item. It doesn't really see much on-station use, but the cyborg version is default with service borgs.

![image](https://user-images.githubusercontent.com/41715314/72609654-818e0c80-38f3-11ea-861a-ea9e895740ac.png)


## Why It's Good For The Game

The default has service borgs using the RCD sprite instead, and this uses a distinct, green tool in it's place, differentiating it from other Rapid - X - Dispenser items that we have.

## Changelog
:cl:
imageadd: the Rapid Service Fabricator now actually has and uses it's own sprite instead of the RCD.
/:cl: