### PR TITLE
Change cable layer only in hand.

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -434,6 +434,8 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 	return TRUE
 
 /obj/item/stack/cable_coil/CtrlClick(mob/living/user)
+	if(loc!=user)
+		return ..()
 	if(!user)
 		return
 	var/list/layer_list = list(


### PR DESCRIPTION
## About The Pull Request

Now you can change cable layer only in hand

## Why It's Good For The Game

Now you can pull cable by Ctrl+Click again.

## Changelog
:cl:
tweak: Now you can change cable layer only in hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
