### PR TITLE
Removes Functional Cerebral Necrosis

### DIFF
--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -241,32 +241,6 @@
 	REMOVE_TRAIT(owner, TRAIT_NOHARDCRIT, TRAUMA_TRAIT)
 	..()
 
-/datum/brain_trauma/special/death_whispers
-	name = "Functional Cerebral Necrosis"
-	desc = "Patient's brain is stuck in a functional near-death state, causing occasional moments of lucid hallucinations, which are often interpreted as the voices of the dead."
-	scan_desc = "chronic functional necrosis"
-	gain_text = "<span class='warning'>You feel dead inside.</span>"
-	lose_text = "<span class='notice'>You feel alive again.</span>"
-	var/active = FALSE
-
-/datum/brain_trauma/special/death_whispers/on_life()
-	..()
-	if(!active && prob(2))
-		whispering()
-
-/datum/brain_trauma/special/death_whispers/on_lose()
-	if(active)
-		cease_whispering()
-	..()
-
-/datum/brain_trauma/special/death_whispers/proc/whispering()
-	ADD_TRAIT(owner, TRAIT_SIXTHSENSE, TRAUMA_TRAIT)
-	active = TRUE
-	addtimer(CALLBACK(src, .proc/cease_whispering), rand(50, 300))
-
-/datum/brain_trauma/special/death_whispers/proc/cease_whispering()
-	REMOVE_TRAIT(owner, TRAIT_SIXTHSENSE, TRAUMA_TRAIT)
-	active = FALSE
 
 /datum/brain_trauma/special/existential_crisis
 	name = "Existential Crisis"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I sincerely do not know why this still exists. This made sense way back when you could only really get deadchat, but it now shows people what events are going off due to the dead chat notifications sooooo bitch gotta go
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Because even if it's rare as hell I'd rather not have something that tells people there's a blob on the station five minutes before they should know.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removes the Functional Cerebral Necrosis brain trauma.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
