### PR TITLE
Fixes pestles

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -88,8 +88,8 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	null, \
 	new/datum/stack_recipe("iron door", /obj/structure/mineral_door/iron, 20, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("floodlight frame", /obj/structure/floodlight_frame, 5, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("voting box", /obj/structure/votebox, 15, time = 50), \
-	new/datum/stack_recipe("pestle", /obj/item/pestle, 1, time = 50)
+	new/datum/stack_recipe("pestle", /obj/item/pestle, 1, time = 50), \
+	new/datum/stack_recipe("voting box", /obj/structure/votebox, 15, time = 50)
 ))
 
 /obj/item/stack/sheet/metal


### PR DESCRIPTION

## About The Pull Request

Fixes a bug caused by #48901 which caused pestles to be uncraftable on the main servers due to the testmerge.
Allows for said testmerge without causing issues with crafting.

## Why It's Good For The Game

People will stop intermittently bringing this up in the discord, confusing me and ruining all discussion.
Also yaknow some people sometimes use this for things like ghetto chem, xeno shit, nerd stuff. Ehhh whatever.

## Changelog
:cl:
fix: Fixed pestles not being craft-able. 
/:cl:
