### PR TITLE
Adds a suicide to moth plushies

### DIFF
--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -690,9 +690,9 @@
 		divine = TRUE
 		resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | LAVA_PROOF
 	playsound(src, 'sound/hallucinations/wail.ogg', 50, TRUE, -1)
-	var/list/available_spots = get_adjacent_open_turfs(src.loc)
-	if(available_spots.len >= 1) //If the user is in a confined space the plushie will drop normally as the user dies, but in the open the plush is placed one tile away from the user to prevent squeak spam
+	var/list/available_spots = get_adjacent_open_turfs(loc)
+	if(available_spots.len) //If the user is in a confined space the plushie will drop normally as the user dies, but in the open the plush is placed one tile away from the user to prevent squeak spam
 		var/turf/open/random_open_spot = pick(available_spots)
-		src.forceMove(random_open_spot)
+		forceMove(random_open_spot)
 	user.dust(just_ash = FALSE, drop_items = TRUE)
 	return MANUAL_SUICIDE

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -22,6 +22,7 @@
 	var/heartbroken = FALSE
 	var/vowbroken = FALSE
 	var/young = FALSE
+///Prevents players from cutting stuffing out of a plushie if true
 	var/divine = FALSE
 	var/mood_message
 	var/list/love_message
@@ -676,23 +677,18 @@
 	item_state = "moffplush"
 	attack_verb = list("fluttered", "flapped")
 	squeak_override = list('sound/voice/moth/scream_moth.ogg'=1)
-	var/souls = 0
+///Used to track how many people killed themselves with item/toy/plush/moth
+	var/suicide_count = 0
 
 /obj/item/toy/plush/moth/suicide_act(mob/living/user)
-	user.visible_message("<span class='suicide'>[user] begins staring deeply into the eyes of [src]!  It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	if(do_after(user, 50, target = user) && !user.hellbound)
-		souls++
-		switch(souls)
-			if(1 to 2)
-				desc = "A plushie depicting an unsettling mothperson. After eating [souls] [souls == 1 ? "soul" : "souls"] it's not looking so huggable now..."
-			if(3 to INFINITY)
-				desc = "A plushie depicting a creepy mothperson. It's eaten [souls] souls! I don't think I want to hug it any more!"
-				divine = TRUE
-				resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | LAVA_PROOF
-		user.visible_message("<span class='suicide'>[src] rips the soul out of [user] and consumes it!</span>")
-		playsound(src, 'sound/hallucinations/wail.ogg', 50, TRUE, -1)
-		user.unequip_everything()
-		user.dust()
-		return MANUAL_SUICIDE
-	user.visible_message("<span class='suicide'>[user] couldn't do it!</span>")
-	return SHAME
+	user.visible_message("<span class='suicide'>[user] stares deeply into the eyes of [src] and it begins consuming [user.p_them()]!  It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	suicide_count++
+	if(suicide_count < 3)
+		desc = "A plushie depicting an unsettling mothperson. After killing [suicide_count] [suicide_count == 1 ? "person" : "people"] it's not looking so huggable now..."
+	else
+		desc = "A plushie depicting a creepy mothperson. It's killed [suicide_count] people! I don't think I want to hug it any more!"
+		divine = TRUE
+		resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | LAVA_PROOF
+	playsound(src, 'sound/hallucinations/wail.ogg', 50, TRUE, -1)
+	user.dust(just_ash = FALSE, drop_items = TRUE)
+	return MANUAL_SUICIDE

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -680,7 +680,7 @@
 
 /obj/item/toy/plush/moth/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] begins staring deeply into the eyes of [src]!  It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	if(do_after(user, 50, target = user))
+	if(do_after(user, 50, target = user) && !user.hellbound)
 		souls++
 		switch(souls)
 			if(1 to 2)

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -689,6 +689,10 @@
 		desc = "A plushie depicting a creepy mothperson. It's killed [suicide_count] people! I don't think I want to hug it any more!"
 		divine = TRUE
 		resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | LAVA_PROOF
-	playsound(src, 'sound/voice/moth/scream_moth.ogg', 100)
+	playsound(src, 'sound/hallucinations/wail.ogg', 50, TRUE, -1)
+	var/list/available_spots = get_adjacent_open_turfs(src.loc)
+	if(available_spots.len >= 1) //If the user is in a confined space the plushie will drop normally as the user dies, but in the open the plush is placed one tile away from the user to prevent squeak spam
+		var/turf/open/random_open_spot = pick(available_spots)
+		src.forceMove(random_open_spot)
 	user.dust(just_ash = FALSE, drop_items = TRUE)
 	return MANUAL_SUICIDE

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -676,3 +676,23 @@
 	item_state = "moffplush"
 	attack_verb = list("fluttered", "flapped")
 	squeak_override = list('sound/voice/moth/scream_moth.ogg'=1)
+	var/souls = 0
+
+/obj/item/toy/plush/moth/suicide_act(mob/living/user)
+	user.visible_message("<span class='suicide'>[user] begins staring deeply into the eyes of [src]!  It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	if(do_after(user, 50, target = user))
+		souls++
+		switch(souls)
+			if(1 to 2)
+				desc = "A plushie depicting an unsettling mothperson. After eating [souls] [souls == 1 ? "soul" : "souls"] it's not looking so huggable now..."
+			if(3 to INFINITY)
+				desc = "A plushie depicting a creepy mothperson. It's eaten [souls] souls! I don't think I want to hug it any more!"
+				divine = TRUE
+				resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | LAVA_PROOF
+		user.visible_message("<span class='suicide'>[src] rips the soul out of [user] and consumes it!</span>")
+		playsound(src, 'sound/hallucinations/wail.ogg', 50, TRUE, -1)
+		user.unequip_everything()
+		user.dust()
+		return MANUAL_SUICIDE
+	user.visible_message("<span class='suicide'>[user] couldn't do it!</span>")
+	return SHAME

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -689,6 +689,6 @@
 		desc = "A plushie depicting a creepy mothperson. It's killed [suicide_count] people! I don't think I want to hug it any more!"
 		divine = TRUE
 		resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | LAVA_PROOF
-	playsound(src, 'sound/hallucinations/wail.ogg', 50, TRUE, -1)
+	playsound(src, 'sound/voice/moth/scream_moth.ogg', 100)
 	user.dust(just_ash = FALSE, drop_items = TRUE)
 	return MANUAL_SUICIDE

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -27,14 +27,13 @@
 	return
 
 /mob/living/dust(just_ash, drop_items, force)
-	death(TRUE)
-
 	if(drop_items)
 		unequip_everything()
 
 	if(buckled)
 		buckled.unbuckle_mob(src, force = TRUE)
 
+	death(TRUE)
 	dust_animation()
 	spawn_dust(just_ash)
 	QDEL_IN(src,5) // since this is sometimes called in the middle of movement, allow half a second for movement to finish, ghosting to happen and animation to play. Looks much nicer and doesn't cause multiple runtimes.

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -27,13 +27,14 @@
 	return
 
 /mob/living/dust(just_ash, drop_items, force)
+	death(TRUE)
+
 	if(drop_items)
 		unequip_everything()
 
 	if(buckled)
 		buckled.unbuckle_mob(src, force = TRUE)
 
-	death(TRUE)
 	dust_animation()
 	spawn_dust(just_ash)
 	QDEL_IN(src,5) // since this is sometimes called in the middle of movement, allow half a second for movement to finish, ghosting to happen and animation to play. Looks much nicer and doesn't cause multiple runtimes.


### PR DESCRIPTION
## About The Pull Request

Adds a suicide to moth plushies that keeps track of and displays how many people have killed themselves with it. After three suicides the plushie becomes indestructible.
The user is stripped of their equipment to prevent any issues with people deleting items on their person when they're dusted.

## Why It's Good For The Game

Gives the cute moff plushes a dark side

## Changelog
:cl:
add: Reports have been coming in that the "adorable moth plushies" have on occasion "consumed souls and ascended to godhood."
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
