### PR TITLE
Makes a changelog correctly for the Families Update.

### DIFF
--- a/strings/boomer.json
+++ b/strings/boomer.json
@@ -2,6 +2,7 @@
     "boomer": [
 	"@pick(kids) these days have it too easy!",
 	"Do I look like I know what a @pick(file) is!?",
+	"Listen here Jack, how do I open @pick(file)?",
 	"How do I open a @pick(file) again?",
 	"Unlike you snowflakes, I'm not offended so easily.",
 	"Back in my day...",


### PR DESCRIPTION
## About The Pull Request
The webhook for changelogs died so I have to redo this. Adds a boomer line so that it lets me make the PR.

## Why It's Good For The Game
Changelogs are important.

## Changelog
:cl:
balance: There is now a preference for Families Antagonist roles.
balance: There is now one Undercover Cop per Family.
balance: Police can no longer join Families. They will, however, fake join it if they use the induction package to get the uniform to stay undercover.
balance: The Space Cops are reminded that they are NOT Nanotrasen employees.
balance: Dead gangs or gangs with 1 member no longer count towards the auto-balance to avoid issues with AFK players or dead gangs limiting the rest of the active gangs.
balance: The Space Cops now have ballistic weaponry outside of 5 stars.
balance: The shuttle will now no longer take off in Families until after an hour and 10 minutes.
/:cl: