### PR TITLE
Some grabbing tweaks

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -759,7 +759,7 @@
 		if((resting || HAS_TRAIT(src, TRAIT_GRABWEAKNESS)) && pulledby.grab_state < GRAB_KILL) //If resting, resisting out of a grab is equivalent to 1 grab state higher. wont make the grab state exceed the normal max, however
 			altered_grab_state++
 		var/resist_chance = BASE_GRAB_RESIST_CHANCE // see defines/combat.dm
-		resist_chance = max(resist_chance/altered_grab_state-sqrt((getStaminaLoss()+getBruteLoss()/2)*(3-altered_grab_state)), 0) // https://i.imgur.com/6yAT90T.png for sample output values
+		resist_chance = max((resist_chance/altered_grab_state)-sqrt(((getBruteLoss()/2)+getStaminaLoss())*altered_grab_state), 0)
 		if(prob(resist_chance))
 			visible_message("<span class='danger'>[src] breaks free of [pulledby]'s grip!</span>", \
 							"<span class='danger'>You break free of [pulledby]'s grip!</span>", null, null, pulledby)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -759,7 +759,7 @@
 		if((resting || HAS_TRAIT(src, TRAIT_GRABWEAKNESS)) && pulledby.grab_state < GRAB_KILL) //If resting, resisting out of a grab is equivalent to 1 grab state higher. wont make the grab state exceed the normal max, however
 			altered_grab_state++
 		var/resist_chance = BASE_GRAB_RESIST_CHANCE // see defines/combat.dm
-		resist_chance = max((resist_chance/altered_grab_state)-sqrt(((getBruteLoss()/2)+getStaminaLoss())*altered_grab_state), 0)
+		resist_chance = max((resist_chance/altered_grab_state)-sqrt(((getBruteLoss()*0.5)+getStaminaLoss())*altered_grab_state), 0)
 		if(prob(resist_chance))
 			visible_message("<span class='danger'>[src] breaks free of [pulledby]'s grip!</span>", \
 							"<span class='danger'>You break free of [pulledby]'s grip!</span>", null, null, pulledby)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -759,7 +759,7 @@
 		if((resting || HAS_TRAIT(src, TRAIT_GRABWEAKNESS)) && pulledby.grab_state < GRAB_KILL) //If resting, resisting out of a grab is equivalent to 1 grab state higher. wont make the grab state exceed the normal max, however
 			altered_grab_state++
 		var/resist_chance = BASE_GRAB_RESIST_CHANCE // see defines/combat.dm
-		resist_chance = max((resist_chance/altered_grab_state)-sqrt(((getBruteLoss()*0.5)+getStaminaLoss())*altered_grab_state), 0)
+		resist_chance = max((resist_chance/altered_grab_state)-sqrt((getBruteLoss()+getFireLoss()+getOxyLoss()+getToxLoss()+getCloneLoss())*0.5+getStaminaLoss()), 0) //stamina loss is weighted twice as heavily as the other damage types in this calculation
 		if(prob(resist_chance))
 			visible_message("<span class='danger'>[src] breaks free of [pulledby]'s grip!</span>", \
 							"<span class='danger'>You break free of [pulledby]'s grip!</span>", null, null, pulledby)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -180,7 +180,7 @@
 					visible_message("<span class='danger'>[user] grabs [src] aggressively!</span>", \
 									"<span class='userdanger'>[user] grabs you aggressively!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", null, user)
 					to_chat(user, "<span class='danger'>You grab [src] aggressively!</span>")
-					drop_all_held_items()
+				drop_all_held_items()
 				stop_pulling()
 				log_combat(user, src, "grabbed", addition="aggressive grab[add_log]")
 			if(GRAB_NECK)


### PR DESCRIPTION
## About The Pull Request

Aggressive grabs from pacifists now make people drop their items, just like aggressive grabs from non-pacifists do.

I also altered the formula for calculating your chance to resist out of a grab to `max((resist_chance/altered_grab_state)-sqrt((getBruteLoss()+getFireLoss()+getOxyLoss()+getToxLoss()+getCloneLoss())*0.5+getStaminaLoss()), 0)`.

This should make how damaged you are actually affect your chances for breaking out of a neck grab, which in turn should mean that a neck grab on someone who's heavily damaged won't sometimes be HARDER to break out of than a kill grab on that person (as far as I can tell, the last column of https://i.imgur.com/6yAT90T.png is wrong, as the base chance per attempt to break out of a kill grab under the current system should be 10%, not 5%).

I also added some parenthesis and moved some stuff around to make the order of operations/logic of the equation more clear (hopefully)

## Why It's Good For The Game

Making someone drop their held items doesn't damage them, and pacifists are allowed to use things like stun batons, so I don't see why they shouldn't be allowed to make people drop their items when they aggressively grab them (which is what aggressive grabs from non-pacifists already do).

The change to the chance to break out of a grab will fix an unintuitive oddity and hopefully make choking someone out more viable when you don't have cuffs or the like. Someone needs to basically be helpless for you to put them in a kill grab anyway, so I felt like it shouldn't be easy to break out of it if you're not in cuffs or stunned.

## Changelog
:cl: ATHATH
balance: Aggressive grabs from pacifists now make people drop their items, just like aggressive grabs from non-pacifists do.
balance: The chances to break out of aggressive, neck, and kill grabs have been modified slightly, and having large amounts of damage should actually affect how hard it is to break out of a kill grab now.
balance: All types of damage now affect how hard it is to break out of a grab, not just brute and stamina damage. Stamina damage is, as before, weighted twice as much as the other damage types in the grab escape chance calculation(s).
/:cl: