### PR TITLE
Killing a morph resets its description.

### DIFF
--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -131,6 +131,7 @@
 	form = null
 	alpha = initial(alpha)
 	color = initial(color)
+	desc = initial(desc)
 	animate_movement = SLIDE_STEPS
 	maptext = null
 


### PR DESCRIPTION
## About The Pull Request

Killing a morph (a morph un-transforming technically) resets its description to the starting morph description.

Fixes https://github.com/tgstation/tgstation/issues/49114.

## Why It's Good For The Game

bugfix 
