### PR TITLE
Fixes external armory camera on Meta.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6552,7 +6552,7 @@
 "ank" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
-	c_tag = "E.V.A. Storage";
+	c_tag = "Armory External";
 	dir = 8
 	},
 /turf/open/space/basic,
@@ -54308,7 +54308,6 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/computer/scan_consolenew{
-	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -72350,7 +72349,6 @@
 "hFV" = (
 /obj/machinery/door/window/westleft{
 	name = "safety door";
-	req_access_txt = "0";
 	req_one_access_txt = "47"
 	},
 /turf/open/floor/plasteel/white,


### PR DESCRIPTION
## About The Pull Request
Armory external camera was named E.V.A. Storage causing it to conflict with the actual E.V.A. Storage camera. Its now properly renamed to Armory External. Fixes #48698 .
## Why It's Good For The Game

Camera console can now use the external armory camera on meta.

## Changelog
:cl:
fix: Fixes meta armory external camera by naming it properly.
/:cl:
