### PR TITLE
Various fixes to Genetics codebase and DNA Consoles

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -86,13 +86,18 @@
 		if(A.used)
 			to_chat(user,"<span class='notice'>Recycled [I].</span>")
 			if(A.research)
-				var/c_typepath = generate_chromosome()
-				var/obj/item/chromosome/CM = new c_typepath (drop_location())
-				to_chat(user,"<span class='notice'>Recycled [I].</span>")
-				if((LAZYLEN(stored_chromosomes) < max_chromosomes) && prob(60))
-					CM.forceMove(src)
-					stored_chromosomes += CM
-					to_chat(user,"<span class='notice'>[capitalize(CM.name)] added to storage.</span>")
+				if(prob(60))
+					var/c_typepath = generate_chromosome()
+					var/obj/item/chromosome/CM = new c_typepath (drop_location())
+					if(LAZYLEN(stored_chromosomes) < max_chromosomes)
+						CM.forceMove(src)
+						stored_chromosomes += CM
+						to_chat(user,"<span class='notice'>[capitalize(CM.name)] added to storage.</span>")
+					else
+						to_chat(user, "<span class='warning'>You cannot store any more chromosomes!</span>")
+						to_chat(user, "<span class='notice'>[capitalize(CM.name)] added on top of the console.</span>")
+				else
+					to_chat(user, "<span class='notice'>There was not enough genetic data to extract a viable chromosome.</span>")
 			qdel(I)
 			return
 
@@ -877,13 +882,13 @@
 				else
 					to_chat(usr, "<span class='warning'>Not enough space to store potential mutation.</span>")
 		if("ejectchromosome")
-			if(LAZYLEN(stored_chromosomes) <= num)
+			if(LAZYLEN(stored_chromosomes) >= num)
 				var/obj/item/chromosome/CM = stored_chromosomes[num]
 				CM.forceMove(drop_location())
 				adjust_item_drop_location(CM)
 				stored_chromosomes -= CM
 		if("applychromosome")
-			if(viable_occupant && (LAZYLEN(viable_occupant.dna.mutations) <= num))
+			if(viable_occupant && (LAZYLEN(viable_occupant.dna.mutations) >= num))
 				var/datum/mutation/human/HM = viable_occupant.dna.mutations[num]
 				var/list/chromosomes = list()
 				for(var/obj/item/chromosome/CM in stored_chromosomes)
@@ -920,7 +925,7 @@
 					var/datum/mutation/human/HM = B
 					if(HM.type == mutation)
 						true_selection -= HM
-					break
+						break
 
 		if("remove_advinjector")
 			var/selection = href_list["injector"]

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -513,6 +513,7 @@
 	if(M.has_dna() && !HAS_TRAIT(M, TRAIT_RADIMMUNE) && !HAS_TRAIT(M, TRAIT_BADDNA))
 		M.radiation += rand(20/(damage_coeff  ** 2),50/(damage_coeff  ** 2))
 		var/log_msg = "[key_name(user)] injected [key_name(M)] with the [name]"
+		var/pref = ""
 		for(var/mutation in add_mutations)
 			var/datum/mutation/human/HM = mutation
 			if(istype(HM, /datum/mutation/human))
@@ -522,13 +523,14 @@
 					log_msg += "(FAILED)"
 				else
 					M.dna.add_mutation(HM, MUT_EXTRA)
-					name = "expended [name]"
+					pref = "expended"
 			else if(research && M.client)
 				filled = TRUE
-				name = "filled [name]"
+				pref = "filled"
 			else
-				name = "expended [name]"
+				pref = "expended"
 			log_msg += "([mutation])"
+		name = "[pref] [name]"
 		log_attack("[log_msg] [loc_name(user)]")
 		return TRUE
 	return FALSE


### PR DESCRIPTION
## Issues Fixed
Fixes #47907

## Change 1
Added a single tab to code/game/machinery/computer/dna_console.dm to restore broken functionality due to incorrectly indented break in a for loop.

The broken functionality is removing mutations from the stored list of mutations within an Advanced Injector. Due to the incorrectly indented break at line 923, the for loop only ever looks at the first mutator stored in the Advanced Injector list and will always immediately break on the first iteration.

This resulted in only being able to remove mutations from advanced injectors as if you were popping them off a stack rather than being able to remove specific mutations as per what the UI and code indicate you should be able to do.

Indenting the break into the comparitive if statement instead of the for loop now restores that functionality. The for loop will now only break if it finds the relevant mutation stored in the advanced injector and removes it, which should restore the expected functionality.

## Change 2
Advanced Injectors would have an "expended" prefix added for every mutation due to them being renamed in a for loop, leading to "expanded expanded expanded expanded expanded advanced Lots Of Negative Traits injector".

Added a simple fix where the actual renaming code is only called once the for loop finishes and the appropriate prefix is set in the for loop. Inelegant but saves refactoring the entire loop/code.

## Change 3
Chromosomes used to only be able to be removed in, quoting the wiki, the following manner:

>Clicking on the last chromosome in the mutations tab will eject it into its physical form.

The code to eject arbitrary chromosomes was there, however an incorrect comparison operator meant only the last chromosome could be ejected. This has now been fixed by turning if(LAZYLEN(stored_chromosomes) <= num) into if(LAZYLEN(stored_chromosomes) >= num).

**This change will require a wiki update as this changes wiki-documented DNA Scanner functionality - https://tgstation13.org/wiki/Guide_to_genetics#Chromosome_21**

## Change 4
Fixes #47907

The code handling inserting used activators (aka research injectors) into DNA Consoles was written by someone highly under the influence of alcohol.

The code printed a recycled message, generated a chromosome, printed a second recycled message then had a 60% chance of inserting the chromosome into the DNA Console and a 40% chance of leaving it on the floor.

Now when recyling used activators, it prints a single recycled message, there's a 60% chance of creating a chromosome, the chromosome will be pushed into the DNA Console unless the DNA Console is full. If the DNA Console is full, an additional message will be generated notifying the player and new text stating the chromosome is added on top of the console is also present. Finally, if the 60% chance to create a chromosome fails, there's a another new message informing the user about it.

This change was done for the following reasons - It looks like it was intended for there to be a 60% chance of a used activator generating a chromosome. I refactored the code to implement this and added additional feedback where necessary to alert of any failures (to add to the DNA Console because it's full of chromosomes already and for failure to create a chromosome at all).

This represents a slight nerf to genetics, although in practice there are plenty of easy methods to generate all the chromosomes you'll ever need in 10 minutes.

**This change will require a wiki update as this changes wiki-documented chromosome generation functionality - https://tgstation13.org/wiki/Guide_to_genetics#Chromosome_21**

## Change 5
Fixes #47907

Similar issue to Change 3. The same logic error elsewhere in the code prevented adding chromosomes to mutations other than the last one. This is fixed.

## Changelog
🆑
fix: DNA Consoles have had a firmware update. Mutations can once again be removed properly from the selection list of Advanced Injectors and chromosomes can be removed from storage in any order.
fix: Advanced Injectors no longer super-hyper-mega-ultra-expend themselves and will now only expend themselves once.
fix: Genetic data from used Mutation Activators may now be too limited to extract a new chromosome at DNA Consoles.
fix: Chromosomes now always insert themselves into DNA Consoles when created, unless the console storage buffer is full in which case the chromosome is left on top of the console. There are now additional feedback messages during this process to keep the user informed.
fix: Chromosomes can now be added to all activated mutations on a test subject using the DNA Console instead of just the last activated mutation in the list.
/🆑 