### PR TITLE
Removes dry heat sterilization reaction research point generation.

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -33,7 +33,6 @@
 #define NOBLIUM_RESEARCH_AMOUNT				1000
 #define BZ_RESEARCH_SCALE					4
 #define BZ_RESEARCH_MAX_AMOUNT				400
-#define MIASMA_RESEARCH_AMOUNT				40
 #define STIMULUM_RESEARCH_AMOUNT			50
 //Plasma fusion properties
 #define FUSION_ENERGY_THRESHOLD				3e9 	//Amount of energy it takes to start a fusion reaction

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -494,7 +494,6 @@
 
 	//Possibly burning a bit of organic matter through maillard reaction, so a *tiny* bit more heat would be understandable
 	air.temperature += cleaned_air * 0.002
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, cleaned_air*MIASMA_RESEARCH_AMOUNT)//Turns out the burning of miasma is kinda interesting to scientists
 
 /datum/gas_reaction/stim_ball
 	priority = 7


### PR DESCRIPTION
## About The Pull Request
Removes research generation from Dry Heat Sterilization reaction as lavaland can now be heated to research everything just few minutes in to the round.
The reason this removes it completely is because even with a small research point gain it will still generate way too many research points.

## Why It's Good For The Game
this is research nine minutes in with just few heat exchange pipes in lavaland: 
![image](https://user-images.githubusercontent.com/34602646/72667264-91f0d500-3a22-11ea-8249-19847e0d0981.png) (yes, that is 2 million research points)

## Changelog
:cl:
balance: Dry Heat Sterilization (converting miasma to oxygen with heat) no longer generates research points.
/:cl:
