### PR TITLE
Adds Configurable Living Time Requirement to Discord Auto Enrollment

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -487,7 +487,10 @@
 
 // DISCORD ROLE STUFFS
 // Using strings for everything because BYOND does not like numbers this big
+// (exception to the above is required living hours haha)
 /datum/config_entry/flag/enable_discord_autorole
+
+/datum/config_entry/number/required_living_hours
 
 /datum/config_entry/string/discord_token
 

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -30,16 +30,22 @@ SUBSYSTEM_DEF(discord)
 	wait = 3000
 	init_order = INIT_ORDER_DISCORD
 
-	var/list/notify_members = list() // People to save to notify file
-	var/list/notify_members_cache = list() // Copy of previous list, so the SS doesnt have to fire if no new members have been added
-	var/list/people_to_notify = list() // People to notify on roundstart
-	var/list/account_link_cache = list() // List that holds accounts to link, used in conjunction with TGS
-	var/list/reverify_cache = list() // list of people who tried to reverify, so they can only do it once per round as a shitty slowdown
+	/// People to save to notify file
+	var/list/notify_members = list()
+	/// Copy of previous list, so the SS doesnt have to fire if no new members have been added
+	var/list/notify_members_cache = list()
+	/// People to notify on roundstart
+	var/list/people_to_notify = list()
+	/// List that holds accounts to link, used in conjunction with TGS
+	var/list/account_link_cache = list()
+	/// list of people who tried to reverify, so they can only do it once per round as a shitty slowdown
+	var/list/reverify_cache = list()
 	var/notify_file = file("data/notify.json")
-	var/enabled = 0 // Is TGS enabled (If not we wont fire because otherwise this is useless)
+	/// Is TGS enabled (If not we wont fire because otherwise this is useless)
+	var/enabled = 0
 
 /datum/controller/subsystem/discord/Initialize(start_timeofday)
-	// Check for if we are using TGS, otherwise return and disabless firing
+	// Check for if we are using TGS, otherwise return and disables firing
 	if(world.TgsAvailable())
 		enabled = 1 // Allows other procs to use this (Account linking, etc)
 	else
@@ -49,7 +55,7 @@ SUBSYSTEM_DEF(discord)
 	try
 		people_to_notify = json_decode(file2text(notify_file))
 	catch
-		pass() // The list can just stay as its defualt (blank). Pass() exists because it needs a catch
+		pass() // The list can just stay as its default (blank). Pass() exists because it needs a catch
 	var/notifymsg = ""
 	for(var/id in people_to_notify)
 		// I would use jointext here, but I dont think you can two-side glue with it, and I would have to strip characters otherwise
@@ -115,6 +121,9 @@ SUBSYSTEM_DEF(discord)
 	var/regex/num_only = regex("\[^0-9\]", "g")
 	return num_only.Replace(input, "")
 
+/datum/controller/subsystem/discord/proc/has_hour_requirement(ckey)
+
+
 /datum/controller/subsystem/discord/proc/grant_role(id)
 	// Ignore this shit if config isnt enabled for it
 	if(!CONFIG_GET(flag/enable_discord_autorole))
@@ -123,7 +132,6 @@ SUBSYSTEM_DEF(discord)
 	var/url = "https://discordapp.com/api/guilds/[CONFIG_GET(string/discord_guildid)]/members/[id]/roles/[CONFIG_GET(string/discord_roleid)]"
 
 	// Make the request
-
 	var/datum/http_request/req = new()
 	req.prepare(RUSTG_HTTP_METHOD_PUT, url, "", list("Authorization" = "Bot [CONFIG_GET(string/discord_token)]"))
 	req.begin_async()

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -121,9 +121,6 @@ SUBSYSTEM_DEF(discord)
 	var/regex/num_only = regex("\[^0-9\]", "g")
 	return num_only.Replace(input, "")
 
-/datum/controller/subsystem/discord/proc/has_hour_requirement(ckey)
-
-
 /datum/controller/subsystem/discord/proc/grant_role(id)
 	// Ignore this shit if config isnt enabled for it
 	if(!CONFIG_GET(flag/enable_discord_autorole))

--- a/code/modules/discord/accountlink.dm
+++ b/code/modules/discord/accountlink.dm
@@ -78,8 +78,8 @@
 		return
 
 	// check for living hours requirement
-	var/required_living_hours = CONFIG_GET(number/required_living_hours) * 60
-	var/living_hours = usr.client ? usr.client.get_exp_living(TRUE) : 0
+	var/required_living_minutes = CONFIG_GET(number/required_living_hours) * 60
+	var/living_minutes = usr.client ? usr.client.get_exp_living(TRUE) : 0
 	if(required_living_hours > 0 && living_hours < required_living_hours)
 		to_chat(usr, "<span class='warning'>You must have at least [required_living_hours] minutes of living " \
 			+ "playtime in a round to verify. You have [living_hours] minutes. Play more!</span>")

--- a/code/modules/discord/accountlink.dm
+++ b/code/modules/discord/accountlink.dm
@@ -55,23 +55,35 @@
 		to_chat(src, "<span class='warning'>This feature requires the SQL backend to be running.</span>")
 		return
 
-	if(!SSdiscord) // SS is still starting
+	// ss is still starting
+	if(!SSdiscord)
 		to_chat(src, "<span class='notice'>The server is still starting up. Please wait before attempting to link your account!</span>")
 		return
 
+	// check that tgs is alive and well
 	if(!SSdiscord.enabled)
 		to_chat(src, "<span class='warning'>This feature requires the server is running on the TGS toolkit.</span>")
 		return
+
+	// check that this is not an IDIOT mistaking us for an attack vector
 	if(SSdiscord.reverify_cache[usr.ckey] == TRUE)
 		to_chat(src, "<span class='warning'>Thou can only do this once a round, if you're stuck seek help.</span>")
 		return
 	SSdiscord.reverify_cache[usr.ckey] = TRUE
 
+	// check that account is linked with discord
 	var/stored_id = SSdiscord.lookup_id(usr.ckey)
 	if(!stored_id) // Account is not linked
 		to_chat(usr, "Link your discord account via the linkdiscord verb in the OOC tab first");
-		return;
+		return
 
-	else // Account is already linked
-		// Role the user
-		SSdiscord.grant_role(stored_id)
+	// check for living hours requirement
+	var/required_living_hours = CONFIG_GET(number/required_living_hours) / 60
+	var/living_hours = usr.client ? usr.client.get_exp_living(TRUE) : 0
+	if(required_living_hours > 0 && living_hours < required_living_hours)
+		to_chat(usr, "<span class='warning'>You must have at least [required_living_hours] hours of living " \
+			+ "playtime in a round to verify. You have [living_hours] hours. Play more!</span>")
+		return
+
+	// honey its time for your role flattening
+	SSdiscord.grant_role(stored_id)

--- a/code/modules/discord/accountlink.dm
+++ b/code/modules/discord/accountlink.dm
@@ -80,7 +80,7 @@
 	// check for living hours requirement
 	var/required_living_minutes = CONFIG_GET(number/required_living_hours) * 60
 	var/living_minutes = usr.client ? usr.client.get_exp_living(TRUE) : 0
-	if(required_living_hours > 0 && living_hours < required_living_hours)
+	if(required_living_minutes > 0 && living_minutes < required_living_minutes)
 		to_chat(usr, "<span class='warning'>You must have at least [required_living_minutes] minutes of living " \
 			+ "playtime in a round to verify. You have [living_minutes] minutes. Play more!</span>")
 		return

--- a/code/modules/discord/accountlink.dm
+++ b/code/modules/discord/accountlink.dm
@@ -81,8 +81,8 @@
 	var/required_living_minutes = CONFIG_GET(number/required_living_hours) * 60
 	var/living_minutes = usr.client ? usr.client.get_exp_living(TRUE) : 0
 	if(required_living_hours > 0 && living_hours < required_living_hours)
-		to_chat(usr, "<span class='warning'>You must have at least [required_living_hours] minutes of living " \
-			+ "playtime in a round to verify. You have [living_hours] minutes. Play more!</span>")
+		to_chat(usr, "<span class='warning'>You must have at least [required_living_minutes] minutes of living " \
+			+ "playtime in a round to verify. You have [living_minutes] minutes. Play more!</span>")
 		return
 
 	// honey its time for your role flattening

--- a/code/modules/discord/accountlink.dm
+++ b/code/modules/discord/accountlink.dm
@@ -78,11 +78,11 @@
 		return
 
 	// check for living hours requirement
-	var/required_living_hours = CONFIG_GET(number/required_living_hours) / 60
+	var/required_living_hours = CONFIG_GET(number/required_living_hours) * 60
 	var/living_hours = usr.client ? usr.client.get_exp_living(TRUE) : 0
 	if(required_living_hours > 0 && living_hours < required_living_hours)
-		to_chat(usr, "<span class='warning'>You must have at least [required_living_hours] hours of living " \
-			+ "playtime in a round to verify. You have [living_hours] hours. Play more!</span>")
+		to_chat(usr, "<span class='warning'>You must have at least [required_living_hours] minutes of living " \
+			+ "playtime in a round to verify. You have [living_hours] minutes. Play more!</span>")
 		return
 
 	// honey its time for your role flattening

--- a/code/modules/discord/accountlink.dm
+++ b/code/modules/discord/accountlink.dm
@@ -48,7 +48,7 @@
 /client/verb/verify_in_discord()
 	set category = "OOC"
 	set name = "Verify Discord Account"
-	set desc = "Reverify your account to the discord if you get banned, you bad banana"
+	set desc = "Verify or reverify your discord account against your linked ckey"
 
 	// Safety checks
 	if(!CONFIG_GET(flag/sql_enabled))

--- a/code/modules/discord/tgs_commands.dm
+++ b/code/modules/discord/tgs_commands.dm
@@ -25,8 +25,6 @@
 		if(SSdiscord.account_link_cache[lowerparams] == discordid) // If the associated ID is the correct one
 			// Link the account in the DB table
 			SSdiscord.link_account(lowerparams)
-			// Role the user
-			SSdiscord.grant_role(discordid)
 			return "Successfully linked accounts"
 		else
 			return "That ckey is not associated to this discord account. If someone has used your ID, please inform an administrator"

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -124,7 +124,7 @@ GLOBAL_PROTECT(exp_to_update)
 
 /client/proc/get_exp_living(pure_numeric = FALSE)
 	if(!prefs.exp)
-		return "No data"
+		return pure_numeric ? 0 : "No data"
 	var/exp_living = text2num(prefs.exp[EXP_TYPE_LIVING])
 	return pure_numeric ? exp_living : get_exp_format(exp_living)
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -508,6 +508,9 @@ DEFAULT_VIEW_SQUARE 15x15
 ## Uncomment to enable discord auto-roling when users link their BYOND and Discord accounts
 #ENABLE_DISCORD_AUTOROLE
 
+## Set to a value greater than zero to require a user to have at least this many hours of living role time to be assigned the role
+REQUIRED_LIVING_HOURS 0
+
 ## Add your discord bot token here. Make sure it has the ability to manage roles
 #DISCORD_TOKEN someDiscordToken
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As requested by @optimumtact this enforces a requirement, when configured, that a player must have a certain amount of living playtime in hours to auto-enroll into a discord role.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes discord moderation requirement
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
server: Discord role auto enrollment can now be configured to require a certain number of living hours.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
