### PR TITLE
Fix for space ninjas not living in space

### DIFF
--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -71,8 +71,7 @@ Contents:
 
 	//Cell Init
 	cell = new/obj/item/stock_parts/cell/high
-	cell.charge = 9000 // larger as it now heats
-	cell.maxcharge = 9000
+	cell.charge = 9000
 	cell.name = "black power cell"
 	cell.icon_state = "bscell"
 

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -21,8 +21,8 @@ Contents:
 	resistance_flags = LAVA_PROOF | ACID_PROOF
 	armor = list("melee" = 60, "bullet" = 50, "laser" = 30,"energy" = 40, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 100, "acid" = 100)
 	strip_delay = 12
-
-	actions_types = list(/datum/action/item_action/toggle_spacesuit, /datum/action/item_action/initialize_ninja_suit, /datum/action/item_action/ninjasmoke, /datum/action/item_action/ninjaboost, /datum/action/item_action/ninjapulse, /datum/action/item_action/ninjastar, /datum/action/item_action/ninjanet, /datum/action/item_action/ninja_sword_recall, /datum/action/item_action/ninja_stealth, /datum/action/item_action/toggle_glove)
+	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
+	actions_types = list(/datum/action/item_action/initialize_ninja_suit, /datum/action/item_action/ninjasmoke, /datum/action/item_action/ninjaboost, /datum/action/item_action/ninjapulse, /datum/action/item_action/ninjastar, /datum/action/item_action/ninjanet, /datum/action/item_action/ninja_sword_recall, /datum/action/item_action/ninja_stealth, /datum/action/item_action/toggle_glove)
 
 		//Important parts of the suit.
 	var/mob/living/carbon/human/affecting = null
@@ -71,14 +71,21 @@ Contents:
 
 	//Cell Init
 	cell = new/obj/item/stock_parts/cell/high
-	cell.charge = 60000 // larger as it now heats
-	cell.maxcharge = 60000
+	cell.charge = 9000 // larger as it now heats
+	cell.maxcharge = 9000
 	cell.name = "black power cell"
 	cell.icon_state = "bscell"
 
 // seal the cell in the ninja outfit
 /obj/item/clothing/suit/space/space_ninja/toggle_spacesuit_cell(mob/user)
 	return
+
+// Space Suit temperature regulation and power usage
+/obj/item/clothing/suit/space/space_ninja/process()
+	var/mob/living/carbon/human/user = src.loc
+	if(!user || !ishuman(user) || !(user.wear_suit == src))
+		return
+	user.adjust_bodytemperature(BODYTEMP_NORMAL - user.bodytemperature)
 
 //Simply deletes all the attachments and self, killing all related procs.
 /obj/item/clothing/suit/space/space_ninja/proc/terminate()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The temp controls got all wonky.
This will fix the space ninja to have an advanced suit that does not fail in space, and even keeps lizard ninjas warm in space now.

Fixes: #49455

![spaceninja now safe in space](https://user-images.githubusercontent.com/6491940/74944649-f73a3c00-53bb-11ea-8f21-d547437eaf89.PNG)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes an oversight on space ninja

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: space ninja space suit to warm the wearer now, no more button for that
fix: space ninja cell size is now reverted to original size
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
