### PR TITLE
Removes the Lavaland mint

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1003,7 +1003,8 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "da" = (
-/obj/machinery/mineral/mint,
+/obj/item/reagent_containers/food/snacks/mint,
+/obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "db" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For those unaware, the mint can be used to convert minerals to coins. Coins can then be used on your ID to add their value to your account. You can then use this money to buy private crates through cargo and at vending machines. Each mineral sheet mints 5 coins, and it takes about a minute to mint an entire stack of 50 sheets. Coins are worth more money than just exporting the sheet (aside from plasma, which has its k-elasticity set to 0, whatever that means). With public mining anyone can access the mint. 

Below is a table that gives the credit value of each coin, and each mineral sheet and mineral stack when converted to coins.
| Mineral    | Credit value per coin | Credit value per sheet when coined | Credit value per stack (50 sheets) when coined |
|------------|------------------|-------------------------------|-------------------------------------------|
| Iron       | 1                | 5                             | 250                                       |
| Plastic    | 5                | 25                            | 1250                                      |
| Silver     | 10               | 50                            | 2500                                      |
| Uranium    | 20               | 100                           | 5000                                      |
| Gold       | 25               | 125                           | 6250                                      |
| Titanium   |  25              | 125                           | 6250                                      |
| Plasma     | 40               | 200                           | 10000                                     |
| Diamond    | 100              | 500                           | 25000                                     |
| Adamantine | 100              | 500                           | 25000                                    |
| Runite     | 120              | 600                           | 30000                                     |
| Bananium   | 200              | 1000                          | 50000                                    |
| Mythril    | 300              | 1500                          | 75000                                 |

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The problem is that when taken advantage of this causes inflation (i.e. devalues the money) which further lowers what little leverage our money has between players and allows people to take advantage of cargo and vending machines' fixed prices (which don't take into account supply and demand, something that also affects currencies) and are supposed to be balanced around salaries. 

Removing the mint from this map (it's still on two away missions) doesn't mean it can't make a return if balanced properly. Coin values, coins per sheet, and time per sheet to coin could all be tweaked.

## Why It's Good For The Game

Moves currency a step closer to having actual leverage between players, and removes a source of inflation that allows players to take advantage of cargo private crates and vending machines.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
del: Lavaland mint has been deleted from the map for the sake of Economy, possibly to make a return if balanced in future
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
