### PR TITLE
Sleeping Carp Knee Jerk Nerf: Nyoops Edition

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -24,21 +24,22 @@
 	return FALSE
 
 /datum/martial_art/the_sleeping_carp/proc/strongPunch(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
+	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))//this var is so that the strong punch is always aiming for the body part the user is targeting and not trying to apply to the chest before deviating
 	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
 	var/atk_verb = pick("kick", "chop", "hit", "slam")
-	var/crit_damage = 0
+	var/crit_damage = 0//this is the critical hit damage added to the attack if it rolls, it starts at 0 because it'll be changed when rolled
 	D.visible_message("<span class='danger'>[A] [atk_verb]s [D]!</span>", \
 					"<span class='userdanger'>[A] [atk_verb]s you!</span>", null, null, A)
 	to_chat(A, "<span class='danger'>You [atk_verb] [D]!</span>")
 	if(prob(10))
-		crit_damage += 20
+		crit_damage += 20//here is where the critical damage is adjusted
 		playsound(get_turf(D), 'sound/weapons/bite.ogg', 50, TRUE, -1)
 		D.visible_message("<span class='warning'>[D] sputters blood as the blow strikes them with inhuman force!</span>", "<span class='userdanger'>You are struck with incredible precision by [A]!</span>")
+		log_combat(A, D, "critcal strong punched (Sleeping Carp)")//log it here because a critical can swing for 40 force and it's important for the sake of how hard they hit
 	else
 		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
+		log_combat(A, D, "strong punched (Sleeping Carp)")//so as to not double up on logging
 	D.apply_damage(20 + crit_damage, A.dna.species.attack_type, affecting)
-	log_combat(A, D, "strong punched (Sleeping Carp)")
 	return
 
 /datum/martial_art/the_sleeping_carp/proc/launchKick(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -49,7 +50,7 @@
 	var/atom/throw_target = get_edge_target_turf(D, A.dir)
 	D.throw_at(throw_target, 7, 14, A)
 	D.apply_damage(15, A.dna.species.attack_type, BODY_ZONE_CHEST)
-	log_combat(A, D, "launch kicked (Sleeping Carp)")
+	log_combat(A, D, "launchkicked (Sleeping Carp)")
 	return
 
 /datum/martial_art/the_sleeping_carp/proc/dropKick(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -66,12 +67,14 @@
 		D.drop_all_held_items()
 		D.visible_message("<span class='warning'>[A] kicks [D] in the head!</span>", \
 					"<span class='userdanger'>You are kicked in the head by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
+	log_combat(A, D, "dropkicked (Sleeping Carp)")
 	return
 
 /datum/martial_art/the_sleeping_carp/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	add_to_streak("G",D)
 	if(check_streak(A,D))
 		return TRUE
+	log_combat(A, D, "grabbed (Sleeping Carp)")
 	return ..()
 
 /datum/martial_art/the_sleeping_carp/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -80,38 +83,39 @@
 		return TRUE
 	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
 	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
-	var/atk_verb = pick("kick", "chop", "hit", "slam")
-	D.visible_message("<span class='danger'>[A] [atk_verb]s [D]!</span>", \
+	var/atk_verb = pick("kicks", "chops", "hits", "slams")//picks one of the verbs, mostly for flavour, cool karate moves and stuff
+	D.visible_message("<span class='danger'>[A] [atk_verb] [D]!</span>", \
 					"<span class='userdanger'>[A] [atk_verb]s you!</span>", null, null, A)
 	to_chat(A, "<span class='danger'>You [atk_verb] [D]!</span>")
 	D.apply_damage(rand(10,15), BRUTE, affecting)
 	playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
-	log_combat(A, D, "[atk_verb] (Sleeping Carp)")
+	log_combat(A, D, "punched (Sleeping Carp)")
 	return TRUE
 
 /datum/martial_art/the_sleeping_carp/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return TRUE
+	log_combat(A, D, "disarmed (Sleeping Carp)")
 	return ..()
 
-/datum/martial_art/the_sleeping_carp/on_projectile_hit(mob/living/carbon/human/A, obj/projectile/P, def_zone)
-	. = ..()
-	if(A.incapacitated(FALSE, TRUE)) //NO STUN
-		return BULLET_ACT_HIT
-	if(!(A.mobility_flags & MOBILITY_USE)) //NO UNABLE TO USE
-		return BULLET_ACT_HIT
-	if(A.dna && A.dna.check_mutation(HULK)) //NO HULK
-		return BULLET_ACT_HIT
-	if(!isturf(A.loc)) //NO MOTHERFLIPPIN MECHS!
-		return BULLET_ACT_HIT
-	if(A.in_throw_mode)
-		A.visible_message("<span class='danger'>[A] effortlessly swats the projectile aside! They can block bullets with their bare hands!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
-		playsound(get_turf(A), pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
-		P.firer = A
-		P.setAngle(rand(0, 360))//SHING
-		return BULLET_ACT_FORCE_PIERCE
-	return BULLET_ACT_HIT
+//datum/martial_art/the_sleeping_carp/on_projectile_hit(mob/living/carbon/human/A, obj/projectile/P, def_zone)
+	//. = ..()
+	//if(A.incapacitated(FALSE, TRUE)) //NO STUN
+		//return BULLET_ACT_HIT
+	//if(!(A.mobility_flags & MOBILITY_USE)) //NO UNABLE TO USE
+		//return BULLET_ACT_HIT
+	//if(A.dna && A.dna.check_mutation(HULK)) //NO HULK
+		//return BULLET_ACT_HIT
+	//if(!isturf(A.loc)) //NO MOTHERFLIPPIN MECHS!
+		//return BULLET_ACT_HIT
+	//if(A.in_throw_mode)
+		//A.visible_message("<span class='danger'>[A] effortlessly swats the projectile aside! They can block bullets with their bare hands!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
+		//playsound(get_turf(A), pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
+		//P.firer = A
+		//P.setAngle(rand(0, 360))//SHING
+		//return BULLET_ACT_FORCE_PIERCE
+	//return BULLET_ACT_HIT
 
 /datum/martial_art/the_sleeping_carp/teach(mob/living/carbon/human/H, make_temporary = FALSE)
 	. = ..()
@@ -121,12 +125,13 @@
 	ADD_TRAIT(H, TRAIT_PIERCEIMMUNE, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(H, TRAIT_STUNRESISTANCE, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
-	H.physiology.brute_mod *= 0.3
-	H.physiology.burn_mod *= 0.3
-	H.physiology.stamina_mod *= 0.3
-	H.physiology.stun_mod *= 0.3
+	H.physiology.brute_mod *= 0.2 //brute is borderline useless
+	H.physiology.burn_mod *= 0.7 //burn is distinctly more useful against them than brute but they're still resistant
+	H.physiology.stamina_mod *= 0.5 //stun batons prove to be one of the few ways to fight them. They have stun resistance already, so I think doubling down too hard on this resistance is a bit much.
+	H.physiology.stun_mod *= 0.3 //for those rare stuns
 	H.physiology.pressure_mod *= 0.3 //go hang out with carp
-	H.physiology.cold_mod *= 0.3 //seriously go say hi
+	H.physiology.cold_mod *= 0.3 //cold mods are different to burn mods, they don't interact even though they both do burn damage
+	H.physiology.heat_mod *= 1.5 //this is mostly so sleeping carp has a viable weakness. Cooking them alive. Setting them on fire and heating them will be their biggest weakness. The reason for this is....filet jokes.
 
 	H.faction |= "carp" //:D
 
@@ -142,6 +147,7 @@
 	H.physiology.stun_mod = initial(H.physiology.stun_mod)
 	H.physiology.pressure_mod = initial(H.physiology.pressure_mod) //no more carpies
 	H.physiology.cold_mod = initial(H.physiology.cold_mod)
+	H.physiology.heat_mod = initial(H.physiology.heat_mod)
 
 	H.faction -= "carp" //:(
 

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -23,11 +23,14 @@
 		return TRUE
 	return FALSE
 
+///Gnashing Teeth: Harm Harm, consistent 20 force punch on every second harm punch, has a chance to crit
 /datum/martial_art/the_sleeping_carp/proc/strongPunch(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))///this var is so that the strong punch is always aiming for the body part the user is targeting and not trying to apply to the chest before deviating
+	///this var is so that the strong punch is always aiming for the body part the user is targeting and not trying to apply to the chest before deviating
+	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
 	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
 	var/atk_verb = pick("kick", "chop", "hit", "slam")
-	var/crit_damage = 0///this is the critical hit damage added to the attack if it rolls, it starts at 0 because it'll be changed when rolled
+	///this is the critical hit damage added to the attack if it rolls, it starts at 0 because it'll be changed when rolled
+	var/crit_damage = 0
 	D.visible_message("<span class='danger'>[A] [atk_verb]s [D]!</span>", \
 					"<span class='userdanger'>[A] [atk_verb]s you!</span>", null, null, A)
 	to_chat(A, "<span class='danger'>You [atk_verb] [D]!</span>")
@@ -42,6 +45,7 @@
 	D.apply_damage(20 + crit_damage, A.dna.species.attack_type, affecting)
 	return
 
+///Crashing Wave Kick: Harm Disarm combo, throws people seven tiles backwards
 /datum/martial_art/the_sleeping_carp/proc/launchKick(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	A.do_attack_animation(D, ATTACK_EFFECT_KICK)
 	D.visible_message("<span class='warning'>[A] kicks [D] square in the chest, sending them flying!</span>", \
@@ -53,6 +57,7 @@
 	log_combat(A, D, "launchkicked (Sleeping Carp)")
 	return
 
+///Keelhaul: Harm Grab combo, knocks people down, deals stamina damage while they're on the floor
 /datum/martial_art/the_sleeping_carp/proc/dropKick(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	A.do_attack_animation(D, ATTACK_EFFECT_KICK)
 	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
@@ -83,7 +88,7 @@
 		return TRUE
 	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
 	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
-	var/atk_verb = pick("kicks", "chops", "hits", "slams")//picks one of the verbs, mostly for flavour, cool karate moves and stuff
+	var/atk_verb = pick("kicks", "chops", "hits", "slams")
 	D.visible_message("<span class='danger'>[A] [atk_verb] [D]!</span>", \
 					"<span class='userdanger'>[A] [atk_verb]s you!</span>", null, null, A)
 	to_chat(A, "<span class='danger'>You [atk_verb] [D]!</span>")
@@ -161,7 +166,7 @@
 	to_chat(usr, "<span class='notice'>Gnashing Teeth</span>: Harm Harm. Deal additional damage every second punch, with a chance for even more damage!")
 	to_chat(usr, "<span class='notice'>Crashing Wave Kick</span>: Harm Disarm. Launch people brutally across rooms, and away from you.")
 	to_chat(usr, "<span class='notice'>Keelhaul</span>: Harm Grab. Kick opponents to the floor. Against prone targets, deal additional stamina damage and disarm them.")
-	to_chat(usr, "<span class='notice'>In addition, your body has become incredibly resilient to most forms of attack. Weapons cannot readily pierce your hardened skin, and you are highly resistant to stuns and knockdowns, and can block all projectiles in Throw Mode. However, you are not invincible, and sustained damage will take it's toll.</span>")
+	to_chat(usr, "<span class='notice'>In addition, your body has become incredibly resilient to most forms of attack. Weapons cannot readily pierce your hardened skin, and you are highly resistant to stuns and knockdowns, and can block all projectiles in Throw Mode. However, you are not invincible, and sustained damage will take it's toll. Avoid heat at all costs!</span>")
 
 /obj/item/twohanded/bostaff
 	name = "bo staff"

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -130,8 +130,8 @@
 	H.physiology.stamina_mod *= 0.5 //stun batons prove to be one of the few ways to fight them. They have stun resistance already, so I think doubling down too hard on this resistance is a bit much.
 	H.physiology.stun_mod *= 0.3 //for those rare stuns
 	H.physiology.pressure_mod *= 0.3 //go hang out with carp
-	H.physiology.cold_mod *= 0.3 //cold mods are different to burn mods, they don't interact even though they both do burn damage
-	H.physiology.heat_mod *= 1.5 //this is mostly so sleeping carp has a viable weakness. Cooking them alive. Setting them on fire and heating them will be their biggest weakness. The reason for this is....filet jokes.
+	H.physiology.cold_mod *= 0.3 //cold mods are different to burn mods, they do stack however
+	H.physiology.heat_mod *= 2 //this is mostly so sleeping carp has a viable weakness. Cooking them alive. Setting them on fire and heating them will be their biggest weakness. The reason for this is....filet jokes.
 
 	H.faction |= "carp" //:D
 

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -24,10 +24,10 @@
 	return FALSE
 
 /datum/martial_art/the_sleeping_carp/proc/strongPunch(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))//this var is so that the strong punch is always aiming for the body part the user is targeting and not trying to apply to the chest before deviating
+	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))///this var is so that the strong punch is always aiming for the body part the user is targeting and not trying to apply to the chest before deviating
 	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
 	var/atk_verb = pick("kick", "chop", "hit", "slam")
-	var/crit_damage = 0//this is the critical hit damage added to the attack if it rolls, it starts at 0 because it'll be changed when rolled
+	var/crit_damage = 0///this is the critical hit damage added to the attack if it rolls, it starts at 0 because it'll be changed when rolled
 	D.visible_message("<span class='danger'>[A] [atk_verb]s [D]!</span>", \
 					"<span class='userdanger'>[A] [atk_verb]s you!</span>", null, null, A)
 	to_chat(A, "<span class='danger'>You [atk_verb] [D]!</span>")
@@ -125,7 +125,7 @@
 	ADD_TRAIT(H, TRAIT_PIERCEIMMUNE, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(H, TRAIT_STUNRESISTANCE, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
-	H.physiology.brute_mod *= 0.2 //brute is borderline useless
+	H.physiology.brute_mod *= 0.4 //brute is really not gonna cut it
 	H.physiology.burn_mod *= 0.7 //burn is distinctly more useful against them than brute but they're still resistant
 	H.physiology.stamina_mod *= 0.5 //stun batons prove to be one of the few ways to fight them. They have stun resistance already, so I think doubling down too hard on this resistance is a bit much.
 	H.physiology.stun_mod *= 0.3 //for those rare stuns

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -32,7 +32,7 @@
 					"<span class='userdanger'>[A] [atk_verb]s you!</span>", null, null, A)
 	to_chat(A, "<span class='danger'>You [atk_verb] [D]!</span>")
 	if(prob(10))
-		crit_damage += 20//here is where the critical damage is adjusted
+		crit_damage += 20
 		playsound(get_turf(D), 'sound/weapons/bite.ogg', 50, TRUE, -1)
 		D.visible_message("<span class='warning'>[D] sputters blood as the blow strikes them with inhuman force!</span>", "<span class='userdanger'>You are struck with incredible precision by [A]!</span>")
 		log_combat(A, D, "critcal strong punched (Sleeping Carp)")//log it here because a critical can swing for 40 force and it's important for the sake of how hard they hit
@@ -98,24 +98,6 @@
 		return TRUE
 	log_combat(A, D, "disarmed (Sleeping Carp)")
 	return ..()
-
-//datum/martial_art/the_sleeping_carp/on_projectile_hit(mob/living/carbon/human/A, obj/projectile/P, def_zone)
-	//. = ..()
-	//if(A.incapacitated(FALSE, TRUE)) //NO STUN
-		//return BULLET_ACT_HIT
-	//if(!(A.mobility_flags & MOBILITY_USE)) //NO UNABLE TO USE
-		//return BULLET_ACT_HIT
-	//if(A.dna && A.dna.check_mutation(HULK)) //NO HULK
-		//return BULLET_ACT_HIT
-	//if(!isturf(A.loc)) //NO MOTHERFLIPPIN MECHS!
-		//return BULLET_ACT_HIT
-	//if(A.in_throw_mode)
-		//A.visible_message("<span class='danger'>[A] effortlessly swats the projectile aside! They can block bullets with their bare hands!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
-		//playsound(get_turf(A), pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
-		//P.firer = A
-		//P.setAngle(rand(0, 360))//SHING
-		//return BULLET_ACT_FORCE_PIERCE
-	//return BULLET_ACT_HIT
 
 /datum/martial_art/the_sleeping_carp/teach(mob/living/carbon/human/H, make_temporary = FALSE)
 	. = ..()

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -99,6 +99,24 @@
 	log_combat(A, D, "disarmed (Sleeping Carp)")
 	return ..()
 
+/datum/martial_art/the_sleeping_carp/on_projectile_hit(mob/living/carbon/human/A, obj/projectile/P, def_zone)
+	. = ..()
+	if(A.incapacitated(FALSE, TRUE)) //NO STUN
+		return BULLET_ACT_HIT
+	if(!(A.mobility_flags & MOBILITY_USE)) //NO UNABLE TO USE
+		return BULLET_ACT_HIT
+	if(A.dna && A.dna.check_mutation(HULK)) //NO HULK
+		return BULLET_ACT_HIT
+	if(!isturf(A.loc)) //NO MOTHERFLIPPIN MECHS!
+		return BULLET_ACT_HIT
+	if(A.in_throw_mode)
+		A.visible_message("<span class='danger'>[A] effortlessly swats the projectile aside! They can block bullets with their bare hands!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
+		playsound(get_turf(A), pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
+		P.firer = A
+		P.setAngle(rand(0, 360))//SHING
+		return BULLET_ACT_FORCE_PIERCE
+	return BULLET_ACT_HIT
+
 /datum/martial_art/the_sleeping_carp/teach(mob/living/carbon/human/H, make_temporary = FALSE)
 	. = ..()
 	if(!.)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -571,7 +571,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat, \
 			gain skin as hard as steel and swat bullets from the air, but you also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/book/granter/martial/carp
-	cost = 15
+	cost = 17
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm still feel like it could do without deflection but we'll keep it for now.

Anyway, sleeping carp users now have distinct weaknesses. Burning them. Lasers, welders, anything that burns. They still have some resistance to it but it's far more mild than their brute mod.

Cooking them is also now not only viable, but encouraged.

Also it's 17TC again.

## Why It's Good For The Game

Watching a miner face off against a sleeping carp user walk menacingly towards them and only just barely staying alive under a mountain of legion cores and medipens while the sleeping carp user is barely affected by the variety of powerful gear they brought to the fight, I kinda realized I probably made a god and not a fish man.

I would suggest merging this one pretty quick.

## Changelog
:cl: NecromancerAnne
balance: Sleeping Carp costs 17tc again.
balance: Sleeping Carp users are distinctly worse against sources of burn damage, except the cold.
balance: Sleeping Carp users are extremely vulnerable to being cooked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
