### PR TITLE
Make RCD constructing effect unclickable.

### DIFF
--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -461,6 +461,7 @@
 	icon_state = ""
 	layer = ABOVE_ALL_MOB_LAYER
 	anchored = TRUE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/status = 0
 	var/delay = 0
 


### PR DESCRIPTION
## About The Pull Request

Make RCD constructing effect click transparent.

## Why It's Good For The Game

Effect make all (mobs and below) on turf unclickable while active.

## Changelog
:cl:
tweak: Now RCD constructing effect unclickable.
/:cl:
