### PR TITLE
skateboard now buckles you automatically when you activate it in hand

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -519,7 +519,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	var/board_item_type = /obj/vehicle/ridden/scooter/skateboard
 
 /obj/item/melee/skateboard/attack_self(mob/user)
-	new board_item_type(get_turf(user))
+	var/obj/vehicle/ridden/scooter/skateboard/S = new board_item_type(get_turf(user))//this probably has fucky interactions with telekinesis but for the record it wasnt my fault
+	S.buckle_mob(user)
 	qdel(src)
 
 /obj/item/melee/skateboard/pro


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
skateboard now buckles you automatically when you activate it in hand
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
buckling yourself to a skateboard is shitty with its tiny sprite, ruins immersion when IRL skaters do the thing where they drop it and hop on and look really cool and makes you think "wow i wish i learned how to skate when i was younger those guys look really cool"

you can drop them normally with your preferred method of dropping items, the buckle only happens when you click it in hand. 

p.s. i was thinking about adding a way to quick pick up the skateboards like when you see a skater step on the back and grab it at the front, probably action button like the ollie. picking up skateboards is almost as bad as trying to hop on one with clickdragging. i also thought about adding more skater tricks locked behind higher tiers of skateboards and or skateboard experience if there is interest and ideas for it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: skateboards now buckle you after activating them in hand. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
