### PR TITLE
Defib and Nanite Defib use the same can_defib proc

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -439,24 +439,11 @@
 		do_harm(H, user)
 		return
 
-	if(can_defib(H))
+	if(H.can_defib())
 		H.notify_ghost_cloning("Your heart is being defibrillated!")
 		H.grab_ghost() // Shove them back in their body.
 
 	do_help(H, user)
-
-/obj/item/twohanded/shockpaddles/proc/can_defib(mob/living/carbon/H)
-	var/obj/item/organ/heart = H.getorgan(/obj/item/organ/heart)
-	if(H.suiciding || H.hellbound || HAS_TRAIT(H, TRAIT_HUSK))
-		return
-	if((H.getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE) || (H.getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE))
-		return
-	if(!heart || (heart.organ_flags & ORGAN_FAILING))
-		return
-	var/obj/item/organ/brain/BR = H.getorgan(/obj/item/organ/brain)
-	if(QDELETED(BR) || (BR.organ_flags & ORGAN_FAILING) || BR.suicided)
-		return
-	return TRUE
 
 /obj/item/twohanded/shockpaddles/proc/shock_touching(dmg, mob/H)
 	if(isliving(H.pulledby))		//CLEAR!

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -821,6 +821,19 @@
 	if(!getorgan(/obj/item/organ/brain) && (!mind || !mind.has_antag_datum(/datum/antagonist/changeling)))
 		return 0
 
+/mob/living/carbon/proc/can_defib()
+	var/obj/item/organ/heart = getorgan(/obj/item/organ/heart)
+	if(suiciding || hellbound || HAS_TRAIT(src, TRAIT_HUSK))
+		return
+	if((getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE) || (getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE))
+		return
+	if(!heart || (heart.organ_flags & ORGAN_FAILING))
+		return
+	var/obj/item/organ/brain/BR = getorgan(/obj/item/organ/brain)
+	if(QDELETED(BR) || (BR.organ_flags & ORGAN_FAILING) || BR.suicided)
+		return
+	return TRUE
+
 /mob/living/carbon/harvest(mob/living/user)
 	if(QDELETED(src))
 		return

--- a/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/code/modules/research/nanites/nanite_programs/healing.dm
@@ -223,20 +223,9 @@
 	if(!iscarbon(host_mob)) //nonstandard biology
 		return FALSE
 	var/mob/living/carbon/C = host_mob
-	if(C.suiciding || C.hellbound || HAS_TRAIT(C, TRAIT_HUSK)) //can't revive
-		return FALSE
-	if((world.time - C.timeofdeath) > 1800) //too late
-		return FALSE
-	if((C.getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE) || (C.getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE) || !C.can_be_revived()) //too damaged
-		return FALSE
-	if(!C.getorgan(/obj/item/organ/heart)) //what are we even shocking
-		return FALSE
-	var/obj/item/organ/brain/BR = C.getorgan(/obj/item/organ/brain)
-	if(QDELETED(BR) || (BR.organ_flags & ORGAN_FAILING) || BR.suicided)
-		return FALSE
 	if(C.get_ghost())
 		return FALSE
-	return TRUE
+	return C.can_defib()
 
 /datum/nanite_program/defib/proc/zap()
 	var/mob/living/carbon/C = host_mob


### PR DESCRIPTION
## About The Pull Request
This moves the `can_defib` proc out of defibrillators and into /mob/living/carbon, then changes both the Defibrillators and Nanite Defibrillator program.

They used to have identical behavior, but #48715 changed that by changing the defibrillator's `can_defib` proc. This is an example of DRY failing and consequences following.

Closes #49238

## Why It's Good For The Game
Brings them to consistency with each other.

## Changelog
:cl: JJRcop
refactor: Defibs and Defibbing Nanites act the same way again.
/:cl: