### PR TITLE
Miners now start with journeyman skill in mining.

### DIFF
--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -17,6 +17,8 @@
 	paycheck_department = ACCOUNT_CAR
 
 	display_order = JOB_DISPLAY_ORDER_SHAFT_MINER
+	/// Miners start with Journeyman level skill in mining.
+	roundstart_experience = list(SKILL_MINING = SKILL_EXP_JOURNEYMAN)
 
 /datum/outfit/job/miner
 	name = "Shaft Miner"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

From the original skills PR.
> This adds a framework for skills. It's currently only used for a mining skill, which miners start at an intermediate (Journeyman) level of. This means they mine at normal speed.

:eyes: 

Comments don't mention anything about this not being in the game.

## Why It's Good For The Game

Flavour. This is the correct way of adding job specific abilities and precedent for that is good.

## Changelog
:cl:
add: Miners now start with journeyman skill in mining.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
