### PR TITLE
Organs can once again be sold on the black market.

### DIFF
--- a/code/modules/cargo/exports/organs.dm
+++ b/code/modules/cargo/exports/organs.dm
@@ -3,12 +3,12 @@
 	export_category = EXPORT_CONTRABAND
 
 /datum/export/organ/heart
-	cost = 20 //For the man who has everything and nothing.
+	cost = 10 //For the man who has everything and nothing.
 	unit_name = "humanoid heart"
 	export_types = list(/obj/item/organ/heart)
 
 /datum/export/organ/eyes
-	cost = 10
+	cost = 5
 	unit_name = "humanoid eyes"
 	export_types = list(/obj/item/organ/eyes)
 
@@ -18,12 +18,12 @@
 	export_types = list(/obj/item/organ/ears)
 
 /datum/export/organ/liver
-	cost = 15
+	cost = 5
 	unit_name = "humanoid liver"
 	export_types = list(/obj/item/organ/liver)
 
 /datum/export/organ/lungs
-	cost = 10
+	cost = 5
 	unit_name = "humanoid lungs"
 	export_types = list(/obj/item/organ/lungs)
 

--- a/code/modules/cargo/exports/organs.dm
+++ b/code/modules/cargo/exports/organs.dm
@@ -1,0 +1,38 @@
+/datum/export/organ
+	include_subtypes = FALSE	//Centcom doesn't need organs from non-humans.
+	export_category = EXPORT_CONTRABAND
+
+/datum/export/organ/heart
+	cost = 20 //For the man who has everything and nothing.
+	unit_name = "humanoid heart"
+	export_types = list(/obj/item/organ/heart)
+
+/datum/export/organ/eyes
+	cost = 10
+	unit_name = "humanoid eyes"
+	export_types = list(/obj/item/organ/eyes)
+
+/datum/export/organ/ears
+	cost = 5
+	unit_name = "humanoid ears"
+	export_types = list(/obj/item/organ/ears)
+
+/datum/export/organ/liver
+	cost = 15
+	unit_name = "humanoid liver"
+	export_types = list(/obj/item/organ/liver)
+
+/datum/export/organ/lungs
+	cost = 10
+	unit_name = "humanoid lungs"
+	export_types = list(/obj/item/organ/lungs)
+
+/datum/export/organ/stomach
+	cost = 5
+	unit_name = "humanoid stomach"
+	export_types = list(/obj/item/organ/stomach)
+
+/datum/export/organ/tongue
+	cost = 5
+	unit_name = "humanoid tounge"
+	export_types = list(/obj/item/organ/tongue)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1597,6 +1597,7 @@
 #include "code\modules\cargo\exports\lavaland.dm"
 #include "code\modules\cargo\exports\manifest.dm"
 #include "code\modules\cargo\exports\materials.dm"
+#include "code\modules\cargo\exports\organs.dm"
 #include "code\modules\cargo\exports\parts.dm"
 #include "code\modules\cargo\exports\seeds.dm"
 #include "code\modules\cargo\exports\sheets.dm"


### PR DESCRIPTION
Look I SWEAR this was a thing at one point.

## About The Pull Request

At some point in the past, likely due to the addition of bounties, we got rid of the ability to sell organs over the black market. Personally I don't know if there was a specific reason, but all organ sales got moved over to individual bounties instead, which is fine, but the flavor of selling organs over the black market in cargo is still very nice. To balance the possible ease involved in mass-producing monkey cubes and butchering them for tasty, tasty organs, I set most all organ values exceedingly low, but if you really wind up with a dozen pairs of standard, organic human hearts than who am I to judge?

## Why It's Good For The Game

We've had the blurb on the wiki that selling you can sell organs over the black market for years, and honestly I was convinced you still could until coul made me realize you couldn't. Also opens up the possibility of selling upgraded organs legally if anyone's interested in that, but this was just done in the interest of parity with the old mechanic.

## Changelog
:cl:
add: Human organs can once again be sold on the black market.
/:cl: