### PR TITLE
Saves a bit of memory per decal

### DIFF
--- a/code/__DEFINES/cleaning.dm
+++ b/code/__DEFINES/cleaning.dm
@@ -9,6 +9,8 @@
 #define CLEAN_IMPRESSIVE	5
 /// Cleans things spotless down to the atomic structure
 #define CLEAN_GOD			6
+/// Never cleaned
+#define CLEAN_NEVER 7
 
 //How strong things have to be to wipe forensic evidence...
 #define CLEAN_STRENGTH_FINGERPRINTS CLEAN_IMPRESSIVE

--- a/code/datums/components/decal.dm
+++ b/code/datums/components/decal.dm
@@ -7,7 +7,7 @@
 
 	var/first_dir // This only stores the dir arg from init
 
-/datum/component/decal/Initialize(_icon, _icon_state, _dir, _cleanable=CLEAN_GOD, _color, _layer=TURF_LAYER, _description, _alpha=255)
+/datum/component/decal/Initialize(_icon, _icon_state, _dir, _cleanable=CLEAN_NEVER, _color, _layer=TURF_LAYER, _description, _alpha=255)
 	if(!isatom(parent) || !generate_appearance(_icon, _icon_state, _dir, _layer, _color, _alpha))
 		return COMPONENT_INCOMPATIBLE
 	first_dir = _dir
@@ -19,7 +19,7 @@
 /datum/component/decal/RegisterWithParent()
 	if(first_dir)
 		RegisterSignal(parent, COMSIG_ATOM_DIR_CHANGE, .proc/rotate_react)
-	if(cleanable)
+	if(cleanable != CLEAN_NEVER)
 		RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean_react)
 	if(description)
 		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/examine)

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -45,4 +45,4 @@
 	var/turf/T = loc
 	if(!istype(T)) //you know this will happen somehow
 		CRASH("Turf decal initialized in an object/nullspace")
-	T.AddComponent(/datum/component/decal, icon, icon_state, dir, CLEAN_GOD, color, null, null, alpha)
+	T.AddComponent(/datum/component/decal, icon, icon_state, dir, CLEAN_NEVER, color, null, null, alpha)


### PR DESCRIPTION
Since these never get cleaned, creating that signal list on every single turf with decal is kinda wasteful. Turn too, but that would need some more sensible shuttle detection and init.