### PR TITLE
AI can now look up and down zlevels

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1011,3 +1011,6 @@
 	. = ..()
 	if(.)
 		end_multicam()
+
+/mob/living/silicon/ai/zMove(dir, feedback = FALSE)
+	. = eyeobj.zMove(dir, feedback)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -94,6 +94,25 @@
 		if(ai.master_multicam)
 			ai.master_multicam.refresh_view()
 
+//it uses setLoc not forceMove, talks to the sillycone and not the camera mob
+/mob/camera/aiEye/zMove(dir, feedback = FALSE)
+	if(dir != UP && dir != DOWN)
+		return FALSE
+	var/turf/target = get_step_multiz(src, dir)
+	if(!target)
+		if(feedback)
+			to_chat(ai, "<span class='warning'>There's nowhere to go in that direction!</span>")
+		return FALSE
+	if(!canZMove(dir, target))
+		if(feedback)
+			to_chat(ai, "<span class='warning'>You couldn't move there!</span>")
+		return FALSE
+	setLoc(target, TRUE)
+	return TRUE
+
+/mob/camera/aiEye/canZMove(direction, turf/target) //cameras do not respect these FLOORS you speak so much of
+	return TRUE
+
 /mob/camera/aiEye/Move()
 	return 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

AI look up and down verb works now

## Why It's Good For The Game

AI has trouble with multi-z maps right now. the button does nothing

## Changelog
:cl:
add: AI's go up and down commands finally work
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
