### PR TITLE
Parallax planet fix

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -324,7 +324,7 @@
 	layer = 30
 
 /obj/screen/parallax_layer/planet/update_status(mob/M)
-	var/client/C = mymob.client
+	var/client/C = M.client
 	var/turf/posobj = get_turf(C.eye)
 	if(!posobj)
 		return

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -201,7 +201,7 @@
 
 	for(var/thing in C.parallax_layers)
 		var/obj/screen/parallax_layer/L = thing
-		L.update_status(posobj)
+		L.update_status(mymob)
 		if (L.view_sized != C.view)
 			L.update_o(C.view)
 
@@ -283,7 +283,7 @@
 	add_overlay(new_overlays)
 	view_sized = view
 
-/obj/screen/parallax_layer/proc/update_status(turf/posobj)
+/obj/screen/parallax_layer/proc/update_status(mob/M)
 	return
 
 /obj/screen/parallax_layer/layer_1
@@ -323,7 +323,11 @@
 	speed = 3
 	layer = 30
 
-/obj/screen/parallax_layer/planet/update_status(turf/posobj)
+/obj/screen/parallax_layer/planet/update_status(mob/M)
+	var/client/C = mymob.client
+	var/turf/posobj = get_turf(C.eye)
+	if(!posobj)
+		return
 	invisibility = is_station_level(posobj.z) ? 0 : INVISIBILITY_ABSTRACT
 
 /obj/screen/parallax_layer/planet/update_o()

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -201,7 +201,7 @@
 
 	for(var/thing in C.parallax_layers)
 		var/obj/screen/parallax_layer/L = thing
-		L.update_status(mymob)
+		L.update_status(posobj)
 		if (L.view_sized != C.view)
 			L.update_o(C.view)
 
@@ -283,7 +283,7 @@
 	add_overlay(new_overlays)
 	view_sized = view
 
-/obj/screen/parallax_layer/proc/update_status(mob/M)
+/obj/screen/parallax_layer/proc/update_status(turf/posobj)
 	return
 
 /obj/screen/parallax_layer/layer_1
@@ -323,12 +323,8 @@
 	speed = 3
 	layer = 30
 
-/obj/screen/parallax_layer/planet/update_status(mob/M)
-	var/turf/T = get_turf(M)
-	if(is_station_level(T.z))
-		invisibility = 0
-	else
-		invisibility = INVISIBILITY_ABSTRACT
+/obj/screen/parallax_layer/planet/update_status(turf/posobj)
+	invisibility = is_station_level(posobj.z) ? 0 : INVISIBILITY_ABSTRACT
 
 /obj/screen/parallax_layer/planet/update_o()
 	return //Shit wont move


### PR DESCRIPTION
## About The Pull Request

Some change `obj/screen/parallax_layer/planet/update_status`

## Why It's Good For The Game

Now you do not see the planet when you see on something, using the camera console to another z lvl, or vice versa, you see the planet when you observe the station from afar.
Camera consoles.
Ghost Observe too but updates after observe target moves.
 
To test check Navigation Computer

Before fix:<details>
<summary>Spoiler</summary>

Station from Deep space
![before 1](https://user-images.githubusercontent.com/7734424/75181878-dbca8a80-5747-11ea-9340-de282cfc2857.png)
Deep space from station
![before 2](https://user-images.githubusercontent.com/7734424/75181884-dd944e00-5747-11ea-93aa-82c399dd03b7.png)
</details>
Now after fix:<details>
<summary>Spoiler</summary>

Station from Deep space
![paralax station from deep space](https://user-images.githubusercontent.com/7734424/75178376-a66e6e80-5740-11ea-9fd7-a34ee16e7745.png)
Deep space from station
![Deep space from station](https://user-images.githubusercontent.com/7734424/75178382-a8d0c880-5740-11ea-85fc-6f6722f7b51e.png)
</details>

## Changelog
:cl:
fix: Parallax shows planets and asteroids properly when you use remote vision.
/:cl: