### PR TITLE
Buffs wittel spawnrate

### DIFF
--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -44,7 +44,7 @@
 
 /obj/structure/geyser/random
 	erupting_state = null
-	var/list/options = list(/datum/reagent/clf3 = 10, /datum/reagent/water/hollowwater = 10, /datum/reagent/medicine/omnizine/protozine = 6, /datum/reagent/wittel = 1)
+	var/list/options = list(/datum/reagent/clf3 = 10, /datum/reagent/water/hollowwater = 10, /datum/reagent/medicine/omnizine/protozine = 6, /datum/reagent/wittel = 2)
 
 /obj/structure/geyser/random/Initialize()
 	. = ..()

--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -44,7 +44,7 @@
 
 /obj/structure/geyser/random
 	erupting_state = null
-	var/list/options = list(/datum/reagent/clf3 = 10, /datum/reagent/water/hollowwater = 10, /datum/reagent/medicine/omnizine/protozine = 6, /datum/reagent/wittel = 2)
+	var/list/options = list(/datum/reagent/clf3 = 8, /datum/reagent/water/hollowwater = 8, /datum/reagent/medicine/omnizine/protozine = 5, /datum/reagent/wittel = 1)
 
 /obj/structure/geyser/random/Initialize()
 	. = ..()


### PR DESCRIPTION
Wittel ended up being a little too rare, to the point where you could go multiple rounds looking for it and not be guaranteed a find.

I'd like to turn it back down once more chems are added to the geysers, since right now wittel is the only unique geyser chem people are looking for. 

I changed it from 1/27 to 1/22

:cl:
balance: wittel spawns twice as much
/:cl: