### PR TITLE
Fixes empty tape recorders getting stuck on pocket and belt slots

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -56,11 +56,8 @@
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/taperecorder/attack_hand(mob/user)
-	if(loc == user)
-		if(mytape)
-			if(!user.is_holding(src))
-				return ..()
-			eject(user)
+	if(loc == user && mytape && user.is_holding(src))
+		eject(user)
 	else
 		return ..()
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -56,10 +56,9 @@
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/taperecorder/attack_hand(mob/user)
-	if(loc == user && mytape && user.is_holding(src))
-		eject(user)
-	else
+	if(loc != user || !mytape || !user.is_holding(src))
 		return ..()
+	eject(user)
 
 /obj/item/taperecorder/proc/can_use(mob/user)
 	if(user && ismob(user))


### PR DESCRIPTION
## About The Pull Request

Currently, empty tape recorders get stuck on pocket and belt slots and can't be removed without either putting a tape back in the recorder or taking off your jumpsuit.

## Why It's Good For The Game

They probably shouldn't do that.

## Changelog
:cl: CDranzer
fix: Empty tape recorders no longer get stuck on pocket and belt slots
/:cl: