### PR TITLE
Revenants can now eat salt

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -14,6 +14,15 @@
 		else if(in_range(src, A))
 			Harvest(A)
 
+	else if(istype(A, /obj/effect/decal/cleanable/food/salt))
+		to_chat(src, "<span class='revennotice'>You start dissipating \the [A]...</span>")
+		if(do_after(src, 10, FALSE, target))
+			if(!QDELETED(A))
+				qdel(A)
+				visible_message("<span class='warning'>\The [A] scatters into nothingness...</span>",
+				"<span class='revennotice'>You dissipate \the [A].</span>",
+				"<span class='hear'>You hear something scatter into the wind.</span>")
+
 
 //Harvest; activated by clicking the target, will try to drain their essence.
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -18,10 +18,10 @@
 		to_chat(src, "<span class='revennotice'>You start dissipating \the [A]...</span>")
 		if(do_after(src, 10, FALSE, target))
 			if(!QDELETED(A))
-				qdel(A)
 				visible_message("<span class='warning'>\The [A] scatters into nothingness...</span>",
 				"<span class='revennotice'>You dissipate \the [A].</span>",
 				"<span class='hear'>You hear something scatter into the wind.</span>")
+				qdel(A)
 
 
 //Harvest; activated by clicking the target, will try to drain their essence.

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -16,7 +16,7 @@
 
 	else if(istype(A, /obj/effect/decal/cleanable/food/salt))
 		to_chat(src, "<span class='revennotice'>You start dissipating \the [A]...</span>")
-		if(do_after(src, 10, FALSE, target))
+		if(do_after(src, 10, FALSE, A))
 			if(!QDELETED(A))
 				visible_message("<span class='warning'>\The [A] scatters into nothingness...</span>",
 				"<span class='revennotice'>You dissipate \the [A].</span>",

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -237,11 +237,12 @@
 			var/turf/open/floor/stepTurf = get_step(L, direct)
 			if(stepTurf)
 				for(var/obj/effect/decal/cleanable/food/salt/S in stepTurf)
-					to_chat(L, "<span class='warning'>[S] bars your passage!</span>")
+					to_chat(L, "<span class='warning'>[S] bars your passage, then dissipates!</span>")
 					if(isrevenant(L))
 						var/mob/living/simple_animal/revenant/R = L
 						R.reveal(20)
 						R.stun(20)
+						qdel(S)
 					return
 				if(stepTurf.flags_1 & NOJAUNT_1)
 					to_chat(L, "<span class='warning'>Some strange aura is blocking the way.</span>")


### PR DESCRIPTION
## About The Pull Request

Well not really, but they can dissipate it by scattering it to the wind using ghostly magicks. If they step on it the same thing will happen as before, but the salt will get destroyed. If they click on it, a do_after(10) will run and then they will dissipate it.

## Why It's Good For The Game

I got to roll revenant today, and within a minute of me getting found out, the crew used 1 salt-smoke to immediately deny me entrance to medbay permanently. Salt is pretty easy to apply and impossible to play around, which sucks, so I thought this would be a good change.
It's pretty noticeable and not very fast when a revenant eats through salt, so you'll know that one is coming if they try this.

## Changelog
:cl:
add: Revenants can now click on salt to scatter it to the wind after a very brief delay. They will do this automatically to any salt pile that they get stunned on.
/:cl:
