### PR TITLE
Higadrite Metabolization Fix

### DIFF
--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -580,6 +580,15 @@
 	target = null
 	visible_message("<span class='notice'>[src] looks disinterested.</span>")
 
+/obj/item/toy/plush/goatplushie/angry/emag_act(mob/user)
+	if (obj_flags&EMAGGED)
+		visible_message("<span class='notice'>[src] already looks angry enough, you shouldn't anger it more.</span>")
+		return
+	cooldown_modifier = 5
+	throwforce = 20
+	obj_flags |= EMAGGED
+	visible_message("<span class='danger'>[src] stares at [user] angrily before going docile.</span>")
+
 /obj/item/toy/plush/goatplushie/angry/Destroy()
 	STOP_PROCESSING(SSprocessing, src)
 	return ..()

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -580,15 +580,6 @@
 	target = null
 	visible_message("<span class='notice'>[src] looks disinterested.</span>")
 
-/obj/item/toy/plush/goatplushie/angry/emag_act(mob/user)
-	if (obj_flags&EMAGGED)
-		visible_message("<span class='notice'>[src] already looks angry enough, you shouldn't anger it more.</span>")
-		return
-	cooldown_modifier = 5
-	throwforce = 20
-	obj_flags |= EMAGGED
-	visible_message("<span class='danger'>[src] stares at [user] angrily before going docile.</span>")
-
 /obj/item/toy/plush/goatplushie/angry/Destroy()
 	STOP_PROCESSING(SSprocessing, src)
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1061,7 +1061,7 @@
 	self_consuming = TRUE
 
 /datum/reagent/medicine/higadrite/on_mob_metabolize(mob/living/M)
-	..()
+	. = ..()
 	ADD_TRAIT(M, TRAIT_STABLELIVER, type)
 
 /datum/reagent/medicine/higadrite/on_mob_end_metabolize(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1060,7 +1060,7 @@
 	color = "#FF3542"
 	self_consuming = TRUE
 
-/datum/reagent/medicine/higadrite/on_mob_add(mob/living/M)
+/datum/reagent/medicine/higadrite/on_mob_metabolize(mob/living/M)
 	..()
 	ADD_TRAIT(M, TRAIT_STABLELIVER, type)
 


### PR DESCRIPTION
## About The Pull Request
Fixes #49512 

There has been issues regarding the chemical higadrite, since the chemical doesn't disappear, and keeps on metabolizing. The issue was caused by the on_mob_add that keeps on adding the chemical, without it stopping. Which is why it is replaced with on_mob_metabolize.


## Why It's Good For The Game

Well, it fixes the exploit which is that it keeps giving the liver infinite protection from toxin damage.

