### PR TITLE
Fixes constructed display cases starting with an alarm system

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -214,7 +214,7 @@
 		to_chat(user, "<span class='notice'>You start adding [G] to [src]...</span>")
 		if(do_after(user, 20, target = src))
 			G.use(10)
-			var/obj/structure/displaycase/display = new(src.loc)
+			var/obj/structure/displaycase/noalert/display = new(src.loc)
 			if(electronics)
 				electronics.forceMove(display)
 				display.electronics = electronics
@@ -226,12 +226,10 @@
 	else
 		return ..()
 
-//The captains display case requiring specops ID access is intentional.
-//The lab cage and captains display case do not spawn with electronics, which is why req_access is needed.
+//The lab cage and captain's display case do not spawn with electronics, which is why req_access is needed.
 /obj/structure/displaycase/captain
-	alert = TRUE
 	start_showpiece_type = /obj/item/gun/energy/laser/captain
-	req_access = list(ACCESS_CENT_SPECOPS)
+	req_access = list(ACCESS_CENT_SPECOPS) //this was intentional, presumably to make it slightly harder for caps to grab their gun roundstart
 
 /obj/structure/displaycase/labcage
 	name = "lab cage"
@@ -239,14 +237,15 @@
 	start_showpiece_type = /obj/item/clothing/mask/facehugger/lamarr
 	req_access = list(ACCESS_RD)
 
+/obj/structure/displaycase/noalert
+	alert = FALSE
+
 /obj/structure/displaycase/trophy
 	name = "trophy display case"
 	desc = "Store your trophies of accomplishment in here, and they will stay forever."
 	var/placer_key = ""
 	var/added_roundstart = TRUE
 	var/is_locked = TRUE
-
-	alert = TRUE
 	integrity_failure = 0
 	openable = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes constructed display cases start without an alarm system. 
This may sound like fun removal, but consider the following: Anyone can build a case with a little wood+glass and smash it, which then bolts all doors in the area and toggles the fire alarm. Huge ~~fun~~ griff potential.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Closes: #41040
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Denton
tweak: Constructed display cases no longer spawn with an alarm that bolts all nearby doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
