### PR TITLE
Rewords cult sacrifice objective to use the correct rune name

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -348,7 +348,7 @@
 
 /datum/objective/sacrifice/update_explanation_text()
 	if(target)
-		explanation_text = "Sacrifice [target], the [target.assigned_role] via invoking a Sacrifice rune with [target.p_them()] on it and three acolytes around it."
+		explanation_text = "Sacrifice [target], the [target.assigned_role] via invoking an Offer rune with [target.p_them()] on it and three acolytes around it."
 	else
 		explanation_text = "The veil has already been weakened here, proceed to the final objective."
 


### PR DESCRIPTION
:cl:
fix: Cult sacrifice objective now tells you to use Offer instead of a non-existent Sacrifice rune
/:cl:
Apparently this slipped through the cracks during whichever rework merged sacrifice and convert