### PR TITLE
Removes the Emag functionality from the Goat Plushie

### DIFF
--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -573,6 +573,7 @@
 		ram()
 
 /obj/item/toy/plush/goatplushie/angry/proc/ram()
+if(prob(90) && isturf(loc) && considered_alive(target.mind) && !faction_check(list("goat"), target.faction, FALSE))
 		throw_at(target, 10, 10)
 		visible_message("<span class='danger'>[src] rams [target]!</span>")
 		cooldown = world.time + cooldown_modifier

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -573,7 +573,7 @@
 		ram()
 
 /obj/item/toy/plush/goatplushie/angry/proc/ram()
-if(prob(90) && isturf(loc) && considered_alive(target.mind) && !faction_check(list("goat"), target.faction, FALSE))
+    if(prob(90) && isturf(loc) && considered_alive(target.mind) && !faction_check(list("goat"), target.faction, FALSE))
 		throw_at(target, 10, 10)
 		visible_message("<span class='danger'>[src] rams [target]!</span>")
 		cooldown = world.time + cooldown_modifier

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -573,7 +573,6 @@
 		ram()
 
 /obj/item/toy/plush/goatplushie/angry/proc/ram()
-	if(prob((obj_flags & EMAGGED) ? 98:90) && isturf(loc) && considered_alive(target.mind) && !faction_check(list("goat"), target.faction, FALSE))
 		throw_at(target, 10, 10)
 		visible_message("<span class='danger'>[src] rams [target]!</span>")
 		cooldown = world.time + cooldown_modifier

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -580,15 +580,6 @@
 	target = null
 	visible_message("<span class='notice'>[src] looks disinterested.</span>")
 
-/obj/item/toy/plush/goatplushie/angry/emag_act(mob/user)
-	if (obj_flags&EMAGGED)
-		visible_message("<span class='notice'>[src] already looks angry enough, you shouldn't anger it more.</span>")
-		return
-	cooldown_modifier = 5
-	throwforce = 20
-	obj_flags |= EMAGGED
-	visible_message("<span class='danger'>[src] stares at [user] angrily before going docile.</span>")
-
 /obj/item/toy/plush/goatplushie/angry/Destroy()
 	STOP_PROCESSING(SSprocessing, src)
 	return ..()


### PR DESCRIPTION

## About The Pull Request

The purpose of this PR was to fix the throw force of the goat plushie which was affected by the emagging of the plushie. Which is why removing the regarding emagging fixes the throwforce. 

## Why It's Good For The Game

It fixes's the throwforce issue of the goat plushie, since emagging it reduces the throwforce. Which is why removing the emag code is crucial.

## Changelog
:cl:
del: Emagged Goat Plushie which fixes throwforce.
/:cl:


