### PR TITLE
Adds Weekend at Bernies'ing People

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -115,7 +115,7 @@
 		appears_dead = TRUE
 
 		var/obj/item/clothing/glasses/G = get_item_by_slot(ITEM_SLOT_EYES)
-		var/are_we_in_weekend_at_bernies = G && G.tint && buckled && istype(buckled, /obj/vehicle/ridden/wheelchair)
+		var/are_we_in_weekend_at_bernies = G?.tint && buckled && istype(buckled, /obj/vehicle/ridden/wheelchair)
 
 		if(isliving(user) && (HAS_TRAIT(user, TRAIT_NAIVE) || are_we_in_weekend_at_bernies))
 			just_sleeping = TRUE

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -114,7 +114,10 @@
 	if(stat == DEAD || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))
 		appears_dead = TRUE
 
-		if(isliving(user) && HAS_TRAIT(user, TRAIT_NAIVE))
+		var/obj/item/clothing/glasses/G = get_item_by_slot(ITEM_SLOT_EYES)
+		var/are_we_in_weekend_at_bernies = G && G.tint && buckled && istype(buckled, /obj/vehicle/ridden/wheelchair)
+
+		if(isliving(user) && (HAS_TRAIT(user, TRAIT_NAIVE) || are_we_in_weekend_at_bernies))
 			just_sleeping = TRUE
 
 		if(!just_sleeping)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -106,9 +106,9 @@
 	/// The last known IP of the client who was in this mob
 	var/lastKnownIP = null
 
-	/// movable atoms buckled to this mob
-	var/atom/movable/buckled = null//Living
 	/// movable atom we are buckled to
+	var/atom/movable/buckled = null//Living
+	/// movable atoms buckled to this mob
 	var/atom/movable/buckling
 
 	//Hands


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
[![Photoshop_2020-03-05_19-20-44.png](https://i.imgur.com/qEfOJrQ.png)](https://i.imgur.com/qEfOJrQ.png)
## About The Pull Request
Dead people who are propped up in a wheelchair and wearing sunglasses or some sort of tinted eyewear will just look like they dozed off, allowing you to get into all sorts of hijinx as long as no one questions you too closely.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As much of a meme as this idea is, the thought of moving a dead body through a public space with only the absolute thinnest of cover stories and praying to God no one notices you or walks by with a MedHUD sounds like exactly the kind of desperate bluff SS13's social gameplay thrives on.

Also, there is the distinct possibility that at some point a paraplegic security officer will die in a public place and no one will even realize he's dead until someone walks by with a MedHUD or tries to loot him, which is going to be equal parts tragic and hilarious.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
add: "Holy shit! We just accidentally killed the Captain! Here, uhh... oh god, stuff him in that wheelchair over there, before anyone comes in. Yeah, yeah! Get his sunglasses, cover his face. Oh my god, oh my god, oh my god. No one will be able to tell, he looks sorta fine, right? Right?"
add: You can now Weekend at Bernies dead people with a wheelchair and tinted glasses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
