### PR TITLE
Hand Tele try place portal ahead of user.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -281,7 +281,7 @@
 	if(trydir)
 		if(AM.Move(get_step(T, trydir)))
 			return TRUE
-	for(var/direction in GLOB.cardinals)
+	for(var/direction in (GLOB.cardinals-trydir))
 		if(AM.Move(get_step(T, direction)))
 			return TRUE
 	return FALSE

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -276,12 +276,15 @@
 	else
 		return 0
 
-
-/proc/try_move_adjacent(atom/movable/AM)
+/proc/try_move_adjacent(atom/movable/AM, trydir)
 	var/turf/T = get_turf(AM)
+	if(trydir)
+		if(AM.Move(get_step(T, trydir)))
+			return TRUE
 	for(var/direction in GLOB.cardinals)
 		if(AM.Move(get_step(T, direction)))
-			break
+			return TRUE
+	return FALSE
 
 /proc/get_mob_by_key(key)
 	var/ckey = ckey(key)

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -203,7 +203,7 @@
 		return
 	RegisterSignal(created[1], COMSIG_PARENT_QDELETING, .proc/on_portal_destroy) //Gosh darn it kevinz.
 	RegisterSignal(created[2], COMSIG_PARENT_QDELETING, .proc/on_portal_destroy)
-	try_move_adjacent(created[1])
+	try_move_adjacent(created[1], user.dir)
 	active_portal_pairs[created[1]] = created[2]
 	var/obj/effect/portal/c1 = created[1]
 	var/obj/effect/portal/c2 = created[2]


### PR DESCRIPTION
## About The Pull Request

Hand Tele try place portal ahead of user.
try_move_adjacent can take desirable dir and return TRUE on succes.

## Why It's Good For The Game

I remember this puts the portal in front of the user,
before something change this.

## Changelog
:cl:
tweak: Hand Tele try place portal ahead of user now.
tweak: try_move_adjacent can take desirable dir
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
