### PR TITLE
Announcement on lavaland and off station content.

### DIFF
--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -66,7 +66,7 @@
 		return ..()
 
 /obj/structure/destructible/cult/ratvar_act()
-	if(take_damage(rand(25, 50), BURN) && src) //if we still exist
+	if(take_damage(rand(25, 50), BURN) && !QDELETED(src)) //if we still exist
 		var/previouscolor = color
 		color = "#FAE48C"
 		animate(src, color = previouscolor, time = 8)


### PR DESCRIPTION
Okay so this has been something spinning around in my head for a while.

Basically, I think we're in a situation where people are spending a lot of time focusing on stuff that isn't on the station and doesn't interact with our core gameplay. We have lost a lot of focus, and it's hampering our momentum in terms of actually changing and improving things about the station, where most of the playerbase spends most of their time.

So as such, I am asking all maintainers to deny things that are not laser focused on the station and crew.

We will not carry code or content outside of the station unless it's burden is very small and minimal, that means lavaland ruins, space ruins and away missions.

You will notice I have already killed off lavaland dwarves and icemoon PR's, both are endemic of the focus on stuff that is outside the station.

Note: This does not mean these ideas are dead forever or the content they have is not useable.

space has already expressed interest in taking a station and putting it *on* the icemoon. This is totally acceptable, because the content is now focused in on the the station and the crew and I think we are past overdue such an idea.

Mixing the content in with the station makes carrying all the sprites and code worth it, because it's much more approachable.

anyway, that's it, feel free to complain here I guess, please don’t' be rude.