### PR TITLE
Adds range check to beaker eject for grinder and biogen

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -292,10 +292,11 @@
 	return .
 
 /obj/machinery/biogenerator/proc/detach(mob/living/user)
-	if(beaker)
-		user.put_in_hands(beaker)
-		beaker = null
-		update_icon()
+	if(!can_interact(user) || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+		if(beaker)
+			user.put_in_hands(beaker)
+			beaker = null
+			update_icon()
 
 /obj/machinery/biogenerator/Topic(href, href_list)
 	if(..() || panel_open)

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -292,11 +292,13 @@
 	return .
 
 /obj/machinery/biogenerator/proc/detach(mob/living/user)
-	if(!can_interact(user) || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
-		if(beaker)
+	if(beaker)
+		if(can_interact(user))
 			user.put_in_hands(beaker)
-			beaker = null
-			update_icon()
+		else
+			beaker.drop_location(get_turf(src))
+		beaker = null
+		update_icon()
 
 /obj/machinery/biogenerator/Topic(href, href_list)
 	if(..() || panel_open)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -106,7 +106,10 @@
 	if(!user)
 		return FALSE
 	if(beaker)
-		user.put_in_hands(beaker)
+		if(can_interact(user))
+			user.put_in_hands(beaker)
+		else
+			beaker.drop_location(get_turf(src))
 		beaker = null
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -218,12 +218,13 @@
 			examine(user)
 
 /obj/machinery/reagentgrinder/proc/eject(mob/user)
-	for(var/i in holdingitems)
-		var/obj/item/O = i
-		O.forceMove(drop_location())
-		holdingitems -= O
-	if(beaker)
-		replace_beaker(user)
+	if(!can_interact(user) || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+		for(var/i in holdingitems)
+			var/obj/item/O = i
+			O.forceMove(drop_location())
+			holdingitems -= O
+		if(beaker)
+			replace_beaker(user)
 
 /obj/machinery/reagentgrinder/proc/remove_object(obj/item/O)
 	holdingitems -= O


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Since these put in hand, adds range check to the eject proc as well. Stops TK users and borgs from teleporting beakers around.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #49856
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Grinder and biogen now rangecheck before ejecting beaker into hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
