### PR TITLE
Replaces parent wand with wand of nothing on Donut

### DIFF
--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -44377,7 +44377,7 @@
 	dir = 8
 	},
 /obj/item/toy/figure/mime,
-/obj/item/gun/magic/wand,
+/obj/item/gun/magic/wand/nothing,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "caf" = (

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/magic/wand
-	name = "wand of nothing"
-	desc = "It's not just a stick, it's a MAGIC stick! You shouldn't have this."
+	name = "wand"
+	desc = "You shouldn't have this."
 	ammo_type = /obj/item/ammo_casing/magic
 	icon_state = "nothingwand"
 	item_state = "wand"
@@ -30,6 +30,10 @@
 	..()
 
 /obj/item/gun/magic/wand/afterattack(atom/target, mob/living/user)
+	if(type == /obj/item/gun/magic/wand)
+		qdel(src)
+		to_chat(user, "<span class='warning'>You suddenly forget what you were doing.</span>")
+		return
 	if(!charges)
 		shoot_with_empty_chamber(user)
 		return
@@ -233,6 +237,7 @@
 /////////////////////////////////////
 
 /obj/item/gun/magic/wand/nothing
+	name = "wand of nothing"
 	desc = "It's not just a stick, it's a MAGIC stick?"
 	ammo_type = /obj/item/ammo_casing/magic/nothing
 

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -10,6 +10,10 @@
 	var/variable_charges = TRUE
 
 /obj/item/gun/magic/wand/Initialize()
+	if(type == /obj/item/gun/magic/wand)
+		visible_message("<span class='warning'>[src] disappears!</span>")
+		qdel(src)
+		return
 	if(prob(75) && variable_charges) //25% chance of listed max charges, 50% chance of 1/2 max charges, 25% chance of 1/3 max charges
 		if(prob(33))
 			max_charges = CEILING(max_charges / 3, 1)
@@ -30,10 +34,6 @@
 	..()
 
 /obj/item/gun/magic/wand/afterattack(atom/target, mob/living/user)
-	if(type == /obj/item/gun/magic/wand)
-		qdel(src)
-		to_chat(user, "<span class='warning'>You suddenly forget what you were doing.</span>")
-		return
 	if(!charges)
 		shoot_with_empty_chamber(user)
 		return

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -10,10 +10,6 @@
 	var/variable_charges = TRUE
 
 /obj/item/gun/magic/wand/Initialize()
-	if(type == /obj/item/gun/magic/wand)
-		visible_message("<span class='warning'>[src] disappears!</span>")
-		qdel(src)
-		return
 	if(prob(75) && variable_charges) //25% chance of listed max charges, 50% chance of 1/2 max charges, 25% chance of 1/3 max charges
 		if(prob(33))
 			max_charges = CEILING(max_charges / 3, 1)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -1,5 +1,5 @@
 /obj/projectile/magic
-	name = "bolt of nothing"
+	name = "bolt"
 	icon_state = "energy"
 	damage = 0
 	damage_type = OXY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #49883

- Renames prototype wand 'wand' to distinguish it from wand of nothing
- Simplifies prototype wand's description to "You shouldn't have this."
- Renames prototype magic projectile to "bolt" to differentiate it from bolt of nothing

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The lizard mime can use the thing

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
fix: Wand of nothing on the theatre stage on Donut can now be used by pacifists
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
