### PR TITLE
Set Linkage traits to multiz debug map config

### DIFF
--- a/_maps/multiz_debug.json
+++ b/_maps/multiz_debug.json
@@ -2,5 +2,5 @@
     "map_name": "MultiZ Debug",
     "map_path": "map_files/debug",
     "map_file": "multiz.dmm",
-	"traits": [{"Up": 1}, {"Up": 1, "Down": -1, "Baseturf" : "/turf/open/openspace"}, {"Down": -1, "Baseturf" : "/turf/open/openspace"}]
+	"traits": [{"Up" : 1, "Linkage" : "Cross"}, {"Up" : 1, "Down" : -1, "Baseturf" : "/turf/open/openspace", "Linkage" : "Cross"}, {"Down" : -1, "Baseturf" : "/turf/open/openspace", "Linkage" : "Cross"}]
 	}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Set Linkage traits to multiz debug map config
Related #49009 but you need set config in your own. This only for multiz debug map.

## Why It's Good For The Game

Make multiz great.

## Changelog
:cl:
fix: Now MultiZ Debug connected to neighbor space, in strange way.
/:cl:

![image](https://user-images.githubusercontent.com/7734424/74463601-bbbedf80-4e9a-11ea-9cdb-835bd8c066cc.png)