### PR TITLE
Removes the FRAME cartridge

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -20,7 +20,6 @@
 	var/datum/game_mode/gamemode
 	var/datum/uplink_purchase_log/purchase_log
 	var/list/uplink_items
-	var/hidden_crystals = 0
 	var/unlock_note
 	var/unlock_code
 	var/failsafe_code
@@ -195,8 +194,6 @@
 		if("lock")
 			active = FALSE
 			locked = TRUE
-			telecrystals += hidden_crystals
-			hidden_crystals = 0
 			SStgui.close_uis(src)
 		if("select")
 			selected_cat = params["category"]

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -79,28 +79,3 @@
 			target.explode()
 	else
 		to_chat(U, "<span class='alert'>PDA not found.</span>")
-
-/obj/item/cartridge/virus/frame
-	name = "\improper F.R.A.M.E. cartridge"
-	icon_state = "cart"
-	var/telecrystals = 0
-
-/obj/item/cartridge/virus/frame/send_virus(obj/item/pda/target, mob/living/U)
-	if(charges <= 0)
-		to_chat(U, "<span class='alert'>Out of charges.</span>")
-		return
-	if(!isnull(target) && !target.toff)
-		charges--
-		var/lock_code = "[rand(100,999)] [pick(GLOB.phonetic_alphabet)]"
-		to_chat(U, "<span class='notice'>Virus Sent! The unlock code to the target is: [lock_code]</span>")
-		var/datum/component/uplink/hidden_uplink = target.GetComponent(/datum/component/uplink)
-		if(!hidden_uplink)
-			hidden_uplink = target.AddComponent(/datum/component/uplink)
-			hidden_uplink.unlock_code = lock_code
-		else
-			hidden_uplink.hidden_crystals += hidden_uplink.telecrystals //Temporarially hide the PDA's crystals, so you can't steal telecrystals.
-		hidden_uplink.telecrystals = telecrystals
-		telecrystals = 0
-		hidden_uplink.active = TRUE
-	else
-		to_chat(U, "<span class='alert'>PDA not found.</span>")

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -21,19 +21,6 @@
 	else
 		return ..()
 
-/obj/item/stack/telecrystal/afterattack(obj/item/I, mob/user, proximity)
-	. = ..()
-	if(!proximity)
-		return
-	if(istype(I, /obj/item/cartridge/virus/frame))
-		var/obj/item/cartridge/virus/frame/cart = I
-		if(!cart.charges)
-			to_chat(user, "<span class='notice'>[cart] is out of charges, it's refusing to accept [src].</span>")
-			return
-		cart.telecrystals += amount
-		use(amount)
-		to_chat(user, "<span class='notice'>You slot [src] into [cart]. The next time it's used, it will also give telecrystals.</span>")
-
 /obj/item/stack/telecrystal/five
 	amount = 5
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1330,16 +1330,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 1
 	surplus = 1
 
-/datum/uplink_item/device_tools/frame
-	name = "F.R.A.M.E. PDA Cartridge"
-	desc = "When inserted into a personal digital assistant, this cartridge gives you five PDA viruses which \
-			when used cause the targeted PDA to become a new uplink with zero TCs, and immediately become unlocked. \
-			You will receive the unlock code upon activating the virus, and the new uplink may be charged with \
-			telecrystals normally."
-	item = /obj/item/cartridge/virus/frame
-	cost = 4
-	restricted = TRUE
-
 /datum/uplink_item/device_tools/failsafe
 	name = "Failsafe Uplink Code"
 	desc = "When entered the uplink will self-destruct immediately."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the frame cartridge from the game. That includes the ability to buy it from the uplink (duh).
Closes https://github.com/tgstation/tgstation/issues/49705

## Why It's Good For The Game

This is one of the worst offenders in terms of traitor item bloat. It has never worked as a framing device and there are other, better, options if you want a backup uplink.
It's expensive bait. Doesn't work from a conceptual level. Would be great if it did but it doesn't.
Removies don't improvies.

## Changelog
:cl:
del: Removed F.R.A.M.E. cartridge
/:cl:
