### PR TITLE
fix BSA deploy

### DIFF
--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -142,15 +142,15 @@
 		if(WEST)
 			return locate(x - 7,y,z)
 		if(EAST)
-			return locate(x + 4,y,z)
+			return locate(x + 7,y,z)
 	return get_turf(src)
 
 /obj/machinery/bsa/full/proc/get_back_turf()
 	switch(dir)
 		if(WEST)
-			return locate(x + 4,y,z)
+			return locate(x + 5,y,z)
 		if(EAST)
-			return locate(x - 6,y,z)
+			return locate(x - 5,y,z)
 	return get_turf(src)
 
 /obj/machinery/bsa/full/proc/get_target_turf()
@@ -167,11 +167,12 @@
 	switch(cannon_direction)
 		if(WEST)
 			setDir(WEST)
-			pixel_x = -192
 			top_layer.icon_state = "top_west"
 			icon_state = "cannon_west"
 		if(EAST)
 			setDir(EAST)
+			pixel_x = -128
+			bound_x = -128
 			top_layer.icon_state = "top_east"
 			icon_state = "cannon_east"
 	add_overlay(top_layer)


### PR DESCRIPTION
## About The Pull Request

Some fix BSA deploy.

Before:
![wrong BSA space check 1](https://user-images.githubusercontent.com/7734424/75611885-23c22680-5b27-11ea-9bab-3de13984376b.png)
![BSA placement](https://user-images.githubusercontent.com/7734424/75611886-24f35380-5b27-11ea-853c-b951b30d1f5a.png)

After:
![BSA placement fixed](https://user-images.githubusercontent.com/7734424/75611898-3dfc0480-5b27-11ea-987d-6c4e88a5f619.png)
Red is `has_space()` check area.

## Why It's Good For The Game

Bugs is bad.
Part of BSA in wall is bad.

## Changelog
:cl:
fix: Nanotrasen engineering department calibrate nanite deploying system. Now Bluespace Artillery dont shifts on 2 meters on deploy.
/:cl:
