### PR TITLE
Fixes shitty mesons on borgs and mining drones

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -86,7 +86,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	wanted_lvl.icon_state = "wanted_0"
 	wanted_lvl.screen_loc = ui_wanted_lvl
 	infodisplay += wanted_lvl
-
+	owner.overlay_fullscreen("see_through_darkness", /obj/screen/fullscreen/see_through_darkness)
 
 /datum/hud/Destroy()
 	if(mymob.hud_used == src)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -82,7 +82,6 @@
 
 /datum/hud/human/New(mob/living/carbon/human/owner)
 	..()
-	owner.overlay_fullscreen("see_through_darkness", /obj/screen/fullscreen/see_through_darkness)
 
 	var/widescreen_layout = FALSE
 	if(owner.client?.prefs?.widescreenpref)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -733,7 +733,7 @@
 
 	if(sight_mode & BORGMESON)
 		sight |= SEE_TURFS
-		lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+		lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 		see_in_dark = 1
 
 	if(sight_mode & BORGMATERIAL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #49511
IT WAS CAUSED BY THE FUCKING HUD BACKGROUND NOT BEING SET ON ANYTHING THAT ISN'T FUCKING CARBONS WHYYYYYYYYYYYYYYYYYYYYYYYYYYYYY

Makes brings brog mesons alpha in line with the default mesons. It used to look like this :
![image](https://user-images.githubusercontent.com/58055496/76578299-6ec42e00-6485-11ea-8c25-3c489be83cb5.png)
Ignore the textbar, I'm still clawing at the void that is negative molar counts.
Now looks like this:
![image](https://user-images.githubusercontent.com/58055496/76578369-96b39180-6485-11ea-8c1f-66f1f74fb93c.png)



## Why It's Good For The Game

Used to look like trash. No longer looks like trash.
![image](https://user-images.githubusercontent.com/58055496/76578461-ea25df80-6485-11ea-953c-079f88407ec7.png)
![image](https://user-images.githubusercontent.com/58055496/76578745-d4fd8080-6486-11ea-8d75-05bda2ac7406.png)



## Changelog
:cl: LemonInTheDark with thanks to ArcaneDefense
tweak: Makes borg mesons non full-bright 
fix: Fixes mining drone mesons being non full-bright
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
