### PR TITLE
Slime split fixes.

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/death.dm
+++ b/code/modules/mob/living/simple_animal/slime/death.dm
@@ -3,7 +3,7 @@
 		return
 	if(!gibbed)
 		if(is_adult)
-			var/mob/living/simple_animal/slime/M = new(loc, colour)
+			var/mob/living/simple_animal/slime/M = new(get_turf(src), colour)
 			M.rabid = TRUE
 			M.regenerate_icons()
 

--- a/code/modules/mob/living/simple_animal/slime/death.dm
+++ b/code/modules/mob/living/simple_animal/slime/death.dm
@@ -3,7 +3,7 @@
 		return
 	if(!gibbed)
 		if(is_adult)
-			var/mob/living/simple_animal/slime/M = new(get_turf(src), colour)
+			var/mob/living/simple_animal/slime/M = new(drop_location(), colour)
 			M.rabid = TRUE
 			M.regenerate_icons()
 

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -241,7 +241,7 @@
 		update_action_buttons_icon()
 
 	if(amount_grown >= SLIME_EVOLUTION_THRESHOLD && !buckled && !Target && !ckey)
-		if(is_adult)
+		if(is_adult && isturf(loc))
 			Reproduce()
 		else
 			Evolve()

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -241,7 +241,7 @@
 		update_action_buttons_icon()
 
 	if(amount_grown >= SLIME_EVOLUTION_THRESHOLD && !buckled && !Target && !ckey)
-		if(is_adult && isturf(loc))
+		if(is_adult && loc.AllowDrop())
 			Reproduce()
 		else
 			Evolve()

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -174,7 +174,7 @@
 			var/new_nutrition = round(nutrition * 0.9)
 			var/new_powerlevel = round(powerlevel / 4)
 			var/datum/component/nanites/original_nanites = GetComponent(/datum/component/nanites)
-			var/turf/drop_loc = get_turf(src)
+			var/turf/drop_loc = drop_location()
 
 			for(var/i=1,i<=4,i++)
 				var/child_colour

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -174,6 +174,7 @@
 			var/new_nutrition = round(nutrition * 0.9)
 			var/new_powerlevel = round(powerlevel / 4)
 			var/datum/component/nanites/original_nanites = GetComponent(/datum/component/nanites)
+			var/turf/drop_loc = get_turf(src)
 
 			for(var/i=1,i<=4,i++)
 				var/child_colour
@@ -184,7 +185,7 @@
 				else
 					child_colour = colour
 				var/mob/living/simple_animal/slime/M
-				M = new(loc, child_colour)
+				M = new(drop_loc, child_colour)
 				if(ckey)
 					M.set_nutrition(new_nutrition) //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
 				M.powerlevel = new_powerlevel


### PR DESCRIPTION
## About The Pull Request

Some fixes for slime splitting.

## Why It's Good For The Game

Slimes in unreachable corners of containers is bad.

## Changelog
:cl:
fix: Slimes try don't split while not in suitable container. 
fix: On slime split new slimes appears in turf.
fix: On slime death new slime appears in turf.
/:cl:
