### PR TITLE
Slimes can no longer destroy objects.

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -96,7 +96,7 @@
 			return
 	take_damage(400, BRUTE, "melee", 0, get_dir(src, B))
 
-/obj/proc/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, armor_penetration = 0) //used by attack_alien, attack_animal, and attack_slime
+/obj/proc/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, armor_penetration = 0) //used by attack_alien and attack_animal
 	user.do_attack_animation(src)
 	user.changeNext_move(CLICK_CD_MELEE)
 	return take_damage(damage_amount, damage_type, damage_flag, sound_effect, get_dir(src, user), armor_penetration)
@@ -134,7 +134,6 @@
 /obj/attack_slime(mob/living/simple_animal/slime/user)
 	if(!user.is_adult)
 		return
-	attack_generic(user, rand(10, 15), "melee", 1)
 
 /obj/mech_melee_attack(obj/mecha/M)
 	M.do_attack_animation(src)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -131,10 +131,6 @@
 	var/amt = max(0, ((force - (move_resist * MOVE_FORCE_CRUSH_RATIO)) / (move_resist * MOVE_FORCE_CRUSH_RATIO)) * 10)
 	take_damage(amt, BRUTE)
 
-/obj/attack_slime(mob/living/simple_animal/slime/user)
-	if(!user.is_adult)
-		return
-
 /obj/mech_melee_attack(obj/mecha/M)
 	M.do_attack_animation(src)
 	var/play_soundeffect = 0

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -134,7 +134,7 @@
 /obj/attack_slime(mob/living/simple_animal/slime/user)
 	if(!user.is_adult)
 		return
-	attack_generic(user, rand(10, 15), BRUTE, "melee", 1)
+	attack_generic(user, rand(10, 15), "melee", 1)
 
 /obj/mech_melee_attack(obj/mecha/M)
 	M.do_attack_animation(src)


### PR DESCRIPTION
Reverts tgstation/tgstation#46718

Alternative to #49277

Closes #49277

This reverts adult slimes being able to attack structures and windows. The original discussion in #46718 points out that this was assumed behavior.

I'm doing this because I do not support the changes being suggested in the alternate PR and would prefer a reversion.

## Changelog
:cl:
balance: Slimes can't destory APC's and other objects.
/:cl: