### PR TITLE
Removes the wait time and separate page for the Exosuit Fabricator's research synchronization

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -242,16 +242,8 @@
 	return output
 
 /obj/machinery/mecha_part_fabricator/proc/sync()
-	temp = "Updating local R&D database..."
-	updateUsrDialog()
-	sleep(30) //only sleep if called by user
-
 	for(var/obj/machinery/computer/rdconsole/RDC in oview(7,src))
 		RDC.stored_research.copy_research_to(stored_research)
-		temp = "Processed equipment designs.<br>"
-		//check if the tech coefficients have changed
-		temp += "<a href='?src=[REF(src)];clear_temp=1'>Return</a>"
-
 		updateUsrDialog()
 		say("Successfully synchronized with R&D server.")
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the sleep, initial setting of the temp text and the success temp text in the mechfab's sync proc.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes pointless wait times.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The Exosuit Fabricator's sync with R&D operation is now instant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
