### PR TITLE
Fixes all atmos pipes being hidden under tiles

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -26,6 +26,9 @@
 	var/piping_layer = PIPING_LAYER_DEFAULT
 	var/pipe_flags = NONE
 
+	///This only works on pipes, because they have 1000 subtypes wich need to be visible and invisible under tiles, so we track this here
+	var/hide = TRUE
+
 	var/static/list/iconsetids = list()
 	var/static/list/pipeimages = list()
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -14,6 +14,8 @@
 	name = "dual-port air vent"
 	desc = "Has a valve and pump attached to it. There are two ports."
 
+	hide = TRUE
+
 	var/frequency = 0
 	var/id = null
 	var/datum/radio_frequency/radio_connection

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -20,10 +20,20 @@
 		A.volume = 200
 		airs[i] = A
 
+/obj/machinery/atmospherics/components/Initialize()
+	. = ..()
+
+	if(hide)
+		RegisterSignal(src, COMSIG_OBJ_HIDE, .proc/hide_pipe)
+
 // Iconnery
 
 /obj/machinery/atmospherics/components/proc/update_icon_nopipes()
 	return
+
+/obj/machinery/atmospherics/components/proc/hide_pipe(datum/source, covered)
+	showpipe = !covered
+	update_icon()
 
 /obj/machinery/atmospherics/components/update_icon()
 	update_icon_nopipes()

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -2,6 +2,8 @@
 // On top of that, now people can add component-speciic procs/vars if they want!
 
 /obj/machinery/atmospherics/components
+	hide = FALSE
+
 	var/welded = FALSE //Used on pumps and scrubbers
 	var/showpipe = TRUE
 	var/shift_underlay_only = TRUE //Layering only shifts underlay?

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -3,7 +3,7 @@
 
 /obj/machinery/atmospherics/components
 	var/welded = FALSE //Used on pumps and scrubbers
-	var/showpipe = FALSE
+	var/showpipe = TRUE
 	var/shift_underlay_only = TRUE //Layering only shifts underlay?
 
 	var/list/datum/pipeline/parents
@@ -20,26 +20,15 @@
 		A.volume = 200
 		airs[i] = A
 
-/obj/machinery/atmospherics/components/Initialize()
-	. = ..()
-
-	RegisterSignal(src, COMSIG_OBJ_HIDE, .proc/hide_pipe)
-
 // Iconnery
 
 /obj/machinery/atmospherics/components/proc/update_icon_nopipes()
 	return
 
-/obj/machinery/atmospherics/components/proc/hide_pipe(datum/source, covered)
-	showpipe = !covered
-	update_icon()
-
 /obj/machinery/atmospherics/components/update_icon()
 	update_icon_nopipes()
 
 	underlays.Cut()
-
-
 
 	plane = showpipe ? GAME_PLANE : FLOOR_PLANE
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -7,6 +7,7 @@
 	use_power = IDLE_POWER_USE
 	can_unwrench = TRUE
 	shift_underlay_only = FALSE
+	hide = TRUE
 
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF //really helpful in building gas chambers for xenomorphs
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -3,8 +3,9 @@
 
 	name = "passive vent"
 	desc = "It is an open vent."
-	can_unwrench = TRUE
 
+	can_unwrench = TRUE
+	hide = TRUE
 	layer = GAS_SCRUBBER_LAYER
 
 	pipe_state = "pvent"

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -50,8 +50,8 @@
 	piping_layer = 3
 	icon_state = "connector_map-3"
 
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/
-	hide = TRUE
+/obj/machinery/atmospherics/components/unary/portables_connector/visible
+	hide = FALSE
 
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1
 	piping_layer = 1

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -19,11 +19,6 @@
 	var/datum/gas_mixture/air_contents = airs[1]
 	air_contents.volume = 0
 
-/obj/machinery/atmospherics/components/unary/portables_connector/Initialize()
-	. = ..()
-
-	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE) //if changing this, change the subtypes RemoveElements too, because thats how bespoke works
-
 /obj/machinery/atmospherics/components/unary/portables_connector/Destroy()
 	if(connected_device)
 		connected_device.disconnect()
@@ -53,11 +48,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer3
 	piping_layer = 3
 	icon_state = "connector_map-3"
-
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/Initialize()
-	. = ..()
-
-	RemoveElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE) //if changing this, change the subtypes RemoveElements too, because thats how bespoke works
 
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1
 	piping_layer = 1

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -8,6 +8,7 @@
 
 	use_power = NO_POWER_USE
 	layer = GAS_FILTER_LAYER
+	hide = TRUE
 
 	pipe_flags = PIPING_ONE_PER_TURF
 	pipe_state = "connector"
@@ -48,6 +49,9 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer3
 	piping_layer = 3
 	icon_state = "connector_map-3"
+
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/
+	hide = TRUE
 
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1
 	piping_layer = 1

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -19,6 +19,11 @@
 	var/datum/gas_mixture/air_contents = airs[1]
 	air_contents.volume = 0
 
+/obj/machinery/atmospherics/components/unary/portables_connector/Initialize()
+	. = ..()
+
+	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE) //if changing this, change the subtypes RemoveElements too, because thats how bespoke works
+
 /obj/machinery/atmospherics/components/unary/portables_connector/Destroy()
 	if(connected_device)
 		connected_device.disconnect()
@@ -48,6 +53,11 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer3
 	piping_layer = 3
 	icon_state = "connector_map-3"
+
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/Initialize()
+	. = ..()
+
+	RemoveElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE) //if changing this, change the subtypes RemoveElements too, because thats how bespoke works
 
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1
 	piping_layer = 1

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -15,6 +15,7 @@
 	can_unwrench = TRUE
 	welded = FALSE
 	layer = GAS_SCRUBBER_LAYER
+	hide = TRUE
 
 	var/id_tag = null
 	var/pump_direction = RELEASING

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -12,6 +12,7 @@
 	can_unwrench = TRUE
 	welded = FALSE
 	layer = GAS_SCRUBBER_LAYER
+	hide = TRUE
 
 	var/id_tag = null
 	var/scrubbing = SCRUBBING //0 = siphoning, 1 = scrubbing

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
@@ -6,8 +6,11 @@
 	var/icon_temperature = T20C //stop small changes in temperature causing icon refresh
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 
+	hide = FALSE
+
 /obj/machinery/atmospherics/pipe/heat_exchanging/Initialize()
 	. = ..()
+
 	add_atom_colour("#404040", FIXED_COLOUR_PRIORITY)
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/isConnectable(obj/machinery/atmospherics/pipe/heat_exchanging/target, given_layer, HE_type_check = TRUE)

--- a/code/modules/atmospherics/machinery/pipes/mapping.dm
+++ b/code/modules/atmospherics/machinery/pipes/mapping.dm
@@ -6,6 +6,7 @@
 		color = Color;					\
 	}									\
 	##Fulltype/visible {				\
+		hide = FALSE;					\
 		layer = GAS_PIPE_VISIBLE_LAYER;	\
 	}									\
 	##Fulltype/visible/layer1 {			\
@@ -15,6 +16,9 @@
 	##Fulltype/visible/layer3 {			\
 		piping_layer = 3;				\
 		icon_state = Iconbase + "-3";	\
+	}									\
+	##Fulltype/hidden {					\
+		hide = TRUE;					\
 	}									\
 	##Fulltype/hidden/layer1 {			\
 		piping_layer = 1;				\

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -12,6 +12,9 @@
 	buckle_requires_restraints = 1
 	buckle_lying = -1
 
+	///This only works on pipes, because they have 1000 subtypes wich need to be visible and invisible under tiles, so we track this here
+	var/hide = TRUE
+
 /obj/machinery/atmospherics/pipe/New()
 	add_atom_colour(pipe_color, FIXED_COLOUR_PRIORITY)
 	volume = 35 * device_type
@@ -21,7 +24,8 @@
 /obj/machinery/atmospherics/pipe/Initialize(mapload)
 	. = ..()
 
-	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
+	if(hide)
+		AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE) //if changing this, change the subtypes RemoveElements too, because thats how bespoke works
 
 /obj/machinery/atmospherics/pipe/nullifyNode(i)
 	var/obj/machinery/atmospherics/oldN = nodes[i]

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -12,9 +12,6 @@
 	buckle_requires_restraints = 1
 	buckle_lying = -1
 
-	///This only works on pipes, because they have 1000 subtypes wich need to be visible and invisible under tiles, so we track this here
-	var/hide = TRUE
-
 /obj/machinery/atmospherics/pipe/New()
 	add_atom_colour(pipe_color, FIXED_COLOUR_PRIORITY)
 	volume = 35 * device_type


### PR DESCRIPTION
Same applies for the SM and some other pipes that are on tiles but shouldnt be hidden beneath it.

It hasn't actually occured anywhere yet, since the servers haven't been updated. It just kinda hit me in a cold sweat

:cl:
fix: fixes all atmos pipes being hidden under tiles
/:cl: