### PR TITLE
[Ready]Adds the Stray Cargo pod event

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2535,7 +2535,7 @@
 ///Special supply crate that generates random syndicate gear up to a determined TC value
 /datum/supply_pack/misc/syndicate
 	name = "Assorted Syndicate Gear"
-	desc = "Contains a random assortment of syndicate gear collected over several failed syndicate plots."
+	desc = "Contains a random assortment of syndicate gear."
 	special = TRUE ///Cannot be ordered via cargo
 	contains = list()
 	crate_name = "syndicate gear crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2531,3 +2531,27 @@
 		/obj/item/stock_parts/subspace/ansible
 	)
 	crate_name = "crate"
+
+///Special supply crate that generates random syndicate gear up to a determined TC value
+/datum/supply_pack/misc/syndicate
+	name = "Assorted Syndicate Gear"
+	desc = "Contains a random assortment of syndicate gear collected over several failed syndicate plots."
+	special = TRUE ///Cannot be ordered via cargo
+	contains = list()
+	crate_name = "syndicate gear crate"
+	crate_type = /obj/structure/closet/crate
+	var/crate_value = 30 ///Total TC worth of contained uplink items
+
+///Generate assorted uplink items, taking into account the same surplus modifiers used for surplus crates
+/datum/supply_pack/misc/syndicate/fill(obj/structure/closet/crate/C)
+	var/list/uplink_items = get_uplink_items(SSticker.mode)
+	while(crate_value)
+		var/category = pick(uplink_items)
+		var/item = pick(uplink_items[category])
+		var/datum/uplink_item/I = uplink_items[category][item]
+		if(!I.surplus || prob(100 - I.surplus))
+			continue
+		if(crate_value < I.cost)
+			continue
+		crate_value -= I.cost
+		new I.item(C)

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -51,12 +51,6 @@
 	explosionSize = list(0,0,1,2)
 	landingDelay = 15 //Slightly quicker than the supplypod
 
-///A syndicate reskin of a normal pod
-/obj/structure/closet/supplypod/syndicate
-	name = "syndicate supply pod"
-	desc = "A Syndicate supply drop pod."
-	style = STYLE_SYNDICATE
-
 /obj/structure/closet/supplypod/extractionpod
 	name = "Syndicate Extraction Pod"
 	desc = "A specalised, blood-red styled pod for extracting high-value targets out of active mission areas."

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -51,6 +51,12 @@
 	explosionSize = list(0,0,1,2)
 	landingDelay = 15 //Slightly quicker than the supplypod
 
+///A syndicate reskin of a normal pod
+/obj/structure/closet/supplypod/syndicate
+	name = "syndicate supply pod"
+	desc = "A Syndicate supply drop pod."
+	style = STYLE_SYNDICATE
+
 /obj/structure/closet/supplypod/extractionpod
 	name = "Syndicate Extraction Pod"
 	desc = "A specalised, blood-red styled pod for extracting high-value targets out of active mission areas."

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -12,7 +12,6 @@
 	announceChance = 75
 	var/list/possible_pack_types = list() ///List of possible supply packs dropped in the pod, if empty picks from the cargo list
 	var/static/list/stray_spawnable_supply_packs = list() ///List of default spawnable supply packs, filtered from the cargo list
-	var/pod_type = /obj/structure/closet/supplypod
 
 /datum/round_event/stray_cargo/announce(fake)
 	priority_announce("Stray cargo pod detected on long-range scanners. Expected location of impact: [impact_area.name].", "Collision Alert")
@@ -52,10 +51,16 @@
 	else
 		pack_type = pick(stray_spawnable_supply_packs)
 	var/datum/supply_pack/SP = new pack_type
-	var/obj/structure/closet/crate/C = SP.generate(null)
-	C.locked = FALSE //Unlock secure crates
-	C.update_icon()
-	new /obj/effect/DPtarget(LZ, pod_type, C)
+	var/obj/structure/closet/crate/crate = SP.generate(null)
+	crate.locked = FALSE //Unlock secure crates
+	crate.update_icon()
+	var/obj/structure/closet/supplypod/pod = make_pod()
+	new /obj/effect/DPtarget(LZ, pod, crate)
+
+///Handles the creation of the pod, in case it needs to be modified beforehand
+/datum/round_event/stray_cargo/proc/make_pod()
+	var/obj/structure/closet/supplypod/S = new
+	return S
 
 ///Picks an area that wouldn't risk critical damage if hit by a pod explosion
 /datum/round_event/stray_cargo/proc/find_event_area()
@@ -86,4 +91,9 @@
 
 /datum/round_event/stray_cargo/syndicate
 	possible_pack_types = list(/datum/supply_pack/misc/syndicate)
-	pod_type = /obj/structure/closet/supplypod/syndicate
+
+///Apply the syndicate pod skin
+/datum/round_event/stray_cargo/syndicate/make_pod()
+	var/obj/structure/closet/supplypod/S = new
+	S.setStyle(STYLE_SYNDICATE)
+	return S

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -46,6 +46,8 @@
 		pack_type = pick(stray_spawnable_supply_packs)
 	var/datum/supply_pack/SP = new pack_type
 	var/obj/structure/closet/crate/C = SP.generate(null)
+	C.locked = FALSE //Unlock secure crates
+	C.update_icon()
 	new /obj/effect/DPtarget(LZ, /obj/structure/closet/supplypod, C)
 
 ///Picks an area that wouldn't risk critical damage if hit by a pod explosion

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -21,7 +21,7 @@
 */
 /datum/round_event/stray_cargo/setup()
 	startWhen = rand(20, 40)
-	impact_area = findEventArea()
+	impact_area = find_event_area()
 	if(!impact_area)
 		CRASH("No valid areas for cargo pod found.")
 	var/list/turf_test = get_area_turfs(impact_area)

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -10,7 +10,7 @@
 /datum/round_event/stray_cargo
 	var/area/impact_area ///Randomly picked area
 	announceChance = 75
-	announceWhen
+	var/list/possible_pack_types = list() ///List of possible supply packs dropped in the pod, if empty picks from the cargo list
 
 /datum/round_event/stray_cargo/announce(fake)
 	priority_announce("Stray cargo pod detected on long-range scanners. Expected location of impact: [impact_area.name].", "Collision Alert")
@@ -31,7 +31,12 @@
 ///Spawns a random supply pack, puts it in a pod, and spawns it on a random tile of the selected area
 /datum/round_event/stray_cargo/start()
 	var/turf/LZ = pick(get_area_turfs(impact_area))
-	var/datum/supply_pack/SP = pick(SSshuttle.supply_packs)
+	var/pack_type
+	if(possible_pack_types.len)
+		pack_type = pick(possible_pack_types)
+	else
+		pack_type = pick(SSshuttle.supply_packs)
+	var/datum/supply_pack/SP = new pack_type
 	var/obj/structure/closet/crate/C = SP.generate(null)
 	new /obj/effect/DPtarget(LZ, /obj/structure/closet/supplypod, C)
 
@@ -53,3 +58,14 @@
 	var/list/possible_areas = typecache_filter_list(GLOB.sortedAreas,allowed_areas)
 	if (length(possible_areas))
 		return pick(possible_areas)
+
+///A rare variant that drops a crate containing syndicate uplink items
+/datum/round_event_control/stray_cargo/syndicate
+	name = "Stray Syndicate Cargo Pod"
+	typepath = /datum/round_event/stray_cargo/syndicate
+	weight = 6
+	max_occurrences = 1
+	earliest_start = 30 MINUTES
+
+/datum/round_event/stray_cargo/syndicate
+	possible_pack_types = list(/datum/supply_pack/misc/syndicate)

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -11,6 +11,7 @@
 	var/area/impact_area ///Randomly picked area
 	announceChance = 75
 	var/list/possible_pack_types = list() ///List of possible supply packs dropped in the pod, if empty picks from the cargo list
+	var/static/list/stray_spawnable_supply_packs = list() ///List of default spawnable supply packs, filtered from the cargo list
 
 /datum/round_event/stray_cargo/announce(fake)
 	priority_announce("Stray cargo pod detected on long-range scanners. Expected location of impact: [impact_area.name].", "Collision Alert")
@@ -28,6 +29,13 @@
 	if(!turf_test.len)
 		CRASH("Stray Cargo Pod : No valid turfs found for [impact_area] - [impact_area.type]")
 
+	if(!stray_spawnable_supply_packs.len)
+		stray_spawnable_supply_packs = SSshuttle.supply_packs.Copy()
+		for(var/pack in stray_spawnable_supply_packs)
+			var/datum/supply_pack/pack_type = pack
+			if(initial(pack_type.special))
+				stray_spawnable_supply_packs -= pack
+
 ///Spawns a random supply pack, puts it in a pod, and spawns it on a random tile of the selected area
 /datum/round_event/stray_cargo/start()
 	var/turf/LZ = pick(get_area_turfs(impact_area))
@@ -35,7 +43,7 @@
 	if(possible_pack_types.len)
 		pack_type = pick(possible_pack_types)
 	else
-		pack_type = pick(SSshuttle.supply_packs)
+		pack_type = pick(stray_spawnable_supply_packs)
 	var/datum/supply_pack/SP = new pack_type
 	var/obj/structure/closet/crate/C = SP.generate(null)
 	new /obj/effect/DPtarget(LZ, /obj/structure/closet/supplypod, C)

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -1,0 +1,55 @@
+///Spawns a cargo pod containing a random cargo supply pack on a random area of the station
+/datum/round_event_control/stray_cargo
+	name = "Stray Cargo Pod"
+	typepath = /datum/round_event/stray_cargo
+	weight = 20
+	max_occurrences = 4
+	earliest_start = 10 MINUTES
+
+///Spawns a cargo pod containing a random cargo supply pack on a random area of the station
+/datum/round_event/stray_cargo
+	var/area/impact_area ///Randomly picked area
+	announceChance = 75
+	announceWhen
+
+/datum/round_event/stray_cargo/announce(fake)
+	priority_announce("Stray cargo pod detected on long-range scanners. Expected location of impact: [impact_area.name].", "Collision Alert")
+
+/**
+* Tries to find a valid area, throws an error if none are found
+* Also randomizes the start timer
+*/
+/datum/round_event/stray_cargo/setup()
+	startWhen = rand(20, 40)
+	impact_area = findEventArea()
+	if(!impact_area)
+		CRASH("No valid areas for cargo pod found.")
+	var/list/turf_test = get_area_turfs(impact_area)
+	if(!turf_test.len)
+		CRASH("Stray Cargo Pod : No valid turfs found for [impact_area] - [impact_area.type]")
+
+///Spawns a random supply pack, puts it in a pod, and spawns it on a random tile of the selected area
+/datum/round_event/stray_cargo/start()
+	var/turf/LZ = pick(get_area_turfs(impact_area))
+	var/datum/supply_pack/SP = pick(SSshuttle.supply_packs)
+	var/obj/structure/closet/crate/C = SP.generate(null)
+	new /obj/effect/DPtarget(LZ, /obj/structure/closet/supplypod, C)
+
+///Picks an area that wouldn't risk critical damage if hit by a pod explosion
+/datum/round_event/stray_cargo/proc/find_event_area()
+	var/static/list/allowed_areas
+	if(!allowed_areas)
+		///Places that shouldn't explode
+		var/list/safe_area_types = typecacheof(list(
+		/area/ai_monitored/turret_protected/ai,
+		/area/ai_monitored/turret_protected/ai_upload,
+		/area/engine,
+		/area/shuttle)
+		)
+
+		///Subtypes from the above that actually should explode.
+		var/list/unsafe_area_subtypes = typecacheof(list(/area/engine/break_room))
+		allowed_areas = make_associative(GLOB.the_station_areas) - safe_area_types + unsafe_area_subtypes
+	var/list/possible_areas = typecache_filter_list(GLOB.sortedAreas,allowed_areas)
+	if (length(possible_areas))
+		return pick(possible_areas)

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -12,6 +12,7 @@
 	announceChance = 75
 	var/list/possible_pack_types = list() ///List of possible supply packs dropped in the pod, if empty picks from the cargo list
 	var/static/list/stray_spawnable_supply_packs = list() ///List of default spawnable supply packs, filtered from the cargo list
+	var/pod_type = /obj/structure/closet/supplypod
 
 /datum/round_event/stray_cargo/announce(fake)
 	priority_announce("Stray cargo pod detected on long-range scanners. Expected location of impact: [impact_area.name].", "Collision Alert")
@@ -54,7 +55,7 @@
 	var/obj/structure/closet/crate/C = SP.generate(null)
 	C.locked = FALSE //Unlock secure crates
 	C.update_icon()
-	new /obj/effect/DPtarget(LZ, /obj/structure/closet/supplypod, C)
+	new /obj/effect/DPtarget(LZ, pod_type, C)
 
 ///Picks an area that wouldn't risk critical damage if hit by a pod explosion
 /datum/round_event/stray_cargo/proc/find_event_area()
@@ -85,3 +86,4 @@
 
 /datum/round_event/stray_cargo/syndicate
 	possible_pack_types = list(/datum/supply_pack/misc/syndicate)
+	pod_type = /obj/structure/closet/supplypod/syndicate

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -38,7 +38,13 @@
 
 ///Spawns a random supply pack, puts it in a pod, and spawns it on a random tile of the selected area
 /datum/round_event/stray_cargo/start()
-	var/turf/LZ = pick(get_area_turfs(impact_area))
+	var/list/turf/valid_turfs = get_area_turfs(impact_area)
+	//Only target non-dense turfs to prevent wall-embedded pods
+	for(var/i in valid_turfs)
+		var/turf/T = i
+		if(T.density)
+			valid_turfs -= T
+	var/turf/LZ = pick(valid_turfs)
 	var/pack_type
 	if(possible_pack_types.len)
 		pack_type = pick(possible_pack_types)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1778,6 +1778,7 @@
 #include "code\modules\events\spacevine.dm"
 #include "code\modules\events\spider_infestation.dm"
 #include "code\modules\events\spontaneous_appendicitis.dm"
+#include "code\modules\events\stray_cargo.dm"
 #include "code\modules\events\vent_clog.dm"
 #include "code\modules\events\wormholes.dm"
 #include "code\modules\events\holiday\halloween.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds an event where a cargo pod containing a random cargo supply pack crash-lands on a random spot on the station.
Added a rare variant (post 30 minutes) that spawns a null crate with 30 TCs of gear.

Crates which would be locked when ordered from cargo will start unlocked when falling with a stray cargo pod.

<s>_Note: i'm not yet able to compile or test the code myself, will do it as soon as possible, before tomorrow_</s> done, all fine

## Why It's Good For The Game

A fairly neutral event that could benefit some lucky assistant, throw shotguns inside the cult base, or simply land on the head of some very unlucky person.

I think more variety will be nice for the game.

## Changelog
:cl: XDTM
add: Added the Stray Cargo Pod event, which drops a pod containing a random cargo crate into a random location. Rarely, one might even contain assorted syndicate gear!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
