### PR TITLE
obsessed is back to creep

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -75,8 +75,8 @@
 #define ANTAG_HUD_SINTOUCHED	20
 #define ANTAG_HUD_SOULLESS		21
 #define ANTAG_HUD_BROTHER		22
-#define ANTAG_HUD_OBSESSED	23
-#define ANTAG_HUD_FUGITIVE	24
+#define ANTAG_HUD_CREEP			23
+#define ANTAG_HUD_FUGITIVE		24
 
 // Notification action types
 #define NOTIFY_JUMP "jump"

--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -27,7 +27,7 @@
 #define ROLE_BRAINWASHED		"Brainwashed Victim"
 #define ROLE_OVERTHROW			"Syndicate Mutineer"		//Role removed, left here for safety.
 #define ROLE_HIVE				"Hivemind Host"				//Role removed, left here for safety.
-#define ROLE_OBSESSED				"Obsessed"
+#define ROLE_CREEP				"Creep"
 #define ROLE_SENTIENCE			"Sentience Potion Spawn"
 #define ROLE_MIND_TRANSFER		"Mind Transfer Potion"
 #define ROLE_POSIBRAIN			"Posibrain"
@@ -52,7 +52,7 @@ GLOBAL_LIST_INIT(special_roles, list(
 	ROLE_CULTIST = /datum/game_mode/cult,
 	ROLE_BLOB,
 	ROLE_NINJA,
-	ROLE_OBSESSED,
+	ROLE_CREEP,
 	ROLE_MONKEY = /datum/game_mode/monkey,
 	ROLE_REVENANT,
 	ROLE_ABDUCTOR,

--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -1,22 +1,22 @@
-/datum/brain_trauma/special/obsessed
+/datum/brain_trauma/special/creep
 	name = "Psychotic Schizophrenia"
 	desc = "Patient has a subtype of delusional disorder, becoming irrationally attached to someone."
 	scan_desc = "psychotic schizophrenic delusions"
 	gain_text = "If you see this message, make a github issue report. The trauma initialized wrong."
-	lose_text = "<span class='warning'>The voices in your head fall silent.</span>"
+	lose_text = "<span class='warning'>You no longer feel so attached.</span>"
 	can_gain = TRUE
 	random_gain = FALSE
 	resilience = TRAUMA_RESILIENCE_SURGERY
 	var/mob/living/obsession
-	var/datum/objective/spendtime/attachedobsessedobj
-	var/datum/antagonist/obsessed/antagonist
+	var/datum/objective/spendtime/attachedcreepobj
+	var/datum/antagonist/creep/antagonist
 	var/viewing = FALSE //it's a lot better to store if the owner is watching the obsession than checking it twice between two procs
 
 	var/total_time_creeping = 0 //just for roundend fun
 	var/time_spent_away = 0
 	var/obsession_hug_count = 0
 
-/datum/brain_trauma/special/obsessed/on_gain()
+/datum/brain_trauma/special/creep/on_gain()
 
 	//setup, linking, etc//
 	if(!obsession)//admins didn't set one
@@ -26,15 +26,15 @@
 			qdel(src)
 			return
 	gain_text = "<span class='warning'>You hear a sickening, raspy voice in your head. It wants one small task of you...</span>"
-	owner.mind.add_antag_datum(/datum/antagonist/obsessed)
-	antagonist = owner.mind.has_antag_datum(/datum/antagonist/obsessed)
+	owner.mind.add_antag_datum(/datum/antagonist/creep)
+	antagonist = owner.mind.has_antag_datum(/datum/antagonist/creep)
 	antagonist.trauma = src
 	..()
 	//antag stuff//
 	antagonist.forge_objectives(obsession.mind)
 	antagonist.greet()
 
-/datum/brain_trauma/special/obsessed/on_life()
+/datum/brain_trauma/special/creep/on_life()
 	if(!obsession || obsession.stat == DEAD)
 		viewing = FALSE//important, makes sure you no longer stutter when happy if you murdered them while viewing
 		return
@@ -50,34 +50,34 @@
 		SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "creeping", /datum/mood_event/creeping, obsession.name)
 		total_time_creeping += 20
 		time_spent_away = 0
-		if(attachedobsessedobj)//if an objective needs to tick down, we can do that since traumas coexist with the antagonist datum
-			attachedobsessedobj.timer -= 20 //mob subsystem ticks every 2 seconds(?), remove 20 deciseconds from the timer. sure, that makes sense.
+		if(attachedcreepobj)//if an objective needs to tick down, we can do that since traumas coexist with the antagonist datum
+			attachedcreepobj.timer -= 20 //mob subsystem ticks every 2 seconds(?), remove 20 deciseconds from the timer. sure, that makes sense.
 	else
 		out_of_view()
 
-/datum/brain_trauma/special/obsessed/proc/out_of_view()
+/datum/brain_trauma/special/creep/proc/out_of_view()
 	time_spent_away += 20
 	if(time_spent_away > 1800) //3 minutes
 		SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "creeping", /datum/mood_event/notcreepingsevere, obsession.name)
 	else
 		SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "creeping", /datum/mood_event/notcreeping, obsession.name)
 
-/datum/brain_trauma/special/obsessed/on_lose()
+/datum/brain_trauma/special/creep/on_lose()
 	..()
-	owner.mind.remove_antag_datum(/datum/antagonist/obsessed)
+	owner.mind.remove_antag_datum(/datum/antagonist/creep)
 
-/datum/brain_trauma/special/obsessed/handle_speech(datum/source, list/speech_args)
+/datum/brain_trauma/special/creep/handle_speech(datum/source, list/speech_args)
 	if(!viewing)
 		return
 	var/datum/component/mood/mood = owner.GetComponent(/datum/component/mood)
 	if(mood && mood.sanity >= SANITY_GREAT && social_interaction())
 		speech_args[SPEECH_MESSAGE] = ""
 
-/datum/brain_trauma/special/obsessed/on_hug(mob/living/hugger, mob/living/hugged)
+/datum/brain_trauma/special/creep/on_hug(mob/living/hugger, mob/living/hugged)
 	if(hugged == obsession)
 		obsession_hug_count++
 
-/datum/brain_trauma/special/obsessed/proc/social_interaction()
+/datum/brain_trauma/special/creep/proc/social_interaction()
 	var/fail = FALSE //whether you can finish a sentence while doing it
 	owner.stuttering = max(3, owner.stuttering)
 	owner.blur_eyes(10)
@@ -101,7 +101,7 @@
 	return fail
 
 
-/datum/brain_trauma/special/obsessed/proc/find_obsession()
+/datum/brain_trauma/special/creep/proc/find_obsession()
 	var/chosen_victim
 	var/list/possible_targets = list()
 	var/list/viable_minds = list()

--- a/code/datums/components/heirloom.dm
+++ b/code/datums/components/heirloom.dm
@@ -17,6 +17,6 @@
 	else if(isobserver(user))
 		examine_list += "<span class='notice'>It is the [family_name] family heirloom, belonging to [owner].</span>"
 	else
-		var/datum/antagonist/obsessed/creeper = user.mind.has_antag_datum(/datum/antagonist/obsessed)
+		var/datum/antagonist/creep/creeper = user.mind.has_antag_datum(/datum/antagonist/creep)
 		if(creeper && creeper.trauma.obsession == owner)
 			examine_list += "<span class='nicegreen'>This must be [owner]'s family heirloom! It smells just like them...</span>"

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(huds, list(
 	ANTAG_HUD_SINTOUCHED = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_SOULLESS = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_BROTHER = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_OBSESSED = new/datum/atom_hud/antag/hidden(),
+	ANTAG_HUD_CREEP = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_FUGITIVE = new/datum/atom_hud/antag()
 	))
 

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -163,13 +163,16 @@
 	timeout = 2 MINUTES
 
 /datum/mood_event/notcreeping
-	description = "<span class='warning'>The voices are not happy, and they painfully contort my thoughts into getting back on task.</span>\n"
+	description = "<span class='warning'>I sure wish I was around my obsession...</span>\n"
 	mood_change = -6
 	timeout = 30
 	hidden = TRUE
 
+/datum/mood_event/notcreeping/add_effects(name)
+	description = "<span class='warning'>I sure wish I was around [name]...</span>\n"
+
 /datum/mood_event/notcreepingsevere//not hidden since it's so severe
-	description = "<span class='boldwarning'>THEY NEEEEEEED OBSESSIONNNN!!</span>\n"
+	description = "<span class='boldwarning'>OBSESSIONNNN WHERE ARE YOUUUUUUUUUUUUU?!</span>\n"
 	mood_change = -30
 	timeout = 30
 
@@ -178,7 +181,7 @@
 	for(var/i in 1 to rand(3,5))
 		unstable += copytext_char(name, -1)
 	var/unhinged = uppertext(unstable.Join(""))//example Tinea Luxor > TINEA LUXORRRR (with randomness in how long that slur is)
-	description = "<span class='boldwarning'>THEY NEEEEEEED [unhinged]!!</span>\n"
+	description = "<span class='boldwarning'>[unhinged] WHERE ARE YOUUUUUUUUUUUUU?!</span>\n"
 
 /datum/mood_event/sapped
 	description = "<span class='boldwarning'>Some unexplainable sadness is consuming me...</span>\n"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -86,7 +86,7 @@
 	special_screen_replace = FALSE
 
 /datum/mood_event/creeping
-	description = "<span class='greentext'>The voices have released their hooks on my mind! I feel free again!</span>\n" //creeps get it when they are around their obsession
+	description = "<span class='greentext'>I'm so close to my obsession!</span>\n" //creeps get it when they are around their obsession
 	mood_change = 18
 	timeout = 3 SECONDS
 	hidden = TRUE

--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -213,7 +213,7 @@
 		timer += pick(-600, 0)
 	var/datum/antagonist/creep/creeper = owner.has_antag_datum(/datum/antagonist/creep)
 	if(target && target.current && creeper)
-		creeper.trauma.attachedobsessedobj = src
+		creeper.trauma.attachedcreepobj = src
 		explanation_text = "Spend [DisplayTimeText(timer)] around [target.name] while they're alive."
 	else
 		explanation_text = "Free Objective"

--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -1,16 +1,16 @@
-/datum/antagonist/obsessed
-	name = "Obsessed"
+/datum/antagonist/creep
+	name = "Creep"
 	show_in_antagpanel = TRUE
 	antagpanel_category = "Other"
-	job_rank = ROLE_OBSESSED
-	antag_hud_type = ANTAG_HUD_OBSESSED
-	antag_hud_name = "obsessed"
+	job_rank = ROLE_CREEP
+	antag_hud_type = ANTAG_HUD_CREEP
+	antag_hud_name = "creep"
 	show_name_in_check_antagonists = TRUE
-	roundend_category = "obsessed"
+	roundend_category = "creep"
 	silent = TRUE //not actually silent, because greet will be called by the trauma anyway.
-	var/datum/brain_trauma/special/obsessed/trauma
+	var/datum/brain_trauma/special/creep/trauma
 
-/datum/antagonist/obsessed/admin_add(datum/mind/new_owner,mob/admin)
+/datum/antagonist/creep/admin_add(datum/mind/new_owner,mob/admin)
 	var/mob/living/carbon/C = new_owner.current
 	if(!istype(C))
 		to_chat(admin, "[roundend_category] come from a brain trauma, so they need to at least be a carbon!")
@@ -21,33 +21,33 @@
 	message_admins("[key_name_admin(admin)] made [key_name_admin(new_owner)] into [name].")
 	log_admin("[key_name(admin)] made [key_name(new_owner)] into [name].")
 	//PRESTO FUCKIN MAJESTO
-	C.gain_trauma(/datum/brain_trauma/special/obsessed)//ZAP
+	C.gain_trauma(/datum/brain_trauma/special/creep)//ZAP
 
-/datum/antagonist/obsessed/greet()
+/datum/antagonist/creep/greet()
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/creepalert.ogg', 100, FALSE, pressure_affected = FALSE)
-	to_chat(owner, "<span class='userdanger'>You are the Obsessed!</span>")
+	to_chat(owner, "<span class='userdanger'>You are the Creep!</span>")
 	to_chat(owner, "<B>The Voices have reached out to you, and are using you to complete their evil deeds.</B>")
 	to_chat(owner, "<B>You don't know their connection, but The Voices compel you to stalk [trauma.obsession], forcing them into a state of constant paranoia.</B>")
 	to_chat(owner, "<B>The Voices will retaliate if you fail to complete your tasks or spend too long away from your target.</B>")
 	to_chat(owner, "<span class='boldannounce'>This role does NOT enable you to otherwise surpass what's deemed creepy behavior per the rules.</span>")//ironic if you know the history of the antag
 	owner.announce_objectives()
 
-/datum/antagonist/obsessed/Destroy()
+/datum/antagonist/creep/Destroy()
 	if(trauma)
 		qdel(trauma)
 	. = ..()
 
-/datum/antagonist/obsessed/apply_innate_effects(mob/living/mob_override)
+/datum/antagonist/creep/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
 	add_antag_hud(antag_hud_type, antag_hud_name, M)
 
-/datum/antagonist/obsessed/remove_innate_effects(mob/living/mob_override)
+/datum/antagonist/creep/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
 	remove_antag_hud(antag_hud_type, M)
 
-/datum/antagonist/obsessed/proc/forge_objectives(var/datum/mind/obsessionmind)
+/datum/antagonist/creep/proc/forge_objectives(var/datum/mind/obsessionmind)
 	var/list/objectives_left = list("spendtime", "polaroid", "hug")
-	var/datum/objective/assassinate/obsessed/kill = new
+	var/datum/objective/assassinate/creep/kill = new
 	kill.owner = owner
 	kill.target = obsessionmind
 	var/datum/quirk/family_heirloom/family_heirloom
@@ -97,10 +97,10 @@
 	for(var/datum/objective/O in objectives)
 		O.update_explanation_text()
 
-/datum/antagonist/obsessed/roundend_report_header()
-	return 	"<span class='header'>Someone became obsessed!</span><br>"
+/datum/antagonist/creep/roundend_report_header()
+	return 	"<span class='header'>Someone became the creep!</span><br>"
 
-/datum/antagonist/obsessed/roundend_report()
+/datum/antagonist/creep/roundend_report()
 	var/list/report = list()
 
 	if(!owner)
@@ -134,14 +134,14 @@
 ///CREEPY objectives (few chosen per obsession)///
 //////////////////////////////////////////////////
 
-/datum/objective/assassinate/obsessed //just a creepy version of assassinate
+/datum/objective/assassinate/creep //just a creepy version of assassinate
 
-/datum/objective/assassinate/obsessed/update_explanation_text()
+/datum/objective/assassinate/creep/update_explanation_text()
 	..()
 	if(target && target.current)
 		explanation_text = "Murder [target.name], the [!target_role_type ? target.assigned_role : target.special_role]."
 	else
-		message_admins("WARNING! [ADMIN_LOOKUPFLW(owner)] obsessed objectives forged without an obsession!")
+		message_admins("WARNING! [ADMIN_LOOKUPFLW(owner)] creep objectives forged without an obsession!")
 		explanation_text = "Free Objective"
 
 /datum/objective/assassinate/jealous //assassinate, but it changes the target to someone else in the previous target's department. cool, right?
@@ -178,8 +178,8 @@
 	for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)
 		if(!H.mind)
 			continue
-		if(!SSjob.GetJob(H.mind.assigned_role) || H == oldmind.current || H.mind.has_antag_datum(/datum/antagonist/obsessed))
-			continue //the jealousy target has to have a job, and not be the obsession or obsessed.
+		if(!SSjob.GetJob(H.mind.assigned_role) || H == oldmind.current || H.mind.has_antag_datum(/datum/antagonist/creep))
+			continue //the jealousy target has to have a job, and not be the obsession or creep.
 		all_coworkers += H.mind
 		//this won't be called often thankfully.
 		if(H.mind.assigned_role in GLOB.security_positions)
@@ -204,14 +204,14 @@
 		target = pick(all_coworkers)
 	return oldmind
 
-/datum/objective/spendtime //spend some time around someone, handled by the obsessed trauma since that ticks
+/datum/objective/spendtime //spend some time around someone, handled by the creep trauma since that ticks
 	name = "spendtime"
 	var/timer = 1800 //5 minutes
 
 /datum/objective/spendtime/update_explanation_text()
 	if(timer == initial(timer))//just so admins can mess with it
 		timer += pick(-600, 0)
-	var/datum/antagonist/obsessed/creeper = owner.has_antag_datum(/datum/antagonist/obsessed)
+	var/datum/antagonist/creep/creeper = owner.has_antag_datum(/datum/antagonist/creep)
 	if(target && target.current && creeper)
 		creeper.trauma.attachedobsessedobj = src
 		explanation_text = "Spend [DisplayTimeText(timer)] around [target.name] while they're alive."
@@ -230,14 +230,14 @@
 	..()
 	if(!hugs_needed)//just so admins can mess with it
 		hugs_needed = rand(4,6)
-	var/datum/antagonist/obsessed/creeper = owner.has_antag_datum(/datum/antagonist/obsessed)
+	var/datum/antagonist/creep/creeper = owner.has_antag_datum(/datum/antagonist/creep)
 	if(target && target.current && creeper)
 		explanation_text = "Hug [target.name] [hugs_needed] times while they're alive."
 	else
 		explanation_text = "Free Objective"
 
 /datum/objective/hug/check_completion()
-	var/datum/antagonist/obsessed/creeper = owner.has_antag_datum(/datum/antagonist/obsessed)
+	var/datum/antagonist/creep/creeper = owner.has_antag_datum(/datum/antagonist/creep)
 	if(!creeper || !creeper.trauma || !hugs_needed)
 		return TRUE//free objective
 	return creeper.trauma.obsession_hug_count >= hugs_needed

--- a/code/modules/events/creep_awakening.dm
+++ b/code/modules/events/creep_awakening.dm
@@ -9,7 +9,7 @@
 
 /datum/round_event/creep/start()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
-		if(!H.client || !(ROLE_OBSESSED in H.client.prefs.be_special))
+		if(!H.client || !(ROLE_CREEP in H.client.prefs.be_special))
 			continue
 		if(H.stat == DEAD)
 			continue

--- a/code/modules/events/creep_awakening.dm
+++ b/code/modules/events/creep_awakening.dm
@@ -1,13 +1,13 @@
-/datum/round_event_control/obsessed
-	name = "Obsession Awakening"
-	typepath = /datum/round_event/obsessed
+/datum/round_event_control/creep
+	name = "Creep Awakening"
+	typepath = /datum/round_event/creep
 	max_occurrences = 1
 	min_players = 20
 
-/datum/round_event/obsessed
+/datum/round_event/creep
 	fakeable = FALSE
 
-/datum/round_event/obsessed/start()
+/datum/round_event/creep/start()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
 		if(!H.client || !(ROLE_OBSESSED in H.client.prefs.be_special))
 			continue
@@ -15,10 +15,10 @@
 			continue
 		if(!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.nonhuman_positions)) //only station jobs sans nonhuman roles, prevents ashwalkers trying to stalk with crewmembers they never met
 			continue
-		if(H.mind.has_antag_datum(/datum/antagonist/obsessed))
+		if(H.mind.has_antag_datum(/datum/antagonist/creep))
 			continue
 		if(!H.getorgan(/obj/item/organ/brain))
 			continue
-		H.gain_trauma(/datum/brain_trauma/special/obsessed)
+		H.gain_trauma(/datum/brain_trauma/special/creep)
 		announce_to_ghosts(H)
 		break


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Obsessed has returned to it's original, much much better name. I have still left out some of the oldest parts of old creep like the love status effect to make sure it doesn't return to what it was on release. A couple other things left out: The special moodlet face creeps would get, a bit more restraint on the moodlets for being near the obsession.

## Why It's Good For The Game

On release, someone used creep as an excuse to rape someone in a round and I was blamed for promoting rape. But obviously this is the fault of the person who thought an antag could let them rape people. Still, it needed to be changed because it was a new angle on a role play antag that some people would exploit or not understand. Now that things have calmed down, we can stop using the really horrible theme of "Obsessed"

## Changelog
:cl:
tweak: Obsessed is back to being called the creep.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
