### PR TITLE
Nuke Ops reinforcements now work on-station

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -110,9 +110,6 @@
 	if(!user.mind.has_antag_datum(/datum/antagonist/nukeop,TRUE))
 		to_chat(user, "<span class='danger'>AUTHENTICATION FAILURE. ACCESS DENIED.</span>")
 		return FALSE
-	if(!user.onSyndieBase())
-		to_chat(user, "<span class='warning'>[src] is out of range! It can only be used at your base!</span>")
-		return FALSE
 	return TRUE
 
 


### PR DESCRIPTION
I've seen this cause a lot of issues and wasted TC, and I'm not particularly sure why this exists. If the Ops want to try to tactically summon, brief, and equip new operatives in the middle of enemy territory, all the power to them.

Any advantage they get is offset by the fact that the new operatives have less time to prepare and strategize, and if the person with the reinforcement summoner/TC for the reinforcement summoner dies in combat then they've lost that TC. Seems like a reasonable tradeoff to me.

:cl: 
tweak: Beware! The Syndicate have upgraded their stolen teleportation machinery, they are now capable of providing reinforcements to their elite operatives nearly anywhere, even in the middle of combat! Not that that would be wise, to say the least.
/:cl: