### PR TITLE
Heads can no longer grant all access.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -232,13 +232,13 @@
 				playsound(computer, "terminal_type", 50, FALSE)
 				return TRUE
 		if("PRG_grantall")
-			if(!computer || !authenticated)
+			if(!computer || !authenticated || minor)
 				return
 			id_card.access |= (is_centcom ? get_all_centcom_access() : get_all_accesses())
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_denyall")
-			if(!computer || !authenticated)
+			if(!computer || !authenticated || minor)
 				return
 			id_card.access.Cut()
 			playsound(computer, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes bug with the ID software.
Heads can no longer grant all access.
Heads can no longer deny all access.
Still works for the HOP.
I would grey out the buttons if I knew how that worked.

## Why It's Good For The Game

Exploit bad
Fixes https://github.com/tgstation/tgstation/issues/49530

## Changelog
:cl:
fix: Fixed fucky wucky that gave all heads all access.
/:cl:
