### PR TITLE
Removes bolt of change from magicarps

### DIFF
--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -60,10 +60,10 @@
 
 /mob/living/simple_animal/hostile/carp/ranged/xenobiology // these are for the xenobio gold slime pool
 	gold_core_spawnable = HOSTILE_SPAWN
-	allowed_projectile_types = list(/obj/projectile/magic/change, /obj/projectile/magic/animate, /obj/projectile/magic/teleport,
+	allowed_projectile_types = list(/obj/projectile/magic/animate, /obj/projectile/magic/teleport,
 	/obj/projectile/magic/door, /obj/projectile/magic/aoe/fireball, /obj/projectile/magic/spellblade, /obj/projectile/magic/arcane_barrage) //thanks Lett1
 
 /mob/living/simple_animal/hostile/carp/ranged/chaos/xenobiology
 	gold_core_spawnable = HOSTILE_SPAWN
-	allowed_projectile_types = list(/obj/projectile/magic/change, /obj/projectile/magic/animate, /obj/projectile/magic/teleport,
+	allowed_projectile_types = list(/obj/projectile/magic/animate, /obj/projectile/magic/teleport,
 	/obj/projectile/magic/door, /obj/projectile/magic/aoe/fireball, /obj/projectile/magic/spellblade, /obj/projectile/magic/arcane_barrage)


### PR DESCRIPTION
## About The Pull Request

Removes bolt of change from magicarps and chaos carps.

## Why It's Good For The Game
Because i consider the  ## bolt of change carp the cheese carp
Because lets say a threat poses on the station like a ninja. or something with non strippable items due its locked to them. just get a carp and he gets stripped wholely. no counter play can't even block the shot with the fucking katana? miner unsleashes megafauna onboard the station? magicarp no counterplay. Magic can't be blocked besides anti-magic items((not like anyone bothers getting them in a non wizard/cult excepts chaplains/miners round due it being a normal round without magic))

Bolt of change currently allows for the following cheese which i think is bad.
You can rush rainbow slimes by changing some random mob rapidly((can even be a slaved unit))
You can make a army of lesser drakes because fuck you((you can argue that its RNG based but bro rng isn't that hard when its only a tiny list bruh...))
You can transform anything in a syndicate borg and if you deconstruct/transform them they drop a syndikey headset which cheeses and potentionally fuck over antags by just doing your normal job(syndikey should be received either trough a event/spaceruin/or auctally catching a fucking agent, just because somoene was doing xenobio shouldnt have let security get all syndikeys cuz fuck your antag round and auctally communicating to other traitors right?)
 
## Changelog
:cl:
del: Removes magicarp bolt of change
/:cl:

