### PR TITLE
Clothing armour values on examine

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -176,7 +176,7 @@
 	. = ..()
 
 	if(href_list["list_armor"])
-		var/list/readout = list("<span class='notice'><b>PROTECTION CLASSES (I-V)</b>")
+		var/list/readout = list("<span class='notice'><b>PROTECTION CLASSES (I-X)</b>")
 		if(LAZYLEN(armor_list))
 			readout += "\n<b>ARMOR</b>"
 			for(var/dam_type in armor_list)
@@ -193,18 +193,26 @@
 
 /obj/item/clothing/proc/number_to_level(number)
 	switch (number)
-		if (1 to 20)
+		if (1 to 19)
 			. = "I"
-		if (21 to 40)
+		if (20 to 29)
 			. = "II"
-		if (41 to 60)
+		if (30 to 39)
 			. = "III"
-		if (61 to 80)
+		if (40 to 49)
 			. = "IV"
-		if (81 to 99)
+		if (50 to 59)
 			. = "V"
+		if (60 to 69)
+			. = "VI"
+		if (70 to 79)
+			. = "VII"
+		if (80 to 89)
+			. = "VIII"
+		if (90 to 99)
+			. = "IX"
 		if (100 to INFINITY)
-			. = "∞"
+			. = "X"
 	return .
 
 /obj/item/clothing/obj_break(damage_flag)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -191,6 +191,7 @@
 
 		to_chat(usr, "[readout.Join()]")
 
+///Used to convert armour values of clothing to IC "protection classes" to show the player
 /obj/item/clothing/proc/number_to_level(number)
 	switch (number)
 		if (1 to 19)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -140,6 +140,52 @@
 		how_cool_are_your_threads += "</span>"
 		. += how_cool_are_your_threads.Join()
 
+	var/list/armor_list = list()
+	if(armor.acid)
+		armor_list += list("Acid" = armor.acid)
+	if(armor.bio)
+		armor_list += list("Toxin" = armor.bio)
+	if(armor.bomb)
+		armor_list += list("Bomb" = armor.bomb)
+	if(armor.bullet)
+		armor_list += list("Bullet" = armor.bullet)
+	if(armor.energy)
+		armor_list += list("Energy" = armor.energy)
+	if(armor.fire)
+		armor_list += list("Fire" = armor.fire)
+	if(armor.laser)
+		armor_list += list("Laser" = armor.laser)
+	if(armor.magic)
+		armor_list += list("Magic" = armor.magic)
+	if(armor.melee)
+		armor_list += list("Melee" = armor.melee)
+	if(armor.rad)
+		armor_list += list("Radiation" = armor.rad)
+
+	if(LAZYLEN(armor_list))
+		var/list/readout = list("<span class='notice'>[src] [gender == "plural" ? "have" : "has"] the following armor:")
+		for(var/dam_type in armor_list)
+			var/armor_amount = armor_list[dam_type]
+			readout += "\n[dam_type]: [number_to_robustness(armor_amount)]" //e.g. Bomb: Very high
+		readout += "</span>"
+		. += readout.Join()
+
+/obj/item/clothing/proc/number_to_robustness(var/number)
+	switch (number)
+		if (1 to 20)
+			. = "Low"
+		if (20 to 40)
+			. = "Medium"
+		if (40 to 60)
+			. = "High"
+		if (60 to 80)
+			. = "Very high"
+		if (80 to 100)
+			. = "Superb"
+		if (100 to INFINITY)
+			. = "Complete"
+	return .
+
 /obj/item/clothing/obj_break(damage_flag)
 	if(!damaged_clothes)
 		update_clothes_damaged_state(TRUE)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -37,6 +37,7 @@
 	var/dynamic_hair_suffix = ""//head > mask for head hair
 	var/dynamic_fhair_suffix = ""//mask > head for facial hair
 
+	///This is its armor values in list form. List populates and updates on examine as it's currently only used to print armor ratings to chat in Topic()
 	var/list/armor_list = list()
 
 /obj/item/clothing/Initialize()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -37,7 +37,7 @@
 	var/dynamic_hair_suffix = ""//head > mask for head hair
 	var/dynamic_fhair_suffix = ""//mask > head for facial hair
 
-
+	var/list/armor_list = list()
 
 /obj/item/clothing/Initialize()
 	if((clothing_flags & VOICEBOX_TOGGLABLE))
@@ -140,50 +140,58 @@
 		how_cool_are_your_threads += "</span>"
 		. += how_cool_are_your_threads.Join()
 
-	var/list/armor_list = list()
+	if(LAZYLEN(armor_list))
+		armor_list.Cut()
 	if(armor.acid)
-		armor_list += list("Acid" = armor.acid)
+		armor_list += list("ACID" = armor.acid)
 	if(armor.bio)
-		armor_list += list("Toxin" = armor.bio)
+		armor_list += list("TOXIN" = armor.bio)
 	if(armor.bomb)
-		armor_list += list("Bomb" = armor.bomb)
+		armor_list += list("EXPLOSIVE" = armor.bomb)
 	if(armor.bullet)
-		armor_list += list("Bullet" = armor.bullet)
+		armor_list += list("BULLET" = armor.bullet)
 	if(armor.energy)
-		armor_list += list("Energy" = armor.energy)
+		armor_list += list("ENERGY" = armor.energy)
 	if(armor.fire)
-		armor_list += list("Fire" = armor.fire)
+		armor_list += list("FIRE" = armor.fire)
 	if(armor.laser)
-		armor_list += list("Laser" = armor.laser)
+		armor_list += list("LASER" = armor.laser)
 	if(armor.magic)
-		armor_list += list("Magic" = armor.magic)
+		armor_list += list("MAGIC" = armor.magic)
 	if(armor.melee)
-		armor_list += list("Melee" = armor.melee)
+		armor_list += list("MELEE" = armor.melee)
 	if(armor.rad)
-		armor_list += list("Radiation" = armor.rad)
+		armor_list += list("RADIATION" = armor.rad)
 
 	if(LAZYLEN(armor_list))
-		var/list/readout = list("<span class='notice'>[src] [gender == "plural" ? "have" : "has"] the following armor:")
+		. += "<span class='notice'>It has a <a href='?src=[REF(src)];list_armor=1'>tag</a> listing its protection levels.</span>"
+
+/obj/item/clothing/Topic(href, href_list)
+	. = ..()
+
+	if(href_list["list_armor"])
+		var/list/readout = list("<span class='notice'><b>PROTECTION CLASSES</b>")
 		for(var/dam_type in armor_list)
 			var/armor_amount = armor_list[dam_type]
-			readout += "\n[dam_type]: [number_to_robustness(armor_amount)]" //e.g. Bomb: Very high
+			readout += "\n[dam_type] [number_to_level(armor_amount)]" //e.g. BOMB IV
 		readout += "</span>"
-		. += readout.Join()
 
-/obj/item/clothing/proc/number_to_robustness(var/number)
+		to_chat(usr, "[readout.Join()]")
+
+/obj/item/clothing/proc/number_to_level(number)
 	switch (number)
 		if (1 to 20)
-			. = "Low"
+			. = "I"
 		if (21 to 40)
-			. = "Medium"
+			. = "II"
 		if (41 to 60)
-			. = "High"
+			. = "III"
 		if (61 to 80)
-			. = "Very high"
+			. = "IV"
 		if (81 to 99)
-			. = "Superb"
+			. = "V"
 		if (100 to INFINITY)
-			. = "Complete"
+			. = "∞"
 	return .
 
 /obj/item/clothing/obj_break(damage_flag)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -37,8 +37,10 @@
 	var/dynamic_hair_suffix = ""//head > mask for head hair
 	var/dynamic_fhair_suffix = ""//mask > head for facial hair
 
-	///This is its armor values in list form. List populates and updates on examine as it's currently only used to print armor ratings to chat in Topic()
+	///These are its armor values that affect the wearer from its armor datum converted to an associative list. List populates and updates on examine as it's currently only used to print armor ratings to chat in Topic()
 	var/list/armor_list = list()
+	///These are its armor values that affect the item's durability from its armor datum converted to an associative list. List populates and updates on examine as it's currently only used to print armor ratings to chat in Topic()
+	var/list/durability_list = list()
 
 /obj/item/clothing/Initialize()
 	if((clothing_flags & VOICEBOX_TOGGLABLE))
@@ -143,8 +145,6 @@
 
 	if(LAZYLEN(armor_list))
 		armor_list.Cut()
-	if(armor.acid)
-		armor_list += list("ACID" = armor.acid)
 	if(armor.bio)
 		armor_list += list("TOXIN" = armor.bio)
 	if(armor.bomb)
@@ -153,8 +153,6 @@
 		armor_list += list("BULLET" = armor.bullet)
 	if(armor.energy)
 		armor_list += list("ENERGY" = armor.energy)
-	if(armor.fire)
-		armor_list += list("FIRE" = armor.fire)
 	if(armor.laser)
 		armor_list += list("LASER" = armor.laser)
 	if(armor.magic)
@@ -164,17 +162,31 @@
 	if(armor.rad)
 		armor_list += list("RADIATION" = armor.rad)
 
-	if(LAZYLEN(armor_list))
-		. += "<span class='notice'>It has a <a href='?src=[REF(src)];list_armor=1'>tag</a> listing its protection levels.</span>"
+	if(LAZYLEN(durability_list))
+		durability_list.Cut()
+	if(armor.fire)
+		durability_list += list("FIRE" = armor.fire)
+	if(armor.acid)
+		durability_list += list("ACID" = armor.acid)
+
+	if(LAZYLEN(armor_list) || LAZYLEN(durability_list))
+		. += "<span class='notice'>It has a <a href='?src=[REF(src)];list_armor=1'>tag</a> listing its protection classes.</span>"
 
 /obj/item/clothing/Topic(href, href_list)
 	. = ..()
 
 	if(href_list["list_armor"])
 		var/list/readout = list("<span class='notice'><b>PROTECTION CLASSES (I-V)</b>")
-		for(var/dam_type in armor_list)
-			var/armor_amount = armor_list[dam_type]
-			readout += "\n[dam_type] [number_to_level(armor_amount)]" //e.g. BOMB IV
+		if(LAZYLEN(armor_list))
+			readout += "\n<b>ARMOR</b>"
+			for(var/dam_type in armor_list)
+				var/armor_amount = armor_list[dam_type]
+				readout += "\n[dam_type] [number_to_level(armor_amount)]" //e.g. BOMB IV
+		if(LAZYLEN(durability_list))
+			readout += "\n<b>DURABILITY</b>"
+			for(var/dam_type in durability_list)
+				var/durability_amount = durability_list[dam_type]
+				readout += "\n[dam_type] [number_to_level(durability_amount)]" //e.g. FIRE II
 		readout += "</span>"
 
 		to_chat(usr, "[readout.Join()]")

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -178,12 +178,12 @@
 	if(href_list["list_armor"])
 		var/list/readout = list("<span class='notice'><b>PROTECTION CLASSES (I-X)</b>")
 		if(LAZYLEN(armor_list))
-			readout += "\n\n<b>ARMOR</b>"
+			readout += "\n<u>ARMOR</u>"
 			for(var/dam_type in armor_list)
 				var/armor_amount = armor_list[dam_type]
 				readout += "\n[dam_type] [number_to_level(armor_amount)]" //e.g. BOMB IV
 		if(LAZYLEN(durability_list))
-			readout += "\n\n<b>DURABILITY</b>"
+			readout += "\n<u>DURABILITY</u>"
 			for(var/dam_type in durability_list)
 				var/durability_amount = durability_list[dam_type]
 				readout += "\n[dam_type] [number_to_level(durability_amount)]" //e.g. FIRE II

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -174,13 +174,13 @@
 	switch (number)
 		if (1 to 20)
 			. = "Low"
-		if (20 to 40)
+		if (21 to 40)
 			. = "Medium"
-		if (40 to 60)
+		if (41 to 60)
 			. = "High"
-		if (60 to 80)
+		if (61 to 80)
 			. = "Very high"
-		if (80 to 100)
+		if (81 to 99)
 			. = "Superb"
 		if (100 to INFINITY)
 			. = "Complete"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -37,9 +37,9 @@
 	var/dynamic_hair_suffix = ""//head > mask for head hair
 	var/dynamic_fhair_suffix = ""//mask > head for facial hair
 
-	///These are its armor values that affect the wearer from its armor datum converted to an associative list. List populates and updates on examine as it's currently only used to print armor ratings to chat in Topic()
+	///These are armor values that protect the wearer, taken from the clothing's armor datum. List updates on examine because it's currently only used to print armor ratings to chat in Topic().
 	var/list/armor_list = list()
-	///These are its armor values that affect the item's durability from its armor datum converted to an associative list. List populates and updates on examine as it's currently only used to print armor ratings to chat in Topic()
+	///These are armor values that protect the clothing, taken from its armor datum. List updates on examine because it's currently only used to print armor ratings to chat in Topic().
 	var/list/durability_list = list()
 
 /obj/item/clothing/Initialize()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -176,43 +176,51 @@
 	. = ..()
 
 	if(href_list["list_armor"])
-		var/list/readout = list("<span class='notice'><b>PROTECTION CLASSES (I-X)</b>")
+		var/list/readout = list("<span class='notice'><u><b>PROTECTION CLASSES (I-X)</u></b>")
 		if(LAZYLEN(armor_list))
-			readout += "\n<u>ARMOR</u>"
+			readout += "\n<b>ARMOR</b>"
 			for(var/dam_type in armor_list)
 				var/armor_amount = armor_list[dam_type]
-				readout += "\n[dam_type] [number_to_level(armor_amount)]" //e.g. BOMB IV
+				readout += "\n[dam_type] [armor_to_protection_class(armor_amount)]" //e.g. BOMB IV
 		if(LAZYLEN(durability_list))
-			readout += "\n<u>DURABILITY</u>"
+			readout += "\n<b>DURABILITY</b>"
 			for(var/dam_type in durability_list)
 				var/durability_amount = durability_list[dam_type]
-				readout += "\n[dam_type] [number_to_level(durability_amount)]" //e.g. FIRE II
+				readout += "\n[dam_type] [armor_to_protection_class(durability_amount)]" //e.g. FIRE II
 		readout += "</span>"
 
 		to_chat(usr, "[readout.Join()]")
 
-///Used to convert armour values of clothing to IC "protection classes" to show the player
-/obj/item/clothing/proc/number_to_level(number)
-	switch (number)
-		if (1 to 19)
+/**
+  * Rounds armor_value to nearest 10, divides it by 10 and then expresses it in roman numerals up to 10
+  *
+  * Rounds armor_value to nearest 10, divides it by 10
+  * and then expresses it in roman numerals up to 10
+  * Arguments:
+  * * armor_value - Number we're converting
+  */
+/obj/item/clothing/proc/armor_to_protection_class(armor_value)
+	armor_value = round(armor_value,10) / 10
+	switch (armor_value)
+		if (1)
 			. = "I"
-		if (20 to 29)
+		if (2)
 			. = "II"
-		if (30 to 39)
+		if (3)
 			. = "III"
-		if (40 to 49)
+		if (4)
 			. = "IV"
-		if (50 to 59)
+		if (5)
 			. = "V"
-		if (60 to 69)
+		if (6)
 			. = "VI"
-		if (70 to 79)
+		if (7)
 			. = "VII"
-		if (80 to 89)
+		if (8)
 			. = "VIII"
-		if (90 to 99)
+		if (9)
 			. = "IX"
-		if (100 to INFINITY)
+		if (10 to INFINITY)
 			. = "X"
 	return .
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -170,7 +170,7 @@
 	. = ..()
 
 	if(href_list["list_armor"])
-		var/list/readout = list("<span class='notice'><b>PROTECTION CLASSES</b>")
+		var/list/readout = list("<span class='notice'><b>PROTECTION CLASSES (I-V)</b>")
 		for(var/dam_type in armor_list)
 			var/armor_amount = armor_list[dam_type]
 			readout += "\n[dam_type] [number_to_level(armor_amount)]" //e.g. BOMB IV

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -178,12 +178,12 @@
 	if(href_list["list_armor"])
 		var/list/readout = list("<span class='notice'><b>PROTECTION CLASSES (I-X)</b>")
 		if(LAZYLEN(armor_list))
-			readout += "\n<b>ARMOR</b>"
+			readout += "\n\n<b>ARMOR</b>"
 			for(var/dam_type in armor_list)
 				var/armor_amount = armor_list[dam_type]
 				readout += "\n[dam_type] [number_to_level(armor_amount)]" //e.g. BOMB IV
 		if(LAZYLEN(durability_list))
-			readout += "\n<b>DURABILITY</b>"
+			readout += "\n\n<b>DURABILITY</b>"
 			for(var/dam_type in durability_list)
 				var/durability_amount = durability_list[dam_type]
 				readout += "\n[dam_type] [number_to_level(durability_amount)]" //e.g. FIRE II


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When clothing has armour and you examine it it'll give you a hyperlink to a list of armour and an estimate of its strength.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No more is armour meta information for code divers while everyone else relies on incomplete descriptions, names and sprites.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
add: Space's big players are more beholden to OSH than one might've thought. Newly manufactured clothing now comes with a tag listing its protection ratings (if applicable). Deciding which armour to "borrow" from the armoury has never been easier.
/:cl:

### Todo
- [x] Hide values behind link on single line

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
