### PR TITLE
Off hand item drop fix

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -100,8 +100,8 @@
 		unwield(user, show_message=TRUE)
 	if(wielded)
 		unwield(user)
-	if(source == offhand_item && !QDELETED(src))
-		qdel(src)
+	if(source == offhand_item && !QDELETED(source))
+		qdel(source)
 
 /// Triggered on attack self of the item containing the component
 /datum/component/two_handed/proc/on_attack_self(datum/source, mob/user)
@@ -300,6 +300,10 @@
 	item_flags = ABSTRACT
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	var/wielded = FALSE // Off Hand tracking of wielded status
+
+/obj/item/offhand/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
 
 /obj/item/offhand/Destroy()
 	wielded = FALSE

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -107,7 +107,7 @@
 /datum/component/two_handed/proc/on_attack_self(datum/source, mob/user)
 	if(wielded)
 		unwield(user)
-	else
+	if(user.is_holding(parent))
 		wield(user)
 
 /**
@@ -117,7 +117,7 @@
  * * user The mob/living/carbon that is wielding the item
  */
 /datum/component/two_handed/proc/wield(mob/living/carbon/user)
-	if(wielded)
+	if(wielded || !istype(user))
 		return
 	if(ismonkey(user))
 		to_chat(user, "<span class='warning'>It's too heavy for you to wield fully.</span>")
@@ -177,7 +177,7 @@
  * * show_message (option) show a message to chat on unwield
  */
 /datum/component/two_handed/proc/unwield(mob/living/carbon/user, show_message=TRUE)
-	if(!wielded || !user)
+	if(!wielded || !istype(user))
 		return
 
 	// wield update status
@@ -266,6 +266,11 @@
 		return
 	if(held_item == parent)
 		return COMPONENT_BLOCK_SWAP
+	// check if we are holding an item with telekinesis, is that item our parent?
+	if(istype(held_item, /obj/item/tk_grab))
+		var/obj/item/tk_grab/tk_item = held_item
+		if (tk_item?.focus == parent)
+			return COMPONENT_BLOCK_SWAP
 
 /**
  * on_sharpen Triggers on usage of a sharpening stone on the item

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -177,7 +177,7 @@
  * * show_message (option) show a message to chat on unwield
  */
 /datum/component/two_handed/proc/unwield(mob/living/carbon/user, show_message=TRUE)
-	if(!wielded || !istype(user))
+	if(!wielded)
 		return
 
 	// wield update status

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -117,7 +117,7 @@
  * * user The mob/living/carbon that is wielding the item
  */
 /datum/component/two_handed/proc/wield(mob/living/carbon/user)
-	if(wielded || !istype(user))
+	if(wielded)
 		return
 	if(ismonkey(user))
 		to_chat(user, "<span class='warning'>It's too heavy for you to wield fully.</span>")
@@ -266,11 +266,6 @@
 		return
 	if(held_item == parent)
 		return COMPONENT_BLOCK_SWAP
-	// check if we are holding an item with telekinesis, is that item our parent?
-	if(istype(held_item, /obj/item/tk_grab))
-		var/obj/item/tk_grab/tk_item = held_item
-		if (tk_item?.focus == parent)
-			return COMPONENT_BLOCK_SWAP
 
 /**
  * on_sharpen Triggers on usage of a sharpening stone on the item

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -107,7 +107,7 @@
 /datum/component/two_handed/proc/on_attack_self(datum/source, mob/user)
 	if(wielded)
 		unwield(user)
-	if(user.is_holding(parent))
+	else if(user.is_holding(parent))
 		wield(user)
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Made the off hand item have the no drop trait and fixed up off hand item deleting the wrong object.

Fixes #49722
Fixes #48966
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The offhand item should not be droppable
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: offhand placeholder should not be droppable
fix: no more holding objects in two hands with your mind
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
