### PR TITLE
Wood Floors no longer runtime on examine.

### DIFF
--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -11,7 +11,6 @@
 	desc = "Stylish dark wood."
 	icon_state = "wood"
 	floor_tile = /obj/item/stack/tile/wood
-	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 0.25)
 	broken_states = list("wood-broken", "wood-broken2", "wood-broken3", "wood-broken4", "wood-broken5", "wood-broken6", "wood-broken7")
 	footstep = FOOTSTEP_WOOD
 	barefootstep = FOOTSTEP_WOOD_BAREFOOT


### PR DESCRIPTION
## About The Pull Request

Custom materials not working on turfs, an age old romance. Accidently gave wooden floors custom materials in the wood datum PR.
 
## Why It's Good For The Game

Bugs are baaaad.

## Changelog
:cl:
fix: Wooden Plank Floors no longer runtime.
/:cl:

