### PR TITLE
Adds the label component; Small tweaks to the hand labeler

### DIFF
--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -1,0 +1,49 @@
+/**
+	The label component.
+
+	This component is used to manage labels applied by the hand labeler.
+
+	Atoms can only have one instance of this component, and therefore only one label at a time.
+	This is to avoid having names like "Backpack (label1) (label2) (label3)". This is annoying and abnoxious to read.
+
+	When a player clicks the atom with a hand labeler to apply a label, this component gets applied to it.
+	If the labeler is off, the component will be removed from it, and the label will be removed from its name.
+ */
+/datum/component/label
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	/// The name of the label the player is applying to the parent.
+	var/label_name
+
+/datum/component/label/Initialize(_label_name)
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	label_name = _label_name
+
+	// Add the label to the name of the object in the format of: "Item name (label)"
+	var/atom/owner = parent
+	owner.name += " ([label_name])"
+
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/RemoveLabel)
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/Examine)
+
+/datum/component/label/Destroy()
+	UnregisterSignal(parent, list(COMSIG_PARENT_ATTACKBY, COMSIG_PARENT_EXAMINE))
+	return ..()
+
+/datum/component/label/proc/RemoveLabel(datum/source, obj/item/attacker, mob/user, params)
+	// If the attacking object is not a hand labeler or its mode is 1 (has a label ready to apply), return.
+	// The hand labeler should be off (mode is 0), in order to remove a label.
+	var/obj/item/hand_labeler/labeler = attacker
+	if(!istype(labeler) || labeler.mode)
+		return
+
+	var/atom/owner = source // Source will be the owner / parent of this component.
+	owner.name = replacetext(owner.name, "([label_name])", "") // Remove the label text from the parent's name, wherever it may be.
+	owner.name = trim(owner.name) // Shave off any white space from the beginning or end of the parent's name.
+	playsound(owner, 'sound/items/poster_ripped.ogg', 20, TRUE)
+	to_chat(user, "<span class='warning'>You remove the label from [owner].</span>")
+	Destroy() // Remove the component from the object.
+
+/datum/component/label/proc/Examine(datum/source, mob/user, list/examine_list)
+	examine_list += "<span class='notice'>It has a label with some words written on it. Use a hand labeler to remove it.</span>"

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -24,12 +24,12 @@
 	var/atom/owner = parent
 	owner.name += " ([label_name])"
 
+/datum/component/label/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/RemoveLabel)
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/Examine)
 
-/datum/component/label/Destroy()
+/datum/component/label/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_PARENT_ATTACKBY, COMSIG_PARENT_EXAMINE))
-	return ..()
 
 /datum/component/label/proc/RemoveLabel(datum/source, obj/item/attacker, mob/user, params)
 	// If the attacking object is not a hand labeler or its mode is 1 (has a label ready to apply), return.

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -31,7 +31,18 @@
 /datum/component/label/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_PARENT_ATTACKBY, COMSIG_PARENT_EXAMINE))
 
-/datum/component/label/proc/RemoveLabel(datum/source, obj/item/attacker, mob/user, params)
+/**
+	This proc will trigger when any object is used to attack the parent.
+
+	If the attacking object is not a hand labeler, it will return.
+	If the attacking object is a hand labeler it will restore the name of the parent to what it was before this component was added to it, and the component will be deleted.
+
+	Arguments:
+	* source: The parent.
+	* attacker: The object that is hitting the parent.
+	* user: The mob who is wielding the attacking object.
+*/
+/datum/component/label/proc/RemoveLabel(datum/source, obj/item/attacker, mob/user)
 	// If the attacking object is not a hand labeler or its mode is 1 (has a label ready to apply), return.
 	// The hand labeler should be off (mode is 0), in order to remove a label.
 	var/obj/item/hand_labeler/labeler = attacker
@@ -43,7 +54,16 @@
 	owner.name = trim(owner.name) // Shave off any white space from the beginning or end of the parent's name.
 	playsound(owner, 'sound/items/poster_ripped.ogg', 20, TRUE)
 	to_chat(user, "<span class='warning'>You remove the label from [owner].</span>")
-	Destroy() // Remove the component from the object.
+	qdel(src) // Remove the component from the object.
 
+/**
+	This proc will trigger when someone examines the parent.
+	It will attach the text found in the body of the proc to the `examine_list` and display it to the player examining the parent.
+
+	Arguments:
+	* source: The parent.
+	* user: The mob exmaining the parent.
+	* examine_list: The current list of text getting passed from the parent's normal examine() proc.
+*/
 /datum/component/label/proc/Examine(datum/source, mob/user, list/examine_list)
 	examine_list += "<span class='notice'>It has a label with some words written on it. Use a hand labeler to remove it.</span>"

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -1,6 +1,6 @@
 /obj/item/hand_labeler
 	name = "hand labeler"
-	desc = "A combined label printer and applicator in a portable device, designed to be easy to operate and use."
+	desc = "A combined label printer, applicator, and remover, all in a single portable device. Designed to be easy to operate and use."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler0"
 	item_state = "flight"
@@ -55,9 +55,10 @@
 		to_chat(user, "<span class='warning'>You can't label creatures!</span>") // use a collar
 		return
 
-	user.visible_message("<span class='notice'>[user] labels [A] as [label].</span>", \
-						 "<span class='notice'>You label [A] as [label].</span>")
-	A.name = "[A.name] ([label])"
+	user.visible_message("<span class='notice'>[user] labels [A] with \"[label]\".</span>", \
+						 "<span class='notice'>You label [A] with \"[label]\".</span>")
+	A.AddComponent(/datum/component/label, label)
+	playsound(A, 'sound/items/handling/component_pickup.ogg', 20, TRUE)
 	labels_left--
 
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -400,6 +400,7 @@
 #include "code\datums\components\jousting.dm"
 #include "code\datums\components\knockback.dm"
 #include "code\datums\components\knockoff.dm"
+#include "code\datums\components\label.dm"
 #include "code\datums\components\lifesteal.dm"
 #include "code\datums\components\lockon_aiming.dm"
 #include "code\datums\components\magnetic_catch.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the label component, which gets added to objects you label with the hand labeler. It is used to keep track of the label that was applied to it can be removed later on. This is paired with:

- You can now remove labels by hitting objects with the hand labeler while it's off.
- Limits the amount of labels an object can have to one. This was done mostly for code simplicity. I can probably make it possible to spam items with a bunch of labels again... if that's really wanted.

## Changelog
:cl:
code: Adds the label component, which gets added to objects you label with the hand labeler. It is used to keep track of the label that was applied to it can be removed later on.
soundadd: Adds a sound for labeling an object with the hand labeler
soundadd: Adds a sound for removing a label from an object with the hand labeler
tweak: Limits the amount of labels an object can have to one.
tweak: You can now remove labels from objects, by hitting it with the hand labeler, while it's off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
