### PR TITLE
Fixes helmets not properly updating icons when worn

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -324,7 +324,7 @@
 
 //LightToggle
 
-/obj/item/clothing/head/helment/ComponentInitialize()
+/obj/item/clothing/head/helmet/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 


### PR DESCRIPTION
Fixes #49395
:cl: ShizCalev
fix: Fixed a typo that was causing helmets to not update icons when worn.
/:cl:
