### PR TITLE
Nanites shock protection fix.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -55,6 +55,7 @@
 	} while (0)
 #define HAS_TRAIT(target, trait) (target.status_traits ? (target.status_traits[trait] ? TRUE : FALSE) : FALSE)
 #define HAS_TRAIT_FROM(target, trait, source) (target.status_traits ? (target.status_traits[trait] ? (source in target.status_traits[trait]) : FALSE) : FALSE)
+#define HAS_TRAIT_NOT_FROM(target, trait, source) (target.status_traits ? (target.status_traits[trait] ? (length(target.status_traits[trait] - source) > 0) : FALSE) : FALSE)
 
 /*
 Remember to update _globalvars/traits.dm if you're adding/removing/renaming traits.

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -200,12 +200,17 @@
 		var/datum/nanite_program/NP = X
 		NP.on_emp(severity)
 
-/datum/component/nanites/proc/on_shock(datum/source, shock_damage)
-	nanite_volume *= (rand(45, 80) * 0.01)		//Lose 20-55% of nanites
-	adjust_nanites(null, -(rand(5, 50)))			//Lose 5-50 flat nanite volume
-	for(var/X in programs)
-		var/datum/nanite_program/NP = X
-		NP.on_shock(shock_damage)
+
+/datum/component/nanites/proc/on_shock(datum/source, shock_damage, siemens_coeff = 1, flags = NONE)
+	if(flags & SHOCK_ILLUSION || shock_damage < 1)
+		return
+
+	if(!HAS_TRAIT_NOT_FROM(host_mob, TRAIT_SHOCKIMMUNE, "nanites"))//Another shock protection must protect nanites too, but nanites protect only host
+		nanite_volume *= (rand(45, 80) * 0.01)		//Lose 20-55% of nanites
+		adjust_nanites(null, -(rand(5, 50)))			//Lose 5-50 flat nanite volume
+		for(var/X in programs)
+			var/datum/nanite_program/NP = X
+			NP.on_shock(shock_damage)
 
 /datum/component/nanites/proc/on_minor_shock(datum/source)
 	adjust_nanites(null, -(rand(5, 15)))			//Lose 5-15 flat nanite volume


### PR DESCRIPTION
## About The Pull Request

Now nanites respects shock protection from anoher sources.
fix #49151

## Why It's Good For The Game

bug is bad.

## Changelog
:cl:
fix: Now nanites don't die from illusions and placing unpowered cable by bare hands.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
