### PR TITLE
Blood dripping scales with bleeding rate

### DIFF
--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -11,8 +11,7 @@
 /obj/effect/decal/cleanable/blood/replace_decal(obj/effect/decal/cleanable/blood/C)
 	C.add_blood_DNA(return_blood_DNA())
 	if (bloodiness)
-		if (C.bloodiness < MAX_SHOE_BLOODINESS)
-			C.bloodiness += bloodiness
+		C.bloodiness = min((C.bloodiness + bloodiness),MAX_SHOE_BLOODINESS)
 	return ..()
 
 /obj/effect/decal/cleanable/blood/old

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -1,3 +1,5 @@
+#define BLOOD_DRIP_RATE_MOD 90 //Greater number means creating blood drips more often while bleeding
+
 /****************************************************
 				BLOOD SYSTEM
 ****************************************************/
@@ -101,11 +103,12 @@
 /mob/living/carbon/proc/bleed(amt)
 	if(blood_volume)
 		blood_volume = max(blood_volume - amt, 0)
-		if(isturf(src.loc)) //Blood loss still happens in locker, floor stays clean
-			if(amt >= 10)
-				add_splatter_floor(src.loc)
-			else
-				add_splatter_floor(src.loc, 1)
+		if (prob(sqrt(amt)*BLOOD_DRIP_RATE_MOD))
+			if(isturf(src.loc)) //Blood loss still happens in locker, floor stays clean
+				if(amt >= 10)
+					add_splatter_floor(src.loc)
+				else
+					add_splatter_floor(src.loc, 1)
 
 /mob/living/carbon/human/bleed(amt)
 	amt *= physiology.bleed_mod
@@ -280,8 +283,7 @@
 	var/obj/effect/decal/cleanable/blood/B = locate() in T
 	if(!B)
 		B = new /obj/effect/decal/cleanable/blood/splatter(T, get_static_viruses())
-	if (B.bloodiness < MAX_SHOE_BLOODINESS) //add more blood, up to a limit
-		B.bloodiness += BLOOD_AMOUNT_PER_DECAL
+	B.bloodiness = min((B.bloodiness + BLOOD_AMOUNT_PER_DECAL),MAX_SHOE_BLOODINESS)
 	B.transfer_mob_blood_dna(src) //give blood info to the blood decal.
 	if(temp_blood_DNA)
 		B.add_blood_DNA(temp_blood_DNA)


### PR DESCRIPTION
The frequency of blood dripping is now slightly random and scales by bleed_rate so you can visibly tell if someone is losing a lot of blood or is only lightly injured

While I was here I fixed a small bug where blood decals could contain more blood than the the allowed cap
:cl:
tweak: Blood dripping frequency now scales with blood loss
fix: Fixed blood decals occasionally containing more blood than they should
/:cl:
