### PR TITLE
SM Engine area no longer powered by magic

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -44174,10 +44174,6 @@
 	dir = 1;
 	name = "Gas to Filter"
 	},
-/obj/machinery/airalarm/engine{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -47640,13 +47636,13 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "cEw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "cEx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
 /turf/open/floor/engine,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -9950,7 +9950,7 @@
 /turf/open/floor/circuit/green,
 /area/engine/supermatter)
 "axy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -9959,7 +9959,7 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "axA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -13426,9 +13426,6 @@
 /area/engine/atmospherics_engine)
 "aEt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/engine{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -13437,7 +13434,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/engine/supermatter)
+/area/engine/atmospherics_engine)
 "aEu" = (
 /obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -4714,7 +4714,7 @@
 /turf/closed/wall,
 /area/medical/pharmacy)
 "als" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -26997,12 +26997,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/airalarm/engine{
-	pixel_y = 25
-	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/engine/supermatter)
+/area/engine/engine_room)
 "biX" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -50668,7 +50665,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "sYx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
 /turf/open/floor/engine,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -15639,7 +15639,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -73584,7 +73584,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -78888,12 +78888,8 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
 	},
-/obj/machinery/airalarm/engine{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/open/floor/engine,
-/area/engine/supermatter)
+/area/engine/engineering)
 "cpA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -17587,7 +17587,7 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "aNv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/passive_vent,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "aNw" = (
@@ -47863,17 +47863,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/bot/medbot{
-	auto_patrol = 1;
-	desc = "A little medical robot, officially part of the Nanotrasen medical inspectorate. He looks somewhat underwhelmed.";
-	name = "Inspector Johnson"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/mob/living/simple_animal/bot/medbot{
+	auto_patrol = 1;
+	desc = "A little medical robot, officially part of the Nanotrasen medical inspectorate. He looks somewhat underwhelmed.";
+	name = "Inspector Johnson"
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
@@ -53261,16 +53261,12 @@
 	dir = 8;
 	network = list("ss13","engine")
 	},
-/obj/machinery/airalarm/engine{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/engine/supermatter)
+/area/engine/engineering)
 "cpU" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced,
@@ -54051,7 +54047,6 @@
 /area/crew_quarters/heads/cmo)
 "crC" = (
 /obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/Runtime,
 /obj/item/toy/cattoy,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/airalarm{
@@ -54061,6 +54056,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
+/mob/living/simple_animal/pet/cat/Runtime,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
 "crD" = (
@@ -65065,7 +65061,7 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "dbb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -68476,10 +68472,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dzq" = (
-/mob/living/carbon/monkey,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
 "dzI" = (
@@ -72990,8 +72986,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "mfI" = (
-/mob/living/carbon/monkey,
 /obj/structure/cable,
+/mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
 "mha" = (
@@ -76423,10 +76419,10 @@
 /area/medical/medbay/central)
 "ubW" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/mob/living/carbon/monkey,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
+/mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
 "ueg" = (
@@ -77170,13 +77166,13 @@
 	desc = "Presumably placed here by top men.";
 	name = "\improper Ark of the Covenant"
 	},
-/mob/living/simple_animal/pet/dog/corgi{
-	desc = "Make sure you give him plenty of bellyrubs, or he'll melt your skin off.";
-	name = "\improper Keeper of the Ark"
-	},
 /obj/item/toy/clockwork_watch{
 	desc = "An ancient piece of machinery, made from an unknown metal by an unknown maker.";
 	name = "\improper Ancient Relic"
+	},
+/mob/living/simple_animal/pet/dog/corgi{
+	desc = "Make sure you give him plenty of bellyrubs, or he'll melt your skin off.";
+	name = "\improper Keeper of the Ark"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -43980,7 +43980,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -44006,7 +44006,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -50942,7 +50942,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -52127,18 +52127,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"jMt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/machinery/airalarm/engine{
-	pixel_y = 24
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "jMS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/xmastree,
@@ -54279,7 +54267,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -55856,7 +55844,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -56198,7 +56186,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -90579,7 +90567,7 @@ cgY
 uRk
 uRk
 uRk
-jMt
+dWO
 sWj
 bXk
 oex

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -1,8 +1,6 @@
 #define BP_MAX_ROOM_SIZE 300
 
 GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/engine/engineering, \
-															    /area/engine/supermatter, \
-															    /area/engine/atmospherics_engine, \
 															    /area/ai_monitored/turret_protected/ai))
 
 // Gets an atmos isolated contained space


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The typecache_powerfailure_safe_areas contained the SM core areas.

Fixes #49641

This was done (as I understand it) because of issues getting a power terminal and wiring to it, in the SM core.

This is now resolved with passive vents, the vents do not need power and share air and pressure with the room they are in. The basic setup will run on two cans of n2, no modification to the pipes (just turning on pumps), and the basic 3 lasers. This ran for hours without dropping below 96%, yes this is not perfect but it powers the station and is stable, clean up the pipes, change the pumps, and this will run just as well as the old injectors and scrubbers.

On the point of scrubbers and injectors, they added an extra setup step that did do much for intermediate setup, and cause nothing but issues for some beginners. 

Picture, Because
![SM Passive Vents](https://user-images.githubusercontent.com/6491940/76042053-57cb8c00-5f19-11ea-9abc-1e6b4d9bc60f.PNG)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Two less magic powered areas.

Also more interesting SM setups.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Removed magic powered areas
tweak: The SM uses passive vents instead of scrubbers and injectors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
