### PR TITLE
Removes the Double Baton 'Tech' / Fixes targeting issues related to the stunbaton

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -89,6 +89,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_XENO_HOST			"xeno_host"	//Tracks whether we're gonna be a baby alien's mummy.
 #define TRAIT_STUNIMMUNE		"stun_immunity"
 #define TRAIT_STUNRESISTANCE    "stun_resistance"
+#define TRAIT_IWASBATONED    	"iwasbatoned" //Anti Dual-baton cooldown bypass exploit.
 #define TRAIT_SLEEPIMMUNE		"sleep_immunity"
 #define TRAIT_PUSHIMMUNE		"push_immunity"
 #define TRAIT_SHOCKIMMUNE		"shock_immunity"

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -225,7 +225,7 @@
 	L.Jitter(20)
 	L.confused = max(confusion_amt, L.confused)
 	L.stuttering = max(8, L.stuttering)
-	L.apply_damage(stamina_loss_amt, STAMINA)
+	L.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)
 
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	addtimer(CALLBACK(src, .proc/apply_stun_effect_end, L), apply_stun_delay)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -217,6 +217,9 @@
 	else
 		if(!deductcharge(cell_hit_cost))
 			return FALSE
+	if(HAS_TRAIT_FROM(L, TRAIT_IWASBATONED, user))
+		to_chat(user, "<span class='danger'>[L] manages to avoid the attack!</span>")
+		return FALSE
 
 	/// After a target is hit, we do a chunk of stamina damage, along with other effects.
 	/// After a period of time, we then check to see what stun duration we give.
@@ -242,6 +245,9 @@
 		H.forcesay(GLOB.hit_appends)
 
 	attack_cooldown_check = world.time + attack_cooldown
+
+	ADD_TRAIT(L, TRAIT_IWASBATONED, user)
+	addtimer(TRAIT_CALLBACK_REMOVE(L, TRAIT_IWASBATONED, user), attack_cooldown)
 
 	return 1
 

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -210,6 +210,9 @@
 /obj/item/melee/baton/proc/baton_effect(mob/living/L, mob/user)
 	if(shields_blocked(L, user))
 		return FALSE
+	if(HAS_TRAIT_FROM(L, TRAIT_IWASBATONED, user)) //no doublebaton abuse anon!
+		to_chat(user, "<span class='danger'>[L] manages to avoid the attack!</span>")
+		return FALSE
 	if(iscyborg(loc))
 		var/mob/living/silicon/robot/R = loc
 		if(!R || !R.cell || !R.cell.use(cell_hit_cost))
@@ -217,10 +220,6 @@
 	else
 		if(!deductcharge(cell_hit_cost))
 			return FALSE
-	if(HAS_TRAIT_FROM(L, TRAIT_IWASBATONED, user))
-		to_chat(user, "<span class='danger'>[L] manages to avoid the attack!</span>")
-		return FALSE
-
 	/// After a target is hit, we do a chunk of stamina damage, along with other effects.
 	/// After a period of time, we then check to see what stun duration we give.
 	L.Jitter(20)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You now have to obey the cooldown of chain hitting as it was designed while still allowing for multi-user chainstunning.

Also fixes an issue with stun baton targeting.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It seems like (is) an oversight, as the cooldown's purpose is to avoid repeated attacks from the player without having to infringe on the stunner's next_move (IE so they can follow up with cuffs).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Cobby
balance: You will tend to miss attacks if trying to stun someone with a baton recently after using a different baton to stun them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
