### PR TITLE
Move drunken scientist quotes to strings

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -399,6 +399,7 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 #define BOOMER_FILE "boomer.json"
 #define LOCATIONS_FILE "locations.json"
 #define WANTED_FILE "wanted_message.json"
+#define VISTA_FILE "steve.json"
 
 //Fullscreen overlay resolution in tiles.
 #define FULLSCREEN_OVERLAY_RESOLUTION_X 15

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -415,19 +415,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 91-100: Dangerously toxic - swift death
 */
 #define BALLMER_POINTS 5
-GLOBAL_LIST_INIT(ballmer_good_msg, list("Hey guys, what if we rolled out a bluespace wiring system so mice can't destroy the powergrid anymore?",
-										"Hear me out here. What if, and this is just a theory, we made R&D controllable from our PDAs?",
-										"I'm thinking we should roll out a git repository for our research under the AGPLv3 license so that we can share it among the other stations freely.",
-										"I dunno about you guys, but IDs and PDAs being separate is clunky as fuck. Maybe we should merge them into a chip in our arms? That way they can't be stolen easily.",
-										"Why the fuck aren't we just making every pair of shoes into galoshes? We have the technology."))
-GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put a webserver that's automatically turned on with default admin passwords into every PDA?",
-												"So like, you know how we separate our codebase from the master copy that runs on our consumer boxes? What if we merged the two and undid the separation between codebase and server?",
-												"Dude, radical idea: H.O.N.K mechs but with no bananium required.",
-												"Best idea ever: Disposal pipes instead of hallways.",
-												"We should store bank records in a webscale datastore, like /dev/null.",
-												"You ever wonder if /dev/null supports sharding?",
-												"Do you know who ate all the donuts?",
-												"What if we use a language that was written on a napkin and created over 1 weekend for all of our servers?"))
 
 //this updates all special effects: stun, sleeping, knockdown, druggy, stuttering, etc..
 /mob/living/carbon/handle_status_effects()
@@ -524,12 +511,12 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 					else
 						ballmer_percent = (-abs(drunkenness - 13.35) / 0.9) + 1
 					if(prob(5))
-						say(pick(GLOB.ballmer_good_msg), forced = "ballmer")
+						say(pick_list_replacements(VISTA_FILE, "ballmer_good_msg"), forced = "ballmer")
 					SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = BALLMER_POINTS * ballmer_percent))
 				if(drunkenness > 26) // by this point you're into windows ME territory
 					if(prob(5))
 						SSresearch.science_tech.remove_point_list(list(TECHWEB_POINT_TYPE_GENERIC = BALLMER_POINTS))
-						say(pick(GLOB.ballmer_windows_me_msg), forced = "ballmer")
+						say(pick_list_replacements(VISTA_FILE, "ballmer_windows_me_msg"), forced = "ballmer")
 
 		if(drunkenness >= 41)
 			if(prob(25))

--- a/strings/steve.json
+++ b/strings/steve.json
@@ -1,0 +1,20 @@
+{
+    "ballmer_good_msg": [
+        "Hey guys, what if we rolled out a bluespace wiring system so mice can't destroy the powergrid anymore?",
+        "Hear me out here. What if, and this is just a theory, we made R&D controllable from our PDAs?",
+        "I'm thinking we should roll out a git repository for our research under the AGPLv3 license so that we can share it among the other stations freely.",
+        "I dunno about you guys, but IDs and PDAs being separate is clunky as fuck. Maybe we should merge them into a chip in our arms? That way they can't be stolen easily.",
+        "Why the fuck aren't we just making every pair of shoes into galoshes? We have the technology."
+    ],
+
+    "ballmer_windows_me_msg": [
+        "Yo man, what if, we like, uh, put a webserver that's automatically turned on with default admin passwords into every PDA?",
+        "So like, you know how we separate our codebase from the master copy that runs on our consumer boxes? What if we merged the two and undid the separation between codebase and server?",
+        "Dude, radical idea: H.O.N.K mechs but with no bananium required.",
+        "Best idea ever: Disposal pipes instead of hallways.",
+        "We should store bank records in a webscale datastore, like /dev/null.",
+        "You ever wonder if /dev/null supports sharding?",
+        "Do you know who ate all the donuts?",
+        "What if we use a language that was written on a napkin and created over 1 weekend for all of our servers?"
+    ]
+}


### PR DESCRIPTION
This moves the drunken scientist quotes into a strings file.

I used the `pick_list_replacements` proc even though there are no replacements, in case someone who edits the file wants to add some replacements.

I didn't take the opportunity to sneak in any lines, they are copied verbatim.