### PR TITLE
Fixes #49763 where prosthetic arms were broken but undamaged on round start.

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -369,8 +369,9 @@
 		if(BODY_ZONE_R_LEG)
 			prosthetic = new/obj/item/bodypart/r_leg/robot/surplus(quirk_holder)
 			slot_string = "right leg"
-	prosthetic.replace_limb(H)
+	old_part.drop_limb(1)
 	qdel(old_part)
+	prosthetic.replace_limb(H)
 	H.regenerate_icons()
 
 /datum/quirk/prosthetic_limb/post_add()


### PR DESCRIPTION
## About The Pull Request

Fix to resolve issue #49763 

Functionality was broken in PR #49062 when modifying code/modules/surgery/bodyparts/dismemberment.dm at line 263

Prior to the above PR, old limbs were dropped before new ones were attached.

The above PR now allows limb attachment to fail, and thus moved limb dropping to after the limb attachment was successfully completed. This is a sound, logical change - From a game logic perspective you want to make sure the procedure is successful before you start lopping off old limbs.

When I reverted this code change in private testing, quirk prosthetics worked again. However, rather than revert this PR's change as I'm unsure if any systems rely on this new functionality, I have opted to make the prosthetic quirk on_spawn sever and destroy the limb of choice itself prior to adding the prosthetic, resolving this new incompatibility, I believe, gracefully. This seemed to resolve the issue in my internal testing.

## Changelog
🆑 
Fix: Roundstart prosthetic owners can once again use their surplus limbs without visiting robotics.
/🆑 