### PR TITLE
Tweaks paramedic loadout

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -177,7 +177,7 @@
 
 /obj/item/storage/belt/medical/paramedic/PopulateContents()
 	new /obj/item/sensor_device(src)
-	new /obj/item/flashlight/pen(src)
+	new /obj/item/pinpointer/crew/prox(src)
 	new /obj/item/stack/medical/gauze/twelve(src)
 	new /obj/item/reagent_containers/syringe(src)
 	new /obj/item/reagent_containers/glass/bottle/epinephrine(src)

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -32,7 +32,7 @@
 	id = /obj/item/card/id
 	l_pocket = /obj/item/pda/medical
 	suit_store = /obj/item/flashlight/pen
-	backpack_contents = list(/obj/item/storage/bag/bio=1, /obj/item/roller=1)
+	backpack_contents = list(/obj/item/roller=1)
 	pda_slot = ITEM_SLOT_LPOCKET
 
 	backpack = /obj/item/storage/backpack/medic

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -31,8 +31,8 @@
 	belt = /obj/item/storage/belt/medical/paramedic
 	id = /obj/item/card/id
 	l_pocket = /obj/item/pda/medical
-	r_pocket = /obj/item/pinpointer/crew/prox
-	backpack_contents = list(/obj/item/roller=1)
+	suit_store = /obj/item/flashlight/pen
+	backpack_contents = list(/obj/item/storage/bag/bio=1, /obj/item/roller=1)
 	pda_slot = ITEM_SLOT_LPOCKET
 
 	backpack = /obj/item/storage/backpack/medic


### PR DESCRIPTION
Moved the pinpointer to the medical belt and the medical pen to suit storage

Just a few tweaks to avoid always having to shuffle your items at roundstart since both pinpointer and medipen have limited use, and I think we should generally avoid using pocket slots for starting loadouts if possible.
## Changelog
:cl:
tweak: Tweaked paramedic loadout, moved pinpointer to medical belt, moved medipen to suit storage
/:cl: