### PR TITLE
AI Shell naming consistency

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -51,6 +51,7 @@
 	var/emag_cooldown = 0
 	var/wiresexposed = 0
 
+	/// Random serial number generated for each cyborg upon its initialization
 	var/ident = 0
 	var/locked = TRUE
 	var/list/req_access = list(ACCESS_ROBOTICS)
@@ -866,18 +867,27 @@
 	update_icons()
 	. = ..()
 
-/mob/living/silicon/robot/proc/make_shell(var/obj/item/borg/upgrade/ai/board)
+/**
+  * make_shell: Makes an AI shell out of a cyborg unit
+  *
+  * Arguments:
+  * * board - B.O.R.I.S. module board used for transforming the cyborg into AI shell
+  */
+/mob/living/silicon/robot/proc/make_shell(obj/item/borg/upgrade/ai/board)
 	if(!board)
 		upgrades |= new /obj/item/borg/upgrade/ai(src)
 	shell = TRUE
 	braintype = "AI Shell"
-	name = "[designation] AI Shell [rand(100,999)]"
+	name = "Empty AI Shell-[ident]"
 	real_name = name
 	GLOB.available_ai_shells |= src
 	if(!QDELETED(builtInCamera))
 		builtInCamera.c_tag = real_name	//update the camera name too
 	diag_hud_set_aishell()
 
+/**
+  * revert_shell: Reverts AI shell back into a normal cyborg unit
+  */
 /mob/living/silicon/robot/proc/revert_shell()
 	if(!shell)
 		return
@@ -887,14 +897,20 @@
 		qdel(boris)
 	shell = FALSE
 	GLOB.available_ai_shells -= src
-	name = "Unformatted Cyborg [rand(100,999)]"
+	name = "Unformatted Cyborg-[ident]"
 	real_name = name
 	if(!QDELETED(builtInCamera))
 		builtInCamera.c_tag = real_name
 	diag_hud_set_aishell()
 
-/mob/living/silicon/robot/proc/deploy_init(var/mob/living/silicon/ai/AI)
-	real_name = "[AI.real_name] shell [rand(100, 999)] - [designation]"	//Randomizing the name so it shows up separately in the shells list
+/**
+  * deploy_init: Deploys AI unit into AI shell
+  *
+  * Arguments:
+  * * AI - AI unit that initiated the deployment into the AI shell
+  */
+/mob/living/silicon/robot/proc/deploy_init(mob/living/silicon/ai/AI)
+	real_name = "[AI.real_name] Shell-[ident]"
 	name = real_name
 	if(!QDELETED(builtInCamera))
 		builtInCamera.c_tag = real_name	//update the camera name too


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR brings a naming consistency to AI shells in all their forms.

1) AI shells will no longer generate totally random number upon creation and each AI deployment into it. The number will stay consistent at all times, from the shell creation to AI deploying into it.

2) AI shells will no longer show their designation in their name, because it could lead to a very long names, and because it could even be misleading - AI shell with an engineering designation could end up resetting into medical, but name would stay the same. It was not very useful either, as you can see the module clearly on the unit itself or in Robotics Control Console.

Fixes #42865
Fixes #48725

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Consistency.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
tweak: AI shells will now have consistent names across deployments.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
