### PR TITLE
Fix late join menu to handle disabled AI

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_INIT(position_categories, list(
 	EXP_TYPE_COMMAND = list("jobs" = command_positions, "color" = "#ccccff"),
 	EXP_TYPE_ENGINEERING = list("jobs" = engineering_positions, "color" = "#ffeeaa"),
 	EXP_TYPE_SUPPLY = list("jobs" = supply_positions, "color" = "#ddddff"),
-	EXP_TYPE_SILICON = list("jobs" = GLOB.nonhuman_positions - "pAI", "color" = "#ccffcc"),
+	EXP_TYPE_SILICON = list("jobs" = nonhuman_positions - "pAI", "color" = "#ccffcc"),
 	EXP_TYPE_SERVICE = list("jobs" = civilian_positions, "color" = "#bbe291"),
 	EXP_TYPE_MEDICAL = list("jobs" = medical_positions, "color" = "#ffddf0"),
 	EXP_TYPE_SCIENCE = list("jobs" = science_positions, "color" = "#ffddff"),

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -60,16 +60,17 @@ GLOBAL_LIST_INIT(nonhuman_positions, list(
 	"Cyborg",
 	ROLE_PAI))
 
+// include department colors for rendering the late join menu
 GLOBAL_LIST_INIT(exp_jobsmap, list(
-	EXP_TYPE_CREW = list("titles" = command_positions | engineering_positions | medical_positions | science_positions | supply_positions | security_positions | civilian_positions | list("AI","Cyborg")), // crew positions
-	EXP_TYPE_COMMAND = list("titles" = command_positions),
-	EXP_TYPE_ENGINEERING = list("titles" = engineering_positions),
-	EXP_TYPE_MEDICAL = list("titles" = medical_positions),
-	EXP_TYPE_SCIENCE = list("titles" = science_positions),
-	EXP_TYPE_SUPPLY = list("titles" = supply_positions),
-	EXP_TYPE_SECURITY = list("titles" = security_positions),
-	EXP_TYPE_SILICON = list("titles" = list("AI","Cyborg")),
-	EXP_TYPE_SERVICE = list("titles" = civilian_positions),
+	EXP_TYPE_CREW = list("titles" = command_positions | engineering_positions | medical_positions | science_positions | supply_positions | security_positions | civilian_positions | list("AI","Cyborg"), "color" = "#dddddd"), // crew positions
+	EXP_TYPE_COMMAND = list("titles" = command_positions, "color" = "#ccccff"),
+	EXP_TYPE_ENGINEERING = list("titles" = engineering_positions, "color" = "#ffeeaa"),
+	EXP_TYPE_SUPPLY = list("titles" = supply_positions, "color" = "#ddddff"),
+	EXP_TYPE_SILICON = list("titles" = list("AI","Cyborg"), "color" = "#ccffcc"),
+	EXP_TYPE_SERVICE = list("titles" = civilian_positions, "color" = "#bbe291"),
+	EXP_TYPE_MEDICAL = list("titles" = medical_positions, "color" = "#ffddf0"),
+	EXP_TYPE_SCIENCE = list("titles" = science_positions, "color" = "#ffddff"),
+	EXP_TYPE_SECURITY = list("titles" = security_positions, "color" = "#ffdddd")
 ))
 
 GLOBAL_LIST_INIT(exp_specialmap, list(

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -60,17 +60,28 @@ GLOBAL_LIST_INIT(nonhuman_positions, list(
 	"Cyborg",
 	ROLE_PAI))
 
-// include department colors for rendering the late join menu
+// job categories for rendering the late join menu
+GLOBAL_LIST_INIT(position_categories, list(
+	EXP_TYPE_COMMAND = list("jobs" = command_positions, "color" = "#ccccff"),
+	EXP_TYPE_ENGINEERING = list("jobs" = engineering_positions, "color" = "#ffeeaa"),
+	EXP_TYPE_SUPPLY = list("jobs" = supply_positions, "color" = "#ddddff"),
+	EXP_TYPE_SILICON = list("jobs" = GLOB.nonhuman_positions - "pAI", "color" = "#ccffcc"),
+	EXP_TYPE_SERVICE = list("jobs" = civilian_positions, "color" = "#bbe291"),
+	EXP_TYPE_MEDICAL = list("jobs" = medical_positions, "color" = "#ffddf0"),
+	EXP_TYPE_SCIENCE = list("jobs" = science_positions, "color" = "#ffddff"),
+	EXP_TYPE_SECURITY = list("jobs" = security_positions, "color" = "#ffdddd")
+))
+
 GLOBAL_LIST_INIT(exp_jobsmap, list(
-	EXP_TYPE_CREW = list("titles" = command_positions | engineering_positions | medical_positions | science_positions | supply_positions | security_positions | civilian_positions | list("AI","Cyborg"), "color" = "#dddddd"), // crew positions
-	EXP_TYPE_COMMAND = list("titles" = command_positions, "color" = "#ccccff"),
-	EXP_TYPE_ENGINEERING = list("titles" = engineering_positions, "color" = "#ffeeaa"),
-	EXP_TYPE_SUPPLY = list("titles" = supply_positions, "color" = "#ddddff"),
-	EXP_TYPE_SILICON = list("titles" = list("AI","Cyborg"), "color" = "#ccffcc"),
-	EXP_TYPE_SERVICE = list("titles" = civilian_positions, "color" = "#bbe291"),
-	EXP_TYPE_MEDICAL = list("titles" = medical_positions, "color" = "#ffddf0"),
-	EXP_TYPE_SCIENCE = list("titles" = science_positions, "color" = "#ffddff"),
-	EXP_TYPE_SECURITY = list("titles" = security_positions, "color" = "#ffdddd")
+	EXP_TYPE_CREW = list("titles" = command_positions | engineering_positions | medical_positions | science_positions | supply_positions | security_positions | civilian_positions | list("AI","Cyborg")), // crew positions
+	EXP_TYPE_COMMAND = list("titles" = command_positions),
+	EXP_TYPE_ENGINEERING = list("titles" = engineering_positions),
+	EXP_TYPE_MEDICAL = list("titles" = medical_positions),
+	EXP_TYPE_SCIENCE = list("titles" = science_positions),
+	EXP_TYPE_SUPPLY = list("titles" = supply_positions),
+	EXP_TYPE_SECURITY = list("titles" = security_positions),
+	EXP_TYPE_SILICON = list("titles" = list("AI","Cyborg")),
+	EXP_TYPE_SERVICE = list("titles" = civilian_positions)
 ))
 
 GLOBAL_LIST_INIT(exp_specialmap, list(

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -438,14 +438,14 @@
 			SSjob.prioritized_jobs -= prioritized_job
 	dat += "<table><tr><td valign='top'>"
 	var/column_counter = 0
-	// render each department's available jobs
-	for(var/category in (GLOB.exp_jobsmap - EXP_TYPE_CREW))
-		// exp_jobsmap contains department names mapped to available jobs and an appropriate color
-		var/cat_color = GLOB.exp_jobsmap[category]["color"]
+	// render each category's available jobs
+	for(var/category in GLOB.position_categories)
+		// position_categories contains category names mapped to available jobs and an appropriate color
+		var/cat_color = GLOB.position_categories[category]["color"]
 		dat += "<fieldset style='width: 185px; border: 2px solid [cat_color]; display: inline'>"
 		dat += "<legend align='center' style='color: [cat_color]'>[category]</legend>"
 		var/list/dept_dat = list()
-		for(var/job in GLOB.exp_jobsmap[category]["titles"])
+		for(var/job in GLOB.position_categories[category]["jobs"])
 			var/datum/job/job_datum = SSjob.name_occupations[job]
 			if(job_datum && IsJobUnavailable(job_datum.title, TRUE) == JOB_AVAILABLE)
 				var/command_bold = ""

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -438,12 +438,14 @@
 			SSjob.prioritized_jobs -= prioritized_job
 	dat += "<table><tr><td valign='top'>"
 	var/column_counter = 0
-	for(var/list/category in list(GLOB.command_positions) + list(GLOB.engineering_positions) + list(GLOB.supply_positions) + list(GLOB.nonhuman_positions - "pAI") + list(GLOB.civilian_positions) + list(GLOB.medical_positions) + list(GLOB.science_positions) + list(GLOB.security_positions))
-		var/cat_color = SSjob.name_occupations[category[1]].selection_color //use the color of the first job in the category (the department head) as the category color
+	// render each department's available jobs
+	for(var/category in (GLOB.exp_jobsmap - EXP_TYPE_CREW))
+		// exp_jobsmap contains department names mapped to available jobs and an appropriate color
+		var/cat_color = GLOB.exp_jobsmap[category]["color"]
 		dat += "<fieldset style='width: 185px; border: 2px solid [cat_color]; display: inline'>"
-		dat += "<legend align='center' style='color: [cat_color]'>[SSjob.name_occupations[category[1]].exp_type_department]</legend>"
+		dat += "<legend align='center' style='color: [cat_color]'>[category]</legend>"
 		var/list/dept_dat = list()
-		for(var/job in category)
+		for(var/job in GLOB.exp_jobsmap[category]["titles"])
 			var/datum/job/job_datum = SSjob.name_occupations[job]
 			if(job_datum && IsJobUnavailable(job_datum.title, TRUE) == JOB_AVAILABLE)
 				var/command_bold = ""


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes the problem found in  #48916 when AI is disabled. The late join menu was originally retrieving the category name and color from the first job in each category (typically the department head) and using that to style the menu. When AI is disabled it couldn't provide this information, and would crash the late join menu during rendering. This has been fixed by storing the category color in `exp_jobsmap`, which is an existing global list of job categories that was appropriately structured to store this data. Additionally `exp_jobsmap` has been reordered to retain the category order of the late join screen. Existing uses of this list did not care about index ordering, and are thus unaffected.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This change allows /tg/station and downstream stations to disable the AI without breaking the late join menu, which would prevent anyone from joining after the round starts. It does not change the perceived behavior of the screen at all and should go unnoticed by players.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed late join menu to work when AI is disabled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
