### PR TITLE
Removes AI satellite turret's dropping guns

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -41,7 +41,7 @@
 	var/locked = TRUE			//if the turret's behaviour control access is locked
 	var/controllock = FALSE		//if the turret responds to control panels
 
-	var/installation = /obj/item/gun/energy/e_gun/turret		//the type of weapon installed by default
+	var/installation = null		//the type of weapon installed by default
 	var/obj/item/gun/stored_gun = null
 	var/gun_charge = 0		//the charge of the gun when retrieved from wreckage
 
@@ -713,6 +713,10 @@
 		return TRUE
 
 /obj/machinery/porta_turret/ai
+	stun_projectile = /obj/projectile/energy/electrode
+	stun_projectile_sound = 'sound/weapons/taser.ogg'
+	lethal_projectile = /obj/projectile/beam/laser
+	lethal_projectile_sound = 'sound/weapons/laser.ogg'
 	faction = list("silicon")
 	turret_flags = TURRET_FLAG_SHOOT_CRIMINALS | TURRET_FLAG_SHOOT_ANOMALOUS | TURRET_FLAG_SHOOT_HEADS
 

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -41,7 +41,7 @@
 	var/locked = TRUE			//if the turret's behaviour control access is locked
 	var/controllock = FALSE		//if the turret responds to control panels
 
-	var/installation = null		//the type of weapon installed by default
+	var/installation = /obj/item/gun/energy/e_gun/turret		//the type of weapon installed by default
 	var/obj/item/gun/stored_gun = null
 	var/gun_charge = 0		//the charge of the gun when retrieved from wreckage
 
@@ -713,12 +713,17 @@
 		return TRUE
 
 /obj/machinery/porta_turret/ai
+	installation = null
 	stun_projectile = /obj/projectile/energy/electrode
 	stun_projectile_sound = 'sound/weapons/taser.ogg'
 	lethal_projectile = /obj/projectile/beam/laser
 	lethal_projectile_sound = 'sound/weapons/laser.ogg'
 	faction = list("silicon")
 	turret_flags = TURRET_FLAG_SHOOT_CRIMINALS | TURRET_FLAG_SHOOT_ANOMALOUS | TURRET_FLAG_SHOOT_HEADS
+
+/obj/machinery/porta_turret/ai/setup()
+	return
+
 
 /obj/machinery/porta_turret/ai/assess_perp(mob/living/carbon/human/perp)
 	return 10 //AI turrets shoot at everything not in their faction


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR stops AI satellite turrets from dropping a custom egun that:

a) has a taser setting
b) can be installed in turrets that do not have the AI turret's behaviours (shooting at all non-silicons)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Stops crew making stun turrets by nabbing special super guns on AI turrets.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arianya
tweak: In new cost saving measures, AI satellite turrets no longer come with a detachable hybrid energy gun. The new ingrained unit is irretrievably destroyed if the turret is destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
