### PR TITLE
Adds a minimum drinking/smoking age

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -284,6 +284,7 @@
 //MINOR TWEAKS/MISC
 #define AGE_MIN				17	//youngest a character can be
 #define AGE_MAX				85	//oldest a character can be
+#define AGE_MINOR			20  //legal age of space drinking and smoking
 #define WIZARD_AGE_MIN		30	//youngest a wizard can be
 #define APPRENTICE_AGE_MIN	29	//youngest an apprentice can be
 #define SHOES_SLOWDOWN		0	//How much shoes slow you down by default. Negative values speed you up

--- a/code/__DEFINES/wires.dm
+++ b/code/__DEFINES/wires.dm
@@ -50,4 +50,5 @@
 #define WIRE_ZAP2 "High Voltage Circuit 2"
 #define WIRE_PRIZEVEND "Emergency Prize Vend"
 #define WIRE_RESETOWNER "Reset Owner"
+#define WIRE_AGELIMIT "Age Limit"
 

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -30,6 +30,8 @@ GLOBAL_LIST_INIT(simple_animals, list(list(),list(),list(),list())) // One for e
 GLOBAL_LIST_EMPTY(spidermobs)				//all sentient spider mobs
 GLOBAL_LIST_EMPTY(bots_list)
 GLOBAL_LIST_EMPTY(aiEyes)
+///underages who have been reported to security for trying to buy things they shouldn't, so they can't spam
+GLOBAL_LIST_EMPTY(narcd_underages)
 
 GLOBAL_LIST_EMPTY(language_datum_instances)
 GLOBAL_LIST_EMPTY(all_languages)

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -24,7 +24,7 @@
 	status += "The red light is [V.shoot_inventory ? "off" : "blinking"]."
 	status += "The green light is [V.extended_inventory ? "on" : "off"]."
 	status += "A [V.scan_id ? "purple" : "yellow"] light is on."
-	status += "A white light is [V.age_restriction ? "on" : "off"]."
+	status += "A white light is [V.age_restrictions ? "on" : "off"]."
 	status += "The speaker light is [V.shut_up ? "off" : "on"]."
 	return status
 
@@ -42,7 +42,7 @@
 		if(WIRE_SPEAKER)
 			V.shut_up = !V.shut_up
 		if(WIRE_AGELIMIT)
-			V.age_restriction = !V.age_restriction
+			V.age_restrictions = !V.age_restrictions
 
 /datum/wires/vending/on_cut(wire, mend)
 	var/obj/machinery/vending/V = holder

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -24,6 +24,7 @@
 	status += "The red light is [V.shoot_inventory ? "off" : "blinking"]."
 	status += "The green light is [V.extended_inventory ? "on" : "off"]."
 	status += "A [V.scan_id ? "purple" : "yellow"] light is on."
+	status += "A white light is [V.age_restriction ? "on" : "off"]."
 	status += "The speaker light is [V.shut_up ? "off" : "on"]."
 	return status
 
@@ -40,6 +41,8 @@
 			V.scan_id = !V.scan_id
 		if(WIRE_SPEAKER)
 			V.shut_up = !V.shut_up
+		if(WIRE_AGELIMIT)
+			V.age_restriction = !V.age_restriction
 
 /datum/wires/vending/on_cut(wire, mend)
 	var/obj/machinery/vending/V = holder

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -60,6 +60,8 @@
 	var/custom_price
 	///Economy cost of item in premium vendor
 	var/custom_premium_price
+	///Whether spessmen with an ID with an age below AGE_MINOR (20 by default) can buy this item
+	var/age_restricted = FALSE
 
 	//List of datums orbiting this atom
 	var/datum/component/orbiter/orbiters

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -257,6 +257,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		var/target_name = inserted_modify_id ? html_encode(inserted_modify_id.name) : "--------"
 		var/target_owner = (inserted_modify_id && inserted_modify_id.registered_name) ? html_encode(inserted_modify_id.registered_name) : "--------"
 		var/target_rank = (inserted_modify_id && inserted_modify_id.assignment) ? html_encode(inserted_modify_id.assignment) : "Unassigned"
+		var/target_age = (inserted_modify_id && inserted_modify_id.registered_age) ? html_encode(inserted_modify_id.registered_age) : "--------"
 
 		if(!authenticated)
 			header += {"<br><i>Please insert the cards into the slots</i><br>
@@ -303,7 +304,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 					<input type='hidden' name='src' value='[REF(src)]'>
 					<input type='hidden' name='choice' value='reg'>
 					<b>registered name:</b> <input type='text' id='namefield' name='reg' value='[target_owner]' style='width:250px; background-color:white;' onchange='markRed()'>
-					<input type='submit' value='Rename' onclick='markGreen()'>
+					<b>registered age:</b> <input type='number' id='namefield' name='setage' value='[target_age]' style='width:50px; background-color:white;' onchange='markRed()'>
+					<input type='submit' value='Submit' onclick='markGreen()'>
 					</form>
 					<b>Assignment:</b> "}
 
@@ -482,6 +484,14 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			if (authenticated)
 				var/t2 = inserted_modify_id
 				if ((authenticated && inserted_modify_id == t2 && (in_range(src, usr) || issilicon(usr)) && isturf(loc)))
+					var/newAge = text2num(href_list["setage"])|null
+					if(newAge && isnum(newAge))
+						inserted_modify_id.registered_age = newAge
+						playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
+					else if(!isnull(newAge))
+						to_chat(usr, "<span class='alert'>Invalid age entered- age not updated.</span>")
+						updateUsrDialog()
+
 					var/newName = reject_bad_name(href_list["reg"])
 					if(newName)
 						inserted_modify_id.registered_name = newName

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -119,6 +119,7 @@
 	var/obj/machinery/paystand/my_store
 	var/uses_overlays = TRUE
 	var/icon/cached_flat_icon
+	var/registered_age = 13 // default age for ss13 players
 
 /obj/item/card/id/Initialize(mapload)
 	. = ..()
@@ -142,7 +143,7 @@
 	. = ..()
 	if(.)
 		switch(var_name)
-			if("assignment","registered_name")
+			if("assignment","registered_name","registered_age")
 				update_label()
 
 /obj/item/card/id/attackby(obj/item/W, mob/user, params)
@@ -274,6 +275,8 @@
 
 /obj/item/card/id/examine(mob/user)
 	. = ..()
+	if(registered_age)
+		. += "The card indicates that the holder is [registered_age] years old. [(registered_age < AGE_MINOR) ? "There's a holographic stripe that reads <b><span class='danger'>'MINOR: DO NOT SERVE ALCOHOL OR TOBACCO'</span></b> along the bottom of the card." : ""]"
 	if(mining_points)
 		. += "There's [mining_points] mining equipment redemption point\s loaded onto this card."
 	if(registered_account)
@@ -335,7 +338,7 @@ update_label()
 
 /obj/item/card/id/proc/update_label()
 	var/blank = !registered_name
-	name = "[blank ? id_type_name : "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"]"
+	name = "[blank ? id_type_name : "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"][!blank && registered_age < AGE_MINOR ? " <b>(MINOR)</b>":""]"
 	update_icon()
 
 /obj/item/card/id/silver
@@ -412,6 +415,11 @@ update_label()
 			var/target_occupation = stripped_input(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels other than Maintenance.", "Agent card job assignment", assignment ? assignment : "Assistant", MAX_MESSAGE_LEN)
 			if(!target_occupation)
 				return
+
+			var/newAge = input(user, "Choose the ID's age:\n([AGE_MIN]-[AGE_MAX])", "Agent card age") as num|null
+			if(newAge)
+				registered_age = max(round(text2num(newAge)), 0)
+
 			registered_name = input_name
 			assignment = target_occupation
 			update_label()
@@ -460,6 +468,7 @@ update_label()
 	icon_state = "syndie"
 	access = list(ACCESS_SYNDICATE)
 	uses_overlays = FALSE
+	registered_age = null
 
 /obj/item/card/id/syndicate_command/crew_id
 	name = "syndicate ID card"
@@ -491,6 +500,7 @@ update_label()
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	registered_name = "Captain"
 	assignment = "Captain"
+	registered_age = null
 
 /obj/item/card/id/captains_spare/Initialize()
 	var/datum/job/captain/J = new/datum/job/captain
@@ -513,6 +523,7 @@ update_label()
 	registered_name = "Central Command"
 	assignment = "Central Command"
 	uses_overlays = FALSE
+	registered_age = null
 
 /obj/item/card/id/centcom/Initialize()
 	access = get_all_centcom_access()
@@ -526,6 +537,7 @@ update_label()
 	registered_name = "Emergency Response Team Commander"
 	assignment = "Emergency Response Team Commander"
 	uses_overlays = FALSE
+	registered_age = null
 
 /obj/item/card/id/ert/Initialize()
 	access = get_all_accesses()+get_ert_access("commander")-ACCESS_CHANGE_IDS
@@ -619,6 +631,7 @@ update_label()
 	uses_overlays = FALSE
 	var/goal = 0 //How far from freedom?
 	var/points = 0
+	registered_age = null
 
 /obj/item/card/id/prisoner/attack_self(mob/user)
 	to_chat(usr, "<span class='notice'>You have accumulated [points] out of the [goal] points you need for freedom.</span>")
@@ -668,6 +681,7 @@ update_label()
 	access = list(ACCESS_AWAY_GENERAL)
 	icon_state = "retro"
 	uses_overlays = FALSE
+	registered_age = null
 
 /obj/item/card/id/away/hotel
 	name = "Staff ID"
@@ -715,6 +729,7 @@ update_label()
 	uses_overlays = FALSE
 	var/department_ID = ACCOUNT_CIV
 	var/department_name = ACCOUNT_CIV_NAME
+	registered_age = null
 
 /obj/item/card/id/departmental_budget/Initialize()
 	. = ..()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -136,7 +136,10 @@
 
 /obj/item/card/id/attack_self(mob/user)
 	if(Adjacent(user))
-		user.visible_message("<span class='notice'>[user] shows you: [icon2html(src, viewers(user))] [src.name].</span>", "<span class='notice'>You show \the [src.name].</span>")
+		var/minor
+		if(registered_name && registered_age && registered_age < AGE_MINOR)
+			minor = " <b>(MINOR)</b>"
+		user.visible_message("<span class='notice'>[user] shows you: [icon2html(src, viewers(user))] [src.name][minor].</span>", "<span class='notice'>You show \the [src.name][minor].</span>")
 	add_fingerprint(user)
 
 /obj/item/card/id/vv_edit_var(var_name, var_value)
@@ -338,7 +341,7 @@ update_label()
 
 /obj/item/card/id/proc/update_label()
 	var/blank = !registered_name
-	name = "[blank ? id_type_name : "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"][!blank && registered_age < AGE_MINOR ? " <b>(MINOR)</b>":""]"
+	name = "[blank ? id_type_name : "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"]"
 	update_icon()
 
 /obj/item/card/id/silver

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -137,6 +137,7 @@
 	spawn_type = /obj/item/clothing/mask/cigarette/space_cigarette
 	var/candy = FALSE //for cigarette overlay
 	custom_price = 75
+	age_restricted = TRUE
 
 /obj/item/storage/fancy/cigarettes/ComponentInitialize()
 	. = ..()
@@ -253,6 +254,7 @@
 	icon_type = "candy cigarette"
 	spawn_type = /obj/item/clothing/mask/cigarette/candy
 	candy = TRUE
+	age_restricted = FALSE
 
 /obj/item/storage/fancy/cigarettes/cigpack_candy/Initialize()
 	. = ..()

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -408,6 +408,14 @@
 	glasses = /obj/item/clothing/glasses/sunglasses/reagent
 	id = /obj/item/card/id
 
+/datum/outfit/spacebartender/post_equip(mob/living/carbon/human/H, visualsOnly)
+	. = ..()
+
+	var/obj/item/card/id/W = H.wear_id
+	if(H.age < AGE_MINOR)
+		W.registered_age = AGE_MINOR
+		to_chat(H, "<span class='notice'>You're not technically old enough to access or serve alcohol, but your ID has been discreetly modified to display your age as [AGE_MINOR]. Try to keep that a secret!</span>")
+
 /obj/effect/mob_spawn/human/beach
 	outfit = /datum/outfit/beachbum
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -221,6 +221,8 @@
 
 	var/obj/item/card/id/W = H.wear_id
 	if(W)
+		if(H.age)
+			W.registered_age = H.age
 		if(id_access)
 			for(var/jobtype in typesof(/datum/job))
 				var/datum/job/J = new jobtype

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -576,6 +576,9 @@
 	spillable = FALSE
 	isGlass = FALSE
 	custom_price = 45
+	var/pierced = FALSE
+	obj_flags = CAN_BE_HIT
+
 
 /obj/item/reagent_containers/food/drinks/soda_cans/random/Initialize()
 	..()
@@ -615,7 +618,25 @@
 		crushed_can.icon_state = icon_state
 		qdel(src)
 		return TRUE
+	var/chugged = reagents.total_volume
 	. = ..()
+	if(is_drainable() && pierced && chugged)
+		M.changeNext_move(CLICK_CD_RAPID)
+		if(iscarbon(M))
+			var/mob/living/carbon/broh = M
+			broh.adjustOxyLoss(2)
+			broh.losebreath++
+			switch(broh.losebreath)
+				if(-INFINITY to 0)
+				if(1 to 2)
+					if(prob(30))
+						user.visible_message("<b>[broh]</b>'s eyes water as [broh.p_they()] chug the can of [src]!")
+				if(3 to 6)
+					if(prob(20))
+						user.visible_message("<b>[broh]</b> makes \an [pick(list("uncomfortable", "gross", "troubling"))] gurgling noise as [broh.p_they()] chug the can of [src]!")
+				if(9 to INFINITY)
+					broh.vomit(2, stun=FALSE)
+
 
 /obj/item/reagent_containers/food/drinks/soda_cans/bullet_act(obj/projectile/P)
 	. = ..()
@@ -637,6 +658,24 @@
 	if(!is_drainable())
 		open_soda(user)
 	return ..()
+
+/obj/item/reagent_containers/food/drinks/soda_cans/attacked_by(obj/item/I, mob/living/user)
+	if(I.sharpness && !pierced && user && user.a_intent != INTENT_HARM)
+		user.visible_message("<b>[user]</b> pierces [src] with [I].", "<span class='notice'>You pierce \the [src] with [I].</span>")
+		playsound(src, "can_open", 50, TRUE)
+		pierced = TRUE
+		return
+	else if(I.force)
+		user.visible_message("<b>[user]</b> crushes [src] with [I]! Party foul!", "<span class='warning'>You crush \the [src] with [I]! Party foul!</span>")
+		playsound(src, "can_open", 50, TRUE)
+		var/obj/item/trash/can/crushed_can = new /obj/item/trash/can(src.loc)
+		crushed_can.icon_state = icon_state
+		var/atom/throw_target = get_edge_target_turf(crushed_can, pick(GLOB.alldirs))
+		crushed_can.throw_at(throw_target, rand(1,3), 7)
+		qdel(src)
+		return
+
+	. = ..()
 
 /obj/item/reagent_containers/food/drinks/soda_cans/cola
 	name = "Space Cola"

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -20,6 +20,7 @@
 	var/const/duration = 13 //Directly relates to the 'knockdown' duration. Lowered by armor (i.e. helmets)
 	isGlass = TRUE
 	foodtype = ALCOHOL
+	age_restricted = TRUE // wrryy can't set an init value to see if foodtype contains ALCOHOL so here we go
 
 /obj/item/reagent_containers/food/drinks/bottle/update_overlays()
 	. = ..()
@@ -197,6 +198,7 @@
 	icon_state = "bottleofnothing"
 	list_reagents = list(/datum/reagent/consumable/nothing = 100)
 	foodtype = NONE
+	age_restricted = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/patron
 	name = "Wrapp Artiste Patron"
@@ -362,6 +364,7 @@
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/consumable/orangejuice = 100)
 	foodtype = FRUIT | BREAKFAST
+	age_restricted = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/cream
 	name = "milk cream"
@@ -374,6 +377,7 @@
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/consumable/cream = 100)
 	foodtype = DAIRY
+	age_restricted = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/tomatojuice
 	name = "tomato juice"
@@ -386,6 +390,7 @@
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/consumable/tomatojuice = 100)
 	foodtype = VEGETABLES
+	age_restricted = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/limejuice
 	name = "lime juice"
@@ -398,6 +403,7 @@
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/consumable/limejuice = 100)
 	foodtype = FRUIT
+	age_restricted = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/pineapplejuice
 	name = "pineapple juice"
@@ -410,6 +416,7 @@
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/consumable/pineapplejuice = 100)
 	foodtype = FRUIT | PINEAPPLE
+	age_restricted = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/menthol
 	name = "menthol"
@@ -430,6 +437,7 @@
 	isGlass = TRUE
 	list_reagents = list(/datum/reagent/consumable/grenadine = 100)
 	foodtype = FRUIT
+	age_restricted = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/applejack
 	name = "Buckin' Bronco's Applejack"

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -224,6 +224,8 @@
 		shuffle_inplace(C.access) // Shuffle access list to make NTNet passkeys less predictable
 		C.registered_name = H.real_name
 		C.assignment = J.title
+		if(H.age)
+			C.registered_age = H.age
 		C.update_label()
 		for(var/A in SSeconomy.bank_accounts)
 			var/datum/bank_account/B = A

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -29,3 +29,10 @@
 	backpack_contents = list(/obj/item/storage/box/beanbag=1)
 	shoes = /obj/item/clothing/shoes/laceup
 
+/datum/outfit/job/bartender/post_equip(mob/living/carbon/human/H, visualsOnly)
+	. = ..()
+
+	var/obj/item/card/id/W = H.wear_id
+	if(H.age < AGE_MINOR)
+		W.registered_age = AGE_MINOR
+		to_chat(H, "<span class='notice'>You're not technically old enough to access or serve alcohol, but your ID has been discreetly modified to display your age as [AGE_MINOR]. Try to keep that a secret!</span>")

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -402,6 +402,12 @@
 	message = "yawns."
 	emote_type = EMOTE_AUDIBLE
 
+/datum/emote/living/gurgle
+	key = "gurgle"
+	key_third_person = "gurgles"
+	message = "makes an uncomfortable gurgle."
+	emote_type = EMOTE_AUDIBLE
+
 /datum/emote/living/custom
 	key = "me"
 	key_third_person = "custom"

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -34,6 +34,8 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/custom_price
 	///Does the item have a custom premium price override
 	var/custom_premium_price
+	///Whether spessmen with an ID with an age below AGE_MINOR (20 by default) can buy this item
+	var/age_restricted = FALSE
 
 /**
   * # vending machines
@@ -136,6 +138,8 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/default_price = 25
 	///Default price of premium items if not overridden
 	var/extra_price = 50
+	///Whether our age check is currently functional
+	var/age_restrictions = TRUE
   	/**
 	  * Is this item on station or not
 	  *
@@ -161,6 +165,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 
 	///Name of lighting mask for the vending machine
 	var/light_mask
+
+	/// used for narcing on underages
+	var/obj/item/radio/Radio
 
 /obj/item/circuitboard
     ///determines if the circuit board originated from a vendor off station or not.
@@ -204,11 +211,14 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 				circuit.onstation = onstation //sync up the circuit so the pricing schema is carried over if it's reconstructed.
 	else if(circuit && (circuit.onstation != onstation)) //check if they're not the same to minimize the amount of edited values.
 		onstation = circuit.onstation //if it was constructed outside mapload, sync the vendor up with the circuit's var so you can't bypass price requirements by moving / reconstructing it off station.
+	Radio = new /obj/item/radio(src)
+	Radio.listening = 0
 
 /obj/machinery/vending/Destroy()
 	QDEL_NULL(wires)
 	QDEL_NULL(coin)
 	QDEL_NULL(bill)
+	QDEL_NULL(Radio)
 	return ..()
 
 /obj/machinery/vending/can_speak()
@@ -310,6 +320,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		R.max_amount = amount
 		R.custom_price = initial(temp.custom_price)
 		R.custom_premium_price = initial(temp.custom_premium_price)
+		R.age_restricted = initial(temp.age_restricted)
 		recordlist += R
 /**
   * Refill a vending machine from a refill canister
@@ -783,6 +794,15 @@ GLOBAL_LIST_EMPTY(vending_products)
 					return
 				else if (!C.registered_account)
 					say("No account found.")
+					flick(icon_deny,src)
+					vend_ready = TRUE
+					return
+				else if(R.age_restricted && (!C.registered_age || C.registered_age < AGE_MINOR))
+					say("You are not of legal age to purchase [R.name].")
+					if(!(usr in GLOB.narcd_underages))
+						Radio.set_frequency(FREQ_SECURITY)
+						Radio.talk_into(src, "SECURITY ALERT: Underaged crewmember [H] recorded attempting to purchase [R.name] in [get_area(src)]. Please watch for substance abuse.", FREQ_SECURITY)
+						GLOB.narcd_underages += H
 					flick(icon_deny,src)
 					vend_ready = TRUE
 					return

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -797,7 +797,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 					flick(icon_deny,src)
 					vend_ready = TRUE
 					return
-				else if(R.age_restricted && (!C.registered_age || C.registered_age < AGE_MINOR))
+				else if(age_restrictions && R.age_restricted && (!C.registered_age || C.registered_age < AGE_MINOR))
 					say("You are not of legal age to purchase [R.name].")
 					if(!(usr in GLOB.narcd_underages))
 						Radio.set_frequency(FREQ_SECURITY)

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -66,6 +66,7 @@
 			/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 6,
 			/obj/item/reagent_containers/food/drinks/flask = 1)
 	req_access = null
+	age_restrictions = FALSE
 
 /obj/machinery/vending/boozeomat/pubby_captain //Captain's quarters on Pubbystation
 	products = list(/obj/item/reagent_containers/food/drinks/bottle/rum = 1,
@@ -78,6 +79,7 @@
 
 /obj/machinery/vending/boozeomat/syndicate_access
 	req_access = list(ACCESS_SYNDICATE)
+	age_restrictions = FALSE
 
 /obj/item/vending_refill/boozeomat
 	machine_name = "Booze-O-Mat"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
NT is finally cracking down on underage drinking and smoking on its stations, and you must now be at least 20 years old in order to purchase alcohol or tobacco at vendors. Underage ID's will be visible as such when shown or inspected. Bartenders below the age have discreetly had their IDs modified to be the minimum age, though if anyone cross references the station datacore records, they'll be exposed!

[![dreamseeker_2020-03-31_05-04-22.png](https://i.imgur.com/FRwbz4Ol.jpg)](https://i.imgur.com/FRwbz4O.png)

You can adjust the registered age for an ID at the HoP's console, the same way you would adjust the registered name. You can also pulse the age restriction wire on vending machines to disable the age checking system if you want to hack the system. I chose 20 as the legal limit because I don't care to listen to people fighting about 21 vs 18 and America vs the world, and it still will affect a decent amount of people I figure.

[![2020-03-15_21-40-54.png](https://i.imgur.com/RZZcawl.png)](https://i.imgur.com/RZZcawl.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes age a teeny bit relevant, you can now more easily identify and bully 17 year old Heads of Staff.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
add: Due to pressure from various organizations, Nanotrasen is implementing a new ban on the purchase of alcohol and tobacco products for crewmembers under the age of 20 onboard its Spinward space stations. Please remember that providing alcohol or tobacco products to underage crewmembers is against Space Law, and remember to check those cards bartenders!
add: Standard Nanotrasen IDs now display the registered age of the holder, which you can change at the HoP's access console. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
