### PR TITLE
Removes stetchkin out of armory contrabrand spawns

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -49,16 +49,13 @@
 	name = "armory contraband gun spawner"
 	lootdoubles = FALSE
 
-	loot = list(
-				/obj/item/gun/ballistic/automatic/pistol = 8,
-				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
+	loot = list(/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
 				/obj/item/gun/ballistic/automatic/pistol/deagle,
 				/obj/item/gun/ballistic/revolver/mateba
 				)
 
 /obj/effect/spawner/lootdrop/armory_contraband/metastation
-	loot = list(/obj/item/gun/ballistic/automatic/pistol = 5,
-				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
+	loot = list(/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
 				/obj/item/gun/ballistic/automatic/pistol/deagle,
 				/obj/item/storage/box/syndie_kit/throwing_weapons = 3,
 				/obj/item/gun/ballistic/revolver/mateba)


### PR DESCRIPTION
Sorry gamer rushing armory for free illegal tech(which has no downsides to deconstruct and isnt at all an accomplishment like locked nodes should be (see alien/bepis tech) l

## Changelog
:cl: Improvedname
balance: Removes stetchkin from armory lootspawn
/:cl:
