### PR TITLE
No more remote untying of shoes

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -273,7 +273,7 @@
 			update_body()
 
 	var/mob/living/user = usr
-	if(istype(user) && href_list["shoes"] && (user.mobility_flags & MOBILITY_USE)) // we need to be on the ground, so we'll be a bit looser
+	if(istype(user) && href_list["shoes"] && usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY)) // we need to be on the ground, so we'll be a bit looser
 		shoes.handle_tying(usr)
 
 ///////HUDs///////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You now need to be next to a person to unty their shoelaces.
Closes https://github.com/tgstation/tgstation/issues/50077

## Why It's Good For The Game

No advanced clownery allowed

## Changelog
:cl:
fix: You can no longer interact with shoelaces from afar.
/:cl:
