### PR TITLE
Logs malfunction modules purchases in the feedback database

### DIFF
--- a/code/modules/antagonists/traitor/equipment/module_picker.dm
+++ b/code/modules/antagonists/traitor/equipment/module_picker.dm
@@ -123,3 +123,4 @@
 				action.desc = "[initial(action.desc)] It has [action.uses] use\s remaining."
 				action.UpdateButtonIcon()
 	processing_time -= AM.cost
+	SSblackbox.record_feedback("nested tally", "malfunction_modules_bought", 1, list("[initial(AM.name)]", "[AM.cost]"))


### PR DESCRIPTION
I was surprised this was already not the case, as we practically log all similiar cases, from uplink items bought to changeling power purchases.