### PR TITLE
Shoelace fixes, adds helper for seeing if you're already interacting with a target

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -341,3 +341,4 @@
 #define WABBAJACK     (1<<6)
 
 #define SLEEP_CHECK_DEATH(X) sleep(X); if(QDELETED(src) || stat == DEAD) return;
+#define INTERACTING_WITH(X, Y) (Y in X.do_afters)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -238,13 +238,14 @@ GLOBAL_LIST_EMPTY(species_list)
 /proc/do_after(mob/user, var/delay, needhand = 1, atom/target = null, progress = 1, datum/callback/extra_checks = null)
 	if(!user)
 		return 0
+
 	var/atom/Tloc = null
 	if(target && !isturf(target))
 		Tloc = target.loc
 
 	if(target)
-		LAZYADD(user.do_afters, target) // i know technically it already handles if we try to add a null but we're already checking if target exists so shut up
-		LAZYADD(target.targeted_by, user) // i know technically it already handles if we try to add a null but we're already checking if target exists so shut up
+		LAZYADD(user.do_afters, target)
+		LAZYADD(target.targeted_by, user)
 
 	var/atom/Uloc = user.loc
 
@@ -291,7 +292,7 @@ GLOBAL_LIST_EMPTY(species_list)
 				. = 0
 				break
 
-		if(target && (!(target in user.do_afters) || !(user in target.targeted_by)))
+		if(target && !(target in user.do_afters))
 			. = 0
 			break
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -291,6 +291,10 @@ GLOBAL_LIST_EMPTY(species_list)
 				. = 0
 				break
 
+		if(target && (!(target in user.do_afters) || !(user in target.targeted_by)))
+			. = 0
+			break
+
 		if(needhand)
 			//This might seem like an odd check, but you can still need a hand even when it's empty
 			//i.e the hand is used to pull some item/tool out of the construction

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -233,7 +233,7 @@ GLOBAL_LIST_EMPTY(species_list)
 
 ///Checks to see if our mob is currently in a do_after with the target as the target
 /mob/proc/is_interacting_with(atom/target)
-	return(target && (target in do_afters))
+	return(target in do_afters)
 
 /proc/do_after(mob/user, var/delay, needhand = 1, atom/target = null, progress = 1, datum/callback/extra_checks = null)
 	if(!user)
@@ -242,7 +242,9 @@ GLOBAL_LIST_EMPTY(species_list)
 	if(target && !isturf(target))
 		Tloc = target.loc
 
-	user.do_afters += target
+	if(target)
+		LAZYADD(user.do_afters, target) // i know technically it already handles if we try to add a null but we're already checking if target exists so shut up
+		LAZYADD(target.targeted_by, user) // i know technically it already handles if we try to add a null but we're already checking if target exists so shut up
 
 	var/atom/Uloc = user.loc
 
@@ -301,8 +303,10 @@ GLOBAL_LIST_EMPTY(species_list)
 				break
 	if (progress)
 		qdel(progbar)
-	if(target)
-		user.do_afters -= target
+
+	if(!QDELETED(target))
+		LAZYREMOVE(user.do_afters, target)
+		LAZYREMOVE(target.targeted_by, user)
 
 /mob/proc/do_after_coefficent() // This gets added to the delay on a do_after, default 1
 	. = 1

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -231,10 +231,6 @@ GLOBAL_LIST_EMPTY(species_list)
 		checked_health["health"] = health
 	return ..()
 
-///Checks to see if our mob is currently in a do_after with the target as the target
-/mob/proc/is_interacting_with(atom/target)
-	return(target in do_afters)
-
 /proc/do_after(mob/user, var/delay, needhand = 1, atom/target = null, progress = 1, datum/callback/extra_checks = null)
 	if(!user)
 		return 0

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -233,7 +233,7 @@ GLOBAL_LIST_EMPTY(species_list)
 
 ///Checks to see if our mob is currently in a do_after with the target as the target
 /mob/proc/is_interacting_with(atom/target)
-	return(target && target in do_afters)
+	return(target && (target in do_afters))
 
 /proc/do_after(mob/user, var/delay, needhand = 1, atom/target = null, progress = 1, datum/callback/extra_checks = null)
 	if(!user)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -231,12 +231,18 @@ GLOBAL_LIST_EMPTY(species_list)
 		checked_health["health"] = health
 	return ..()
 
+///Checks to see if our mob is currently in a do_after with the target as the target
+/mob/proc/is_interacting_with(atom/target)
+	return(target && target in do_afters)
+
 /proc/do_after(mob/user, var/delay, needhand = 1, atom/target = null, progress = 1, datum/callback/extra_checks = null)
 	if(!user)
 		return 0
 	var/atom/Tloc = null
 	if(target && !isturf(target))
 		Tloc = target.loc
+
+	user.do_afters += target
 
 	var/atom/Uloc = user.loc
 
@@ -295,6 +301,8 @@ GLOBAL_LIST_EMPTY(species_list)
 				break
 	if (progress)
 		qdel(progbar)
+	if(target)
+		user.do_afters -= target
 
 /mob/proc/do_after_coefficent() // This gets added to the delay on a do_after, default 1
 	. = 1

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -80,6 +80,9 @@
 
 	var/list/alternate_appearances
 
+	///Mobs that are currently do_after'ing this atom, to be cleared from on Destroy()
+	var/list/targeted_by
+
 /**
   * Called when an atom is created in byond (built in engine proc)
   *
@@ -212,6 +215,10 @@
 
 	LAZYCLEARLIST(overlays)
 	LAZYCLEARLIST(priority_overlays)
+
+	for(var/i in targeted_by)
+		var/mob/M = i
+		LAZYREMOVE(M.do_afters, src)
 
 	QDEL_NULL(light)
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -220,6 +220,7 @@
 		var/mob/M = i
 		LAZYREMOVE(M.do_afters, src)
 
+	targeted_by = null
 	QDEL_NULL(light)
 
 	return ..()

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -196,7 +196,7 @@
 				adjust_laces(SHOES_UNTIED, user)
 		else // if one of us moved
 			user.visible_message("<span class='danger'>[our_guy] stamps on [user]'s hand, mid-shoelace [tied ? "knotting" : "untying"]!</span>", "<span class='userdanger'>Ow! [our_guy] stamps on your hand!</span>", list(our_guy))
-			to_chat(our_guy, "<span class='userdanger'>You stamp on [user]'s hand! What the- they were [tied ? "knotting" : "untying"] your shoelaces!</span>")
+			to_chat(our_guy, "<span class='userdanger'>You stamp on [user]'s hand! What the- [user.p_they()] [user.p_were()] [tied ? "knotting" : "untying"] your shoelaces!</span>")
 			user.emote("scream")
 			var/obj/item/bodypart/ouchie = user.get_bodypart(pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 			if(ouchie)
@@ -254,13 +254,14 @@
 /obj/item/clothing/shoes/attack_hand(mob/living/carbon/human/user)
 	if(!istype(user))
 		return ..()
-	if(loc == user && tied != SHOES_TIED)
+	if(loc == user && tied != SHOES_TIED && (user.mobility_flags & MOBILITY_USE))
 		handle_tying(user)
 		return
 	..()
 
 /obj/item/clothing/shoes/attack_self(mob/user)
 	. = ..()
+
 	if(user.is_interacting_with(src))
 		to_chat(user, "<span class='warning'>You're already interacting with [src]!</span>")
 		return

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -158,7 +158,7 @@
 	if(user == loc && tied != SHOES_TIED) // if they're our own shoes, go tie-wards
 		user.visible_message("<span class='notice'>[user] begins [tied ? "unknotting" : "tying"] the laces of [user.p_their()] [src.name].</span>", "<span class='notice'>You begin [tied ? "unknotting" : "tying"] the laces of your [src.name]...</span>")
 
-		if(do_after(user, lace_time, needhand=TRUE, target=src))
+		if(do_after(user, lace_time, needhand=TRUE, target=our_guy))
 			to_chat(user, "<span class='notice'>You [tied ? "unknot" : "tie"] the laces of your [src.name].</span>")
 			if(tied == SHOES_UNTIED)
 				adjust_laces(SHOES_TIED, user)
@@ -178,7 +178,7 @@
 		if(HAS_TRAIT(user, TRAIT_CLUMSY)) // based clowns trained their whole lives for this
 			mod_time *= 0.75
 
-		if(do_after(user, mod_time, needhand=TRUE, target=src))
+		if(do_after(user, mod_time, needhand=TRUE, target=our_guy))
 			to_chat(user, "<span class='notice'>You [tied ? "untie" : "knot"] the laces on [loc]'s [src.name].</span>")
 			if(tied == SHOES_UNTIED)
 				adjust_laces(SHOES_KNOTTED, user)

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -160,7 +160,7 @@
 		return
 
 	if(user == loc && tied != SHOES_TIED) // if they're our own shoes, go tie-wards
-		if(user.is_interacting_with(our_guy))
+		if(INTERACTING_WITH(user, our_guy))
 			to_chat(user, "<span class='warning'>You're already interacting with [src]!</span>")
 			return
 		user.visible_message("<span class='notice'>[user] begins [tied ? "unknotting" : "tying"] the laces of [user.p_their()] [src.name].</span>", "<span class='notice'>You begin [tied ? "unknotting" : "tying"] the laces of your [src.name]...</span>")
@@ -180,7 +180,7 @@
 		if(tied == SHOES_KNOTTED)
 			to_chat(user, "<span class='warning'>The laces on [loc]'s [src.name] are already a hopelessly tangled mess!</span>")
 			return
-		if(user.is_interacting_with(our_guy))
+		if(INTERACTING_WITH(user, our_guy))
 			to_chat(user, "<span class='warning'>You're already interacting with [src]!</span>")
 			return
 
@@ -207,7 +207,7 @@
 
 ///checking to make sure we're still on the person we're supposed to be, for lacing do_after's
 /obj/item/clothing/shoes/proc/still_shoed(mob/living/carbon/our_guy)
-	return (our_guy == src.loc)
+	return (loc == our_guy)
 
 ///check_trip runs on each step to see if we fall over as a result of our lace status. Knotted laces are a guaranteed trip, while untied shoes are just a chance to stumble
 /obj/item/clothing/shoes/proc/check_trip()
@@ -266,7 +266,7 @@
 /obj/item/clothing/shoes/attack_self(mob/user)
 	. = ..()
 
-	if(user.is_interacting_with(src))
+	if(INTERACTING_WITH(user, src))
 		to_chat(user, "<span class='warning'>You're already interacting with [src]!</span>")
 		return
 

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -165,7 +165,7 @@
 			return
 		user.visible_message("<span class='notice'>[user] begins [tied ? "unknotting" : "tying"] the laces of [user.p_their()] [src.name].</span>", "<span class='notice'>You begin [tied ? "unknotting" : "tying"] the laces of your [src.name]...</span>")
 
-		if(do_after(user, lace_time, needhand=TRUE, target=our_guy))
+		if(do_after(user, lace_time, needhand=TRUE, target=our_guy, extra_checks=CALLBACK(src, .proc/still_shoed, our_guy)))
 			to_chat(user, "<span class='notice'>You [tied ? "unknot" : "tie"] the laces of your [src.name].</span>")
 			if(tied == SHOES_UNTIED)
 				adjust_laces(SHOES_TIED, user)
@@ -189,7 +189,7 @@
 		if(HAS_TRAIT(user, TRAIT_CLUMSY)) // based clowns trained their whole lives for this
 			mod_time *= 0.75
 
-		if(do_after(user, mod_time, needhand=TRUE, target=our_guy))
+		if(do_after(user, mod_time, needhand=TRUE, target=our_guy, extra_checks=CALLBACK(src, .proc/still_shoed, our_guy)))
 			to_chat(user, "<span class='notice'>You [tied ? "untie" : "knot"] the laces on [loc]'s [src.name].</span>")
 			if(tied == SHOES_UNTIED)
 				adjust_laces(SHOES_KNOTTED, user)
@@ -205,9 +205,11 @@
 					ouchie.receive_damage(brute = 10, stamina = 40)
 				L.Paralyze(10)
 
-/**
-  * check_trip runs on each step to see if we fall over as a result of our lace status. Knotted laces are a guaranteed trip, while untied shoes are just a chance to stumble
-  */
+///checking to make sure we're still on the person we're supposed to be, for lacing do_after's
+/obj/item/clothing/shoes/proc/still_shoed(mob/living/carbon/our_guy)
+	return (our_guy == src.loc)
+
+///check_trip runs on each step to see if we fall over as a result of our lace status. Knotted laces are a guaranteed trip, while untied shoes are just a chance to stumble
 /obj/item/clothing/shoes/proc/check_trip()
 	var/mob/living/carbon/human/our_guy = loc
 	if(!istype(our_guy)) // are they REALLY /our guy/?
@@ -270,6 +272,6 @@
 
 	to_chat(user, "<span class='notice'>You begin [tied ? "untying" : "tying"] the laces on [src]...</span>")
 
-	if(do_after(user, lace_time, needhand=TRUE, target=src))
+	if(do_after(user, lace_time, needhand=TRUE, target=src,extra_checks=CALLBACK(src, .proc/still_shoed, user)))
 		to_chat(user, "<span class='notice'>You [tied ? "untie" : "tie"] the laces on [src].</span>")
 		adjust_laces(tied ? SHOES_TIED : SHOES_UNTIED, user)

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -149,7 +149,7 @@
   * *
   * * user: who is the person interacting with the shoes?
   */
-/obj/item/clothing/shoes/proc/handle_tying(mob/living/carbon/human/user)
+/obj/item/clothing/shoes/proc/handle_tying(mob/user)
 	///our_guy here is the wearer, if one exists (and he must exist, or we don't care)
 	var/mob/living/carbon/human/our_guy = loc
 	if(!istype(our_guy))
@@ -173,7 +173,8 @@
 				adjust_laces(SHOES_UNTIED, user)
 
 	else // if they're someone else's shoes, go knot-wards
-		if(user.mobility_flags & MOBILITY_STAND)
+		var/mob/living/L = user
+		if(istype(L) && (L.mobility_flags & MOBILITY_STAND))
 			to_chat(user, "<span class='warning'>You must be on the floor to interact with [src]!</span>")
 			return
 		if(tied == SHOES_KNOTTED)
@@ -198,10 +199,11 @@
 			user.visible_message("<span class='danger'>[our_guy] stamps on [user]'s hand, mid-shoelace [tied ? "knotting" : "untying"]!</span>", "<span class='userdanger'>Ow! [our_guy] stamps on your hand!</span>", list(our_guy))
 			to_chat(our_guy, "<span class='userdanger'>You stamp on [user]'s hand! What the- [user.p_they()] [user.p_were()] [tied ? "knotting" : "untying"] your shoelaces!</span>")
 			user.emote("scream")
-			var/obj/item/bodypart/ouchie = user.get_bodypart(pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
-			if(ouchie)
-				ouchie.receive_damage(brute = 10, stamina = 40)
-			user.Paralyze(10)
+			if(istype(L))
+				var/obj/item/bodypart/ouchie = L.get_bodypart(pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
+				if(ouchie)
+					ouchie.receive_damage(brute = 10, stamina = 40)
+				L.Paralyze(10)
 
 /**
   * check_trip runs on each step to see if we fall over as a result of our lace status. Knotted laces are a guaranteed trip, while untied shoes are just a chance to stumble

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -188,7 +188,7 @@
 	var/list/progressbars = null	//for stacking do_after bars
 
 	///For storing what do_after's someone has, in case we want to restrict them to only one of a certain do_after at a time
-	var/list/do_afters = list()
+	var/list/do_afters
 
 	///Allows a datum to intercept all click calls this mob is the source of
 	var/datum/click_intercept

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -187,6 +187,9 @@
 	///List of progress bars this mob is currently seeing for actions
 	var/list/progressbars = null	//for stacking do_after bars
 
+	///For storing what do_after's someone has, in case we want to restrict them to only one of a certain do_after at a time
+	var/list/do_afters = list()
+
 	///Allows a datum to intercept all click calls this mob is the source of
 	var/datum/click_intercept
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can no longer mess with people's shoelaces from anywhere in the world, and the target moving will properly trigger the hand stomp.

Also adds a list of current do_after targets to /mob and a related helper mob/is_interacting_with(atom/target) which lets you see if you are currently already interacting with a given atom, letting you block stacking if you so choose (or requiring no other interactions in general). This is only used so you can't queue a bunch of shoe unlacing's at once, but feel free to use it elsewhere.

Also adds more stamina damage to getting your hand stomped on by failing shoe-sabotage, and a slightly longer stun.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes and code functionality
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
balance: Failing unlacing someone's shoes and getting your hand stepped on is a bit more punishing
fix: You can no longer untie and knot peoples' shoes from across the world, nor can you queue a bunch of unties to knot them quicker.
fix: Moving while your shoes are being tampered with will properly trigger stamping on the saboteur's hand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
