### PR TITLE
Adds exports for several advanced tools.

### DIFF
--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -95,6 +95,31 @@
 	export_types = list(/obj/item/radio)
 	exclude_types = list(/obj/item/radio/mech)
 
+//Advanced/Power Tools.
+/datum/export/weldingtool/experimental
+	cost = 90
+	unit_name = "experimental welding tool"
+	export_types = list(/obj/item/weldingtool/experimental)
+
+/datum/export/jawsoflife
+	cost = 100
+	unit_name = "jaws of life"
+	export_types = list(/obj/item/crowbar/power)
+
+/datum/export/handdrill
+	cost = 100
+	unit_name = "hand drill"
+	export_types = list(/obj/item/screwdriver/power)
+
+/datum/export/rld_mini
+	cost = 150
+	unit_name = "mini rapid lighting device"
+	export_types = list(/obj/item/construction/rld/mini)
+
+/datum/export/rsf
+	cost = 100
+	unit_name = "rapid service fabricator"
+	export_types = list(/obj/item/rsf)
 
 /datum/export/rcd
 	cost = 100


### PR DESCRIPTION
Everything can be bought or sold for the right amount of _PLASMA_.

## About The Pull Request

Adds the advanced tools from the experimental tools tech as cargo exports, expanding on the existing tools available to export. This includes the jaws of life, hand drill, experimental welder, Mini RLD, all that jazz. Prices are all open for discussion, based on the existing export value of the RCD and RPD.

## Why It's Good For The Game

Improves cargo's ability to make money, one variety of mass-producible good at a time. We already have all the basic in-game tools 

## Changelog
:cl:
add: Cargo can now sell more advanced tools from RnD, for a higher profit.
/:cl: