### PR TITLE
Pubby wayfinding beacons

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -7504,6 +7504,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
+/obj/machinery/navbeacon/wayfinding/minisat_access_ai,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "atN" = (
@@ -8072,6 +8073,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/vault,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "auZ" = (
@@ -8086,6 +8088,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/gateway,
 /turf/open/floor/plasteel,
 /area/gateway)
 "avb" = (
@@ -8932,6 +8935,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/navbeacon/wayfinding/sec,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "awO" = (
@@ -10322,6 +10326,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/aiupload,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aAD" = (
@@ -10485,6 +10490,7 @@
 	req_access_txt = "4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/navbeacon/wayfinding/det,
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "aBg" = (
@@ -11318,6 +11324,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/hop,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aCW" = (
@@ -13055,6 +13062,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/navbeacon/wayfinding/bridge,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aHh" = (
@@ -14252,6 +14260,7 @@
 	req_access_txt = "18"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/navbeacon/wayfinding/eva,
 /turf/open/floor/plasteel,
 /area/storage/eva)
 "aLc" = (
@@ -14267,6 +14276,7 @@
 	req_access_txt = "17"
 	},
 /obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/teleporter,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aLe" = (
@@ -17461,6 +17471,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/disposals,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aTz" = (
@@ -17784,6 +17795,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/navbeacon/wayfinding/cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aUp" = (
@@ -22080,6 +22092,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/navbeacon/wayfinding/hydro,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bel" = (
@@ -22135,6 +22148,7 @@
 	id = "kitchenwindowshutters";
 	name = "kitchen shutters"
 	},
+/obj/machinery/navbeacon/wayfinding/kitchen,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bep" = (
@@ -22471,6 +22485,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/janitor,
 /turf/open/floor/plasteel,
 /area/janitor)
 "bfj" = (
@@ -22943,6 +22958,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
 	},
+/obj/machinery/navbeacon/wayfinding/bar,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "bgv" = (
@@ -26361,6 +26377,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/navbeacon/wayfinding/med,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpV" = (
@@ -29114,6 +29131,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/navbeacon/wayfinding/minisat_access_chapel_library,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bws" = (
@@ -29568,6 +29586,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/research,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxr" = (
@@ -33443,10 +33462,10 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "bFy" = (
-/mob/living/carbon/monkey,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/science/genetics)
 "bFB" = (
@@ -38643,6 +38662,7 @@
 	name = "Atmospherics Monitoring";
 	req_access_txt = "24"
 	},
+/obj/machinery/navbeacon/wayfinding/atmos,
 /turf/open/floor/plasteel,
 /area/engine/lobby)
 "bRs" = (
@@ -38896,6 +38916,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/techstorage,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bRV" = (
@@ -39599,6 +39620,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/engineering,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bTG" = (
@@ -41580,6 +41602,7 @@
 	req_access_txt = "24"
 	},
 /obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/incinerator,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bYv" = (
@@ -43384,6 +43407,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding/minisat_access_tcomms,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cet" = (
@@ -45803,6 +45827,7 @@
 	name = "Dormitories"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/navbeacon/wayfinding/dorms,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cor" = (
@@ -50257,6 +50282,14 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"fTZ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/machinery/navbeacon/wayfinding/dockarrival,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "fUA" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
@@ -51453,6 +51486,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/navbeacon/wayfinding/dockescpod,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "izF" = (
@@ -53971,6 +54005,7 @@
 	id = "assistantshutters";
 	name = "storage shutters"
 	},
+/obj/machinery/navbeacon/wayfinding/tools,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "ooh" = (
@@ -55257,10 +55292,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "rlj" = (
-/mob/living/carbon/monkey,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/science/genetics)
 "rlV" = (
@@ -55839,6 +55874,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/lobby)
+"sEz" = (
+/obj/machinery/pinpointer_dispenser,
+/turf/closed/wall/r_wall,
+/area/security/checkpoint/customs)
 "sEB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -57497,6 +57536,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"wDs" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock";
+	safety_mode = 1
+	},
+/obj/machinery/navbeacon/wayfinding/dockesc,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "wDA" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel,
@@ -58069,6 +58119,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/navbeacon/wayfinding/lawyer,
 /turf/open/floor/plasteel/dark,
 /area/lawoffice)
 "xNx" = (
@@ -76334,7 +76385,7 @@ aHA
 aHA
 aHA
 xee
-aKB
+wDs
 nYn
 fTY
 xee
@@ -78654,7 +78705,7 @@ aWK
 aYG
 aZA
 baN
-bbQ
+fTZ
 bcX
 bdV
 aaa
@@ -80196,7 +80247,7 @@ aXK
 aXH
 aXH
 aXH
-aXH
+sEz
 bdc
 bdX
 bfa

--- a/code/game/objects/items/wayfinding.dm
+++ b/code/game/objects/items/wayfinding.dm
@@ -176,3 +176,134 @@
 //Navbeacon that initialises with wayfinding codes
 /obj/machinery/navbeacon/wayfinding
 	wayfinding = TRUE
+
+/* Defining these here instead of relying on map edits because it makes it easier to place them */
+
+//Command
+/obj/machinery/navbeacon/wayfinding/bridge
+	location = "Bridge"
+
+/obj/machinery/navbeacon/wayfinding/hop
+	location = "Head of Personnel's Office"
+
+/obj/machinery/navbeacon/wayfinding/vault
+	location = "Vault"
+
+/obj/machinery/navbeacon/wayfinding/teleporter
+	location = "Teleporter"
+
+/obj/machinery/navbeacon/wayfinding/gateway
+	location = "Gateway"
+
+/obj/machinery/navbeacon/wayfinding/eva
+	location = "EVA Storage"
+
+/obj/machinery/navbeacon/wayfinding/aiupload
+	location = "AI Upload"
+
+/obj/machinery/navbeacon/wayfinding/minisat_access_ai
+	location = "AI MiniSat Access"
+
+/obj/machinery/navbeacon/wayfinding/minisat_access_tcomms
+	location = "Telecomms MiniSat Access"
+
+/obj/machinery/navbeacon/wayfinding/minisat_access_tcomms_ai
+	location = "AI and Telecomms MiniSat Access"
+
+/obj/machinery/navbeacon/wayfinding/tcomms
+	location = "Telecommunications"
+
+//Departments
+/obj/machinery/navbeacon/wayfinding/sec
+	location = "Security"
+
+/obj/machinery/navbeacon/wayfinding/det
+	location = "Detective's Office"
+
+/obj/machinery/navbeacon/wayfinding/research
+	location = "Research"
+
+/obj/machinery/navbeacon/wayfinding/engineering
+	location = "Engineering"
+
+/obj/machinery/navbeacon/wayfinding/techstorage
+	location = "Technical Storage"
+
+/obj/machinery/navbeacon/wayfinding/atmos
+	location = "Atmospherics"
+
+/obj/machinery/navbeacon/wayfinding/med
+	location = "Medical"
+
+/obj/machinery/navbeacon/wayfinding/chemfactory
+	location = "Chemistry Factory"
+
+/obj/machinery/navbeacon/wayfinding/cargo
+	location = "Cargo"
+
+//Common areas
+/obj/machinery/navbeacon/wayfinding/bar
+	location = "Bar"
+
+/obj/machinery/navbeacon/wayfinding/dorms
+	location = "Dormitories"
+
+/obj/machinery/navbeacon/wayfinding/court
+	location = "Courtroom"
+
+/obj/machinery/navbeacon/wayfinding/tools
+	location = "Tool Storage"
+
+/obj/machinery/navbeacon/wayfinding/library
+	location = "Library"
+
+/obj/machinery/navbeacon/wayfinding/chapel
+	location = "Chapel"
+
+/obj/machinery/navbeacon/wayfinding/minisat_access_chapel_library
+	location = "Chapel and Library MiniSat Access"
+
+//Service
+/obj/machinery/navbeacon/wayfinding/kitchen
+	location = "Kitchen"
+
+/obj/machinery/navbeacon/wayfinding/hydro
+	location = "Hydroponics"
+
+/obj/machinery/navbeacon/wayfinding/janitor
+	location = "Janitor's Closet"
+
+/obj/machinery/navbeacon/wayfinding/lawyer
+	location = "Lawyer's Office"
+
+//Shuttle docks
+/obj/machinery/navbeacon/wayfinding/dockarrival
+	location = "Arrival Shuttle Dock"
+
+/obj/machinery/navbeacon/wayfinding/dockesc
+	location = "Escape Shuttle Dock"
+
+/obj/machinery/navbeacon/wayfinding/dockescpod
+	location = "Escape Pod Dock"
+
+/obj/machinery/navbeacon/wayfinding/dockescpod1
+	location = "Escape Pod 1 Dock"
+
+/obj/machinery/navbeacon/wayfinding/dockescpod2
+	location = "Escape Pod 2 Dock"
+
+/obj/machinery/navbeacon/wayfinding/dockescpod3
+	location = "Escape Pod 3 Dock"
+
+/obj/machinery/navbeacon/wayfinding/dockescpod4
+	location = "Escape Pod 4 Dock"
+
+/obj/machinery/navbeacon/wayfinding/dockaux
+	location = "Auxiliary Dock"
+
+//Maint
+/obj/machinery/navbeacon/wayfinding/incinerator
+	location = "Incinerator"
+
+/obj/machinery/navbeacon/wayfinding/disposals
+	location = "Disposals"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds wayfinding beacons and dispenser to PubbyStation. 

Also defines the beacons in code instead of using map edits. I'll change this on the other maps in a different PR later. This won't affect them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Help players who haven't mastered the map yet find their way around.

I think defining the beacons' location in code and making them children of the main one just makes them easier to place and maintain. You know where to put them, which areas you've already done and what will show on the player's pinpointer (e.g. Arrival Shuttle Dock instead of External Docking Port).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
tweak: Pubby has wayfinding now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
