### PR TITLE
Fixes #49061

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_potions.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_potions.dm
@@ -41,24 +41,24 @@ Slimecrossing Potions
 
 /obj/item/slimepotion/peacepotion/attack(mob/living/M, mob/user)
 	if(!isliving(M) || M.stat == DEAD)
-		to_chat(user, "<span class='warning'>\The [src] only works on the living.</span>")
+		to_chat(user, "<span class='warning'>[src] only works on the living.</span>")
 		return ..()
 	if(istype(M, /mob/living/simple_animal/hostile/megafauna))
-		to_chat(user, "<span class='warning'>\The [src] does not work on beings of pure evil!</span>")
+		to_chat(user, "<span class='warning'>[src] does not work on beings of pure evil!</span>")
 		return ..()
 	if(M != user)
-		M.visible_message("<span class='danger'>[user] starts to feed [M] \a [src]!</span>",
-			"<span class='userdanger'>[user] starts to feed you \a [src]!</span>")
+		M.visible_message("<span class='danger'>[user] starts to feed [M] [src]!</span>",
+			"<span class='userdanger'>[user] starts to feed you [src]!</span>")
 	else
-		M.visible_message("<span class='danger'>[user] starts to drink \the [src]!</span>",
-			"<span class='danger'>You start to drink \the [src]!</span>")
+		M.visible_message("<span class='danger'>[user] starts to drink [src]!</span>",
+			"<span class='danger'>You start to drink [src]!</span>")
 
 	if(!do_after(user, 100, target = M))
 		return
 	if(M != user)
-		to_chat(user, "<span class='notice'>You feed [M] \the [src]!</span>")
+		to_chat(user, "<span class='notice'>You feed [M] [src]!</span>")
 	else
-		to_chat(user, "<span class='warning'>You drink \the [src]!</span>")
+		to_chat(user, "<span class='warning'>You drink [src]!</span>")
 	if(isanimal(M))
 		ADD_TRAIT(M, TRAIT_PACIFISM, MAGIC_TRAIT)
 	else if(iscarbon(M))

--- a/code/modules/research/xenobiology/crossbreeding/_potions.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_potions.dm
@@ -41,24 +41,24 @@ Slimecrossing Potions
 
 /obj/item/slimepotion/peacepotion/attack(mob/living/M, mob/user)
 	if(!isliving(M) || M.stat == DEAD)
-		to_chat(user, "<span class='warning'>The pacification potion only works on the living.</span>")
+		to_chat(user, "<span class='warning'>\The [src] only works on the living.</span>")
 		return ..()
 	if(istype(M, /mob/living/simple_animal/hostile/megafauna))
-		to_chat(user, "<span class='warning'>The pacification potion does not work on beings of pure evil!</span>")
+		to_chat(user, "<span class='warning'>\The [src] does not work on beings of pure evil!</span>")
 		return ..()
 	if(M != user)
-		M.visible_message("<span class='danger'>[user] starts to feed [M] a pacification potion!</span>",
-			"<span class='userdanger'>[user] starts to feed you a pacification!</span>")
+		M.visible_message("<span class='danger'>[user] starts to feed [M] \a [src]!</span>",
+			"<span class='userdanger'>[user] starts to feed you \a [src]!</span>")
 	else
-		M.visible_message("<span class='danger'>[user] starts to drink the pacification potion!</span>",
-			"<span class='danger'>You start to drink the pacification potion!</span>")
+		M.visible_message("<span class='danger'>[user] starts to drink \the [src]!</span>",
+			"<span class='danger'>You start to drink \the [src]!</span>")
 
 	if(!do_after(user, 100, target = M))
 		return
 	if(M != user)
-		to_chat(user, "<span class='notice'>You feed [M] the pacification potion!</span>")
+		to_chat(user, "<span class='notice'>You feed [M] \the [src]!</span>")
 	else
-		to_chat(user, "<span class='warning'>You drink the pacification potion!</span>")
+		to_chat(user, "<span class='warning'>You drink \the [src]!</span>")
 	if(isanimal(M))
 		ADD_TRAIT(M, TRAIT_PACIFISM, MAGIC_TRAIT)
 	else if(iscarbon(M))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the pacification potion userdanger message properly name the potion instead of "[user] starts to feed you a pacification!"

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
spellcheck: Being fed a pacification potion no longer refers to it as "a pacification"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
