### PR TITLE
Fix chair examine edge case

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/chairs.dmi'
 	icon_state = "chair"
 	anchored = TRUE
-	can_buckle = 1
+	can_buckle = TRUE
 	buckle_lying = 0 //you sit in a chair, not lay
 	resistance_flags = NONE
 	max_integrity = 250
@@ -18,7 +18,7 @@
 /obj/structure/chair/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>It's held together by a couple of <b>bolts</b>.</span>"
-	if(!has_buckled_mobs() && (can_buckle == 1))
+	if(!has_buckled_mobs() && can_buckle)
 		. += "<span class='notice'>While stood on the same tile as the chair, drag your sprite to sit in it.</span>"
 
 /obj/structure/chair/Initialize()
@@ -227,7 +227,7 @@
 	name = "stool"
 	desc = "Apply butt."
 	icon_state = "stool"
-	can_buckle = 0
+	can_buckle = FALSE
 	buildstackamount = 1
 	item_chair = /obj/item/chair/stool
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -18,8 +18,8 @@
 /obj/structure/chair/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>It's held together by a couple of <b>bolts</b>.</span>"
-	if(!has_buckled_mobs())
-		. += "<span class='notice'>Drag your sprite to sit in it.</span>"
+	if(!has_buckled_mobs() && (can_buckle == 1))
+		. += "<span class='notice'>While stood on the same tile as the chair, drag your sprite to sit in it.</span>"
 
 /obj/structure/chair/Initialize()
 	. = ..()

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -19,7 +19,7 @@
 	. = ..()
 	. += "<span class='notice'>It's held together by a couple of <b>bolts</b>.</span>"
 	if(!has_buckled_mobs() && can_buckle)
-		. += "<span class='notice'>While stood on the same tile as the chair, drag your sprite to sit in it.</span>"
+		. += "<span class='notice'>While standing on [src], drag and drop your sprite onto [src] to buckle to it.</span>"
 
 /obj/structure/chair/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #49778

Quick and cheeky logic change. When examining chair-class objects, the chair both needs to not have a mob buckled to it AND has to be of a buckle-able type in order for the additional flavour text explaining how to buckle to the damn thing to show.

This means that stools, which have can_buckle = FALSE specifically set, will no longer lie to poor, unsuspecting players when examined.

Being partially pedantic, I've also enhanced this flavour text slightly to be friendlier to newcomers by also having it mention that you need to be stood on the same tile as the chair, as this was also an point raised in the associated issue. Feel free to remove or revert that specific change if you feel necessary.

## Changelog
🆑 
tweak: Stools are now appropriately truthful when interrogated via the examine command.
/🆑 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
