### PR TITLE
ladder radial red arrow

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -89,8 +89,8 @@
 		return
 
 	var/list/tool_list = list(
-		"Up" = image(icon = 'icons/testing/turf_analysis.dmi', icon_state = "arrow", dir = NORTH),
-		"Down" = image(icon = 'icons/testing/turf_analysis.dmi', icon_state = "arrow", dir = SOUTH)
+		"Up" = image(icon = 'icons/testing/turf_analysis.dmi', icon_state = "red_arrow", dir = NORTH),
+		"Down" = image(icon = 'icons/testing/turf_analysis.dmi', icon_state = "red_arrow", dir = SOUTH)
 		)
 
 	if (up && down)


### PR DESCRIPTION
## About The Pull Request

Set ladder radial red arrow

![new red arrow](https://user-images.githubusercontent.com/7734424/76360789-61dcf880-6326-11ea-8912-c0242112e4ac.png)

<details>
  <summary>old</summary>

![old blue arrows](https://user-images.githubusercontent.com/7734424/76159014-d7797680-6124-11ea-8234-8a9fdf3fd15a.png)
</details>


## Why It's Good For The Game

Better visibility?

## Changelog
:cl:
tweak: Ladder radial buttons now red arrow
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
