### PR TITLE
Autoclose airlocks on power on.

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -412,3 +412,7 @@
 
 /obj/machinery/door/GetExplosionBlock()
 	return density ? real_explosion_block : 0
+
+/obj/machinery/door/power_change()
+	.=..()
+	autoclose_in(rand(5,30))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -414,5 +414,6 @@
 	return density ? real_explosion_block : 0
 
 /obj/machinery/door/power_change()
-	.=..()
-	autoclose_in(rand(5,30))
+	. = ..()
+	if(. && !(machine_stat & NOPOWER))
+		autoclose_in(rand(0.5 SECONDS, 3 SECONDS))


### PR DESCRIPTION

## About The Pull Request

Autoclose airlocks on power on.

## Why It's Good For The Game

Airlocks forever lost open after opened while unpowered is bad.

## Changelog
:cl:
tweak: Airlocks now try close self on power up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
