### PR TITLE
Soil is no longer called hydroponics tray when something is planted

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -90,6 +90,10 @@
 
 	return connected
 
+/obj/machinery/hydroponics/proc/UpdateTrayName(mob/user)
+	name = initial(name)
+	if(myseed)
+		name += " ([myseed.plantname])"
 
 /obj/machinery/hydroponics/bullet_act(obj/projectile/Proj) //Works with the Somatoray to modify plant variables.
 	if(!myseed)
@@ -388,12 +392,7 @@
 	pestlevel = 0 // Reset
 	update_icon()
 	visible_message("<span class='warning'>The [oldPlantName] is overtaken by some [myseed.plantname]!</span>")
-	name = "hydroponics tray ([myseed.plantname])"
-	if(myseed.product)
-		desc = initial(myseed.product.desc)
-	else
-		desc = initial(desc)
-
+	UpdateTrayName()
 
 /obj/machinery/hydroponics/proc/mutate(lifemut = 2, endmut = 5, productmut = 1, yieldmut = 2, potmut = 25, wrmut = 2, wcmut = 5, traitmut = 0) // Mutates the current seed
 	if(!myseed)
@@ -427,12 +426,7 @@
 	sleep(5) // Wait a while
 	update_icon()
 	visible_message("<span class='warning'>[oldPlantName] suddenly mutates into [myseed.plantname]!</span>")
-	name = "hydroponics tray ([myseed.plantname])"
-	if(myseed.product)
-		desc = initial(myseed.product.desc)
-	else
-		desc = initial(desc)
-
+	UpdateTrayName()
 
 /obj/machinery/hydroponics/proc/mutateweed() // If the weeds gets the mutagent instead. Mind you, this pretty much destroys the old plant
 	if( weedlevel > 5 )
@@ -452,6 +446,7 @@
 		sleep(5) // Wait a while
 		update_icon()
 		visible_message("<span class='warning'>The mutated weeds in [src] spawn some [myseed.plantname]!</span>")
+		UpdateTrayName()
 	else
 		to_chat(usr, "<span class='warning'>The few weeds in [src] seem to react, but only for a moment...</span>")
 
@@ -797,15 +792,7 @@
 			to_chat(user, "<span class='notice'>You plant [O].</span>")
 			dead = 0
 			myseed = O
-			name = "hydroponics tray ([myseed.plantname])"
-			if(!myseed.productdesc) //we haven't changed our produce's description
-				if(myseed.product)
-					myseed.productdesc = initial(myseed.product.desc)
-				else if(myseed.desc)
-					myseed.productdesc = myseed.desc
-				else
-					myseed.productdesc = "A fascinating specimen."
-			desc = myseed.productdesc
+			UpdateTrayName()
 			age = 1
 			plant_health = myseed.endurance
 			lastcycle = world.time
@@ -907,8 +894,7 @@
 		qdel(myseed)
 		myseed = null
 		update_icon()
-		name = initial(name)
-		desc = initial(desc)
+		UpdateTrayName()
 	else
 		if(user)
 			examine(user)
@@ -926,8 +912,7 @@
 		qdel(myseed)
 		myseed = null
 		dead = 0
-		name = initial(name)
-		desc = initial(desc)
+		UpdateTrayName()
 	update_icon()
 
 /// Tray Setters - The following procs adjust the tray or plants variables, and make sure that the stat doesn't go out of bounds.///
@@ -970,6 +955,7 @@
 	desc = "A patch of dirt."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "soil"
+	gender = PLURAL
 	circuit = null
 	density = FALSE
 	use_power = NO_POWER_USE

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1,3 +1,5 @@
+#define TRAY_NAME_UPDATE name = myseed ? "[initial(name)] ([myseed.plantname])" : initial(name)
+
 /obj/machinery/hydroponics
 	name = "hydroponics tray"
 	icon = 'icons/obj/hydroponics/equipment.dmi'
@@ -89,11 +91,6 @@
 		connected += a
 
 	return connected
-
-/obj/machinery/hydroponics/proc/UpdateTrayName(mob/user)
-	name = initial(name)
-	if(myseed)
-		name += " ([myseed.plantname])"
 
 /obj/machinery/hydroponics/bullet_act(obj/projectile/Proj) //Works with the Somatoray to modify plant variables.
 	if(!myseed)
@@ -392,7 +389,7 @@
 	pestlevel = 0 // Reset
 	update_icon()
 	visible_message("<span class='warning'>The [oldPlantName] is overtaken by some [myseed.plantname]!</span>")
-	UpdateTrayName()
+	TRAY_NAME_UPDATE
 
 /obj/machinery/hydroponics/proc/mutate(lifemut = 2, endmut = 5, productmut = 1, yieldmut = 2, potmut = 25, wrmut = 2, wcmut = 5, traitmut = 0) // Mutates the current seed
 	if(!myseed)
@@ -426,7 +423,7 @@
 	sleep(5) // Wait a while
 	update_icon()
 	visible_message("<span class='warning'>[oldPlantName] suddenly mutates into [myseed.plantname]!</span>")
-	UpdateTrayName()
+	TRAY_NAME_UPDATE
 
 /obj/machinery/hydroponics/proc/mutateweed() // If the weeds gets the mutagent instead. Mind you, this pretty much destroys the old plant
 	if( weedlevel > 5 )
@@ -446,7 +443,7 @@
 		sleep(5) // Wait a while
 		update_icon()
 		visible_message("<span class='warning'>The mutated weeds in [src] spawn some [myseed.plantname]!</span>")
-		UpdateTrayName()
+		TRAY_NAME_UPDATE
 	else
 		to_chat(usr, "<span class='warning'>The few weeds in [src] seem to react, but only for a moment...</span>")
 
@@ -792,7 +789,7 @@
 			to_chat(user, "<span class='notice'>You plant [O].</span>")
 			dead = 0
 			myseed = O
-			UpdateTrayName()
+			TRAY_NAME_UPDATE
 			age = 1
 			plant_health = myseed.endurance
 			lastcycle = world.time
@@ -894,7 +891,7 @@
 		qdel(myseed)
 		myseed = null
 		update_icon()
-		UpdateTrayName()
+		TRAY_NAME_UPDATE
 	else
 		if(user)
 			examine(user)
@@ -912,7 +909,7 @@
 		qdel(myseed)
 		myseed = null
 		dead = 0
-		UpdateTrayName()
+		TRAY_NAME_UPDATE
 	update_icon()
 
 /// Tray Setters - The following procs adjust the tray or plants variables, and make sure that the stat doesn't go out of bounds.///


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixing some of my shitty code. Soil is currently renamed "hydroponics tray (plantname)" when something is planted in it.

Also does the following:
- Simplifies tray renaming and reduces the copypasted code by making it a define (thanks cob)
- Removes a planter's description changing to the plant's; I couldn't make the descriptions work grammatically with the plant name and they don't make sense on their own
- Makes soil PLURAL gender so it's referred to as some soil instead of a soil
- Removes unnecessary setting of a seed's productdesc when planting, it already gets that when customising it with a pen and that's the only time it's relevant
- Updates the tray name when weeds are mutated, which didn't used to happen and was an oversight on my part

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Soil isn't a hydroponics tray                    
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
fix: Soil no longer renames itself hydroponics tray while something is planted in it
fix: Hydroponics planter names will update when weeds are mutated
del: Planters no longer change description to match that of what's planted in them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
