### PR TITLE
Adds biosuit and biohood to JaniDrobe

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -295,7 +295,9 @@
 					/obj/item/storage/bag/trash = 2,
 					/obj/item/clothing/shoes/galoshes = 2,
 					/obj/item/watertank/janitor = 1,
-					/obj/item/storage/belt/janitor = 2)
+					/obj/item/storage/belt/janitor = 2,
+					/obj/item/clothing/suit/bio_suit/janitor = 2,
+					/obj/item/clothing/head/bio_hood/janitor = 2)
 	refill_canister = /obj/item/vending_refill/wardrobe/jani_wardrobe
 	payment_department = ACCOUNT_SRV
 /obj/item/vending_refill/wardrobe/jani_wardrobe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Puts two biosuit hoods and biosuits in JaniDrobes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Not all stations (e.g. Donut) have the janitor's L3 Closet, and those that do only have one biosuit for two janitors. The biosuit is the only way to equip a trashbag while using a janibelt without taking up a hand slot. You can also use the janicart, but it's not always available, or the janitorial cart, which is a clunky piece of shit that goes careening down the hallway anytime someone accidentally runs into it and probably will be until somebody converts it to use the radial menu and locks it to the janitor's grip like someone in handcuffs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
tweak: The JaniDrobe now has two biosuits. Janitors can use the exosuit slots on these to equip their trashbag, in exchange for a slowdown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
