### PR TITLE
[Ready] Syndicate Forgotten Ship ruin. Balance+Bug fix.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -1215,7 +1215,10 @@
 	req_one_access_txt = "150"
 	},
 /obj/item/stack/sheet/mineral/titanium{
-	amount = 50
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 10
 	},
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -19,7 +19,8 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ad" = (
-/turf/closed/wall/r_wall/syndicate,
+/obj/machinery/computer/operating,
+/turf/open/floor/plastic,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ae" = (
 /obj/structure/fans/tiny,
@@ -50,24 +51,19 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "aj" = (
-/obj/machinery/airalarm/syndicate{
-	pixel_y = 24
-	},
-/mob/living/simple_animal/hostile/nanotrasen/ranged/assault,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/structure/table/optable,
+/turf/open/floor/plastic,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ak" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/structure/table/reinforced,
+/turf/open/floor/plastic,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "al" = (
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "am" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plastic,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "an" = (
 /obj/structure/sign/warning/vacuum/external,
@@ -84,14 +80,14 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ar" = (
-/obj/machinery/power/apc/syndicate{
-	dir = 1;
-	name = "Syndicate Forgotten Ship APC";
-	pixel_y = 32;
-	start_charge = 0
+/obj/machinery/camera/xray{
+	c_tag = "Medbay";
+	dir = 9;
+	name = "security camera";
+	network = list("fsci");
+	screen_loc = ""
 	},
-/obj/structure/cable,
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/plastic,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "as" = (
 /obj/structure/shuttle/engine/huge{
@@ -478,9 +474,14 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "bv" = (
-/obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/machinery/power/apc/syndicate{
+	dir = 1;
+	name = "Syndicate Forgotten Ship APC";
+	pixel_y = 32;
+	start_charge = 0
+	},
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bw" = (
 /obj/structure/closet/syndicate{
@@ -627,15 +628,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bP" = (
-/obj/structure/cable,
-/obj/machinery/camera/xray{
-	c_tag = "Interrogation room";
-	dir = 9;
-	name = "security camera";
-	network = list("fsci");
-	screen_loc = ""
+/obj/machinery/airalarm/syndicate{
+	pixel_y = 24
 	},
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bQ" = (
 /obj/structure/chair/comfy/shuttle{
@@ -652,6 +648,16 @@
 /obj/machinery/button/crematorium{
 	id = "fscremate";
 	pixel_x = -32
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_forgotten_ship)
+"bT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/interrogation{
+	name = "Cameras monitor";
+	network = list("fsci");
+	req_one_access_txt = "150";
+	screen_loc = ""
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
@@ -769,9 +775,8 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "cj" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/machinery/stasis,
+/turf/open/floor/plastic,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ck" = (
 /obj/structure/sign/departments/cargo,
@@ -786,13 +791,11 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "cm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/interrogation{
-	network = list("fsci");
-	req_one_access_txt = "150";
-	screen_loc = ""
+/obj/machinery/door/airlock/grunge{
+	name = "Syndicate Ship Airlock";
+	req_one_access_txt = "150"
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "cn" = (
 /obj/machinery/recharge_station,
@@ -838,8 +841,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "ct" = (
-/obj/machinery/vending/medical/syndicate_access,
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/vending/medical/syndicate_access{
+	premium = list(/obj/item/reagent_containers/medigel/instabitaluri = 2, /obj/item/storage/pill_bottle/psicodine = 2, /obj/item/reagent_containers/hypospray/medipen = 3, /obj/item/storage/belt/medical = 3, /obj/item/sensor_device = 2, /obj/item/pinpointer/crew = 2, /obj/item/storage/firstaid = 5, /obj/item/storage/firstaid/advanced = 2, /obj/item/storage/firstaid/tactical = 1, /obj/item/shears = 1, /obj/item/plunger/reinforced = 2)
+	},
+/turf/open/floor/plastic,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "cu" = (
 /obj/machinery/computer/security{
@@ -852,12 +857,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "cv" = (
-/obj/machinery/computer/security/telescreen/interrogation{
-	network = list("fsci");
-	pixel_y = 32;
-	req_one_access_txt = "150";
-	screen_loc = ""
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "cw" = (
@@ -886,10 +886,17 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "cz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/syndicate_forgotten_ship)
+/obj/structure/closet/crate/secure/gear{
+	req_one_access_txt = "150"
+	},
+/obj/item/stack/sheet/mineral/titanium{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 20
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
 "cA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_pump,
@@ -1185,22 +1192,24 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "di" = (
-/obj/structure/cable,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/syndicate_forgotten_ship)
-"dj" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/syndicate_forgotten_ship)
-"dk" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Syndicate Ship Airlock";
+/obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
 	},
-/obj/structure/cable,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/item/disk/surgery{
+	name = "Advanced Surgery Disk";
+	surgeries = list(/datum/surgery/advanced/brainwashing,/datum/surgery/advanced/lobotomy,/datum/surgery/advanced/bioware/vein_threading,/datum/surgery/advanced/bioware/nerve_splicing)
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
+"dj" = (
+/turf/closed/mineral/random/high_chance,
+/area/space)
+"dk" = (
+/obj/structure/closet/crate/secure/gear{
+	req_one_access_txt = "150"
+	},
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "dl" = (
 /obj/machinery/door/password/voice/sfc{
@@ -1219,14 +1228,11 @@
 /obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
 	},
-/obj/item/stack/sheet/mineral/titanium{
-	amount = 25
+/obj/item/stack/ore/diamond{
+	amount = 3
 	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 10
-	},
-/turf/open/floor/pod/dark,
-/area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_forgotten_ship)
 "dn" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Syndicate Ship Airlock";
@@ -1247,15 +1253,33 @@
 /obj/machinery/light,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
+"dp" = (
+/obj/structure/closet/crate/secure/gear{
+	req_one_access_txt = "150"
+	},
+/obj/item/stack/ore/plasma{
+	amount = 19
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_forgotten_ship)
+"dq" = (
+/obj/structure/closet/crate/secure/gear{
+	req_one_access_txt = "150"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_forgotten_ship)
 "dr" = (
 /obj/structure/table/reinforced,
 /obj/item/paper/fluff/ruins/forgottenship/missionobj,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
-"dv" = (
+"ds" = (
 /obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
 	},
+/obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 
@@ -1431,8 +1455,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+dj
+dj
 aa
 aa
 aa
@@ -1478,9 +1502,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+dj
+dj
+dj
 aa
 aa
 aa
@@ -1526,8 +1550,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+dj
+dj
 aa
 aa
 aa
@@ -1676,9 +1700,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+dj
+dj
+dj
 aa
 aa
 "}
@@ -1690,21 +1714,21 @@ aa
 aa
 aa
 aa
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
 aa
 aa
 aa
@@ -1724,9 +1748,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+dj
+dj
+dj
 aa
 "}
 (11,1,1) = {"
@@ -1737,21 +1761,21 @@ aa
 aa
 aa
 ci
-ad
-dv
+bZ
+dk
 al
 al
 al
-dv
+dm
 al
 al
-dv
-dv
+dp
+dq
 al
 al
 al
-dv
-ad
+ds
+bZ
 ci
 aa
 aa
@@ -1783,7 +1807,7 @@ aa
 aa
 aa
 aa
-ad
+bZ
 al
 al
 al
@@ -1799,7 +1823,7 @@ al
 al
 al
 al
-ad
+bZ
 aa
 aa
 aa
@@ -1830,23 +1854,23 @@ aa
 aa
 aa
 aa
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
 dn
-ad
-ad
-ad
+bZ
+bZ
+bZ
 dn
-ad
-ad
-ad
-ad
+bZ
+bZ
+bZ
+bZ
 aa
 aa
 aa
@@ -1877,23 +1901,23 @@ aa
 aa
 aa
 aa
-ad
-ad
+bZ
+bZ
 bV
-ad
+bZ
 ag
 bw
-ad
+bZ
 av
 aR
 az
-ad
+bZ
 bz
 bD
 al
 bY
 al
-ad
+bZ
 aa
 aa
 aa
@@ -1924,23 +1948,23 @@ aa
 aa
 aa
 aa
-ad
+bZ
 aA
 aw
-ad
+bZ
 ao
 aO
-ad
+bZ
 aN
 cC
 bc
-ad
+bZ
 bY
 bE
 al
 al
 cY
-ad
+bZ
 aa
 aa
 aa
@@ -1971,7 +1995,7 @@ aa
 aa
 aa
 aa
-ad
+bZ
 cf
 aw
 ch
@@ -1987,7 +2011,7 @@ al
 al
 cc
 dr
-ad
+bZ
 aa
 aa
 aa
@@ -2018,10 +2042,10 @@ aa
 aa
 aa
 aa
-ad
+bZ
 ay
 aw
-ad
+bZ
 ao
 ao
 bx
@@ -2034,7 +2058,7 @@ al
 al
 cc
 da
-ad
+bZ
 aa
 aa
 aa
@@ -2065,23 +2089,23 @@ aa
 aa
 aa
 aa
-ad
+bZ
 cl
 aw
-ad
+bZ
 aB
 bn
-ad
+bZ
 cy
 cE
 cV
-ad
+bZ
 bY
 bE
 al
 al
 cY
-ad
+bZ
 aa
 aa
 aa
@@ -2093,7 +2117,7 @@ aZ
 bd
 de
 de
-dm
+cz
 aZ
 ba
 aY
@@ -2113,21 +2137,21 @@ aa
 aa
 aa
 ac
-ad
+bZ
 co
-ad
+bZ
 aI
-cm
+bT
 bg
 aD
 cF
 cM
-ad
+bZ
 ah
 bD
 al
 bY
-ad
+bZ
 ac
 aa
 aa
@@ -2160,21 +2184,21 @@ aa
 aa
 aa
 aa
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
 cG
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
 aa
 aa
 aa
@@ -2187,7 +2211,7 @@ aZ
 dd
 de
 de
-dm
+di
 aZ
 ba
 ba
@@ -2207,21 +2231,21 @@ aa
 aa
 aa
 aa
+bZ
 ad
-aj
-aw
-cj
-aw
-ad
-cv
+am
+am
+ct
+bZ
+al
 cH
 al
-ad
+bZ
 bG
 bI
 cZ
 db
-ad
+bZ
 aa
 aa
 aa
@@ -2254,21 +2278,21 @@ aa
 aa
 aa
 aa
-ad
-ak
-bv
-bV
-dj
-ad
+bZ
+aj
+am
+am
+cj
+bZ
 aJ
 cI
 aC
-ad
+bZ
 bH
 cd
-ad
-ad
-ad
+bZ
+bZ
+bZ
 aa
 aa
 aa
@@ -2301,13 +2325,13 @@ aa
 aa
 aa
 aa
-ad
+bZ
+ak
 ar
-bP
-di
-di
-dk
-cz
+am
+am
+cm
+cv
 cW
 al
 aQ
@@ -2315,7 +2339,7 @@ bI
 bI
 cZ
 dc
-ad
+bZ
 aa
 aa
 aa
@@ -2348,21 +2372,21 @@ aa
 aa
 aa
 ci
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
 cK
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
 ci
 aa
 aa
@@ -2394,23 +2418,23 @@ aa
 aa
 aa
 aa
-ad
+bZ
 bO
 bS
-ad
-al
-al
-am
-al
+bZ
+bv
+aP
+aK
+aP
 cH
 aP
 aK
 aP
 al
-ad
+bZ
 al
 bJ
-ad
+bZ
 aa
 aa
 aa
@@ -2441,11 +2465,11 @@ aa
 aa
 aa
 aa
-ad
+bZ
 ai
 al
-ad
-al
+bZ
+bP
 al
 ax
 ax
@@ -2454,10 +2478,10 @@ ax
 ax
 aP
 al
-ad
+bZ
 al
 bK
-ad
+bZ
 aa
 aa
 aa
@@ -2535,7 +2559,7 @@ aa
 aa
 aa
 aa
-ad
+bZ
 ai
 al
 an
@@ -2551,7 +2575,7 @@ al
 an
 al
 bK
-ad
+bZ
 aa
 aa
 aa
@@ -2582,10 +2606,10 @@ aa
 aa
 aa
 aa
-ad
+bZ
 cn
 al
-ad
+bZ
 al
 al
 al
@@ -2595,10 +2619,10 @@ ah
 al
 al
 al
-ad
+bZ
 al
 bL
-ad
+bZ
 aa
 aa
 aa
@@ -2630,9 +2654,9 @@ aa
 aa
 aa
 ac
-ad
+bZ
 ah
-ad
+bZ
 cr
 al
 aF
@@ -2641,10 +2665,10 @@ cR
 cX
 aF
 al
-ct
-ad
+al
+bZ
 ah
-ad
+bZ
 ac
 aa
 aa
@@ -2677,21 +2701,21 @@ aa
 aa
 aa
 aa
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
 cq
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
 aa
 aa
 aa
@@ -2736,7 +2760,7 @@ aw
 bW
 cg
 ce
-ad
+bZ
 aa
 aa
 aa
@@ -2770,10 +2794,10 @@ aa
 aa
 aa
 aa
-ad
-ad
-ad
-ad
+bZ
+bZ
+bZ
+bZ
 aw
 aw
 aw
@@ -2783,10 +2807,10 @@ aw
 aw
 aw
 aw
-ad
-ad
-ad
-ad
+bZ
+bZ
+bZ
+bZ
 aa
 aa
 aa
@@ -2817,10 +2841,10 @@ aa
 aa
 aa
 aa
-ad
+bZ
 aG
 aw
-ad
+bZ
 aw
 aw
 aw
@@ -2830,10 +2854,10 @@ aw
 aw
 aw
 aw
-ad
+bZ
 df
 df
-ad
+bZ
 aa
 aa
 aa
@@ -2864,7 +2888,7 @@ aa
 aa
 aa
 aa
-ad
+bZ
 br
 aw
 cp
@@ -2880,7 +2904,7 @@ aw
 cJ
 aw
 bt
-ad
+bZ
 aa
 aa
 aa
@@ -2912,9 +2936,9 @@ aa
 aa
 aa
 ac
-ad
+bZ
 aw
-ad
+bZ
 aw
 cu
 aw
@@ -2924,9 +2948,9 @@ ca
 aw
 cb
 aw
-ad
+bZ
 dg
-ad
+bZ
 ac
 aa
 aa
@@ -2959,9 +2983,9 @@ aa
 aa
 aa
 aa
-ad
-ad
-ad
+bZ
+bZ
+bZ
 aw
 aw
 aw
@@ -2971,9 +2995,9 @@ aw
 aw
 aw
 aw
-ad
-ad
-ad
+bZ
+bZ
+bZ
 aa
 aa
 aa
@@ -3007,8 +3031,8 @@ aa
 aa
 aa
 aa
-ad
-ad
+bZ
+bZ
 bV
 bV
 aW
@@ -3019,7 +3043,7 @@ bV
 bV
 bV
 bZ
-ad
+bZ
 aa
 aa
 aa
@@ -3036,7 +3060,7 @@ aa
 aa
 aa
 aa
-aa
+dj
 aa
 aa
 aa
@@ -3081,10 +3105,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+dj
+dj
+dj
+dj
 aa
 aa
 aa
@@ -3128,9 +3152,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+dj
+dj
+dj
 aa
 aa
 aa
@@ -3166,7 +3190,7 @@ aa
 aa
 aa
 aa
-aa
+dj
 aa
 aa
 aa
@@ -3212,9 +3236,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+dj
+dj
+dj
 aa
 aa
 aa
@@ -3259,10 +3283,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+dj
+dj
+dj
+dj
 aa
 aa
 aa
@@ -3307,7 +3331,7 @@ aa
 aa
 aa
 aa
-aa
+dj
 aa
 aa
 aa

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -390,9 +390,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/storage/toolbox/mechanical
-/obj/item/storage/toolbox/mechanical
-/obj/item/storage/toolbox/electrical
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/electrical,
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
@@ -1216,9 +1216,6 @@
 	req_one_access_txt = "150"
 	},
 /obj/item/stack/sheet/mineral/titanium{
-	amount = 50
-	},
-/obj/item/stack/sheet/mineral/silver{
 	amount = 50
 	},
 /turf/open/floor/pod/dark,

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -138,11 +138,9 @@
 	},
 /obj/item/coin/antagtoken,
 /obj/item/coin/gold,
-/obj/item/coin/gold,
-/obj/item/coin/gold,
-/obj/item/coin/gold,
 /obj/item/dnainjector/thermal,
-/obj/item/firing_pin/implant/pindicate,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "az" = (
@@ -339,6 +337,8 @@
 	req_one_access_txt = "150"
 	},
 /obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/plasteel/twenty,
 /obj/item/stack/sheet/mineral/plastitanium{
 	amount = 50
@@ -390,11 +390,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/multitool,
-/obj/item/screwdriver/nuke,
-/obj/item/wrench,
-/obj/item/weldingtool/hugetank,
-/obj/item/wirecutters,
+/obj/item/storage/toolbox/mechanical
+/obj/item/storage/toolbox/mechanical
+/obj/item/storage/toolbox/electrical
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
 /obj/structure/closet/crate/secure/engineering{
 	req_one_access_txt = "150"
@@ -1215,6 +1215,12 @@
 /obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
 	},
+/obj/item/stack/sheet/mineral/titanium{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/silver{
+	amount = 50
+	},
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
 "dn" = (
@@ -1227,6 +1233,12 @@
 "do" = (
 /obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
+	},
+/obj/item/stack/sheet/mineral/gold{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/silver{
+	amount = 50
 	},
 /obj/machinery/light,
 /turf/open/floor/pod/dark,

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -1279,6 +1279,10 @@
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"dt" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_forgotten_ship)
 
 (1,1,1) = {"
 aa
@@ -1760,17 +1764,17 @@ aa
 ci
 bZ
 dk
-al
+dt
 al
 al
 dm
-al
+dt
 al
 dp
 dq
 al
 al
-al
+dt
 ds
 bZ
 ci

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -1195,10 +1195,7 @@
 /obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
 	},
-/obj/item/disk/surgery{
-	name = "Advanced Surgery Disk";
-	surgeries = list(/datum/surgery/advanced/brainwashing,/datum/surgery/advanced/lobotomy,/datum/surgery/advanced/bioware/vein_threading,/datum/surgery/advanced/bioware/nerve_splicing)
-	},
+/obj/item/disk/surgery/forgottenship,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
 "dj" = (

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -374,6 +374,8 @@
 	},
 /obj/item/stack/cable_coil,
 /obj/item/circuitboard/computer/rdconsole,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "bg" = (

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -685,7 +685,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bZ" = (
-/obj/structure/table/reinforced,
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ca" = (

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -376,6 +376,7 @@
 /obj/item/circuitboard/computer/rdconsole,
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/beakers,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "bg" = (
@@ -470,6 +471,10 @@
 	req_one_access_txt = "150"
 	},
 /obj/item/toy/nuke,
+/obj/item/clothing/under/chameleon,
+/obj/item/pda/chameleon,
+/obj/item/clothing/mask/chameleon,
+/obj/item/card/id/syndicate/anyone,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "bv" = (

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -680,6 +680,9 @@
 /datum/outfit/syndicatespace/syndicaptain/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE
 
+/obj/effect/mob_spawn/human/syndicatespace/captain/Destroy()
+	new/obj/structure/fluff/empty_sleeper/syndicate/captain(get_turf(src))
+
 /datum/outfit/syndicatespace/syndicrew
 	name = "Syndicate Ship Crew Member"
 	uniform = /obj/item/clothing/under/syndicate/combat

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -682,6 +682,7 @@
 
 /obj/effect/mob_spawn/human/syndicatespace/captain/Destroy()
 	new/obj/structure/fluff/empty_sleeper/syndicate/captain(get_turf(src))
+	return ..()
 
 /datum/outfit/syndicatespace/syndicrew
 	name = "Syndicate Ship Crew Member"

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -651,7 +651,7 @@
 	icon_state = "sleeper_s"
 	short_desc = "You are a syndicate operative on old ship, stuck in hostile space."
 	flavour_text = "Your ship docks after a long time somewhere in hostile space, reporting a malfunction. You are stuck here, with Nanotrasen station nearby. Fix the ship, find a way to power it and follow your captain's orders."
-	important_info = "Obey orders given by your captain. DO NOT let ship fall into enemy's hands."
+	important_info = "Obey orders given by your captain. DO NOT let the ship fall into enemy's hands."
 	outfit = /datum/outfit/syndicatespace/syndicrew
 
 /datum/outfit/syndicatespace/syndicrew/post_equip(mob/living/carbon/human/H)
@@ -673,7 +673,7 @@
 	icon_state = "sleeper_s"
 	short_desc = "You are the captain of an old ship, stuck in hostile space."
 	flavour_text = "Your ship docks after a long time somewhere in hostile space, reporting a malfunction. You are stuck here, with Nanotrasen station nearby. Command your crew and turn your ship into the most protected fortress."
-	important_info = "Protect the ship and secret documents in your backpack with your own life. DO NOT let ship fall into enemy's hands."
+	important_info = "Protect the ship and secret documents in your backpack with your own life. DO NOT let the ship fall into enemy's hands."
 	mob_gender = "male"
 	outfit = /datum/outfit/syndicatespace/syndicaptain
 

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -651,7 +651,7 @@
 	icon_state = "sleeper_s"
 	short_desc = "You are a syndicate operative on old ship, stuck in hostile space."
 	flavour_text = "Your ship docks after a long time somewhere in hostile space, reporting a malfunction. You are stuck here, with Nanotrasen station nearby. Fix the ship, find a way to power it and follow your captain's orders."
-	important_info = "Obey orders given by your captain. DO NOT leave the ship."
+	important_info = "Obey orders given by your captain. DO NOT let ship fall into enemy's hands."
 	outfit = /datum/outfit/syndicatespace/syndicrew
 
 /datum/outfit/syndicatespace/syndicrew/post_equip(mob/living/carbon/human/H)
@@ -673,7 +673,7 @@
 	icon_state = "sleeper_s"
 	short_desc = "You are the captain of an old ship, stuck in hostile space."
 	flavour_text = "Your ship docks after a long time somewhere in hostile space, reporting a malfunction. You are stuck here, with Nanotrasen station nearby. Command your crew and turn your ship into the most protected fortress."
-	important_info = "Protect the ship and secret documents in your backpack with your own life. DO NOT leave the ship."
+	important_info = "Protect the ship and secret documents in your backpack with your own life. DO NOT let ship fall into enemy's hands."
 	mob_gender = "male"
 	outfit = /datum/outfit/syndicatespace/syndicaptain
 

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -651,7 +651,7 @@
 	icon_state = "sleeper_s"
 	short_desc = "You are a syndicate operative on old ship, stuck in hostile space."
 	flavour_text = "Your ship docks after a long time somewhere in hostile space, reporting a malfunction. You are stuck here, with Nanotrasen station nearby. Fix the ship, find a way to power it and follow your captain's orders."
-	important_info = "Obey orders given by your captain. DO NOT let the ship fall into enemy's hands."
+	important_info = "Obey orders given by your captain. DO NOT let the ship fall into enemy hands."
 	outfit = /datum/outfit/syndicatespace/syndicrew
 
 /datum/outfit/syndicatespace/syndicrew/post_equip(mob/living/carbon/human/H)
@@ -673,7 +673,7 @@
 	icon_state = "sleeper_s"
 	short_desc = "You are the captain of an old ship, stuck in hostile space."
 	flavour_text = "Your ship docks after a long time somewhere in hostile space, reporting a malfunction. You are stuck here, with Nanotrasen station nearby. Command your crew and turn your ship into the most protected fortress."
-	important_info = "Protect the ship and secret documents in your backpack with your own life. DO NOT let the ship fall into enemy's hands."
+	important_info = "Protect the ship and secret documents in your backpack with your own life. DO NOT let the ship fall into enemy hands."
 	mob_gender = "male"
 	outfit = /datum/outfit/syndicatespace/syndicaptain
 

--- a/code/modules/ruins/spaceruin_code/forgottenship.dm
+++ b/code/modules/ruins/spaceruin_code/forgottenship.dm
@@ -38,6 +38,13 @@ GLOBAL_VAR_INIT(fscpassword, generate_password())
 	desc = "A disk that contains advanced surgery procedures, must be loaded into an Operating Console."
 	surgeries = list(/datum/surgery/advanced/lobotomy, /datum/surgery/advanced/bioware/vein_threading, /datum/surgery/advanced/bioware/nerve_splicing)
 
+/obj/structure/fluff/empty_sleeper/syndicate/captain
+	icon_state = "sleeper_s-open"
+
+/obj/structure/fluff/empty_sleeper/syndicate/captain/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/gps, "Old Encrypted Signal")
+
 ///////////	forgottenship areas
 
 /area/ruin/space/has_grav/syndicate_forgotten_ship

--- a/code/modules/ruins/spaceruin_code/forgottenship.dm
+++ b/code/modules/ruins/spaceruin_code/forgottenship.dm
@@ -69,7 +69,7 @@ GLOBAL_VAR_INIT(fscpassword, generate_password())
 	armor = list("melee" = 25, "bullet" = 25, "laser" = 70, "energy" = 50, "bomb" = 15, "bio" = 100, "rad" = 50, "fire" = 60, "acid" = 60)
 	strip_delay = 600
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/cybersun
-	actions_types = list(/datum/action/item_action/toggle_helmet)
+	actions_types = list(/datum/action/item_action/toggle_helmet, /datum/action/item_action/toggle_spacesuit)
 	jetpack = /obj/item/tank/jetpack/suit
 
 //Special NT NPCs

--- a/code/modules/ruins/spaceruin_code/forgottenship.dm
+++ b/code/modules/ruins/spaceruin_code/forgottenship.dm
@@ -32,6 +32,12 @@ GLOBAL_VAR_INIT(fscpassword, generate_password())
 	name = "Mission objectives"
 	info = "Greetings, operatives. You are assigned to SCSBC-12(Syndicate Cyber Sun Battle Cruiser 12) to protect our high-ranking officer while he is on his way to next outpost. While you are travelling, he is the captain of this ship and <b>you must</b> obey his orders.<br><br>Remember, disobeying high-ranking officer orders is a reason for termination."
 
+///////////	forgottenship items
+/obj/item/disk/surgery/forgottenship
+	name = "Advanced Surgery Disk"
+	desc = "A disk that contains advanced surgery procedures, must be loaded into an Operating Console."
+	surgeries = list(/datum/surgery/advanced/lobotomy, /datum/surgery/advanced/bioware/vein_threading, /datum/surgery/advanced/bioware/nerve_splicing)
+
 ///////////	forgottenship areas
 
 /area/ruin/space/has_grav/syndicate_forgotten_ship


### PR DESCRIPTION
## About The Pull Request

Fixes problem with Cybersun hardsuits not having thermo-regulation button to protect from cold/hot environments.
Adds more useful stuff to the ship and cargo pod.

Fixes #50122
Fixes #50117

## Why It's Good For The Game

Bugs aren't good for health and having circuit boards with no parts to finish machines is lame!

## Changelog
:cl: EgorDinamit
add: Forgotten ship ruin now additionally contains: Deluxe stock parts box, box with beakers, 3 toolboxes, box with basic firing pins and a little bit more of resources in a protected vault and so on, find it out!
add: Replaces interrogation room with medbay.
fix: Fixed cybersun hardsuits by adding thermo-regulation button to it.
/:cl:
