### PR TITLE
Makes gum boxes tiny items

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1275,6 +1275,7 @@
 	name = "bubblegum packet"
 	desc = "The packaging is entirely in japanese, apparently. You can't make out a single word of it."
 	icon_state = "bubblegum_generic"
+	w_class = WEIGHT_CLASS_TINY
 	illustration = null
 	foldable = null
 	custom_price = 120


### PR DESCRIPTION
They didn't fit in pockets cause I forgot to set their size

:cl:
fix: Decreased the size of bubblegum boxes so that they correctly fit in pockets
/:cl: