### PR TITLE
Stasis bed now considers diagonals for linking to op computers

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -21,7 +21,7 @@
 
 /obj/machinery/stasis/Initialize()
 	. = ..()
-	for(var/direction in GLOB.cardinals)
+	for(var/direction in GLOB.alldirs)
 		op_computer = locate(/obj/machinery/computer/operating, get_step(src, direction))
 		if(op_computer)
 			op_computer.sbed = src


### PR DESCRIPTION
:cl: oranges
tweak: The stasis bed now links in all directions, including diagonals
/:cl: