### PR TITLE
Republish - Machinery processing refactor

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -418,7 +418,6 @@
 /obj/machinery/mineral/ore_redemption{
 	name = "Syndicate ore redemption machine";
 	ore_multiplier = 4;
-	ore_pickup_rate = 20;
 	req_access = list(150)
 	},
 /turf/open/floor/mineral/plastitanium,

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -47,6 +47,7 @@
 #define COMSIG_ELEMENT_DETACH "element_detach"
 
 // /atom signals
+#define COMSIG_ATOM_CREATED "atom_created"						///from base of atom/proc/Initialize(): sent any time a new atom is created
 #define COMSIG_PARENT_ATTACKBY "atom_attackby"			        ///from base of atom/attackby(): (/obj/item, /mob/living, params)
 	#define COMPONENT_NO_AFTERATTACK 1								//Return this in response if you don't want afterattack to be called
 #define COMSIG_ATOM_HULK_ATTACK "hulk_attack"					///from base of atom/attack_hulk(): (/mob/living/carbon/human)

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -15,7 +15,6 @@
 // bitflags for a machine's preferences on when it should start processing
 #define START_PROCESSING_ON_INIT	(1<<0)	// if the machine should start processing on Initialize()
 #define START_PROCESSING_MANUALLY	(1<<1)	// if the machine will start processing in the future, after Initialize(), such as when a certain condition is met
-#define NEVER_PROCESS				(1<<2)	// if the machine has no reason to process
 
 //bitflags for door switches.
 #define OPEN	(1<<0)

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -12,6 +12,10 @@
 #define IDLE_POWER_USE 1
 #define ACTIVE_POWER_USE 2
 
+// bitflags for a machine's preferences on when it should start processing
+#define START_PROCESSING_ON_INIT	(1<<0)	// if the machine should start processing on Initialize()
+#define START_PROCESSING_MANUALLY	(1<<1)	// if the machine will start processing in the future, after Initialize(), such as when a certain condition is met
+#define NEVER_PROCESS				(1<<2)	// if the machine has no reason to process
 
 //bitflags for door switches.
 #define OPEN	(1<<0)

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -12,9 +12,9 @@
 #define IDLE_POWER_USE 1
 #define ACTIVE_POWER_USE 2
 
-// bitflags for a machine's preferences on when it should start processing
-#define START_PROCESSING_ON_INIT	(1<<0)	// if the machine should start processing on Initialize()
-#define START_PROCESSING_MANUALLY	(1<<1)	// if the machine will start processing in the future, after Initialize(), such as when a certain condition is met
+/// Bitflags for a machine's preferences on when it should start processing. For use with machinery's `processing_flags` var.
+#define START_PROCESSING_ON_INIT	(1<<0) /// Indicates the machine will automatically start processing right after it's `Initialize()` is ran.
+#define START_PROCESSING_MANUALLY	(1<<1) /// Machines with this flag will not start processing when it's spawned. Use this if you want to manually control when a machine starts processing.
 
 //bitflags for door switches.
 #define OPEN	(1<<0)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -148,8 +148,6 @@
 
 	if(loc)
 		SEND_SIGNAL(loc, COMSIG_ATOM_ENTERED, src) // if the new item is created over a turf, send a signal that it entered that turf, `loc` in this case
-		for(var/atom/A in loc) // send a signal for every item on the `loc` turf to let them know a new item just crossed it
-			SEND_SIGNAL(A, COMSIG_MOVABLE_CROSSED, src)
 
 	//atom color stuff
 	if(color)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -147,7 +147,7 @@
 	flags_1 |= INITIALIZED_1
 
 	if(loc)
-		SEND_SIGNAL(loc, COMSIG_ATOM_ENTERED, src) // if the new item is created over a turf, send a signal that it entered that turf, `loc` in this case
+		SEND_SIGNAL(loc, COMSIG_ATOM_CREATED, src) /// Sends a signal that the new atom `src`, has been created at `loc`
 
 	//atom color stuff
 	if(color)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -146,6 +146,11 @@
 		stack_trace("Warning: [src]([type]) initialized multiple times!")
 	flags_1 |= INITIALIZED_1
 
+	if(loc)
+		SEND_SIGNAL(loc, COMSIG_ATOM_ENTERED, src) // if the new item is created over a turf, send a signal that it entered that turf, `loc` in this case
+		for(var/atom/A in loc) // send a signal for every item on the `loc` turf to let them know a new item just crossed it
+			SEND_SIGNAL(A, COMSIG_MOVABLE_CROSSED, src)
+
 	//atom color stuff
 	if(color)
 		add_atom_colour(color, FIXED_COLOUR_PRIORITY)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -146,7 +146,7 @@ Class Procs:
 
 	return INITIALIZE_HINT_LATELOAD
 
-// helper procs for starting and stoppping the appropriate subsystem that a machine uses. Uses their `subsystem_type` var to choose
+/// helper procs for starting and stoppping the appropriate subsystem that a machine uses. Uses their `subsystem_type` var to choose
 /obj/machinery/proc/begin_processing()
 	var/datum/controller/subsystem/processing/subsystem = locate(subsystem_type) in Master.subsystems
 	START_PROCESSING(subsystem, src)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -113,7 +113,8 @@ Class Procs:
 	var/critical_machine = FALSE //If this machine is critical to station operation and should have the area be excempted from power failures.
 	var/list/occupant_typecache //if set, turned into typecache in Initialize, other wise, defaults to mob/living typecache
 	var/atom/movable/occupant = null
-	var/speed_process = FALSE // Process as fast as possible?
+	var/processing_flags = START_PROCESSING_ON_INIT // By default all machinery will start processing when the round loads up
+	var/subsystem_type = /datum/controller/subsystem/machines // By default all machinery use SSmachines. This fires a machine's process() roughly every 2 seconds
 	var/obj/item/circuitboard/circuit // Circuit to be created and inserted when the machinery is created
 
 	var/interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_SET_MACHINE
@@ -137,15 +138,22 @@ Class Procs:
 		circuit = new circuit
 		circuit.apply_default_parts(src)
 
-	if(!speed_process)
-		START_PROCESSING(SSmachines, src)
-	else
-		START_PROCESSING(SSfastprocess, src)
+	if(processing_flags & START_PROCESSING_ON_INIT)
+		begin_processing()
 
-	if (occupant_typecache)
+	if(occupant_typecache)
 		occupant_typecache = typecacheof(occupant_typecache)
 
 	return INITIALIZE_HINT_LATELOAD
+
+// helper procs for starting and stoppping the appropriate subsystem that a machine uses. Uses their `subsystem_type` var to choose
+/obj/machinery/proc/begin_processing()
+	var/datum/controller/subsystem/processing/subsystem = locate(subsystem_type) in Master.subsystems
+	START_PROCESSING(subsystem, src)
+
+/obj/machinery/proc/end_processing()
+	var/datum/controller/subsystem/processing/subsystem = locate(subsystem_type) in Master.subsystems
+	STOP_PROCESSING(subsystem, src)
 
 /obj/machinery/LateInitialize()
 	. = ..()
@@ -154,10 +162,7 @@ Class Procs:
 
 /obj/machinery/Destroy()
 	GLOB.machines.Remove(src)
-	if(!speed_process)
-		STOP_PROCESSING(SSmachines, src)
-	else
-		STOP_PROCESSING(SSfastprocess, src)
+	end_processing()
 	dropContents()
 	if(length(component_parts))
 		for(var/atom/A in component_parts)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -113,8 +113,10 @@ Class Procs:
 	var/critical_machine = FALSE //If this machine is critical to station operation and should have the area be excempted from power failures.
 	var/list/occupant_typecache //if set, turned into typecache in Initialize, other wise, defaults to mob/living typecache
 	var/atom/movable/occupant = null
-	var/processing_flags = START_PROCESSING_ON_INIT // By default all machinery will start processing when the round loads up
-	var/subsystem_type = /datum/controller/subsystem/machines // By default all machinery use SSmachines. This fires a machine's process() roughly every 2 seconds
+	/// Viable flags to go here are START_PROCESSING_ON_INIT, or START_PROCESSING_MANUALLY. See code\__DEFINES\machines.dm for more information on these flags.
+	var/processing_flags = START_PROCESSING_ON_INIT
+	/// What subsystem this machine will use, which is generally SSmachines or SSfastprocess. By default all machinery use SSmachines. This fires a machine's process() roughly every 2 seconds.
+	var/subsystem_type = /datum/controller/subsystem/machines
 	var/obj/item/circuitboard/circuit // Circuit to be created and inserted when the machinery is created
 
 	var/interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_SET_MACHINE
@@ -146,11 +148,12 @@ Class Procs:
 
 	return INITIALIZE_HINT_LATELOAD
 
-/// helper procs for starting and stoppping the appropriate subsystem that a machine uses. Uses their `subsystem_type` var to choose
+/// Helper proc for telling a machine to start processing with the subsystem type that is located in its `subsystem_type` var.
 /obj/machinery/proc/begin_processing()
 	var/datum/controller/subsystem/processing/subsystem = locate(subsystem_type) in Master.subsystems
 	START_PROCESSING(subsystem, src)
 
+/// Helper proc for telling a machine to stop processing with the subsystem type that is located in its `subsystem_type` var.
 /obj/machinery/proc/end_processing()
 	var/datum/controller/subsystem/processing/subsystem = locate(subsystem_type) in Master.subsystems
 	STOP_PROCESSING(subsystem, src)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -11,7 +11,8 @@
 	density = FALSE
 	layer = BELOW_MOB_LAYER //so people can't hide it and it's REALLY OBVIOUS
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	speed_process = TRUE
+	processing_flags = START_PROCESSING_MANUALLY
+	subsystem_type = /datum/controller/subsystem/processing/fastprocess
 
 	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_OFFLINE
 
@@ -48,7 +49,7 @@
 
 /obj/machinery/syndicatebomb/process()
 	if(!active)
-		STOP_PROCESSING(SSfastprocess, src)
+		end_processing()
 		detonation_timer = null
 		next_beep = null
 		countdown.stop()
@@ -87,12 +88,12 @@
 		payload = new payload(src)
 	update_icon()
 	countdown = new(src)
-	STOP_PROCESSING(SSfastprocess, src)
+	end_processing()
 
 /obj/machinery/syndicatebomb/Destroy()
 	QDEL_NULL(wires)
 	QDEL_NULL(countdown)
-	STOP_PROCESSING(SSfastprocess, src)
+	end_processing()
 	return ..()
 
 /obj/machinery/syndicatebomb/examine(mob/user)
@@ -183,7 +184,7 @@
 
 /obj/machinery/syndicatebomb/proc/activate()
 	active = TRUE
-	START_PROCESSING(SSfastprocess, src)
+	begin_processing()
 	countdown.start()
 	next_beep = world.time + 10
 	detonation_timer = world.time + (timer_set * 10)

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -22,9 +22,10 @@
 
 /obj/machinery/mineral/proc/register_input_turf()
 	input_turf = get_step(src, input_dir) // get the turf that players need to place the ore/items onto, defaults to NORTH at round start
-	if(input_turf && istype(input_turf)) // make sure there is actually a turf
+	if(input_turf) // make sure there is actually a turf
 		// listens for when an atom ENTERS the input_turf, tells the machine to deal with the ores/items
 		RegisterSignal(input_turf, COMSIG_ATOM_ENTERED, .proc/pickup_item)
+		RegisterSignal(input_turf, COMSIG_ATOM_CREATED, .proc/pickup_item)
 
 /obj/machinery/mineral/proc/unregister_input_turf()
 	if(input_turf)

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -24,8 +24,7 @@
 	input_turf = get_step(src, input_dir) // get the turf that players need to place the ore/items onto, defaults to NORTH at round start
 	if(input_turf) // make sure there is actually a turf
 		// listens for when an atom ENTERS the input_turf, tells the machine to deal with the ores/items
-		RegisterSignal(input_turf, COMSIG_ATOM_ENTERED, .proc/pickup_item)
-		RegisterSignal(input_turf, COMSIG_ATOM_CREATED, .proc/pickup_item)
+		RegisterSignal(input_turf, list(COMSIG_ATOM_CREATED, COMSIG_ATOM_ENTERED), .proc/pickup_item)
 
 /obj/machinery/mineral/proc/unregister_input_turf()
 	if(input_turf)
@@ -168,11 +167,8 @@
 	return dat
 
 /obj/machinery/mineral/processing_unit/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
-	if(!istype(target, /obj/item/stack/ore))
-		return
-
-	var/obj/item/stack/ore/O = target
-	process_ore(O)
+	if(istype(target, /obj/item/stack/ore))
+		process_ore(target)
 
 /obj/machinery/mineral/processing_unit/process()
 	if(on)

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -24,13 +24,13 @@
 	input_turf = get_step(src, input_dir) // get the turf that players need to place the ore/items onto, defaults to NORTH at round start
 	if(input_turf && istype(input_turf)) // make sure there is actually a turf
 		// listens for when an atom ENTERS the input_turf, tells the machine to deal with the ores/items
-		RegisterSignal(input_turf, COMSIG_ATOM_ENTERED, .proc/pickup_items, TRUE)
+		RegisterSignal(input_turf, COMSIG_ATOM_ENTERED, .proc/pickup_item)
 
 /obj/machinery/mineral/proc/unregister_input_turf()
 	if(input_turf)
 		UnregisterSignal(input_turf, COMSIG_ATOM_ENTERED)
 
-/obj/machinery/mineral/proc/pickup_items()
+/obj/machinery/mineral/proc/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
 	return
 
 /obj/machinery/mineral/proc/unload_mineral(atom/movable/S)
@@ -166,9 +166,12 @@
 
 	return dat
 
-/obj/machinery/mineral/processing_unit/pickup_items()
-	for(var/obj/item/stack/ore/O in input_turf)
-		process_ore(O)
+/obj/machinery/mineral/processing_unit/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
+	if(!istype(target, /obj/item/stack/ore))
+		return
+
+	var/obj/item/stack/ore/O = target
+	process_ore(O)
 
 /obj/machinery/mineral/processing_unit/process()
 	if(on)

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -29,7 +29,7 @@
 
 /obj/machinery/mineral/proc/unregister_input_turf()
 	if(input_turf)
-		UnregisterSignal(input_turf, COMSIG_ATOM_ENTERED)
+		UnregisterSignal(input_turf, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_CREATED))
 
 /obj/machinery/mineral/proc/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
 	return

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -15,11 +15,6 @@
 	if(needs_item_input)
 		register_input_turf()
 
-/obj/machinery/mineral/Destroy()
-	. = ..()
-	if(input_turf)
-		unregister_input_turf()
-
 /obj/machinery/mineral/proc/register_input_turf()
 	input_turf = get_step(src, input_dir) // get the turf that players need to place the ore/items onto, defaults to NORTH at round start
 	if(input_turf) // make sure there is actually a turf

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -5,6 +5,33 @@
 /obj/machinery/mineral
 	var/input_dir = NORTH
 	var/output_dir = SOUTH
+	var/turf/input_turf = null // The turf that the machines will be listening to for ores/items
+	var/needs_item_input = FALSE // whether or not the machine needs to pick up items, i.e. the ORM picking up ores
+	processing_flags = START_PROCESSING_MANUALLY
+	subsystem_type = /datum/controller/subsystem/processing/fastprocess
+
+/obj/machinery/mineral/Initialize(mapload)
+	. = ..()
+	if(needs_item_input)
+		register_input_turf()
+
+/obj/machinery/mineral/Destroy()
+	. = ..()
+	if(input_turf)
+		unregister_input_turf()
+
+/obj/machinery/mineral/proc/register_input_turf()
+	input_turf = get_step(src, input_dir) // get the turf that players need to place the ore/items onto, defaults to NORTH at round start
+	if(input_turf && istype(input_turf)) // make sure there is actually a turf
+		// listens for when an atom ENTERS the input_turf, tells the machine to deal with the ores/items
+		RegisterSignal(input_turf, COMSIG_ATOM_ENTERED, .proc/pickup_items, TRUE)
+
+/obj/machinery/mineral/proc/unregister_input_turf()
+	if(input_turf)
+		UnregisterSignal(input_turf, COMSIG_ATOM_ENTERED)
+
+/obj/machinery/mineral/proc/pickup_items()
+	return
 
 /obj/machinery/mineral/proc/unload_mineral(atom/movable/S)
 	S.forceMove(drop_location())
@@ -19,7 +46,6 @@
 	density = TRUE
 	var/obj/machinery/mineral/processing_unit/machine = null
 	var/machinedir = EAST
-	speed_process = TRUE
 
 /obj/machinery/mineral/processing_unit_console/Initialize()
 	. = ..()
@@ -58,6 +84,7 @@
 
 	if(href_list["set_on"])
 		machine.on = (href_list["set_on"] == "on")
+		machine.begin_processing()
 
 	updateUsrDialog()
 	return
@@ -80,6 +107,7 @@
 	var/datum/material/selected_material = null
 	var/selected_alloy = null
 	var/datum/techweb/stored_research
+	needs_item_input = TRUE
 
 /obj/machinery/mineral/processing_unit/Initialize()
 	. = ..()
@@ -92,10 +120,6 @@
 	CONSOLE = null
 	QDEL_NULL(stored_research)
 	return ..()
-
-/obj/machinery/mineral/processing_unit/HasProximity(atom/movable/AM)
-	if(istype(AM, /obj/item/stack/ore) && AM.loc == get_step(src, input_dir))
-		process_ore(AM)
 
 /obj/machinery/mineral/processing_unit/proc/process_ore(obj/item/stack/ore/O)
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
@@ -142,8 +166,12 @@
 
 	return dat
 
+/obj/machinery/mineral/processing_unit/pickup_items()
+	for(var/obj/item/stack/ore/O in input_turf)
+		process_ore(O)
+
 /obj/machinery/mineral/processing_unit/process()
-	if (on)
+	if(on)
 		if(selected_material)
 			smelt_ore()
 
@@ -153,6 +181,8 @@
 
 		if(CONSOLE)
 			CONSOLE.updateUsrDialog()
+	else
+		end_processing()
 
 /obj/machinery/mineral/processing_unit/proc/smelt_ore()
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -3,31 +3,47 @@
 /**********************Mineral processing unit console**************************/
 
 /obj/machinery/mineral
-	var/input_dir = NORTH
-	var/output_dir = SOUTH
-	var/turf/input_turf = null // The turf that the machines will be listening to for ores/items
-	var/needs_item_input = FALSE // whether or not the machine needs to pick up items, i.e. the ORM picking up ores
 	processing_flags = START_PROCESSING_MANUALLY
 	subsystem_type = /datum/controller/subsystem/processing/fastprocess
+	/// The current direction of `input_turf`, in relation to the machine.
+	var/input_dir = NORTH
+	/// The current direction, in relation to the machine, that items will be output to.
+	var/output_dir = SOUTH
+	/// The turf the machines listens to for items to pick up. Calls the `pickup_item()` proc.
+	var/turf/input_turf = null
+	/// Determines if this machine needs to pick up items. Used to avoid registering signals to `/mineral` machines that don't pickup items.
+	var/needs_item_input = FALSE
 
 /obj/machinery/mineral/Initialize(mapload)
 	. = ..()
 	if(needs_item_input)
 		register_input_turf()
 
+/// Gets the turf in the `input_dir` direction adjacent to the machine, and registers signals for ATOM_ENTERED and ATOM_CREATED. Calls the `pickup_item()` proc when it recieves these signals.
 /obj/machinery/mineral/proc/register_input_turf()
-	input_turf = get_step(src, input_dir) // get the turf that players need to place the ore/items onto, defaults to NORTH at round start
+	input_turf = get_step(src, input_dir)
 	if(input_turf) // make sure there is actually a turf
-		// listens for when an atom ENTERS the input_turf, tells the machine to deal with the ores/items
 		RegisterSignal(input_turf, list(COMSIG_ATOM_CREATED, COMSIG_ATOM_ENTERED), .proc/pickup_item)
 
+/// Unregisters signals that are registered the machine's input turf, if it has one.
 /obj/machinery/mineral/proc/unregister_input_turf()
 	if(input_turf)
 		UnregisterSignal(input_turf, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_CREATED))
 
+/**
+	Base proc for all `/mineral` subtype machines to use. Place your item pickup behavior in this proc when you override it for your specific machine.
+
+	Called when the COMSIG_ATOM_ENTERED and COMSIG_ATOM_CREATED signals are sent.
+
+	Arguments:
+	* source - the turf that is listening for the signals.
+	* target - the atom that just moved onto the `source` turf.
+	* oldLoc - the old location that `target` was at before moving onto `source`.
+*/
 /obj/machinery/mineral/proc/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
 	return
 
+/// Generic unloading proc. Takes an atom as an argument and forceMove's it to the turf adjacent to this machine in the `output_dir` direction.
 /obj/machinery/mineral/proc/unload_mineral(atom/movable/S)
 	S.forceMove(drop_location())
 	var/turf/T = get_step(src,output_dir)
@@ -97,12 +113,12 @@
 	icon = 'icons/obj/machines/mining_machines.dmi'
 	icon_state = "furnace"
 	density = TRUE
+	needs_item_input = TRUE
 	var/obj/machinery/mineral/CONSOLE = null
 	var/on = FALSE
 	var/datum/material/selected_material = null
 	var/selected_alloy = null
 	var/datum/techweb/stored_research
-	needs_item_input = TRUE
 
 /obj/machinery/mineral/processing_unit/Initialize()
 	. = ..()

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -24,7 +24,7 @@
 	var/obj/item/disk/design_disk/inserted_disk
 	var/datum/component/remote_materials/materials
 	needs_item_input = TRUE
-	processing_flags = NEVER_PROCESS
+	processing_flags = START_PROCESSING_MANUALLY
 
 /obj/machinery/mineral/ore_redemption/Initialize(mapload)
 	. = ..()
@@ -155,14 +155,17 @@
 
 	if(!console_notify_timer)
 		// gives 5 seconds for a load of ores to be sucked up by the ORM before it sends out request console notifications. This should be enough time for most deposits that people make
-		console_notify_timer = addtimer(CALLBACK(src, .proc/send_console_message), 50)
+		console_notify_timer = addtimer(CALLBACK(src, .proc/send_console_message), 5 SECONDS)
+
+/obj/machinery/mineral/ore_redemption/default_unfasten_wrench(mob/user, obj/item/I)
+	. = ..()
+	if(anchored)
+		register_input_turf() // someone just wrenched us down, re-register the turf
+	else
+		unregister_input_turf() // someone just un-wrenched us, unregister the turf
 
 /obj/machinery/mineral/ore_redemption/attackby(obj/item/W, mob/user, params)
 	if(default_unfasten_wrench(user, W))
-		if(anchored)
-			register_input_turf() // someone just wrenched us down, re-register the turf
-		else
-			unregister_input_turf() // someone just un-wrenched us, unregister the turf
 		return
 	if(default_deconstruction_screwdriver(user, "ore_redemption-open", "ore_redemption", W))
 		updateUsrDialog()

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -10,7 +10,6 @@
 	input_dir = NORTH
 	output_dir = SOUTH
 	req_access = list(ACCESS_MINERAL_STOREROOM)
-	speed_process = TRUE
 	layer = BELOW_OBJ_LAYER
 	circuit = /obj/item/circuitboard/machine/ore_redemption
 	ui_x = 440
@@ -21,11 +20,13 @@
 	var/ore_multiplier = 1
 	var/point_upgrade = 1
 	var/list/ore_values = list(/datum/material/iron = 1, /datum/material/glass = 1,  /datum/material/plasma = 15,  /datum/material/silver = 16, /datum/material/gold = 18, /datum/material/titanium = 30, /datum/material/uranium = 30, /datum/material/diamond = 50, /datum/material/bluespace = 50, /datum/material/bananium = 60)
-	var/message_sent = FALSE
+	var/console_notify_timer // timer used for callbacks to send_console_message(). Used for preventing multiple calls to the proc while the ORM is eating a stack of ores
 	var/list/ore_buffer = list()
 	var/datum/techweb/stored_research
 	var/obj/item/disk/design_disk/inserted_disk
 	var/datum/component/remote_materials/materials
+	needs_item_input = TRUE
+	processing_flags = NEVER_PROCESS
 
 /obj/machinery/mineral/ore_redemption/Initialize(mapload)
 	. = ..()
@@ -123,7 +124,8 @@
 	var/datum/component/material_container/mat_container = materials.mat_container
 	if(!mat_container || !is_station_level(z))
 		return
-	message_sent = TRUE
+
+	console_notify_timer = null
 
 	var/area/A = get_area(src)
 	var/msg = "Now available in [A]:<br>"
@@ -149,10 +151,11 @@
 	))
 	signal.send_to_receivers()
 
-/obj/machinery/mineral/ore_redemption/process()
+/obj/machinery/mineral/ore_redemption/pickup_items()
 	if(!materials.mat_container || panel_open || !powered())
 		return
-	var/atom/input = get_step(src, input_dir)
+
+	var/atom/input = input_turf
 	var/obj/structure/ore_box/OB = locate() in input
 	if(OB)
 		input = OB
@@ -165,13 +168,18 @@
 		CHECK_TICK
 
 	if(LAZYLEN(ore_buffer))
-		message_sent = FALSE
 		process_ores(ore_buffer)
-	else if(!message_sent)
-		send_console_message()
+		if(!console_notify_timer)
+			// gives 5 seconds for a load of ores to be sucked up by the ORM before it sends out request console notifications. This should be enough time for most deposits that people make
+			console_notify_timer = addtimer(CALLBACK(src, .proc/send_console_message), 50)
 
 /obj/machinery/mineral/ore_redemption/attackby(obj/item/W, mob/user, params)
 	if(default_unfasten_wrench(user, W))
+		if(anchored)
+			register_input_turf() // someone just wrenched us down, re-register the turf
+			pickup_items() // in case there's any ore already sitting on the input_turf when we wrench the ORM down, we want to pick up the ores immediately
+		else
+			unregister_input_turf() // someone just un-wrenched us, unregister the turf
 		return
 	if(default_deconstruction_screwdriver(user, "ore_redemption-open", "ore_redemption", W))
 		updateUsrDialog()
@@ -199,10 +207,12 @@
 	. = ..()
 	if(!user.canUseTopic(src, BE_CLOSE))
 		return
-	if (panel_open)
+	if(panel_open)
 		input_dir = turn(input_dir, -90)
 		output_dir = turn(output_dir, -90)
 		to_chat(user, "<span class='notice'>You change [src]'s I/O settings, setting the input to [dir2text(input_dir)] and the output to [dir2text(output_dir)].</span>")
+		unregister_input_turf() // someone just rotated the input and output directions, unregister the old turf
+		register_input_turf() // register the new one
 		return TRUE
 
 /obj/machinery/mineral/ore_redemption/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -14,17 +14,18 @@
 	circuit = /obj/item/circuitboard/machine/ore_redemption
 	ui_x = 440
 	ui_y = 550
+	needs_item_input = TRUE
+	processing_flags = START_PROCESSING_MANUALLY
 
 	var/points = 0
 	var/ore_multiplier = 1
 	var/point_upgrade = 1
 	var/list/ore_values = list(/datum/material/iron = 1, /datum/material/glass = 1,  /datum/material/plasma = 15,  /datum/material/silver = 16, /datum/material/gold = 18, /datum/material/titanium = 30, /datum/material/uranium = 30, /datum/material/diamond = 50, /datum/material/bluespace = 50, /datum/material/bananium = 60)
-	var/console_notify_timer // timer used for callbacks to send_console_message(). Used for preventing multiple calls to the proc while the ORM is eating a stack of ores
+	/// Variable that holds a timer which is used for callbacks to `send_console_message()`. Used for preventing multiple calls to this proc while the ORM is eating a stack of ores.
+	var/console_notify_timer
 	var/datum/techweb/stored_research
 	var/obj/item/disk/design_disk/inserted_disk
 	var/datum/component/remote_materials/materials
-	needs_item_input = TRUE
-	processing_flags = START_PROCESSING_MANUALLY
 
 /obj/machinery/mineral/ore_redemption/Initialize(mapload)
 	. = ..()

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -11,21 +11,11 @@
 	needs_item_input = TRUE
 	processing_flags = NEVER_PROCESS
 
-/obj/machinery/mineral/unloading_machine/pickup_items()
-	if(input_turf)
-		var/limit
-		for(var/obj/structure/ore_box/B in input_turf)
-			for(var/obj/item/stack/ore/O in B)
-				B.contents -= O
-				unload_mineral(O)
-				limit++
-				if (limit>=10)
-					return
-				CHECK_TICK
-			CHECK_TICK
-		for(var/obj/item/I in input_turf)
-			unload_mineral(I)
-			limit++
-			if (limit>=10)
-				return
-			CHECK_TICK
+/obj/machinery/mineral/unloading_machine/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
+	if(istype(target, /obj/structure/ore_box))
+		var/obj/structure/ore_box/box = target
+		for(var/obj/item/stack/ore/O in box)
+			unload_mineral(O)
+	else if(istype(target, /obj/item/stack/ore))
+		var/obj/item/stack/ore/O = target
+		unload_mineral(O)

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -9,7 +9,7 @@
 	input_dir = WEST
 	output_dir = EAST
 	needs_item_input = TRUE
-	processing_flags = NEVER_PROCESS
+	processing_flags = START_PROCESSING_MANUALLY
 
 /obj/machinery/mineral/unloading_machine/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
 	if(istype(target, /obj/structure/ore_box))

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -8,14 +8,14 @@
 	density = TRUE
 	input_dir = WEST
 	output_dir = EAST
-	speed_process = TRUE
+	needs_item_input = TRUE
+	processing_flags = NEVER_PROCESS
 
-/obj/machinery/mineral/unloading_machine/process()
-	var/turf/T = get_step(src,input_dir)
-	if(T)
+/obj/machinery/mineral/unloading_machine/pickup_items()
+	if(input_turf)
 		var/limit
-		for(var/obj/structure/ore_box/B in T)
-			for (var/obj/item/stack/ore/O in B)
+		for(var/obj/structure/ore_box/B in input_turf)
+			for(var/obj/item/stack/ore/O in B)
 				B.contents -= O
 				unload_mineral(O)
 				limit++
@@ -23,7 +23,7 @@
 					return
 				CHECK_TICK
 			CHECK_TICK
-		for(var/obj/item/I in T)
+		for(var/obj/item/I in input_turf)
 			unload_mineral(I)
 			limit++
 			if (limit>=10)

--- a/code/modules/mining/mint.dm
+++ b/code/modules/mining/mint.dm
@@ -13,6 +13,7 @@
 	var/produced_coins = 0 // how many coins the machine has made in it's last cycle
 	var/processing = FALSE
 	var/chosen = /datum/material/iron //which material will be used to make coins
+	needs_item_input = TRUE
 
 
 /obj/machinery/mineral/mint/Initialize()
@@ -34,16 +35,16 @@
 	chosen = SSmaterials.GetMaterialRef(chosen)
 
 
-/obj/machinery/mineral/mint/process()
-	var/turf/T = get_step(src, input_dir)
+/obj/machinery/mineral/mint/pickup_items()
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
-
-	for(var/obj/item/stack/O in T)
+	for(var/obj/item/stack/O in input_turf)
 		var/inserted = materials.insert_item(O)
 		if(inserted)
 			qdel(O)
 
+/obj/machinery/mineral/mint/process()
 	if(processing)
+		var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 		var/datum/material/M = chosen
 
 		if(!M)
@@ -71,6 +72,7 @@
 				if(!found_new)
 					processing = FALSE
 	else
+		end_processing()
 		icon_state = "coinpress0"
 
 /obj/machinery/mineral/mint/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
@@ -114,8 +116,10 @@
 			if (!processing)
 				produced_coins = 0
 			processing = TRUE
+			begin_processing()
 		if ("stoppress")
 			processing = FALSE
+			end_processing()
 		if ("changematerial")
 			var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 			for(var/datum/material/mat in materials.materials)

--- a/code/modules/mining/mint.dm
+++ b/code/modules/mining/mint.dm
@@ -35,12 +35,15 @@
 	chosen = SSmaterials.GetMaterialRef(chosen)
 
 
-/obj/machinery/mineral/mint/pickup_items()
+/obj/machinery/mineral/mint/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
+	if(!istype(target, /obj/item/stack))
+		return
+
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
-	for(var/obj/item/stack/O in input_turf)
-		var/inserted = materials.insert_item(O)
-		if(inserted)
-			qdel(O)
+	var/obj/item/stack/S = target
+
+	if(materials.insert_item(S))
+		qdel(S)
 
 /obj/machinery/mineral/mint/process()
 	if(processing)

--- a/code/modules/mining/mint.dm
+++ b/code/modules/mining/mint.dm
@@ -9,11 +9,11 @@
 	input_dir = EAST
 	ui_x = 300
 	ui_y = 250
+	needs_item_input = TRUE
 
 	var/produced_coins = 0 // how many coins the machine has made in it's last cycle
 	var/processing = FALSE
 	var/chosen = /datum/material/iron //which material will be used to make coins
-	needs_item_input = TRUE
 
 
 /obj/machinery/mineral/mint/Initialize()

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -56,6 +56,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(newid)
 		id = newid
 	update_move_direction()
+	RegisterSignal(src, COMSIG_MOVABLE_CROSSED, .Crossed) // For receiving signals from newly created items. These do not call Crossed() so it needs a signal
 	LAZYADD(GLOB.conveyors_by_id[id], src)
 
 /obj/machinery/conveyor/Destroy()
@@ -143,7 +144,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 			affecting.Add(AM)
 
 // when some item or mob moves over the conveyor belt
-/obj/machinery/conveyor/Crossed()
+/obj/machinery/conveyor/Crossed(atom/movable/AM, atom/oldLoc)
 	// if the conveyor isn't switched on or is broken / has no power
 	if(!operating || machine_stat & (BROKEN | NOPOWER))
 		return

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -56,7 +56,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(newid)
 		id = newid
 	update_move_direction()
-	RegisterSignal(src, COMSIG_MOVABLE_CROSSED, .proc/conveyorCrossed) // For receiving signals from newly created items. These do not call Crossed() so it needs a signal
+	RegisterSignal(loc, COMSIG_ATOM_ENTERED, .proc/conveyorCrossed) // For receiving signals from newly created items.
 	LAZYADD(GLOB.conveyors_by_id[id], src)
 
 /obj/machinery/conveyor/Destroy()

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -139,7 +139,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	for(var/atom/movable/AM in loc)
 		if(AM.anchored) // If it can't be moved, ignore it
 			continue
-		if(++i >= MAX_CONVEYOR_ITEMS_MOVE)
+		if(++i > MAX_CONVEYOR_ITEMS_MOVE)
 			break
 		affecting.Add(AM)
 

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -144,7 +144,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 			affecting.Add(AM)
 
 // when some item or mob moves over the conveyor belt
-/obj/machinery/conveyor/proc/conveyorCrossed(datum/source, atom/movable/AM, atom/oldLoc)//
+/obj/machinery/conveyor/proc/conveyorCrossed(datum/source, atom/movable/AM, atom/oldLoc)
 	// if the conveyor isn't switched on or is broken / has no power
 	if(!operating || machine_stat & (BROKEN | NOPOWER))
 		return
@@ -161,7 +161,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 			stoplag()
 
 	if(check_belt_contents())
-		Crossed() // If something is still on the belt, call crossed again
+		conveyorCrossed() // If something is still on the belt, call conveyorCrossed again
 
 // attack with item, place item on conveyor
 /obj/machinery/conveyor/attackby(obj/item/I, mob/user, params)
@@ -293,7 +293,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		C.update_move_direction()
 		C.update_icon()
 		if(abs(C.operating)) // equals 1 if the conveyor is moving in either direction, 0 if turned off
-			C.Crossed() // if there's items on the belt already, start moving them immediately
+			C.conveyorCrossed() // if there's items on the belt already, start moving them immediately
 			C.begin_processing()
 		else
 			C.end_processing()

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -56,7 +56,8 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(newid)
 		id = newid
 	update_move_direction()
-	RegisterSignal(loc, COMSIG_ATOM_ENTERED, .proc/conveyorCrossed) // For receiving signals from newly created items.
+	RegisterSignal(loc, COMSIG_ATOM_CREATED, .proc/conveyorCrossed) // For receiving signals from newly created items.
+	RegisterSignal(loc, COMSIG_ATOM_ENTERED, .proc/conveyorCrossed) // When any atom moves onto the location of this belt
 	LAZYADD(GLOB.conveyors_by_id[id], src)
 
 /obj/machinery/conveyor/Destroy()

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -248,7 +248,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	var/invert_icon = FALSE		// If the level points the opposite direction when it's turned on.
 
 	var/id = "" 				// must match conveyor IDs to control them
-	processing_flags = NEVER_PROCESS
+	processing_flags = START_PROCESSING_MANUALLY
 
 /obj/machinery/conveyor_switch/Initialize(mapload, newid)
 	. = ..()

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -56,8 +56,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(newid)
 		id = newid
 	update_move_direction()
-	RegisterSignal(loc, COMSIG_ATOM_CREATED, .proc/conveyorCrossed) // For receiving signals from newly created items.
-	RegisterSignal(loc, COMSIG_ATOM_ENTERED, .proc/conveyorCrossed) // When any atom moves onto the location of this belt
+	RegisterSignal(loc, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_CREATED), .proc/conveyorCrossed) // When any atom moves onto the belt or gets created over the belt.
 	LAZYADD(GLOB.conveyors_by_id[id], src)
 
 /obj/machinery/conveyor/Destroy()
@@ -128,8 +127,8 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 
 // returns true if there is at least 1 item on the belt that can be moved
 /obj/machinery/conveyor/proc/check_belt_contents()
-	for(var/atom/movable/AM in loc.contents)
-		if(AM && !AM.anchored)
+	for(var/atom/movable/AM in loc)
+		if(!AM.anchored)
 			return TRUE
 	return FALSE
 
@@ -137,12 +136,12 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 /obj/machinery/conveyor/proc/get_belt_contents()
 	affecting = list()
 	var/i = 0
-	for(var/atom/movable/AM in loc.contents)
-		if(AM && !AM.anchored)
-			i += 1
-			if(i >= MAX_CONVEYOR_ITEMS_MOVE)
-				break
-			affecting.Add(AM)
+	for(var/atom/movable/AM in loc)
+		if(AM.anchored) // If it can't be moved, ignore it
+			continue
+		if(++i >= MAX_CONVEYOR_ITEMS_MOVE)
+			break
+		affecting.Add(AM)
 
 // when some item or mob moves over the conveyor belt
 /obj/machinery/conveyor/proc/conveyorCrossed(datum/source, atom/movable/AM, atom/oldLoc)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -56,7 +56,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(newid)
 		id = newid
 	update_move_direction()
-	RegisterSignal(src, COMSIG_MOVABLE_CROSSED, .Crossed) // For receiving signals from newly created items. These do not call Crossed() so it needs a signal
+	RegisterSignal(src, COMSIG_MOVABLE_CROSSED, .proc/conveyorCrossed) // For receiving signals from newly created items. These do not call Crossed() so it needs a signal
 	LAZYADD(GLOB.conveyors_by_id[id], src)
 
 /obj/machinery/conveyor/Destroy()
@@ -144,7 +144,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 			affecting.Add(AM)
 
 // when some item or mob moves over the conveyor belt
-/obj/machinery/conveyor/Crossed(atom/movable/AM, atom/oldLoc)
+/obj/machinery/conveyor/proc/conveyorCrossed(datum/source, atom/movable/AM, atom/oldLoc)//
 	// if the conveyor isn't switched on or is broken / has no power
 	if(!operating || machine_stat & (BROKEN | NOPOWER))
 		return

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -139,9 +139,8 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	//get the first 30 items in contents
 	affecting = list()
 	var/i = 0
-	for(var/item in loc.contents)
-		if(item == src)
-			continue
+	var/list/items = loc.contents - src
+	for(var/item in items)
 		i++ // we're sure it's a real target to move at this point
 		if(i >= MAX_CONVEYOR_ITEMS_MOVE)
 			break
@@ -236,6 +235,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	desc = "A conveyor control switch."
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "switch-off"
+	processing_flags = START_PROCESSING_MANUALLY
 
 	var/position = 0			// 0 off, -1 reverse, 1 forward
 	var/last_pos = -1			// last direction setting
@@ -243,7 +243,6 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	var/invert_icon = FALSE		// If the level points the opposite direction when it's turned on.
 
 	var/id = "" 				// must match conveyor IDs to control them
-	processing_flags = START_PROCESSING_MANUALLY
 
 /obj/machinery/conveyor_switch/Initialize(mapload, newid)
 	. = ..()
@@ -281,7 +280,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	else
 		icon_state = "switch-off"
 
-// if the switch changed, update the linked conveyors
+/// Updates all conveyor belts that are linked to this switch, and tells them to start processing.
 /obj/machinery/conveyor_switch/proc/update_linked_conveyors()
 	for(var/obj/machinery/conveyor/C in GLOB.conveyors_by_id[id])
 		C.operating = position
@@ -293,7 +292,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 			C.end_processing()
 		CHECK_TICK
 
-// find any switches with same id as this one, and set their positions to match us
+/// Finds any switches with same `id` as this one, and set their position and icon to match us.
 /obj/machinery/conveyor_switch/proc/update_linked_switches()
 	for(var/obj/machinery/conveyor_switch/S in GLOB.conveyors_by_id[id])
 		S.invert_icon = invert_icon
@@ -301,6 +300,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		S.update_icon()
 		CHECK_TICK
 
+/// Updates the switch's `position` and `last_pos` variable. Useful so that the switch can properly cycle between the forwards, backwards and neutral positions.
 /obj/machinery/conveyor_switch/proc/update_position()
 	if(position == 0)
 		if(oneway)   //is it a oneway switch
@@ -316,7 +316,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		last_pos = position
 		position = 0
 
-// attack with hand, switch position
+/// Called when a user clicks on this switch with an open hand.
 /obj/machinery/conveyor_switch/interact(mob/user)
 	add_fingerprint(user)
 	update_position()

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -114,9 +114,11 @@
 		to_chat(user, "<span class='notice'>You [active ? "deactivate": "activate"] [src].</span>")
 	active = !active
 	if(active)
+		begin_processing()
 		animate(src, pixel_y = 2, time = 10, loop = -1)
 		anchored = TRUE
 	else
+		end_processing()
 		animate(src, pixel_y = 0, time = 10)
 		anchored = FALSE
 	update_icon()
@@ -133,7 +135,8 @@
 	name = "\improper Meteor Shield Satellite"
 	desc = "A meteor point-defense satellite."
 	mode = "M-SHIELD"
-	speed_process = TRUE
+	processing_flags = START_PROCESSING_MANUALLY
+	subsystem_type = /datum/controller/subsystem/processing/fastprocess
 	var/kill_range = 14
 
 /obj/machinery/satellite/meteor_shield/proc/space_los(meteor)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Republish of  #49170

I haven't changed how the processing stuff works that much compared to the old PR, but I learned some new things and I just wanted to start from a clean slate. Still, a majority of the information in that old PR description is still valid.

Just as TL;DR as to what this PR does:
It takes fast processing machines which constantly `process()` and makes it so that they only start processing when they need to, like when they're switched on for example. Some machines now don't even use processing at all, like the ORM. It just listens for ores that enter it's input turf and sucks them up.

## Why It's Good For The Game
This will save a small amount of server resources, because the game won't have to pointlessly execute code when it doesn't need to.

## Changelog
:cl:
code: Updates various machines, which currently use SSfastprocess, so that they only start processing when it's necessary. Some of these updated machines have been changed so that they don't ever need to process.
refactor: Replaces the speed_process var with two new variables. The processing_flags variable stores bitflags with information about a machine's preferences on when it should start processing. The subsystem_type var holds the path to which type of subsystem that machine should use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
