### PR TITLE
Enhances multi-z falling, adds anvil-ing people with vendors and divebomb tackles

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -113,6 +113,10 @@
 	#define COMPONENT_NO_ATTACK_HAND 1							//works on all 3.
 //This signal return value bitflags can be found in __DEFINES/misc.dm
 #define COMSIG_ATOM_INTERCEPT_Z_FALL "movable_intercept_z_impact"	///called for each movable in a turf contents on /turf/zImpact(): (atom/movable/A, levels)
+#define COMSIG_MOVABLE_Z_FALL_IMPACT "movable_z_fall_impact" ///
+	#define FALL_NO_IMPACT 1
+#define COMSIG_MOVABLE_Z_FALL_SKIPFALL "movable_z_fall_skipfall" /// if we want to skip the falling time
+	#define FALL_SKIP_FALLTIME 1
 #define COMSIG_ATOM_START_PULL "movable_start_pull"	///called on a movable (NOT living) when someone starts pulling it (atom/movable/puller, state, force)
 #define COMSIG_LIVING_START_PULL "living_start_pull"	///called on /living when someone starts pulling it (atom/movable/puller, state, force)
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -126,6 +126,7 @@ Class Procs:
 	var/ui_style // ID of custom TGUI style (optional)
 	var/ui_x // Default size of TGUI window, in pixels
 	var/ui_y
+	falling_time = 2 SECONDS
 
 /obj/machinery/Initialize()
 	if(!armor)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -150,6 +150,8 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 		if(damtype == "brute")
 			hitsound = "swing_hit"
 
+	falling_time = w_class * 0.33 SECONDS
+
 /obj/item/Destroy()
 	item_flags &= ~DROPDEL	//prevent reqdels
 	if(ismob(loc))
@@ -894,3 +896,17 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	if(embedding)
 		return !isnull(embedding["pain_mult"]) && !isnull(embedding["jostle_pain_mult"]) && embedding["pain_mult"] == 0 && embedding["jostle_pain_mult"] == 0
 
+/obj/item/onZImpact(turf/T, levels)
+	. = ..()
+	// TODO: find a way to not have to duplicate this from the parent
+	var/atom/highest = T
+	for(var/i in T.contents)
+		var/atom/A = i
+		if(!A.density)
+			continue
+		if(isobj(A) || ismob(A))
+			if(A.layer > highest.layer)
+				highest = A
+	if(isliving(highest))
+		var/mob/living/L = highest
+		L.apply_damage(w_class * 5) // this is very rough, no thought put to balance, make this better

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -10,6 +10,7 @@
 	var/climbable = FALSE
 	var/mob/living/structureclimber
 	var/broken = 0 //similar to machinery's stat BROKEN
+	falling_time = 2.5 SECONDS
 
 
 /obj/structure/Initialize()

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -16,7 +16,21 @@
 	/turf/closed/wall,
 	/obj/structure/falsewall)
 	smooth = SMOOTH_MORE
+	///how long it takes to cut these with wirecutters
+	var/cut_time = 1 SECONDS
 	//	flags = CONDUCT_1
+
+/obj/structure/lattice/Destroy()
+	var/fall = FALSE
+	var/turf/T = get_turf(src)
+	if(isgroundlessturf(T))
+		fall = TRUE
+	. = ..()
+	if(!fall)
+		return
+
+	for(var/atom/movable/AM in T)
+		T.zFall(AM)
 
 /obj/structure/lattice/examine(mob/user)
 	. = ..()
@@ -38,8 +52,10 @@
 	if(resistance_flags & INDESTRUCTIBLE)
 		return
 	if(C.tool_behaviour == TOOL_WIRECUTTER)
-		to_chat(user, "<span class='notice'>Slicing [name] joints ...</span>")
-		deconstruct()
+		user.visible_message("<span class='notice'>[user] begins cutting [src]...</span>", "<span class='notice'>You begin cutting [src]...</span>")
+		if(do_after(user, cut_time * C.toolspeed, TRUE, src))
+			user.visible_message("<span class='notice'>[user] cuts [src].</span>", "<span class='notice'>You cut [src].</span>")
+			deconstruct()
 	else
 		var/turf/T = get_turf(src)
 		return T.attackby(C, user) //hand this off to the turf instead (for building plating, catwalks, etc)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -169,8 +169,16 @@
 		return
 	if(zFall(A, ++levels))
 		return FALSE
-	A.visible_message("<span class='danger'>[A] crashes into [src]!</span>")
-	A.onZImpact(src, levels)
+
+	var/skip_effects = NONE
+	skip_effects |= SEND_SIGNAL(A, COMSIG_MOVABLE_Z_FALL_SKIPFALL, src, levels)
+
+	if(skip_effects & FALL_SKIP_FALLTIME)
+		A.onZImpact(src, levels)
+	else
+		INVOKE_ASYNC(A, /atom/.proc/SpinAnimation, 8,A.falling_time / 8)
+		addtimer(CALLBACK(A, /atom/movable/.proc/onZImpact, src, levels), A.falling_time)
+
 	return TRUE
 
 /turf/proc/can_zFall(atom/movable/A, levels = 1, turf/target)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -46,9 +46,9 @@
 	return ..()
 
 /mob/living/onZImpact(turf/T, levels)
-	if(!isgroundlessturf(T))
+	. = ..()
+	if(!(.) && !isgroundlessturf(T))
 		ZImpactDamage(T, levels)
-	return ..()
 
 /mob/living/proc/ZImpactDamage(turf/T, levels)
 	visible_message("<span class='danger'>[src] crashes into [T] with a sickening noise!</span>", \

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -157,6 +157,8 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	/// how many items have been inserted in a vendor
 	var/loaded_items = 0
 
+	falling_time = 2.5 SECONDS
+
 /obj/item/circuitboard
     ///determines if the circuit board originated from a vendor off station or not.
 	var/onstation = TRUE
@@ -559,6 +561,13 @@ GLOBAL_LIST_EMPTY(vending_products)
 	var/matrix/M = matrix()
 	M.Turn(0)
 	transform = M
+
+
+/obj/machinery/vending/onZImpact(turf/T, levels)
+	for(var/mob/living/L in T)
+		tilt(L)
+		return
+	visible_message("<span class='warning'>[src] slams into [T] from above!</span>")
 
 /obj/machinery/vending/proc/loadingAttempt(obj/item/I, mob/user)
 	. = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
[![dreamseeker_2020-03-17_03-12-01.png](https://i.imgur.com/HeOr5Ws.png)](https://i.imgur.com/HeOr5Ws.png)

Multi-Z falls needed some dire love and SOUL, and this is a start. Falling atoms will take a bit of time  (2-3 seconds at max, most less than a half second) to fall, giving warning to those below that they should move out of the way, allowing falling objects to be much more hazardous without being instant death. Heavier and more dangerous objects take slightly longer to fall, with vendors doing automatic tilts on anyone they land on, items dealing damage based on their size (still needs work and ignoring soft items like boxes), and other heavy things planned.

You can also launch tackles over ledges now! It's really probably not a good idea since the penalty for missing and hitting the ground is around a 5% chance of instant death and dismemberment, and a 45% chance of heavy full-body damage, but if you manage to land a tackle on someone from above, you'll get a nice bonus to your tackle roll!

Still need to do a bit of fleshing out balance wise, as well as making a nicer effect for the falling (shadows/scaling/something to indicate falling speed), but I think this is a really good start for making the most of muti-z!

Video:
https://cdn.discordapp.com/attachments/564124572392226838/689367729735598117/fall.mp4
*[Note that the outright gibbing at the end was ridiculously unlucky, that's a 2% chance without protection, most of the tackle splats are less dangerous than that, but still incredibly dangerous]*

Also fixes #49685 which was what started me on all this in the first place, and as a side effect, made cutting lattices and catwalks require a short 1 second action rather than being instant
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds more depth to multi-z interactions, the current behavior of just bonking the highest atom on the target turf is a bit lame.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
add: You can now launch tackles off ledges on multi-z maps on unsuspecting targets on lower levels! It's really, really, really dangerous, but you can still do it! Just don't miss!
tweak: Objects falling down z-levels have a short falling delay before impact, giving you some warning before that vending machine someone pushed off crushes you to death.
balance: rebalanced something

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
