### PR TITLE
SSprofiler performance enhancements 

### DIFF
--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -10,8 +10,8 @@ SUBSYSTEM_DEF(profiler)
 	var/write_cost = 0
 
 /datum/controller/subsystem/profiler/stat_entry(msg)
-	msg += "F:[round(fetch_cost,1)]"
-	msg += "W:[round(write_cost,1)]"
+	msg += "F:[round(fetch_cost,1)]ms"
+	msg += "|W:[round(write_cost,1)]ms"
 	..(msg)
 
 /datum/controller/subsystem/profiler/Initialize()

--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -4,7 +4,8 @@ SUBSYSTEM_DEF(profiler)
 	name = "Profiler"
 	init_order = INIT_ORDER_PROFILER
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
-	wait = 600
+	wait = 3000
+	flags = SS_NO_TICK_CHECK 
 	var/fetch_cost = 0
 	var/write_cost = 0
 
@@ -50,6 +51,7 @@ SUBSYSTEM_DEF(profiler)
 	var/timer = TICK_USAGE_REAL
 	var/current_profile_data = world.Profile(PROFILE_REFRESH,format="json")
 	fetch_cost = MC_AVERAGE(fetch_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+	CHECK_TICK
 	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, profiling stopped manually before dump.")
 	var/json_file = file("[GLOB.log_directory]/[PROFILER_FILENAME]")

--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -49,7 +49,7 @@ SUBSYSTEM_DEF(profiler)
 #else
 	var/timer = TICK_USAGE_REAL
 	var/current_profile_data = world.Profile(PROFILE_REFRESH,format="json")
-	cost_fetch = MC_AVERAGE(cost_fetch, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+	fetch_cost = MC_AVERAGE(fetch_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, profiling stopped manually before dump.")
 	var/json_file = file("[GLOB.log_directory]/[PROFILER_FILENAME]")
@@ -57,5 +57,5 @@ SUBSYSTEM_DEF(profiler)
 		fdel(json_file)
 	timer = TICK_USAGE_REAL
 	WRITE_FILE(json_file, current_profile_data)
-	cost_write = MC_AVERAGE(cost_write, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+	write_cost = MC_AVERAGE(write_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 #endif

--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -9,8 +9,8 @@ SUBSYSTEM_DEF(profiler)
 	var/write_cost = 0
 
 /datum/controller/subsystem/profiler/stat_entry(msg)
-	msg += "F:round(fetch_cost,1)"
-	msg += "W:round(write_cost,1)"
+	msg += "F:[round(fetch_cost,1)]"
+	msg += "W:[round(write_cost,1)]"
 	..(msg)
 
 /datum/controller/subsystem/profiler/Initialize()


### PR DESCRIPTION
SSprofiler runs every 5 minutes now, it tells the mc that it might tick_overrun, and it sleeps between fetching the profiler data (the longer part of this operation) and saving it to disk. fetch and write costs are logged to the stat panel. 

@AnturK 