### PR TITLE
Fixes a few donutstation mapping issues

### DIFF
--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -6107,7 +6107,7 @@
 /area/hallway/primary/central)
 "aqG" = (
 /obj/structure/sink{
-	dir = 4;
+	dir = 8;
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel,
@@ -10891,7 +10891,7 @@
 /area/security/prison)
 "aDT" = (
 /obj/structure/sink{
-	dir = 4;
+	dir = 8;
 	pixel_x = 11
 	},
 /obj/structure/cable,
@@ -10977,7 +10977,7 @@
 /area/security/prison)
 "aEe" = (
 /obj/structure/sink{
-	dir = 4;
+	dir = 8;
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/freezer,
@@ -20168,7 +20168,7 @@
 	dir = 6
 	},
 /obj/structure/sink{
-	dir = 8;
+	dir = 4;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -21234,7 +21234,7 @@
 /area/crew_quarters/bar)
 "bgc" = (
 /obj/structure/sink{
-	dir = 4;
+	dir = 8;
 	pixel_x = 12
 	},
 /obj/structure/mirror{
@@ -24940,7 +24940,7 @@
 	dir = 4
 	},
 /obj/structure/sink{
-	dir = 8;
+	dir = 4;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -25239,7 +25239,7 @@
 /area/engine/atmos)
 "bqa" = (
 /obj/structure/sink{
-	dir = 8;
+	dir = 4;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -30621,7 +30621,7 @@
 /area/hydroponics/garden)
 "bCS" = (
 /obj/structure/sink{
-	dir = 4;
+	dir = 8;
 	pixel_x = 12
 	},
 /obj/item/radio/intercom{
@@ -32144,7 +32144,7 @@
 /area/security/courtroom)
 "bGp" = (
 /obj/structure/sink{
-	dir = 8;
+	dir = 4;
 	pixel_x = -12
 	},
 /turf/open/floor/plating,
@@ -35291,7 +35291,7 @@
 /area/gateway)
 "bOM" = (
 /obj/structure/sink{
-	dir = 4;
+	dir = 8;
 	pixel_x = 12
 	},
 /obj/structure/mirror{
@@ -36990,7 +36990,7 @@
 /area/science/lab)
 "bTq" = (
 /obj/structure/sink{
-	dir = 4;
+	dir = 8;
 	pixel_x = 11
 	},
 /obj/structure/mirror{
@@ -40248,7 +40248,7 @@
 /area/maintenance/port/fore)
 "ceh" = (
 /obj/structure/sink{
-	dir = 4;
+	dir = 8;
 	pixel_x = 12
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -1014,9 +1014,6 @@
 /area/maintenance/port)
 "acC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/sparker/toxmix{
-	pixel_y = -20
-	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
 "acD" = (
@@ -1034,9 +1031,6 @@
 /area/bridge)
 "acE" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input,
-/obj/machinery/sparker/toxmix{
-	pixel_y = -20
-	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
 "acF" = (
@@ -1173,11 +1167,11 @@
 /area/bridge)
 "acS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "acT" = (
@@ -1800,7 +1794,7 @@
 /area/gateway)
 "aev" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -8773,10 +8767,8 @@
 /area/engine/atmos)
 "ayb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "ayc" = (
@@ -9985,7 +9977,8 @@
 "aBf" = (
 /obj/machinery/door/airlock/research{
 	name = "Genetics Research Access";
-	req_access_txt = "9; 30"
+	req_access_txt = null;
+	req_one_access_txt = "9; 30"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -10571,12 +10564,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "aCY" = (
-/obj/machinery/door/airlock/research{
-	name = "Genetics Research Access";
-	req_access_txt = "47"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/research{
+	name = "Genetics Research Access";
+	req_access_txt = null;
+	req_one_access_txt = "9;30;47"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aCZ" = (
@@ -11972,15 +11966,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "aGw" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "Genetics Research";
-	req_access_txt = "9; 68"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/plasteel/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/genetics/cloning)
 "aGx" = (
 /obj/structure/disposalpipe/segment{
@@ -15367,7 +15358,6 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/landmark/start/geneticist,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aQE" = (
@@ -17390,7 +17380,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -18063,6 +18052,7 @@
 /area/medical/genetics)
 "aYg" = (
 /mob/living/carbon/monkey,
+/obj/effect/landmark/start/geneticist,
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "aYh" = (
@@ -23148,8 +23138,9 @@
 /area/science/robotics/lab)
 "bkF" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Medical/Science Maintenance Access";
-	req_one_access_txt = "5;47"
+	delayed_close_requested = null;
+	name = "Science Maintenance Access";
+	req_one_access_txt = "9;30;47;12"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37321,18 +37312,12 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bUf" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -37351,17 +37336,11 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bUh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -37375,9 +37354,6 @@
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -37393,13 +37369,6 @@
 /area/science/mixing)
 "bUm" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"bUn" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bUo" = (
@@ -43683,6 +43652,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"isH" = (
+/obj/machinery/igniter/incinerator_toxmix,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing)
 "itU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -45673,6 +45646,7 @@
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hydroponics)
 "naE" = (
@@ -46654,9 +46628,6 @@
 /obj/machinery/camera{
 	c_tag = "Research - Toxins Main 2";
 	network = list("ss13","Research")
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
 	},
 /obj/item/radio/intercom{
 	pixel_y = 29
@@ -48140,6 +48111,16 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
 /area/science/research)
+"rUP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "rUR" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -51095,6 +51076,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"yaP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/maintenance/port/fore)
 "ybh" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes/line{
@@ -71630,7 +71615,7 @@ acb
 acb
 adj
 aco
-bUn
+adQ
 adQ
 adQ
 aew
@@ -72139,7 +72124,7 @@ gJq
 jtf
 aal
 acm
-acr
+isH
 uuc
 ada
 adU
@@ -72649,15 +72634,15 @@ aeS
 aeS
 aeS
 eIR
-gJq
-aeS
-aeS
-aco
-aco
-aco
-aco
-aev
+rUP
+yaP
+yaP
 aiZ
+aiZ
+aiZ
+aiZ
+aev
+aco
 oMw
 njx
 bUr


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes a double window in brig.
Adds a missing disposal pipe to botany, trash chute now works.
Removes genetics door to medbay, gives access to former back door to science. They didnt have medbay access anyway. Moved a geneticist spawner out of cloning.
Replaced toxins wall igniters with a floor igniter. 
Moved toxins airlock cycling distro pipe so its not in the way of custom setups.
Flipped all dir 4 and dir 8 sinks, those had their icons changed recently.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #48848 and various other unreported issues.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Various donut station fixes: Toxins igniter works, distro pipe moved. Sinks flipped. Genetics access. Hydroponics disposals. Brig double window.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
