### PR TITLE
Fixes metabolization not being called on sudden death

### DIFF
--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -7,6 +7,7 @@
 
 	if(!gibbed)
 		emote("deathgasp")
+	reagents.end_metabolization(src)
 
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request
Fixes #50037 
There was an issue regarding metabolization not properly working upon sudden death (i.e gibbing), and the reason was that there was no reagents.end_metabolization; however, when added after if statement regarding being gibbed. It seems the issue to this problem was that reagents don't stop metabolizing upon death.

## Why It's Good For The Game

Well, it fixes the issue of metabolization not ending upon sudden death

## Changelog
:cl:
add: reagents.end_metabolization which ensures that the reagents will stop metabolization upon death
/:cl:

