### PR TITLE
Removes transformation sting

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -64,53 +64,6 @@
 	return 1
 
 
-/datum/action/changeling/sting/transformation
-	name = "Transformation Sting"
-	desc = "We silently sting a human, injecting a retrovirus that forces them to transform. Costs 50 chemicals."
-	helptext = "The victim will transform much like a changeling would. Does not provide a warning to others. Mutations will not be transferred, and monkeys will become human."
-	button_icon_state = "sting_transform"
-	chemical_cost = 50
-	dna_cost = 3
-	var/datum/changelingprofile/selected_dna = null
-
-/datum/action/changeling/sting/transformation/Trigger()
-	var/mob/user = usr
-	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
-	if(changeling.chosen_sting)
-		unset_sting(user)
-		return
-	selected_dna = changeling.select_dna("Select the target DNA: ", "Target DNA")
-	if(!selected_dna)
-		return
-	if(NOTRANSSTING in selected_dna.dna.species.species_traits)
-		to_chat(user, "<span class='notice'>That DNA is not compatible with changeling retrovirus!</span>")
-		return
-	..()
-
-/datum/action/changeling/sting/transformation/can_sting(mob/user, mob/living/carbon/target)
-	if(!..())
-		return
-	if((HAS_TRAIT(target, TRAIT_HUSK)) || !iscarbon(target) || (NOTRANSSTING in target.dna.species.species_traits))
-		to_chat(user, "<span class='warning'>Our sting appears ineffective against its DNA.</span>")
-		return 0
-	return 1
-
-/datum/action/changeling/sting/transformation/sting_action(mob/user, mob/target)
-	log_combat(user, target, "stung", "transformation sting", " new identity is '[selected_dna.dna.real_name]'")
-	var/datum/dna/NewDNA = selected_dna.dna
-	if(ismonkey(target))
-		to_chat(user, "<span class='notice'>Our genes cry out as we sting [target.name]!</span>")
-
-	var/mob/living/carbon/C = target
-	. = TRUE
-	if(istype(C))
-		C.real_name = NewDNA.real_name
-		NewDNA.transfer_identity(C)
-		if(ismonkey(C))
-			C.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_KEEPSTUNS | TR_KEEPREAGENTS | TR_DEFAULTMSG)
-		C.updateappearance(mutcolor_update=1)
-
-
 /datum/action/changeling/sting/false_armblade
 	name = "False Armblade Sting"
 	desc = "We silently sting a human, injecting a retrovirus that mutates their arm to temporarily appear as an armblade. Costs 20 chemicals."


### PR DESCRIPTION
@imsxz 
---
I think i did this right, i loaded it up and it compiled and it wasn't in the emporium so ¯\_(ツ)_/¯
## Why It's Good For The Game
This is only used to mass transform the crew and is a blatant grief tool. Can't believe this hasn't been done before.
## Changelog
:cl:
del: Removed transformation sting
/:cl: