### PR TITLE
Lawyer's department backpack is a briefcase

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -35,13 +35,14 @@
 #define ITEM_SLOT_NECK			(1<<12)
 #define ITEM_SLOT_HANDS			(1<<13)
 #define ITEM_SLOT_BACKPACK		(1<<14)
-#define ITEM_SLOT_SUITSTORE		(1<<15)
-#define ITEM_SLOT_LPOCKET		(1<<16)
-#define ITEM_SLOT_RPOCKET		(1<<17)
-#define ITEM_SLOT_HANDCUFFED	(1<<18)
-#define ITEM_SLOT_LEGCUFFED		(1<<19)
+#define ITEM_SLOT_LHANDSTORE	(1<<15)
+#define ITEM_SLOT_SUITSTORE		(1<<16)
+#define ITEM_SLOT_LPOCKET		(1<<17)
+#define ITEM_SLOT_RPOCKET		(1<<18)
+#define ITEM_SLOT_HANDCUFFED	(1<<19)
+#define ITEM_SLOT_LEGCUFFED		(1<<20)
 
-#define SLOTS_AMT				20 // Keep this up to date!
+#define SLOTS_AMT				21 // Keep this up to date!
 
 //SLOT GROUP HELPERS
 #define ITEM_SLOT_POCKETS		(ITEM_SLOT_LPOCKET|ITEM_SLOT_RPOCKET)

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -25,24 +25,47 @@
 	jobtype = /datum/job/lawyer
 
 	back = null
+	box = null//need to put it in backpack_contents instead since our backpack may not be on our back
 	belt = /obj/item/pda/lawyer
 	ears = /obj/item/radio/headset/headset_srvsec
 	uniform = /obj/item/clothing/under/rank/civilian/lawyer/bluesuit
 	suit = /obj/item/clothing/suit/toggle/lawyer
 	shoes = /obj/item/clothing/shoes/laceup
-	l_hand = /obj/item/storage/briefcase/lawyer
 	l_pocket = /obj/item/laser_pointer
 	r_pocket = /obj/item/clothing/accessory/lawyers_badge
 
 	chameleon_extras = /obj/item/stamp/law
 
-	backpack = null
-	satchel = null //any department backpack for the lawyer is no backpack, but you may still start with one by specifying your own
-	duffelbag = null
+	//see pre_equip for department gear
+	backpack_contents = list(/obj/item/storage/box/survival) //transfered to briefcase contents if they have it
+	var/list/briefcase_contents = list()
 
 
 /datum/outfit/job/lawyer/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
+	switch(H.backpack)
+		if(GBACKPACK)
+			back = /obj/item/storage/backpack //Grey backpack
+		if(GSATCHEL)
+			back = /obj/item/storage/backpack/satchel //Grey satchel
+		if(GDUFFELBAG)
+			back = /obj/item/storage/backpack/duffelbag //Grey Duffel bag
+		if(LSATCHEL)
+			back = /obj/item/storage/backpack/satchel/leather //Leather Satchel
+		else //departmental
+			back = null //Department gear is a suitcase for lawyer
+			l_hand = /obj/item/storage/briefcase/lawyer
+			briefcase_contents.Add(backpack_contents)
+			backpack_contents = list()
+
+	//converts the uniform string into the path we'll wear, whether it's the skirt or regular variant
+	var/holder
+	if(H.jumpsuit_style == PREF_SKIRT)
+		holder = "[uniform]/skirt"
+		if(!text2path(holder))
+			holder = "[uniform]"
+	else
+		holder = "[uniform]"
+	uniform = text2path(holder)
 	if(visualsOnly)
 		return
 
@@ -51,3 +74,15 @@
 	if(J.lawyers>1)
 		uniform = /obj/item/clothing/under/rank/civilian/lawyer/purpsuit
 		suit = /obj/item/clothing/suit/toggle/lawyer/purple
+
+/datum/outfit/job/lawyer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	if(briefcase_contents)
+		for(var/path in briefcase_contents)
+			var/number = briefcase_contents[path]
+			if(!isnum(number))//Default to 1
+				number = 1
+			for(var/i in 1 to number)
+				H.equip_to_slot_or_del(new path(H),ITEM_SLOT_LHANDSTORE, TRUE)

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -24,6 +24,7 @@
 	name = "Lawyer"
 	jobtype = /datum/job/lawyer
 
+	back = null
 	belt = /obj/item/pda/lawyer
 	ears = /obj/item/radio/headset/headset_srvsec
 	uniform = /obj/item/clothing/under/rank/civilian/lawyer/bluesuit
@@ -34,6 +35,10 @@
 	r_pocket = /obj/item/clothing/accessory/lawyers_badge
 
 	chameleon_extras = /obj/item/stamp/law
+
+	backpack = null
+	satchel = null //any department backpack for the lawyer is no backpack, but you may still start with one by specifying your own
+	duffelbag = null
 
 
 /datum/outfit/job/lawyer/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -989,6 +989,10 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			if(H.back)
 				if(SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_CAN_INSERT, I, H, TRUE))
 					return TRUE
+		if(ITEM_SLOT_LHANDSTORE)
+			if(H.held_items[LEFT_HANDS])
+				if(SEND_SIGNAL(H.held_items[LEFT_HANDS], COMSIG_TRY_STORAGE_CAN_INSERT, I, H, TRUE))
+					return TRUE
 			return FALSE
 	return FALSE //Unsupported slot
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -990,8 +990,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				if(SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_CAN_INSERT, I, H, TRUE))
 					return TRUE
 		if(ITEM_SLOT_LHANDSTORE)
-			if(H.held_items[LEFT_HANDS])
-				if(SEND_SIGNAL(H.held_items[LEFT_HANDS], COMSIG_TRY_STORAGE_CAN_INSERT, I, H, TRUE))
+			var/obj/item/held_left = H.get_held_items_for_side(LEFT_HANDS)
+			if(held_left)
+				if(SEND_SIGNAL(held_left, COMSIG_TRY_STORAGE_CAN_INSERT, I, H, TRUE))
 					return TRUE
 			return FALSE
 	return FALSE //Unsupported slot

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -75,7 +75,8 @@
 			if(!back || !SEND_SIGNAL(back, COMSIG_TRY_STORAGE_INSERT, I, src, TRUE))
 				not_handled = TRUE
 		if(ITEM_SLOT_LHANDSTORE)
-			if(!held_items[LEFT_HANDS] || !SEND_SIGNAL(held_items[LEFT_HANDS], COMSIG_TRY_STORAGE_INSERT, I, src, TRUE))
+			var/obj/item/held_left = get_held_items_for_side(LEFT_HANDS)
+			if(!held_left || !SEND_SIGNAL(held_left, COMSIG_TRY_STORAGE_INSERT, I, src, TRUE))
 				not_handled = TRUE
 		else
 			not_handled = TRUE

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -74,6 +74,9 @@
 		if(ITEM_SLOT_BACKPACK)
 			if(!back || !SEND_SIGNAL(back, COMSIG_TRY_STORAGE_INSERT, I, src, TRUE))
 				not_handled = TRUE
+		if(ITEM_SLOT_LHANDSTORE)
+			if(!held_items[LEFT_HANDS] || !SEND_SIGNAL(held_items[LEFT_HANDS], COMSIG_TRY_STORAGE_INSERT, I, src, TRUE))
+				not_handled = TRUE
 		else
 			not_handled = TRUE
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The lawyer may still start with a backpack by making their backpack style not departmental.

## Why It's Good For The Game

Lawyers should make more use of their really cool suitcases, including the passcode locked one they get roundstart. Style wise, the grey backpack totally ruins the look. And if they don't wanna be cool, they can easily opt out! I would also like to say this isnt part of some grand conspiracy about inventory so dont start you rats

## Changelog
:cl:
tweak: lawyer's department backpack... is no backpack!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
