### PR TITLE
Fixes AI's carp hologram.

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -686,7 +686,7 @@
 		if("Animal")
 			var/list/icon_list = list(
 			"bear" = 'icons/mob/animal.dmi',
-			"carp" = 'icons/mob/animal.dmi',
+			"carp" = 'icons/mob/carp.dmi',
 			"chicken" = 'icons/mob/animal.dmi',
 			"corgi" = 'icons/mob/pets.dmi',
 			"cow" = 'icons/mob/animal.dmi',


### PR DESCRIPTION


## About The Pull Request

Fixes #48812 . The path for the carp hologram lead to animal.dmi when it should have led to carp.dmi.

## Why It's Good For The Game

Fixes the AI's carp hologram.

## Changelog
:cl:
fix: AI can use the carp hologram again.
/:cl:

