### PR TITLE
Fixes reaction chamber, again, again and again

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -29,7 +29,6 @@
 #define ADD_REAGENT		2	// reagent added
 #define REM_REAGENT		3	// reagent removed (may still exist)
 #define CLEAR_REAGENTS	4	// all reagents were cleared
-#define REACT_REAGENTS	5	// a reaction occured
 
 #define MIMEDRINK_SILENCE_DURATION 30  //ends up being 60 seconds given 1 tick every 2 seconds
 #define TRESHOLD_UNHUSK 50 //Health treshold for instabitaluri and rezadone to unhusk someone

--- a/code/datums/components/plumbing/reaction_chamber.dm
+++ b/code/datums/components/plumbing/reaction_chamber.dm
@@ -31,8 +31,11 @@
 			return
 
 	reagents.flags &= ~NO_REACT
-	RC.emptying = TRUE
 	reagents.handle_reactions()
+
+	RC.emptying = TRUE //If we move this up, it'll instantly get turned off since any reaction always sets the reagent_total to zero. Other option is make the reaction update
+	//everything for every chemical removed, wich isn't a good option either.
+	RC.on_reagent_change() //We need to check it now, because some reactions leave nothing left.
 
 /datum/component/plumbing/reaction_chamber/can_give(amount, reagent, datum/ductnet/net)
 	. = ..()

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -577,7 +577,6 @@
 							ME2.name = "used slime extract"
 							ME2.desc = "This extract has been used up."
 
-			my_atom?.on_reagent_change(REACT_REAGENTS)
 			selected_reaction.on_reaction(src, multiplier)
 			reaction_occurred = 1
 


### PR DESCRIPTION
The whole on_reagent_change just isn't made for this and after the third or so attempt, I gave up and just added an exception the permanently fix the whole mess.

I think what the bug report meant was this
closes #49213 

:cl:
fix: reaction chamber empties again
/:cl: