### PR TITLE
golems can now become botanists and virologists AND chefs

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -218,8 +218,8 @@
 		new /datum/data/mining_equipment("Toolbelt",					/obj/item/storage/belt/utility,	    							350),
 		new /datum/data/mining_equipment("Royal Cape of the Liberator", /obj/item/bedsheet/rd/royal_cape, 								500),
 		new /datum/data/mining_equipment("Grey Slime Extract",			/obj/item/slime_extract/grey,									1000),
-		new /datum/data/mining_equipment("MegaSeed Servitor Refill",	/obj/item/vending_refill/hydroseeds,							500),
-		new /datum/data/mining_equipment("Rhinovirus culture bottle",	/obj/item/reagent_containers/glass/bottle/cold,					500),
+		new /datum/data/mining_equipment("MegaSeed Servitor Refill",	/obj/item/vending_refill/hydroseeds,							1000),
+		new /datum/data/mining_equipment("Rhinovirus culture bottle",	/obj/item/reagent_containers/glass/bottle/cold,					1000),
 		new /datum/data/mining_equipment("Modification Kit",    		/obj/item/borg/upgrade/modkit/trigger_guard,					1700),
 		new /datum/data/mining_equipment("The Liberator's Legacy",  	/obj/item/storage/box/rndboards,								2000)
 		)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -218,6 +218,8 @@
 		new /datum/data/mining_equipment("Toolbelt",					/obj/item/storage/belt/utility,	    							350),
 		new /datum/data/mining_equipment("Royal Cape of the Liberator", /obj/item/bedsheet/rd/royal_cape, 								500),
 		new /datum/data/mining_equipment("Grey Slime Extract",			/obj/item/slime_extract/grey,									1000),
+		new /datum/data/mining_equipment("MegaSeed Servitor Refill",	/obj/item/vending_refill/hydroseeds,							500),
+		new /datum/data/mining_equipment("Rhinovirus culture bottle",	/obj/item/reagent_containers/glass/bottle/cold,					500),
 		new /datum/data/mining_equipment("Modification Kit",    		/obj/item/borg/upgrade/modkit/trigger_guard,					1700),
 		new /datum/data/mining_equipment("The Liberator's Legacy",  	/obj/item/storage/box/rndboards,								2000)
 		)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

golem vendor now gets a rhinovirus culture bottle and a seed vendor refill, allowing them to do jobs of botanists, chefs and virologists, both cost 1000 points
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

golems are a really fun lavaland role, the only one thats able to come close to doing what the station can, would be nice for them to be able to do these 3 jobs they couldn't previously
they can already buy a start for a xenobio department with the grey slime and thats a much more powerful department so 2 more starting things shouldnt hurt
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The Golem Ship vendor now has a bottle of rhinovirus and a seed vendor refill, both for 1000 points, allowing you to do more fun stuff!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
