### PR TITLE
Fix shuttle timer seconds counter not displaying leading 0 with numbers <10

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -704,7 +704,7 @@
 	if(timeleft > 1 HOURS)
 		return "--:--"
 	else if(timeleft > 0)
-		return "[add_leading(num2text((timeleft / 60) % 60), 2, "0")]:[add_leading(num2text(timeleft % 60), 2, " ")]"
+		return "[add_leading(num2text((timeleft / 60) % 60), 2, "0")]:[add_leading(num2text(timeleft % 60), 2, "0")]"
 	else
 		return "00:00"
 


### PR DESCRIPTION
The shuttle timer on the status displays doesn't display leading 0s in the seconds counter for numbers less than 10.

What you actually see: 01:[ ]5

What this change does instead: 01:[0]5

It was triggering me so I had to fix it.

Simple change in code/modules/shuttle/shuttle.dm to change line 707, swapping the space character with the 0 character.

🆑
fix: Shuttle countdowns once again read like "01:05" instead of "01: 5".
/🆑

Closes #49390.