### PR TITLE
Fixes undercover cop sunglasses not having flash protection

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -229,6 +229,11 @@
 	desc = "For thinking you look cool while brutalizing protestors and minorities."
 	icon_state = "bigsunglasses"
 	hud_type = ANTAG_HUD_GANGSTER
+	darkness_view = 1
+	flash_protect = FLASH_PROTECTION_FLASH
+	tint = 1
+	glass_colour_type = /datum/client_colour/glass_colour/gray
+
 
 /obj/item/clothing/glasses/hud/spacecop/hidden // for the undercover cop
 	name = "sunglasses"


### PR DESCRIPTION
Fixes #49892
:cl: ShizCalev
fix: Fixed beatcop/gangster sunglasses not giving you flash protection.
/:cl:
