### PR TITLE
Makes compile changelogs action only run if secret is present.

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -8,6 +8,7 @@ jobs:
   compile:
     name: "Compile changelogs"
     runs-on: ubuntu-latest
+    if: secrets.CompileChangelogs == true
     steps:
       - name: "Setup python"
         uses: actions/setup-python@v1


### PR DESCRIPTION
So you don't need to turn off action on the fork, to not get partial changelog compiles.

@optimumtact you'll need to create that secret if this is merged.