### PR TITLE
Removes an unused config (map rotation chance delta )

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -284,12 +284,6 @@
 
 /datum/config_entry/flag/maprotation
 
-/datum/config_entry/number/maprotatechancedelta
-	config_entry_value = 0.75
-	min_val = 0
-	max_val = 1
-	integer = FALSE
-
 /datum/config_entry/number/soft_popcap
 	config_entry_value = null
 	min_val = 0

--- a/config/config.txt
+++ b/config/config.txt
@@ -381,12 +381,6 @@ MAPROTATION
 ## When it's set to zero, the map will be randomly picked each round
 PREFERENCE_MAP_VOTING 1
 
-## Map rotate chance delta
-## This is the chance of map rotation factored to the round length.
-## A value of 1 would mean the map rotation chance is the round length in minutes (hour long round == 60% rotation chance)
-## A value of 0.5 would mean the map rotation chance is half of the round length in minutes (hour long round == 30% rotation chance)
-#MAPROTATECHANCEDELTA 0.75
-
 ## AUTOADMIN
 ## The default admin rank
 AUTOADMIN_RANK Game Master

--- a/config/config.txt
+++ b/config/config.txt
@@ -385,7 +385,7 @@ PREFERENCE_MAP_VOTING 1
 ## This is the chance of map rotation factored to the round length.
 ## A value of 1 would mean the map rotation chance is the round length in minutes (hour long round == 60% rotation chance)
 ## A value of 0.5 would mean the map rotation chance is half of the round length in minutes (hour long round == 30% rotation chance)
-#MAPROTATIONCHANCEDELTA 0.75
+#MAPROTATECHANCEDELTA 0.75
 
 ## AUTOADMIN
 ## The default admin rank


### PR DESCRIPTION
## About The Pull Request
> Since #48602 map rotation is forced on sudden round end though, so this config option doesnt do anything anymore and can be completely removed.

Removes map rotation chance delta config that no longer has a use