### PR TITLE
Fixes #49763 - Quirk arm prosthetics and arm augmentations not working

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -90,8 +90,11 @@
 	C.bodyparts -= src
 
 	if(held_index)
-		C.dropItemToGround(owner.get_item_for_held_index(held_index), 1)
-		C.hand_bodyparts[held_index] = null
+		if(C.hand_bodyparts[held_index] == src)
+			// We only want to do this if the limb being removed is the active hand part.
+			// This catches situations where limbs are "hot-swapped" such as augmentations and roundstart prosthetics.
+			C.dropItemToGround(owner.get_item_for_held_index(held_index), 1)
+			C.hand_bodyparts[held_index] = null
 
 	owner = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #49763
Fixes #49777 alongside the minor fix for Outbomb Cuban Pete on NTOS devices in PR #49823

Functionality was broken in PR #49062 when modifying code/modules/surgery/bodyparts/dismemberment.dm at line 263

Prior to the above PR, old limbs were dropped before new ones were attached.

The above PR now allows limb attachment to fail, and thus moved limb dropping to after the limb attachment was successfully completed. This is a sound, logical change - From a game logic perspective you want to make sure the procedure is successful before you start lopping off old limbs.

This introducd a new logical error, though. Prior to the above PR the logic flow for "limb replacements" such as augmenting and quirk prosthetics went DROP OLD LIMB -> ATTACH NEW LIMB. Removing the old limb would null the appropriate hand_bodyparts and then attaching the new limb would set it as appropriate.

These two were switched to ATTEMPT TO ATTACH NEW LIMB -> IF IT WORKED, DROP OLD LIMB. This change makes sense in the logic context of only wanting to remove the old limb when adding the new limb succeeds. I didn't want to revert this and break this new potential functionality.

The problem is that IF IT WORKED, DROP OLD LIMB would null the appropriate hand_bodyparts AFTER it had been set in ATTEMPT TO ATTACH NEW LIMB.

This caused phantom limbs - In testing, my VV would show the quirk prosthetic however my character would act as if their limb had been amputated. The hand_bodyparts index showed null. When I manually set the Atom Reference to the phantom prosthetic part, everything worked as it should have from the start.

The change is short, simple and commented. When nulling hand_bodyparts, there's an additional check added that makes sure the limb being removed is ALSO the hand_bodypart. If it isn't, it skips the logic that nulls the hand_bodypart and drops held items.

I have done limited testing on my own server and it appears to resolve the relevant issues, but I'm not an SS13 veteran and a I'm certainly a BYOND coding novice.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
🆑 
fix: Augmentations can now be successfully completed without creating phantom limbs and forcing amputations.
fix: Roundstart Quirk Prosthetic arms should now function correctly and not act as if your arm is amputated.
/🆑 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
