### PR TITLE
Adds a couple mood events

### DIFF
--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -42,6 +42,7 @@
 
 	target.do_alert_animation(target)
 	target.playsound_local(target.loc, 'sound/machines/chime.ogg', 50, TRUE)
+	SEND_SIGNAL(target, COMSIG_ADD_MOOD_EVENT, "gunpoint", /datum/mood_event/gunpoint)
 
 	addtimer(CALLBACK(src, .proc/update_stage, 2), GUNPOINT_DELAY_STAGE_2)
 
@@ -97,6 +98,7 @@
 		cancel()
 
 /datum/component/gunpoint/proc/trigger_reaction()
+	SEND_SIGNAL(target, COMSIG_CLEAR_MOOD_EVENT, "gunpoint")
 	if(point_of_no_return)
 		return
 	point_of_no_return = TRUE
@@ -124,6 +126,7 @@
 	shooter.visible_message("<span class='danger'>[shooter] breaks [shooter.p_their()] aim on [target]!</span>", \
 		"<span class='danger'>You are no longer aiming [weapon] at [target].</span>", target)
 	to_chat(target, "<span class='userdanger'>[shooter] breaks [shooter.p_their()] aim on you!</span>")
+	SEND_SIGNAL(target, COMSIG_CLEAR_MOOD_EVENT, "gunpoint")
 	qdel(src)
 
 /datum/component/gunpoint/proc/flinch(attacker, damage, damagetype, def_zone)

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -212,6 +212,14 @@
 	mood_change = -8
 	timeout = 3 MINUTES
 
+/datum/mood_event/deaths_door
+	description = "<span class='boldwarning'>This is it... I'm really going to die.</span>\n"
+	mood_change = -20
+
+/datum/mood_event/gunpoint
+	description = "<span class='boldwarning'>This guy is insane! I better be careful....</span>\n"
+	mood_change = -10
+
 //These are unused so far but I want to remember them to use them later
 /datum/mood_event/surgery
 	description = "<span class='boldwarning'>HE'S CUTTING ME OPEN!!</span>\n"
@@ -223,4 +231,3 @@
 
 /datum/mood_event/nanite_sadness/add_effects(message)
 	description = "<span class='warning robot'>+++++++[message]+++++++</span>\n"
-

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -44,3 +44,9 @@
 			to_chat(buckled_mob, "<span class='userdanger'>You feel a deep shock course through your body!</span>")
 			addtimer(CALLBACK(buckled_mob, /mob/living.proc/electrocute_act, 85, src, 1), 1)
 	visible_message("<span class='danger'>The electric chair went off!</span>", "<span class='hear'>You hear a deep sharp shock!</span>")
+
+/obj/structure/chair/e_chair/post_buckle_mob(mob/living/L)
+	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "dying", /datum/mood_event/deaths_door)
+
+/obj/structure/chair/e_chair/post_unbuckle_mob(mob/living/L)
+	SEND_SIGNAL(L, COMSIG_CLEAR_MOOD_EVENT, "dying")

--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -208,6 +208,7 @@
 	if (!istype(M, /mob/living/carbon/human))
 		return
 
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "dying", /datum/mood_event/deaths_door)
 	var/mob/living/carbon/human/H = M
 
 	if (H.dna)
@@ -232,6 +233,7 @@
 	M.regenerate_icons()
 	M.pixel_y -= -GUILLOTINE_HEAD_OFFSET // Move their body back
 	M.layer -= GUILLOTINE_LAYER_DIFF
+	SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "dying")
 	..()
 
 /obj/structure/guillotine/can_be_unfasten_wrench(mob/user, silent)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Being put in an electric chair/guillotine now gives you a terrible mood debuff. Being held up also gives you a bad mood debuff, but not as bad. (note: neither are lasting, so shitters cant point a laser tag gun at you or strap you into a e chair to fuck with your mood)

## Why It's Good For The Game

Adds more flavor to small things in the game, better IMMERSION

## Changelog
:cl:
add: Adds a couple new mood events for being held up and put in an electric chair/guillotine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
