### PR TITLE
Wooden Barrels are now cheaper to craft, and can be made by stackcrafting.

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -193,6 +193,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("coffin", /obj/structure/closet/crate/coffin, 5, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("book case", /obj/structure/bookcase, 4, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("drying rack", /obj/machinery/smartfridge/drying_rack, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe("wooden barrel", /obj/structure/fermenting_barrel, 8, time = 50, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("dog bed", /obj/structure/bed/dogbed, 10, time = 10, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("dresser", /obj/structure/dresser, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("picture frame", /obj/item/wallframe/picture, 1, time = 10),\

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -74,6 +74,6 @@
 /datum/crafting_recipe/fermenting_barrel
 	name = "Wooden Barrel"
 	result = /obj/structure/fermenting_barrel
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 30)
+	reqs = list(/obj/item/stack/sheet/mineral/wood = 8)
 	time = 50
 	category = CAT_PRIMAL


### PR DESCRIPTION

## About The Pull Request

Fairly self descriptive here, before wooden fermenting barrels cost 30 wooden planks to craft, making them virtually never used. More than that though, the only way to craft fermenting barrels was through the crafting menu. Considering that crafting a barrel takes no tools, I see no reason they can't be found from stack-crafting as well. Hopefully this will help introduce players to the fermenting system in-game as opposed to it being a largely hidden feature.

## Why It's Good For The Game

Improves clarity on where to find and use fermenting barrels, and improves the availability of the fermenting system in-game, so that it sees more use.

## Changelog
:cl:
tweak: Wooden Fermenting barrels now cost 8 wooden planks to craft, down from 30.
balance: Wooden Fermenting barrels can now be made in the stack crafting menu, in addition to the crafting menu.
/:cl:
