### PR TITLE
caltrops damage you after they send a visible message 

### DIFF
--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -47,7 +47,6 @@
 		var/damage = rand(min_damage, max_damage)
 		if(HAS_TRAIT(H, TRAIT_LIGHT_STEP))
 			damage *= 0.75
-		H.apply_damage(damage, BRUTE, picked_def_zone)
 
 		if(cooldown < world.time - 10) //cooldown to avoid message spam.
 			var/atom/A = parent
@@ -57,6 +56,7 @@
 			else
 				H.visible_message("<span class='danger'>[H] slides on [A]!</span>", \
 						"<span class='userdanger'>You slide on [A]!</span>")
+		H.apply_damage(damage, BRUTE, picked_def_zone)
 
 			cooldown = world.time
 		H.Paralyze(60)

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -56,7 +56,7 @@
 			else
 				H.visible_message("<span class='danger'>[H] slides on [A]!</span>", \
 						"<span class='userdanger'>You slide on [A]!</span>")
-		H.apply_damage(damage, BRUTE, picked_def_zone)
 
 			cooldown = world.time
+		H.apply_damage(damage, BRUTE, picked_def_zone)
 		H.Paralyze(60)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

prevents this

![image](https://user-images.githubusercontent.com/40974010/76033907-428f3700-5ef2-11ea-9af4-24faed6f7fa7.png)


## Why It's Good For The Game

see above

:cl:
fix: caltrop component now sends a visible message before damage instead of the other way around
/:cl:

