### PR TITLE
hunter spider now has doubled poison injections

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -166,7 +166,7 @@
 	health = 120
 	melee_damage_lower = 10
 	melee_damage_upper = 20
-	poison_per_bite = 5
+	poison_per_bite = 10
 	move_to_delay = 5
 	gold_core_spawnable = NO_SPAWN
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

hunter spider now has doubled poison injections, up from 5 to 10

## Why It's Good For The Game

hunter spiders are literally just a worse red spider with no reason to pick the purple ones other than speed, they were supposed to have more toxin but someone nerfed that and now both red and purple inject the same amount of toxin

## Changelog
:cl:
balance: hunter spider now has doubled poison injections
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
