### PR TITLE
[Needs testing] Allows mobs in bodybags / closets / ect to break out of morgue trays

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -17,6 +17,7 @@
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	drag_slowdown = 0
 	var/foldedbag_path = /obj/item/bodybag
+	var/breaking_out = FALSE
 	var/obj/item/bodybag/foldedbag_instance = null
 	var/tagged = 0 // so closet code knows to put the tag overlay back
 
@@ -58,6 +59,24 @@
 	. = ..()
 	if(.)
 		mouse_drag_pointer = MOUSE_INACTIVE_POINTER
+
+/obj/structure/closet/body_bag/relaymove(mob/user)
+	if(user.stat)
+		return
+	if(istype(loc, /obj/structure/bodycontainer))
+		var/obj/structure/bodycontainer/bc = loc
+		if(!bc.locked)
+			breaking_out = TRUE
+			to_chat(user, "<span class='notice'>You start wiggling around inside of [bc], trying to hit the release button within it.</span>")
+			bc.audible_message("<span class='hear'>You hear a metallic creaking from [bc].</span>")
+			playsound(bc, 'sound/effects/clang.ogg', 50, TRUE)
+			if(do_after(user, (bc.breakout_time * 0.25), FALSE, src))
+				bc.relaymove(user) //forward it to the container's relay move to make sure the user hasn't died, the morgue tray wasn't locked afterwards, ect.
+			breaking_out = FALSE
+		else
+			bc.relaymove(user) //let the morgue tray handle warning messages.
+	else
+		return ..()
 
 /obj/structure/closet/body_bag/close()
 	. = ..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -48,7 +48,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 /obj/structure/bodycontainer/update_icon()
 	return
 
-/obj/structure/bodycontainer/relaymove(mob/user)
+/obj/structure/bodycontainer/relaymove(mob/user) //also called by /obj/structure/closet/body_bag/relaymove()
 	if(user.stat || !isturf(loc))
 		return
 	if(locked)
@@ -57,6 +57,20 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 			to_chat(user, "<span class='warning'>[src]'s door won't budge!</span>")
 		return
 	open()
+
+/obj/structure/bodycontainer/relay_container_resist(mob/living/user, obj/O)
+	if(!locked)
+		user.visible_message(null, \
+		"<span class='notice'>You lean on the back of [src] and start pushing the tray open... (this will take about [DisplayTimeText(breakout_time *0.25)].)</span>", \
+		"<span class='hear'>You hear a metallic creaking from [src].</span>")
+		user.changeNext_move(CLICK_CD_BREAKOUT)
+		user.last_special = world.time + CLICK_CD_BREAKOUT
+		if(!do_after(user, (breakout_time * 0.25), FALSE, user.loc))
+			return
+		if(locked)
+			to_chat(user, "<span class='warning'>[src]'s door won't budge, perhaps you should try again...</span>")
+			return
+	return container_resist(user)
 
 /obj/structure/bodycontainer/attack_paw(mob/user)
 	return attack_hand(user)


### PR DESCRIPTION
Fixes #49080

todo: actually test it.

:cl: ShizCalev
fix: Fixed mobs inside of bodybags not having their movements / resists passed to morgue trays.
/:cl:
