### PR TITLE
grammar fix in drug_events and generic_negative_events dm(reupload)

### DIFF
--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -35,7 +35,7 @@
 	mood_change = -8
 
 /datum/mood_event/withdrawal_severe/add_effects(drug_name)
-	description = "<span class='boldwarning'>Oh god I need some [drug_name]</span>\n"
+	description = "<span class='boldwarning'>Oh god I need some of that [drug_name]</span>\n"
 
 /datum/mood_event/withdrawal_critical
 	mood_change = -10
@@ -65,12 +65,12 @@
 	timeout = 3 MINUTES
 
 /datum/mood_event/narcotic_heavy
-	description = "<span class='nicegreen'>I feel like I'm wrapped in cotton!</span>\n"
+	description = "<span class='nicegreen'>I feel like I'm wrapped up in cotton!</span>\n"
 	mood_change = 9
 	timeout = 3 MINUTES
 
 /datum/mood_event/stimulant_medium
-	description = "<span class='nicegreen'>I have so much energy and I feel like I could do anything.</span>\n"
+	description = "<span class='nicegreen'>I have so much energy! I feel like I could do anything!</span>\n"
 	mood_change = 4
 	timeout = 3 MINUTES
 

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -100,7 +100,7 @@
 		mood_change = 2
 
 /datum/mood_event/table_headsmash
-	description = "<span class='warning'>My fucking head, that hurt...</span>"
+	description = "<span class='warning'>My fucking head, that hurts...</span>"
 	mood_change = -3
 	timeout = 3 MINUTES
 


### PR DESCRIPTION

## About The Pull Request

Nothing major, it simply fixes some grammar issues in the descriptions for drug_events and generic_negative_event.

## Why It's Good For The Game

It just fixes some grammatical mistakes.

## Changelog
:cl:
spellcheck: Fixes some grammatical mistakes in the code for drug_events and generic_negative_event
/:cl: