### PR TITLE
Goliath Riding: 2.0 You Can (Not) Move Nukes

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -399,7 +399,12 @@
 	if(isinspace() && !anchored)
 		to_chat(usr, "<span class='warning'>There is nothing to anchor to!</span>")
 	else
-		anchored = !anchored
+		if(anchored)
+			anchored = FALSE
+			move_resist = MOVE_FORCE_NORMAL
+		else
+			anchored = TRUE
+			move_resist = MOVE_FORCE_OVERPOWERING
 
 /obj/machinery/nuclearbomb/proc/set_safety()
 	safety = !safety

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -69,6 +69,7 @@
 	icon = 'icons/obj/machines/nuke_terminal.dmi'
 	icon_state = "nuclearbomb_base"
 	anchored = TRUE //stops it being moved
+	move_resist = INFINITY //I SAID STOP
 
 /obj/machinery/nuclearbomb/syndicate
 	//ui_style = "syndicate" // actually the nuke op bomb is a stole nt bomb

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -111,7 +111,7 @@
 	if(isliving(whomst))
 		var/mob/living/fren = whomst
 		friends = fren
-		faction = fren.faction.Copy()
+		faction = list("[REF(fren)]")
 	..()
 
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/attackby(obj/item/O, mob/user, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

goliath when you tame it only becomes YOUR friend, not everyone that you share the faction with (scary i know)

the vault nuke now has infinite move resist, you CANNOT move it
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

i dont know if the first part is good, since its take your poison
either make the goliath become friends with all neutral mobs which is kinda lame or make it attack everyone except the owner which is cool but also sad
also the nuke thats anchored into the station shouldnt be movable
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: goliaths become only friends to you, not your allies too
fix: the vault self destruct nuke is no longer movable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
