### PR TITLE
fixes typo in wisdom cow

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -218,7 +218,7 @@
 ///Give intense wisdom to the attacker if they're being friendly about it
 /mob/living/simple_animal/cow/wisdom/attack_hand(mob/living/carbon/M)
 	if(!stat && M.a_intent == INTENT_HELP)
-		to_chat(M, "<span class='nicegreen'>[src] whispers you some intense wisdoms and then dissapears!</span>")
+		to_chat(M, "<span class='nicegreen'>[src] whispers you some intense wisdoms and then disappears!</span>")
 		M.mind?.adjust_experience(pick(subtypesof(/datum/skill)), 500)
 		do_smoke(1, get_turf(src))
 		qdel(src)


### PR DESCRIPTION
imagine writing over 100 lines of wisdoms a cow says but not being able to spell disappears

## Changelog
:cl:
spellcheck: fixes typo in wisdom cow
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
