### PR TITLE
Fixes Strange Reagent not working when the holder is empty

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -529,7 +529,23 @@
 		clear_fullscreen("brute")
 
 //Proc used to resuscitate a mob, for full_heal see fully_heal()
-/mob/living/proc/revive(full_heal = FALSE, admin_revive = FALSE)
+/mob/living/proc/revive(full_heal = FALSE, admin_revive = FALSE, excess_healing = 0)
+	if(excess_healing)
+		if(iscarbon(src) && excess_healing)
+			var/mob/living/carbon/C = src
+			if(!(C.dna?.species && (NOBLOOD in C.dna.species.species_traits)))
+				C.blood_volume += (excess_healing*2)//1 excess = 10 blood
+
+			for(var/i in C.internal_organs)
+				var/obj/item/organ/O = i
+				if(O.organ_flags & ORGAN_SYNTHETIC)
+					continue
+				O.applyOrganDamage(excess_healing*-1)//1 excess = 5 organ damage healed
+
+		adjustOxyLoss(-20, TRUE)
+		adjustToxLoss(-20, TRUE) //slime friendly
+		updatehealth()
+		grab_ghost()
 	SEND_SIGNAL(src, COMSIG_LIVING_REVIVE, full_heal, admin_revive)
 	if(full_heal)
 		fully_heal(admin_revive = admin_revive)
@@ -548,6 +564,9 @@
 			for(var/S in mind.spell_list)
 				var/obj/effect/proc_holder/spell/spell = S
 				spell.updateButtonIcon()
+		if(excess_healing)
+			emote("gasp")
+			log_combat(src, src, "revived")
 
 /mob/living/proc/remove_CC(should_update_mobility = TRUE)
 	SetStun(0, FALSE)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -736,32 +736,11 @@
 	M.visible_message("<span class='warning'>[M]'s body starts convulsing!</span>")
 	M.notify_ghost_cloning("Your body is being revived with Strange Reagent!")
 	M.do_jitter_animation(10)
+	var/excess_healing = 5*(reac_volume-amount_to_revive) //excess reagent will heal blood and organs across the board
 	addtimer(CALLBACK(M, /mob/living/carbon.proc/do_jitter_animation, 10), 40) //jitter immediately, then again after 4 and 8 seconds
 	addtimer(CALLBACK(M, /mob/living/carbon.proc/do_jitter_animation, 10), 80)
-	addtimer(CALLBACK(src, .proc/do_strange_revive,M,reac_volume,amount_to_revive), 79) //timing is everything!
+	addtimer(CALLBACK(M, /mob/living.proc/revive, FALSE, FALSE, excess_healing), 79)
 	..()
-
-/datum/reagent/medicine/strange_reagent/proc/do_strange_revive(mob/living/M,reac_volume,revive_requirement) //we store revive_requirement because if we calculate it now we might have changed our damage numbers.
-	var/excess_healing = 5*(reac_volume-revive_requirement) //excess reagent will heal blood and organs across the board
-	if(iscarbon(M) && excess_healing)
-		var/mob/living/carbon/C = M
-		if(!(C.dna?.species && (NOBLOOD in C.dna.species.species_traits)))
-			C.blood_volume += (excess_healing*2)//1 excess = 10 blood
-
-		for(var/i in C.internal_organs)
-			var/obj/item/organ/O = i
-			if(O.organ_flags & ORGAN_SYNTHETIC)
-				continue
-			O.applyOrganDamage(excess_healing*-1)//1 excess = 5 organ damage healed
-
-	M.adjustOxyLoss(-20, TRUE)
-	M.adjustToxLoss(-20, TRUE) //slime friendly
-	M.updatehealth()
-	M.grab_ghost()
-	if(M.revive(full_heal = FALSE, admin_revive = FALSE))
-		M.emote("gasp")
-		log_combat(M, M, "revived", src)
-
 
 /datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/carbon/M)
 	var/damage_at_random = rand(0,250)/100 //0 to 2.5


### PR DESCRIPTION
## About The Pull Request

Fixes #49502 which was caused by #49082, the sleep call was turned into a callback on the reagent stored in the holder, which meant that if the reagent was completely destroyed, the callback would well not call back.

This returns the callback to a sleep

## Why It's Good For The Game

People can use SR consistently now, and the nightmares will cease.

## Changelog
:cl: LemonInTheDark: applying head to wall, ArcaneDefence: doing the brunt of the debugging and work
fix: Fixes Strange Reagent's inconsistent revival.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
