### PR TITLE
Fixes bugs in the mc related to combos of SS_BACKGROUND and other flags

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -32,17 +32,16 @@
 /// (Requires a MC restart to change)
 #define SS_NO_FIRE 2
 
-/** subsystem only runs on spare cpu (after all non-background subsystems have ran that tick) */
-/// SS_BACKGROUND has its own priority bracket
+/** Subsystem only runs on spare cpu (after all non-background subsystems have ran that tick) */
+/// SS_BACKGROUND has its own priority bracket, this overrides SS_TICKER's priority bump
 #define SS_BACKGROUND 4
 
 /// subsystem does not tick check, and should not run unless there is enough time (or its running behind (unless background))
 #define SS_NO_TICK_CHECK 8
 
 /** Treat wait as a tick count, not DS, run every wait ticks. */
-/// (also forces it to run first in the tick, above even SS_NO_TICK_CHECK subsystems)
+/// (also forces it to run first in the tick (unless SS_BACKGROUND))
 /// (implies all runlevels because of how it works)
-/// (overrides SS_BACKGROUND)
 /// This is designed for basically anything that works as a mini-mc (like SStimer)
 #define SS_TICKER 16
 

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -455,14 +455,15 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 			//	in those cases, so we just let them run)
 			if (queue_node_flags & SS_NO_TICK_CHECK)
 				if (queue_node.tick_usage > TICK_LIMIT_RUNNING - TICK_USAGE && ran_non_ticker)
-					queue_node.queued_priority += queue_priority_count * 0.1
-					queue_priority_count -= queue_node_priority
-					queue_priority_count += queue_node.queued_priority
-					current_tick_budget -= queue_node_priority
-					queue_node = queue_node.queue_next
+					if (!(queue_node_flags & SS_BACKGROUND))
+						queue_node.queued_priority += queue_priority_count * 0.1
+						queue_priority_count -= queue_node_priority
+						queue_priority_count += queue_node.queued_priority
+						current_tick_budget -= queue_node_priority
+						queue_node = queue_node.queue_next
 					continue
 
-			if ((queue_node_flags & SS_BACKGROUND) && !bg_calc)
+			if (!bg_calc && (queue_node_flags & SS_BACKGROUND))
 				current_tick_budget = queue_priority_count_bg
 				bg_calc = TRUE
 
@@ -515,7 +516,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 			queue_node.paused_ticks = 0
 			queue_node.paused_tick_usage = 0
 
-			if (queue_node_flags & SS_BACKGROUND) //update our running total
+			if (bg_calc) //update our running total
 				queue_priority_count_bg -= queue_node_priority
 			else
 				queue_priority_count -= queue_node_priority

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -137,7 +137,7 @@
 		queue_node_flags = queue_node.flags
 
 		if (queue_node_flags & SS_TICKER)
-			if (!(SS_flags & SS_TICKER))
+			if (!(SS_flags & (SS_TICKER|SS_BACKGROUND)) == SS_TICKER)
 				continue
 			if (queue_node_priority < SS_priority)
 				break


### PR DESCRIPTION
`SS_BACKGROUND` Conflicts with `SS_TICKER` and `SS_NO_TICK_CHECK`'s behavior in certain ways. This fixes that breaking the mc.

`SS_BACKGROUND` has its own priority bracket that assumes that all remaining subsystems to run are also `SS_BACKGROUND`, allowing one of these to run when running `SS_TICKER` subsystems would cause the MC to assume all subsystems that run after it that tick were background subsystems, breaking the math of how much time to allocate the subsystem. This was fixed by making SS_BACKGROUND's bottom of the queue preference override SS_TICKER's top of the queue preference. 

When delaying a run of a `SS_NO_TICK_CHECK` subsystem for lack of time, the MC will modify it's priority so it runs sooner next tick, if this happened on a background `SS_NO_TICK_CHECK` subsystem, it would update the wrong running total and desync the running total of the priority of all queued subsystem from the actual sum of those subsystem's priority. The docs actually state that priority increasing should not happen on background subsystems, so I added the check needed to ensure that.
