### PR TITLE
Adds in discord auto-roling

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -1,6 +1,10 @@
 // rust_g.dm - DM API for rust_g extension library
 #define RUST_G "rust_g"
 
+#define RUSTG_JOB_NO_RESULTS_YET "NO_RESULTS_YET"
+#define RUSTG_JOB_NO_SUCH_JOB "NO_SUCH_JOB"
+#define RUSTG_JOB_ERROR "JOB_PANICKED"
+
 #define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
 
 #define rustg_git_revparse(rev) call(RUST_G, "rg_git_revparse")(rev)
@@ -8,3 +12,15 @@
 
 #define rustg_log_write(fname, text) call(RUST_G, "log_write")(fname, text)
 /proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
+
+// RUST-G defines & procs for HTTP component
+#define RUSTG_HTTP_METHOD_GET "get"
+#define RUSTG_HTTP_METHOD_POST "post"
+#define RUSTG_HTTP_METHOD_PUT "put"
+#define RUSTG_HTTP_METHOD_DELETE "delete"
+#define RUSTG_HTTP_METHOD_PATCH "patch"
+#define RUSTG_HTTP_METHOD_HEAD "head"
+
+#define rustg_http_request_blocking(method, url, body, headers) call(RUST_G, "http_request_blocking")(method, url, body, headers)
+#define rustg_http_request_async(method, url, body, headers) call(RUST_G, "http_request_async")(method, url, body, headers)
+#define rustg_http_check_request(req_id) call(RUST_G, "http_check_request")(req_id)

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -1,9 +1,9 @@
 // rust_g.dm - DM API for rust_g extension library
 #define RUST_G "rust_g"
 
-#define RUSTG_JOB_NO_RESULTS_YET "NO_RESULTS_YET"
-#define RUSTG_JOB_NO_SUCH_JOB "NO_SUCH_JOB"
-#define RUSTG_JOB_ERROR "JOB_PANICKED"
+#define RUSTG_JOB_NO_RESULTS_YET "NO RESULTS YET"
+#define RUSTG_JOB_NO_SUCH_JOB "NO SUCH JOB"
+#define RUSTG_JOB_ERROR "JOB PANICKED"
 
 #define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
 

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -42,6 +42,8 @@ GLOBAL_VAR(tgui_log)
 GLOBAL_PROTECT(tgui_log)
 GLOBAL_VAR(world_shuttle_log)
 GLOBAL_PROTECT(world_shuttle_log)
+GLOBAL_VAR(discord_api_log)
+GLOBAL_PROTECT(discord_api_log)
 
 GLOBAL_LIST_EMPTY(bombers)
 GLOBAL_PROTECT(bombers)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -484,3 +484,13 @@
 /datum/config_entry/flag/reopen_roundstart_suicide_roles_command_report
 
 /datum/config_entry/flag/auto_profile
+
+// DISCORD ROLE STUFFS
+// Using strings for everything because BYOND does not like numbers this big
+/datum/config_entry/flag/enable_discord_autorole
+
+/datum/config_entry/string/discord_token
+
+/datum/config_entry/string/discord_guildid
+
+/datum/config_entry/string/discord_roleid

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -38,7 +38,6 @@ SUBSYSTEM_DEF(discord)
 	var/enabled = 0 // Is TGS enabled (If not we wont fire because otherwise this is useless)
 
 /datum/controller/subsystem/discord/Initialize(start_timeofday)
-	grant_role("200631029675982858")
 	// Check for if we are using TGS, otherwise return and disabless firing
 	if(world.TgsAvailable())
 		enabled = 1 // Allows other procs to use this (Account linking, etc)

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -120,4 +120,5 @@ SUBSYSTEM_DEF(discord)
 		return
 
 	// Make the request
-	rustg_http_request_blocking(RUSTG_HTTP_METHOD_PUT, "https://discordapp.com/api/guilds/[CONFIG_GET(string/discord_guildid)]/members/[id]/roles/[CONFIG_GET(string/discord_roleid)]", "",  "{\"Authorization\":\"Bot [CONFIG_GET(string/discord_token)]\"}")
+	var/response = rustg_http_request_blocking(RUSTG_HTTP_METHOD_PUT, "https://discordapp.com/api/guilds/[CONFIG_GET(string/discord_guildid)]/members/[id]/roles/[CONFIG_GET(string/discord_roleid)]", "",  "{\"Authorization\":\"Bot [CONFIG_GET(string/discord_token)]\"}")
+	WRITE_LOG(GLOB.discord_api_log, "DISCORD API: [response]")

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -1,4 +1,4 @@
-/* 
+/*
 NOTES:
 There is a DB table to track ckeys and associated discord IDs.
 This system REQUIRES TGS, and will auto-disable if TGS is not present.
@@ -15,7 +15,7 @@ ROUNDSTART:
 2] A ping is sent to the discord with the IDs of people who wished to be notified
 3] The file is emptied
 
-MIDROUND: 
+MIDROUND:
 1] Someone usees the notify verb, it adds their discord ID to the list.
 2] On fire, it will write that to the disk, as long as conditions above are correct
 
@@ -38,12 +38,13 @@ SUBSYSTEM_DEF(discord)
 	var/enabled = 0 // Is TGS enabled (If not we wont fire because otherwise this is useless)
 
 /datum/controller/subsystem/discord/Initialize(start_timeofday)
+	grant_role("200631029675982858")
 	// Check for if we are using TGS, otherwise return and disabless firing
 	if(world.TgsAvailable())
 		enabled = 1 // Allows other procs to use this (Account linking, etc)
 	else
 		can_fire = 0 // We dont want excess firing
-		return ..() // Cancel 
+		return ..() // Cancel
 
 	try
 		people_to_notify = json_decode(file2text(notify_file))
@@ -57,18 +58,18 @@ SUBSYSTEM_DEF(discord)
 		send2chat("[notifymsg]", CONFIG_GET(string/chat_announce_new_game)) // Sends the message to the discord, using same config option as the roundstart notification
 	fdel(notify_file) // Deletes the file
 	return ..()
-	
+
 /datum/controller/subsystem/discord/fire()
 	if(!enabled)
 		return // Dont do shit if its disabled
 	if(notify_members == notify_members_cache)
-		return // Dont re-write the file 
+		return // Dont re-write the file
 	// If we are all clear
 	write_notify_file()
-	
+
 /datum/controller/subsystem/discord/Shutdown()
 	write_notify_file() // Guaranteed force-write on server close
-	
+
 /datum/controller/subsystem/discord/proc/write_notify_file()
 	if(!enabled) // Dont do shit if its disabled
 		return
@@ -113,3 +114,11 @@ SUBSYSTEM_DEF(discord)
 /datum/controller/subsystem/discord/proc/id_clean(input)
 	var/regex/num_only = regex("\[^0-9\]", "g")
 	return num_only.Replace(input, "")
+
+/datum/controller/subsystem/discord/proc/grant_role(id)
+	// Ignore this shit if config isnt enabled for it
+	if(!CONFIG_GET(flag/enable_discord_autorole))
+		return
+
+	// Make the request
+	rustg_http_request_blocking(RUSTG_HTTP_METHOD_PUT, "https://discordapp.com/api/guilds/[CONFIG_GET(string/discord_guildid)]/members/[id]/roles/[CONFIG_GET(string/discord_roleid)]", "",  "{\"Authorization\":\"Bot [CONFIG_GET(string/discord_token)]\"}")

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -120,6 +120,13 @@ SUBSYSTEM_DEF(discord)
 		return
 
 	var/url = "https://discordapp.com/api/guilds/[CONFIG_GET(string/discord_guildid)]/members/[id]/roles/[CONFIG_GET(string/discord_roleid)]"
+
 	// Make the request
-	var/response = rustg_http_request_blocking(RUSTG_HTTP_METHOD_PUT, url, "",  "{\"Authorization\":\"Bot [CONFIG_GET(string/discord_token)]\"}")
-	WRITE_LOG(GLOB.discord_api_log, "PUT [url] returned [response]")
+
+	var/datum/http_request/req = new()
+	req.prepare(RUSTG_HTTP_METHOD_PUT, url, "", list("Authorization" = "Bot [CONFIG_GET(string/discord_token)]"))
+	req.begin_async()
+	UNTIL(req.is_complete())
+	var/datum/http_response/res = req.into_response()
+
+	WRITE_LOG(GLOB.discord_api_log, "PUT [url] returned [res.status_code] [res.body]")

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -119,6 +119,7 @@ SUBSYSTEM_DEF(discord)
 	if(!CONFIG_GET(flag/enable_discord_autorole))
 		return
 
+	var/url = "https://discordapp.com/api/guilds/[CONFIG_GET(string/discord_guildid)]/members/[id]/roles/[CONFIG_GET(string/discord_roleid)]"
 	// Make the request
-	var/response = rustg_http_request_blocking(RUSTG_HTTP_METHOD_PUT, "https://discordapp.com/api/guilds/[CONFIG_GET(string/discord_guildid)]/members/[id]/roles/[CONFIG_GET(string/discord_roleid)]", "",  "{\"Authorization\":\"Bot [CONFIG_GET(string/discord_token)]\"}")
-	WRITE_LOG(GLOB.discord_api_log, "DISCORD API: [response]")
+	var/response = rustg_http_request_blocking(RUSTG_HTTP_METHOD_PUT, url, "",  "{\"Authorization\":\"Bot [CONFIG_GET(string/discord_token)]\"}")
+	WRITE_LOG(GLOB.discord_api_log, "PUT [url] returned [response]")

--- a/code/datums/http.dm
+++ b/code/datums/http.dm
@@ -1,0 +1,74 @@
+/datum/http_request
+	var/id
+	var/in_progress = FALSE
+
+	var/method
+	var/body
+	var/headers
+	var/url
+
+	var/_raw_response
+
+/datum/http_request/proc/prepare(method, url, body = "", list/headers)
+	if (!length(headers))
+		headers = ""
+	else
+		headers = json_encode(headers)
+
+	src.method = method
+	src.url = url
+	src.body = body
+	src.headers = headers
+
+/datum/http_request/proc/execute_blocking()
+	_raw_response = rustg_http_request_blocking(method, url, body, headers)
+
+/datum/http_request/proc/begin_async()
+	if (in_progress)
+		CRASH("Attempted to re-use a request object.")
+
+	id = rustg_http_request_async(method, url, body, headers)
+
+	if (isnull(text2num(id)))
+		CRASH("Proc error: [id]")
+		_raw_response = "Proc error: [id]"
+	else
+		in_progress = TRUE
+
+/datum/http_request/proc/is_complete()
+	if (isnull(id))
+		return TRUE
+
+	if (!in_progress)
+		return TRUE
+
+	var/r = rustg_http_check_request(id)
+
+	if (r == RUSTG_JOB_NO_RESULTS_YET)
+		return FALSE
+	else
+		_raw_response = r
+		in_progress = FALSE
+		return TRUE
+
+/datum/http_request/proc/into_response()
+	var/datum/http_response/R = new()
+
+	try
+		var/list/L = json_decode(_raw_response)
+		R.status_code = L["status_code"]
+		R.headers = L["headers"]
+		R.body = L["body"]
+	catch
+		R.errored = TRUE
+		R.error = _raw_response
+
+	return R
+
+/datum/http_response
+	var/status_code
+	var/body
+	var/list/headers
+
+	var/errored = FALSE
+	var/error

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -138,6 +138,7 @@ GLOBAL_VAR(restart_counter)
 	GLOB.world_paper_log = "[GLOB.log_directory]/paper.log"
 	GLOB.tgui_log = "[GLOB.log_directory]/tgui.log"
 	GLOB.world_shuttle_log = "[GLOB.log_directory]/shuttle.log"
+	GLOB.discord_api_log = "[GLOB.log_directory]/discord_api_log.log"
 
 #ifdef UNIT_TESTS
 	GLOB.test_log = file("[GLOB.log_directory]/tests.log")
@@ -154,6 +155,7 @@ GLOBAL_VAR(restart_counter)
 	start_log(GLOB.world_job_debug_log)
 	start_log(GLOB.tgui_log)
 	start_log(GLOB.world_shuttle_log)
+	start_log(GLOB.discord_api_log)
 
 	GLOB.changelog_hash = md5('html/changelog.html') //for telling if the changelog has changed recently
 	if(fexists(GLOB.config_error_log))

--- a/code/modules/discord/tgs_commands.dm
+++ b/code/modules/discord/tgs_commands.dm
@@ -8,7 +8,7 @@
 		if(member == "[sender.mention]")
 			SSdiscord.notify_members -= "[SSdiscord.id_clean(sender.mention)]" // The list uses strings because BYOND cannot handle a 17 digit integer
 			return "You will no longer be notified when the server restarts"
-		
+
 	// If we got here, they arent in the list. Chuck 'em in!
 	SSdiscord.notify_members += "[SSdiscord.id_clean(sender.mention)]" // The list uses strings because BYOND cannot handle a 17 digit integer
 	return "You will now be notified when the server restarts"
@@ -22,7 +22,10 @@
 	var/lowerparams = replacetext(lowertext(params), " ", "") // Fuck spaces
 	if(SSdiscord.account_link_cache[lowerparams]) // First if they are in the list, then if the ckey matches
 		if(SSdiscord.account_link_cache[lowerparams] == "[SSdiscord.id_clean(sender.mention)]") // If the associated ID is the correct one
+			// Link the account in the DB table
 			SSdiscord.link_account(lowerparams)
+			// Role the user
+			SSdiscord.grant_role(lowerparams)
 			return "Successfully linked accounts"
 		else
 			return "That ckey is not associated to this discord account. If someone has used your ID, please inform an administrator"

--- a/config/config.txt
+++ b/config/config.txt
@@ -500,3 +500,19 @@ DEFAULT_VIEW_SQUARE 15x15
 
 ## Enable automatic profiling - Byond 513.1506 and newer only.
 #AUTO_PROFILE
+
+#### DISCORD STUFFS ####
+## MAKE SURE ALL SECTIONS OF THIS ARE FILLED OUT BEFORE ENABLING
+## Discord IDs can be obtained by following this guide: https://support.discordapp.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-
+
+## Uncomment to enable discord auto-roling when users link their BYOND and Discord accounts
+#ENABLE_DISCORD_AUTOROLE
+
+## Add your discord bot token here. Make sure it has the ability to manage roles
+#DISCORD_TOKEN someDiscordToken
+
+## Add the ID of your guild (server) here
+#DISCORD_GUILDID 000000000000000000
+
+## Add the ID of the role you want assigning here
+#DISCORD_ROLEID 000000000000000000

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -326,6 +326,7 @@
 #include "code\datums\forced_movement.dm"
 #include "code\datums\hailer_phrase.dm"
 #include "code\datums\holocall.dm"
+#include "code\datums\http.dm"
 #include "code\datums\hud.dm"
 #include "code\datums\map_config.dm"
 #include "code\datums\mind.dm"

--- a/tools/discordRoleScript/README.MD
+++ b/tools/discordRoleScript/README.MD
@@ -1,0 +1,11 @@
+This is a script to role members in a discord if they have their ckey linked. It should only have to be ran **once**, since the game will handle any other new roles
+
+Requirements:
+  - Python 3 (Tested on 3.6.4)
+  - `Mysql-Connector` module
+  - `Requests` module
+
+How to use:
+  1. Ensure you have the correct dependencies installed
+  2. Fill out the config sections in the script (Discord details and SS13 server details)
+  3. Run the script, and leave it running until its done. It will give progress indicators as it runs

--- a/tools/discordRoleScript/Script.py
+++ b/tools/discordRoleScript/Script.py
@@ -1,0 +1,59 @@
+# Script to role discord members who have already associated their BYOND account
+# Author: AffectedArc07
+
+# From Discord API:
+# Clients are allowed 120 events every 60 seconds, meaning you can send on average at a rate of up to 2 events per second.
+
+# So lets send every 0.6 seconds to ensure we arent rate capped
+
+####### CONFIG ######
+
+# Discord section. Make sure the IDs are strings to avoid issues with IDs that start with a 0
+botToken = "Put your discord bot token here"
+guildID = "000000000000000000"
+roleID = "000000000000000000"
+
+# SS13 Database section
+dbHost = "127.0.0.1"
+dbUser = "root"
+dbPass = "your password here"
+dbDatabase = "tg_db"
+
+##### DO NOT TOUCH ANYTHING BELOW HERE UNLESS YOURE FAMILIAR WITH PYTHON #####
+import requests, mysql.connector, time
+
+# Connect to DB
+dbCon = mysql.connector.connect(
+    host = dbHost,
+    user = dbUser,
+    passwd = dbPass,
+    database = dbDatabase
+)
+cur = dbCon.cursor()
+
+# Grab all users who need to be processed
+cur.execute("SELECT byond_key, discord_id FROM player WHERE discord_id IS NOT NULL")
+usersToProcess = cur.fetchall()
+
+# We dont need the DB anymore, so close it up
+dbCon.close()
+
+# Calculate a total for better monitoring
+total = len(usersToProcess)
+count = 0
+print("Found "+str(total)+" accounts to process.")
+
+# Now the actual processing
+for user in usersToProcess:
+    count += 1  # Why the fuck does python not have ++
+    # user[0] = ckey, user[1] = discord ID
+    print("Processing "+str(user[0])+" (Discord ID: " + str(user[1]) + ") | User "+str(count)+"/"+str(total))
+    url = "https://discordapp.com/api/guilds/"+str(guildID)+"/members/"+str(user[1])+"/roles/"+str(roleID)
+    response = requests.put(url, headers={"Authorization": "Bot "+str(botToken)})
+    # Adding a role returns a code 204, not a code 204. Dont ask
+    if response.status_code != 204:
+        print("WARNING: Returned non-204 status code. Request used: PUT "+str(url))
+
+    # Sleep for 0.6. This way we stay under discords rate limiting.
+    time.sleep(0.6)
+

--- a/tools/discordRoleScript/Script.py
+++ b/tools/discordRoleScript/Script.py
@@ -50,7 +50,7 @@ for user in usersToProcess:
     print("Processing "+str(user[0])+" (Discord ID: " + str(user[1]) + ") | User "+str(count)+"/"+str(total))
     url = "https://discordapp.com/api/guilds/"+str(guildID)+"/members/"+str(user[1])+"/roles/"+str(roleID)
     response = requests.put(url, headers={"Authorization": "Bot "+str(botToken)})
-    # Adding a role returns a code 204, not a code 204. Dont ask
+    # Adding a role returns a code 204, not a code 200. Dont ask
     if response.status_code != 204:
         print("WARNING: Returned non-204 status code. Request used: PUT "+str(url))
 


### PR DESCRIPTION
## About The Pull Request
Oranges asked for this

When a user successfully links their BYOND accounts and discord accounts, they will now be automatically roled, based on config settings. 

NOTE: This does not update pre-linked accounts, but I can write an external bot to do that if needed

RUST-G has also been updated in this PR, to be inline with this PR over at RUST-G https://github.com/tgstation/rust-g/pull/23

## Why It's Good For The Game
People with linked accounts can now be given a specific role in the discord, which is good for verification.

## Changelog
:cl: AffectedArc07
add: Linking your discord and BYOND accounts will now give you a role in the discord
/:cl:
