### PR TITLE
Fixes spawned IEDs not having cans

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -163,7 +163,7 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/restraints/handcuffs/cable = 1,
 		/obj/item/spear = 1,
 		/obj/item/shield/riot/buckler = 1,
-		/obj/item/grenade/iedcasing = 1,
+		/obj/item/grenade/iedcasing/spawned = 1,
 		/obj/item/melee/baton/cattleprod = 1,
 		/obj/item/throwing_star = 1,
 		) = 8,

--- a/code/game/objects/items/grenades/ghettobomb.dm
+++ b/code/game/objects/items/grenades/ghettobomb.dm
@@ -17,7 +17,6 @@
 	det_time = 50
 	display_timer = 0
 	var/check_parts = FALSE
-	var/obj/item/reagent_containers/food/drinks/soda_cans/drink_can
 	var/range = 3
 	var/list/times
 
@@ -39,20 +38,19 @@
 	check_parts = TRUE
 
 /obj/item/grenade/iedcasing/spawned/Initialize()
-	drink_can = new /obj/item/reagent_containers/food/drinks/soda_cans/cola(src)
+	new /obj/item/reagent_containers/food/drinks/soda_cans/random(src)
 	return ..()
 
 /obj/item/grenade/iedcasing/CheckParts(list/parts_list)
 	..()
-	if(!drink_can)
-		drink_can = locate(/obj/item/reagent_containers/food/drinks/soda_cans) in contents
-		if(!drink_can)
-			stack_trace("[src] generated without a soda can!") //this shouldn't happen.
-			qdel(src)
-			return
-	drink_can.pixel_x = 0 //Reset the sprite's position to make it consistent with the rest of the IED
-	drink_can.pixel_y = 0
-	var/mutable_appearance/can_underlay = new(drink_can)
+	var/obj/item/reagent_containers/food/drinks/soda_cans/can = locate() in contents
+	if(!can)
+		stack_trace("[src] generated without a soda can!") //this shouldn't happen.
+		qdel(src)
+		return
+	can.pixel_x = 0 //Reset the sprite's position to make it consistent with the rest of the IED
+	can.pixel_y = 0
+	var/mutable_appearance/can_underlay = new(can)
 	can_underlay.layer = FLOAT_LAYER
 	can_underlay.plane = FLOAT_PLANE
 	underlays += can_underlay

--- a/code/game/objects/items/grenades/ghettobomb.dm
+++ b/code/game/objects/items/grenades/ghettobomb.dm
@@ -16,6 +16,8 @@
 	active = 0
 	det_time = 50
 	display_timer = 0
+	var/check_parts = FALSE
+	var/obj/item/reagent_containers/food/drinks/soda_cans/drink_can
 	var/range = 3
 	var/list/times
 
@@ -30,17 +32,30 @@
 		det_time = rand(30,80)
 	else
 		range = pick(2,2,2,3,3,3,4)
+	if(check_parts) //since construction code calls this itself, no need to always call it. This does have the downside that adminspawned ones can potentially not have cans if they don't use the /spawned subtype.
+		CheckParts()
+
+/obj/item/grenade/iedcasing/spawned
+	check_parts = TRUE
+
+/obj/item/grenade/iedcasing/spawned/Initialize()
+	drink_can = new /obj/item/reagent_containers/food/drinks/soda_cans/cola(src)
+	return ..()
 
 /obj/item/grenade/iedcasing/CheckParts(list/parts_list)
 	..()
-	var/obj/item/reagent_containers/food/drinks/soda_cans/can = locate() in contents
-	if(can)
-		can.pixel_x = 0 //Reset the sprite's position to make it consistent with the rest of the IED
-		can.pixel_y = 0
-		var/mutable_appearance/can_underlay = new(can)
-		can_underlay.layer = FLOAT_LAYER
-		can_underlay.plane = FLOAT_PLANE
-		underlays += can_underlay
+	if(!drink_can)
+		drink_can = locate(/obj/item/reagent_containers/food/drinks/soda_cans) in contents
+		if(!drink_can)
+			stack_trace("[src] generated without a soda can!") //this shouldn't happen.
+			qdel(src)
+			return
+	drink_can.pixel_x = 0 //Reset the sprite's position to make it consistent with the rest of the IED
+	drink_can.pixel_y = 0
+	var/mutable_appearance/can_underlay = new(drink_can)
+	can_underlay.layer = FLOAT_LAYER
+	can_underlay.plane = FLOAT_PLANE
+	underlays += can_underlay
 
 
 /obj/item/grenade/iedcasing/attack_self(mob/user) //

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -53,7 +53,7 @@
 	. = ..()
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, .proc/on_wield)
 	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, .proc/on_unwield)
-	set_explosive(new /obj/item/grenade/iedcasing()) //For admin-spawned explosive lances
+	set_explosive(new /obj/item/grenade/iedcasing/spawned()) //For admin-spawned explosive lances
 
 /obj/item/spear/explosive/ComponentInitialize()
 	. = ..()

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -574,6 +574,12 @@
 	isGlass = FALSE
 	custom_price = 45
 
+/obj/item/reagent_containers/food/drinks/soda_cans/random/Initialize()
+	..()
+	var/T = pick(subtypesof(/obj/item/reagent_containers/food/drinks/soda_cans) - /obj/item/reagent_containers/food/drinks/soda_cans/random)
+	new T(loc)
+	return INITIALIZE_HINT_QDEL
+
 /obj/item/reagent_containers/food/drinks/soda_cans/suicide_act(mob/living/carbon/human/H)
 	if(!reagents.total_volume)
 		H.visible_message("<span class='warning'>[H] is trying to take a big sip from [src]... The can is empty!</span>")

--- a/code/modules/research/xenobiology/crossbreeding/industrial.dm
+++ b/code/modules/research/xenobiology/crossbreeding/industrial.dm
@@ -174,7 +174,7 @@ Industrial extracts:
 	colour = "oil"
 	effect_desc = "Produces IEDs."
 	plasmarequired = 4
-	itempath = /obj/item/grenade/iedcasing
+	itempath = /obj/item/grenade/iedcasing/spawned
 
 /obj/item/slimecross/industrial/black //What does this have to do with black slimes? No clue! Fun, though
 	colour = "black"


### PR DESCRIPTION
Fixes #49754
:cl: ShizCalev
fix: Fixed IEDs spawned in maintenance at roundstart or via slime cores not having cans.
/:cl:
