### PR TITLE
Krav Maga: Stompies Edition

### DIFF
--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -96,7 +96,7 @@
 	to_chat(A, "<span class='danger'>You leg sweep [D]!</span>")
 	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
 	D.apply_damage(rand(20,30), STAMINA, affecting, armor_block)
-	D.Knockdown(100)
+	D.Knockdown(60)
 	log_combat(A, D, "leg sweeped")
 	return 1
 

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -135,11 +135,11 @@
 	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
 	var/armor_block = D.run_armor_check(affecting, "melee")
 	var/picked_hit_type = pick("punch", "kick")
-	var/bonus_damage = 10
+	var/bonus_damage = 0
 	if(!(D.mobility_flags & MOBILITY_STAND))
 		bonus_damage += 5
 		picked_hit_type = "stomp"
-	D.apply_damage(bonus_damage, A.dna.species.attack_type, affecting, armor_block)
+	D.apply_damage(rand(5,10) + bonus_damage, A.dna.species.attack_type, affecting, armor_block)
 	if(picked_hit_type == "kick" || picked_hit_type == "stomp")
 		A.do_attack_animation(D, ATTACK_EFFECT_KICK)
 		playsound(get_turf(D), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
@@ -157,31 +157,25 @@
 		return 1
 	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
 	var/armor_block = D.run_armor_check(affecting, "melee")
-	var/obj/item/I = null
+	if((D.mobility_flags & MOBILITY_STAND))
+		D.visible_message("<span class='danger'>[A] reprimands [D]!</span>", \
+					"<span class='userdanger'>You're slapped by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
+		to_chat(A, "<span class='danger'>You jab [D]!</span>")
+		A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+		playsound(D, 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
+		D.apply_damage(rand(5,10), STAMINA, affecting, armor_block)
+		log_combat(A, D, "punched nonlethally")
 	if(!(D.mobility_flags & MOBILITY_STAND))
 		D.visible_message("<span class='danger'>[A] reprimands [D]!</span>", \
 					"<span class='userdanger'>You're manhandled by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
 		to_chat(A, "<span class='danger'>You stomp [D]!</span>")
 		A.do_attack_animation(D, ATTACK_EFFECT_KICK)
 		playsound(D, 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
-		D.apply_damage(rand(5,15), STAMINA, affecting, armor_block)
+		D.apply_damage(rand(10,15), STAMINA, affecting, armor_block)
 		log_combat(A, D, "stomped nonlethally")
-	if((D.mobility_flags & MOBILITY_STAND))
-		I = D.get_active_held_item()
-		if(prob(60))
-			if(I)
-				if(D.temporarilyRemoveItemFromInventory(I))
-					A.put_in_hands(I)
-			D.visible_message("<span class='danger'>[A] disarms [D]!</span>", \
-						"<span class='userdanger'>You're disarmed by [A]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", COMBAT_MESSAGE_RANGE, A)
-			to_chat(A, "<span class='danger'>You disarm [D]!</span>")
-			playsound(D, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
-		else
-			D.visible_message("<span class='danger'>[A] fails to disarm [D]!</span>", \
-						"<span class='userdanger'>You're nearly disarmed by [A]!</span>", "<span class='hear'>You hear a swoosh!</span>", COMBAT_MESSAGE_RANGE, A)
-			to_chat(A, "<span class='warning'>You fail to disarm [D]!</span>")
-			playsound(D, 'sound/weapons/punchmiss.ogg', 25, TRUE, -1)
-	log_combat(A, D, "disarmed (Krav Maga)", "[I ? " removing \the [I]" : ""]")
+	if(prob(D.getStaminaLoss()))
+		D.visible_message("<span class='warning'>[D] sputters and recoils in pain!</span>", "<span class='userdanger'>You recoil in pain as you are jabbed in a nerve!</span>")
+		D.drop_all_held_items()
 	return 1
 
 //Krav Maga Gloves

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -132,12 +132,14 @@
 	if(check_streak(A,D))
 		return 1
 	log_combat(A, D, "punched")
+	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
+	var/armor_block = D.run_armor_check(affecting, "melee")
 	var/picked_hit_type = pick("punch", "kick")
 	var/bonus_damage = 10
 	if(!(D.mobility_flags & MOBILITY_STAND))
 		bonus_damage += 5
 		picked_hit_type = "stomp"
-	D.apply_damage(bonus_damage, A.dna.species.attack_type)
+	D.apply_damage(bonus_damage, A.dna.species.attack_type, affecting, armor_block)
 	if(picked_hit_type == "kick" || picked_hit_type == "stomp")
 		A.do_attack_animation(D, ATTACK_EFFECT_KICK)
 		playsound(get_turf(D), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

An alternative to https://github.com/tgstation/tgstation/pull/49079 and https://github.com/tgstation/tgstation/pull/49099  ~~because that changes the availability of krav maga and not the martial art itself. I do not consider this to be related to that change and neither do I think this change is invalidated by what ATHATH is attempting to do.~~ because I noticed he's actually changing more than availability, but also the actual abilities of krav maga. Eurgh.

This makes legsweep do a fairly decent amount of stamina damage and long knockdown. In addition, disarm intent **is now a nonlethal jab, which do more stamina damage on targets who are on the floor**. They also respect melee armor. **They also have a chance to disarm based on stamina loss, which makes them much stronger against people with high stamina damage.**

~~Come to think of it, I don't even think harm stomps respect armor. ~~

~~Come to think of it I don't think any martial art even does for the most part. But most are antag shit so I'm not gonna change that.~~

I've made krav maga's harm intent respect melee armor and additionally have made it more variable than 10 punch damage and 15 stomp.

The attack description is subject to change. I have idea how to best describe it.

Also I'm not a very good coder so if I did something wrong please yell at me. It compiled okay? It didn't even runtime!

## Why It's Good For The Game

I do agree that krav maga really needs to have the stun stripped out but I don't want to entirely remove the bite from the martial art and I want it to be an asset to the person who will be using it. The warden. This way, it's actually still useful for all the reasons you'll be using it! VIOLENT COMPLIANCE.

Closes #49079 

## Changelog
:cl:
balance: Removes the stun from Krav Maga and makes it a high duration knockdown with stamina damage (20-30), respecting chest armor for the damage.
adds: Disarm intent is now a nonlethal jab that does (5-10) stamina damage. If used on people who are prone, it does (10-15) stamina damage. It also has a chance to completely disarm someone based on the amount of stamina damage they have.
balance: Krav Maga harm stomps/punches now respect armor and have a variance of (5-10) for punches and (5-10+5) for stomps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
