### PR TITLE
Adds a customizable "seed" to posibrains to tell ghosts what the posibrain will be used for

### DIFF
--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -172,7 +172,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 		. += "[dead_message]"
 		if(ask_role)
 			. += "<span class='notice'>Current consciousness seed: \"[ask_role]\"</span>"
-		. += "<span class='boldnotice'>Alt-click to set a consciousness seed, specifying what [src] will be used for. This can help generate a personality in that role.</span>"
+		. += "<span class='boldnotice'>Alt-click to set a consciousness seed, specifying what [src] will be used for. This can help generate a personality interested in that role.</span>"
 
 /obj/item/mmi/posibrain/Initialize()
 	. = ..()

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -6,27 +6,36 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "posibrain"
 	w_class = WEIGHT_CLASS_NORMAL
-	var/next_ask
-	var/askDelay = 600 //one minute
+	var/ask_role = "" ///Can be set to tell ghosts what the brain will be used for
+	var/next_ask ///World time tick when ghost polling will be available again
+	var/askDelay = 600 ///Delay after polling ghosts
 	var/searching = FALSE
 	brainmob = null
 	req_access = list(ACCESS_ROBOTICS)
 	mecha = null//This does not appear to be used outside of reference in mecha.dm.
 	braintype = "Android"
-	var/autoping = TRUE //if it pings on creation immediately
+	var/autoping = TRUE ///If it pings on creation immediately
+	///Message sent to the user when polling ghosts
 	var/begin_activation_message = "<span class='notice'>You carefully locate the manual activation switch and start the positronic brain's boot process.</span>"
+	///Message sent as a visible message on success
 	var/success_message = "<span class='notice'>The positronic brain pings, and its lights start flashing. Success!</span>"
+	///Message sent as a visible message on failure
 	var/fail_message = "<span class='notice'>The positronic brain buzzes quietly, and the golden lights fade away. Perhaps you could try again?</span>"
+	///Role assigned to the newly created mind
 	var/new_role = "Positronic Brain"
+	///Message sent to the player possessing the brain
 	var/welcome_message = "<span class='warning'>ALL PAST LIVES ARE FORGOTTEN.</span>\n\
 	<b>You are a positronic brain, brought into existence aboard Space Station 13.\n\
 	As a synthetic intelligence, you answer to all crewmembers and the AI.\n\
 	Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>"
+	///Visible message sent when a player possesses the brain
 	var/new_mob_message = "<span class='notice'>The positronic brain chimes quietly.</span>"
+	///Examine message when the posibrain has no mob
 	var/dead_message = "<span class='deadsay'>It appears to be completely inactive. The reset light is blinking.</span>"
+	///Examine message when the posibrain cannot poll ghosts due to cooldown
 	var/recharge_message = "<span class='warning'>The positronic brain isn't ready to activate again yet! Give it some time to recharge.</span>"
-	var/list/possible_names //If you leave this blank, it will use the global posibrain names
-	var/picked_name
+	var/list/possible_names ///One of these names is randomly picked as the posibrain's name on possession. If left blank, it will use the global posibrain names
+	var/picked_name ///Picked posibrain name
 
 /obj/item/mmi/posibrain/Topic(href, href_list)
 	if(href_list["activate"])
@@ -34,9 +43,10 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 		if(istype(ghost))
 			activate(ghost)
 
+///Notify ghosts that the posibrain is up for grabs
 /obj/item/mmi/posibrain/proc/ping_ghosts(msg, newlymade)
 	if(newlymade || GLOB.posibrain_notify_cooldown <= world.time)
-		notify_ghosts("[name] [msg] in [get_area(src)]!", ghost_sound = !newlymade ? 'sound/effects/ghost2.ogg':null, notify_volume = 75, enter_link = "<a href=?src=[REF(src)];activate=1>(Click to enter)</a>", source = src, action = NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_POSIBRAIN, notify_suiciders = FALSE)
+		notify_ghosts("[name] [msg] in [get_area(src)]! [ask_role ? "Personality requested: \[[ask_role]\]" : ""]", ghost_sound = !newlymade ? 'sound/effects/ghost2.ogg':null, notify_volume = 75, enter_link = "<a href=?src=[REF(src)];activate=1>(Click to enter)</a>", source = src, action = NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_POSIBRAIN, notify_suiciders = FALSE)
 		if(!newlymade)
 			GLOB.posibrain_notify_cooldown = world.time + askDelay
 
@@ -57,6 +67,16 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	update_icon()
 	addtimer(CALLBACK(src, .proc/check_success), askDelay)
 
+/obj/item/mmi/posibrain/AltClick(mob/living/user)
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
+		return
+	var/input_seed = stripped_input(user, "Enter a personality seed", "Enter seed", ask_role)
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
+		return
+	if(input_seed)
+		ask_role = input_seed
+		update_icon()
+
 /obj/item/mmi/posibrain/proc/check_success()
 	searching = FALSE
 	update_icon()
@@ -68,7 +88,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	else
 		visible_message(fail_message)
 
-//ATTACK GHOST IGNORING PARENT RETURN VALUE
+///ATTACK GHOST IGNORING PARENT RETURN VALUE
 /obj/item/mmi/posibrain/attack_ghost(mob/user)
 	activate(user)
 
@@ -81,7 +101,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 			return TRUE
 	return FALSE
 
-//Two ways to activate a positronic brain. A clickable link in the ghost notif, or simply clicking the object itself.
+///Two ways to activate a positronic brain. A clickable link in the ghost notif, or simply clicking the object itself.
 /obj/item/mmi/posibrain/proc/activate(mob/user)
 	if(QDELETED(brainmob))
 		return
@@ -116,6 +136,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	brainmob.mind.wipe_memory()
 	update_icon()
 
+///Moves the candidate from the ghost to the posibrain
 /obj/item/mmi/posibrain/proc/transfer_personality(mob/candidate)
 	if(QDELETED(brainmob))
 		return
@@ -149,6 +170,9 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 				. += "<span class='deadsay'>It appears to be completely inactive.</span>"
 	else
 		. += "[dead_message]"
+		if(ask_role)
+			. += "<span class='notice'>Current consciousness seed: \"[ask_role]\"</span>"
+		. += "<span class='boldnotice'>Alt-click to set a consciousness seed, specifying what [src] will be used for. This can help generate a personality in that role.</span>"
 
 /obj/item/mmi/posibrain/Initialize()
 	. = ..()

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -70,10 +70,11 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 /obj/item/mmi/posibrain/AltClick(mob/living/user)
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
-	var/input_seed = stripped_input(user, "Enter a personality seed", "Enter seed", ask_role)
+	var/input_seed = stripped_input(user, "Enter a personality seed", "Enter seed", ask_role, MAX_NAME_LEN)
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
 	if(input_seed)
+		to_chat(user, "<span class='notice'>You set the personality seed to \"[input_seed]\".</span>")
 		ask_role = input_seed
 		update_icon()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As the title says.
The seed can be set with Alt-click, as explained in an examine message.

This is _not_ meant to be an objective, just a kind of advertisement.

Also codedoc'd some of the code while i was there.

![posibrain](https://user-images.githubusercontent.com/18611020/76161782-d94c3580-6136-11ea-8650-4b04d4504e34.png)


## Why It's Good For The Game
Sometimes someone might make positronic brains for some interesting, unique and/or nonstandard use, and ghosts might ignore it assuming they're end up as a cyborg as usual, or enter the brain with the same assumption and be let down when the posibrain is instead made into an AI, or implanted in someone's chest cavity.

So this lets ghosts know in advance what they're in for.

## Changelog
:cl: XDTM
add: Positronic brains can now be given a "personality seed" by Alt-clicking them. Effectively, this tells ghosts what you plan on using the posibrain for, to advertise and prevent misunderstandings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
