### PR TITLE
fixes bug with rolling tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -237,8 +237,18 @@
 	UnregisterSignal(source, COMSIG_MOVABLE_MOVED)
 
 /obj/structure/table/rolling/Moved(atom/OldLoc, Dir)
+
 	for(var/mob/M in OldLoc.contents)//Kidnap everyone on top
+		var/atom/movable/pulled = M.pulling
+
 		M.forceMove(loc)
+		if(pulled)
+			pulled.moving_from_pull = M
+			pulled.Move(OldLoc, get_dir(pulling, OldLoc)) //the pullee tries to reach our previous position
+			pulled.moving_from_pull = null
+			M.pulling = pulled // dont kill me idk a better way to do this, i dont wanna do start_pulling every time the table moves
+			M.check_pulling()
+
 	for(var/x in attached_items)
 		var/atom/movable/AM = x
 		if(!AM.Move(loc))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -14,6 +14,7 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
+#include "_maps\map_files\debug\runtimestation.dmm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DEFINES\_globals.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -14,7 +14,6 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
-#include "_maps\map_files\debug\runtimestation.dmm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DEFINES\_globals.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
i stole from pullcode to make mobs continue pulling whatever when their rolling table is moved, currently your pull gets broken when the table moves while you're on top of it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
i need rolling table conga lines for god's sake
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:imzx
fix: rolling tables no longer break the pulls of table surfers on move
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
