### PR TITLE
Moves a light to not be directly attached to an airlock

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55319,9 +55319,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "cud" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -72009,6 +72006,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "fUC" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/circuit,
 /area/science/misc_lab/range)
 "fWc" = (


### PR DESCRIPTION
## About The Pull Request
this
![dreammaker_2020-02-04_13-43-29](https://user-images.githubusercontent.com/17747087/73746859-7a218c80-4756-11ea-9b81-1adcc2aa73cb.png)
to this
![dreammaker_2020-02-04_13-43-39](https://user-images.githubusercontent.com/17747087/73746863-7d1c7d00-4756-11ea-85fe-f4ece1842d05.png)

and here's the entire room view in-game
![dreamseeker_2020-02-04_13-49-59](https://user-images.githubusercontent.com/17747087/73746874-860d4e80-4756-11ea-9714-2f68caff21d1.png)

## Why It's Good For The Game
A light fixture attached to an airlock looks dumb.

## Changelog
:cl: Vondiech
tweak: There is no longer a light fixture attached to an airlock in the Experimentation Lab on Metastation.
/:cl:
