### PR TITLE
Make watchers great again

### DIFF
--- a/code/__DEFINES/movespeed_modification.dm
+++ b/code/__DEFINES/movespeed_modification.dm
@@ -79,3 +79,4 @@
 #define MOVESPEED_ID_DAMAGE_SLOWDOWN_FLYING				"FLYING"
 #define MOVESPEED_ID_LENTURI                            "LENTURI_SLOWDOWN"
 
+#define MOVESPEED_ID_BASILISK                           "BASILISK"

--- a/code/datums/status_effects/gas.dm
+++ b/code/datums/status_effects/gas.dm
@@ -5,7 +5,8 @@
 	alert_type = /obj/screen/alert/status_effect/freon
 	var/icon/cube
 	var/can_melt = TRUE
-	var/icewing = FALSE //Is checked to prevent icewing watcher freezing blasts from warming you up when they expire
+///Prevents the frozen solid debuff from restoring body temperature when it expires
+	var/icewing = FALSE
 
 /obj/screen/alert/status_effect/freon
 	name = "Frozen Solid"

--- a/code/datums/status_effects/gas.dm
+++ b/code/datums/status_effects/gas.dm
@@ -5,6 +5,7 @@
 	alert_type = /obj/screen/alert/status_effect/freon
 	var/icon/cube
 	var/can_melt = TRUE
+	var/icewing = FALSE //Is checked to prevent icewing watcher freezing blasts from warming you up when they expire
 
 /obj/screen/alert/status_effect/freon
 	name = "Frozen Solid"
@@ -37,10 +38,12 @@
 	if(!owner.stat)
 		to_chat(owner, "<span class='notice'>The cube melts!</span>")
 	owner.cut_overlay(cube)
-	owner.adjust_bodytemperature(100)
+	if(!icewing)
+		owner.adjust_bodytemperature(100)
 	owner.update_mobility()
 	UnregisterSignal(owner, COMSIG_LIVING_RESIST)
 
 /datum/status_effect/freon/watcher
-	duration = 8
+	duration = 20 //Gives them a moment to panic about losing control, combined with their slow this should be pretty hazardous as it is
 	can_melt = FALSE
+	icewing = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -39,11 +39,21 @@
 /obj/projectile/temp/basilisk
 	name = "freezing blast"
 	icon_state = "ice_2"
-	damage = 0
+	damage = 15 //Allows projectile to harm races that warm up faster than they can chill, without making the chill so strong that a lizardperson dies by seeing it. Borgs take brute here
 	damage_type = BURN
-	nodamage = TRUE
+	nodamage = FALSE
 	flag = "energy"
-	temperature = -50 // Cools you down! per hit!
+	temperature = -50 // Practically speaking this only serves as a damage over time effect against lizard people, as most other races warm up plenty to ignore this effect entirely
+	var/slowdown = TRUE //Defines whether or not the target will have an on hit slow effect, borgs are immune
+
+/obj/projectile/temp/basilisk/on_hit(atom/target, blocked = 0) //Makes being hit a potential environmental threat again, as body temperature is a situational slowing tool that genocides lizardpeople
+	. = ..()
+	if(isliving(target) && slowdown)
+		var/mob/living/L = target
+		if(iscyborg(L))
+			return
+		L.add_movespeed_modifier(MOVESPEED_ID_BASILISK, update=TRUE, priority=100, multiplicative_slowdown=1)
+		addtimer(CALLBACK(L, /mob.proc/remove_movespeed_modifier, MOVESPEED_ID_BASILISK, TRUE), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 
 /obj/projectile/temp/basilisk/heated
 	name = "energy blast"
@@ -188,6 +198,7 @@ mob/living/simple_animal/hostile/asteroid/basilisk/proc/cool_down()
 	damage_type = BURN
 	nodamage = FALSE
 	temperature = 200 // Heats you up! per hit!
+	slowdown = FALSE //This beam is not cold, and should not slow you
 
 /obj/projectile/temp/basilisk/magmawing/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -198,9 +209,10 @@ mob/living/simple_animal/hostile/asteroid/basilisk/proc/cool_down()
 			L.IgniteMob()
 
 /obj/projectile/temp/basilisk/icewing
-	damage = 5
+	damage = 20 //Makes icewing projectiles at least hurt races that warm up faster than they can chill them by a reasonable amount
 	damage_type = BURN
 	nodamage = FALSE
+	temperature = -100 // We're going to make watchers great again! And make the lizardpeople pay for it!
 
 /obj/projectile/temp/basilisk/icewing/on_hit(atom/target, blocked = FALSE)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -44,7 +44,8 @@
 	nodamage = FALSE
 	flag = "energy"
 	temperature = -50 // Practically speaking this only serves as a damage over time effect against lizard people, as most other races warm up plenty to ignore this effect entirely
-	var/slowdown = TRUE //Defines whether or not the target will have an on hit slow effect, borgs are immune
+///Applies an on-hit slowdown that borgs are immune to if true
+	var/slowdown = TRUE
 
 /obj/projectile/temp/basilisk/on_hit(atom/target, blocked = 0) //Makes being hit a potential environmental threat again, as body temperature is a situational slowing tool that genocides lizardpeople
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/49999
After body temperature mechanics were changed watchers were left in the dust, untouched and unloved.
It's time to make them threatening again.

Doesn't touch melee attacks by watchers to encourage close quarters engagements as the old watcher bolt used to.
Normal watcher bolts deal a bit of initial damage and apply a slow down effect independent of the freezing effect they do, borgs are not slowed by this effect, but suffer a small amount of brute damage.
Icewing watchers deal more initial damage and apply the same slowing effect, and their freezing solid effect lasts longer and does not restore your body temperature to normal when it expires.
Magmawing watchers do not do the slow down, and have been untouched by this pr.

## Why It's Good For The Game

The body temperature mechanics that were changed allowed almost everyone to stand at least one tile away from a watcher and shoot at them for free loot, making farming watcher tendrils for diamonds a complete non-issue.

Watchers lost what defined them as a mob, and I hope this brings that feeling back to them, in a way that doesn't instantly kill lizardpeople.

## Changelog
:cl:
balance: Reports from lavaland indicate watchers have evolved and are more threatening! Lizardfolk miners are highly encouraged to bring coffee if an icewing watcher is spotted! 
/:cl: