### PR TITLE
security and medical inquisition ert are now holy

### DIFF
--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -78,8 +78,16 @@
 /datum/antagonist/ert/medic/inquisitor
 	outfit = /datum/outfit/centcom/ert/medic/inquisitor
 
+/datum/antagonist/ert/medic/inquisitor/on_gain()
+	. = ..()
+	owner.isholy = TRUE
+
 /datum/antagonist/ert/security/inquisitor
 	outfit = /datum/outfit/centcom/ert/security/inquisitor
+
+/datum/antagonist/ert/security/inquisitor/on_gain()
+	. = ..()
+	owner.isholy = TRUE
 
 /datum/antagonist/ert/chaplain
 	role = "Chaplain"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
title explains it

## Why It's Good For The Game

they could be converted if their implant was removed even though they are literally the paranormal ert, you would think that the nanotrasen anti cult/wizard/other shit division would be actually holy

## Changelog
:cl:
tweak: security and medical inquisition ert are now holy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
