### PR TITLE
Speed Nerfs pt2: Antag Edition

### DIFF
--- a/code/modules/movespeed/modifiers/innate.dm
+++ b/code/modules/movespeed/modifiers/innate.dm
@@ -1,5 +1,5 @@
 /datum/movespeed_modifier/strained_muscles
-	multiplicative_slowdown = -1
+	multiplicative_slowdown = -0.55
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/pai_spacewalk

--- a/code/modules/movespeed/modifiers/misc.dm
+++ b/code/modules/movespeed/modifiers/misc.dm
@@ -2,5 +2,5 @@
 	variable = TRUE
 
 /datum/movespeed_modifier/yellow_orb
-	multiplicative_slowdown = -2
+	multiplicative_slowdown = -0.65
 	blacklisted_movetypes = (FLYING|FLOATING)

--- a/code/modules/movespeed/modifiers/reagent.dm
+++ b/code/modules/movespeed/modifiers/reagent.dm
@@ -2,7 +2,7 @@
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/reagent/stimulants
-	multiplicative_slowdown = -1
+	multiplicative_slowdown = -0.55
 
 /datum/movespeed_modifier/reagent/ephedrine
 	multiplicative_slowdown = -0.5
@@ -17,7 +17,7 @@
 	multiplicative_slowdown = -0.35
 
 /datum/movespeed_modifier/reagent/changelinghaste
-	multiplicative_slowdown = -2
+	multiplicative_slowdown = -0.8
 
 /datum/movespeed_modifier/reagent/methamphetamine
 	multiplicative_slowdown = -0.65


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Strained muscles and stimulants have been both reduced from -1 to -0.55 speed modifier, due to the similar effects and intended usage of both. They still provide a noticeable speed boost, however not as fast as things like meth/nitryl.

Changeling haste (lings get it for ~6 seconds after activating adrenals) is down from -2 to -0.8, its the fastest speed buff you can find, but temporary and without its drawbacks. Number for this one was requested by skog.

Yellow orb speed boost down from -2 to -0.65. No one ever sees them though so it doesn't really matter.

## Why It's Good For The Game

Finishes the work started by #48532, combat against super fast enemies is cancer and bad gameplay. Antag speedups are still generally pretty good, and preferable to those which the crew can obtain. 

## Changelog
:cl:
balance: The speed buffs of antag chems as well as the yellow orb have been reduced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
