### PR TITLE
Label component code fixes

### DIFF
--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -33,7 +33,7 @@
 	Since the parent already has a label, it will remove the old one from the parent's name, and apply the new one.
 */
 /datum/component/label/InheritComponent(datum/component/label/new_comp , i_am_original, _label_name)
-	removel_label()
+	remove_label()
 	if(new_comp)
 		label_name = new_comp.label_name
 	else
@@ -58,7 +58,7 @@
 	if(!istype(labeler) || labeler.mode)
 		return
 
-	removel_label()
+	remove_label()
 	playsound(parent, 'sound/items/poster_ripped.ogg', 20, TRUE)
 	to_chat(user, "<span class='warning'>You remove the label from [parent].</span>")
 	qdel(src) // Remove the component from the object.
@@ -81,7 +81,7 @@
 	owner.name += " ([label_name])"
 
 /// Removes the label from the parent's name
-/datum/component/label/proc/removel_label()
+/datum/component/label/proc/remove_label()
 	var/atom/owner = parent
 	owner.name = replacetext(owner.name, "([label_name])", "") // Remove the label text from the parent's name, wherever it's located.
 	owner.name = trim(owner.name) // Shave off any white space from the beginning or end of the parent's name.

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -75,7 +75,7 @@
 /datum/component/label/proc/Examine(datum/source, mob/user, list/examine_list)
 	examine_list += "<span class='notice'>It has a label with some words written on it. Use a hand labeler to remove it.</span>"
 
-/// Applys a label to the name of the parent in the format of: "parent_name (label)"
+/// Applies a label to the name of the parent in the format of: "parent_name (label)"
 /datum/component/label/proc/apply_label()
 	var/atom/owner = parent
 	owner.name += " ([label_name])"

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -19,17 +19,26 @@
 		return COMPONENT_INCOMPATIBLE
 
 	label_name = _label_name
-
-	// Add the label to the name of the object in the format of: "Item name (label)"
-	var/atom/owner = parent
-	owner.name += " ([label_name])"
+	apply_label()
 
 /datum/component/label/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/RemoveLabel)
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/OnAttackby)
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/Examine)
 
 /datum/component/label/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_PARENT_ATTACKBY, COMSIG_PARENT_EXAMINE))
+
+/**
+	This proc will fire after the parent is hit by a hand labeler which is trying to apply another label.
+	Since the parent already has a label, it will remove the old one from the parent's name, and apply the new one.
+*/
+/datum/component/label/InheritComponent(datum/component/label/new_comp , i_am_original, _label_name)
+	removel_label()
+	if(new_comp)
+		label_name = new_comp.label_name
+	else
+		label_name = _label_name
+	apply_label()
 
 /**
 	This proc will trigger when any object is used to attack the parent.
@@ -42,18 +51,16 @@
 	* attacker: The object that is hitting the parent.
 	* user: The mob who is wielding the attacking object.
 */
-/datum/component/label/proc/RemoveLabel(datum/source, obj/item/attacker, mob/user)
+/datum/component/label/proc/OnAttackby(datum/source, obj/item/attacker, mob/user)
 	// If the attacking object is not a hand labeler or its mode is 1 (has a label ready to apply), return.
 	// The hand labeler should be off (mode is 0), in order to remove a label.
 	var/obj/item/hand_labeler/labeler = attacker
 	if(!istype(labeler) || labeler.mode)
 		return
 
-	var/atom/owner = source // Source will be the owner / parent of this component.
-	owner.name = replacetext(owner.name, "([label_name])", "") // Remove the label text from the parent's name, wherever it may be.
-	owner.name = trim(owner.name) // Shave off any white space from the beginning or end of the parent's name.
-	playsound(owner, 'sound/items/poster_ripped.ogg', 20, TRUE)
-	to_chat(user, "<span class='warning'>You remove the label from [owner].</span>")
+	removel_label()
+	playsound(parent, 'sound/items/poster_ripped.ogg', 20, TRUE)
+	to_chat(user, "<span class='warning'>You remove the label from [parent].</span>")
 	qdel(src) // Remove the component from the object.
 
 /**
@@ -67,3 +74,14 @@
 */
 /datum/component/label/proc/Examine(datum/source, mob/user, list/examine_list)
 	examine_list += "<span class='notice'>It has a label with some words written on it. Use a hand labeler to remove it.</span>"
+
+/// Applys a label to the name of the parent in the format of: "parent_name (label)"
+/datum/component/label/proc/apply_label()
+	var/atom/owner = parent
+	owner.name += " ([label_name])"
+
+/// Removes the label from the parent's name
+/datum/component/label/proc/removel_label()
+	var/atom/owner = parent
+	owner.name = replacetext(owner.name, "([label_name])", "") // Remove the label text from the parent's name, wherever it's located.
+	owner.name = trim(owner.name) // Shave off any white space from the beginning or end of the parent's name.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When I made this component originally in #49700, I didn't understand component inheriting, and I left out an important part of the component. 

Players will now be able to properly apply a label to an object that already has one, and have the new label automatically replace the original one. No need to remove it first, and then apply another one.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
code: Fixes up the label component's code to work as it was intended to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
