### PR TITLE
Donutstation maint space turf fix

### DIFF
--- a/_maps/map_files/Donutstation/Donutstation_LVL2.dmm
+++ b/_maps/map_files/Donutstation/Donutstation_LVL2.dmm
@@ -2755,7 +2755,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
+/turf/open/openspace,
 /area/maintenance/central)
 "gp" = (
 /obj/effect/turf_decal/trimline/white/filled/corner{
@@ -5734,7 +5734,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
+/turf/open/openspace,
 /area/maintenance/central)
 "mn" = (
 /obj/structure/chair/stool,
@@ -5890,7 +5890,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
+/turf/open/openspace,
 /area/maintenance/central)
 "mH" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -6117,7 +6117,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
+/turf/open/openspace,
 /area/maintenance/central)
 "nf" = (
 /obj/effect/turf_decal/tile/red{

--- a/_maps/map_files/Donutstation/Donutstation_LVL2.dmm
+++ b/_maps/map_files/Donutstation/Donutstation_LVL2.dmm
@@ -2755,7 +2755,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/maintenance/central)
 "gp" = (
 /obj/effect/turf_decal/trimline/white/filled/corner{
@@ -5734,7 +5734,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/maintenance/central)
 "mn" = (
 /obj/structure/chair/stool,
@@ -5890,7 +5890,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/maintenance/central)
 "mH" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -6117,7 +6117,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/maintenance/central)
 "nf" = (
 /obj/effect/turf_decal/tile/red{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixed issue where a "space" turf was used instead of "open space", leading to depressurisation. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Maint South of chemistry on donutstation floor 2 no longer loses air for no reason.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fixed #49938
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
