### PR TITLE
Removes Summon Events from Wizard

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -523,32 +523,6 @@
 	to_chat(user, "<span class='notice'>You have cast summon magic!</span>")
 	return TRUE
 
-/datum/spellbook_entry/summon/events
-	name = "Summon Events"
-	desc = "Give Murphy's law a little push and replace all events with special wizard ones that will confound and confuse everyone. Multiple castings increase the rate of these events."
-	var/times = 0
-
-/datum/spellbook_entry/summon/events/IsAvailible()
-	if(!SSticker.mode) // In case spellbook is placed on map
-		return FALSE
-	if(istype(SSticker.mode, /datum/game_mode/dynamic)) // Disable events on dynamic
-		return FALSE
-	return !CONFIG_GET(flag/no_summon_events)
-
-/datum/spellbook_entry/summon/events/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
-	SSblackbox.record_feedback("tally", "wizard_spell_learned", 1, name)
-	summonevents()
-	times++
-	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, TRUE)
-	to_chat(user, "<span class='notice'>You have cast summon events.</span>")
-	return TRUE
-
-/datum/spellbook_entry/summon/events/GetInfo()
-	. = ..()
-	if(times>0)
-		. += "You cast it [times] times.<br>"
-	return .
-
 /datum/spellbook_entry/summon/curse_of_madness
 	name = "Curse of Madness"
 	desc = "Curses the station, warping the minds of everyone inside, causing lasting traumas. Warning: this spell can affect you if not cast from a safe distance."


### PR DESCRIPTION
:cl: Gameplay Sanity Committee
del: Wizards may no longer summon events. Admins on the other hand...
/:cl:

C'mon... We all know it's too much. Nobody has fun during it except the wizard. In a normal wizard round, crew can atleast have fun banding together to fight the wiz.