### PR TITLE
Improves the feedback on vend-a-trays.

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -439,7 +439,11 @@
 			//Setting the object's price.
 			if(INTENT_GRAB)
 				var/new_price_input = input(user,"Set the sale price for this vend-a-tray.","new price",0) as num|null
-				if(isnull(new_price_input) || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK) || (payments_acc != potential_acc.registered_account))
+				if(isnull(new_price_input) || (payments_acc != potential_acc.registered_account))
+					to_chat(user, "<span class='warning'>The vend-a-tray rejects your new price.</span>")
+					return
+				if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK) )
+					to_chat(user, "<span class='warning'>You need to get closer!</span>")
 					return
 				new_price_input = clamp(round(new_price_input, 1), 10, 1000)
 				sale_price = new_price_input


### PR DESCRIPTION
## About The Pull Request

Quick tweak to feedback on vend-a-trays, now they give more clear feedback when you alter the price of the tray and it fails.

## Why It's Good For The Game

Good feedback I got from people using them, which is pretty valid and an easy fix.

## Changelog
:cl:
tweak: adjusting the price of vend-a-trays is now more responsive.
/:cl: