### PR TITLE
[READY] Makes the Paper Wizard Unable to Be Made Sentient

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bosses/boss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/boss.dm
@@ -5,6 +5,7 @@
 	stat_attack = UNCONSCIOUS
 	status_flags = 0
 	a_intent = INTENT_HARM
+	sentience_type = SENTIENCE_BOSS
 	gender = NEUTER
 	var/list/boss_abilities = list() //list of /datum/action/boss
 	var/datum/boss_active_timed_battle/atb


### PR DESCRIPTION
## About The Pull Request

Makes the paper wizard unable to be made sentient or mindswapped with using xenobio potions.

## Why It's Good For The Game

Paper wizard is pretty strong, letting him be made sentient seems more like an oversight than an intended feature.

## Changelog
:cl: Indie-ana Jones
fix: The Wizard Federation reports that the paper wizard has completely, "lost it", making any form of sentience potion or mindswap potion useless on him.
/:cl: