### PR TITLE
Corrects network lists on some Box medical cameras

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -23003,7 +23003,8 @@
 /area/security/checkpoint/medical)
 "bhj" = (
 /obj/machinery/camera{
-	c_tag = "Security Post - Medbay"
+	c_tag = "Security Post - Medbay";
+	network = list("ss13","medbay")
 	},
 /obj/machinery/requests_console{
 	department = "Security";

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -22951,7 +22951,8 @@
 /area/medical/pharmacy)
 "bhc" = (
 /obj/machinery/camera{
-	c_tag = "Chemistry"
+	c_tag = "Chemistry";
+	network = list("ss13","medbay")
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -42968,7 +42969,7 @@
 "clp" = (
 /obj/machinery/camera{
 	c_tag = "Chemistry Lab Northeast";
-	network = list("xeno","rd")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -50114,7 +50115,8 @@
 /obj/machinery/chem_dispenser,
 /obj/machinery/camera{
 	c_tag = "Chemistry Lab West";
-	dir = 4
+	dir = 4;
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -51401,7 +51403,8 @@
 "oZc" = (
 /obj/machinery/camera{
 	c_tag = "Chemistry Lab East";
-	dir = 8
+	dir = 8;
+	network = list("ss13","medbay")
 	},
 /obj/machinery/light{
 	dir = 4
@@ -53430,7 +53433,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chemistry Lab North";
-	network = list("xeno","rd")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes xeno and RD networks from two Box chem factory cameras. Adds pharmacy, med security post and chem factory to medbay network. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
fix: Removes two Box chem factory cameras from xeno and RD networks
tweak: Adds Box chem factory, pharmacy and med sec post to medbay network (listed on CMO telescreen)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
