### PR TITLE
Fixes damaged snow tile icons.

### DIFF
--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -111,6 +111,7 @@
 	icon = 'icons/turf/snow.dmi'
 	desc = "Looks cold."
 	icon_state = "snow"
+	broken_states = list("snow_dug")
 	ore_type = /obj/item/stack/sheet/mineral/snow
 	planetary_atmos = TRUE
 	floor_tile = null

--- a/code/game/turfs/open/floor/plating/asteroid.dm
+++ b/code/game/turfs/open/floor/plating/asteroid.dm
@@ -327,6 +327,7 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 	environment_type = "snow"
 	flags_1 = NONE
 	planetary_atmos = TRUE
+	broken_states = list("snow_dug")
 	burnt_states = list("snow_dug")
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = null


### PR DESCRIPTION
## About The Pull Request
Fixes #35750. Damaged snow tiles now share the dug snow icon_state, and applies this to both the snow tile derivatives. 

## Why It's Good For The Game

Bugs are the enemy of mankind.

## Changelog
:cl:
fix: Snow tiles now show the correct sprite when burned or damaged.
/:cl: