### PR TITLE
Fixes Zombie Powder Permastun

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -169,8 +169,9 @@
 	..()
 	ADD_TRAIT(L, TRAIT_FAKEDEATH, type)
 
-/datum/reagent/toxin/zombiepowder/on_mob_end_metabolize(mob/living/L)
+/datum/reagent/toxin/zombiepowder/on_mob_delete(mob/living/L)
 	L.cure_fakedeath(type)
+	fakedeath_active = FALSE
 	..()
 
 /datum/reagent/toxin/zombiepowder/reaction_mob(mob/living/L, method=TOUCH, reac_volume)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a problem with zombie powder that caused microdoses to apply a permanent fakedeath state. Should fix #49518 (hopefully). Not the cleanest fix but suffices to patch up a fairly big oversight. Big thanks to @4dplanner for actually making this work.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stuns are bad. Permastuns are worse. Permastuns that persist through death are the worst.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: EOBGames and 4dplanner
fix: unfucks zombie powder
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
