### PR TITLE
Slime powers icons status updates.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -48,7 +48,7 @@
 	if(H.blood_volume < BLOOD_VOLUME_BAD)
 		Cannibalize_Body(H)
 	if(regenerate_limbs)
-		regenerate_limbs.UpdateButtonIcon()
+		regenerate_limbs.UpdateButtonIcon(TRUE) //status_only
 
 /datum/species/jelly/proc/Cannibalize_Body(mob/living/carbon/human/H)
 	var/list/limbs_to_consume = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG) - H.get_missing_limbs()
@@ -102,6 +102,7 @@
 		to_chat(H, "<span class='warning'>...but there is not enough of you to fix everything! You must attain more mass to heal completely!</span>")
 		return
 	to_chat(H, "<span class='warning'>...but there is not enough of you to go around! You must attain more mass to heal!</span>")
+	UpdateButtonIcon(TRUE) //status_only
 
 ////////////////////////////////////////////////////////SLIMEPEOPLE///////////////////////////////////////////////////////////////////
 
@@ -170,6 +171,8 @@
 		H.blood_volume += 3
 		H.adjust_nutrition(-2.5)
 
+	if(slime_split)
+		slime_split.UpdateButtonIcon(TRUE) //status_only
 	..()
 
 /datum/action/innate/split_body
@@ -207,6 +210,8 @@
 		to_chat(H, "<span class='warning'>...but fail to stand perfectly still!</span>")
 
 	H.notransform = FALSE
+
+	UpdateButtonIcon(TRUE) //status_only
 
 /datum/action/innate/split_body/proc/make_dupe()
 	var/mob/living/carbon/human/H = owner
@@ -427,6 +432,13 @@
 	extract_major = new(src)
 	extract_major.Grant(C)
 
+/datum/species/jelly/slime/spec_life(mob/living/carbon/human/H)
+	if(extract_minor)
+		extract_minor.UpdateButtonIcon(TRUE) //status_only
+	if(extract_major)
+		extract_major.UpdateButtonIcon(TRUE) //status_only
+	..()
+
 /datum/species/jelly/luminescent/proc/update_slime_actions()
 	integrate_extract.update_name()
 	integrate_extract.UpdateButtonIcon()
@@ -547,6 +559,8 @@
 		species.extract_cooldown = world.time + 100
 		var/cooldown = species.current_extract.activate(H, species, activation_type)
 		species.extract_cooldown = world.time + cooldown
+	
+	UpdateButtonIcon(TRUE) //status_only
 
 /datum/action/innate/use_extract/major
 	name = "Extract Major Activation"

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -432,7 +432,7 @@
 	extract_major = new(src)
 	extract_major.Grant(C)
 
-/datum/species/jelly/slime/spec_life(mob/living/carbon/human/H)
+/datum/species/jelly/luminescent/spec_life(mob/living/carbon/human/H)
 	if(extract_minor)
 		extract_minor.UpdateButtonIcon(TRUE) //status_only
 	if(extract_major)


### PR DESCRIPTION
## About The Pull Request

Now jelly innate action icons update availability state on use or availability state change

## Why It's Good For The Game

Now slimegirls have actual info about it powers availability.
fix #49559

## Changelog
:cl:
fix: Now jelly innate action icons update availability state on use or availability state change.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
