### PR TITLE
Wigs Now Use Atom Color

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -33,7 +33,6 @@
 /obj/item/clothing/head/welding/attack_self(mob/user)
 	weldingvisortoggle(user)
 
-
 /*
  * Cakehat
  */
@@ -179,7 +178,6 @@
 /obj/item/clothing/head/kitty/genuine
 	desc = "A pair of kitty ears. A tag on the inside says \"Hand made from real cats.\""
 
-
 /obj/item/clothing/head/hardhat/reindeer
 	name = "novelty reindeer hat"
 	desc = "Some fake antlers and a very fake red nose."
@@ -215,8 +213,6 @@
 /obj/item/clothing/head/cardborg/dropped(mob/living/user)
 	..()
 	user.remove_alt_appearance("standard_borg_disguise")
-
-
 
 /obj/item/clothing/head/wig
 	name = "wig"
@@ -326,7 +322,6 @@
 
 	user.gain_trauma(paranoia, TRAUMA_RESILIENCE_MAGIC)
 	to_chat(user, "<span class='warning'>As you don the foiled hat, an entire world of conspiracy theories and seemingly insane ideas suddenly rush into your mind. What you once thought unbelievable suddenly seems.. undeniable. Everything is connected and nothing happens just by accident. You know too much and now they're out to get you. </span>")
-
 
 /obj/item/clothing/head/foilhat/MouseDrop(atom/over_object)
 	//God Im sorry

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -261,12 +261,14 @@
 		hairstyle = new_style
 		user.visible_message("<span class='notice'>[user] changes \the [src]'s hairstyle to [new_style].</span>", "<span class='notice'>You change \the [src]'s hairstyle to [new_style].</span>")
 	if(adjustablecolor)
-		color = input(usr,"","Choose Color",color) as color|null
+		var/newcolor = input(usr,"","Choose Color",color) as color|null
+		if (newcolor != color)
+			add_atom_colour(newcolor, FIXED_COLOUR_PRIORITY)
 	update_icon()
 
 /obj/item/clothing/head/wig/random/Initialize(mapload)
 	hairstyle = pick(GLOB.hairstyles_list - "Bald") //Don't want invisible wig
-	color = "#[random_short_color()]"
+	add_atom_colour("#[random_short_color()]", FIXED_COLOUR_PRIORITY)
 	. = ..()
 
 /obj/item/clothing/head/wig/natural
@@ -283,8 +285,9 @@
 /obj/item/clothing/head/wig/natural/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(ishuman(user) && slot == ITEM_SLOT_HEAD)
-		color = "#[user.hair_color]"
-		update_icon()
+		if (color != "#[user.hair_color]")
+			add_atom_colour("#[user.hair_color]", FIXED_COLOUR_PRIORITY)
+			update_icon()
 		user.update_inv_head()
 
 /obj/item/clothing/head/bronze

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -255,15 +255,14 @@
 
 /obj/item/clothing/head/wig/attack_self(mob/user)
 	var/new_style = input(user, "Select a hairstyle", "Wig Styling")  as null|anything in (GLOB.hairstyles_list - "Bald")
+	var/newcolor = adjustablecolor ? input(usr,"","Choose Color",color) as color|null : null
 	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	if(new_style && new_style != hairstyle)
 		hairstyle = new_style
 		user.visible_message("<span class='notice'>[user] changes \the [src]'s hairstyle to [new_style].</span>", "<span class='notice'>You change \the [src]'s hairstyle to [new_style].</span>")
-	if(adjustablecolor)
-		var/newcolor = input(usr,"","Choose Color",color) as color|null
-		if (newcolor != color)
-			add_atom_colour(newcolor, FIXED_COLOUR_PRIORITY)
+	if(newcolor && newcolor != color) // only update if necessary
+		add_atom_colour(newcolor, FIXED_COLOUR_PRIORITY)
 	update_icon()
 
 /obj/item/clothing/head/wig/random/Initialize(mapload)
@@ -285,7 +284,7 @@
 /obj/item/clothing/head/wig/natural/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(ishuman(user) && slot == ITEM_SLOT_HEAD)
-		if (color != "#[user.hair_color]")
+		if (color != "#[user.hair_color]") // only update if necessary
 			add_atom_colour("#[user.hair_color]", FIXED_COLOUR_PRIORITY)
 			update_icon()
 		user.update_inv_head()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Wigs now use atom color, as suggested by @Time-Green, to avoid being washed off. Also prevented users from changing color of a wig at any distance.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better handling of colors, handling of colors seems to be less confusing. Closes https://github.com/tgstation/tgstation/issues/49480

Tested with zero (0) runtimes.

Note: changes to how atom color updating effects mutable appearances will come in a later pr, out of the scope of this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
tweak: Nanotrasen is now manufacturing wigs with waterproof dye -- shower with new-found confidence!
fix: Wigs can no longer have their color changed when not being held.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
