### PR TITLE
Modular computers, in particular tablets, now have export values.

### DIFF
--- a/code/modules/cargo/exports/parts.dm
+++ b/code/modules/cargo/exports/parts.dm
@@ -30,7 +30,7 @@
 //Processors.
 
 /datum/export/modular_part/processor
-	cost = 60
+	cost = 40
 	unit_name = "computer processor"
 	export_types = list(/obj/item/computer_hardware/processor_unit)
 	include_subtypes = FALSE
@@ -97,7 +97,7 @@
 	include_subtypes = TRUE
 
 /datum/export/modular_part/intellicard
-	cost = 20
+	cost = 40
 	unit_name = "computer intellicard slot"
 	export_types = list(/obj/item/computer_hardware/ai_slot)
 	include_subtypes = TRUE

--- a/code/modules/cargo/exports/parts.dm
+++ b/code/modules/cargo/exports/parts.dm
@@ -19,3 +19,85 @@
 	cost = 2000
 	unit_name = "deactivated alien deconstruction drone"
 	export_types = list(/obj/item/deactivated_swarmer)
+
+//Computer Tablets and Parts
+/datum/export/modular_part
+	cost = 15
+	unit_name = "miscellaneous computer part"
+	export_types = list(/obj/item/computer_hardware)
+	include_subtypes = TRUE
+
+//Processors.
+
+/datum/export/modular_part/processor
+	cost = 60
+	unit_name = "computer processor"
+	export_types = list(/obj/item/computer_hardware/processor_unit)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/processor/photoic
+	cost = 100
+	unit_name = "advanced computer processor"
+	export_types = list(/obj/item/computer_hardware/processor_unit)
+	include_subtypes = FALSE
+
+//Batteries.
+
+/datum/export/modular_part/battery
+	cost = 40
+	unit_name = "computer power cell"
+	export_types = list(/obj/item/stock_parts/cell/computer/nano)
+	include_subtypes = FALSE
+
+
+/datum/export/modular_part/battery
+	cost = 100
+	unit_name = "upgraded computer power cell"
+	export_types = list(/obj/item/stock_parts/cell/computer/micro)
+	include_subtypes = FALSE
+
+
+/datum/export/modular_part/battery/advanced
+	cost = 150
+	unit_name = "advanced computer power cell"
+	export_types = list(/obj/item/stock_parts/cell/computer)
+	include_subtypes = FALSE
+
+//Hard Drives.
+
+/datum/export/modular_part/harddrive
+	cost = 10
+	unit_name = "tiny computer harddrive"
+	export_types = list(/obj/item/computer_hardware/hard_drive/micro)
+	include_subtypes = TRUE
+
+/datum/export/modular_part/harddrive/small
+	cost = 50
+	unit_name = "small computer harddrive"
+	export_types = list(/obj/item/computer_hardware/hard_drive/small)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/harddrive/normal
+	cost = 80
+	unit_name = "computer harddrive"
+	export_types = list(/obj/item/computer_hardware/hard_drive)
+	include_subtypes = FALSE
+
+//Networking/Card Parts
+/datum/export/modular_part/networkcard
+	cost = 50
+	unit_name = "computer network card"
+	export_types = list(/obj/item/computer_hardware/network_card)
+	include_subtypes = TRUE
+
+/datum/export/modular_part/idcard
+	cost = 20
+	unit_name = "computer ID card slot"
+	export_types = list(/obj/item/computer_hardware/card_slot)
+	include_subtypes = TRUE
+
+/datum/export/modular_part/intellicard
+	cost = 20
+	unit_name = "computer intellicard slot"
+	export_types = list(/obj/item/computer_hardware/ai_slot)
+	include_subtypes = TRUE


### PR DESCRIPTION
This is a cargo change, not an economy change. Even if we get rid of economy, export datums will still affect cargo points.

## About The Pull Request

Tired of your job giving you a modular computer (where you can play the arcade app) and not having anything to do with it (outside of playing the arcade app)? Well, now modular computer parts each have export datums, so that they're fully sellable to cargo. The lowest tier tablet sells for just under 199 due to elasticity, so if you really want to part with it you may, and cargo will take it off your hands.

## Why It's Good For The Game

In theory, modular computers are a commodity. By that logic, and considering how only technically trained crewmembers are given one roundstart (And the janitor, for some reason), it would make sense to treat this like a valuable piece of hardware in terms of exports.

## Changelog
:cl:
add: Modular Computers will now sell on the cargo shuttle.
/:cl:
