### PR TITLE
Unanchored solar assemblies go off-centre to indicate they need securing. Anchored ones centre themselves

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -213,16 +213,16 @@
 	anchored = FALSE
 	var/tracker = 0
 	var/glass_type = null
-	var/rndoffsetpxlamt = 6 //how much unwrenched solars have their position altered by to indicate they're unsecured
+	var/random_offset = 6 //amount in pixels an unanchored assembly may be offset by
 
 /obj/item/solar_assembly/Initialize(mapload)
 	. = ..()
 	if(!anchored && !pixel_x && !pixel_y)
-		randomise_offset(rndoffsetpxlamt)
+		randomise_offset(random_offset)
 
-/obj/item/solar_assembly/proc/randomise_offset(amt)
-	pixel_x = rand(-amt,amt)
-	pixel_y = rand(-amt,amt)
+/obj/item/solar_assembly/proc/randomise_offset(amount)
+	pixel_x = rand(-amount,amount)
+	pixel_y = rand(-amount,amount)
 
 // Give back the glass type we were supplied with
 /obj/item/solar_assembly/proc/give_glass(device_broken)
@@ -249,7 +249,7 @@
 		else
 			user.visible_message("<span class='notice'>[user] unwrenches the solar assembly from its place.</span>", "<span class='notice'>You unwrench the solar assembly from its place.</span>")
 			W.play_tool_sound(src, 75)
-			randomise_offset(rndoffsetpxlamt)
+			randomise_offset(random_offset)
 		return 1
 
 	if(istype(W, /obj/item/stack/sheet/glass) || istype(W, /obj/item/stack/sheet/rglass))

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -213,6 +213,16 @@
 	anchored = FALSE
 	var/tracker = 0
 	var/glass_type = null
+	var/rndoffsetpxlamt = 6 //how much unwrenched solars have their position altered by to indicate they're unsecured
+
+/obj/item/solar_assembly/Initialize(mapload)
+	. = ..()
+	if(!anchored && !pixel_x && !pixel_y)
+		randomise_offset(rndoffsetpxlamt)
+
+/obj/item/solar_assembly/proc/randomise_offset(amt)
+	pixel_x = rand(-amt,amt)
+	pixel_y = rand(-amt,amt)
 
 // Give back the glass type we were supplied with
 /obj/item/solar_assembly/proc/give_glass(device_broken)
@@ -234,9 +244,12 @@
 		if(anchored)
 			user.visible_message("<span class='notice'>[user] wrenches the solar assembly into place.</span>", "<span class='notice'>You wrench the solar assembly into place.</span>")
 			W.play_tool_sound(src, 75)
+			pixel_x = 0
+			pixel_y = 0
 		else
 			user.visible_message("<span class='notice'>[user] unwrenches the solar assembly from its place.</span>", "<span class='notice'>You unwrench the solar assembly from its place.</span>")
 			W.play_tool_sound(src, 75)
+			randomise_offset(rndoffsetpxlamt)
 		return 1
 
 	if(istype(W, /obj/item/stack/sheet/glass) || istype(W, /obj/item/stack/sheet/rglass))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Quick visual indication of whether a solar assembly has been secured yet or not
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You can tell whether an assembly needs securing at a glance
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
tweak: Unanchored solar assemblies go off-centre to indicate they need securing. Secured ones centre themselves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
