### PR TITLE
radial repeat close

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -293,7 +293,8 @@ GLOBAL_LIST_EMPTY(radial_menus)
 
 	if(GLOB.radial_menus[uniqueid])
 		if(!no_repeat_close)
-			GLOB.radial_menus[uniqueid].finished = TRUE
+			var/datum/radial_menu/menu = GLOB.radial_menus[uniqueid]
+			menu.finished = TRUE
 		return
 
 	var/datum/radial_menu/menu = new

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -285,13 +285,15 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	Choices should be a list where list keys are movables or text used for element names and return value
 	and list values are movables/icons/images used for element icons
 */
-/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check, require_near = FALSE, tooltips = FALSE)
+/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check, require_near = FALSE, tooltips = FALSE, no_repeat_close = FALSE)
 	if(!user || !anchor || !length(choices))
 		return
 	if(!uniqueid)
 		uniqueid = "defmenu_[REF(user)]_[REF(anchor)]"
 
 	if(GLOB.radial_menus[uniqueid])
+		if(!no_repeat_close)
+			GLOB.radial_menus[uniqueid].finished = TRUE
 		return
 
 	var/datum/radial_menu/menu = new


### PR DESCRIPTION

## About The Pull Request

use radial again to close radial menu

## Why It's Good For The Game

No more button hunting when you need close menu of item in your hand.

## Changelog
:cl:
add: Now you can use radial again to close radial menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
