### PR TITLE
Fix shuttle timer text leading zeroes

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -704,7 +704,7 @@
 	if(timeleft > 1 HOURS)
 		return "--:--"
 	else if(timeleft > 0)
-		return "[add_leading(num2text((timeleft / 60) % 60), 2, "0")]:[add_leading(num2text(timeleft % 60), 2, " ")]"
+		return "[add_leading(num2text(round(timeleft / 60)), 2, "0")]:[add_leading(num2text(timeleft % 60), 2, "0")]"
 	else
 		return "00:00"
 


### PR DESCRIPTION
:cl:
fix: Shuttle countdowns once again read like "01:08" instead of "01: 8".
/:cl:

Broken in #48304.