### PR TITLE
Assemblies, TTV and Electropack now require you to hold them in your hand to use their UI

### DIFF
--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -31,11 +31,9 @@
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/electropack/attack_hand(mob/user)
-	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		if(src == C.back)
-			to_chat(user, "<span class='warning'>You need help taking this off!</span>")
-			return
+	if(!is_interactive(user))
+		to_chat(user, "<span class='warning'>You need help taking this off!</span>")
+		return
 	return ..()
 
 /obj/item/electropack/attackby(obj/item/W, mob/user, params)
@@ -85,11 +83,23 @@
 	frequency = new_frequency
 	SSradio.add_object(src, frequency, RADIO_SIGNALER)
 
+/**
+  * is_interactive: Checks if mob is allowed to interact with the item
+  *
+  * Arguments:
+  * * user - mob for who we are checking if he can interact with the item
+  */
+/obj/item/electropack/proc/is_interactive(mob/user)
+	if(iscarbon(user))
+		var/mob/living/carbon/C = user
+		if(C.back == src)
+			return FALSE
+	return TRUE
+
 /obj/item/electropack/ui_status(mob/user)
-	var/mob/living/carbon/C = user
-	if(C?.back == src)
-		return UI_CLOSE
-	return ..()
+	if(is_interactive(user))
+		return ..()
+	return UI_CLOSE
 
 /obj/item/electropack/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
@@ -110,9 +120,7 @@
 /obj/item/electropack/ui_act(action, params)
 	if(..())
 		return
-
-	var/mob/living/carbon/C = usr
-	if(C?.back == src)
+	if(!is_interactive(usr))
 		return
 
 	switch(action)

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -31,9 +31,11 @@
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/electropack/attack_hand(mob/user)
-	if(!is_interactive(user))
-		to_chat(user, "<span class='warning'>You need help taking this off!</span>")
-		return
+	if(iscarbon(user))
+		var/mob/living/carbon/C = user
+		if(src == C.back)
+			to_chat(user, "<span class='warning'>You need help taking this off!</span>")
+			return
 	return ..()
 
 /obj/item/electropack/attackby(obj/item/W, mob/user, params)
@@ -83,24 +85,6 @@
 	frequency = new_frequency
 	SSradio.add_object(src, frequency, RADIO_SIGNALER)
 
-/**
-  * is_interactive: Checks if mob is allowed to interact with the item
-  *
-  * Arguments:
-  * * user - mob for who we are checking if he can interact with the item
-  */
-/obj/item/electropack/proc/is_interactive(mob/user)
-	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		if(C.back == src)
-			return FALSE
-	return TRUE
-
-/obj/item/electropack/ui_status(mob/user)
-	if(is_interactive(user))
-		return ..()
-	return UI_CLOSE
-
 /obj/item/electropack/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.hands_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
@@ -119,8 +103,6 @@
 
 /obj/item/electropack/ui_act(action, params)
 	if(..())
-		return
-	if(!is_interactive(usr))
 		return
 
 	switch(action)

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -102,7 +102,7 @@
 	return UI_CLOSE
 
 /obj/item/electropack/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
-									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
+									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.hands_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "electropack", name, ui_x, ui_y, master_ui, state)

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -194,7 +194,7 @@
 	return
 
 /obj/item/transfer_valve/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
-									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
+									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.hands_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "transfer_valve", name, ui_x, ui_y, master_ui, state)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -189,7 +189,7 @@
 	return UI_CLOSE
 
 /obj/item/assembly/infra/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
-									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
+									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.hands_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "infrared_emitter", name, ui_x, ui_y, master_ui, state)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -116,7 +116,7 @@
 	return UI_CLOSE
 
 /obj/item/assembly/prox_sensor/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
-									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
+									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.hands_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "proximity_sensor", name, ui_x, ui_y, master_ui, state)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -70,7 +70,7 @@
 	return UI_CLOSE
 
 /obj/item/assembly/signaler/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
-									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
+									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.hands_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "signaler", name, ui_x, ui_y, master_ui, state)

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -91,7 +91,7 @@
 	return UI_CLOSE
 
 /obj/item/assembly/timer/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
-									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
+									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.hands_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "timer", name, ui_x, ui_y, master_ui, state)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You must now hold Assemblies, TTV and Electropack in your hands in order to manipulate with their UI, as that is consistent with other items with an UI and saves us some redundant code Electropack code. This also fixes an issue where observers were unable to view Electropack UI due to bad status check.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix and item UI consistency.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
fix: Observers can now properly view Electropack UI.
tweak: You must now hold Assemblies, TTV and Electropack in your hands in order to use their UIs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
