### PR TITLE
Aliens can attack already open airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1224,21 +1224,24 @@
 		loseBackupPower()
 
 /obj/machinery/door/airlock/attack_alien(mob/living/carbon/alien/humanoid/user)
-	add_fingerprint(user)
 	if(isElectrified())
+		add_fingerprint(user)
 		shock(user, 100) //Mmm, fried xeno!
 		return
 	if(!density) //Already open
-		return
+		return ..()
 	if(locked || welded) //Extremely generic, as aliens only understand the basics of how airlocks work.
+		if(user.a_intent == INTENT_HARM)
+			return ..()
 		to_chat(user, "<span class='warning'>[src] refuses to budge!</span>")
 		return
+	add_fingerprint(user)
 	user.visible_message("<span class='warning'>[user] begins prying open [src].</span>",\
 						"<span class='noticealien'>You begin digging your claws into [src] with all your might!</span>",\
 						"<span class='warning'>You hear groaning metal...</span>")
-	var/time_to_open = 5
+	var/time_to_open = 5 //half a second
 	if(hasPower())
-		time_to_open = 50 //Powered airlocks take longer to open, and are loud.
+		time_to_open = 5 SECONDS //Powered airlocks take longer to open, and are loud.
 		playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE)
 
 


### PR DESCRIPTION
🆑 ShizCalev
tweak: Aliens can now attack normal airlocks after they've been opened, or when using harm intent if they're locked / welded.
/🆑

also fixed some duplicate logging