### PR TITLE
Fix dmdoc generation and revert to SpacemanDMM 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
           - $HOME/SpacemanDMM
       install:
         - tools/travis/install_build_tools.sh
-        - tools/travis/build_spaceman_dmm.sh dreamchecker
+        - tools/travis/install_spaceman_dmm.sh dreamchecker
       script:
         - tools/travis/check_filedirs.sh tgstation.dme
         - tools/travis/check_changelogs.sh

--- a/code/__DEFINES/spaceman_dmm.dm
+++ b/code/__DEFINES/spaceman_dmm.dm
@@ -7,13 +7,13 @@
 	#define SHOULD_CALL_PARENT(X) set SpacemanDMM_should_call_parent = X
 	#define UNLINT(X) SpacemanDMM_unlint(X)
 	#define SHOULD_NOT_OVERRIDE(X) set SpacemanDMM_should_not_override = X
-	#define SHOULD_NOT_SLEEP(X) set SpacemanDMM_should_not_sleep = X
-	#define SHOULD_BE_PURE(X) set SpacemanDMM_should_be_pure = X
-	#define PRIVATE_PROC(X) set SpacemanDMM_private_proc = X
-	#define PROTECTED_PROC(X) set SpacemanDMM_protected_proc = X
+	#define SHOULD_NOT_SLEEP(X)
+	#define SHOULD_BE_PURE(X)
+	#define PRIVATE_PROC(X)
+	#define PROTECTED_PROC(X)
 	#define VAR_FINAL var/SpacemanDMM_final
-	#define VAR_PRIVATE var/SpacemanDMM_private
-	#define VAR_PROTECTED var/SpacemanDMM_protected
+	#define VAR_PRIVATE var
+	#define VAR_PROTECTED var
 #else
 	#define RETURN_TYPE(X)
 	#define SHOULD_CALL_PARENT(X)

--- a/tools/travis/install_spaceman_dmm.sh
+++ b/tools/travis/install_spaceman_dmm.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+source dependencies.sh
+
+wget -O ~/$1 "https://github.com/SpaceManiac/SpacemanDMM/releases/download/$SPACEMAN_DMM_VERSION/$1"
+chmod +x ~/$1
+~/$1 --version


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
apparently both @ninjanomnom and i missed that `install_spaceman_dmm.sh` is used by travis to build dmdocs.

as for the langserver plugin issues in vscode, it's updated independently of spacemandmm and automatically updated by the plugin, you'll need to restart your vscode occasionally for it to update.

Also now reverts to spacemandmm 1.3 and disables the new lints

Closes #49829 