### PR TITLE
Adds the ability for borgs to wear drones and pAIs as hats.

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai_shell.dm
+++ b/code/modules/mob/living/silicon/pai/pai_shell.dm
@@ -55,6 +55,9 @@
 		return
 	visible_message("<span class='notice'>[src] deactivates its holochassis emitter and folds back into a compact card!</span>")
 	stop_pulling()
+	if(istype(loc, /obj/item/clothing/head/mob_holder))
+		var/obj/item/clothing/head/mob_holder/MH = loc
+		MH.release()
 	if(client)
 		client.perspective = EYE_PERSPECTIVE
 		client.eye = card

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -854,6 +854,12 @@
 	new_hat.forceMove(src)
 	update_icons()
 
+/mob/living/silicon/robot/Exited(atom/A)
+	if(hat && hat == A)
+		hat = null
+	update_icons()
+	. = ..()
+
 /mob/living/silicon/robot/proc/make_shell(var/obj/item/borg/upgrade/ai/board)
 	if(!board)
 		upgrades |= new /obj/item/borg/upgrade/ai(src)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -854,6 +854,10 @@
 	new_hat.forceMove(src)
 	update_icons()
 
+/**
+	*Checking Exited() to detect if a hat gets up and walks off.
+	*Drones and pAIs might do this, after all.
+*/
 /mob/living/silicon/robot/Exited(atom/A)
 	if(hat && hat == A)
 		hat = null

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -1,7 +1,6 @@
 GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't really work on borgos
 	/obj/item/clothing/head/helmet/space,
 	/obj/item/clothing/head/welding,
-	/obj/item/clothing/head/mob_holder, //I am so very upset that this breaks things
 	/obj/item/clothing/head/chameleon/broken \
 	)))
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -50,6 +50,7 @@
 		to_chat(user, "<span class='notice'>You pick [src] up.</span>")
 		drop_all_held_items()
 		var/obj/item/clothing/head/mob_holder/drone/DH = new(get_turf(src), src)
+		DH.slot_flags = worn_slot_flags
 		user.put_in_hands(DH)
 
 /mob/living/simple_animal/drone/proc/try_reactivate(mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Removes the mob holder from the borg hat blacklist, enabling their use on borgs.

- Adds an Exited() check to borgs to detect if a hat walks off, and to null the hat and update the borg's icon when this happens.

- Fixes drones' mob holder object not getting the correct slot flags.

- Fixes pAIs breaking things if they return to card form while inside a mob holder object.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/37497534/75738251-a75e4d80-5cb6-11ea-96b4-ccd68723a3d0.png)
A weapon to surpass Metal Gear.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Drones and pAI holoforms are now suitable borg hats (though they require a humanoid's help to get there).
fix: Fixed drones not being equip-able as hats.
fix: Fixed pAIs returning to card form when being held or on someone's head leaving a phantom chassis behind.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
