### PR TITLE
Fixes potential major flaw in wizard gamemode

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -115,6 +115,7 @@
 	say_mod = "says"
 	hair_color = "mutcolor"
 	hair_alpha = 150
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	var/datum/action/innate/split_body/slime_split
 	var/list/mob/living/carbon/bodies
 	var/datum/action/innate/swap_body/swap_body


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes slime people from the magic mirror. Not the greed mirror, just the magic one. This prevents the wiz from splitting on the ship and having permanent access to resetting their spells.
There is no other option, removing food is unmaintainable and the slime link is a fact of life.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Prevents some smartass from actually breaking wizard. Just all of it.

Give thanks to the coder who atomized mirrors.
Speedmerge pls.

## Changelog
:cl:LemonInTheDark, ArcaneDefence for the fucking bughunting/brainstorming
fix: Fixes slime wizards being able to reset their spells from anywhere
del: Removes slime people from the wizard mirror.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
