### PR TITLE
Fixes Delta disposals

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -114378,8 +114378,8 @@
 /area/space)
 "nQQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)


### PR DESCRIPTION
Had a pipe facing the wrong way causing stuff to sometimes get routed to the morgue

:cl:
fix: Deltastation's disposal system will no longer accidentally dump garbage into the morgue
/:cl:
