### PR TITLE
fixes certain item reactions breaking plumbing

### DIFF
--- a/code/datums/components/plumbing/reaction_chamber.dm
+++ b/code/datums/components/plumbing/reaction_chamber.dm
@@ -31,8 +31,8 @@
 			return
 
 	reagents.flags &= ~NO_REACT
-	reagents.handle_reactions()
 	RC.emptying = TRUE
+	reagents.handle_reactions()
 
 /datum/component/plumbing/reaction_chamber/can_give(amount, reagent, datum/ductnet/net)
 	. = ..()


### PR DESCRIPTION
Oops. You can now do flour reactions without the reaction chamber breaking.
![Screenshot_19](https://user-images.githubusercontent.com/7501474/73460828-68686f80-4379-11ea-8680-d9fa018f01e4.png)

:cl:
fix: fixes reaction chamber breaking with flour-like reactions
/:cl: