### PR TITLE
Edgechems: Explosive content pack MK. 2 -Blackpowder and Tatp changes-

### DIFF
--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -136,7 +136,6 @@
 		/datum/reagent/medicine/diphenhydramine,\
 		/datum/reagent/drug/space_drugs,\
 		/datum/reagent/drug/crank,\
-		/datum/reagent/gunpowder,\
 		/datum/reagent/napalm,\
 		/datum/reagent/firefighting_foam,\
 		/datum/reagent/consumable/mayonnaise,\

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -225,7 +225,7 @@
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime()
 	icon_state = "cherry_bomb_lit"
 	playsound(src, 'sound/effects/fuse.ogg', seed.potency, FALSE)
-	sleep(500)
+	sleep(rand(50,100))
 	reagents.chem_temp = 1000 //Sets off the rdx
 	reagents.handle_reactions()
 

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -182,7 +182,7 @@
 	trash = /obj/item/gun/ballistic/revolver
 	bitesize_mod = 2
 	foodtype = FRUIT
-	tastes = list("gunpowder" = 1)
+	tastes = list("sulfur" = 1)
 	wine_power = 90 //It burns going down, too.
 
 //Cherry Bombs
@@ -194,7 +194,7 @@
 	plantname = "Cherry Bomb Tree"
 	product = /obj/item/reagent_containers/food/snacks/grown/cherry_bomb
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/sugar = 0.1, /datum/reagent/gunpowder = 0.7)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/sugar = 0.1, /datum/reagent/rdx = 0.7)
 	rarity = 60 //See above
 
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb
@@ -204,7 +204,7 @@
 	filling_color = rgb(20, 20, 20)
 	seed = /obj/item/seeds/cherry/bomb
 	bitesize_mod = 2
-	volume = 125 //Gives enough room for the gunpowder at max potency
+	volume = 125 //Gives enough room for the rdx at max potency
 	max_integrity = 40
 	wine_power = 80
 
@@ -225,6 +225,7 @@
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime()
 	icon_state = "cherry_bomb_lit"
 	playsound(src, 'sound/effects/fuse.ogg', seed.potency, FALSE)
-	reagents.chem_temp = 1000 //Sets off the gunpowder
+	sleep(500)
+	reagents.chem_temp = 1000 //Sets off the rdx
 	reagents.handle_reactions()
 

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -85,30 +85,6 @@
 	color = "#210021"
 	taste_description = "compressed bitterness"
 
-/datum/reagent/gunpowder
-	name = "Gunpowder"
-	description = "Explodes. Violently."
-	reagent_state = LIQUID
-	color = "#000000"
-	metabolization_rate = 0.05
-	taste_description = "salt"
-
-/datum/reagent/gunpowder/on_mob_life(mob/living/carbon/M)
-	. = TRUE
-	..()
-	if(!isplasmaman(M))
-		return
-	M.set_drugginess(15)
-	if(M.hallucination < volume)
-		M.hallucination += 5
-
-/datum/reagent/gunpowder/on_ex_act()
-	var/location = get_turf(holder.my_atom)
-	var/datum/effect_system/reagents_explosion/e = new()
-	e.set_up(1 + round(volume/6, 1), location, 0, 0, message = 0)
-	e.start()
-	holder.clear_reagents()
-
 /datum/reagent/rdx
 	name = "RDX"
 	description = "Military grade explosive"

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -219,6 +219,7 @@
 	if(created_volume < 10) //if the explosion isnt powerful enough blackpowder deflagerates instead of properly exploding
 		sleep(50)
 		var/turf/T = get_turf(holder.my_atom)
+		var/fire_range = round(created_volume/2)
 		for(var/mob/M in viewers(4, T))
 			to_chat(M, "<span class='notice'>The solution violently deflagerates!</span>")
 		for(var/turf/turf in range(fire_range,T))

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -132,6 +132,9 @@
 /datum/chemical_reaction/reagent_explosion/tatp_explosion/proc/UpdateInfo()
 	required_temp = 550 + rand(-49,49)
 
+/datum/chemical_reaction/reagent_explosion/tatp_explosion/on_reaction(datum/reagents/holder, created_volume)
+	modifier = created_volume == 2100 ? 12 : round(sqrt(created_volume)/4) //formula that increases the potency of the explosion the more chem is used making tatp a top-tier instead of mid-tier
+	. = ..()
 
 /datum/chemical_reaction/reagent_explosion/penthrite_explosion
 	name = "Penthrite explosion"

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -190,7 +190,7 @@
 	var/sulfur_power = 1
 
 	var/multiver_temp = 1
-	var/sulfur_temp = -0.5
+	var/sulfur_temp = -0.66
 
 	var/saltpetre_volume
 	var/multiver_volume
@@ -208,10 +208,12 @@
 	created_volume = min(saltpetre_volume * saltpetre_power, multiver_volume * multiver_power + sulfur_volume * sulfur_power)
 	required_temp = required_temp + multiver_temp * multiver_volume + sulfur_temp * sulfur_volume
 
-	sleep(max(rand(50,100)-saltpetre_volume*saltpetre_power,1 + multiver_volume * multiver_power))
+	sleep(rand( 50 - (saltpetre_volume*saltpetre_power > 50 ? 50 : saltpetre_volume*saltpetre_power) ,100 + multiver_volume * multiver_power + sulfur_volume * sulfur_power))
+
 	holder.remove_reagent(/datum/reagent/saltpetre,saltpetre_volume)
 	holder.remove_reagent(/datum/reagent/medicine/C2/multiver,multiver_volume)
 	holder.remove_reagent(/datum/reagent/sulfur,sulfur_volume)
+
 	if(created_volume < 10) //if the explosion isnt powerful enough blackpowder deflagerates instead of properly exploding
 		var/fire_range = round(created_volume/2)
 		var/turf/T = get_turf(holder.my_atom)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -190,11 +190,11 @@
 	var/sulfur_power = 1
 
 	var/multiver_temp = 1
-	var/sulfur_temp = -0.66
+	var/sulfur_temp = -3.33
 
-	var/saltpetre_volume
-	var/multiver_volume
-	var/sulfur_volume
+	var/saltpetre_volume = 0
+	var/multiver_volume = 0
+	var/sulfur_volume = 0
 	//none of these values add up nicely because i want people to experiment with diffrent ratios
 
 /datum/chemical_reaction/reagent_explosion/gunpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
@@ -214,9 +214,13 @@
 	holder.remove_reagent(/datum/reagent/medicine/C2/multiver,multiver_volume)
 	holder.remove_reagent(/datum/reagent/sulfur,sulfur_volume)
 
+	sleep(rand( 50 - (saltpetre_volume*saltpetre_power > 50 ? 50 : saltpetre_volume*saltpetre_power + sulfur_volume*sulfur_temp)  ,max(100 + multiver_volume * multiver_temp + sulfur_volume * sulfur_temp,500)))
+	//deflageration
 	if(created_volume < 10) //if the explosion isnt powerful enough blackpowder deflagerates instead of properly exploding
-		var/fire_range = round(created_volume/2)
+		sleep(50)
 		var/turf/T = get_turf(holder.my_atom)
+		for(var/mob/M in viewers(4, T))
+			to_chat(M, "<span class='notice'>The solution violently deflagerates!</span>")
 		for(var/turf/turf in range(fire_range,T))
 			new /obj/effect/hotspot(turf)
 		holder.chem_temp = 1000

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -133,7 +133,7 @@
 	required_temp = 550 + rand(-49,49)
 
 /datum/chemical_reaction/reagent_explosion/tatp_explosion/on_reaction(datum/reagents/holder, created_volume)
-	strengthdiv = created_volume == 2100 ? 1 : (created_volume*created_volume)/3000000 //formula that increases the potency of the explosion the more chem is used making tatp a top-tier instead of mid-tier
+	strengthdiv = 3 - (created_volume >= 2100 ? 2 : round(created_volume/1400)) //formula that increases the potency of the explosion the more chem is used making tatp a top-tier instead of mid-tier
 	. = ..()
 
 
@@ -195,7 +195,7 @@
 	var/saltpetre_volume
 	var/multiver_volume
 	var/sulfur_volume
-	//noone of these values add up nicely because i want people to experiment with diffrent ratios
+	//none of these values add up nicely because i want people to experiment with diffrent ratios
 
 /datum/chemical_reaction/reagent_explosion/gunpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
 	for(var/datum/reagent/R in holder.reagent_list)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -212,8 +212,8 @@
 	holder.remove_reagent(/datum/reagent/saltpetre,saltpetre_volume)
 	holder.remove_reagent(/datum/reagent/medicine/C2/multiver,multiver_volume)
 	holder.remove_reagent(/datum/reagent/sulfur,sulfur_volume)
-	if(created_volume < 20) //if the explosion isnt powerful enough blackpowder deflagerates instead of properly exploding
-		var/fire_range = round(created_volume/5)
+	if(created_volume < 10) //if the explosion isnt powerful enough blackpowder deflagerates instead of properly exploding
+		var/fire_range = round(created_volume/2)
 		var/turf/T = get_turf(holder.my_atom)
 		for(var/turf/turf in range(fire_range,T))
 			new /obj/effect/hotspot(turf)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -133,7 +133,7 @@
 	required_temp = 550 + rand(-49,49)
 
 /datum/chemical_reaction/reagent_explosion/tatp_explosion/on_reaction(datum/reagents/holder, created_volume)
-	modifier = created_volume == 2100 ? 12 : round(sqrt(created_volume)/4) //formula that increases the potency of the explosion the more chem is used making tatp a top-tier instead of mid-tier
+	strengthdiv = created_volume == 2100 ? 1 : (created_volume*created_volume)/3000000 //formula that increases the potency of the explosion the more chem is used making tatp a top-tier instead of mid-tier
 	. = ..()
 
 


### PR DESCRIPTION
## About The Pull Request

This PR changes how TaTP and Blackpowder works

TaTP now gets lowered strengthdiv the more you units you use. This bonus is linear, volume/1400. Tops out at 1 strengthdiv for 2100u which is the biggest possible chemical explosion in game.

Blackpowder is basically removed, in its placed a more realistic explosion that requires the same ingridients happens. This is the first of it's kind type of explosive because you can experiment with the ratio's between sulfur , multiver and saltpetre. 


## Why It's Good For The Game
A lot of people were saying that TaTP doesnt provide enough power for the hustle of aquiring it, now it is the best large explosion explosive in the game. Onlty beaten by nitroglycerin in small scale explosions.

I always wanted to experiment with blackpowder , as in real life there are a lot of variations.
This is good for the game because it creates more options for the player when it comes to explosive compound making.  It also allowes you to perfect the craft of BP making which i find quite exciting to be honest.

How new BP works: 

- Saltpetre: the main compound in the reaction. It LIMITS  how much power you can have in the explosion, not providing any power to the equasion itself.  Lowers the lower limit of ignition timer.

- Multiver: Provides the main source of power for the reaction, increases the temperature needed to actually explode BP and increases the upper limit of ignition timer.

- Sulfur: Secondary source of power, 3 times weaker than multiver, but it cools down the temperature needed to start the reaction. Lowers the upper limit of ignition timer

If you code dive you can see that most of values that are used in the equasion dont divide through each other nicely, this is supposed to prevent the creation of "use this mix or it is crap", as diffrent mixes will provide diffrent results. 

also

if BP explosion isnt powerful enough it will DEFLAGERATE. Meaning create a big fire wave that sets things on fire but doesnt actually explode

## Changelog
:cl:
add: TaTP now explodes in a more powerful way if you use big amounts of it
del: Removed Blackpowder, look below for replacement reaction
add: Teslium now uses pentaerythritol instead of blackpowder
add: Instead of Blackpowder Sulfur,Multiver and Saltpetre will explode in a more interesting way
/:cl:
