### PR TITLE
[READY] Cyborgs can finally unbuckle people from chairs

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -326,7 +326,7 @@ Class Procs:
 		if(buckled_mobs.len > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?","Unbuckle Who?") as null|mob in sortNames(buckled_mobs)
 			if(user_unbuckle_mob(unbuckled,user))
-				return 1
+				return TRUE
 		else
 			if(user_unbuckle_mob(buckled_mobs[1],user))
 				return 1

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -322,6 +322,14 @@ Class Procs:
 /obj/machinery/attack_robot(mob/user)
 	if(!(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON) && !IsAdminGhost(user))
 		return FALSE
+	if(Adjacent(user) && can_buckle && has_buckled_mobs()) //so that borgs (but not AIs, sadly (perhaps in a future PR?)) can unbuckle people from machines
+		if(buckled_mobs.len > 1)
+			var/unbuckled = input(user, "Who do you wish to unbuckle?","Unbuckle Who?") as null|mob in sortNames(buckled_mobs)
+			if(user_unbuckle_mob(unbuckled,user))
+				return 1
+		else
+			if(user_unbuckle_mob(buckled_mobs[1],user))
+				return 1
 	return _try_interact(user)
 
 /obj/machinery/attack_ai(mob/user)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -329,7 +329,7 @@ Class Procs:
 				return TRUE
 		else
 			if(user_unbuckle_mob(buckled_mobs[1],user))
-				return 1
+				return TRUE
 	return _try_interact(user)
 
 /obj/machinery/attack_ai(mob/user)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -158,6 +158,13 @@
 	. = ..()
 	return default_deconstruction_crowbar(I) || .
 
+//for some reason, in testing, cyborgs were unable to unbuckle people from stasis beds unless this extension of attack_robot() here was present, so I guess it stays in
+/obj/machinery/stasis/attack_robot(mob/user)
+	if(Adjacent(user) && occupant)
+		unbuckle_mob(occupant)
+	else
+		..()
+
 /obj/machinery/stasis/nap_violation(mob/violator)
 	unbuckle_mob(violator, TRUE)
 #undef STASIS_TOGGLE_COOLDOWN

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -160,10 +160,4 @@
 
 /obj/machinery/stasis/nap_violation(mob/violator)
 	unbuckle_mob(violator, TRUE)
-
-/obj/machinery/stasis/attack_robot(mob/user)
-	if(Adjacent(user) && occupant)
-		unbuckle_mob(occupant)
-	else
-		..()
 #undef STASIS_TOGGLE_COOLDOWN

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -160,4 +160,5 @@
 
 /obj/machinery/stasis/nap_violation(mob/violator)
 	unbuckle_mob(violator, TRUE)
+
 #undef STASIS_TOGGLE_COOLDOWN

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -158,13 +158,6 @@
 	. = ..()
 	return default_deconstruction_crowbar(I) || .
 
-//for some reason, in testing, cyborgs were unable to unbuckle people from stasis beds unless this extension of attack_robot() here was present, so I guess it stays in
-/obj/machinery/stasis/attack_robot(mob/user)
-	if(Adjacent(user) && occupant)
-		unbuckle_mob(occupant)
-	else
-		..()
-
 /obj/machinery/stasis/nap_violation(mob/violator)
 	unbuckle_mob(violator, TRUE)
 #undef STASIS_TOGGLE_COOLDOWN

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -20,7 +20,7 @@
 			if(user_unbuckle_mob(buckled_mobs[1],user))
 				return 1
 
-///literally just the above extension of attack_hand(), but for silicons instead (with an adjacency check, since attack_robot() doesn't require that)
+//literally just the above extension of attack_hand(), but for silicons instead (with an adjacency check, since attack_robot() doesn't require that)
 /atom/movable/attack_robot(mob/living/user)
 	. = ..()
 	if(.)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -29,7 +29,7 @@
 		if(buckled_mobs.len > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?","Unbuckle Who?") as null|mob in sortNames(buckled_mobs)
 			if(user_unbuckle_mob(unbuckled,user))
-				return 1
+				return TRUE
 		else
 			if(user_unbuckle_mob(buckled_mobs[1],user))
 				return 1

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -20,6 +20,22 @@
 			if(user_unbuckle_mob(buckled_mobs[1],user))
 				return 1
 
+///literally just the above extension of attack_hand(), but for silicons instead (with an adjacency check, since attack_robot() doesn't require that)
+/atom/movable/attack_robot(mob/living/user)
+	. = ..()
+	if(.)
+		return
+	if(!Adjacent(user))
+		return
+	if(can_buckle && has_buckled_mobs())
+		if(buckled_mobs.len > 1)
+			var/unbuckled = input(user, "Who do you wish to unbuckle?","Unbuckle Who?") as null|mob in sortNames(buckled_mobs)
+			if(user_unbuckle_mob(unbuckled,user))
+				return 1
+		else
+			if(user_unbuckle_mob(buckled_mobs[1],user))
+				return 1
+
 /atom/movable/MouseDrop_T(mob/living/M, mob/living/user)
 	. = ..()
 	return mouse_buckle_handling(M, user)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -20,14 +20,12 @@
 			if(user_unbuckle_mob(buckled_mobs[1],user))
 				return 1
 
-//literally just the above extension of attack_hand(), but for silicons instead (with an adjacency check, since attack_robot() doesn't require that)
+//literally just the above extension of attack_hand(), but for silicons instead (with an adjacency check, since attack_robot() being called doesn't mean that you're adjacent to something)
 /atom/movable/attack_robot(mob/living/user)
 	. = ..()
 	if(.)
 		return
-	if(!Adjacent(user))
-		return
-	if(can_buckle && has_buckled_mobs())
+	if(Adjacent(user) && can_buckle && has_buckled_mobs())
 		if(buckled_mobs.len > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?","Unbuckle Who?") as null|mob in sortNames(buckled_mobs)
 			if(user_unbuckle_mob(unbuckled,user))

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -32,7 +32,7 @@
 				return TRUE
 		else
 			if(user_unbuckle_mob(buckled_mobs[1],user))
-				return 1
+				return TRUE
 
 /atom/movable/MouseDrop_T(mob/living/M, mob/living/user)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -5,14 +5,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 	/obj/item/clothing/head/chameleon/broken \
 	)))
 
-/mob/living/silicon/robot/attack_robot(mob/user)
-	. = ..()
-	if(user == src && has_buckled_mobs() && user.a_intent == INTENT_HELP)
-		for(var/i in buckled_mobs)
-			var/mob/buckmob = i
-			unbuckle_mob(buckmob)
-
-
 /mob/living/silicon/robot/attackby(obj/item/W, mob/user, params)
 	if(W.tool_behaviour == TOOL_WELDER && (user.a_intent != INTENT_HARM || user == src))
 		user.changeNext_move(CLICK_CD_MELEE)


### PR DESCRIPTION
## About The Pull Request

If you click on something adjacent to you without something in your "hand" as a cyborg, you'll unbuckle them from it.

## Why It's Good For The Game

Cyborgs can already unbuckle people from themselves and stasis beds and buckle people to chairs and the like; now it's time to finally let them unbuckle someone from the chair that they've buckled them to without destroying the chair (or deconstructing it with a wrench).

## Changelog
:cl: ATHATH
balance: Cyborgs (and other silicons) can now unbuckle people from chairs, beds, and other objects.
/:cl: