### PR TITLE
Re-enable full removal of genetic mutations

### DIFF
--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -94,21 +94,20 @@
 
 /datum/mutation/human/proc/on_losing(mob/living/carbon/human/owner)
 	if(owner && istype(owner) && (owner.dna.mutations.Remove(src)))
+		if(text_lose_indication && owner.stat != DEAD)
+			to_chat(owner, text_lose_indication)
+		if(visual_indicators.len)
+			var/list/mut_overlay = list()
+			if(owner.overlays_standing[layer_used])
+				mut_overlay = owner.overlays_standing[layer_used]
+			owner.remove_overlay(layer_used)
+			mut_overlay.Remove(get_visual_indicator())
+			owner.overlays_standing[layer_used] = mut_overlay
+			owner.apply_overlay(layer_used)
+		if(power)
+			owner.RemoveSpell(power)
+			qdel(src)
 		return TRUE
-	. = FALSE
-	if(text_lose_indication && owner.stat != DEAD)
-		to_chat(owner, text_lose_indication)
-	if(visual_indicators.len)
-		var/list/mut_overlay = list()
-		if(owner.overlays_standing[layer_used])
-			mut_overlay = owner.overlays_standing[layer_used]
-		owner.remove_overlay(layer_used)
-		mut_overlay.Remove(get_visual_indicator())
-		owner.overlays_standing[layer_used] = mut_overlay
-		owner.apply_overlay(layer_used)
-	if(power)
-		owner.RemoveSpell(power)
-		qdel(src)
 
 /mob/living/carbon/proc/update_mutations_overlay()
 	return


### PR DESCRIPTION
## About The Pull Request
Partial revert to specific changes in PR #49062 in code/datums/mutations/_mutations.dm

Should resolve issues #49758 and #49762

Code where various genetic visual indicators and powers were removed was completely bypassed by an early return TRUE statement added in #49062. I've done a partial revert to this to enable the functionality again. I've retained the return TRUE statement later on in the logic loop and removed . = FALSE entirely.

I have no clue what the modifications to this code were trying to accomplish other than completely bypassing mutation removal logic. As a result, if this PR is barking up the wrong tree please consign it to the trash can where it belongs.

## Changelog
🆑
Restores the ability for mutations to have their powers and visual effect overlays removed so people can't infinitely stack positive mutations and can actually remove negative mutations.
/🆑
