### PR TITLE
Forces basic keybind reset, fixes some older savefile issues.

### DIFF
--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -6,8 +6,7 @@
 	return iscarbon(user.mob)
 
 /datum/keybinding/carbon/toggle_throw_mode
-	hotkey_keys = list("R")
-	classic_keys = list("Southwest") // END
+	hotkey_keys = list("R", "Southwest") // END
 	name = "toggle_throw_mode"
 	full_name = "Toggle throw mode"
 	description = "Toggle throwing the current item or not."

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -5,7 +5,6 @@
 
 /datum/keybinding/mob/face_north
 	hotkey_keys = list("CtrlW", "CtrlNorth")
-	classic_keys = list("CtrlNorth")
 	name = "face_north"
 	full_name = "Face North"
 	description = ""
@@ -18,7 +17,6 @@
 
 /datum/keybinding/mob/face_east
 	hotkey_keys = list("CtrlD", "CtrlEast")
-	classic_keys = list("CtrlEast")
 	name = "face_east"
 	full_name = "Face East"
 	description = ""
@@ -31,7 +29,6 @@
 
 /datum/keybinding/mob/face_south
 	hotkey_keys = list("CtrlS", "CtrlSouth")
-	classic_keys = list("CtrlSouth")
 	name = "face_south"
 	full_name = "Face South"
 	description = ""
@@ -43,7 +40,6 @@
 
 /datum/keybinding/mob/face_west
 	hotkey_keys = list("CtrlA", "CtrlWest")
-	classic_keys = list("CtrlWest")
 	name = "face_west"
 	full_name = "Face West"
 	description = ""
@@ -55,7 +51,6 @@
 
 /datum/keybinding/mob/stop_pulling
 	hotkey_keys = list("H", "Delete")
-	classic_keys = list("Delete")
 	name = "stop_pulling"
 	full_name = "Stop pulling"
 	description = ""
@@ -91,8 +86,7 @@
 	return TRUE
 
 /datum/keybinding/mob/swap_hands
-	hotkey_keys = list("X")
-	classic_keys = list("Northeast") // PAGEUP
+	hotkey_keys = list("X", "Northeast") // PAGEUP
 	name = "swap_hands"
 	full_name = "Swap hands"
 	description = ""
@@ -103,8 +97,7 @@
 	return TRUE
 
 /datum/keybinding/mob/activate_inhand
-	hotkey_keys = list("Z")
-	classic_keys = list("Southeast") // PAGEDOWN
+	hotkey_keys = list("Z", "Southeast") // PAGEDOWN
 	name = "activate_inhand"
 	full_name = "Activate in-hand"
 	description = "Uses whatever item you have inhand"

--- a/code/datums/keybinding/movement.dm
+++ b/code/datums/keybinding/movement.dm
@@ -4,28 +4,24 @@
 
 /datum/keybinding/movement/north
 	hotkey_keys = list("W", "North")
-	classic_keys = list("North")
 	name = "North"
 	full_name = "Move North"
 	description = "Moves your character north"
 
 /datum/keybinding/movement/south
 	hotkey_keys = list("S", "South")
-	classic_keys = list("South")
 	name = "South"
 	full_name = "Move South"
 	description = "Moves your character south"
 
 /datum/keybinding/movement/west
 	hotkey_keys = list("A", "West")
-	classic_keys = list("West")
 	name = "West"
 	full_name = "Move West"
 	description = "Moves your character left"
 
 /datum/keybinding/movement/east
 	hotkey_keys = list("D", "East")
-	classic_keys = list("East")
 	name = "East"
 	full_name = "Move East"
 	description = "Moves your character east"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1815,3 +1815,15 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			return
 		else
 			custom_names[name_id] = sanitized_name
+
+//Used in savefile update 32, can be removed once that is no longer relevant.
+/datum/preferences/proc/force_reset_keybindings()
+	var/choice = tgalert(parent.mob, "Your basic keybindings need to be reset, emotes will remain as before. Would you prefer 'hotkey' or 'classic' mode?", "Reset keybindings", "Hotkey", "Classic")
+	hotkeys = (choice != "Classic")
+	var/list/oldkeys = key_bindings
+	key_bindings = (hotkeys) ? deepCopyList(GLOB.hotkey_keybinding_list_by_key) : deepCopyList(GLOB.classic_keybinding_list_by_key)
+
+	for(var/key in oldkeys)
+		if(!key_bindings[key])
+			key_bindings[key] = oldkeys[key]
+	parent.update_movement_keys()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	31
+#define SAVEFILE_VERSION_MAX	32
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -42,11 +42,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 //if your savefile is 3 months out of date, then 'tough shit'.
 
 /datum/preferences/proc/update_preferences(current_version, savefile/S)
-	if(current_version < 29)
-		key_bindings = (hotkeys) ? deepCopyList(GLOB.hotkey_keybinding_list_by_key) : deepCopyList(GLOB.classic_keybinding_list_by_key)
-		parent.update_movement_keys(src)
-		to_chat(parent, "<span class='userdanger'>Empty keybindings, setting default to [hotkeys ? "Hotkey" : "Classic"] mode</span>")
-
 	if(current_version < 30)
 		if(clientfps == 0)
 			clientfps = 60
@@ -54,6 +49,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(current_version < 31)
 		if(clientfps == 60)
 			clientfps = 0
+
+	if(current_version < 32)	//If you remove this, remove force_reset_keybindings() too.
+		addtimer(CALLBACK(src, .proc/force_reset_keybindings), 30)	//No mob available when this is run, timer allows user choice.
 
 /datum/preferences/proc/update_character(current_version, savefile/S)
 	if(current_version < 19)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As far as I can tell since classic mode prioritizes the chat bar, just having the alternate keybinds for hotkey mode set doesn't hurt anything. Not having them makes the hotkey/classic toggle in game preferences useless without setting them manually or resetting though, which is causing some issues with newer players.

This makes a tgalert pop up for everyone one time once they log on asking if they want hotkey or classic mode settings, and will set the alternate keybinds as well. Any empty by default keybindings will transfer over from the existing keybinds. This should also clear up any inconsistencies from various savefile versions about keybinds, and gives us a new baseline to work off of.

Even though nothing uses the classic_keys alternates anymore, I have left those in.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Easier for new/returning players, hopefully a lot less need to ahelp about key bindings.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Forced a basic keybind reset for everyone to fix some inconsistencies from various savefiles, as well as making the hotkey/classic toggle in game options work. Your emote keybinds should be untouched.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
