### PR TITLE
Fixes embed examines and runtimes

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -877,9 +877,9 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	return owner.dropItemToGround(src)
 
 /**
-  * Does the current embedding var meet the criteria for being harmless? Namely, does it have a pain multiplier and jostle pain mult of 0? If so, return true.
-  *
+  * Does the current embedding var meet the criteria for being harmless? Namely, does it explicitly define the pain multiplier and jostle pain mult to be 0? If so, return true.
   */
 /obj/item/proc/is_embed_harmless()
 	if(embedding)
-		return (!embedding["pain_mult"] && !embedding["jostle_pain_mult"])
+		return !isnull(embedding["pain_mult"]) && !isnull(embedding["jostle_pain_mult"]) && embedding["pain_mult"] == 0 && embedding["jostle_pain_mult"] == 0
+

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -507,7 +507,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 							shard.embedding = list(embed_chance = 100, ignore_throwspeed_threshold = TRUE, impact_pain_mult=1, pain_chance=5)
 							shard.AddElement(/datum/element/embed, shard.embedding)
 							C.hitby(shard, skipcatch = TRUE, hitpush = FALSE)
-							shard.embedding = initial(shard.embedding)
+							shard.embedding = list()
 							shard.AddElement(/datum/element/embed, shard.embedding)
 					if(4) // paralyze this binch
 						// the new paraplegic gets like 4 lines of losing their legs so skip them


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #49635

Harmful embedded objects that use the default pain mult and jostle pain mult (the vast majority of them) now properly show as embedded rather than sticking to people. Also fixes runtimes caused by special glass shards created by the "glass shard spam" vending machine crit effect.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix and consistency
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Harmful embedded objects will no longer "stick to people" in descriptions, and will look "embedded in" as they should be.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
