### PR TITLE
Custom material output on examine cleanup

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -476,13 +476,11 @@
 		. += desc
 
 	if(custom_materials)
-		var/materials_desc
+		var/list/materials_list = list()
 		for(var/i in custom_materials)
 			var/datum/material/M = i
-			if(materials_desc)
-				materials_desc += ", "
-			materials_desc += "[M.name]"
-		. += "<u>It is made out of [materials_desc]</u>."
+			materials_list += "[M.name]"
+		. += "<u>It is made out of [english_list(materials_list)]</u>."
 	if(reagents)
 		if(reagents.flags & TRANSPARENT)
 			. += "It contains:"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -476,9 +476,13 @@
 		. += desc
 
 	if(custom_materials)
+		var/materials_desc
 		for(var/i in custom_materials)
 			var/datum/material/M = i
-			. += "<u>It is made out of [M.name]</u>."
+			if(materials_desc)
+				materials_desc += ", "
+			materials_desc += "[M.name]"
+		. += "<u>It is made out of [materials_desc]</u>."
 	if(reagents)
 		if(reagents.flags & TRANSPARENT)
 			. += "It contains:"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Each custom material in an item would take a line on examine.
This now puts all materials in a single line.

**Before:**

![custom mats output before](https://user-images.githubusercontent.com/6491940/73616269-f9885200-45d6-11ea-928f-391dccd1dd04.png)


**After:**

![Better readout on materials](https://user-images.githubusercontent.com/6491940/73616235-8252be00-45d6-11ea-870c-156f55efc75a.PNG)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The examine can take up a large amount of space, this reduces the size, and increases readability.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
refactor: Changed custom material output on examine to be on a single line
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
