### PR TITLE
You no longer hit fermenting barrels when transferring reagents

### DIFF
--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -50,6 +50,10 @@
 		to_chat(user, "<span class='notice'>You place [I] into [src] to start the fermentation process.</span>")
 		addtimer(CALLBACK(src, .proc/makeWine, fruit), rand(80, 120) * speed_multiplier)
 		return TRUE
+	var/obj/item/W = I
+	if(W)
+		if(W.is_refillable())
+			return 0 //so we can refill them via their afterattack.
 	else
 		return ..()
 

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -53,7 +53,7 @@
 	var/obj/item/W = I
 	if(W)
 		if(W.is_refillable())
-			return 0 //so we can refill them via their afterattack.
+			return FALSE //so we can refill them via their afterattack.
 	else
 		return ..()
 

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -50,9 +50,8 @@
 		to_chat(user, "<span class='notice'>You place [I] into [src] to start the fermentation process.</span>")
 		addtimer(CALLBACK(src, .proc/makeWine, fruit), rand(80, 120) * speed_multiplier)
 		return TRUE
-	var/obj/item/W = I
-	if(W)
-		if(W.is_refillable())
+	if(I)
+		if(I.is_refillable())
 			return FALSE //so we can refill them via their afterattack.
 	else
 		return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When getting reagents from a fermenting barrel with a glass/anything, you won't hit it anymore.

## Why It's Good For The Game

theres no bug report for this afaik

## Changelog
:cl:
fix: You no longer hit fermenting barrels when taking reagents from them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
