### PR TITLE
Removes bottle/flask gulp adjustment

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -15,10 +15,6 @@
 	resistance_flags = NONE
 	var/isGlass = TRUE //Whether the 'bottle' is made of glass or not so that milk cartons dont shatter when someone gets hit by it
 
-/obj/item/reagent_containers/food/drinks/on_reagent_change(changetype)
-	. = ..()
-	gulp_size = max(round(reagents.total_volume / 5), 5)
-
 /obj/item/reagent_containers/food/drinks/attack(mob/living/M, mob/user, def_zone)
 
 	if(!reagents || !reagents.total_volume)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Drinking glasses and beakers allow for a controlled 5u gulp. For some reason bottles and flasks instead make you drink 1/5th of the current volume. This poses an issue with 100u bottles, where you're made to take in 20u on your first sip.

I've taken out the code that was causing this.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bottles are nifty and immersive but I'm going to forgo them every time because I don't want to lose a full 1/5th of my contents every time I want a sip.

If someone wants to make an argument about how we should be able to shotgun 20u of something into someone with one gulp please do because I'm having a hard time understanding why this is a thing.

Also closes: #49292
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Bottles and Flasks provide 5u on every gulp.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->