### PR TITLE
twix cable_bridge

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -377,7 +377,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 ////////////////////////////////
 
 GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restraints", /obj/item/restraints/handcuffs/cable, 15),
-											new/datum/stack_recipe("cable bridge", /obj/structure/cable_bridge, 15)))
+											new/datum/stack_recipe("cable bridge", /obj/structure/cable_bridge, 5)))
 
 /obj/item/stack/cable_coil
 	name = "cable coil"
@@ -579,6 +579,8 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 
 /obj/structure/cable_bridge/wirecutter_act(mob/living/user, obj/item/I)
 	. = ..()
+	if(!(flags_1 & NODECONSTRUCT_1))
+		new /obj/item/stack/cable_coil(get_turf(loc), 5)
 	qdel(src)
 	return TRUE
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -580,7 +580,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 /obj/structure/cable_bridge/wirecutter_act(mob/living/user, obj/item/I)
 	. = ..()
 	if(!(flags_1 & NODECONSTRUCT_1))
-		new /obj/item/stack/cable_coil(get_turf(loc), 5)
+		new /obj/item/stack/cable_coil(drop_location(), 5)
 	qdel(src)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

cable_bridge now cost 5m of cable
slightly smaller then 3 placed cables

cable_bridge now return used cable on destroy

## Why It's Good For The Game

Multilayered powernet - nice.
Cable used in nowhere - bad.

## Changelog
:cl:
tweak: Cable bridge now cost 5m of cable
fix: Cable bridge now return used cable on destroy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
