### PR TITLE
Fixes pacifist cqc neck grab bug

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -200,7 +200,7 @@
 		to_chat(A, "<span class='danger'>You put [D] into a chokehold!</span>")
 		D.SetSleeping(400)
 		restraining = FALSE
-		if(A.grab_state < GRAB_NECK)
+		if(A.grab_state < GRAB_NECK && !HAS_TRAIT(A, TRAIT_PACIFISM))
 			A.setGrabState(GRAB_NECK)
 	else
 		restraining = FALSE


### PR DESCRIPTION
## About The Pull Request

Adds a check for pacifism before upgrading to a neck grab via chokehold combo.

## Why It's Good For The Game

Removes the ability for pacifists to use CQC to get into a neck grab, without removing the nonharmful parts of the chokehold combo.
This prevents pacifists from headslamming people through tables without removing a very powerful nonharmful de-escalation tool. 

## Changelog
:cl:
fix: Pacifists trained in CQC will no longer automatically upgrade their aggressive grab to a neck grab when putting someone into a chokehold
/:cl: