### PR TITLE
Machinery processing refactor; ORM now uses "event-based" processing

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -13,6 +13,13 @@
 #define ACTIVE_POWER_USE 2
 
 
+// bitflags for a machine's processing preferences
+#define START_PROCESSING_ON_INIT 	(1<<0)	// if the machine should start processing on Initialize()
+#define START_PROCESSING_MANUALLY 	(1<<1)	// if the machine will start processing in the future, after Initialize(), such as when a certain condition is met
+#define NORMAL_PROCESS_SPEED		(1<<2)	// normal processing speed (SSobj and SSmachines)
+#define FAST_PROCESS_SPEED			(1<<3)	// fast processing speed (SSfastprocess)
+
+
 //bitflags for door switches.
 #define OPEN	(1<<0)
 #define IDSCAN	(1<<1)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -11,7 +11,7 @@
 	density = FALSE
 	layer = BELOW_MOB_LAYER //so people can't hide it and it's REALLY OBVIOUS
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	speed_process = TRUE
+	processing_flags = START_PROCESSING_ON_INIT | FAST_PROCESS_SPEED
 
 	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_OFFLINE
 
@@ -192,10 +192,10 @@
 
 /obj/machinery/syndicatebomb/proc/settings(mob/user)
 	var/new_timer = input(user, "Please set the timer.", "Timer", "[timer_set]") as num|null
-	
+
 	if (isnull(new_timer))
 		return
-	
+
 	if(in_range(src, user) && isliving(user)) //No running off and setting bombs from across the station
 		timer_set = CLAMP(new_timer, minimum_timer, maximum_timer)
 		loc.visible_message("<span class='notice'>[icon2html(src, viewers(src))] timer set for [timer_set] seconds.</span>")

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -8,7 +8,6 @@
 	density = TRUE
 	input_dir = WEST
 	output_dir = EAST
-	speed_process = TRUE
 
 /obj/machinery/mineral/unloading_machine/process()
 	var/turf/T = get_step(src,input_dir)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -18,7 +18,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	var/list/affecting	// the list of all items that will be moved this ptick
 	var/id = ""			// the control ID	- must match controller ID
 	var/verted = 1		// Inverts the direction the conveyor belt moves.
-	speed_process = TRUE
+	processing_flags = START_PROCESSING_ON_INIT | FAST_PROCESS_SPEED
 	var/conveying = FALSE
 
 /obj/machinery/conveyor/centcom_auto
@@ -231,7 +231,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	desc = "A conveyor control switch."
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "switch-off"
-	speed_process = TRUE
+	processing_flags = START_PROCESSING_ON_INIT | FAST_PROCESS_SPEED
 
 	var/position = 0			// 0 off, -1 reverse, 1 forward
 	var/last_pos = -1			// last direction setting

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -133,7 +133,7 @@
 	name = "\improper Meteor Shield Satellite"
 	desc = "A meteor point-defense satellite."
 	mode = "M-SHIELD"
-	speed_process = TRUE
+	processing_flags = START_PROCESSING_ON_INIT | FAST_PROCESS_SPEED
 	var/kill_range = 14
 
 /obj/machinery/satellite/meteor_shield/proc/space_los(meteor)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds framework for what I'm calling "event-based" processing for now. The idea here is to stop machines processing all the time regardless of if they need to or not. Ideally they should only begin processing when a certain criteria is met.

As an example I've converted the Ore redemption machine to event-based processing. It will now only begin processing when an atom enters the `input_turf`, which is the turf you're suppose to drop ore at (defaults to north at round start).

Replaces the `speed_process` var in favor of a `processing_flags` var. Four different bitflags are meant to go here, which are:
```js
#define START_PROCESSING_ON_INIT      (1<<0)
#define START_PROCESSING_MANUALLY     (1<<1)
#define NORMAL_PROCESS_SPEED          (1<<2)
#define FAST_PROCESS_SPEED            (1<<3)
```

By default, all `obj/machinery` types start with these flags:
```js
processing_flags = START_PROCESSING_ON_INIT | NORMAL_PROCESS_SPEED
```
if you want to tell a machine to not start processing when the round starts, just replace the first flag with `START_PROCESSING_MANUALLY` instead. This allows it bypass the code in `/obj/machinery/Initialize()` that would normally tell it to immediately start processing. 

Then, simply find the places in the code in which you want to tell the machine to either being or end processing and use the `begin_processing()` and `end_processing()` procs respectively.

The second flag denotes which subsystem you want your machine to use. 
`NORMAL_PROCESS_SPEED` uses `SSmachines`
`FAST_PROCESS_SPEED` uses `SSfastprocess`
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This will save a small amount of server resources, because the game won't have to pointlessly execute code when it doesn't need to. It will save more in the future if this system is adopted and more machines switch over to using event-based processing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Converts the ore redemption machine to use event-based processing, it will now only process whenever an atom enters it's input turf.
refactor: Replaces the speed_process var with a processing_flags var. This new variable stores bitflags with information about a machine's preferences on when it should start processing, and with which subsystem.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
