### PR TITLE
Set MultiZ debug baseturfs

### DIFF
--- a/_maps/multiz_debug.json
+++ b/_maps/multiz_debug.json
@@ -2,5 +2,5 @@
     "map_name": "MultiZ Debug",
     "map_path": "map_files/debug",
     "map_file": "multiz.dmm",
-	"traits": [{"Up": 1}, {"Up": 1, "Down": -1}, {"Down": -1}]
+	"traits": [{"Up": 1}, {"Up": 1, "Down": -1, "Baseturf" : "/turf/open/openspace"}, {"Down": -1, "Baseturf" : "/turf/open/openspace"}]
 	}


### PR DESCRIPTION
## About The Pull Request

Now MultiZ Debug map has proper baseturf. 

## Why It's Good For The Game

No more space under 2, 3 lvl  plating.
fix #49187

## Changelog
:cl:
fix: Now MultiZ Debug map has open space under floor instead of space. 
/:cl:
