### PR TITLE
[Ready][Ready]Adds the Nanite Replication Protocols node to BEPIS

### DIFF
--- a/code/__DEFINES/nanites.dm
+++ b/code/__DEFINES/nanites.dm
@@ -12,6 +12,10 @@
 #define NANITE_CLOUD_DISABLE 2
 #define NANITE_CLOUD_ENABLE	3
 
+///Nanite Protocol types
+#define NANITE_PROTOCOL_REPLICATION "nanite_replication"
+#define NANITE_PROTOCOL_STORAGE "nanite_storage"
+
 ///Nanite extra settings types: used to help uis know what type an extra setting is
 #define NESTYPE_TEXT "text"
 #define NESTYPE_NUMBER "number"

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -12,6 +12,8 @@
 	var/list/datum/nanite_program/programs = list()
 	var/max_programs = NANITE_PROGRAM_LIMIT
 
+	var/list/datum/nanite_program/protocol/protocols = list() ///Separate list of protocol programs, to avoid looping through the whole programs list when cheking for conflicts
+
 	var/stealth = FALSE //if TRUE, does not appear on HUDs and health scans
 	var/diagnostics = TRUE //if TRUE, displays program list when scanned by nanite scanners
 
@@ -114,7 +116,7 @@
 			cloud_sync()
 			next_sync = world.time + NANITE_SYNC_DELAY
 	set_nanite_bar()
-	
+
 
 /datum/component/nanites/proc/delete_nanites()
 	qdel(src)

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -13,7 +13,7 @@
 	var/max_programs = NANITE_PROGRAM_LIMIT
 
 	var/list/datum/nanite_program/protocol/protocols = list() ///Separate list of protocol programs, to avoid looping through the whole programs list when cheking for conflicts
-
+	var/start_time = 0 ///Timestamp to when the nanites were first inserted in the host
 	var/stealth = FALSE //if TRUE, does not appear on HUDs and health scans
 	var/diagnostics = TRUE //if TRUE, displays program list when scanned by nanite scanners
 
@@ -30,6 +30,8 @@
 
 		if(!(host_mob.mob_biotypes & (MOB_ORGANIC|MOB_UNDEAD))) //Shouldn't happen, but this avoids HUD runtimes in case a silicon gets them somehow.
 			return COMPONENT_INCOMPATIBLE
+
+		start_time = world.time
 
 		host_mob.hud_set_nanite_indicator()
 		START_PROCESSING(SSnanites, src)

--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -31,7 +31,7 @@
 	id = "research_nanites"
 	program_type = /datum/nanite_program/research
 	category = list("Utility Nanites")
-	
+
 /datum/design/nanites/researchplus
 	name = "Neural Network"
 	desc = "The nanites link the host's brains together forming a neural research network, that becomes more efficient with the amount of total hosts. Can be overloaded to increase research output."
@@ -532,3 +532,34 @@
 	id = "sensor_species_nanites"
 	program_type = /datum/nanite_program/sensor/species
 	category = list("Sensor Nanites")
+
+////////////////////NANITE PROTOCOLS//////////////////////////////////////
+//Note about the category name: The UI cuts the last 8 characters from the category name to remove the " Nanites" in the other categories
+//Because of this, Protocols was getting cut down to "P", so i had to add some padding
+/datum/design/nanites/kickstart
+	name = "Kickstart Protocol"
+	desc = "Replication Protocol: the nanites focus on early growth, heavily boosting replication rate for a few minutes after the initial implantation."
+	id = "kickstart_nanites"
+	program_type = /datum/nanite_program/protocol/kickstart
+	category = list("Protocols_Nanites")
+
+/datum/design/nanites/factory
+	name = "Factory Protocol"
+	desc = "Replication Protocol: the nanites build a factory matrix within the host, gradually increasing replication speed over time. The factory decays if the protocol is not active."
+	id = "factory_nanites"
+	program_type = /datum/nanite_program/protocol/factory
+	category = list("Protocols_Nanites")
+
+/datum/design/nanites/tinker
+	name = "Tinker Protocol"
+	desc = "Replication Protocol: the nanites learn to use metallic material in the host's bloodstream to speed up the replication process."
+	id = "tinker_nanites"
+	program_type = /datum/nanite_program/protocol/tinker
+	category = list("Protocols_Nanites")
+
+/datum/design/nanites/offline
+	name = "Offline Production Protocol"
+	desc = "Replication Protocol: while the host is asleep or otherwise unconcious, the nanites exploit the reduced interference to replicate more quickly."
+	id = "offline_nanites"
+	program_type = /datum/nanite_program/protocol/offline
+	category = list("Protocols_Nanites")

--- a/code/modules/research/nanites/nanite_program_hub.dm
+++ b/code/modules/research/nanites/nanite_program_hub.dm
@@ -20,7 +20,8 @@
 						list(name = "Sensor Nanites"),
 						list(name = "Augmentation Nanites"),
 						list(name = "Suppression Nanites"),
-						list(name = "Weaponized Nanites")
+						list(name = "Weaponized Nanites"),
+						list(name = "Protocols")
 						)
 
 /obj/machinery/nanite_program_hub/Initialize()

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -289,3 +289,23 @@
 		host_mob.investigate_log("'s [name] nanite program was deleted by [source] with code [code].", INVESTIGATE_NANITES)
 		qdel(src)
 
+///A nanite program containing a behaviour protocol. Only one protocol of each class can be active at once.
+/datum/nanite_program/protocol
+	name = "Nanite Protocol"
+	var/protocol_class = NONE
+
+/datum/nanite_program/protocol/check_conditions()
+	. = ..()
+	for(var/protocol in nanites.protocols)
+		var/datum/nanite_program/protocol/P = protocol
+		if(P != src && P.activated && P.protocol_class == protocol_class)
+			return FALSE
+
+/datum/nanite_program/protocol/on_add(datum/component/nanites/_nanites)
+	..()
+	nanites.protocols += src
+
+/datum/nanite_program/protocol/Destroy()
+	if(nanites)
+		nanites.protocols -= src
+	return ..()

--- a/code/modules/research/nanites/nanite_programs/protocols.dm
+++ b/code/modules/research/nanites/nanite_programs/protocols.dm
@@ -1,0 +1,90 @@
+//Replication Protocols
+/datum/nanite_program/protocol/kickstart
+	name = "Kickstart Protocol"
+	desc = "Replication Protocol: the nanites focus on early growth, heavily boosting replication rate for a few minutes after the initial implantation."
+	use_rate = 0
+	rogue_types = list(/datum/nanite_program/necrotic)
+	protocol_class = NANITE_PROTOCOL_REPLICATION
+	var/implantation_time = 0
+	var/boost_duration = 1200
+
+/datum/nanite_program/protocol/kickstart/on_mob_add()
+	..()
+	implantation_time = world.time
+
+/datum/nanite_program/protocol/kickstart/check_conditions()
+	if(!(world.time < implantation_time + boost_duration))
+		return FALSE
+	return ..()
+
+/datum/nanite_program/protocol/kickstart/active_effect()
+	nanites.adjust_nanites(null, 3.5)
+
+/datum/nanite_program/protocol/factory
+	name = "Factory Protocol"
+	desc = "Replication Protocol: the nanites build a factory matrix within the host, gradually increasing replication speed over time. The factory decays if the protocol is not active."
+	use_rate = 0
+	rogue_types = list(/datum/nanite_program/necrotic)
+	protocol_class = NANITE_PROTOCOL_REPLICATION
+	var/factory_efficiency = 0
+	var/max_efficiency = 400 //Goes up to 2 bonus regen per tick
+
+/datum/nanite_program/protocol/factory/on_process()
+	if(!activated || !check_conditions())
+		factory_efficiency = max(0, factory_efficiency - 3)
+	..()
+
+/datum/nanite_program/protocol/factory/active_effect()
+	factory_efficiency = min(factory_efficiency + 1, max_efficiency)
+	nanites.adjust_nanites(null, round(0.005 * factory_efficiency, 0.5))
+
+/datum/nanite_program/protocol/tinker
+	name = "Tinker Protocol"
+	desc = "Replication Protocol: the nanites learn to use metallic material in the host's bloodstream to speed up the replication process."
+	use_rate = 0
+	rogue_types = list(/datum/nanite_program/necrotic)
+	protocol_class = NANITE_PROTOCOL_REPLICATION
+	var/boost = 1.5
+	var/list/valid_reagents = list(
+		/datum/reagent/iron,
+		/datum/reagent/copper,
+		/datum/reagent/gold,
+		/datum/reagent/silver,
+		/datum/reagent/mercury,
+		/datum/reagent/aluminium,
+		/datum/reagent/silicon)
+
+/datum/nanite_program/protocol/tinker/check_conditions()
+	if(!nanites.host_mob.reagents)
+		return FALSE
+
+	var/found_reagent = FALSE
+
+	var/datum/reagents/R = nanites.host_mob.reagents
+	for(var/VR in valid_reagents)
+		if(R.has_reagent(VR, 0.5))
+			R.remove_reagent(VR, 0.5)
+			found_reagent = TRUE
+			break
+	if(!found_reagent)
+		return FALSE
+	return ..()
+
+/datum/nanite_program/protocol/tinker/active_effect()
+	nanites.adjust_nanites(null, boost)
+
+/datum/nanite_program/protocol/offline
+	name = "Offline Production Protocol"
+	desc = "Replication Protocol: while the host is asleep or otherwise unconcious, the nanites exploit the reduced interference to replicate more quickly."
+	use_rate = 0
+	rogue_types = list(/datum/nanite_program/necrotic)
+	protocol_class = NANITE_PROTOCOL_REPLICATION
+	var/boost = 2.5
+
+/datum/nanite_program/protocol/offline/check_conditions()
+	if(!(nanites.host_mob.IsSleeping() || nanites.host_mob.IsUnconscious() || nanites.host_mob.health <= nanites.host_mob.crit_threshold || HAS_TRAIT(nanites.host_mob, TRAIT_DEATHCOMA)))
+		return FALSE
+	return ..()
+
+/datum/nanite_program/protocol/offline/active_effect()
+	nanites.adjust_nanites(null, boost)

--- a/code/modules/research/nanites/nanite_programs/protocols.dm
+++ b/code/modules/research/nanites/nanite_programs/protocols.dm
@@ -22,21 +22,34 @@
 
 /datum/nanite_program/protocol/factory
 	name = "Factory Protocol"
-	desc = "Replication Protocol: the nanites build a factory matrix within the host, gradually increasing replication speed over time. The factory decays if the protocol is not active."
+	desc = "Replication Protocol: the nanites build a factory matrix within the host, gradually increasing replication speed over time. \
+	The factory decays if the protocol is not active, or if the nanites are disrupted by shocks or EMPs."
 	use_rate = 0
 	rogue_types = list(/datum/nanite_program/necrotic)
 	protocol_class = NANITE_PROTOCOL_REPLICATION
 	var/factory_efficiency = 0
-	var/max_efficiency = 400 //Goes up to 2 bonus regen per tick
+	var/max_efficiency = 2000 //Goes up to 2 bonus regen per tick after 18 minutes and 20 seconds
 
 /datum/nanite_program/protocol/factory/on_process()
 	if(!activated || !check_conditions())
-		factory_efficiency = max(0, factory_efficiency - 3)
+		factory_efficiency = max(0, factory_efficiency - 5)
 	..()
+
+/datum/nanite_program/protocol/factory/on_emp(severity)
+	..()
+	factory_efficiency = max(0, factory_efficiency - 300)
+
+/datum/nanite_program/protocol/factory/on_shock(shock_damage)
+	..()
+	factory_efficiency = max(0, factory_efficiency - 200)
+
+/datum/nanite_program/protocol/factory/on_minor_shock()
+	..()
+	factory_efficiency = max(0, factory_efficiency - 100)
 
 /datum/nanite_program/protocol/factory/active_effect()
 	factory_efficiency = min(factory_efficiency + 1, max_efficiency)
-	nanites.adjust_nanites(null, round(0.005 * factory_efficiency, 0.5))
+	nanites.adjust_nanites(null, round(0.001 * factory_efficiency, 0.1))
 
 /datum/nanite_program/protocol/tinker
 	name = "Tinker Protocol"

--- a/code/modules/research/nanites/nanite_programs/protocols.dm
+++ b/code/modules/research/nanites/nanite_programs/protocols.dm
@@ -95,9 +95,9 @@
 		is_offline = TRUE
 	if(nanites.host_mob.stat == DEAD || HAS_TRAIT(nanites.host_mob, TRAIT_DEATHCOMA))
 		is_offline = TRUE
-	if(nanites.host_mob.InCritical() && !HAS_TRAIT(nanites.host_mob, TRAIT_NOSOFTCRIT)))
+	if(nanites.host_mob.InCritical() && !HAS_TRAIT(nanites.host_mob, TRAIT_NOSOFTCRIT))
 		is_offline = TRUE
-	if(nanites.host_mob.InFullCritical() && !HAS_TRAIT(nanites.host_mob, TRAIT_NOHARDCRIT)))
+	if(nanites.host_mob.InFullCritical() && !HAS_TRAIT(nanites.host_mob, TRAIT_NOHARDCRIT))
 		is_offline = TRUE
 	if(!is_offline)
 		return FALSE

--- a/code/modules/research/nanites/nanite_programs/protocols.dm
+++ b/code/modules/research/nanites/nanite_programs/protocols.dm
@@ -5,15 +5,10 @@
 	use_rate = 0
 	rogue_types = list(/datum/nanite_program/necrotic)
 	protocol_class = NANITE_PROTOCOL_REPLICATION
-	var/implantation_time = 0
 	var/boost_duration = 1200
 
-/datum/nanite_program/protocol/kickstart/on_mob_add()
-	..()
-	implantation_time = world.time
-
 /datum/nanite_program/protocol/kickstart/check_conditions()
-	if(!(world.time < implantation_time + boost_duration))
+	if(!(world.time < nanites.start_time + boost_duration))
 		return FALSE
 	return ..()
 
@@ -28,7 +23,7 @@
 	rogue_types = list(/datum/nanite_program/necrotic)
 	protocol_class = NANITE_PROTOCOL_REPLICATION
 	var/factory_efficiency = 0
-	var/max_efficiency = 2000 //Goes up to 2 bonus regen per tick after 18 minutes and 20 seconds
+	var/max_efficiency = 1000 //Goes up to 2 bonus regen per tick after 16 minutes and 40 seconds
 
 /datum/nanite_program/protocol/factory/on_process()
 	if(!activated || !check_conditions())
@@ -49,7 +44,7 @@
 
 /datum/nanite_program/protocol/factory/active_effect()
 	factory_efficiency = min(factory_efficiency + 1, max_efficiency)
-	nanites.adjust_nanites(null, round(0.001 * factory_efficiency, 0.1))
+	nanites.adjust_nanites(null, round(0.002 * factory_efficiency, 0.1))
 
 /datum/nanite_program/protocol/tinker
 	name = "Tinker Protocol"
@@ -57,7 +52,7 @@
 	use_rate = 0
 	rogue_types = list(/datum/nanite_program/necrotic)
 	protocol_class = NANITE_PROTOCOL_REPLICATION
-	var/boost = 1.5
+	var/boost = 2
 	var/list/valid_reagents = list(
 		/datum/reagent/iron,
 		/datum/reagent/copper,
@@ -92,10 +87,19 @@
 	use_rate = 0
 	rogue_types = list(/datum/nanite_program/necrotic)
 	protocol_class = NANITE_PROTOCOL_REPLICATION
-	var/boost = 2.5
+	var/boost = 3
 
 /datum/nanite_program/protocol/offline/check_conditions()
-	if(!(nanites.host_mob.IsSleeping() || nanites.host_mob.IsUnconscious() || nanites.host_mob.health <= nanites.host_mob.crit_threshold || HAS_TRAIT(nanites.host_mob, TRAIT_DEATHCOMA)))
+	var/is_offline = FALSE
+	if(nanites.host_mob.IsSleeping() || nanites.host_mob.IsUnconscious())
+		is_offline = TRUE
+	if(nanites.host_mob.stat == DEAD || HAS_TRAIT(nanites.host_mob, TRAIT_DEATHCOMA)))
+		is_offline = TRUE
+	if(nanites.host_mob.InCritical() && !HAS_TRAIT(nanites.host_mob, TRAIT_NOSOFTCRIT)))
+		is_offline = TRUE
+	if(nanites.host_mob.InFullCritical() && !HAS_TRAIT(nanites.host_mob, TRAIT_NOHARDCRIT)))
+		is_offline = TRUE
+	if(!is_offline)
 		return FALSE
 	return ..()
 

--- a/code/modules/research/nanites/nanite_programs/protocols.dm
+++ b/code/modules/research/nanites/nanite_programs/protocols.dm
@@ -93,7 +93,7 @@
 	var/is_offline = FALSE
 	if(nanites.host_mob.IsSleeping() || nanites.host_mob.IsUnconscious())
 		is_offline = TRUE
-	if(nanites.host_mob.stat == DEAD || HAS_TRAIT(nanites.host_mob, TRAIT_DEATHCOMA)))
+	if(nanites.host_mob.stat == DEAD || HAS_TRAIT(nanites.host_mob, TRAIT_DEATHCOMA))
 		is_offline = TRUE
 	if(nanites.host_mob.InCritical() && !HAS_TRAIT(nanites.host_mob, TRAIT_NOSOFTCRIT)))
 		is_offline = TRUE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1001,6 +1001,17 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000, TECHWEB_POINT_TYPE_NANITES = 4000)
 	export_price = 15000
 
+/datum/techweb_node/nanite_replication_protocols
+	id = "nanite_replication_protocols"
+	display_name = "Nanite Replication Protocols"
+	description = "Advanced behaviours that allow nanites to exploit certain circumstances to replicate faster."
+	prereq_ids = list("nanite_smart")
+	design_ids = list("kickstart_nanites","factory_nanites","tinker_nanites","offline_nanites")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000, TECHWEB_POINT_TYPE_NANITES = 2500)
+	export_price = 2500
+	hidden = TRUE
+	experimental = TRUE
+
 ////////////////////////Alien technology////////////////////////
 /datum/techweb_node/alientech //AYYYYYYYYLMAOO tech
 	id = "alientech"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2713,6 +2713,7 @@
 #include "code\modules\research\nanites\extra_settings\type.dm"
 #include "code\modules\research\nanites\nanite_programs\buffing.dm"
 #include "code\modules\research\nanites\nanite_programs\healing.dm"
+#include "code\modules\research\nanites\nanite_programs\protocols.dm"
 #include "code\modules\research\nanites\nanite_programs\rogue.dm"
 #include "code\modules\research\nanites\nanite_programs\sensor.dm"
 #include "code\modules\research\nanites\nanite_programs\suppression.dm"
@@ -2973,5 +2974,6 @@
 #include "interface\interface.dm"
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
+#include "tools\HubMigrator\HubMigrator.dm"
 #include "interface\skin.dmf"
 // END_INCLUDE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2974,6 +2974,5 @@
 #include "interface\interface.dm"
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
-#include "tools\HubMigrator\HubMigrator.dm"
 #include "interface\skin.dmf"
 // END_INCLUDE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the Replication Nanite Protocols research node to the BEPIS.
Researching it will unlock 4 different replication protocols.
Nanite protocols of the same category cannot function in the same nanite cloud, so only one can be chosen; although it is possible to switch between different ones by deactivating the unused ones.

The protocols are the following:
- Kickstart Protocol: dramatically increases nanite replication speed for the first two minutes after implantation.
- Factory Protocol: while active, slowly increases the replication rate, reaching the maximum after a bit more than 16 minutes. The bonus decays rapidly if the protocol is inactive, and is set back if affected by EMPs or shocks.
- Tinker Protocol: while active, nanites consume metallic or similar reagents in the host's bloodstream to boost replication rate.
- Offline Production Protocol: heavily increases replication rate while the host is sleeping or unconscious.

Numbers are subject to change.

## Why It's Good For The Game

More Bepis variety, also opens up some strategies in the usage of nanites in case the node gets researched, thanks to a higher replication rate cap.

## Changelog
:cl:
add: Added the Nanite Replication Protocols node to the B.E.P.I.S.
add: It contains 4 Nanite Protocols, i.e. Nanite Programs that cannot be active at the same time in a host. These programs boost Nanite replication rate in different scenarios.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
