### PR TITLE
Salt now dissipates when ran over too much

### DIFF
--- a/code/game/objects/effects/decals/cleanable/food.dm
+++ b/code/game/objects/effects/decals/cleanable/food.dm
@@ -44,14 +44,15 @@
 
 /obj/effect/decal/cleanable/food/salt/Crossed(atom/movable/AM)
 	..()
-	if(isliving(AM))
-		if(iscarbon(AM))
-			var/mob/living/carbon/C = AM
-			if(C.m_intent == MOVE_INTENT_WALK)
-				return
-		safepasses--
-		if(safepasses <= 0 && !QDELETED(src))
-			qdel(src)
+	if(!isliving(AM))
+		return
+	if(iscarbon(AM))
+		var/mob/living/carbon/C = AM
+		if(C.m_intent == MOVE_INTENT_WALK)
+			return
+	safepasses--
+	if(safepasses <= 0 && !QDELETED(src))
+		qdel(src)
 
 /obj/effect/decal/cleanable/food/flour
 	name = "flour"

--- a/code/game/objects/effects/decals/cleanable/food.dm
+++ b/code/game/objects/effects/decals/cleanable/food.dm
@@ -43,6 +43,7 @@
 		to_chat(AM, "<span class='danger'>Your path is obstructed by <span class='phobia'>salt</span>.</span>")
 
 /obj/effect/decal/cleanable/food/salt/Crossed(atom/movable/AM)
+	..()
 	if(isliving(AM))
 		if(iscarbon(AM))
 			var/mob/living/carbon/C = AM

--- a/code/game/objects/effects/decals/cleanable/food.dm
+++ b/code/game/objects/effects/decals/cleanable/food.dm
@@ -39,12 +39,11 @@
 
 /obj/effect/decal/cleanable/food/salt/Bumped(atom/movable/AM)
 	. = ..()
+	if(is_species(AM, /datum/species/snail))
+		to_chat(AM, "<span class='danger'>Your path is obstructed by <span class='phobia'>salt</span>.</span>")
 
+/obj/effect/decal/cleanable/food/salt/Crossed(atom/movable/AM)
 	if(isliving(AM))
-
-		if(is_species(AM, /datum/species/snail))
-			to_chat(AM, "<span class='danger'>Your path is obstructed by <span class='phobia'>salt</span>.</span>")
-
 		if(iscarbon(AM))
 			var/mob/living/carbon/C = AM
 			if(C.m_intent == MOVE_INTENT_WALK)

--- a/code/game/objects/effects/decals/cleanable/food.dm
+++ b/code/game/objects/effects/decals/cleanable/food.dm
@@ -30,6 +30,7 @@
 	name = "salt pile"
 	desc = "A sizable pile of table salt. Someone must be upset."
 	icon_state = "salt_pile"
+	var/safepasses = 3 //how many times can this salt pile be passed before dissipating
 
 /obj/effect/decal/cleanable/food/salt/CanAllowThrough(atom/movable/AM, turf/target)
 	. = ..()
@@ -38,8 +39,19 @@
 
 /obj/effect/decal/cleanable/food/salt/Bumped(atom/movable/AM)
 	. = ..()
-	if(is_species(AM, /datum/species/snail))
-		to_chat(AM, "<span class='danger'>Your path is obstructed by <span class='phobia'>salt</span>.</span>")
+
+	if(isliving(AM))
+
+		if(is_species(AM, /datum/species/snail))
+			to_chat(AM, "<span class='danger'>Your path is obstructed by <span class='phobia'>salt</span>.</span>")
+
+		if(iscarbon(AM))
+			var/mob/living/carbon/C = AM
+			if(C.m_intent == MOVE_INTENT_WALK)
+				return
+		safepasses--
+		if(safepasses <= 0 && !QDELETED(src))
+			qdel(src)
 
 /obj/effect/decal/cleanable/food/flour
 	name = "flour"


### PR DESCRIPTION
## About The Pull Request
Running over salt (that is, moving over salt while not walking) will slowly dissipate it. The first two times, nothing will happen, but the third time the salt will be fully scattered away.

## Why It's Good For The Game
See also: https://github.com/tgstation/tgstation/pull/49248
I think salt is a hard enough counter to revenants that it's impossible to justify how easy it is to apply and how relatively permanent it is once it's applied. Salt smoke can coat entire departments in salt in seconds, locking revenants out of them forever with essentially 0 effort.

## Changelog
:cl:
add: Salt piles now get kicked around and eventually scattered to the wind when ran over too much.
/:cl: