### PR TITLE
Moves all RnD's core consoles to the bridge.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -17056,7 +17056,6 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRo" = (
-/obj/machinery/modular_computer/console/preset/command,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -17064,6 +17063,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/computer/rdconsole/core,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRp" = (
@@ -23146,7 +23146,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bhw" = (
-/obj/machinery/computer/rdconsole/robotics,
+/obj/machinery/computer/rdconsole/production,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bhx" = (
@@ -25497,7 +25497,7 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "bnn" = (
-/obj/machinery/computer/rdconsole/core{
+/obj/machinery/computer/rdconsole/production{
 	dir = 4
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -39349,7 +39349,6 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "byo" = (
-/obj/machinery/computer/station_alert,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -39357,6 +39356,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/computer/rdconsole/core,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "byp" = (
@@ -86546,11 +86546,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "deh" = (
-/obj/machinery/computer/rdconsole/core{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/machinery/computer/rdconsole/production{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
@@ -98716,13 +98716,13 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dEO" = (
-/obj/machinery/computer/rdconsole/robotics{
-	dir = 8
-	},
 /obj/structure/sign/departments/medbay/alt{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/computer/rdconsole/production{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dEP" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -1472,7 +1472,7 @@
 	},
 /area/science/explab)
 "adH" = (
-/obj/machinery/computer/rdconsole/experiment,
+/obj/machinery/computer/rdconsole/production,
 /turf/open/floor/plasteel/white/corner,
 /area/science/explab)
 "adI" = (
@@ -4497,11 +4497,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "akV" = (
-/obj/machinery/computer/rdconsole/core{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/computer/rdconsole/production{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
@@ -40152,13 +40152,13 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bJD" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/computer/rdconsole/core{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bJE" = (

--- a/_maps/map_files/Donutstation/Donutstation_LVL2.dmm
+++ b/_maps/map_files/Donutstation/Donutstation_LVL2.dmm
@@ -1661,7 +1661,7 @@
 /area/library/upper)
 "dO" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/machinery/computer/bookmanagement,
 /turf/open/floor/carpet,
 /area/library/upper)
 "dP" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -33960,9 +33960,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/theatre)
 "bad" = (
-/obj/machinery/computer/rdconsole/robotics{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -33977,6 +33974,9 @@
 	name = "Robotics RC";
 	pixel_x = 30;
 	receive_ore_updates = 1
+	},
+/obj/machinery/computer/rdconsole/production{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -36415,9 +36415,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/mixing)
 "bdG" = (
-/obj/machinery/computer/rdconsole/core{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -36430,6 +36427,9 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
+/obj/machinery/computer/rdconsole/production{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "bdH" = (
@@ -48720,9 +48720,6 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "bvh" = (
-/obj/machinery/computer/prisoner{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -48736,6 +48733,9 @@
 	pixel_x = -30
 	},
 /obj/structure/cable,
+/obj/machinery/computer/rdconsole/core{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bvi" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -26973,7 +26973,6 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bhr" = (
-/obj/machinery/computer/prisoner/management,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -26981,6 +26980,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/computer/rdconsole/core,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bht" = (
@@ -50682,10 +50682,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
 "cjX" = (
-/obj/machinery/computer/rdconsole/core{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/rdconsole/production{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cjY" = (
@@ -58895,9 +58895,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cGa" = (
-/obj/machinery/computer/rdconsole/robotics{
-	dir = 4
-	},
 /obj/machinery/requests_console{
 	department = "Robotics";
 	departmentType = 2;
@@ -58906,6 +58903,9 @@
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/computer/rdconsole/production{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cGb" = (
@@ -77870,7 +77870,7 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/machinery/computer/rdconsole/experiment,
+/obj/machinery/computer/rdconsole/production,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "xgL" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6703,7 +6703,6 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arR" = (
-/obj/machinery/computer/prisoner/management,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -6711,6 +6710,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/computer/rdconsole/core,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arS" = (
@@ -25983,9 +25983,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boX" = (
-/obj/machinery/computer/rdconsole/robotics{
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "robotics";
 	name = "Shutters Control Button";
@@ -25996,6 +25993,9 @@
 /obj/machinery/light_switch{
 	pixel_x = -25;
 	pixel_y = -8
+	},
+/obj/machinery/computer/rdconsole/production{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -26070,7 +26070,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpe" = (
-/obj/machinery/computer/rdconsole/experiment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -26085,6 +26084,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/computer/rdconsole/production,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpf" = (
@@ -28722,10 +28722,10 @@
 /turf/closed/wall,
 /area/maintenance/department/engine)
 "bvw" = (
-/obj/machinery/computer/rdconsole/core{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/computer/rdconsole/production{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "bvx" = (


### PR DESCRIPTION
## About The Pull Request

Removes science's access to a Core RnD Console. The only access science will have to core RnD will be the RD, from the Bridge. 

This is Orange's idea.
https://tgstation13.org/phpBB/viewtopic.php?f=10&t=25889
 
## Changelog
:cl:
del: Removes all core RnD Consoles from the Map, except for the bridge.
tweak: Replaces a console with a Core Console on each map's bridge.
/:cl:
