### PR TITLE
Extinguished burning clothes no longer burn forever.

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -224,7 +224,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	if(resistance_flags & ON_FIRE)
 		resistance_flags &= ~ON_FIRE
 		cut_overlay(GLOB.fire_overlay, TRUE)
-		update_icon_state()
+		update_icon()
 		SSfire_burning.processing -= src
 
 ///Called when the obj is hit by a tesla bolt.

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -224,6 +224,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	if(resistance_flags & ON_FIRE)
 		resistance_flags &= ~ON_FIRE
 		cut_overlay(GLOB.fire_overlay, TRUE)
+		update_icon_state()
 		SSfire_burning.processing -= src
 
 ///Called when the obj is hit by a tesla bolt.

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -855,6 +855,7 @@
 		var/obj/item/I = X
 		I.acid_level = 0 //washes off the acid on our clothes
 		I.extinguish() //extinguishes our clothes
+		I.cut_overlay(GLOB.fire_overlay, TRUE)
 	..()
 
 /mob/living/carbon/fakefire(var/fire_icon = "Generic_mob_burning")

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -163,7 +163,6 @@
 /datum/reagent/water/reaction_obj(obj/O, reac_volume)
 	O.extinguish()
 	O.acid_level = 0
-	O.update_icon()
 	// Monkey cube
 	if(istype(O, /obj/item/reagent_containers/food/snacks/monkeycube))
 		var/obj/item/reagent_containers/food/snacks/monkeycube/cube = O

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -163,6 +163,7 @@
 /datum/reagent/water/reaction_obj(obj/O, reac_volume)
 	O.extinguish()
 	O.acid_level = 0
+	O.cut_overlay(GLOB.fire_overlay, TRUE)
 	// Monkey cube
 	if(istype(O, /obj/item/reagent_containers/food/snacks/monkeycube))
 		var/obj/item/reagent_containers/food/snacks/monkeycube/cube = O
@@ -188,6 +189,13 @@
 	if(method == TOUCH)
 		M.adjust_fire_stacks(-(reac_volume / 10))
 		M.ExtinguishMob()
+		if(istype(M, /mob/living/carbon))
+			var/mob/living/carbon/C = M
+			for(var/X in C.get_equipped_items())
+				var/obj/item/I = X
+				I.acid_level = 0
+				I.extinguish()
+				I.update_overlays()
 	..()
 
 /datum/reagent/water/holywater

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -195,7 +195,7 @@
 				var/obj/item/I = X
 				I.acid_level = 0
 				I.extinguish()
-				I.update_overlays()
+				I.cut_overlay(GLOB.fire_overlay, TRUE)
 	..()
 
 /datum/reagent/water/holywater

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -163,7 +163,7 @@
 /datum/reagent/water/reaction_obj(obj/O, reac_volume)
 	O.extinguish()
 	O.acid_level = 0
-	O.cut_overlay(GLOB.fire_overlay, TRUE)
+	O.update_icon()
 	// Monkey cube
 	if(istype(O, /obj/item/reagent_containers/food/snacks/monkeycube))
 		var/obj/item/reagent_containers/food/snacks/monkeycube/cube = O
@@ -189,13 +189,6 @@
 	if(method == TOUCH)
 		M.adjust_fire_stacks(-(reac_volume / 10))
 		M.ExtinguishMob()
-		if(istype(M, /mob/living/carbon))
-			var/mob/living/carbon/C = M
-			for(var/X in C.get_equipped_items())
-				var/obj/item/I = X
-				I.acid_level = 0
-				I.extinguish()
-				I.cut_overlay(GLOB.fire_overlay, TRUE)
 	..()
 
 /datum/reagent/water/holywater


### PR DESCRIPTION
## About The Pull Request

Fixes #42800 as far as I'm aware.
So from what I understand, clothes sprites were working when they extinguished  immediately after catching fire. But, when your clothes catch fire and get the damage overlay as well, they weren't losing the burning overlay, ever. Solution may be a bit hacky, but it seems to work in all cases, including throwing burning clothes onto showers, and individually extinguishing burning clothes. 

## Why It's Good For The Game

Bugs bad.

## Changelog
:cl:
fix: Burning clothes no longer burn forever if you're set on fire for too long.
/:cl: