### PR TITLE
Items without Export Datums calculate their value based on material datums.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -284,10 +284,14 @@
 
 // /obj/item signals for economy
 #define COMSIG_ITEM_SOLD "item_sold"							//called when an item is sold by the exports subsystem
+#define COMSIG_ITEM_SOLD_MATERIAL "item_sold_material"			//called when an item is sold by the exports subsystem using material datums.
 #define COMSIG_STRUCTURE_UNWRAPPED "structure_unwrapped"		//called when a wrapped up structure is opened by hand
 #define COMSIG_ITEM_UNWRAPPED "item_unwrapped"					//called when a wrapped up item is opened by hand
 	#define COMSIG_ITEM_SPLIT_VALUE  1
+	#define COMSIG_ITEM_SPLIT_VALUE_MATERIAL  1
 #define COMSIG_ITEM_SPLIT_PROFIT "item_split_profits"			//Called when getting the item's exact ratio for cargo's profit.
+#define COMSIG_ITEM_SPLIT_PROFIT_DRY "item_split_profits_dry"			//Called when getting the item's exact ratio for cargo's profit, without selling the item.
+#define COMSIG_ITEM_SPLIT_PROFIT_MATERIAL "item_split_material_profits"	//Called when getting an item's profit ratio, but when calculating wealth from material datums.
 
 
 // /obj/item/clothing signals

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -288,7 +288,6 @@
 #define COMSIG_STRUCTURE_UNWRAPPED "structure_unwrapped"		//called when a wrapped up structure is opened by hand
 #define COMSIG_ITEM_UNWRAPPED "item_unwrapped"					//called when a wrapped up item is opened by hand
 	#define COMSIG_ITEM_SPLIT_VALUE  1
-	#define COMSIG_ITEM_SPLIT_VALUE_MATERIAL  1
 #define COMSIG_ITEM_SPLIT_PROFIT "item_split_profits"			//Called when getting the item's exact ratio for cargo's profit.
 #define COMSIG_ITEM_SPLIT_PROFIT_DRY "item_split_profits_dry"			//Called when getting the item's exact ratio for cargo's profit, without selling the item.
 #define COMSIG_ITEM_SPLIT_PROFIT_MATERIAL "item_split_material_profits"	//Called when getting an item's profit ratio, but when calculating wealth from material datums.

--- a/code/datums/components/pricetag.dm
+++ b/code/datums/components/pricetag.dm
@@ -8,13 +8,9 @@
 	owner = _owner
 	if(_profit_ratio)
 		profit_ratio = _profit_ratio
-	RegisterSignal(parent, COMSIG_ITEM_SOLD, .proc/split_profit)
-	RegisterSignal(parent, COMSIG_ITEM_SOLD_MATERIAL, .proc/split_profit)
-	RegisterSignal(parent, COMSIG_STRUCTURE_UNWRAPPED, .proc/Unwrapped)
-	RegisterSignal(parent, COMSIG_ITEM_UNWRAPPED, .proc/Unwrapped)
-	RegisterSignal(parent, COMSIG_ITEM_SPLIT_PROFIT, .proc/return_ratio)
-	RegisterSignal(parent, COMSIG_ITEM_SPLIT_PROFIT_DRY, .proc/return_ratio)
-	RegisterSignal(parent, COMSIG_ITEM_SPLIT_PROFIT_MATERIAL, .proc/return_ratio)
+	RegisterSignal(parent, list(COMSIG_ITEM_SOLD, COMSIG_ITEM_SOLD_MATERIAL), .proc/split_profit)
+	RegisterSignal(parent, list(COMSIG_STRUCTURE_UNWRAPPED, COMSIG_ITEM_UNWRAPPED), .proc/Unwrapped)
+	RegisterSignal(parent, list(COMSIG_ITEM_SPLIT_PROFIT, COMSIG_ITEM_SPLIT_PROFIT_DRY, COMSIG_ITEM_SPLIT_PROFIT_MATERIAL), .proc/return_ratio)
 
 /datum/component/pricetag/proc/Unwrapped()
 	qdel(src) //Once it leaves it's wrapped container, the object in question should lose it's pricetag component.

--- a/code/datums/components/pricetag.dm
+++ b/code/datums/components/pricetag.dm
@@ -9,9 +9,12 @@
 	if(_profit_ratio)
 		profit_ratio = _profit_ratio
 	RegisterSignal(parent, COMSIG_ITEM_SOLD, .proc/split_profit)
+	RegisterSignal(parent, COMSIG_ITEM_SOLD_MATERIAL, .proc/split_profit)
 	RegisterSignal(parent, COMSIG_STRUCTURE_UNWRAPPED, .proc/Unwrapped)
 	RegisterSignal(parent, COMSIG_ITEM_UNWRAPPED, .proc/Unwrapped)
 	RegisterSignal(parent, COMSIG_ITEM_SPLIT_PROFIT, .proc/return_ratio)
+	RegisterSignal(parent, COMSIG_ITEM_SPLIT_PROFIT_DRY, .proc/return_ratio)
+	RegisterSignal(parent, COMSIG_ITEM_SPLIT_PROFIT_MATERIAL, .proc/return_ratio)
 
 /datum/component/pricetag/proc/Unwrapped()
 	qdel(src) //Once it leaves it's wrapped container, the object in question should lose it's pricetag component.

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -197,7 +197,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	color = "#bb8e53"
 	strength_modifier = 0.5
 	categories = list(MAT_CATEGORY_RIGID = TRUE)
-	value_per_unit = 0.06
+	value_per_unit = 0.01
 	beauty_modifier = 0.1
 	armor_modifiers = list("melee" = 1.1, "bullet" = 1.1, "laser" = 0.4, "energy" = 0.4, "bomb" = 1, "bio" = 0.2, "rad" = 0, "fire" = 0, "acid" = 0.3)
 

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -214,24 +214,24 @@ GLOBAL_LIST_EMPTY(exports_list)
   * Works similarly to the sell object proc, but utilizes the get_material_cost proc in order to obtain it's raw value in terms of materials.
   * Similarly checks for pricetags to split export profit the same way.
   */
-/datum/export/proc/sell_material_item(obj/O, datum/export_report/report, dry_run = TRUE, apply_elastic = TRUE)
+/datum/export/proc/sell_material_item(obj/sold_object, datum/export_report/report, dry_run = TRUE, apply_elastic = TRUE)
 	///This is the value of the object, as derived from material datums.
-	var/material_cost = get_material_cost(O)
+	var/material_cost = get_material_cost(sold_object)
 	///Quantity of the object in question.
-	var/amount = get_amount(O)
+	var/amount = get_amount(sold_object)
 	///Utilized in the pricetag component. Splits the object's profit when it has a pricetag by the specified amount.
 	var/profit_ratio = 0
 
-	if(amount <=0 || material_cost <=0)
+	if(amount <= 0 || material_cost <= 0)
 		return FALSE
-	unit_name = "[O.name]"
-	profit_ratio = SEND_SIGNAL(O, COMSIG_ITEM_SPLIT_PROFIT_MATERIAL)
+	unit_name = "[sold_object.name]"
+	profit_ratio = SEND_SIGNAL(sold_object, COMSIG_ITEM_SPLIT_PROFIT_MATERIAL)
 	material_cost = material_cost * ((100 - profit_ratio) * 0.01)
 	if(dry_run == FALSE & COMSIG_ITEM_SPLIT_VALUE)
-		SEND_SIGNAL(O, COMSIG_ITEM_SOLD_MATERIAL, item_value = material_cost)
+		SEND_SIGNAL(sold_object, COMSIG_ITEM_SOLD_MATERIAL, item_value = material_cost)
 	report.total_value[src] += material_cost
 
-	if(istype(O, /datum/export/material))
+	if(istype(sold_object, /datum/export/material))
 		report.total_amount[src] += amount*MINERAL_MATERIAL_AMOUNT
 	else
 		report.total_amount[src] += amount

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -239,7 +239,7 @@ GLOBAL_LIST_EMPTY(exports_list)
 	if(!dry_run)
 		if(apply_elastic)
 			cost *= NUM_E**(-1*k_elasticity*amount)		//marginal cost modifier
-		SSblackbox.record_feedback("nested tally", "export_sold_cost", 1, list("[O.type]", "[material_cost]"))
+		SSblackbox.record_feedback("nested tally", "export_sold_cost", 1, list("[sold_object.type]", "[material_cost]"))
 	return TRUE
 
 /proc/setupExports()

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -227,7 +227,7 @@ GLOBAL_LIST_EMPTY(exports_list)
 	unit_name = "[sold_object.name]"
 	profit_ratio = SEND_SIGNAL(sold_object, COMSIG_ITEM_SPLIT_PROFIT_MATERIAL)
 	material_cost = material_cost * ((100 - profit_ratio) * 0.01)
-	if(dry_run == FALSE & COMSIG_ITEM_SPLIT_VALUE)
+	if(dry_run == FALSE)
 		SEND_SIGNAL(sold_object, COMSIG_ITEM_SOLD_MATERIAL, item_value = material_cost)
 	report.total_value[src] += material_cost
 

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -220,7 +220,7 @@ GLOBAL_LIST_EMPTY(exports_list)
 
 	if(amount <=0 || material_cost <=0)
 		return FALSE
-	unit_name = "recycled object: [O.name]"
+	unit_name = "[O.name]"
 	if(dry_run == FALSE)
 		if(SEND_SIGNAL(O, COMSIG_ITEM_SOLD, item_value = material_cost & COMSIG_ITEM_SPLIT_VALUE))
 			profit_ratio = SEND_SIGNAL(O, COMSIG_ITEM_SPLIT_PROFIT)

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -53,12 +53,14 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 			if(E.applies_to(thing, allowed_categories, apply_elastic))
 				sold = E.sell_object(thing, report, dry_run, allowed_categories , apply_elastic, profit_ratio)
 				report.exported_atoms += " [thing.name]"
+				sold = TRUE
 				if(!QDELETED(thing))
 					report.exported_atoms_ref += thing
 				break
 		if(!sold && thing.custom_materials)
 			var/datum/export/S = new /datum/export
-			S.sell_material_item(thing, report, dry_run, apply_elastic, profit_ratio)
+			if(S.get_material_cost(thing) && (!S.get_cost(thing, allowed_categories , apply_elastic)))
+				S.sell_material_item(thing, report, dry_run, apply_elastic, profit_ratio)
 		if(!dry_run && (sold || delete_unsold))
 			if(ismob(thing))
 				thing.investigate_log("deleted through cargo export",INVESTIGATE_CARGO)
@@ -218,6 +220,7 @@ GLOBAL_LIST_EMPTY(exports_list)
 
 	if(amount <=0 || material_cost <=0)
 		return FALSE
+	unit_name = "recycled object: [O.name]"
 	if(dry_run == FALSE)
 		if(SEND_SIGNAL(O, COMSIG_ITEM_SOLD, item_value = material_cost & COMSIG_ITEM_SPLIT_VALUE))
 			profit_ratio = SEND_SIGNAL(O, COMSIG_ITEM_SPLIT_PROFIT)

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -197,14 +197,23 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 
 GLOBAL_LIST_EMPTY(exports_list)
 
+/**
+  * Calculates the exact export value of the object based on the object's datum materials.
+  *
+  * loops through the atom's material datums and then multiplies that amount by it's relative worth, and sums the total.
+  */
 /datum/export/proc/get_material_cost(atom/movable/A)
-	var/value = 0
 	for(var/i in A.custom_materials)
 		var/datum/material/M = i
-		value += M.value_per_unit * A.custom_materials[M]
-	value = round(value)  //floor of the value
-	return value
+		. += M.value_per_unit * A.custom_materials[M]
+	. = round(.)  //floor of the value
 
+/**
+  * Sells an object using it's material cost.
+  *
+  * Works similarly to the sell object proc, but utilizes the get_material_cost proc in order to obtain it's raw value in terms of materials.
+  * Similarly checks for pricetags to split export profit the same way.
+  */
 /datum/export/proc/sell_material_item(obj/O, datum/export_report/report, dry_run = TRUE, apply_elastic = TRUE)
 	///This is the value of the object, as derived from material datums.
 	var/material_cost = get_material_cost(O)
@@ -218,8 +227,8 @@ GLOBAL_LIST_EMPTY(exports_list)
 	unit_name = "[O.name]"
 	profit_ratio = SEND_SIGNAL(O, COMSIG_ITEM_SPLIT_PROFIT_MATERIAL)
 	material_cost = material_cost * ((100 - profit_ratio) * 0.01)
-	if(dry_run == FALSE)
-		SEND_SIGNAL(O, COMSIG_ITEM_SOLD_MATERIAL, item_value = material_cost & COMSIG_ITEM_SPLIT_VALUE_MATERIAL)
+	if(dry_run == FALSE & COMSIG_ITEM_SPLIT_VALUE)
+		SEND_SIGNAL(O, COMSIG_ITEM_SOLD_MATERIAL, item_value = material_cost)
 	report.total_value[src] += material_cost
 
 	if(istype(O, /datum/export/material))


### PR DESCRIPTION
## About The Pull Request

Alright, this hits a LOT of things at one time, so I'd say this should get hit with a testmerge just to work out any potential infinite profit loops. That said, it does appear to be working as intended.

When trying to sell an object, that object will first be checked for export an export datum as normal, but if it fails to match an export datum, it will instead have it's cost checked by calculating it's value from it's custom_materials, which is currently the same way it's done with sheets. This allows for greater control over how much each item is worth. A good example of this is the ammo toolbox that cargo gets when they buy a russian surplus crate. The ammo box itself is subject to the toolbox export datum, but the ammo contained within each has it's own material datum, so the whole toolbox is worth 563. Most objects have relatively sane values for their material cost, and when applied to this system at the very least you're getting the same value you would have gotten from just selling the materials outright. It also allows for specific items that need a manual export datum  due to their small material value to become much more obvious.

The actual exports themselves are a bit spammy in the logs at the second, but everything's calculated correctly.
## Why It's Good For The Game

Cargo should be able to sell EVERYTHING. Accept no substitutes.

## Changelog
:cl:
add: The Nanotrasen cargo and export division has discovered a new recycling method, enabling significantly more exports off station.
tweak: Wood's export value per unit has been lowered.
/:cl: