### PR TITLE
Update pillow to 7.0.0

### DIFF
--- a/tools/mapmerge2/requirements.txt
+++ b/tools/mapmerge2/requirements.txt
@@ -1,3 +1,3 @@
 pygit2==1.0.1
 bidict==0.13.1
-Pillow==6.2.0
+Pillow==7.0.0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pillow 6.2.0 doesn't support python 3.8
https://pillow.readthedocs.io/en/stable/installation.html