### PR TITLE
Fixes boxes having writing where it shouldn't be

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -833,6 +833,7 @@
 	name = "box of rubber shots"
 	desc = "A box full of rubber shots, designed for riot shotguns."
 	icon_state = "rubbershot_box"
+	illustration = NULL
 
 /obj/item/storage/box/rubbershot/PopulateContents()
 	for(var/i in 1 to 7)
@@ -842,6 +843,7 @@
 	name = "box of lethal shotgun shots"
 	desc = "A box full of lethal shots, designed for riot shotguns."
 	icon_state = "lethalshot_box"
+	illustration = NULL
 
 /obj/item/storage/box/lethalshot/PopulateContents()
 	for(var/i in 1 to 7)
@@ -851,6 +853,7 @@
 	name = "box of beanbags"
 	desc = "A box full of beanbag shells."
 	illustration = "rubbershot_box"
+	illustration = NULL
 
 /obj/item/storage/box/beanbag/PopulateContents()
 	for(var/i in 1 to 6)
@@ -877,6 +880,7 @@
 	desc = "A sack neatly crafted out of paper."
 	icon_state = "paperbag_None"
 	item_state = "paperbag_None"
+	illustration = NULL
 	resistance_flags = FLAMMABLE
 	foldable = null
 	var/design = NODESIGN

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -833,7 +833,7 @@
 	name = "box of rubber shots"
 	desc = "A box full of rubber shots, designed for riot shotguns."
 	icon_state = "rubbershot_box"
-	illustration = NULL
+	illustration = null
 
 /obj/item/storage/box/rubbershot/PopulateContents()
 	for(var/i in 1 to 7)
@@ -843,7 +843,7 @@
 	name = "box of lethal shotgun shots"
 	desc = "A box full of lethal shots, designed for riot shotguns."
 	icon_state = "lethalshot_box"
-	illustration = NULL
+	illustration = null
 
 /obj/item/storage/box/lethalshot/PopulateContents()
 	for(var/i in 1 to 7)
@@ -853,7 +853,7 @@
 	name = "box of beanbags"
 	desc = "A box full of beanbag shells."
 	illustration = "rubbershot_box"
-	illustration = NULL
+	illustration = null
 
 /obj/item/storage/box/beanbag/PopulateContents()
 	for(var/i in 1 to 6)
@@ -880,7 +880,7 @@
 	desc = "A sack neatly crafted out of paper."
 	icon_state = "paperbag_None"
 	item_state = "paperbag_None"
-	illustration = NULL
+	illustration = null
 	resistance_flags = FLAMMABLE
 	foldable = null
 	var/design = NODESIGN


### PR DESCRIPTION
## About The Pull Request

Makes it so the paper bag and shotgun ammo boxes don't have writing on them that doesn't belong there.
fixes #49242
Also fixes me accidentally removing `illustration = NULL` from the ammo boxes in my previous PR

## Why It's Good For The Game

It's how it was intended.

## Changelog
:cl:
fix: Fixes writing being on paper bags and some ammo boxes
/:cl: