### PR TITLE
DonutStation North research maint fixes

### DIFF
--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -12375,6 +12375,12 @@
 	dir = 4
 	},
 /obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "aCs" = (
@@ -23759,20 +23765,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"bca" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "bcb" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -28861,6 +28853,12 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bmM" = (
@@ -28931,19 +28929,26 @@
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "bmT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"bmU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"bmU" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28963,13 +28968,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bmW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bmX" = (
@@ -29301,12 +29304,16 @@
 	id = "Ferry_Bridge";
 	name = "Ferry Bridge Toggle";
 	pixel_x = -24;
-	pixel_y = 8
+	pixel_y = 24;
+	sync_doors = 0
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/caution,
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bnG" = (
@@ -29477,6 +29484,9 @@
 "bnT" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bnU" = (
@@ -45722,12 +45732,12 @@
 /turf/open/floor/plating,
 /area/library/abandoned)
 "cpK" = (
-/obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "Ferry_Bridge"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "csr" = (
@@ -45917,8 +45927,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/caution,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dfK" = (
@@ -45958,6 +45970,18 @@
 	dir = 5
 	},
 /area/science/research)
+"dlj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "dlq" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Supermatter External Chamber";
@@ -47673,7 +47697,8 @@
 	id = "Ferry_Bridge";
 	name = "Ferry Bridge Toggle";
 	pixel_x = -8;
-	pixel_y = -24
+	pixel_y = -24;
+	sync_doors = 0
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -48122,13 +48147,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engine_room)
-"jTr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "jUK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -48560,7 +48578,6 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "lNg" = (
-/obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "Ferry_Bridge"
@@ -49497,6 +49514,20 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"oYz" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id = "Ferry_Bridge"
+	},
+/obj/machinery/button/door{
+	id = "Ferry_Bridge";
+	name = "Ferry Bridge Toggle";
+	pixel_x = -24;
+	pixel_y = 8;
+	sync_doors = 0
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "peq" = (
 /obj/item/chair,
 /obj/item/chair{
@@ -49668,15 +49699,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
-"pyT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "pBI" = (
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
@@ -49712,6 +49734,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"pNh" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "pNn" = (
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -49904,7 +49933,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "qxY" = (
-/obj/machinery/door/airlock/public/glass,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable,
@@ -50210,6 +50238,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "rzr" = (
@@ -50292,10 +50323,8 @@
 /area/maintenance/port/fore)
 "rLT" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "rMa" = (
@@ -50834,10 +50863,15 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/button/door{
+	id = "Ferry_Bridge";
+	name = "Ferry Bridge Toggle";
+	pixel_x = 24;
+	pixel_y = 24;
+	sync_doors = 0
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "tzv" = (
@@ -51299,6 +51333,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -67779,8 +67816,8 @@ aaa
 aaa
 aaa
 aeS
-bTU
-bca
+bQW
+bbI
 ano
 aAF
 aAF
@@ -72110,14 +72147,14 @@ jtf
 aYM
 vaD
 lNg
-pyT
+bao
 bTU
 bTU
 bTU
 bTU
 bTU
-jTr
-lNg
+blO
+oYz
 bnF
 aYM
 bTU
@@ -78556,7 +78593,7 @@ aVI
 bkY
 bmi
 bmU
-asQ
+pNh
 acy
 acy
 acy
@@ -78812,7 +78849,7 @@ aCj
 bnR
 boB
 bml
-bmU
+dlj
 asQ
 acy
 bVN
@@ -79069,7 +79106,7 @@ aKP
 aVI
 bgh
 bmm
-bmU
+dlj
 asQ
 acy
 bVV

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -45970,18 +45970,6 @@
 	dir = 5
 	},
 /area/science/research)
-"dlj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "dlq" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Supermatter External Chamber";
@@ -47546,6 +47534,18 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"hWl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "hWJ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12"
@@ -48147,6 +48147,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engine_room)
+"jTr" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/button/door{
+	id = "Ferry_Bridge";
+	name = "Ferry Bridge Toggle";
+	pixel_x = -24;
+	pixel_y = -24;
+	sync_doors = 0
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jUK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -49514,20 +49525,6 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"oYz" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/preopen{
-	id = "Ferry_Bridge"
-	},
-/obj/machinery/button/door{
-	id = "Ferry_Bridge";
-	name = "Ferry Bridge Toggle";
-	pixel_x = -24;
-	pixel_y = 8;
-	sync_doors = 0
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "peq" = (
 /obj/item/chair,
 /obj/item/chair{
@@ -49734,13 +49731,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"pNh" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "pNn" = (
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -51408,6 +51398,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"vhK" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "viK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -72153,8 +72150,8 @@ bTU
 bTU
 bTU
 bTU
-blO
-oYz
+jTr
+lNg
 bnF
 aYM
 bTU
@@ -78593,7 +78590,7 @@ aVI
 bkY
 bmi
 bmU
-pNh
+vhK
 acy
 acy
 acy
@@ -78849,7 +78846,7 @@ aCj
 bnR
 boB
 bml
-dlj
+hWl
 asQ
 acy
 bVN
@@ -79106,7 +79103,7 @@ aKP
 aVI
 bgh
 bmm
-dlj
+hWl
 asQ
 acy
 bVV


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes 3 things:

- The ferry bridge in North research maint on DonutStation has been changed to fix #49558. Buttons have been added on the inside of the bridge, the airlocks have been removed to make the bridge look more consistent (blast doors are still present), and vents have been moved outside the bridge to prevent leaking air into space when the bridge is opened. sync_doors on the buttons has also been set to 0 to toggle the blast doors properly.

- Missing pipes South of the holodeck have been added to connect North research maint pipes to the rest of the station pipenet.

- An exposed, electrified grille in the middle of a maint tunnel was moved to no longer be electrified.

**Before and after photos available [here](https://imgur.com/a/zr91htn).**

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It fixes oversights.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: you can no longer get trapped inside the ferry bridge on donutstation as new buttons have been added on the inside
fix: the ferry bridge now opens and closes properly
tweak: moved vents in ferry bridge to no loner leak air into space when the bridge is open
tweak: removed airlocks from the ferry bridge to make it look better
fix: added missing pipes South of holodeck to connect North research maint to the donutstation pipenet
tweak: moved an exposed electrified grille in maint so it's no longer electrified
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
