### PR TITLE
Adds deconstruction and unanchoring to sheetifier

### DIFF
--- a/code/game/machinery/sheetifier.dm
+++ b/code/game/machinery/sheetifier.dm
@@ -51,3 +51,5 @@
 		return
 	if(default_deconstruction_crowbar(I))
 		return
+	else
+		return ..()

--- a/code/game/machinery/sheetifier.dm
+++ b/code/game/machinery/sheetifier.dm
@@ -51,5 +51,4 @@
 		return
 	if(default_deconstruction_crowbar(I))
 		return
-	else
-		return ..()
+	return ..()

--- a/code/game/machinery/sheetifier.dm
+++ b/code/game/machinery/sheetifier.dm
@@ -42,3 +42,12 @@
 	update_icon()
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 	materials.retrieve_all() //Returns all as sheets
+
+/obj/machinery/sheetifier/attackby(obj/item/I, mob/user, params)
+	if(default_unfasten_wrench(user, I))
+		return
+	if(default_deconstruction_screwdriver(user, I))
+		update_icon()
+		return
+	if(default_deconstruction_crowbar(I))
+		return

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1180,6 +1180,7 @@
 	req_components = list(
 		/obj/item/stock_parts/manipulator = 2,
 		/obj/item/stock_parts/matter_bin = 2)
+	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/abductor
 	name = "alien board (Report This)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows unanchoring the sheetifier
Allows the sheetifier to be cannibalised for bits

## Why It's Good For The Game

fixes #50008
not having to blow up machinery to remove it is a positive

## Changelog
:cl:
fix: Sheetifier may now be unanchored and deconstructed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
