### PR TITLE
Adds a not garbage PDA manifest

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -231,13 +231,8 @@ Code:
 <a href='byond://?src=[REF(src)];choice=Signal Code;scode=1'>+</a>
 <a href='byond://?src=[REF(src)];choice=Signal Code;scode=5'>+</a><br>"}
 		if (41) //crew manifest
-
 			menu = "<h4>[PDAIMG(notes)] Crew Manifest</h4>"
-			menu += "Entries cannot be modified from this terminal.<br><br>"
-			if(GLOB.data_core.general)
-				for (var/datum/data/record/t in sortRecord(GLOB.data_core.general))
-					menu += "[t.fields["name"]] - [t.fields["rank"]]<br>"
-			menu += "<br>"
+			menu += "<center>[GLOB.data_core.get_manifest(monochrome=TRUE)]</center>"
 
 
 		if (42) //status displays


### PR DESCRIPTION
## About The Pull Request
~~Makes the PDA crew manifest available to everyone, and also~~ makes it look a whole load cleaner, as it now categorises by department instead of just alphabetical name
![image](https://user-images.githubusercontent.com/25063394/72933709-28423500-3d5a-11ea-8b88-6ed4995a7aee.png)
![image](https://user-images.githubusercontent.com/25063394/72933725-342df700-3d5a-11ea-8679-eceecd626950.png)

## Why It's Good For The Game
The current manifest is fucking atrocious

## Changelog
:cl: AffectedArc07
add: The crew manifest on the PDA is now bearable to use.
/:cl:

cobby edit: strikethrough