### PR TITLE
Fixes spacemandmm hating metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -72630,7 +72630,7 @@
 "lfv" = (
 /obj/effect/mob_spawn/human/corpse/assistant{
 	belt = null;
-	husk = TRUE;
+	husk = 1;
 	id = null;
 	l_pocket = /obj/item/pen
 	},


### PR DESCRIPTION
## About The Pull Request
Someone (Cant be bothered to find out who) tried to use `TRUE` inside a map object. This is a var, not a native BYOND thing, and so spacemandmm shat itself while trying to render

```
parsing tgstation.dme
./_maps/map_files/MetaStation/MetaStation.dmm
Failed to load ./_maps/map_files/MetaStation/MetaStation.dmm:
72633:13:cannot reference variables in this context
```

## Why It's Good For The Game
Allows the map to actually be rendered. Currently I cannot render the webmap, and I dont think mapdiffbot is too happy either.

## Changelog
:cl: AffectedArc07
tweak: MetaStation is now no longer internally broken
/:cl:
