### PR TITLE
Slowdown fixes and tweaks

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -21,6 +21,8 @@
 #define LAZYCLEARLIST(L) if(L) L.Cut()
 #define SANITIZE_LIST(L) ( islist(L) ? L : list() )
 #define reverseList(L) reverseRange(L.Copy())
+#define LAZYADDASSOC(L, K, V) if(!L) { L = list(); } L[K] += list(V);
+#define LAZYREMOVEASSOC(L, K, V) if(L) { if(L[K]) { L[K] -= V; if(!length(L[K])) L -= K; } if(!length(L)) L = null; }
 
 /// Passed into BINARY_INSERT to compare keys
 #define COMPARE_KEY __BIN_LIST[__BIN_MID]

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -4,7 +4,7 @@
 		. = list()
 		for(var/id in considering)
 			var/datum/movespeed_modifier/M = considering[id]
-			if(M.flags & IGNORE_NOSLOW)
+			if(M.flags & IGNORE_NOSLOW || M.multiplicative_slowdown < 0)
 				.[id] = M
 		return
 	return considering

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -1,13 +1,13 @@
 /mob/living/carbon/human/get_movespeed_modifiers()
 	var/list/considering = ..()
-	. = list()
 	if(HAS_TRAIT(src, TRAIT_IGNORESLOWDOWN))
+		. = list()
 		for(var/id in considering)
 			var/datum/movespeed_modifier/M = considering[id]
 			if(M.flags & IGNORE_NOSLOW)
 				.[id] = M
-	else
-		. = considering
+		return
+	return considering
 
 /mob/living/carbon/human/slip(knockdown_amount, obj/O, lube, paralyze, forcedrop)
 	if(HAS_TRAIT(src, TRAIT_NOSLIPALL))

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -439,7 +439,7 @@
 		update_body()
 	else
 		ADD_TRAIT(src, TRAIT_HUSK, source)
-	
+
 /mob/living/proc/cure_fakedeath(source)
 	REMOVE_TRAIT(src, TRAIT_FAKEDEATH, source)
 	REMOVE_TRAIT(src, TRAIT_DEATHCOMA, source)
@@ -457,10 +457,40 @@
 	tod = station_time_timestamp()
 	update_stat()
 
+///Unignores all slowdowns that lack the IGNORE_NOSLOW flag.
 /mob/living/proc/unignore_slowdown(source)
 	REMOVE_TRAIT(src, TRAIT_IGNORESLOWDOWN, source)
-	update_movespeed(FALSE)
+	update_movespeed()
 
+///Ignores all slowdowns that lack the IGNORE_NOSLOW flag.
 /mob/living/proc/ignore_slowdown(source)
 	ADD_TRAIT(src, TRAIT_IGNORESLOWDOWN, source)
-	update_movespeed(FALSE)
+	update_movespeed()
+
+///Ignores specific slowdowns. Accepts a list of slowdowns.
+/mob/living/proc/add_movespeed_mod_immunities(source, slowdown_type, update = TRUE)
+	if(islist(slowdown_type))
+		for(var/listed_type in slowdown_type)
+			if(ispath(listed_type))
+				listed_type = "[listed_type]" //Path2String
+			LAZYADDASSOC(movespeed_mod_immunities, listed_type, source)
+	else
+		if(ispath(slowdown_type))
+			slowdown_type = "[slowdown_type]" //Path2String
+		LAZYADDASSOC(movespeed_mod_immunities, slowdown_type, source)
+	if(update)
+		update_movespeed()
+
+///Unignores specific slowdowns. Accepts a list of slowdowns.
+/mob/living/proc/remove_movespeed_mod_immunities(source, slowdown_type, update = TRUE)
+	if(islist(slowdown_type))
+		for(var/listed_type in slowdown_type)
+			if(ispath(listed_type))
+				listed_type = "[listed_type]" //Path2String
+			LAZYREMOVEASSOC(movespeed_mod_immunities, listed_type, source)
+	else
+		if(ispath(slowdown_type))
+			slowdown_type = "[slowdown_type]" //Path2String
+		LAZYREMOVEASSOC(movespeed_mod_immunities, slowdown_type, source)
+	if(update)
+		update_movespeed()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -24,6 +24,8 @@
 
 	/// List of movement speed modifiers applying to this mob
 	var/list/movespeed_modification				//Lazy list, see mob_movespeed.dm
+	/// List of movement speed modifiers ignored by this mob. List -> List (id) -> List (sources)
+	var/list/movespeed_mod_immunities			//Lazy list, see mob_movespeed.dm
 	/// The calculated mob speed slowdown based on the modifiers list
 	var/cached_multiplicative_slowdown
 	/// List of action hud items the user has
@@ -206,5 +208,5 @@
 
 	/// Used for tracking last uses of emotes for cooldown purposes
 	var/list/emotes_used
-	
+
 	vis_flags = VIS_INHERIT_PLANE //when this be added to vis_contents of something it inherit something.plane, important for visualisation of mob in openspace.

--- a/code/modules/movespeed/_movespeed_modifier.dm
+++ b/code/modules/movespeed/_movespeed_modifier.dm
@@ -29,7 +29,7 @@ Key procs
 	/// Whether or not this is a variable modifier. Variable modifiers can NOT be ever auto-cached. ONLY CHECKED VIA INITIAL(), EFFECTIVELY READ ONLY (and for very good reason)
 	var/variable = FALSE
 
-	/// Unique ID. You can never have different modifications with the same ID. By default, this SHOULD NOT be set. Only set it for cases where you're dynamically making modifiers/need to have two types overwrite each other. If unset, uses path as ID.
+	/// Unique ID. You can never have different modifications with the same ID. By default, this SHOULD NOT be set. Only set it for cases where you're dynamically making modifiers/need to have two types overwrite each other. If unset, uses path (converted to text) as ID.
 	var/id
 
 	/// Higher ones override lower priorities. This is NOT used for ID, ID must be unique, if it isn't unique the newer one overwrites automatically if overriding.
@@ -47,6 +47,11 @@ Key procs
 
 	/// Other modification datums this conflicts with.
 	var/conflicts_with
+
+/datum/movespeed_modifier/New()
+	. = ..()
+	if(!id)
+		id = "[type]" //We turn the path into a string.
 
 GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 
@@ -69,15 +74,14 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 			type_or_datum = get_cached_movespeed_modifier(type_or_datum)
 		else
 			type_or_datum = new type_or_datum
-	var/key = type_or_datum.id || type_or_datum.type		//Our key will be ID if it's overridden, or if not, path.
-	var/datum/movespeed_modifier/existing = LAZYACCESS(movespeed_modification, key)
+	var/datum/movespeed_modifier/existing = LAZYACCESS(movespeed_modification, type_or_datum.id)
 	if(existing)
 		if(existing == type_or_datum)		//same thing don't need to touch
 			return TRUE
 		remove_movespeed_modifier(existing, FALSE)
 	if(length(movespeed_modification))
-		BINARY_INSERT(key, movespeed_modification, datum/movespeed_modifier, type_or_datum, priority, COMPARE_VALUE)
-	LAZYSET(movespeed_modification, key, type_or_datum)
+		BINARY_INSERT(type_or_datum.id, movespeed_modification, datum/movespeed_modifier, type_or_datum, priority, COMPARE_VALUE)
+	LAZYSET(movespeed_modification, type_or_datum.id, type_or_datum)
 	if(update)
 		update_movespeed()
 	return TRUE
@@ -86,9 +90,9 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 /mob/proc/remove_movespeed_modifier(datum/movespeed_modifier/type_id_datum, update = TRUE)
 	var/key
 	if(ispath(type_id_datum))
-		key = initial(type_id_datum.id) || type_id_datum		//id if set, path if not.
+		key = initial(type_id_datum.id) || "[type_id_datum]"		//id if set, path set to string if not.
 	else if(!istext(type_id_datum))		//if it isn't text it has to be a datum, as it isn't a type.
-		key = type_id_datum.id || type_id_datum.type
+		key = type_id_datum.id
 	else								//assume it's an id
 		key = type_id_datum
 	if(!LAZYACCESS(movespeed_modification, key))
@@ -117,8 +121,7 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 	else if(ispath(type_id_datum))
 		if(!initial(type_id_datum.variable))
 			CRASH("Not a variable modifier")
-		var/id = initial(type_id_datum.id)
-		final = LAZYACCESS(movespeed_modification, id || type_id_datum)
+		final = LAZYACCESS(movespeed_modification, initial(type_id_datum.id) || "[type_id_datum]")
 		if(!final)
 			final = new type_id_datum
 			inject = TRUE
@@ -127,7 +130,7 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 		if(!initial(type_id_datum.variable))
 			CRASH("Not a variable modifier")
 		final = type_id_datum
-		if(!LAZYACCESS(movespeed_modification, final.id || final.type))
+		if(!LAZYACCESS(movespeed_modification, final.id))
 			inject = TRUE
 			modified = TRUE
 	if(!isnull(multiplicative_slowdown))
@@ -154,11 +157,11 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 /mob/proc/has_movespeed_modifier(datum/movespeed_modifier/datum_type_id)
 	var/key
 	if(ispath(datum_type_id))
-		key = initial(datum_type_id.id) || datum_type_id
+		key = initial(datum_type_id.id) || "[datum_type_id]"
 	else if(istext(datum_type_id))
 		key = datum_type_id
 	else
-		key = datum_type_id.id || datum_type_id.type
+		key = datum_type_id.id
 	return LAZYACCESS(movespeed_modification, key)
 
 /// Set or update the global movespeed config on a mob
@@ -196,7 +199,9 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 
 /// Get the move speed modifiers list of the mob
 /mob/proc/get_movespeed_modifiers()
-	return movespeed_modification
+	. = movespeed_modification
+	for(var/id in movespeed_mod_immunities)
+		. -= id
 
 /// Calculate the total slowdown of all movespeed modifiers
 /mob/proc/total_multiplicative_slowdown()

--- a/code/modules/movespeed/modifiers/components.dm
+++ b/code/modules/movespeed/modifiers/components.dm
@@ -1,6 +1,7 @@
 /datum/movespeed_modifier/shrink_ray
 	movetypes = GROUND
 	multiplicative_slowdown = 4
+	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/snail_crawl
 	multiplicative_slowdown = -7

--- a/code/modules/movespeed/modifiers/innate.dm
+++ b/code/modules/movespeed/modifiers/innate.dm
@@ -4,6 +4,7 @@
 
 /datum/movespeed_modifier/pai_spacewalk
 	multiplicative_slowdown = 2
+	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/species
 	movetypes = ~FLYING

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -50,6 +50,7 @@
 /datum/movespeed_modifier/config_walk_run
 	multiplicative_slowdown = 1
 	id = MOVESPEED_ID_MOB_WALK_RUN
+	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/config_walk_run/proc/sync()
 
@@ -82,9 +83,11 @@
 /datum/movespeed_modifier/limbless
 	variable = TRUE
 	movetypes = GROUND
+	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/simplemob_varspeed
 	variable = TRUE
+	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/tarantula_web
 	multiplicative_slowdown = 3
@@ -92,15 +95,19 @@
 /datum/movespeed_modifier/gravity
 	blacklisted_movetypes = FLOATING
 	variable = TRUE
+	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/carbon_softcrit
 	multiplicative_slowdown = SOFTCRIT_ADD_SLOWDOWN
+	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/slime_tempmod
 	variable = TRUE
 
 /datum/movespeed_modifier/carbon_crawling
 	multiplicative_slowdown = CRAWLING_ADD_SLOWDOWN
+	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/mob_config_speedmod
 	variable = TRUE
+	flags = IGNORE_NOSLOW

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -546,10 +546,10 @@
 
 /datum/reagent/medicine/morphine/on_mob_metabolize(mob/living/L)
 	..()
-	L.ignore_slowdown(type)
+	L.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 
 /datum/reagent/medicine/morphine/on_mob_end_metabolize(mob/living/L)
-	L.unignore_slowdown(type)
+	L.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 	..()
 
 /datum/reagent/medicine/morphine/on_mob_life(mob/living/carbon/M)
@@ -1020,13 +1020,13 @@
 	..()
 	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	ADD_TRAIT(L, TRAIT_STUNRESISTANCE, type)
-	L.ignore_slowdown(type)
+	L.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 
 /datum/reagent/medicine/changelingadrenaline/on_mob_end_metabolize(mob/living/L)
 	..()
 	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	REMOVE_TRAIT(L, TRAIT_STUNRESISTANCE, type)
-	L.unignore_slowdown(type)
+	L.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 	L.Dizzy(0)
 	L.Jitter(0)
 
@@ -1088,13 +1088,13 @@
 	name = "Muscle Stimulant"
 	description = "A potent chemical that allows someone under its influence to be at full physical ability even when under massive amounts of pain."
 
-/datum/reagent/medicine/muscle_stimulant/on_mob_metabolize(mob/living/M)
+/datum/reagent/medicine/muscle_stimulant/on_mob_metabolize(mob/living/L)
 	. = ..()
-	M.ignore_slowdown(type)
+	L.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 
-/datum/reagent/medicine/muscle_stimulant/on_mob_end_metabolize(mob/living/M)
+/datum/reagent/medicine/muscle_stimulant/on_mob_end_metabolize(mob/living/L)
 	. = ..()
-	M.unignore_slowdown(type)
+	L.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 
 /datum/reagent/medicine/modafinil
 	name = "Modafinil"
@@ -1295,13 +1295,13 @@
 	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	ADD_TRAIT(L, TRAIT_STUNRESISTANCE, type)
 	L.add_movespeed_modifier(/datum/movespeed_modifier/reagent/badstims)
-	L.ignore_slowdown(type)
+	L.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 
 /datum/reagent/medicine/badstims/on_mob_end_metabolize(mob/living/L)
 	..()
 	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	REMOVE_TRAIT(L, TRAIT_STUNRESISTANCE, type)
 	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/badstims)
-	L.unignore_slowdown(type)
+	L.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 	L.Dizzy(0)
 	L.Jitter(0)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -750,11 +750,12 @@ datum/status_effect/stabilized/blue/on_remove()
 	colour = "red"
 
 /datum/status_effect/stabilized/red/on_apply()
-	owner.ignore_slowdown("slimestatus")
-	return ..()
+	. = ..()
+	owner.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/equipment_speedmod)
 
 /datum/status_effect/stabilized/red/on_remove()
-	owner.unignore_slowdown("slimestatus")
+	owner.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/equipment_speedmod)
+	return ..()
 
 /datum/status_effect/stabilized/green
 	id = "stabilizedgreen"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Refactors the `id` var of `movespeed_modifier` to always be strings. Sure, you can have an associative list with both strings and type paths, but that gets messy and creates problems.
* Fixes quite a few things making you nyoooom around without any slowdown.
* Adds a way to implement specific slowdown immunities. And adds some of them.

Fixes #48631

## Changelog
:cl:
fix: You no longer nyooom around after using a survival medipen and several other objects.
balance: Morphine, changeling adrenaline, traitor adrenals and holding a traitor hold potato all make you ignore damage slowdown. Red stabilized slime extracts make you ignore equipment speed variations.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
