### PR TITLE
Light step quirk rebalance

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -128,12 +128,17 @@ datum/quirk/fan_mime
 
 /datum/quirk/light_step
 	name = "Light Step"
-	desc = "You walk with a gentle step; stepping on sharp objects is quieter, less painful and you won't leave footprints behind you."
-	value = 1
+	desc = "You walk with a gentle step; footsteps and stepping on sharp objects is quieter and less painful."
+	value = 2
 	mob_trait = TRAIT_LIGHT_STEP
 	gain_text = "<span class='notice'>You walk with a little more litheness.</span>"
 	lose_text = "<span class='danger'>You start tromping around like a barbarian.</span>"
 	medical_record_text = "Patient's dexterity belies a strong capacity for stealth."
+
+/datum/quirk/light_step/on_spawn()
+	var/datum/component/footstep/C = quirk_holder.GetComponent(/datum/component/footstep)
+	C.volume *= 0.6
+	C.e_range -= 2
 
 /datum/quirk/musician
 	name = "Musician"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -129,7 +129,7 @@ datum/quirk/fan_mime
 /datum/quirk/light_step
 	name = "Light Step"
 	desc = "You walk with a gentle step; footsteps and stepping on sharp objects is quieter and less painful."
-	value = 2
+	value = 1
 	mob_trait = TRAIT_LIGHT_STEP
 	gain_text = "<span class='notice'>You walk with a little more litheness.</span>"
 	lose_text = "<span class='danger'>You start tromping around like a barbarian.</span>"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -137,8 +137,9 @@ datum/quirk/fan_mime
 
 /datum/quirk/light_step/on_spawn()
 	var/datum/component/footstep/C = quirk_holder.GetComponent(/datum/component/footstep)
-	C.volume *= 0.6
-	C.e_range -= 2
+	if(C)
+		C.volume *= 0.6
+		C.e_range -= 2
 
 /datum/quirk/musician
 	name = "Musician"

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -85,7 +85,7 @@
 	..()
 	if(ishuman(O))
 		var/mob/living/carbon/human/H = O
-		if(H.shoes && blood_state && bloodiness && !HAS_TRAIT(H, TRAIT_LIGHT_STEP))
+		if(H.shoes && blood_state && bloodiness)
 			var/obj/item/clothing/shoes/S = H.shoes
 			if(!S.can_be_bloody)
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the no bloody footprints part of light step and replaces it with quieter footsteps that cant be heard from quite as far away. Quirk price upped from 1 to 2.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This quirk is a no-brainer always get right now, because it is extremely useful. This rebalance makes it a bit more on theme, more situational and more expensive.
Should also make some more janitor work, which is always good!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
balance: Light step no longer prevents bloody/oily footprints, instead gives you quieter footsteps. Price upped to 2, from 1.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
