### PR TITLE
[s] Unsanitized input on blob broadcast allows HTML injection

### DIFF
--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -326,7 +326,7 @@
 	set category = "Blob"
 	set name = "Blob Broadcast"
 	set desc = "Speak with your blob spores and blobbernauts as your mouthpieces."
-	var/speak_text = input(src, "What would you like to say with your minions?", "Blob Broadcast", null) as text|null
+	var/speak_text = stripped_input(src, "What would you like to say with your minions?", "Blob Broadcast", null)
 	if(!speak_text)
 		return
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Unsanitized input allows for raw HTML injection on broadcasting message as blob. The repeated message by blob mobs is sanitized, so clients are safe, but still allows HTML injection into the blob's chat window.

unsanitized:
![image](https://user-images.githubusercontent.com/10467687/75197827-871e1400-5735-11ea-8deb-ca6a12e3ae34.png)

sanitized:
![image](https://user-images.githubusercontent.com/10467687/75197879-a3ba4c00-5735-11ea-9995-4cc9a6549852.png)

## Why It's Good For The Game
Exploit
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
fix: Fixed unsanitized blob broadcast allowing html injection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
