### PR TITLE
Removes the requirement for tgui usage from CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -250,12 +250,6 @@ This prevents nesting levels from getting deeper then they need to be.
 	* Please attempt to clean out any dirty variables that may be contained within items you alter through var-editing. For example, due to how DM functions, changing the `pixel_x` variable from 23 to 0 will leave a dirty record in the map's code of `pixel_x = 0`. Likewise this can happen when changing an item's icon to something else and then back. This can lead to some issues where an item's icon has changed within the code, but becomes broken on the map due to it still attempting to use the old entry.
 	* Areas should not be var-edited on a map to change it's name or attributes. All areas of a single type and it's altered instances are considered the same area within the code, and editing their variables on a map can lead to issues with powernets and event subsystems which are difficult to debug.
 
-### User Interfaces
-* All new player-facing user interfaces must use TGUI.
-* Raw HTML is permitted for admin and debug UIs.
-* Documentation for TGUI can be found at:
-	* [tgui/README.md](../tgui/README.md)
-	* [tgui/tutorial-and-examples.md](../tgui/docs/tutorial-and-examples.md)
 
 ### Other Notes
 * Code should be modular where possible; if you are working on a new addition, then strongly consider putting it in its own file unless it makes sense to put it with similar ones (i.e. a new tool would go in the "tools.dm" file)


### PR DESCRIPTION
You zoomers may be talking about how it's the hot new fangled stuff that can *do everything* but I've been sold this lie about 5 times now

until we have solid evidence that stylemistake isnt going to just disappear in a week until another javascript dev floats into the codebase and refactors tgui on a whim, i dont think it should be enshrined in the codebase requirements where we could easily end up with tons of stuff being magic "well, it works, but we dont know how and cant fix it if it breaks" boxes

also i hate javascript