### PR TITLE
Fixes spellbooks becoming unreadable if the mob moves

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -12,7 +12,7 @@
 
 /obj/item/book/granter/proc/turn_page(mob/user)
 	playsound(user, pick('sound/effects/pageturn1.ogg','sound/effects/pageturn2.ogg','sound/effects/pageturn3.ogg'), 30, TRUE)
-	if(do_after(user,50, user))
+	if(do_after(user, 50, TRUE, src))
 		if(remarks.len)
 			to_chat(user, "<span class='notice'>[pick(remarks)]</span>")
 		else
@@ -57,9 +57,9 @@
 			on_reading_stopped()
 			reading = FALSE
 			return
-	if(do_after(user,50, user))
+	if(do_after(user, 50, TRUE, src))
 		on_reading_finished(user)
-		reading = FALSE
+	reading = FALSE
 	return TRUE
 
 ///ACTION BUTTONS///


### PR DESCRIPTION
Fixes #49027

:cl: ShizCalev
fix: Fixed spell books becoming unreadable if you moved while reading them.
fix: Fixed progress bars not showing up for spell books.
fix: Fixed an exploit where spell books didn't always have to be in your hand to finish reading them.
/:cl:
