### PR TITLE
Fixes Boxstation's Rounstart Power Problems

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1777,15 +1777,13 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aeF" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/power/terminal,
 /obj/structure/cable,
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aeG" = (
@@ -26219,10 +26217,14 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bqG" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bqH" = (
@@ -46320,7 +46322,6 @@
 	c_tag = "MiniSat AI Chamber South";
 	network = list("aicore")
 	},
-/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "cBc" = (
@@ -49298,6 +49299,10 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"fsC" = (
+/obj/structure/cable,
+/turf/closed/wall,
+/area/ai_monitored/turret_protected/ai)
 "fsD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -84900,7 +84905,7 @@ bih
 bgN
 bnV
 bph
-afq
+bsc
 bsf
 btG
 buS
@@ -93728,7 +93733,7 @@ cwj
 cwu
 cAV
 cAZ
-cAZ
+cvl
 cvl
 cva
 cva
@@ -93984,7 +93989,7 @@ cww
 cwD
 cvv
 cvv
-cvv
+fsC
 cBb
 cBd
 cva


### PR DESCRIPTION
Almost another first PR since the last one hasn't merged yet. God I hope I'm not accidentally deleting the work I did for the bridge+firelocks PR.

This basically moves some wires around in order to fix the roundstart APC charging issue for the AI + Gravity Generator. I've done a roughly hour long local test with solars wired and power seemed to function normally throughout the station in that timeframe.

**Grav Gen**
Moves an SMES and its terminal, an air alarm, and deletes a wire

![GravGen](https://user-images.githubusercontent.com/8175582/77129200-52d60480-6a10-11ea-869a-3eec958da2ab.png)

**AI Satellite**
In AI chamber mostly just moves the wires by the SMES up a tile.

![AISat](https://user-images.githubusercontent.com/8175582/77129199-523d6e00-6a10-11ea-9937-54a831f5841a.png)




