### PR TITLE
[READY] [FREDDY] [BETTY SPAGHETTI] Adds suicide to toy singularity

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -196,7 +196,7 @@
   * Makes the user vomit and receive 120 suffocation damage if there already is a cavity implant in the user.
   * Throwing the singularity away will cause the user to start choking themself to death.
   *
-  * * arg1 - Whoever is doing the suiciding
+  * * user - Whoever is doing the suiciding
   */
 /obj/item/toy/spinningtoy/proc/manual_suicide(mob/living/carbon/human/user)
 	if(!user)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -186,18 +186,42 @@
 	user.visible_message("<span class='suicide'>[user] consumes [src]! It looks like [user.p_theyre()] trying to commit suicicide!</span>")
 	playsound(user, 'sound/items/eatfood.ogg', 50, TRUE)
 	user.adjust_nutrition(50) // mmmm delicious
-	sleep(3 SECONDS)
+	addtimer(CALLBACK(src, .proc/manual_suicide, user), 30)
+	return MANUAL_SUICIDE
 
+/**
+  * Internal function used in the toy singularity suicide
+  *
+  * Cavity implants the toy singularity into the body of the user (arg1), and kills the user.
+  * Makes the user vomit and receive 120 suffocation damage if there already is a cavity implant in the user.
+  * Throwing the singularity away will cause the user to start choking themself to death.
+  *
+  * * arg1 - Whoever is doing the suiciding
+  */
+/obj/item/toy/spinningtoy/proc/manual_suicide(mob/living/carbon/human/user)
+	if(!user)
+		return
+	if(!user.is_holding(src)) // Half digestion? Start choking to death
+		user.visible_message("<span class='suicide'>[user] panics and starts choking [user.p_them()]self to death!</span>")
+		user.adjustOxyLoss(200)
+		user.death(FALSE) // unfortunately you have to handle the suiciding yourself with a manual suicide
+		user.ghostize(FALSE) // get the fuck out of our body
+		return
 	var/obj/item/bodypart/chest/CH = user.get_bodypart(BODY_ZONE_CHEST)
 	if(CH.cavity_item) // if he's (un)bright enough to have a round and full belly...
 		user.visible_message("<span class='danger'>[user] regurgitates [src]!</span>") // I swear i dont have a fetish
 		user.vomit(100, TRUE, distance = 0)
 		user.adjustOxyLoss(120)
 		user.dropItemToGround(src) // incase the crit state doesn't drop the singulo to the floor
-		return SHAME
+		user.set_suicide(FALSE)
+		return
 	user.transferItemToLoc(src, user, TRUE)
-	CH.cavity_item = src
-	return OXYLOSS // You know how most small toys in the EU have that 3+ onion head icon and a warning that says "Unsuitable for children under 3 years of age due to small parts - choking hazard"? This is why.
+	CH.cavity_item = src // The mother came inside and found Andy, dead with a HUGE belly full of toys
+	user.adjustOxyLoss(200) // You know how most small toys in the EU have that 3+ onion head icon and a warning that says "Unsuitable for children under 3 years of age due to small parts - choking hazard"? This is why.
+	user.death(FALSE)
+	user.ghostize(FALSE)
+
+
 
 /*
  * Toy gun: Why isnt this an /obj/item/gun?

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -184,7 +184,7 @@
 		user.visible_message("<span class='suicide'>[user] tries consuming [src]... but they have no mouth!") // and i must scream
 		return SHAME
 	user.visible_message("<span class='suicide'>[user] consumes [src]! It looks like [user.p_theyre()] trying to commit suicicide!</span>")
-	playsound(src, 'sound/items/eatfood.ogg', 50, TRUE)
+	playsound(user, 'sound/items/eatfood.ogg', 50, TRUE)
 	qdel(src)
 	return OXYLOSS // You know how most small toys in the EU have that 3+ onion head icon and a warning that says "Unsuitable for children under 3 years of age due to small parts - choking hazard"? This is why.
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -195,8 +195,8 @@
   * Cavity implants the toy singularity into the body of the user (arg1), and kills the user.
   * Makes the user vomit and receive 120 suffocation damage if there already is a cavity implant in the user.
   * Throwing the singularity away will cause the user to start choking themself to death.
-  *
-  * user - Whoever is doing the suiciding
+  * Arguments:
+  * * user - Whoever is doing the suiciding
   */
 /obj/item/toy/spinningtoy/proc/manual_suicide(mob/living/carbon/human/user)
 	if(!user)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -181,7 +181,7 @@
 /obj/item/toy/spinningtoy/suicide_act(mob/living/carbon/user)
 	var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)
 	if(!myhead)
-		user.visible_message("<span class='suicide'>[user] tries consuming [src]... but they have no mouth!") // and i must scream
+		user.visible_message("<span class='suicide'>[user] tries consuming [src]... but [user.p_they()] [user.p_have] no mouth!") // and i must scream
 		return SHAME
 	user.visible_message("<span class='suicide'>[user] consumes [src]! It looks like [user.p_theyre()] trying to commit suicicide!</span>")
 	playsound(user, 'sound/items/eatfood.ogg', 50, TRUE)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -196,7 +196,7 @@
   * Makes the user vomit and receive 120 suffocation damage if there already is a cavity implant in the user.
   * Throwing the singularity away will cause the user to start choking themself to death.
   *
-  * * user - Whoever is doing the suiciding
+  * user - Whoever is doing the suiciding
   */
 /obj/item/toy/spinningtoy/proc/manual_suicide(mob/living/carbon/human/user)
 	if(!user)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -181,7 +181,7 @@
 /obj/item/toy/spinningtoy/suicide_act(mob/living/carbon/user)
 	var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)
 	if(!myhead)
-		user.visible_message("<span class='suicide'>[user] tries consuming [src]... but [user.p_they()] [user.p_have] no mouth!") // and i must scream
+		user.visible_message("<span class='suicide'>[user] tries consuming [src]... but [user.p_they()] [user.p_have()] no mouth!") // and i must scream
 		return SHAME
 	user.visible_message("<span class='suicide'>[user] consumes [src]! It looks like [user.p_theyre()] trying to commit suicicide!</span>")
 	playsound(user, 'sound/items/eatfood.ogg', 50, TRUE)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -181,9 +181,9 @@
 /obj/item/toy/spinningtoy/suicide_act(mob/living/carbon/user)
 	var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)
 	if(!myhead)
-		user.visible_message("<span class='suicide'>[user] starts consuming [src]... but they have no mouth!") // and i must scream
+		user.visible_message("<span class='suicide'>[user] tries consuming [src]... but they have no mouth!") // and i must scream
 		return SHAME
-	user.visible_message("<span class='suicide'>[user] starts consuming [src]! It looks like [user.p_theyre()] trying to commit suicicide!</span>")
+	user.visible_message("<span class='suicide'>[user] consumes [src]! It looks like [user.p_theyre()] trying to commit suicicide!</span>")
 	playsound(src, 'sound/items/eatfood.ogg', 50, TRUE)
 	qdel(src)
 	return OXYLOSS // You know how most small toys in the EU have that 3+ onion head icon and a warning that says "Unsuitable for children under 3 years of age due to small parts - choking hazard"? This is why.

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -178,14 +178,25 @@
 	icon = 'icons/obj/singularity.dmi'
 	icon_state = "singularity_s1"
 
-/obj/item/toy/spinningtoy/suicide_act(mob/living/carbon/user)
+/obj/item/toy/spinningtoy/suicide_act(mob/living/carbon/human/user)
 	var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)
 	if(!myhead)
-		user.visible_message("<span class='suicide'>[user] tries consuming [src]... but [user.p_they()] [user.p_have()] no mouth!") // and i must scream
+		user.visible_message("<span class='suicide'>[user] tries consuming [src]... but [user.p_they()] [user.p_have()] no mouth!</span>") // and i must scream
 		return SHAME
 	user.visible_message("<span class='suicide'>[user] consumes [src]! It looks like [user.p_theyre()] trying to commit suicicide!</span>")
 	playsound(user, 'sound/items/eatfood.ogg', 50, TRUE)
-	qdel(src)
+	user.adjust_nutrition(50) // mmmm delicious
+	sleep(1 SECONDS)
+
+	var/obj/item/bodypart/chest/CH = user.get_bodypart(BODY_ZONE_CHEST)
+	if(CH.cavity_item) // if he's (un)bright enough to have a round and full belly...
+		user.visible_message("<span class='danger'>[user] regurgitates [src]!</span>") // I swear i dont have a fetish
+		user.vomit(100, TRUE, distance = 0)
+		user.adjustOxyLoss(120)
+		user.dropItemToGround(src) // incase the crit state doesn't drop the singulo to the floor
+		return SHAME
+	user.transferItemToLoc(src, user, TRUE)
+	CH.cavity_item = src
 	return OXYLOSS // You know how most small toys in the EU have that 3+ onion head icon and a warning that says "Unsuitable for children under 3 years of age due to small parts - choking hazard"? This is why.
 
 /*

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -186,7 +186,7 @@
 	user.visible_message("<span class='suicide'>[user] consumes [src]! It looks like [user.p_theyre()] trying to commit suicicide!</span>")
 	playsound(user, 'sound/items/eatfood.ogg', 50, TRUE)
 	user.adjust_nutrition(50) // mmmm delicious
-	addtimer(CALLBACK(src, .proc/manual_suicide, user), 30)
+	addtimer(CALLBACK(src, .proc/manual_suicide, user), (3SECONDS))
 	return MANUAL_SUICIDE
 
 /**

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -186,7 +186,7 @@
 	user.visible_message("<span class='suicide'>[user] consumes [src]! It looks like [user.p_theyre()] trying to commit suicicide!</span>")
 	playsound(user, 'sound/items/eatfood.ogg', 50, TRUE)
 	user.adjust_nutrition(50) // mmmm delicious
-	sleep(1 SECONDS)
+	sleep(3 SECONDS)
 
 	var/obj/item/bodypart/chest/CH = user.get_bodypart(BODY_ZONE_CHEST)
 	if(CH.cavity_item) // if he's (un)bright enough to have a round and full belly...

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -178,6 +178,16 @@
 	icon = 'icons/obj/singularity.dmi'
 	icon_state = "singularity_s1"
 
+/obj/item/toy/spinningtoy/suicide_act(mob/living/carbon/user)
+	var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)
+	if(!myhead)
+		user.visible_message("<span class='suicide'>[user] starts consuming [src]... but they have no mouth!") // and i must scream
+		return SHAME
+	user.visible_message("<span class='suicide'>[user] starts consuming [src]! It looks like [user.p_theyre()] trying to commit suicicide!</span>")
+	playsound(src, 'sound/items/eatfood.ogg', 50, TRUE)
+	qdel(src)
+	return OXYLOSS // You know how most small toys in the EU have that 3+ onion head icon and a warning that says "Unsuitable for children under 3 years of age due to small parts - choking hazard"? This is why.
+
 /*
  * Toy gun: Why isnt this an /obj/item/gun?
  */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a suicide to the toy singularity, where you eat it and then you choke on it and die. Should've read the safety label.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I tried suiciding with the toy singularity from Citrus the cargo sloth and it resorted to the default suicide, ruining my immersion. This rectifies that.

## Checklist
- [x] The code compiles.
- [x] The code is tested.
- [x] The code works as intended, with no major bugs found.
- [x] The code doesn't runtime.

## Changelog
:cl:
add: Nanotrasen reminds it's employees that consumption of any toys produced by it, and it's subsidiaries may result in choking or asphyxiation.
add: In other news, the Toy Singularity Eating Challenge is hot on the rise! Challenge your friends!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
