### PR TITLE
[s] Energy cake exploit fix

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_cake.dm
+++ b/code/modules/food_and_drinks/food/snacks_cake.dm
@@ -205,6 +205,8 @@
 
 /obj/item/reagent_containers/food/snacks/store/cake/birthday/energy/attack(mob/living/M, mob/living/user)
 	. = ..()
+	if(HAS_TRAIT(user, TRAIT_PACIFISM) && M != user) //Prevents pacifists from attacking others directly
+		return
 	energy_bite(M, user)
 
 /obj/item/reagent_containers/food/snacks/store/cake/birthday/energy/microwave_act(obj/machinery/microwave/M) //super sekriter club
@@ -228,6 +230,8 @@
 
 /obj/item/reagent_containers/food/snacks/cakeslice/birthday/energy/attack(mob/living/M, mob/living/user)
 	. = ..()
+	if(HAS_TRAIT(user, TRAIT_PACIFISM) && M != user) //Prevents pacifists from attacking others directly
+		return
 	energy_bite(M, user)
 
 /obj/item/reagent_containers/food/snacks/store/cake/apple


### PR DESCRIPTION
## About The Pull Request

Fixes an exploit that pacifists could use to deal damage directly to other players, without changing their ability to kill themselves while trying to eat an energy cake.
Doesn't have any effect on non-pacifist energy cake based interactions. 

## Why It's Good For The Game

Pacifists don't need to be doing 30 brute damage directly to someone's head in melee without the environment.
No more tactical assault cakes

## Changelog
:cl:
fix: Pacifists will no longer mutilate their fellow spacemen when attempting to share energy cake
/:cl:
