### PR TITLE
Strange Reagent Rebalance (Mainly Nerfs to Min Req and Free Healing)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -706,15 +706,15 @@
 
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
-	description = "A miracle drug capable of bringing the dead back to life. Works topically if the target has less than 200 total brute and burn damage and hasn't been husked. Requires more reagent depending on damage inflicted. Causes damage to the living."
+	description = "A miracle drug capable of bringing the dead back to life. Works orally if the target has less than 200 total brute and burn damage and hasn't been husked. Requires more reagent depending on damage inflicted. Causes damage to the living."
 	reagent_state = LIQUID
 	color = "#A0E85E"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	metabolization_rate = 1.25 * REAGENTS_METABOLISM
 	taste_description = "magnets"
 	harmful = TRUE
 
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
-	if(M.stat != DEAD || method != TOUCH)
+	if(M.stat != DEAD || method != INGEST)
 		return ..()
 	if(M.suiciding || M.hellbound) //they are never coming back
 		M.visible_message("<span class='warning'>[M]'s body does not react...</span>")

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -706,7 +706,7 @@
 
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
-	description = "A miracle drug capable of bringing the dead back to life. If anotamically complex, works orally if the target has less than 200 total brute and burn damage and hasn't been husked. Requires more reagent depending on damage inflicted. Causes damage to the living."
+	description = "A miracle drug capable of bringing the dead back to life. Works topically unless anotamically complex, in which case works orally. Only works if the target has less than 200 total brute and burn damage and hasn't been husked and requires more reagent depending on damage inflicted. Causes damage to the living."
 	reagent_state = LIQUID
 	color = "#A0E85E"
 	metabolization_rate = 1.25 * REAGENTS_METABOLISM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
~~**WARNING: 🐕 not tested yet but was built off 🐈 which was.**~~

Edit: After testing 🐈, Now Uses Ingest (Touch has non-transfer applications) and metab rate has been bumped to 0.5 per tick.

Edit2: 🐟 now it can work on simplemobs again, fixes #47690

## About The Pull Request

Strange reagent now 

- buffed damage req to 200 total damage instead of 100 of either brute or burn

- requires upto 10u to revive at all. This is dependent on the total Brute/Burn damage

- Does not set organ damage or blood to safe levels. Instead, excess Strange provides more blood and heals each organ (scalable). Mechanical organs cannot be healed this way

- Does 0.00 to 5.00 damage per tick on life instead of 1.0 (Note: half brute/half burn)

- ACTUALLY requires touch method (oversight according to desc)

- Heals toxin if slimegirl (previously didn't)

also some detabbing
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
in order of about

- It isn't as good so I was okay with the buffed cap

- could be used with any reac_volume to revive, set blood to safe levels, and fullheal all organs. Mechanical organs should not get chem-based healing as part of their pros/cons.

- ^

- you will need to prep the body for this since you're foregoing defib, not to mention it heals blood/ALL (nonmechanical) organs so the consequences are pretty tame.

- oversight?

- slimegirls should get the benefit too


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Cloneby
balance: Strange Reagent now requires a set amount to revive dependent on patient wellbeing and requires an excess to heal blood and organs. Does more damage on life. Basically loses one-click wonder status UNLESS you give a considerable amount and deal with the consequences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
