### PR TITLE
Allow DNA Consoles to show compatible chromosomes for activated mutations

### DIFF
--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -44,6 +44,7 @@
 	var/synchronizer_coeff = -1 //makes the mutation hurt the user less
 	var/power_coeff = -1 //boosts mutation strength
 	var/energy_coeff = -1 //lowers mutation cooldown
+	var/list/valid_chrom_list = list() //List of strings of valid chromosomes this mutation can accept.
 
 /datum/mutation/human/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
 	. = ..()
@@ -53,6 +54,7 @@
 		timed = TRUE
 	if(copymut && istype(copymut, /datum/mutation/human))
 		copy_mutation(copymut)
+	update_valid_chromosome_list()
 
 /datum/mutation/human/proc/on_acquiring(mob/living/carbon/human/H)
 	if(!H || !istype(H) || H.stat == DEAD || (src in H.dna.mutations))
@@ -148,6 +150,7 @@
 	energy_coeff = HM.energy_coeff
 	mutadone_proof = HM.mutadone_proof
 	can_chromosome = HM.can_chromosome
+	valid_chrom_list = HM.valid_chrom_list
 
 /datum/mutation/human/proc/remove_chromosome()
 	stabilizer_coeff = initial(stabilizer_coeff)
@@ -173,3 +176,23 @@
 	power.panel = "Genetic"
 	owner.AddSpell(power)
 	return TRUE
+	
+// Runs through all the coefficients and uses this to determine which chromosomes the
+// mutation can take. Stores these as text strings in a list.
+/datum/mutation/human/proc/update_valid_chromosome_list()
+	valid_chrom_list.Cut()
+	
+	if(can_chromosome == CHROMOSOME_NEVER)
+		valid_chrom_list += "none"
+		return
+	
+	valid_chrom_list += "reinforcement"
+	
+	if(stabilizer_coeff != -1)
+		valid_chrom_list += "stabilizer"
+	if(synchronizer_coeff != -1)
+		valid_chrom_list += "synchronizer"
+	if(power_coeff != -1)
+		valid_chrom_list += "power"
+	if(energy_coeff != -1)
+		valid_chrom_list += "energetic"

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -514,15 +514,8 @@
 			if(HM.chromosome_name)
 				chromosome_name = HM.chromosome_name
 			temp_html += "<div class='statusLine'>Chromosome status: [chromosome_name]<br></div>"
-			
-		// Build formatted string containing all valid chromosomes that this mutation can take.
-		var/valid_chrom_text = ""
-		for(var/i in 1 to LAZYLEN(HM.valid_chrom_list))
-			valid_chrom_text += "[HM.valid_chrom_list[i]]"
-			if(i < LAZYLEN(HM.valid_chrom_list))
-				valid_chrom_text += ", "
-		temp_html += "<div class='statusLine'>Compatible chromosomes: [valid_chrom_text]<br></div>"
-		
+		temp_html += "<div class='statusLine'>Compatible chromosomes: [jointext(HM.valid_chrom_list, ", ")]<br></div>"
+
 	temp_html += "<div class='statusLine'>Sequence:<br><br></div>"
 	if(!scrambled)
 		for(var/block in 1 to A.blocks)

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -514,6 +514,15 @@
 			if(HM.chromosome_name)
 				chromosome_name = HM.chromosome_name
 			temp_html += "<div class='statusLine'>Chromosome status: [chromosome_name]<br></div>"
+			
+		// Build formatted string containing all valid chromosomes that this mutation can take.
+		var/valid_chrom_text = ""
+		for(var/i in 1 to LAZYLEN(HM.valid_chrom_list))
+			valid_chrom_text += "[HM.valid_chrom_list[i]]"
+			if(i < LAZYLEN(HM.valid_chrom_list))
+				valid_chrom_text += ", "
+		temp_html += "<div class='statusLine'>Compatible chromosomes: [valid_chrom_text]<br></div>"
+		
 	temp_html += "<div class='statusLine'>Sequence:<br><br></div>"
 	if(!scrambled)
 		for(var/block in 1 to A.blocks)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new proc and var to _mutations.dm to allow mutations to store a list of strings specifying compatible chromosomes. This proc is called at the end of the mutation constructor.

This is then used in dna_console.dm with some string formatting logic to add a new line to active mutations showcasing which chromosomes are compatible with the given specific mutation.

![image](https://user-images.githubusercontent.com/24975989/76163833-8fb51800-6141-11ea-82fd-f1d588d94545.png)

![image](https://user-images.githubusercontent.com/24975989/76163860-ce4ad280-6141-11ea-86a9-47b035a65758.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This goes hand-in-hand with recent genetics updates and is purely a user-information/visual update with no gameplay changes.

Works alongside #49788 which fixes broken logic which prevented adding chromosomes to all mutations other than the last one in the Genetic Sequencer list in the DNA Console. However as this is a new feature and not a bug fix, it is being entered as its own PR.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
🆑 
add: DNA Consoles have had another firmware update. They are now able to accurately predict and output which chromosomes than an activated genetic mutation is compatible with.
/🆑 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
