### PR TITLE
Drops AI Core board costs back down to glass

### DIFF
--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -6,7 +6,6 @@
 	name = "AI Design (AI Core)"
 	desc = "Allows for the construction of circuit boards used to build new AI cores."
 	id = "aicore"
-	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000, /datum/material/bluespace = 500)
 	build_path = /obj/item/circuitboard/aicore
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the AI Core board (used to make new AIs) back to only requiring glass. All other AI-related boards (law board, uploads, etc) remain unchanged.
Fixes #49600 as a side effect.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The increase in cost to make a Core board was reportedly unintended, and I don't believe there is any reason to gate new AIs behind such a mat requirement. The board is tied behind AI tech anyway, so the ability to make a new board is firmly in the mid-game area unless the tech gets rushed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: AI Core boards (used to make new AIs) no longer require gold and bluespace crystals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
