### PR TITLE
BoxStation Maint Bar Rework

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5278,7 +5278,7 @@
 /area/maintenance/disposal/incinerator)
 "alg" = (
 /obj/structure/sign/poster/contraband/random{
-	step_y = 32
+	pixel_y = 32
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
@@ -5961,7 +5961,7 @@
 "amR" = (
 /obj/structure/light_construct,
 /obj/structure/sign/poster/contraband/random{
-	step_y = -32
+	pixel_y = -32
 	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
@@ -6120,7 +6120,7 @@
 /area/maintenance/solars/port/fore)
 "ani" = (
 /obj/machinery/computer/security/telescreen/entertainment{
-	step_y = -32
+	pixel_y = -32
 	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
@@ -6284,8 +6284,7 @@
 "anB" = (
 /obj/item/chair/wood,
 /obj/structure/sign/poster/contraband/random{
-	step_x = 32;
-	step_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5206,6 +5206,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"akY" = (
+/obj/structure/table,
+/obj/item/circuitboard/machine/chem_dispenser/drinks,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
+"akZ" = (
+/obj/item/stack/sheet/metal/five,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"ala" = (
+/obj/machinery/door/window/eastright{
+	name = "Bar Access"
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "alb" = (
 /obj/structure/chair{
 	dir = 4;
@@ -5261,6 +5276,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"alg" = (
+/obj/structure/sign/poster/contraband/random{
+	step_y = 32
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "alh" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -5335,6 +5356,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/processing)
+"als" = (
+/obj/structure/mineral_door/wood{
+	name = "Maintenance Bar"
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "alt" = (
 /obj/structure/reagent_dispensers/peppertank,
 /turf/closed/wall/r_wall,
@@ -5353,6 +5380,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"alv" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "alw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -5487,6 +5518,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"alK" = (
+/obj/machinery/vending/boozeomat/all_access,
+/turf/closed/wall,
+/area/maintenance/port/aft)
 "alL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -5511,6 +5546,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"alN" = (
+/obj/structure/light_construct{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/retaliate/goose/vomit,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "alO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5536,6 +5578,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"alT" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "alU" = (
 /turf/closed/wall,
 /area/maintenance/port/fore)
@@ -5746,8 +5796,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "amu" = (
-/mob/living/simple_animal/hostile/retaliate/goose/vomit,
-/turf/open/floor/wood,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
 /area/maintenance/port/aft)
 "amv" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -5785,6 +5836,11 @@
 "amA" = (
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"amB" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/maintenance/port/aft)
 "amC" = (
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -5831,6 +5887,18 @@
 /obj/item/trash/plate,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"amI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"amJ" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/port/aft)
 "amK" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
@@ -5869,6 +5937,18 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"amO" = (
+/obj/structure/piano{
+	icon_state = "piano"
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
+"amP" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "amQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
@@ -5878,6 +5958,23 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
+"amR" = (
+/obj/structure/light_construct,
+/obj/structure/sign/poster/contraband/random{
+	step_y = -32
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/maintenance/port/aft)
+"amS" = (
+/obj/item/stack/cable_coil{
+	amount = 7;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "amT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -6021,6 +6118,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"ani" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	step_y = -32
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/maintenance/port/aft)
 "anj" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
 	dir = 8
@@ -6064,6 +6169,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"anq" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
+"anr" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck/cas{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/obj/item/toy/cards/deck/cas/black{
+	pixel_x = -7;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "ans" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -6158,6 +6281,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"anB" = (
+/obj/item/chair/wood,
+/obj/structure/sign/poster/contraband/random{
+	step_x = 32;
+	step_y = 0
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "anC" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -33933,14 +34064,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"bJP" = (
-/obj/machinery/vending/boozeomat/all_access,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/aft)
 "bJQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -36150,10 +36273,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"bPR" = (
-/obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
 "bPS" = (
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
@@ -36162,20 +36281,6 @@
 	icon_state = "wood-broken"
 	},
 /area/maintenance/port/aft)
-"bPU" = (
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bPV" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maint Bar Access";
-	req_access_txt = "12"
-	},
-/obj/structure/barricade/wooden{
-	name = "wooden barricade (CLOSED)"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bPW" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -36183,11 +36288,6 @@
 "bPX" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bPY" = (
-/obj/structure/girder,
-/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bPZ" = (
@@ -36543,10 +36643,6 @@
 "bRg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bRh" = (
-/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bRi" = (
@@ -37356,48 +37452,11 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/port/aft)
-"bTt" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/maintenance/port/aft)
-"bTu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
-"bTv" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bTw" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bTx" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bTy" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bTz" = (
@@ -72429,7 +72488,7 @@ bCq
 bCq
 bLv
 bCq
-aoV
+bCq
 cbj
 aoV
 aag
@@ -72682,10 +72741,10 @@ aaa
 aaa
 aaa
 bCq
-bJP
+akY
 bCq
 bSn
-bCq
+amO
 bCq
 cbj
 bLv
@@ -72941,8 +73000,8 @@ aaa
 bCq
 bPS
 aad
-bPS
 amu
+amP
 bCq
 cbk
 bLv
@@ -73196,10 +73255,10 @@ aaa
 aaa
 aaa
 bLv
-bPR
+akZ
 bRc
 bSo
-bTs
+amR
 bCq
 bVy
 bLv
@@ -73452,11 +73511,11 @@ aaa
 aaa
 aaa
 aaa
-bCq
+bLv
 bPS
 bRf
 bSo
-bTu
+amS
 bCq
 bVB
 bHE
@@ -73713,7 +73772,7 @@ bLv
 bPT
 bRe
 bSo
-bTt
+ani
 bCq
 bVA
 bWw
@@ -73966,11 +74025,11 @@ aaa
 aaa
 aaa
 aaa
-bCq
-bPV
-bCq
-bCq
-bTw
+bLv
+bPS
+alv
+bSo
+bPS
 bCq
 bVD
 bWy
@@ -74224,10 +74283,10 @@ bGi
 aoV
 aoV
 bCq
-bPU
-bHE
-bSp
-bTv
+ala
+alK
+bPS
+anq
 bCq
 bVC
 bWx
@@ -74481,10 +74540,10 @@ bGi
 aoV
 aoV
 bCq
-bPW
-bCq
-bCq
-bTy
+alg
+alN
+amB
+anr
 bCq
 bVF
 bWA
@@ -74738,10 +74797,10 @@ bGi
 aoV
 aoV
 bCq
-bHE
-bHE
-bSq
-bTx
+bTs
+bPS
+amI
+anB
 bCq
 bVE
 bWz
@@ -74995,9 +75054,9 @@ bxy
 aaf
 aaf
 bCq
-bPY
+als
 cOw
-bCq
+amJ
 bCq
 bCq
 bCq
@@ -75252,9 +75311,9 @@ bxy
 aaH
 aaH
 bCq
-bPX
+bHE
 bRg
-bRg
+bTx
 bCq
 bHE
 bVG
@@ -76281,7 +76340,7 @@ aaH
 aaH
 bCq
 bHE
-bRh
+alT
 bLu
 bCq
 bHE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Enhances the BoxStation maintenance bar somewhat, also doubles for me to learn about mapping.

Old bar:
![oldbar](https://user-images.githubusercontent.com/52262416/73110338-56647800-3f06-11ea-8e54-9e931966666c.png)
New bar:
![newbar](https://user-images.githubusercontent.com/52262416/73110357-69774800-3f06-11ea-8ab2-341546493e4c.png)


## Why It's Good For The Game

This PR aims to fix a small part about why BoxStation is generally disliked: Maintenance is boring.
Making the bar more interesting -even if a little- helps with exploring maintenance being more rewarding.

## Changelog
:cl:
tweak: BoxStation's abandoned bar has gotten some love from the local assistants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
