### PR TITLE
Allows Strange Plants to distill into Unstable Mutagen

### DIFF
--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -48,7 +48,7 @@
 			to_chat(user, "<span class='warning'>[I] is stuck to your hand!</span>")
 			return TRUE
 		to_chat(user, "<span class='notice'>You place [I] into [src] to start the fermentation process.</span>")
-		addtimer(CALLBACK(src, .proc/makeWine, fruit), rand(80, 120) * speed_multiplier)
+		addtimer(CALLBACK(src, .proc/makeWine, fruit), rand(80, 120) * (speed_multiplier + fruit.distill_difficulty))
 		return TRUE
 	else
 		return ..()

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -18,6 +18,7 @@
 	var/dry_grind = FALSE //If TRUE, this object needs to be dry to be ground up
 	var/can_distill = TRUE //If FALSE, this object cannot be distilled into an alcohol.
 	var/distill_reagent //If NULL and this object can be distilled, it uses a generic fruit_wine reagent and adjusts its variables.
+	var/distill_difficulty = 0 // This is multiplied by the traditional fermentation rate, so that plants can distill at different rates.
 	var/wine_flavor //If NULL, this is automatically set to the fruit's flavor. Determines the flavor of the wine if distill_reagent is NULL.
 	var/wine_power = 10 //Determines the boozepwr of the wine if distill_reagent is NULL.
 

--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -27,6 +27,7 @@
 	desc = "What could this even be?"
 	icon_state = "crunchy"
 	bitesize_mod = 2
+	distill_reagent = /datum/reagent/toxin/mutagen
 
 /obj/item/reagent_containers/food/snacks/grown/random/Initialize()
 	. = ..()

--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -28,6 +28,7 @@
 	icon_state = "crunchy"
 	bitesize_mod = 2
 	distill_reagent = /datum/reagent/toxin/mutagen
+	distill_difficulty = 11.25	//Between 1:30 to 2:15 to ferment, to maintain cooperation as the best method to obtain mutagen.
 
 /obj/item/reagent_containers/food/snacks/grown/random/Initialize()
 	. = ..()


### PR DESCRIPTION
Yeah yeah, I know, another 1 line Botany Buff. Bare with me for a second here.

## About The Pull Request

Came to me during the recent discussions about botany balance on the discord. I understand that most people's concerns are in regard to Botany being Reliant on Strange Seeds/ Advanced Chems/ Cooperation, and I am also aware that MANY, MANY PRs before me have attempted to add unstable mutagen as a reward to the biogenerator before me. In avoiding those pitfalls, I starting thinking about a VERY underutilized mechanic that botany has exclusively: Fermentation. Since Strange Seeds are almost synonymous with botany being able to do the most exceptionally cool things within their department, I considered something different: giving botany an incentive to actually grow strange seeds once they gain access to them.

To do this:
Plants have a variable called distill_difficulty (default is zero) that's added to the barrel's specific distill_speed (default 1). This means that you can at least have a bit more control over how quickly different plants distill in the future, as currently only the barrel determine's fermentation speed, not the plant. Other plants maintain their old distill speeds and reagents, but this at least allows more expansion for easy use. Strange Plants have a very high distill_difficulty, putting them between 1:30 and 2:15 to distill into mutagen. With default, newly spawned strange seeds, if grown and then fermented, it will distill into 12.5 units of unstable mutagen each (ON AVERAGE), in addition to the strange plant's random reagent. This is increased/decreased with the plant's potency as per usual (Not changed).

## Why It's Good For The Game

I have been repeatedly reassured that in almost all cases, unstable mutagen would be faster to be obtained by growing blumpkins and glowshrooms than by fermenting any number of strange plants. In a worst case scenario, where perhaps a player doesn't have access to chemistry in-round for whatever reason (Medbay being bombed quickly, Chemists being snobs, Horrible antisocial behavior, etc.), that botanists would still have a way to access the 80% of botany content gated behind mutagen, but at an exceptionally slower rate. This to me feels like the right balance for interdepartmental balance, You don't have to make it impossible, but exceptionally faster to reward teamwork.

## Changelog
:cl:
add: Strange Plants can now be fermented into unstable mutagen.
/:cl:
