### PR TITLE
Fixes junkie addictions bugging out after a relapse

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -501,7 +501,7 @@
 	if(world.time > next_process)
 		next_process = world.time + process_interval
 		if(!H.reagents.addiction_list.Find(reagent_instance))
-			if(!reagent_instance)
+			if(QDELETED(reagent_instance))
 				reagent_instance = new reagent_type()
 			else
 				reagent_instance.addiction_stage = 0


### PR DESCRIPTION
Addictions get deleted when they expire, but with junkie quirks the deletion was delayed enough for the addiction to get added back to the mob. This stuck a null in the mob's addiction list and lead to general trouble.

:cl: QualityVan
fix: Junkie relapses don't disappear any more.
/:cl: