### PR TITLE
Crate chain-pushing try 2

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -23,7 +23,7 @@
 	drag_slowdown = 0
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 
-	///counter for crates that push this one. Start from 1 and increment when Bumped.
+	///counter for crates that push this one. Start from 1 and increment when Bumped and can move.
 	var/bump_chain = 1
 
 
@@ -49,7 +49,6 @@
 		var/d = get_dir(AM, src)
 		
 		if(step(src, d))
-			///move to follow
 			step(AM, d)
 	bump_chain = 1
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -40,7 +40,8 @@
 			bump_chain = 0
 
 /// When crate bumped by something called Bumped(AM)
-/obj/structure/closet/crate/Bumped(AM as mob|obj)
+/obj/structure/closet/crate/Bumped(atom/movable/AM)
+
 	..()
 	///check, that crate bumbed by crate and can move.
 	if(istype(AM, /obj/structure/closet/crate) && !anchored)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -1,3 +1,5 @@
+#define MAX_CRATE_BUMP_CHAIN 5 //amount of crates that can be pushed at once
+
 /obj/structure/closet/crate
 	name = "crate"
 	desc = "A rectangular steel crate."
@@ -19,6 +21,31 @@
 	close_sound_volume = 50
 	drag_slowdown = 0
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
+
+	var/bump_chain = 1
+
+/obj/structure/closet/crate/Bump(atom/A)
+	..()
+	if(!istype(A, /obj/structure/closet/crate))
+		bump_chain = 0 //hit an obstacle, previous crate must not try to move or it'll loop
+	else
+		var/obj/structure/closet/crate/C = A
+		if(C.anchored)
+			bump_chain = 0 //an anchored crate is an obstacle
+
+/obj/structure/closet/crate/Bumped(AM as mob|obj)
+	..()
+	if(istype(AM, /obj/structure/closet/crate) && !anchored)
+		var/obj/structure/closet/crate/previous_crate = AM
+		bump_chain = previous_crate.bump_chain + 1
+		if(bump_chain > MAX_CRATE_BUMP_CHAIN)
+			bump_chain = 1
+			return
+		var/d = get_dir(AM, src)
+		 
+		if(step(src, d)) // Try to move next crate ,did it hit an obstacle?
+			step(AM, d) //move to follow
+	bump_chain = 1 //reset
 
 /obj/structure/closet/crate/Initialize()
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -38,7 +38,6 @@
 
 /// When crate bumped by something called Bumped(AM)
 /obj/structure/closet/crate/Bumped(atom/movable/AM)
-
 	..()
 	if(istype(AM, /obj/structure/closet/crate) && !anchored)
 		var/obj/structure/closet/crate/previous_crate = AM

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -26,39 +26,31 @@
 	///counter for crates that push this one. Start from 1 and increment when Bumped.
 	var/bump_chain = 1
 
-/// When crate fail move to another place it call Bump(atom/A)
+
 /obj/structure/closet/crate/Bump(atom/A)
 	..()
-	///check that the crate can push the obstacle that is blocking it or not.
 	if(!istype(A, /obj/structure/closet/crate))
-		///hit an obstacle, previous crate must not try to move or it'll loop
 		bump_chain = 0
 	else
 		var/obj/structure/closet/crate/C = A
 		if(C.anchored)
-			///an anchored crate is an obstacle
 			bump_chain = 0
 
 /// When crate bumped by something called Bumped(AM)
 /obj/structure/closet/crate/Bumped(atom/movable/AM)
 
 	..()
-	///check, that crate bumbed by crate and can move.
 	if(istype(AM, /obj/structure/closet/crate) && !anchored)
 		var/obj/structure/closet/crate/previous_crate = AM
 		bump_chain = previous_crate.bump_chain + 1
-		///check for limit of bumped chain.
 		if(bump_chain > MAX_CRATE_BUMP_CHAIN)
-			///when reached, reset self and do nothing.
 			bump_chain = 1
 			return
 		var/d = get_dir(AM, src)
 		
-		/// Try to move next crate ,did it hit an obstacle?
 		if(step(src, d))
 			///move to follow
 			step(AM, d)
-	///reset of chain counter
 	bump_chain = 1
 
 /obj/structure/closet/crate/Initialize()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -1,4 +1,5 @@
-#define MAX_CRATE_BUMP_CHAIN 5 //amount of crates that can be pushed at once
+///amount of crates that can be pushed at once
+#define MAX_CRATE_BUMP_CHAIN 5
 
 /obj/structure/closet/crate
 	name = "crate"
@@ -22,30 +23,42 @@
 	drag_slowdown = 0
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 
+	///counter for crates that push this one. Start from 1 and increment when Bumped.
 	var/bump_chain = 1
 
+/// When crate fail move to another place it call Bump(atom/A)
 /obj/structure/closet/crate/Bump(atom/A)
 	..()
+	///check that the crate can push the obstacle that is blocking it or not.
 	if(!istype(A, /obj/structure/closet/crate))
-		bump_chain = 0 //hit an obstacle, previous crate must not try to move or it'll loop
+		///hit an obstacle, previous crate must not try to move or it'll loop
+		bump_chain = 0
 	else
 		var/obj/structure/closet/crate/C = A
 		if(C.anchored)
-			bump_chain = 0 //an anchored crate is an obstacle
+			///an anchored crate is an obstacle
+			bump_chain = 0
 
+/// When crate bumped by something called Bumped(AM)
 /obj/structure/closet/crate/Bumped(AM as mob|obj)
 	..()
+	///check, that crate bumbed by crate and can move.
 	if(istype(AM, /obj/structure/closet/crate) && !anchored)
 		var/obj/structure/closet/crate/previous_crate = AM
 		bump_chain = previous_crate.bump_chain + 1
+		///check for limit of bumped chain.
 		if(bump_chain > MAX_CRATE_BUMP_CHAIN)
+			///when reached, reset self and do nothing.
 			bump_chain = 1
 			return
 		var/d = get_dir(AM, src)
-		 
-		if(step(src, d)) // Try to move next crate ,did it hit an obstacle?
-			step(AM, d) //move to follow
-	bump_chain = 1 //reset
+		
+		/// Try to move next crate ,did it hit an obstacle?
+		if(step(src, d))
+			///move to follow
+			step(AM, d)
+	///reset of chain counter
+	bump_chain = 1
 
 /obj/structure/closet/crate/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Thanks @XDTM for initial PR.
I take #27510 and fix one string.
99% runtimes less.
Conveyor tested.

## Why It's Good For The Game

If you're pushing a crate and there's a crate in front of that crate, you'll push that crate as well. Pretty much QoL for cargo, so they don't have to push every single crate one by one to get them on/off the shuttle.

## Changelog
:cl:
add: You can now push multiple crates in front of you. This also applies to conveyor belts.
/:cl:
