### PR TITLE
Recycler doesn't qdel you if you're in something that isn't an item

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -98,11 +98,7 @@
 	if(!isturf(AM0.loc))
 		return //I don't know how you called Crossed() but stop it.
 
-	var/list/to_eat
-	if(istype(AM0, /obj/item))
-		to_eat = AM0.GetAllContents()
-	else
-		to_eat = list(AM0)
+	var/list/to_eat = AM0.GetAllContents()
 
 	var/living_detected = FALSE //technically includes silicons as well but eh
 	var/list/nom = list()


### PR DESCRIPTION
fixes #49473, fixes #49464, fixes #49435 
Things that aren't items can have humans in them too

## Changelog
:cl:
fix: Recycler doesn't delete people in mechs, cardboard boxes, spells, etc. anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
