### PR TITLE
Adds Policy Capabilities to Pyro Slime and Changes Ban Type to ROLE_SENTIENCE 

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -29,6 +29,7 @@
 #define ROLE_HIVE				"Hivemind Host"				//Role removed, left here for safety.
 #define ROLE_OBSESSED				"Obsessed"
 #define ROLE_SENTIENCE			"Sentience Potion Spawn"
+#define ROLE_PYROCLASTIC_SLIME 	"Pyroclastic Anomaly Slime"
 #define ROLE_MIND_TRANSFER		"Mind Transfer Potion"
 #define ROLE_POSIBRAIN			"Posibrain"
 #define ROLE_DRONE				"Drone"

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -279,7 +279,7 @@
 	var/datum/action/innate/slime/reproduce/A = new
 	A.Grant(S)
 
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a pyroclastic anomaly slime?", ROLE_PAI, null, null, 100, S, POLL_IGNORE_PYROSLIME)
+	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a pyroclastic anomaly slime?", ROLE_SENTIENCE, null, null, 100, S, POLL_IGNORE_PYROSLIME)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/chosen = pick(candidates)
 		S.key = chosen.key

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -276,6 +276,8 @@
 	S.rabid = TRUE
 	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
 	S.Evolve()
+	var/datum/action/innate/slime/reproduce/A = new
+	A.Grant(S)
 
 	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a pyroclastic anomaly slime?", ROLE_PAI, null, null, 100, S, POLL_IGNORE_PYROSLIME)
 	if(LAZYLEN(candidates))

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -283,6 +283,10 @@
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/chosen = pick(candidates)
 		S.key = chosen.key
+		S.mind.special_role = ROLE_PYROCLASTIC_SLIME
+		var/policy = get_policy(ROLE_PYROCLASTIC_SLIME)
+		if (policy)
+			to_chat(S, policy)
 		log_game("[key_name(S.key)] was made into a slime by pyroclastic anomaly at [AREACOORD(T)].")
 
 /////////////////////


### PR DESCRIPTION
# About The Pull Request

**That's an alternative to #49277,  #49283  and #49296  PRs.**

My struggle with finding the final solution for the anomaly slime problem finely yielded something that should satisfy most of devs and mods.

I chated with some devs and admemes about this problem and answers vary from: [that's cool I like to smash APC](https://github.com/tgstation/tgstation/pull/49277#issuecomment-584185414) and something like ["Don't do it on RP servers like Manuel"](https://tgstation13.org/phpBB/viewtopic.php?f=34&t=25506#p541197) to:

[@ExcessiveUseOfCobblestone](https://github.com/tgstation/tgstation/pull/49296#issuecomment-584761170)
> a slime doesn't need to damage structures i don't know why "well if I can't damage an APC I might as well not play the role at all" is the conclusion people remotely come to.

Also in the private chat on the forum one of mods stated that:

> I can say from a personal standpoint that if I see you doing it on any server, I'm banning you from the role permanently, as I would with anyone else doing it specifically to screw with the round. As others have said, this is a coder trying to fix an admin issue.

^^^ The mod failed to explain how he will prove the intent.

I agree that it can be handled as an admin issue but the problem is that there is no clear cut where being a mischievous ball of slime becomes turning into the round ruining turd nugget. So I propose adding a fair warning for the player when he/she possess an anomaly slime that provides the line.

## Why It's Good For The Game
### [Add policy keywords to pyro slimes](https://github.com/tgstation/tgstation/pull/49319/commits/8a37bce885bd747180edc497752f4ee5d9d45d19)
Pyro slime needs a separate policy because unlike other sentient animals it doesn't have master but at the same time it supposed to feed of the crew and Ian. The policy will be shown when someone takes control over the slime and will remind them that the slime isn't an antagonist(It's just fucking hungry and tried to vore you out of self defence from the starvation). Also it can provide the clear distinction for which parts of the station shouldn't be sabotaged without a serous reason and can get you banned.  The policy can be something like:
``` html
Congratulations! You are barely sentient but voracious slime with no allegiance - act as one. 
Think twice before sabotaging Gravity Generator, Vault, Supermatter, smashing communication
consoles or attacking AI unprovoked. 
Those actions can ruin the round for other players and might
be interpreted as a violation of <a href=https://tgstation13.org/wiki/Rules>the first rule.</a>
```
it might be more strict for the RP servers since slimes aren't considered very bright and attacking something like AI APC seems a bit out of their.. reach.
 
### [Fix anomaly slime role](https://github.com/tgstation/tgstation/commit/1ae32db053ed9621516dd42895ce51e0257a10f7)
 ` ROLE_PAI` is a wrong role for anomaly slime since it isn't a part of the standard antag ban list that admemes use. I have[ experimentally proven that admins will fail to apply proper ban](https://gist.github.com/JAremko/c291d37a3c21b01616a9989e3c3cc1af).

Making it "Sentience Potion Spawn" makes much more sense. Lavaland elite has the same role.

### [Allow anomaly slimes to reproduce](https://github.com/tgstation/tgstation/commit/b53d80283b8e132ddecad42513e1bd14c8d22f78)

It's primary a bug fix since they should be able to anyway.  If you split you will control one baby slimes and it makes you unable to smash things and really vulnerable. I can imagine it being useful as a decoy or to reinforce some area, RP reasons or simply to annoy the crew. Or maybe even as a way to cooperate with Xenobio by producing slimes in exchange for monkeys.

## Changelog
:cl:
add: Added pyroclastic anomaly slime policy key
fix: Fixed anomaly slime role
fix: Now anomaly slimes can reproduce like other slimes do
/:cl: