### PR TITLE
[UNTESTED] Cyborgs can finally unbuckle people from chairs

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -160,10 +160,4 @@
 
 /obj/machinery/stasis/nap_violation(mob/violator)
 	unbuckle_mob(violator, TRUE)
-
-/obj/machinery/stasis/attack_robot(mob/user)
-	if(Adjacent(user) && occupant)
-		unbuckle_mob(occupant)
-	else
-		..()
 #undef STASIS_TOGGLE_COOLDOWN

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -20,7 +20,7 @@
 			if(user_unbuckle_mob(buckled_mobs[1],user))
 				return 1
 
-///literally just the above extension of attack_hand(), but for silicons instead (with an adjacency check, since attack_robot() doesn't require that)
+//literally just the above extension of attack_hand(), but for silicons instead (with an adjacency check, since attack_robot() doesn't require that)
 /atom/movable/attack_robot(mob/living/user)
 	. = ..()
 	if(.)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -20,6 +20,22 @@
 			if(user_unbuckle_mob(buckled_mobs[1],user))
 				return 1
 
+///literally just the above extension of attack_hand(), but for silicons instead (with an adjacency check, since attack_robot() doesn't require that)
+/atom/movable/attack_robot(mob/living/user)
+	. = ..()
+	if(.)
+		return
+	if(!Adjacent(user))
+		return
+	if(can_buckle && has_buckled_mobs())
+		if(buckled_mobs.len > 1)
+			var/unbuckled = input(user, "Who do you wish to unbuckle?","Unbuckle Who?") as null|mob in sortNames(buckled_mobs)
+			if(user_unbuckle_mob(unbuckled,user))
+				return 1
+		else
+			if(user_unbuckle_mob(buckled_mobs[1],user))
+				return 1
+
 /atom/movable/MouseDrop_T(mob/living/M, mob/living/user)
 	. = ..()
 	return mouse_buckle_handling(M, user)

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -5,14 +5,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 	/obj/item/clothing/head/chameleon/broken \
 	)))
 
-/mob/living/silicon/robot/attack_robot(mob/user)
-	. = ..()
-	if(user == src && has_buckled_mobs() && user.a_intent == INTENT_HELP)
-		for(var/i in buckled_mobs)
-			var/mob/buckmob = i
-			unbuckle_mob(buckmob)
-
-
 /mob/living/silicon/robot/attackby(obj/item/W, mob/user, params)
 	if(W.tool_behaviour == TOOL_WELDER && (user.a_intent != INTENT_HARM || user == src))
 		user.changeNext_move(CLICK_CD_MELEE)


### PR DESCRIPTION
## About The Pull Request

If you click on something adjacent to you without something in your "hand" as a cyborg, you'll unbuckle them from it.

## Why It's Good For The Game

Cyborgs can already unbuckle people from themselves and stasis beds and buckle people to chairs and the like; now it's time to finally let them unbuckle someone from the chair that they've buckled them to without destroying the chair (or deconstructing it with a wrench).

## Changelog
:cl: ATHATH
balance: Cyborgs (and other silicons) can now unbuckle people from chairs, beds, and other objects.
/:cl: