### PR TITLE
Stun batons respect shields

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -170,7 +170,7 @@
 		playsound(src, stun_sound, 75, TRUE, -1)
 		user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
 							"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
-		user.Knockdown(stun_time*3) //should be an equivalent to attack(user,user)
+		user.Knockdown(stun_time*3) //should really be an equivalent to attack(user,user)
 		deductcharge(cell_hit_cost)
 		return TRUE
 	return FALSE

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -170,12 +170,14 @@
 		playsound(src, stun_sound, 75, TRUE, -1)
 		user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
 							"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
-		user.Knockdown(stun_time*3)
+		user.Knockdown(stun_time*3) //should be an equivalent to attack(user,user)
 		deductcharge(cell_hit_cost)
-		return
+		return TRUE
+	return FALSE
 
 /obj/item/melee/baton/attack(mob/M, mob/living/carbon/human/user)
-	clumsy_check(user)
+	if(clumsy_check(user))
+		return FALSE
 
 	if(iscyborg(M))
 		..()
@@ -206,7 +208,8 @@
 
 
 /obj/item/melee/baton/proc/baton_effect(mob/living/L, mob/user)
-	check_shields(L, user)
+	if(shields_blocked(L, user))
+		return FALSE
 	if(iscyborg(loc))
 		var/mob/living/silicon/robot/R = loc
 		if(!R || !R.cell || !R.cell.use(cell_hit_cost))
@@ -257,12 +260,13 @@
 	if (!(. & EMP_PROTECT_SELF))
 		deductcharge(1000 / severity)
 
-/obj/item/melee/baton/proc/check_shields(mob/living/L, mob/user)
+/obj/item/melee/baton/proc/shields_blocked(mob/living/L, mob/user)
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		if(H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK)) //No message; check_shields() handles that
-			playsound(L, 'sound/weapons/genhit.ogg', 50, TRUE)
-			return FALSE
+			playsound(H, 'sound/weapons/genhit.ogg', 50, TRUE)
+			return TRUE
+	return FALSE
 
 //Makeshift stun baton. Replacement for stun gloves.
 /obj/item/melee/baton/cattleprod

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -510,7 +510,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 
 /obj/item/melee/baton/abductor/attack(mob/target, mob/living/user)
 	if(!AbductorCheck(user))
-		return
+		return FALSE
 
 	if(!deductcharge(cell_hit_cost))
 		to_chat(user, "<span class='warning'>[src] [cell ? "is out of charge" : "does not have a power source installed"].</span>")
@@ -522,16 +522,20 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	if(iscyborg(target))
 		if(BATON_STUN)
 			..()
-		return
+		return FALSE
 
 	if(!isliving(target))
-		return
+		return FALSE
+
+	if(clumsy_check(user))
+		return FALSE
 
 	var/mob/living/L = target
 
 	user.do_attack_animation(L)
 
-	check_shields(L, user)
+	if(shields_blocked(L, user))
+		return FALSE
 
 	switch (mode)
 		if(BATON_STUN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a mistake I made that means stun batons ignore shields. Also fixes attacks stopped by clumsiness going through.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Things like the wizard's shielded hardsuit and riot shields can block batons again. People don't get hit by attacks that should've been stopped by clumsiness.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
fix: Stun batons now respect shields again (e.g. riot shields, the wizard's shielded hardsuit)
fix: Stun baton attacks that should've been stopped by clumsiness no longer go through
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
