### PR TITLE
Limits Summon Events to one purchase

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -526,6 +526,7 @@
 /datum/spellbook_entry/summon/events
 	name = "Summon Events"
 	desc = "Give Murphy's law a little push and replace all events with special wizard ones that will confound and confuse everyone. Multiple castings increase the rate of these events."
+	cost = 0
 	var/times = 0
 
 /datum/spellbook_entry/summon/events/IsAvailible()

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -526,7 +526,7 @@
 /datum/spellbook_entry/summon/events
 	name = "Summon Events"
 	desc = "Give Murphy's law a little push and replace all events with special wizard ones that will confound and confuse everyone. Multiple castings increase the rate of these events."
-	cost = 0
+	cost = 2
 	limit = 1
 	var/times = 0
 

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -527,6 +527,7 @@
 	name = "Summon Events"
 	desc = "Give Murphy's law a little push and replace all events with special wizard ones that will confound and confuse everyone. Multiple castings increase the rate of these events."
 	cost = 0
+	limit = 1
 	var/times = 0
 
 /datum/spellbook_entry/summon/events/IsAvailible()


### PR DESCRIPTION
Alternative to #49364

As-is, the max amount of summon events (5) uses all of a wizard's points, so any wiz who buys it usually just ends up sitting on their ship and watching the chaos because they're otherwise powerless.

But summon events is relatively neutral; it's just as likely to fuck with the wizard as the crew; be it by swapping them with the CE doing maintenance in the supermatter chamber, or turning the floor into lava while standing near half of the crew with guns, or race swap them into a feline which promptly gets repeatedly shocked, siphoned, flashed and beaten to death by the AI and borgs, etc.

~~So, instead, Summon Events is now free à la summon ghosts. If a wizard wants to take it to spice things up a bit, it's their prerogative. It could help them or hurt them. But either way, they have no reason to sit on their ship and watch when they can get a suite of normal spells as well.~~

So, this changes the maximum number of times you can summon events from 5 to 1. This means that on average, there will be 1 summon events per 5 minutes (as opposed to one per minute with 5x summon events). And because wizards can't spend all their points on it, they won't be so tempted to sit on their ship.

:CL:
tweak: Beware, reports from the Wizard Federation reveal that they've refined the ability to summon and amplify the chaotic events that normally affect a space station, allowing for them to do it for practically free!
/:CL: