### PR TITLE
prevent the github actions bot from closing PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,5 +15,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being closed by a maintainer if it is not updated or reviews are not addressed. If your PR is closed as stale, feel free to open a new one after dealing with the issues. This may also be an indication that the maintainers do not have interest in this change, you can try to convince them otherwise, or persist in the doomed world you have created."
         days-before-stale: 7
+        days-before-close: 99999999
         stale-pr-label: 'Stale'
         exempt-pr-label: 'RED LABEL'


### PR DESCRIPTION
When the github actions bot was first merged in #47936 it was explicitly stated that the stale bot would NOT autoclose PRs.

I don't think the bot should be closing PRs and there's already quite a few situations where people are too busy or there's a long window of time where maints are too busy to even look at PRs before they're closed. Some examples: #49271 #49217 #49315 #48737 

I think there should be discussion before implementing an autocloser and while it may be easier to let the bot close PRs that haven't been touched by maintainers I think that actually deciding to close it needs to be a decision made by a maintainer or the author of the PR