### PR TITLE
energy cakehat buff

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -98,9 +98,10 @@
 	hitsound_on = 'sound/weapons/blade1.ogg'
 	hitsound_off = 'sound/weapons/tap.ogg'
 	damtype_on = BRUTE
-	force_on = 18 //same as epen (but much more obvious)
+	sharpness = IS_SHARP
+	force_on = 30 //same as esword (but makes you an epic gamer)
 	brightness_on = 3 //ditto
-	heat = 0
+	heat = 1000 //energy cakes are hot. they conduct a lot of heat, too.
 
 /obj/item/clothing/head/hardhat/cakehat/energycake/turn_on(mob/living/user)
 	playsound(user, 'sound/weapons/saberon.ogg', 5, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
makes the energy cakehat sharp and do 30 damage instead of 18. Also gives it heat 1000 instead of 0, but this is only used for heating reagents, not combat related. Cakehat has 999 for instance.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Energy cakehat is criminally underused, for one. I believe that people seldom make it because of the massive downgrade compared to what it takes to make an energy cakehat. With this PR, the cakehat will at LEAST be as powerful as an energy sword, making it a much more appealing item to make for stylish murdering. Didn't add in the block chance as of yet, I wanted to gather opinions about how it should be implemented, if at all.

The simplest idea is to just make the energy cakehat have 50 block chance at all times. Alternatively, add a block chance on variable to either cakehat or energy cakehat so it only has the block chance while it's on. I'm not entirely sure how it would affect getting hit by stuff while it's on your head, either, I'll test it if/when a method of block chance is decided upon.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: energy cakehat is now on par with energy swords.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
