### PR TITLE
Fixes the handheld arcade game not working as intended

### DIFF
--- a/code/modules/modular_computers/file_system/programs/arcade.dm
+++ b/code/modules/modular_computers/file_system/programs/arcade.dm
@@ -157,11 +157,11 @@
 				computer.visible_message("<span class='notice'>\The [computer] prints out paper.</span>")
 				if(ticket_count >= 1)
 					new /obj/item/stack/arcadeticket((get_turf(computer)), 1)
-					to_chat(user, "<span class='notice'>[src] dispenses a ticket!</span>")
+					to_chat(usr, "<span class='notice'>[src] dispenses a ticket!</span>")
 					ticket_count -= 1
 					printer.stored_paper -= 1
 				else
-					to_chat(user, "<span class='notice'>You don't have any stored tickets!</span>")
+					to_chat(usr, "<span class='notice'>You don't have any stored tickets!</span>")
 				return TRUE
 		if("Start_Game")
 			game_active = TRUE

--- a/code/modules/modular_computers/file_system/programs/arcade.dm
+++ b/code/modules/modular_computers/file_system/programs/arcade.dm
@@ -101,7 +101,7 @@
 	if(computer)
 		printer = computer.all_components[MC_PRINT]
 
-	var/gamerSkillLevel = user.mind?.get_skill_level(/datum/skill/gaming)
+	var/gamerSkillLevel = usr.mind?.get_skill_level(/datum/skill/gaming)
 	var/gamerSkill = usr.mind?.get_skill_modifier(/datum/skill/gaming, SKILL_RANDS_MODIFIER)
 	switch(action)
 		if("Attack")

--- a/code/modules/modular_computers/file_system/programs/arcade.dm
+++ b/code/modules/modular_computers/file_system/programs/arcade.dm
@@ -94,7 +94,7 @@
 	data["BossID"] = "boss[boss_id].gif"
 	return data
 
-/datum/computer_file/program/arcade/ui_act(action, list/params, mob/user)
+/datum/computer_file/program/arcade/ui_act(action, list/params)
 	if(..())
 		return TRUE
 	var/obj/item/computer_hardware/printer/printer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simple typo correcting to fix one half of #49777

The ntos port of the combat arcade game is now fully functional.

This works alongside #49792 to fully fix #49777 - I will tag my other PR accordingly to allow it to close the issue on the more serious of the two matters.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
🆑 
fix: Fixed a game breaking bug in Nanotrasen Pocket Arcade, fully enabling you to experience the full fury of "Outbomb Cuban Pete" across all NTOS-compatible devices including tablets, laptops and home PCs.
/🆑 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
