### PR TITLE
Adds better clarification for anomaly core types in Phazon construction

### DIFF
--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -1054,7 +1054,7 @@
 			"key" = /obj/item/assembly/signaler/anomaly/bluespace,
 			"action" = ITEM_DELETE,
 			"back_key" = TOOL_WELDER,
-			"desc" = "Anomaly core socket is open.",
+			"desc" = "Bluespace anomaly core socket is open.",
 			"icon_state" = "phazon24"
 		)
 	)

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -234,10 +234,8 @@
 
 /obj/item/mecha_parts/chassis/phazon/attackby(obj/item/I, mob/user, params)
 	. = ..()
-	if(!istype(I, /obj/item/assembly/signaler/anomaly/bluespace) && !istype(I, /obj/item/circuitboard/))
-		to_chat(user, "\The [I.name] doesn't fit in the anomaly core socket. Make sure you're using a Bluespace core.")
-	else
-		return
+	if(istype(I, /obj/item/assembly/signaler/anomaly) && !istype(I, /obj/item/assembly/signaler/anomaly/bluespace))
+		to_chat(user, "The anomaly core socket only accepts bluespace anomaly cores!")
 
 /obj/item/mecha_parts/part/phazon_torso
 	name="\improper Phazon torso"

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -232,6 +232,13 @@
 	name = "\improper Phazon chassis"
 	construct_type = /datum/component/construction/unordered/mecha_chassis/phazon
 
+/obj/item/mecha_parts/chassis/phazon/attackby(obj/item/I, mob/user, params)
+	. = ..()
+	if(!istype(I, /obj/item/assembly/signaler/anomaly/bluespace) && !istype(I, /obj/item/circuitboard/))
+		to_chat(user, "\The [I.name] doesn't fit in the anomaly core socket. Make sure you're using a Bluespace core.")
+	else
+		return
+
 /obj/item/mecha_parts/part/phazon_torso
 	name="\improper Phazon torso"
 	desc="A Phazon torso part. The socket for the bluespace core that powers the exosuit's unique phase drives is located in the middle."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The construction process will now tell you if you try to use anything that isn't the Bluespace anomaly core on it.

## Why It's Good For The Game
Better clarification because apparently people don't read changelogs

## Changelog
:cl:
tweak: Made it more apparent when someone is using the wrong item to finish the Phazon mech's construction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
