### PR TITLE
Auto monkey return for slime management console.

### DIFF
--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -83,4 +83,5 @@
 	build_path = /obj/item/xeno_console_upgrade/redemption
 	category = list("Bluespace Travel")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
 	

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -81,5 +81,5 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/gold = 500, /datum/material/silver = 500)
 	build_path = /obj/item/xeno_console_upgrade/redemption
-	category = list("Bluespace Travel")
+	category = list("Bluespace Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -75,7 +75,8 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/xeno_up_redemption
-	name = "Automatised Monkey Recycling"
+	name = "Automated Monkey Recycling"
+
 	desc = "Upgrade disk for the Slime Management Console. Contains a set of micro sensors and beacons that allow the console to automatically retrieve and recycle dead monkeys."
 
 	id = "xeno_up_redemption"

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -83,3 +83,4 @@
 	build_path = /obj/item/xeno_console_upgrade/redemption
 	category = list("Bluespace Travel")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -73,3 +73,13 @@
 	build_path = /obj/item/swapper
 	category = list("Bluespace Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/xeno_up_redemption
+	name = "Automatised Monkey Recycling"
+	desc = "Slime management console upgrade disk. Contain set of micro sensors and beacons allow automatised monkey recycling."
+	id = "xeno_up_redemption"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/gold = 500, /datum/material/silver = 500)
+	build_path = /obj/item/xeno_console_upgrade/redemption
+	category = list("Bluespace Travel")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -83,5 +83,3 @@
 	build_path = /obj/item/xeno_console_upgrade/redemption
 	category = list("Bluespace Travel")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
-
-	

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -76,7 +76,8 @@
 
 /datum/design/xeno_up_redemption
 	name = "Automatised Monkey Recycling"
-	desc = "Slime management console upgrade disk. Contain set of micro sensors and beacons allow automatised monkey recycling."
+	desc = "Upgrade disk for the Slime Management Console. Contains a set of micro sensors and beacons that allow the console to automatically retrieve and recycle dead monkeys."
+
 	id = "xeno_up_redemption"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/gold = 500, /datum/material/silver = 500)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -199,7 +199,7 @@
 	display_name = "Bluespace Travel"
 	description = "Application of Bluespace for static teleportation technology."
 	prereq_ids = list("practical_bluespace")
-	design_ids = list("xeno_up_redemption", "tele_station", "tele_hub", "teleconsole", "quantumpad", "launchpad", "launchpad_console", "bluespace_pod")
+	design_ids = list("tele_station", "tele_hub", "teleconsole", "quantumpad", "launchpad", "launchpad_console", "bluespace_pod")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 
@@ -226,7 +226,7 @@
 	display_name = "Applied Bluespace Research"
 	description = "Using bluespace to make things faster and better."
 	prereq_ids = list("bluespace_basic", "engineering")
-	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "roastingstick", "ore_silo")
+	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "roastingstick", "ore_silo", "xeno_up_redemption")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -199,7 +199,7 @@
 	display_name = "Bluespace Travel"
 	description = "Application of Bluespace for static teleportation technology."
 	prereq_ids = list("practical_bluespace")
-	design_ids = list("tele_station", "tele_hub", "teleconsole", "quantumpad", "launchpad", "launchpad_console", "bluespace_pod")
+	design_ids = list("xeno_up_redemption", "tele_station", "tele_hub", "teleconsole", "quantumpad", "launchpad", "launchpad_console", "bluespace_pod")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -534,6 +534,6 @@
 	connected_recycler.use_power(500)
 	monkeys += connected_recycler.cube_production
 	monkeys = round(monkeys, 0.1)		//Prevents rounding errors
-	addtimer(CALLBACK(src, qdel(M)), 10) //Prevent some edges
+	qdel(M)
 	visible_message("<span class='notice'>[src] now has [monkeys] monkeys available.</span>")
 

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -534,6 +534,6 @@
 	connected_recycler.use_power(500)
 	monkeys += connected_recycler.cube_production
 	monkeys = round(monkeys, 0.1)		//Prevents rounding errors
-	addtimer(qdel(M), 10) //Prevent some edges
+	addtimer(CALLBACK(src, qdel(M)), 10) //Prevent some edges
 	visible_message("<span class='notice'>[src] now has [monkeys] monkeys available.</span>")
 

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -534,6 +534,6 @@
 	connected_recycler.use_power(500)
 	monkeys += connected_recycler.cube_production
 	monkeys = round(monkeys, 0.1)		//Prevents rounding errors
-	qdel(M)
+	addtimer(qdel(M), 10) //Prevent some edges
 	visible_message("<span class='notice'>[src] now has [monkeys] monkeys available.</span>")
 

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -11,7 +11,7 @@
 
 ///Slime management console redemption upgrade
 /obj/item/xeno_console_upgrade/redemption
-	desc = "Set of micro sensors and beacons allow automatised monkey recycling."
+	desc = "Upgrade disk for the Slime Management Console. Contains a set of micro sensors and beacons that allow the console to automatically retrieve and recycle dead monkeys."
 	upgrade = XENO_UPGRADE_REDEPTION
 
 //Xenobio control console
@@ -536,4 +536,3 @@
 	monkeys = round(monkeys, 0.1)		//Prevents rounding errors
 	qdel(M)
 	visible_message("<span class='notice'>[src] now has [monkeys] monkeys available.</span>")
-

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -1,3 +1,19 @@
+///Slime management console upgrade state define
+#define XENO_UPGRADE_REDEPTION	1
+
+///Slime management console upgrade
+/obj/item/xeno_console_upgrade
+	name = "Slime management console upgrade disk"
+	desc = "It seems to be empty."
+	icon = 'icons/obj/module.dmi'
+	icon_state = "datadisk3"
+	var/upgrade
+
+///Slime management console redemption upgrade
+/obj/item/xeno_console_upgrade/redemption
+	desc = "Set of micro sensors and beacons allow automatised monkey recycling."
+	upgrade = XENO_UPGRADE_REDEPTION
+
 //Xenobio control console
 /mob/camera/aiEye/remote/xenobio
 	visible_icon = TRUE
@@ -40,6 +56,9 @@
 	icon_keyboard = "rd_key"
 
 	light_color = LIGHT_COLOR_PINK
+
+	///Hold upgrades
+	var/upgrade = FALSE 
 
 /obj/machinery/computer/camera_advanced/xenobio/Initialize(mapload)
 	. = ..()
@@ -191,6 +210,12 @@
 			visible_message("<span class='notice'>[src] buzzes and displays a message: Slime extract already researched!</span>")
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 3, -1)
 			return
+	else if(istype(W, /obj/item/xeno_console_upgrade))
+		var/obj/item/xeno_console_upgrade/xeno_up = W
+		if(!(upgrade & xeno_up.upgrade))
+			upgrade |= xeno_up.upgrade
+			playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
+			qdel(W)
 	..()
 
 /obj/machinery/computer/camera_advanced/xenobio/multitool_act(mob/living/user, obj/item/multitool/I)
@@ -469,7 +494,8 @@
 				X.monkeys--
 				X.monkeys = round(X.monkeys, 0.1)		//Prevents rounding errors
 				to_chat(C, "<span class='notice'>[X] now has [X.monkeys] monkeys stored.</span>")
-				X.RegisterSignal(food, COMSIG_MOB_DEATH, .proc/redemption)
+				if(upgrade & XENO_UPGRADE_REDEPTION)
+					X.RegisterSignal(food, COMSIG_MOB_DEATH, .proc/redemption)
 		else
 			to_chat(C, "<span class='warning'>[X] needs to have at least 1 monkey stored. Currently has [X.monkeys] monkeys stored.</span>")
 

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -469,7 +469,7 @@
 				X.monkeys--
 				X.monkeys = round(X.monkeys, 0.1)		//Prevents rounding errors
 				to_chat(C, "<span class='notice'>[X] now has [X.monkeys] monkeys stored.</span>")
-				RegisterSignal(food, COMSIG_MOB_DEATH, .proc/redemption)
+				X.RegisterSignal(food, COMSIG_MOB_DEATH, .proc/redemption)
 		else
 			to_chat(C, "<span class='warning'>[X] needs to have at least 1 monkey stored. Currently has [X.monkeys] monkeys stored.</span>")
 
@@ -499,21 +499,14 @@
 /obj/machinery/computer/camera_advanced/xenobio/proc/redemption(mob/living/carbon/monkey/M, gibbed)
 	UnregisterSignal(M, COMSIG_MOB_DEATH)
 	if(gibbed)
-		visible_message("<span class='warning'>[M] gibbed. End of observation.</span>")
-		return	
+		return
 	if(!connected_recycler)
-		visible_message("<span class='warning'>Error in monkey redemption system. There is no connected monkey recycler. Use a multitool to link one.</span>")
 		return
 	if(!isturf(M.loc) || !GLOB.cameranet.checkTurfVis(M.loc))
-		visible_message("<span class='warning'>Target [M] is not near a camera. Cannot proceed.</span>")
 		return
-	if(mobarea.xenobiology_compatible)
-		if(!M.stat)
-			visible_message("<span class='notice'>Error in stat scan system, [M] don't valid target to reclaim for recycling!</span>")
-			return
-		M.visible_message("<span class='notice'>[M] vanishes as [p_theyre()] reclaimed for recycling!</span>")
-		connected_recycler.use_power(500)
-		monkeys += connected_recycler.cube_production
-		monkeys = round(monkeys, 0.1)		//Prevents rounding errors
-		qdel(M)
-		visible_message("<span class='notice'>[src] now has [monkeys] monkeys available.</span>")
+	M.visible_message("<span class='notice'>[M] vanishes as [p_theyre()] reclaimed for recycling!</span>")
+	connected_recycler.use_power(500)
+	monkeys += connected_recycler.cube_production
+	monkeys = round(monkeys, 0.1)		//Prevents rounding errors
+	qdel(M)
+	visible_message("<span class='notice'>[src] now has [monkeys] monkeys available.</span>")

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -493,3 +493,22 @@
 		X.monkeys = round(X.monkeys, 0.1)		//Prevents rounding errors
 		qdel(M)
 		to_chat(C, "<span class='notice'>[X] now has [X.monkeys] monkeys available.</span>")
+
+//auto pick up monkey
+/obj/machinery/computer/camera_advanced/xenobio/proc/redemption(mob/living/carbon/monkey/M)
+	if(!connected_recycler)
+		visible_message("<span class='warning'>Error in monkey redemption system. There is no connected monkey recycler. Use a multitool to link one.</span>")
+		return
+	if(!isturf(M.loc) || !GLOB.cameranet.checkTurfVis(M.loc))
+		visible_message("<span class='warning'>Target [M] is not near a camera. Cannot proceed.</span>")
+		return
+	if(mobarea.xenobiology_compatible)
+		if(!M.stat)
+			visible_message("<span class='notice'>Error in stat scan system, [M] don't valid target to reclaim for recycling!</span>")
+			return
+		M.visible_message("<span class='notice'>[M] vanishes as [p_theyre()] reclaimed for recycling!</span>")
+		connected_recycler.use_power(500)
+		monkeys += connected_recycler.cube_production
+		monkeys = round(X.monkeys, 0.1)		//Prevents rounding errors
+		qdel(M)
+		visible_message("<span class='notice'>[src] now has [monkeys] monkeys available.</span>")

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -510,3 +510,4 @@
 	monkeys = round(monkeys, 0.1)		//Prevents rounding errors
 	qdel(M)
 	visible_message("<span class='notice'>[src] now has [monkeys] monkeys available.</span>")
+

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -495,7 +495,7 @@
 		qdel(M)
 		to_chat(C, "<span class='notice'>[X] now has [X.monkeys] monkeys available.</span>")
 
-//auto pick up monkey
+///Auto monkey return, called on spawned monkey death
 /obj/machinery/computer/camera_advanced/xenobio/proc/redemption(mob/living/carbon/monkey/M, gibbed)
 	UnregisterSignal(M, COMSIG_MOB_DEATH)
 	if(gibbed)

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -469,6 +469,7 @@
 				X.monkeys--
 				X.monkeys = round(X.monkeys, 0.1)		//Prevents rounding errors
 				to_chat(C, "<span class='notice'>[X] now has [X.monkeys] monkeys stored.</span>")
+				RegisterSignal(food, COMSIG_MOB_DEATH, .proc/redemption)
 		else
 			to_chat(C, "<span class='warning'>[X] needs to have at least 1 monkey stored. Currently has [X.monkeys] monkeys stored.</span>")
 
@@ -495,7 +496,11 @@
 		to_chat(C, "<span class='notice'>[X] now has [X.monkeys] monkeys available.</span>")
 
 //auto pick up monkey
-/obj/machinery/computer/camera_advanced/xenobio/proc/redemption(mob/living/carbon/monkey/M)
+/obj/machinery/computer/camera_advanced/xenobio/proc/redemption(mob/living/carbon/monkey/M, gibbed)
+	UnregisterSignal(M, COMSIG_MOB_DEATH)
+	if(gibbed)
+		visible_message("<span class='warning'>[M] gibbed. End of observation.</span>")
+		return	
 	if(!connected_recycler)
 		visible_message("<span class='warning'>Error in monkey redemption system. There is no connected monkey recycler. Use a multitool to link one.</span>")
 		return
@@ -509,6 +514,6 @@
 		M.visible_message("<span class='notice'>[M] vanishes as [p_theyre()] reclaimed for recycling!</span>")
 		connected_recycler.use_power(500)
 		monkeys += connected_recycler.cube_production
-		monkeys = round(X.monkeys, 0.1)		//Prevents rounding errors
+		monkeys = round(monkeys, 0.1)		//Prevents rounding errors
 		qdel(M)
 		visible_message("<span class='notice'>[src] now has [monkeys] monkeys available.</span>")

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -210,12 +210,12 @@
 			visible_message("<span class='notice'>[src] buzzes and displays a message: Slime extract already researched!</span>")
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 3, -1)
 			return
-	else if(istype(W, /obj/item/xeno_console_upgrade))
-		var/obj/item/xeno_console_upgrade/xeno_up = W
+	else if(istype(O, /obj/item/xeno_console_upgrade))
+		var/obj/item/xeno_console_upgrade/xeno_up = O
 		if(!(upgrade & xeno_up.upgrade))
 			upgrade |= xeno_up.upgrade
 			playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
-			qdel(W)
+			qdel(O)
 	..()
 
 /obj/machinery/computer/camera_advanced/xenobio/multitool_act(mob/living/user, obj/item/multitool/I)


### PR DESCRIPTION
## About The Pull Request

Auto monkey return for slime management console.
Monkeys returned on it death

monkey spawned > monkey died > monkey sucked
monkey bound to console that spawn it. 
Second console cant take monkeys that it dont spawn.

## Why It's Good For The Game

Less miasma in xeno. 

## Changelog
:cl:
add: The Applied Bluespace Research node now contains an update disk for the Slime management console. It contains a set of microsensors and beacons that allow the console to automatically retrieve and recycle dead monkeys created by the updated console.
/:cl:

Sorry for this upgrade system, that i took from rcd.
