### PR TITLE
Improves discord roleapi system

### DIFF
--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -34,6 +34,7 @@ SUBSYSTEM_DEF(discord)
 	var/list/notify_members_cache = list() // Copy of previous list, so the SS doesnt have to fire if no new members have been added
 	var/list/people_to_notify = list() // People to notify on roundstart
 	var/list/account_link_cache = list() // List that holds accounts to link, used in conjunction with TGS
+	var/list/reverify_cache = list() // list of people who tried to reverify, so they can only do it once per round as a shitty slowdown
 	var/notify_file = file("data/notify.json")
 	var/enabled = 0 // Is TGS enabled (If not we wont fire because otherwise this is useless)
 

--- a/code/modules/discord/accountlink.dm
+++ b/code/modules/discord/accountlink.dm
@@ -43,3 +43,35 @@
 			alert(usr, "Account link started. Please ping the bot of the server you\'re currently on, followed by \"verify [usr.ckey]\" in Discord to successfully verify your account (Example: @Mr_Terry verify [usr.ckey])")
 			// This is so people cant fill the notify list with a fuckload of ckeys
 			SSdiscord.notify_members -= "[stored_id]" // The list uses strings because BYOND cannot handle a 17 digit integer
+
+// IF you have linked your account, this will trigger a verify of the user
+/client/verb/verify_in_discord()
+	set category = "OOC"
+	set name = "Verify Discord Account"
+	set desc = "Reverify your account to the discord if you get banned, you bad banana"
+
+	// Safety checks
+	if(!CONFIG_GET(flag/sql_enabled))
+		to_chat(src, "<span class='warning'>This feature requires the SQL backend to be running.</span>")
+		return
+
+	if(!SSdiscord) // SS is still starting
+		to_chat(src, "<span class='notice'>The server is still starting up. Please wait before attempting to link your account!</span>")
+		return
+
+	if(!SSdiscord.enabled)
+		to_chat(src, "<span class='warning'>This feature requires the server is running on the TGS toolkit.</span>")
+		return
+	if(SSdiscord.reverify_cache[usr.ckey] == TRUE)
+		to_chat(src, "<span class='warning'>Thou can only do this once a round, if you're stuck seek help.</span>")
+		return
+	SSdiscord.reverify_cache[usr.ckey] = TRUE
+
+	var/stored_id = SSdiscord.lookup_id(usr.ckey)
+	if(!stored_id) // Account is not linked
+		to_chat(usr, "Link your discord account via the linkdiscord verb in the OOC tab first");
+		return;
+
+	else // Account is already linked
+		// Role the user
+		SSdiscord.grant_role(stored_id)

--- a/code/modules/discord/tgs_commands.dm
+++ b/code/modules/discord/tgs_commands.dm
@@ -20,12 +20,13 @@
 
 /datum/tgs_chat_command/verify/Run(datum/tgs_chat_user/sender, params)
 	var/lowerparams = replacetext(lowertext(params), " ", "") // Fuck spaces
+	var/discordid = SSdiscord.id_clean(sender.mention)
 	if(SSdiscord.account_link_cache[lowerparams]) // First if they are in the list, then if the ckey matches
-		if(SSdiscord.account_link_cache[lowerparams] == "[SSdiscord.id_clean(sender.mention)]") // If the associated ID is the correct one
+		if(SSdiscord.account_link_cache[lowerparams] == discordid) // If the associated ID is the correct one
 			// Link the account in the DB table
 			SSdiscord.link_account(lowerparams)
 			// Role the user
-			SSdiscord.grant_role(lowerparams)
+			SSdiscord.grant_role(discordid)
 			return "Successfully linked accounts"
 		else
 			return "That ckey is not associated to this discord account. If someone has used your ID, please inform an administrator"


### PR DESCRIPTION
Sends the discord id to the patch call, not the ckey

Add the verify command to readd the role to the api, with
a hacky, but effective slowdown to prevent the API being flooded easily
