### PR TITLE
fixes toy dualsabers gaining damage

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -23,7 +23,7 @@
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
-	var/real = TRUE
+	var/two_hand_force = 34
 	var/hacked = FALSE
 	var/brightness_on = 6 //TWICE AS BRIGHT AS A REGULAR ESWORD
 	var/list/possible_colors = list("red", "blue", "green", "purple")
@@ -31,9 +31,7 @@
 
 /obj/item/dualsaber/ComponentInitialize()
 	. = ..()
-	if(real)
-		AddComponent(/datum/component/two_handed, force_unwielded=3, force_wielded=34, \
-						wieldsound='sound/weapons/saberon.ogg', unwieldsound='sound/weapons/saberoff.ogg')
+	AddComponent(/datum/component/two_handed, force_unwielded=force, force_wielded=two_hand_force, wieldsound='sound/weapons/saberon.ogg', unwieldsound='sound/weapons/saberoff.ogg')
 
 /// Triggered on wield of two handed item
 /// Specific hulk checks due to reflection chance for balance issues and switches hitsounds.

--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -23,6 +23,7 @@
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
+	var/real = TRUE
 	var/hacked = FALSE
 	var/brightness_on = 6 //TWICE AS BRIGHT AS A REGULAR ESWORD
 	var/list/possible_colors = list("red", "blue", "green", "purple")
@@ -30,8 +31,9 @@
 
 /obj/item/dualsaber/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded=3, force_wielded=34, \
-					wieldsound='sound/weapons/saberon.ogg', unwieldsound='sound/weapons/saberoff.ogg')
+	if(real)
+		AddComponent(/datum/component/two_handed, force_unwielded=3, force_wielded=34, \
+						wieldsound='sound/weapons/saberon.ogg', unwieldsound='sound/weapons/saberoff.ogg')
 
 /// Triggered on wield of two handed item
 /// Specific hulk checks due to reflection chance for balance issues and switches hitsounds.

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -394,14 +394,8 @@
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 5
-	real = FALSE
+	two_hand_force = 0
 	attack_verb = list("attacked", "struck", "hit")
-
-/obj/item/dualsaber/toy/ComponentInitialize()
-	. = ..()
-	if(!real)
-		AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=0, \
-					wieldsound='sound/weapons/saberon.ogg', unwieldsound='sound/weapons/saberoff.ogg')
 
 /obj/item/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	return 0

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -394,11 +394,14 @@
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 5
+	real = FALSE
 	attack_verb = list("attacked", "struck", "hit")
 
 /obj/item/dualsaber/toy/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, wieldsound='sound/weapons/saberon.ogg', unwieldsound='sound/weapons/saberoff.ogg')
+	if(!real)
+		AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=0, \
+					wieldsound='sound/weapons/saberon.ogg', unwieldsound='sound/weapons/saberoff.ogg')
 
 /obj/item/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	return 0


### PR DESCRIPTION
Got me a much cleaner fix for the dualsaber toy problem. Long story short, the toy version of the saber was inheriting the twohanded component, including damage, from the real dualsaber (as the toy is a subtype). Which means that as soon as it was turned on, it would gain the 34 force.

This keeps spinning and flipping intact too, it only fixes the damage.

🆑 Unit2E
fix: Fixes the toy version of the dual esword becoming almost-real when turned on.
/🆑