### PR TITLE
Fixes chasm passthrough

### DIFF
--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -75,7 +75,9 @@
 				to_chat(user, "<span class='warning'>You need one floor tile to build a floor!</span>")
 		else
 			to_chat(user, "<span class='warning'>The plating is going to need some support! Place metal rods first.</span>")
-
+/turf/open/chasm/CanAllowThrough(atom/movable/mover, turf/target)
+	SHOULD_CALL_PARENT(FALSE)
+	return TRUE
 // Chasms for Lavaland, with planetary atmos and lava glow
 /turf/open/chasm/lavaland
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows passthrough on chasms again.
Issue caused by #48659
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I believe currently it's only possible to end up in a chasm if you are already standing on it while it appears.
This completely removes their threat as anyone who has played mining just once knows to step away from tendrils as they collapse.
Chasms always were and should be deadly.

Closes #50051 
Special thanks to @4dplanner for helping me find and solve the issue
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Butcherman
fix: Chasms are once again deadly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
