### PR TITLE
Fixes Double Flasher Button in Holding Cell (MetaStation)(Reupload)

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -11011,11 +11011,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/button/flasher{
-	id = "holdingflash";
-	pixel_y = -26;
-	req_access_txt = "1"
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "axp" = (


### PR DESCRIPTION
## About The Pull Request

Fixes #50046
![image](https://user-images.githubusercontent.com/59634148/76925070-e0ddae00-689d-11ea-9990-05f8ef8f3ba4.png)

The issue was that in metastation, the holding cell in brig which hold's prisoners had two flasher buttons. As you can see above. After some investigation, it was shown that both of the flashers were used in the holding cell, and it was seemed the flasher button in the window was useless since you couldn't use it unless you broke the window. I went on dream maker, located the flasher and removed the unnecessary flasher button in the window. Which leaves us with two flashers on the wall. One for the brig entrance, and one for the holding cell. As shown below.
![image](https://user-images.githubusercontent.com/59634148/76925156-1d110e80-689e-11ea-9d19-6faa952da993.png)

## Why It's Good For The Game

Well, it seems that the flasher button in the window was pointless, and it had no benefit at all as there was one flasher used for the holding cell already on the wall.

## Changelog

🆑
del: removes flasher button in metastation holding cell window
/🆑
