### PR TITLE
Fixes being able to spin anchored plumbing machinery

### DIFF
--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -29,7 +29,7 @@
 	RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED,COMSIG_PARENT_PREQDELETED), .proc/disable)
 	RegisterSignal(parent, list(COMSIG_OBJ_DEFAULT_UNFASTEN_WRENCH), .proc/toggle_active)
 	RegisterSignal(parent, list(COMSIG_OBJ_HIDE), .proc/hide)
-	RegisterSignal(parent, list(COMSIG_ATOM_UPDATE_OVERLAYS), .proc/create_overlays) //create overlays also gets called after init (no idea by what it just happens)
+	RegisterSignal(parent, list(COMSIG_ATOM_UPDATE_OVERLAYS), .proc/create_overlays) //called by lateinit on startup
 
 	if(start)
 		//timer 0 so it can finish returning initialize, after which we're added to the parent.

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -29,15 +29,12 @@
 	RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED,COMSIG_PARENT_PREQDELETED), .proc/disable)
 	RegisterSignal(parent, list(COMSIG_OBJ_DEFAULT_UNFASTEN_WRENCH), .proc/toggle_active)
 	RegisterSignal(parent, list(COMSIG_OBJ_HIDE), .proc/hide)
-	RegisterSignal(parent, list(COMSIG_ATOM_UPDATE_OVERLAYS), .proc/create_overlays)
+	RegisterSignal(parent, list(COMSIG_ATOM_UPDATE_OVERLAYS), .proc/create_overlays) //create overlays also gets called after init (no idea by what it just happens)
 
 	if(start)
 		//timer 0 so it can finish returning initialize, after which we're added to the parent.
 		//Only then can we tell the duct next to us they can connect, because only then is the component really added. this was a fun one
 		addtimer(CALLBACK(src, .proc/enable), 0)
-
-	if(use_overlays)
-		create_overlays()
 
 /datum/component/plumbing/process()
 	if(!demand_connects || !reagents)
@@ -101,7 +98,7 @@
 		reagents.trans_to(target.parent, amount, round_robin = TRUE)//we deal with alot of precise calculations so we round_robin=TRUE. Otherwise we get floating point errors, 1 != 1 and 2.5 + 2.5 = 6
 
 ///We create our luxurious piping overlays/underlays, to indicate where we do what. only called once if use_overlays = TRUE in Initialize()
-/datum/component/plumbing/proc/create_overlays(atom/A, list/overlays)
+/datum/component/plumbing/proc/create_overlays(atom/movable/AM, list/overlays)
 	if(tile_covered || !use_overlays)
 		return
 
@@ -126,9 +123,10 @@
 					direction = "east"
 				if(WEST)
 					direction = "west"
-			I = image('icons/obj/plumbing/plumbers.dmi', "[direction]-[color]", layer = A.layer - 1)
+			I = image('icons/obj/plumbing/plumbers.dmi', "[direction]-[color]", layer = AM.layer - 1)
+
 		else
-			I = image('icons/obj/plumbing/plumbers.dmi', color, layer = A.layer - 1) //color is not color as in the var, it's just the name
+			I = image('icons/obj/plumbing/plumbers.dmi', color,layer = AM.layer - 1) //color is not color as in the var, it's just the name of the icon_state
 			I.dir = D
 		overlays += I
 

--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -29,7 +29,7 @@
 	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
 
 /obj/machinery/plumbing/proc/can_be_rotated(mob/user,rotation_type)
-	return TRUE
+	return !anchored
 
 /obj/machinery/plumbing/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
Also fixes a runtime

:cl:
fix: fixes plumbing stuff
/:cl:

closes #50053 

I tried to fix #50028 fully, but applying an overlay defaults it to facing north until it moves. At that point it follows the object its applied to. If you change the direction of the overlay it forces it to permanently be in that direction. 

Only fix is to constantly change all the overlays directions on dir change, or change the objects dir and back after a little (because doing it instantly doesnt work, I've tried). I'm hoping someone else comments the magical solution to this. 