### PR TITLE
[READY] Reworks the Venus Human Trap

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -251,7 +251,7 @@
 	holder.obj_integrity = holder.max_integrity
 
 /datum/spacevine_mutation/woodening/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/I, expected_damage)
-	if(I.get_sharpness())
+	if(I?.get_sharpness())
 		. = expected_damage * 0.5
 	else
 		. = expected_damage

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -227,13 +227,13 @@
 	quality = NEGATIVE
 
 /datum/spacevine_mutation/thorns/on_cross(obj/structure/spacevine/holder, mob/living/crosser)
-	if(prob(severity) && istype(crosser) && !isvineimmune(holder))
+	if(prob(severity) && istype(crosser) && !isvineimmune(crosser))
 		var/mob/living/M = crosser
 		M.adjustBruteLoss(5)
 		to_chat(M, "<span class='alert'>You cut yourself on the thorny vines.</span>")
 
 /datum/spacevine_mutation/thorns/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/I, expected_damage)
-	if(prob(severity) && istype(hitter) && !isvineimmune(holder))
+	if(prob(severity) && istype(hitter) && !isvineimmune(hitter))
 		var/mob/living/M = hitter
 		M.adjustBruteLoss(5)
 		to_chat(M, "<span class='alert'>You cut yourself on the thorny vines.</span>")
@@ -251,7 +251,7 @@
 	holder.obj_integrity = holder.max_integrity
 
 /datum/spacevine_mutation/woodening/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/I, expected_damage)
-	if(I && I.get_sharpness())
+	if(I.get_sharpness())
 		. = expected_damage * 0.5
 	else
 		. = expected_damage
@@ -540,8 +540,8 @@
 		return TRUE
 
 /proc/isvineimmune(atom/A)
-	. = FALSE
 	if(isliving(A))
 		var/mob/living/M = A
 		if(("vines" in M.faction) || ("plants" in M.faction))
-			. = TRUE
+			return TRUE
+	return FALSE

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -293,6 +293,11 @@ Key procs
 	spoken_languages = list(/datum/language/swarmer = list(LANGUAGE_ATOM))
 	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 
+/datum/language_holder/venus
+	understood_languages = list(/datum/language/sylvan = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/sylvan = list(LANGUAGE_ATOM))
+	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
+
 /datum/language_holder/synthetic
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 								/datum/language/machine = list(LANGUAGE_ATOM),

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -97,7 +97,7 @@
 	/// Whether or not this plant is ghost possessable
 	var/playable_plant = TRUE
 
-/mob/living/simple_animal/hostile/venus_human_trap/Life(mapload)
+/mob/living/simple_animal/hostile/venus_human_trap/Life()
 	. = ..()
 	pull_vines()
 	

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -150,7 +150,7 @@
 	if(key || !playable_plant || stat)
 		return
 	var/plant_ask = alert("Become a venus human trap?", "Are you reverse vegan?", "Yes", "No")
-	if(plant_ask == "No" || !src || QDELETED(src))
+	if(plant_ask == "No" || QDELETED(src))
 		return
 	if(key)
 		to_chat(user, "<span class='warning'>Someone else already took this plant!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -42,7 +42,7 @@
 	visible_message("<span class='danger'>the plant has borne fruit!</span>")
 	new /mob/living/simple_animal/hostile/venus_human_trap(get_turf(src))
 	qdel(src)
-	
+
 /obj/effect/ebeam/vine
 	name = "thick vine"
 	mouse_opacity = MOUSE_OPACITY_ICON

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -39,7 +39,6 @@
   *
   * Displays a message, spawns a human venus trap, then qdels itself.
   */	
-
 /obj/structure/alien/resin/flower_bud_enemy/proc/bear_fruit()
 	visible_message("<span class='danger'>the plant has borne fruit!</span>")
 	new /mob/living/simple_animal/hostile/venus_human_trap(get_turf(src))

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -1,4 +1,13 @@
-
+/**
+  * Kudzu Flower Bud
+  *
+  * A flower created by flowering kudzu which spawns a venus human trap after a certain amount of time has passed.
+  *
+  * A flower created by kudzu with the flowering mutation.  Spawns a venus human trap after 2 minutes under normal circumstances.
+  * Also spawns 4 vines going out in diagonal directions from the bud.  Any living creature not aligned with plants is damaged by these vines.
+  * Once it grows a venus human trap, the bud itself will destroy itself.
+  *
+  */
 
 /obj/structure/alien/resin/flower_bud_enemy //inheriting basic attack/damage stuff from alien structures
 	name = "flower bud"
@@ -9,8 +18,8 @@
 	opacity = 0
 	canSmoothWith = list()
 	smooth = SMOOTH_FALSE
+	/// The amount of time it takes to create a venus human trap, in deciseconds
 	var/growth_time = 1200
-
 
 /obj/structure/alien/resin/flower_bud_enemy/Initialize()
 	. = ..()
@@ -25,17 +34,21 @@
 		B.sleep_time = 10 //these shouldn't move, so let's slow down updates to 1 second (any slower and the deletion of the vines would be too slow)
 	addtimer(CALLBACK(src, .proc/bear_fruit), growth_time)
 
+/**
+  * Spawns a venus human trap, then qdels itself.
+  *
+  * Displays a message, spawns a human venus trap, then qdels itself.
+  */	
+
 /obj/structure/alien/resin/flower_bud_enemy/proc/bear_fruit()
 	visible_message("<span class='danger'>the plant has borne fruit!</span>")
 	new /mob/living/simple_animal/hostile/venus_human_trap(get_turf(src))
 	qdel(src)
 
-
 /obj/effect/ebeam/vine
 	name = "thick vine"
 	mouse_opacity = MOUSE_OPACITY_ICON
 	desc = "A thick vine, painful to the touch."
-
 
 /obj/effect/ebeam/vine/Crossed(atom/movable/AM)
 	if(isliving(AM))
@@ -44,12 +57,24 @@
 			L.adjustBruteLoss(5)
 			to_chat(L, "<span class='alert'>You cut yourself on the thorny vines.</span>")
 
-
+/**
+  * Venus Human Trap
+  *
+  * The result of a kudzu flower bud, these enemies use vines to drag prey close to them for attack.
+  *
+  * A carnivorious plant which uses vines to catch and ensnare prey.  Spawns from kudzu flower buds.
+  * Each one has a maximum of four vines, which can be attached to a variety of things.  Carbons are stunned when a vine is attached to them, and all living things are pulled closer over time.
+  * Attempting to attach a vine to something with a vine already attached to it will pull all living things closer on command.
+  * Once the prey is in melee range, melee attacks from the venus human trap heals itself for 10% of its max health, assuming the target is alive.
+  * Akin to certain spiders, venus human traps can also be possessed and controlled by ghosts.
+  *
+  */
 
 /mob/living/simple_animal/hostile/venus_human_trap
 	name = "venus human trap"
 	desc = "Now you know how the fly feels."
 	icon_state = "venus_human_trap"
+	health_doll_icon = "venus_human_trap"
 	layer = SPACEVINE_MOB_LAYER
 	health = 50
 	maxHealth = 50
@@ -62,75 +87,94 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 0
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	faction = list("hostile","vines","plants")
-	var/list/grasping = list()
-	var/list/tethers = list()
-	var/max_grasps = 4
-	var/grasp_chance = 20
-	var/grasp_pull_chance = 85
-	var/grasp_range = 4
 	del_on_death = 1
+	/// A list of all the plant's vines
+	var/list/vines = list()
+	/// The maximum amount of vines a plant can have at one time
+	var/max_vines = 4
+	/// How far away a plant can attach a vine to something
+	var/vine_grab_distance = 5
+	/// Whether or not this plant is ghost possessable
+	var/playable_plant = TRUE
 
-/mob/living/simple_animal/hostile/venus_human_trap/Destroy()
-	for(var/L in grasping)
-		var/datum/beam/B = grasping[L]
-		if(B)
-			qdel(B)
-	for(var/datum/component/tether in tethers)
-		tether.RemoveComponent()
-	grasping = null
-	return ..()
-
-/mob/living/simple_animal/hostile/venus_human_trap/handle_automated_action()
-	if(..())
-		for(var/mob/living/L in grasping)
-			if(L.stat == DEAD)
-				var/datum/beam/B = grasping[L]
-				if(B)
-					B.End()
-				grasping -= L
-
-			//Can attack+pull multiple times per cycle
-			if(L.Adjacent(src))
-				L.attack_animal(src)
-			else
-				if(prob(grasp_pull_chance))
-					setDir(get_dir(src,L) )//staaaare
-					step(L,get_dir(L,src)) //reel them in
-					L.Paralyze(60) //you can't get away now~
-
-		if(length(grasping) < max_grasps)
-			grasping:
-				for(var/mob/living/L in view(grasp_range, src))
-					if(L == src || faction_check_mob(L) || (L in grasping) || L == target)
-						continue
-					for(var/turf/T in getline(src,L))
-						if (T.density)
-							continue grasping
-						for(var/obj/O in T)
-							if(O.density)
-								continue grasping
-					if(prob(grasp_chance))
-						to_chat(L, "<span class='userdanger'>\The [src] has you entangled!</span>")
-						grasping[L] = Beam(L, "vine", time=INFINITY, maxdistance=5, beam_type=/obj/effect/ebeam/vine)
-						tethers += list(L.AddComponent(/datum/component/tether, src, grasp_range+1, /obj/effect/ebeam/vine), AddComponent(/datum/component/tether, L, grasp_range+1, /obj/effect/ebeam/vine))
-						break //only take 1 new victim per cycle
-
+/mob/living/simple_animal/hostile/venus_human_trap/Life(mapload)
+	. = ..()
+	pull_vines()
+	
+/mob/living/simple_animal/hostile/venus_human_trap/AttackingTarget()
+	. = ..()
+	if(isliving(target))
+		var/mob/living/L = target
+		if(L.stat != DEAD)
+			adjustHealth(-maxHealth * 0.1)
 
 /mob/living/simple_animal/hostile/venus_human_trap/OpenFire(atom/the_target)
+	for(var/datum/beam/B in vines)
+		if(B.target == the_target)
+			pull_vines()
+			ranged_cooldown = world.time + (ranged_cooldown_time / 2)
+			return
+	if(get_dist(src,the_target) > vine_grab_distance || vines.len == max_vines)
+		return
 	for(var/turf/T in getline(src,target))
 		if (T.density)
 			return
 		for(var/obj/O in T)
 			if(O.density)
 				return
-	var/dist = get_dist(src,the_target)
-	Beam(the_target, "vine", time=dist*2, maxdistance=dist+2, beam_type=/obj/effect/ebeam/vine)
-	the_target.attack_animal(src)
+	vines += Beam(the_target, "vine", time=INFINITY, maxdistance = vine_grab_distance, beam_type=/obj/effect/ebeam/vine)
+	if(isliving(the_target))
+		var/mob/living/L = the_target
+		L.Paralyze(20)
+	ranged_cooldown = world.time + ranged_cooldown_time
 
+/mob/living/simple_animal/hostile/venus_human_trap/Login()
+	..()
+	to_chat(src, "<span class='boldwarning'>You a venus human trap!  Protect the kudzu at all costs, and feast on those who oppose you!</span>")
 
-/mob/living/simple_animal/hostile/venus_human_trap/CanAttack(atom/the_target)
+/mob/living/simple_animal/hostile/venus_human_trap/attack_ghost(mob/user)
 	. = ..()
 	if(.)
-		if(the_target in grasping)
-			return 0
+		return
+	humanize_plant(user)
+
+/**
+  * Sets a ghost to control the plant if the plant is eligible
+  *
+  * Asks the interacting ghost if they would like to control the plant.
+  * If they answer yes, and another ghost hasn't taken control, sets the ghost to control the plant.
+  * Arguments:
+  * * mob/user - The ghost to possibly control the plant
+  */
+
+/mob/living/simple_animal/hostile/venus_human_trap/proc/humanize_plant(mob/user)
+	if(key || !playable_plant || stat)
+		return
+	var/plant_ask = alert("Become a venus human trap?", "Are you reverse vegan?", "Yes", "No")
+	if(plant_ask == "No" || !src || QDELETED(src))
+		return
+	if(key)
+		to_chat(user, "<span class='warning'>Someone else already took this plant!</span>")
+		return
+	key = user.key
+	log_game("[key_name(src)] took control of [name].")
+
+/**
+  * Manages how the vines should affect the things they're attached to.
+  *
+  * Pulls all living targets of the vines closer to the plant
+  * If the target is on the same tile as the plant, destroy the vine
+  * Removes any QDELETED vines from the vines list.
+  */
+
+/mob/living/simple_animal/hostile/venus_human_trap/proc/pull_vines()
+	for(var/datum/beam/B in vines)
+		if(isliving(B.target))
+			var/mob/living/L = B.target
+			step(L,get_dir(L,src))
+		if(get_dist(src,B.target) == 0)
+			B.End()
+		if(QDELETED(B))
+			vines -= B

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -42,7 +42,7 @@
 	visible_message("<span class='danger'>the plant has borne fruit!</span>")
 	new /mob/living/simple_animal/hostile/venus_human_trap(get_turf(src))
 	qdel(src)
-
+	
 /obj/effect/ebeam/vine
 	name = "thick vine"
 	mouse_opacity = MOUSE_OPACITY_ICON
@@ -122,7 +122,10 @@
 		for(var/obj/O in T)
 			if(O.density)
 				return
-	vines += Beam(the_target, "vine", time=INFINITY, maxdistance = vine_grab_distance, beam_type=/obj/effect/ebeam/vine)
+	
+	var/datum/beam/newVine = Beam(the_target, "vine", time=INFINITY, maxdistance = vine_grab_distance, beam_type=/obj/effect/ebeam/vine)
+	RegisterSignal(newVine, COMSIG_PARENT_QDELETING, .proc/remove_vine, newVine)
+	vines += newVine
 	if(isliving(the_target))
 		var/mob/living/L = the_target
 		L.Paralyze(20)
@@ -173,5 +176,14 @@
 				step(AM,get_dir(AM,src))
 		if(get_dist(src,B.target) == 0)
 			B.End()
-		if(QDELETED(B))
-			vines -= B
+
+/**
+  * Removes a vine from the list.
+  *
+  * Removes the vine from our list.
+  * Called specifically when the vine is about to be destroyed, so we don't have any null references.
+  * Arguments:
+  * * datum/beam/vine - The vine to be removed from the list.
+  */
+mob/living/simple_animal/hostile/venus_human_trap/proc/remove_vine(datum/beam/vine)
+	vines -= vine

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -53,7 +53,7 @@
 /obj/effect/ebeam/vine/Crossed(atom/movable/AM)
 	if(isliving(AM))
 		var/mob/living/L = AM
-		if(!("vines" in L.faction))
+		if(!isvineimmune(L))
 			L.adjustBruteLoss(5)
 			to_chat(L, "<span class='alert'>You cut yourself on the thorny vines.</span>")
 
@@ -63,8 +63,8 @@
   * The result of a kudzu flower bud, these enemies use vines to drag prey close to them for attack.
   *
   * A carnivorious plant which uses vines to catch and ensnare prey.  Spawns from kudzu flower buds.
-  * Each one has a maximum of four vines, which can be attached to a variety of things.  Carbons are stunned when a vine is attached to them, and all living things are pulled closer over time.
-  * Attempting to attach a vine to something with a vine already attached to it will pull all living things closer on command.
+  * Each one has a maximum of four vines, which can be attached to a variety of things.  Carbons are stunned when a vine is attached to them, and movable entities are pulled closer over time.
+  * Attempting to attach a vine to something with a vine already attached to it will pull all movable targets closer on command.
   * Once the prey is in melee range, melee attacks from the venus human trap heals itself for 10% of its max health, assuming the target is alive.
   * Akin to certain spiders, venus human traps can also be possessed and controlled by ghosts.
   *
@@ -78,7 +78,7 @@
 	layer = SPACEVINE_MOB_LAYER
 	health = 50
 	maxHealth = 50
-	ranged = 1
+	ranged = TRUE
 	harm_intent_damage = 5
 	obj_damage = 60
 	melee_damage_lower = 25
@@ -89,7 +89,7 @@
 	unsuitable_atmos_damage = 0
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	faction = list("hostile","vines","plants")
-	del_on_death = 1
+	del_on_death = TRUE
 	/// A list of all the plant's vines
 	var/list/vines = list()
 	/// The maximum amount of vines a plant can have at one time
@@ -164,16 +164,17 @@
 /**
   * Manages how the vines should affect the things they're attached to.
   *
-  * Pulls all living targets of the vines closer to the plant
+  * Pulls all movable targets of the vines closer to the plant
   * If the target is on the same tile as the plant, destroy the vine
   * Removes any QDELETED vines from the vines list.
   */
 
 /mob/living/simple_animal/hostile/venus_human_trap/proc/pull_vines()
 	for(var/datum/beam/B in vines)
-		if(isliving(B.target))
-			var/mob/living/L = B.target
-			step(L,get_dir(L,src))
+		if(ismovableatom(B.target))
+			var/atom/movable/AM = B.target
+			if(!AM.anchored)
+				step(AM,get_dir(AM,src))
 		if(get_dist(src,B.target) == 0)
 			B.End()
 		if(QDELETED(B))

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -166,7 +166,6 @@
   * If the target is on the same tile as the plant, destroy the vine
   * Removes any QDELETED vines from the vines list.
   */
-
 /mob/living/simple_animal/hostile/venus_human_trap/proc/pull_vines()
 	for(var/datum/beam/B in vines)
 		if(istype(B.target, /atom/movable))

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -68,7 +68,6 @@
   * Akin to certain spiders, venus human traps can also be possessed and controlled by ghosts.
   *
   */
-
 /mob/living/simple_animal/hostile/venus_human_trap
 	name = "venus human trap"
 	desc = "Now you know how the fly feels."

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -185,5 +185,5 @@
   * Arguments:
   * * datum/beam/vine - The vine to be removed from the list.
   */
-mob/living/simple_animal/hostile/venus_human_trap/proc/remove_vine(datum/beam/vine)
+mob/living/simple_animal/hostile/venus_human_trap/proc/remove_vine(datum/beam/vine, force)
 	vines -= vine

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -89,6 +89,7 @@
 	unsuitable_atmos_damage = 0
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	faction = list("hostile","vines","plants")
+	initial_language_holder = /datum/language_holder/venus
 	del_on_death = TRUE
 	/// A list of all the plant's vines
 	var/list/vines = list()
@@ -171,7 +172,7 @@
 
 /mob/living/simple_animal/hostile/venus_human_trap/proc/pull_vines()
 	for(var/datum/beam/B in vines)
-		if(ismovableatom(B.target))
+		if(istype(B.target, /atom/movable))
 			var/atom/movable/AM = B.target
 			if(!AM.anchored)
 				step(AM,get_dir(AM,src))

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -112,7 +112,7 @@
 	for(var/datum/beam/B in vines)
 		if(B.target == the_target)
 			pull_vines()
-			ranged_cooldown = world.time + (ranged_cooldown_time / 2)
+			ranged_cooldown = world.time + (ranged_cooldown_time * 0.5)
 			return
 	if(get_dist(src,the_target) > vine_grab_distance || vines.len == max_vines)
 		return

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -129,7 +129,7 @@
 	ranged_cooldown = world.time + ranged_cooldown_time
 
 /mob/living/simple_animal/hostile/venus_human_trap/Login()
-	..()
+	. = ..()
 	to_chat(src, "<span class='boldwarning'>You a venus human trap!  Protect the kudzu at all costs, and feast on those who oppose you!</span>")
 
 /mob/living/simple_animal/hostile/venus_human_trap/attack_ghost(mob/user)

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -8,7 +8,6 @@
   * Once it grows a venus human trap, the bud itself will destroy itself.
   *
   */
-
 /obj/structure/alien/resin/flower_bud_enemy //inheriting basic attack/damage stuff from alien structures
 	name = "flower bud"
 	desc = "A large pulsating plant..."

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -147,7 +147,6 @@
   * Arguments:
   * * mob/user - The ghost to possibly control the plant
   */
-
 /mob/living/simple_animal/hostile/venus_human_trap/proc/humanize_plant(mob/user)
 	if(key || !playable_plant || stat)
 		return


### PR DESCRIPTION
## About The Pull Request

Fixes the currently broken implementation of the venus human trap, a mob spawned by the flowering mutation of kudzu.  They're supposed to attach vines to you and reel you in (I think), but that functionality was entirely busted, only meleeing you with their vines.  Along with this, sentient venus human traps could attack you as fast as they could click, pretty much killing anyone instantly.  So, I completely wiped them and started from scratch, ending up with the following:

Venus Human Trap
- Can attach vines to their targets within a 5-tile radius.
- Vines stun carbons for 2 seconds when first applied, and will attempt to bring the affected closer to the plant.  If the target gets far enough away from the plant or shares the same tile as the plant, the vine will be destroyed.
- If a plant tries to attach a vine to something they already have a vine on, they will reel everything they can towards themselves.  This also happens passively every second.
- Plants heal 10% of their max health when attacking with melee if their target is alive.
- Sentient plants can attach their vines to a wide variety of things, allowing them to take advantage of the damage dealt when walking though them.
- Plants can be possessed by ghosts akin to spiders born from a sentient mother.

Along with all that, I also autodoc'd the whole file as well, as well as fixing the apparently broken feature of kudzu not affecting plant-based creatures (venus human traps and podpeople).

## Why It's Good For The Game

Fixes an entirely broken mechanic to be functional, along with adding a new role for ghosts to possibly take up.

## Changelog
:cl: Indie-ana Jones
balance: Venus Human Traps have mutated to better hunt their prey, becoming smarter and able to attach vines to their prey.
fix: Plant-based creatures being affected by kudzu has been fixed.
/:cl: