### PR TITLE
Headrev antag check exploit fix

### DIFF
--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -240,7 +240,7 @@
 		return
 
 	if(give_flash)
-		var/obj/item/assembly/flash/T = new(C)
+		var/obj/item/assembly/flash/handheld/T = new(C)
 		var/list/slots = list (
 			"backpack" = ITEM_SLOT_BACKPACK,
 			"left pocket" = ITEM_SLOT_LPOCKET,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/49695 by giving headrevs the same flash type that exists everywhere else, instead of the base item.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes the ability to antag check a headrev by attempting to cram the flash they spawned with into a secbelt or secvest.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Head revolutionaries will find that the flashes provided to them by the Syndicate now fit in security webbing and belts. Convenient!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
