### PR TITLE
Misc mapping debug verb fixes

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -132,11 +132,11 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
 "aR" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "aW" = (
@@ -4106,10 +4106,6 @@
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
 	dir = 6;
 	name = "N2 to Mix"
-	},
-/obj/machinery/atmospherics/pipe/simple/supplymain/visible/layer1{
-	dir = 4;
-	name = "N2"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/engineering)

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -350,6 +350,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/abandonedzoo)
 "be" = (

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -428,6 +428,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "bs" = (

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1055,6 +1055,7 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/awaymission/BMPship/Aft)
 "ed" = (

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -180,6 +180,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
 "u" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -2097,6 +2097,7 @@
 	dir = 5
 	},
 /obj/machinery/power/terminal,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aeG" = (
@@ -10766,6 +10767,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "aAz" = (
@@ -10780,6 +10782,7 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "aAC" = (
@@ -21114,6 +21117,7 @@
 /obj/structure/table,
 /obj/item/aiModule/supplied/quarantine,
 /obj/machinery/camera/motion{
+	c_tag = "AI Upload West";
 	dir = 4;
 	network = list("aiupload")
 	},
@@ -21131,6 +21135,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/camera/motion{
+	c_tag = "AI Upload East";
 	dir = 8;
 	network = list("aiupload")
 	},
@@ -24734,7 +24739,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	areastring = "/area/medical/morgue";
+	areastring = "/area/maintenance/department/medical/morgue";
 	dir = 4;
 	name = "Morgue Maintenance APC";
 	pixel_x = 24
@@ -29689,6 +29694,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "byP" = (
@@ -30232,7 +30238,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bAi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -42962,7 +42967,7 @@
 /area/medical/chemistry)
 "clp" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Test Chamber";
+	c_tag = "Chemistry Lab Northeast";
 	network = list("xeno","rd")
 	},
 /turf/open/floor/plasteel/white,
@@ -46781,10 +46786,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"cAY" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/ai_monitored/turret_protected/ai)
 "cAZ" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
@@ -46801,6 +46802,7 @@
 	c_tag = "MiniSat AI Chamber South";
 	network = list("aicore")
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "cBc" = (
@@ -46810,6 +46812,7 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "cBd" = (
@@ -48676,6 +48679,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "cSG" = (
@@ -50109,7 +50113,7 @@
 "jox" = (
 /obj/machinery/chem_dispenser,
 /obj/machinery/camera{
-	c_tag = "Engineering Storage";
+	c_tag = "Chemistry Lab West";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -50277,6 +50281,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"jYm" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "jYO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -51392,8 +51400,11 @@
 /area/medical/medbay/zone2)
 "oZc" = (
 /obj/machinery/camera{
-	c_tag = "Chapel South";
+	c_tag = "Chemistry Lab East";
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -53416,6 +53427,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Chemistry Lab North";
+	network = list("xeno","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -91561,7 +91576,7 @@ cwj
 cwu
 cAV
 cAZ
-cvl
+cAZ
 cvl
 cva
 cva
@@ -91817,7 +91832,7 @@ cww
 cwD
 cvv
 cvv
-cAY
+cvv
 cBb
 cBd
 cva
@@ -92805,7 +92820,7 @@ nEk
 djq
 bip
 bip
-bip
+jYm
 hTU
 aoV
 aaa

--- a/_maps/shuttles/aux_base_default.dmm
+++ b/_maps/shuttles/aux_base_default.dmm
@@ -73,6 +73,7 @@
 /area/shuttle/auxillary_base)
 "X" = (
 /obj/machinery/camera{
+	c_tag = "Auxiliary Base";
 	dir = 1;
 	network = list("auxbase")
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Uses the debug verbs under the Mapping tab to fix mapping errors on Box and whatever ruins were loaded at the time. 

- Wires unwired terminals
- Corrects misplaced pipes
- Renames duplicate camera tags
- Adds missing lights to Box chem factory to fix dark patches
- Adds a light to supply security checkpoint because area lacked any
- Adds an extra camera to Box chem factory to remove a blindspot
- Fixes duplicated area string on Box morgue maintenance APC

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I use these to fix my mistakes whenever I make map changes and all the "legacy" errors hide my own. Hopefully this benefits other mappers too.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
fix: Fixes a few small map errors, mainly on BoxStation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
