### PR TITLE
Removes dorms toolboxes, tool storage insuls and multitools.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -11700,10 +11700,6 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/obj/item/multitool,
-/obj/item/multitool{
-	pixel_x = 4
-	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aDo" = (
@@ -17723,14 +17719,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aTA" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "aTB" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -17739,10 +17727,6 @@
 /area/crew_quarters/locker)
 "aTC" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -70749,7 +70733,7 @@ aOp
 aPA
 aQR
 aQN
-aTA
+aTz
 aUq
 aWq
 aXs

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -46708,9 +46708,9 @@
 /area/storage/primary)
 "bKt" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/yellow,
 /obj/item/storage/box/lights/mixed,
 /obj/effect/turf_decal/bot,
+/obj/item/clothing/gloves/color/fyellow,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bKu" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -50214,8 +50214,6 @@
 /obj/structure/table/reinforced,
 /obj/item/assembly/timer,
 /obj/item/assembly/timer,
-/obj/item/multitool,
-/obj/item/multitool,
 /obj/machinery/light,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -70084,11 +70082,6 @@
 /area/crew_quarters/locker)
 "cAq" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/toolbox/emergency,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -4602,8 +4602,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Cargo - Docking Bay North";
-	dir = 2
+	c_tag = "Cargo - Docking Bay North"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -20242,10 +20241,6 @@
 /area/crew_quarters/kitchen)
 "bdD" = (
 /obj/structure/table,
-/obj/item/multitool{
-	pixel_x = 6
-	},
-/obj/item/multitool,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
 /obj/effect/turf_decal/tile/brown{

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -22847,7 +22847,6 @@
 	pixel_y = 4
 	},
 /obj/item/storage/toolbox/electrical,
-/obj/item/multitool,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -22855,7 +22854,6 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/item/multitool,
 /turf/open/floor/plasteel/dark,
 /area/storage/primary)
 "aKe" = (
@@ -58082,11 +58080,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/emergency,
+/obj/item/razor,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "bJp" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -72103,7 +72103,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/head/welding{
 	pixel_y = 4
 	},
@@ -72119,6 +72118,7 @@
 	network = list("ss13","engine")
 	},
 /obj/structure/cable,
+/obj/item/clothing/gloves/color/fyellow,
 /turf/open/floor/plasteel/dark,
 /area/storage/primary)
 "cen" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -16695,10 +16695,6 @@
 /obj/structure/table,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
-/obj/item/multitool,
-/obj/item/multitool{
-	pixel_x = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
@@ -18662,18 +18658,11 @@
 /area/crew_quarters/locker)
 "aPM" = (
 /obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 4;
-	pixel_y = -4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aPN" = (
@@ -19249,7 +19238,6 @@
 /area/crew_quarters/locker)
 "aRa" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/costume,
 /obj/effect/spawner/lootdrop/costume,
 /obj/item/clothing/mask/balaclava,
 /obj/machinery/airalarm{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18984,12 +18984,12 @@
 	dir = 4;
 	pixel_x = 27
 	},
-/obj/item/clothing/gloves/color/yellow,
 /obj/item/t_scanner,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/item/clothing/gloves/color/fyellow,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aQz" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -11069,8 +11069,6 @@
 /obj/structure/table,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
-/obj/item/multitool,
-/obj/item/multitool,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -27,9 +27,10 @@
 	drop_sound = 'sound/items/handling/multitool_drop.ogg'
 	pickup_sound =  'sound/items/handling/multitool_pickup.ogg'
 	custom_materials = list(/datum/material/iron=50, /datum/material/glass=20)
-	var/obj/machinery/buffer // simple machine buffer for device linkage
+	custom_premium_price = 450
 	toolspeed = 1
 	usesound = 'sound/weapons/empty.ogg'
+	var/obj/machinery/buffer // simple machine buffer for device linkage
 	var/mode = 0
 
 /obj/item/multitool/examine(mob/user)

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -4,22 +4,23 @@
 	icon_state = "tool"
 	icon_deny = "tool-deny"
 	products = list(/obj/item/stack/cable_coil = 10,
-		            /obj/item/crowbar = 5,
-		            /obj/item/weldingtool = 3,
-		            /obj/item/wirecutters = 5,
-		            /obj/item/wrench = 5,
-		            /obj/item/analyzer = 5,
-		            /obj/item/t_scanner = 5,
-		            /obj/item/screwdriver = 5,
-		            /obj/item/flashlight/glowstick = 3,
-		            /obj/item/flashlight/glowstick/red = 3,
-		            /obj/item/flashlight = 5,
-		            /obj/item/clothing/ears/earmuffs = 1)
+					/obj/item/crowbar = 5,
+					/obj/item/weldingtool = 3,
+					/obj/item/wirecutters = 5,
+					/obj/item/wrench = 5,
+					/obj/item/analyzer = 5,
+					/obj/item/t_scanner = 5,
+					/obj/item/screwdriver = 5,
+					/obj/item/flashlight/glowstick = 3,
+					/obj/item/flashlight/glowstick/red = 3,
+					/obj/item/flashlight = 5,
+					/obj/item/clothing/ears/earmuffs = 1)
 	contraband = list(/obj/item/clothing/gloves/color/fyellow = 2)
 	premium = list(/obj/item/storage/belt/utility = 2,
-		           /obj/item/weldingtool/hugetank = 2,
-		           /obj/item/clothing/head/welding = 2,
-		           /obj/item/clothing/gloves/color/yellow = 1)
+					/obj/item/multitool = 2,
+					/obj/item/weldingtool/hugetank = 2,
+					/obj/item/clothing/head/welding = 2,
+					/obj/item/clothing/gloves/color/yellow = 1)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
 	default_price = 125


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gets rid of the dorms toolboxes, the tool storage multitools and replaces the remaining (meta, delta, kilo) tool storage insuls with budgets.
Added two multitools to the youtool premium section at 450 cr each.
Added a razor to kilostation dorms to fill the toolbox void.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less freebies, more economy.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
balance: Meta, Delta and Kilo tool storage insuls replaced with budgets.
balance: All stations have had their dorms toolboxes removed.
balance: Tool storage multitools removed, two added to the youtool premium section at 450cr each.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
