### PR TITLE
Fixes positive sanity not decreasing

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -185,13 +185,13 @@
 		if(7)
 			setSanity(sanity+0.3, SANITY_UNSTABLE)
 		if(8)
-			setSanity(sanity+0.4, SANITY_NEUTRAL)
+			setSanity(sanity+0.4, SANITY_NEUTRAL, SANITY_MAXIMUM)
 		if(9)
-			setSanity(sanity+0.6, SANITY_NEUTRAL)
+			setSanity(sanity+0.6, SANITY_NEUTRAL, SANITY_MAXIMUM)
 	HandleNutrition()
 
 ///Sets sanity to the specified amount and applies effects.
-/datum/component/mood/proc/setSanity(amount, minimum=SANITY_INSANE, maximum=SANITY_MAXIMUM, override = FALSE)
+/datum/component/mood/proc/setSanity(amount, minimum=SANITY_INSANE, maximum=SANITY_GREAT, override = FALSE)
 	// If we're out of the acceptable minimum-maximum range move back towards it in steps of 0.5
 	// If the new amount would move towards the acceptable range faster then use it instead
 	if(amount < minimum)
@@ -200,7 +200,7 @@
 		if(!override && HAS_TRAIT(parent, TRAIT_UNSTABLE))
 			maximum = sanity
 		if(amount > maximum)
-			amount = max(maximum, sanity)
+			amount = min(maximum, sanity)
 	if(amount == sanity) //Prevents stuff from flicking around.
 		return
 	sanity = amount

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -185,13 +185,13 @@
 		if(7)
 			setSanity(sanity+0.3, SANITY_UNSTABLE)
 		if(8)
-			setSanity(sanity+0.4, SANITY_NEUTRAL, SANITY_MAXIMUM)
+			setSanity(sanity+0.4, SANITY_NEUTRAL)
 		if(9)
-			setSanity(sanity+0.6, SANITY_NEUTRAL, SANITY_MAXIMUM)
+			setSanity(sanity+0.6, SANITY_NEUTRAL)
 	HandleNutrition()
 
 ///Sets sanity to the specified amount and applies effects.
-/datum/component/mood/proc/setSanity(amount, minimum=SANITY_INSANE, maximum=SANITY_GREAT, override = FALSE)
+/datum/component/mood/proc/setSanity(amount, minimum=SANITY_INSANE, maximum=SANITY_MAXIMUM, override = FALSE)
 	// If we're out of the acceptable minimum-maximum range move back towards it in steps of 0.5
 	// If the new amount would move towards the acceptable range faster then use it instead
 	if(amount < minimum)


### PR DESCRIPTION
Props to Nemvar for the correct fix

Closes #49091
:cl:
fix: Fixed sanity not decreasing after reaching a positive threshold
/:cl:
