### PR TITLE
Fixes Singularity Weirdness

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -27,6 +27,7 @@
 	var/last_failed_movement = 0//Will not move in the same dir if it couldnt before, will help with the getting stuck on fields thing
 	var/last_warning
 	var/consumedSupermatter = 0 //If the singularity has eaten a supermatter shard and can go to stage six
+	var/drifting_dir = 0 // Chosen direction to drift in
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	obj_flags = CAN_BE_HIT | DANGEROUS_POSSESSION
 
@@ -53,6 +54,17 @@
 	return ..()
 
 /obj/singularity/Move(atom/newloc, direct)
+	var/turf/T = get_turf(src)
+	for(var/dir in GLOB.cardinals)
+		if(direct & dir)
+			T = get_step(T, dir)
+			if(!T)
+				break
+			// eat the stuff if we're going to move into it so it doesn't mess up our movement
+			for(var/atom/A in T.contents)
+				consume(A)
+			consume(T)
+
 	if(current_size >= STAGE_FIVE || check_turfs_in(direct))
 		last_failed_movement = 0//Reset this because we moved
 		return ..()
@@ -120,8 +132,12 @@
 
 /obj/singularity/Bump(atom/A)
 	consume(A)
+	step(src, drifting_dir)
 	return
 
+/obj/singularity/Crossed(atom/A)
+	..()
+	consume(A)
 
 /obj/singularity/Bumped(atom/movable/AM)
 	consume(AM)
@@ -302,15 +318,15 @@
 	if(!move_self)
 		return 0
 
-	var/movement_dir = pick(GLOB.alldirs - last_failed_movement)
+	var/drifting_dir = pick(GLOB.alldirs - last_failed_movement)
 
 	if(force_move)
-		movement_dir = force_move
+		drifting_dir = force_move
 
 	if(target && prob(60))
-		movement_dir = get_dir(src,target) //moves to a singulo beacon, if there is one
+		drifting_dir = get_dir(src,target) //moves to a singulo beacon, if there is one
 
-	step(src, movement_dir)
+	step(src, drifting_dir)
 
 /obj/singularity/proc/check_cardinals_range(steps, retry_with_move = FALSE)
 	. = length(GLOB.cardinals)			//Should be 4.

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -132,7 +132,8 @@
 
 /obj/singularity/Bump(atom/A)
 	consume(A)
-	step(src, drifting_dir)
+	if(QDELETED(A)) // don't keep moving into objects that weren't destroyed infinitely
+		step(src, drifting_dir)
 	return
 
 /obj/singularity/Crossed(atom/A)


### PR DESCRIPTION
## About The Pull Request

Fixes #9946 by making the singularity eat objects before it moves into them, or if it is blocked by the object (usually something it spawns when it is broken), it attempts to eat it and move again. This as well as objects the singularity crosses are automatically eaten, no longer can you avoid destruction by moving through the singularity really fast.

## Why It's Good For The Game

Makes the singularity move real smooth and clears out an old issue.

## Changelog
:cl:
fix: The singularity no longer stops moving when it hits machinery objects that drop their machine frames.
/:cl:
