### PR TITLE
Slimy business

### DIFF
--- a/code/_globalvars/lists/poll_ignore.dm
+++ b/code/_globalvars/lists/poll_ignore.dm
@@ -14,7 +14,6 @@
 #define POLL_IGNORE_SWARMER "swarmer"
 #define POLL_IGNORE_DRONE "drone"
 #define POLL_IGNORE_FUGITIVE "fugitive"
-#define POLL_IGNORE_PYROSLIME "slime"
 #define POLL_IGNORE_SHADE "shade"
 #define POLL_IGNORE_IMAGINARYFRIEND "imaginary_friend"
 #define POLL_IGNORE_SPLITPERSONALITY "split_personality"
@@ -37,7 +36,6 @@ GLOBAL_LIST_INIT(poll_ignore_desc, list(
 	POLL_IGNORE_SWARMER = "Swarmer shells",
 	POLL_IGNORE_DRONE = "Drone shells",
 	POLL_IGNORE_FUGITIVE = "Fugitive Hunter",
-	POLL_IGNORE_PYROSLIME = "Slime",
 	POLL_IGNORE_SHADE = "Shade",
 	POLL_IGNORE_IMAGINARYFRIEND = "Imaginary Friend",
 	POLL_IGNORE_SPLITPERSONALITY = "Split Personality",

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -265,23 +265,9 @@
 		T.atmos_spawn_air("o2=5;plasma=5;TEMP=1000")
 
 /obj/effect/anomaly/pyro/detonate()
-	INVOKE_ASYNC(src, .proc/makepyroslime)
-
-/obj/effect/anomaly/pyro/proc/makepyroslime()
 	var/turf/open/T = get_turf(src)
 	if(istype(T))
-		T.atmos_spawn_air("o2=500;plasma=500;TEMP=1000") //Make it hot and burny for the new slime
-	var/new_colour = pick("red", "orange")
-	var/mob/living/simple_animal/slime/S = new(T, new_colour)
-	S.rabid = TRUE
-	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
-	S.Evolve()
-
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a pyroclastic anomaly slime?", ROLE_PAI, null, null, 100, S, POLL_IGNORE_PYROSLIME)
-	if(LAZYLEN(candidates))
-		var/mob/dead/observer/chosen = pick(candidates)
-		S.key = chosen.key
-		log_game("[key_name(S.key)] was made into a slime by pyroclastic anomaly at [AREACOORD(T)].")
+		T.atmos_spawn_air("o2=500;plasma=500;TEMP=1000") // Punishment for ignoring the anomaly
 
 /////////////////////
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -533,6 +533,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 		if(prob(15) && power > POWER_PENALTY_THRESHOLD)
 			supermatter_pull(src, power/750)
+
+		if(power > POWER_PENALTY_THRESHOLD && prob(3) || power > SEVERE_POWER_PENALTY_THRESHOLD && prob(5) || power > CRITICAL_POWER_PENALTY_THRESHOLD && prob(10))
+			supermatter_slime_gen(src, power, rand(5, 10))
+
 		if(prob(5))
 			supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 10))
 		if(power > SEVERE_POWER_PENALTY_THRESHOLD && prob(5) || prob(1))
@@ -842,6 +846,81 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			step_towards(P,center)
 			step_towards(P,center)
 			step_towards(P,center)
+
+/obj/machinery/power/supermatter_crystal/proc/supermatter_slime_gen(turf/slimecenter, sm_power, slimerange = 5)
+	var/turf/L = pick(orange(slimerange, slimecenter))
+	if(L)
+		var/slime_colour="grey"
+		// Gotta go fast! Gotta hardcode those probabilities!
+		switch (sm_power)
+			if (0 to POWER_PENALTY_THRESHOLD)
+				return
+			if (POWER_PENALTY_THRESHOLD to SEVERE_POWER_PENALTY_THRESHOLD)
+				switch (rand(100))
+					if (0 to 40)
+					// Pleb level slime for starting your own farm
+						slime_colour = "grey"
+					// Pretty useless on their own and available via xenobio at 5 minute mark
+					if (41 to 50)
+						slime_colour = "orange"
+					if (51 to 60)
+						slime_colour = "metal"
+					if (61 to 70)
+						slime_colour = "blue"
+					if (71 to 80)
+						slime_colour = "purple"
+					// Can be useful at engineering
+					if (81 to 85)
+						slime_colour = "yellow"
+					if (86 to 90)
+						slime_colour = "dark purple"
+					if (91 to 95)
+						slime_colour = "green"
+					if (96 to 100)
+						slime_colour = "silver"
+			if (SEVERE_POWER_PENALTY_THRESHOLD to CRITICAL_POWER_PENALTY_THRESHOLD)
+				switch (rand(100))
+					// Basically now we get less greys and more T3 stuff
+					if (0 to 10)
+						slime_colour = "grey"
+					if (11 to 20)
+						slime_colour = "orange"
+					if (21 to 30)
+						slime_colour = "metal"
+					if (31 to 40)
+						slime_colour = "blue"
+					if (41 to 50)
+						slime_colour = "purple"
+					if (51 to 60)
+						slime_colour = "yellow"
+					if (61 to 70)
+						slime_colour = "dark purple"
+					if (71 to 80)
+						slime_colour = "green"
+					if (81 to 90)
+						slime_colour = "silver"
+					// You got lucky!
+					if (91 to 98)
+						slime_colour = pick("gold", "bluespace", "light pin", "adamantine", "black", "oil")
+					// Both you and clown got real lucky!
+					if (91 to 98)
+						slime_colour = pick("pyrite", "rainbow")
+			else
+				// Gotta Catch ‘Em All!!!111 For the absolute mad lads who are willing to power delaminate SM for dem slimes
+				if (prob(70))
+					// Not gonna give up top slimes that easy
+					slime_colour = "grey"
+				else
+					slime_colour = pick("orange","metal","grey","blue",
+										"purple","dark purple","dark blue","green",
+										"silver","yellow","gold","red",
+										"pink","cerulean","sepia","bluespace",
+										"pyrite","light pin","oil", "adamantine",
+									  	"black", "rainbow")
+		var/mob/living/simple_animal/slime/S = new(L, slime_colour)
+		S.rabid = TRUE
+		S.amount_grown = SLIME_EVOLUTION_THRESHOLD
+		S.Evolve()
 
 /obj/machinery/power/supermatter_crystal/proc/supermatter_anomaly_gen(turf/anomalycenter, type = FLUX_ANOMALY, anomalyrange = 5)
 	var/turf/L = pick(orange(anomalyrange, anomalycenter))

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -901,9 +901,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 						slime_colour = "silver"
 					// You got lucky!
 					if (91 to 98)
-						slime_colour = pick("gold", "bluespace", "light pin", "adamantine", "black", "oil")
+						slime_colour = pick("gold", "bluespace", "light pink", "adamantine", "black", "oil")
 					// Both you and clown got real lucky!
-					if (91 to 98)
+					if (99 to 100)
 						slime_colour = pick("pyrite", "rainbow")
 			else
 				// Gotta Catch ‘Em All!!!111 For the absolute mad lads who are willing to power delaminate SM for dem slimes
@@ -915,7 +915,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 										"purple","dark purple","dark blue","green",
 										"silver","yellow","gold","red",
 										"pink","cerulean","sepia","bluespace",
-										"pyrite","light pin","oil", "adamantine",
+										"pyrite","light pink","oil", "adamantine",
 									  	"black", "rainbow")
 		var/mob/living/simple_animal/slime/S = new(L, slime_colour)
 		S.rabid = TRUE


### PR DESCRIPTION
## About The Pull Request

I was bullied by mods and coders into fixing the issue with "gamer slimes" 
[See this thread](https://tgstation13.org/phpBB/viewtopic.php?f=10&t=25488)


## Why It's Good For The Game
Slimes spawned by SM and random "pyro anomaly" event have  huge destructive potential (see the thread I linked)

Initial plan was to prevent slims form attacking machinery but:
  1. It is cheesy.  At least for Swarmers there are lore reasons for why they can't vore APC and stuff around SM.  Adding something similar to the slimes doesn't make sense and removing their ability to destroy non organics also won't work since they need to break windows and stuff.
  2. Removing slimes ability to attack machines is a nerf to sentience potion since without gold cores slimes are the only option xenobio memers have.

So I ended up removing sentient slime spawns and instead made it so that SM spawns different types of non-sentient slimes depending on the current SM power level. This is cool because:
  1.  Randomly spawned sentient slimes are pretty dull ghost role that has no direction or a purpose. They often end up inside SM core or frozen in space/around SM chamber, spawned in maints without vents to crawl.
  2.  They have ability to destroy SM cooling loop, went crawl into gravy gen and kill it, kill silo and APC in bolted vault (f-ing the station for good) and even kill AI since they don't get damaged by its turrets. Also you can vent crawl around the station and break APCs faster than they get repaired... So you either do this or try to murderbone because slimes life is boring.
  3. Pyro anomaly is one of the most destructive ones since it can burn down important stuff - it doesn't need a slime gimmick.
  4. Using complex SM setup to spawn slimes makes it more rewarding since generating more energy makes no sense - there is no use for it and TEGs are much better and safer for this purpose.
  5. Allows for an interesting cooperation between xenobio and engineering departments.
  6. It will encourage engineers to push SM to the very limit since the best slimes are locked behind delamination levels of power.
  7. Making xenobio lab around SM sounds like a real interesting green shift project.
  8. Xenobio is still faster and simpler way to get slimes.  Engineers will have to deal with anomalies, randomly spawning rabid slimes, fires and power zaps, while SM prolly delaminates. Sounds like hell. And the spawn rate pretty low, also it has heavy bias to spawn gray slimes.

## Changelog
:cl:
add: SM spawns slimes. The higer energy level - the better slimes.
del: Removed random sentient slime spawns.
/:cl: