### PR TITLE
Fixes Delta library windoor access requirement

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -381,7 +381,8 @@
 "aaQ" = (
 /obj/machinery/door/window{
 	dir = 2;
-	name = "Secure Art Exhibition"
+	name = "Secure Art Exhibition";
+	req_access_txt = "37"
 	},
 /obj/structure/table/wood/fancy,
 /obj/structure/sign/painting/library_secure{
@@ -64400,7 +64401,8 @@
 	},
 /obj/machinery/door/window{
 	dir = 8;
-	name = "Library Desk"
+	name = "Library Desk";
+	req_access_txt = "37"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/library)


### PR DESCRIPTION
I thought copy pasting the library desk windoor for the art gallery was a great idea until I realized that it was already missing the access requirement. So I added it to both.

:cl:
fix: Deltastation library windoors now correctly require library access
/:cl:
