### PR TITLE
adds monkey cube suicide

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -182,10 +182,12 @@
 /obj/item/reagent_containers/food/snacks/monkeycube/suicide_act(mob/user)
 	var/mob/living/M = user
 	user.visible_message("<span class='suicide'>[M] is putting [src] in [M.p_their()] mouth! It looks like [M.p_theyre()] trying to commit suicide!</span>")
+	sleep(10)
 	playsound(M.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
 	if(HAS_TRAIT(M, TRAIT_NOHUNGER))
 		to_chat(user, "<span class='warning'>Your body won't activate [src]...</span>")
 		return SHAME
+	sleep(10)
 	Expand()
 	visible_message("<span class='danger'>[M]'s torso bursts open as a primate emerges!</span>")
 	ADD_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -179,6 +179,19 @@
 		visible_message("<span class='notice'>[src] fails to expand!</span>")
 	qdel(src)
 
+/obj/item/reagent_containers/food/snacks/monkeycube/suicide_act(mob/user)
+	var/mob/living/M = user
+	user.visible_message("<span class='suicide'>[M] is putting [src] in [M.p_their()] mouth! It looks like [M.p_theyre()] trying to commit suicide!</span>")
+	playsound(M.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
+	if(HAS_TRAIT(M, TRAIT_NOHUNGER))
+		to_chat(user, "<span class='warning'>Your body won't activate [src]...</span>")
+	return SHAME
+	Expand()
+	visible_message("<span class='danger'>[M]'s torso bursts open as a primate emerges!</span>")
+	ADD_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
+	M.gib(null, True, null, True)
+	return MANUAL_SUICIDE
+
 /obj/item/reagent_containers/food/snacks/monkeycube/syndicate
 	faction = list("neutral", ROLE_SYNDICATE)
 

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -185,7 +185,7 @@
 	playsound(M.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
 	if(HAS_TRAIT(M, TRAIT_NOHUNGER))
 		to_chat(user, "<span class='warning'>Your body won't activate [src]...</span>")
-	return SHAME
+		return SHAME
 	Expand()
 	visible_message("<span class='danger'>[M]'s torso bursts open as a primate emerges!</span>")
 	ADD_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -191,7 +191,7 @@
 		M.visible_message("<span class='suicide'>[M] realizes [M.p_their()] body won't activate [src]!</span>"
 		,"<span class='warning'>Your body won't activate [src]...</span>")
 		return SHAME
-	playsound(M.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
+	playsound(M, 'sound/items/eatfood.ogg', rand(10,50), TRUE)
 	M.temporarilyRemoveItemFromInventory(src) //removes from hands, keeps in M
 	sleep(15) //you've eaten it, you can run now
 	if(QDELETED(M) || QDELETED(src))

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -189,7 +189,7 @@
 		return SHAME
 	sleep(10)
 	Expand()
-	visible_message("<span class='danger'>[M]'s torso bursts open as a primate emerges!</span>")
+	M.visible_message("<span class='danger'>[M]'s torso bursts open as a primate emerges!</span>")
 	ADD_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
 	M.gib(null, TRUE, null, TRUE)
 	return MANUAL_SUICIDE

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -190,7 +190,6 @@
 	sleep(10)
 	Expand()
 	M.visible_message("<span class='danger'>[M]'s torso bursts open as a primate emerges!</span>")
-	ADD_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
 	M.gib(null, TRUE, null, TRUE)
 	return MANUAL_SUICIDE
 

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -196,7 +196,7 @@
 	addtimer(CALLBACK(src, .proc/finish_suicide, M), 15) //you've eaten it, you can run now
 	return MANUAL_SUICIDE
 
-/obj/item/reagent_containers/food/snacks/monkecube/proc/finish_suicide(mob/living/M) ///internal proc called by a monkeycube's suicide_act using a timer and callback. takes as argument the mob/living who activated the suicide
+/obj/item/reagent_containers/food/snacks/monkeycube/proc/finish_suicide(mob/living/M) ///internal proc called by a monkeycube's suicide_act using a timer and callback. takes as argument the mob/living who activated the suicide
 	if(QDELETED(M) || QDELETED(src))
 		return
 	if((src.loc != M)) //how the hell did you manage this

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -189,7 +189,7 @@
 	Expand()
 	visible_message("<span class='danger'>[M]'s torso bursts open as a primate emerges!</span>")
 	ADD_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
-	M.gib(null, True, null, True)
+	M.gib(null, TRUE, null, TRUE)
 	return MANUAL_SUICIDE
 
 /obj/item/reagent_containers/food/snacks/monkeycube/syndicate

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -193,16 +193,18 @@
 		return SHAME
 	playsound(M, 'sound/items/eatfood.ogg', rand(10,50), TRUE)
 	M.temporarilyRemoveItemFromInventory(src) //removes from hands, keeps in M
-	sleep(15) //you've eaten it, you can run now
+	addtimer(CALLBACK(src, .proc/finish_suicide, M), 15) //you've eaten it, you can run now
+	return MANUAL_SUICIDE
+
+/obj/item/reagent_containers/food/snacks/monkecube/proc/finish_suicide(mob/living/M) ///internal proc called by a monkeycube's suicide_act using a timer and callback. takes as argument the mob/living who activated the suicide
 	if(QDELETED(M) || QDELETED(src))
-		return SHAME
+		return
 	if((src.loc != M)) //how the hell did you manage this
 		to_chat(M, "<span class='warning'>Something happened to [src]...</span>")
-		return SHAME
+		return
 	Expand()
 	M.visible_message("<span class='danger'>[M]'s torso bursts open as a primate emerges!</span>")
 	M.gib(null, TRUE, null, TRUE)
-	return MANUAL_SUICIDE
 
 /obj/item/reagent_containers/food/snacks/monkeycube/syndicate
 	faction = list("neutral", ROLE_SYNDICATE)

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -179,8 +179,7 @@
 		visible_message("<span class='notice'>[src] fails to expand!</span>")
 	qdel(src)
 
-/obj/item/reagent_containers/food/snacks/monkeycube/suicide_act(mob/user)
-	var/mob/living/M = user
+/obj/item/reagent_containers/food/snacks/monkeycube/suicide_act(mob/living/M)
 	M.visible_message("<span class='suicide'>[M] is putting [src] in [M.p_their()] mouth! It looks like [M.p_theyre()] trying to commit suicide!</span>")
 	var/eating_success = do_after(M, 10, TRUE, src, TRUE)
 	if(QDELETED(M)) //qdeletion: the nuclear option of self-harm

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -181,13 +181,25 @@
 
 /obj/item/reagent_containers/food/snacks/monkeycube/suicide_act(mob/user)
 	var/mob/living/M = user
-	user.visible_message("<span class='suicide'>[M] is putting [src] in [M.p_their()] mouth! It looks like [M.p_theyre()] trying to commit suicide!</span>")
-	sleep(10)
-	playsound(M.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
-	if(HAS_TRAIT(M, TRAIT_NOHUNGER))
-		to_chat(user, "<span class='warning'>Your body won't activate [src]...</span>")
+	M.visible_message("<span class='suicide'>[M] is putting [src] in [M.p_their()] mouth! It looks like [M.p_theyre()] trying to commit suicide!</span>")
+	var/eating_success = do_after(M, 10, TRUE, src, TRUE)
+	if(QDELETED(M)) //qdeletion: the nuclear option of self-harm
 		return SHAME
-	sleep(10)
+	if(!eating_success || QDELETED(src)) //checks if src is gone or if they failed to wait for a second
+		M.visible_message("<span class='suicide'>[M] chickens out!</span>")
+		return SHAME
+	if(HAS_TRAIT(M, TRAIT_NOHUNGER)) //plasmamen don't have saliva/stomach acid
+		M.visible_message("<span class='suicide'>[M] realizes [M.p_their()] body won't activate [src]!</span>"
+		,"<span class='warning'>Your body won't activate [src]...</span>")
+		return SHAME
+	playsound(M.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
+	M.temporarilyRemoveItemFromInventory(src) //removes from hands, keeps in M
+	sleep(15) //you've eaten it, you can run now
+	if(QDELETED(M) || QDELETED(src))
+		return SHAME
+	if((src.loc != M)) //how the hell did you manage this
+		to_chat(M, "<span class='warning'>Something happened to [src]...</span>")
+		return SHAME
 	Expand()
 	M.visible_message("<span class='danger'>[M]'s torso bursts open as a primate emerges!</span>")
 	M.gib(null, TRUE, null, TRUE)


### PR DESCRIPTION
## About The Pull Request

if you try to commit suicide with a monkey cube, it gibs you and spawns a monkey (also works with gorilla cubes). see, monkey cubes activate in water, and when you think about it, stomach acid is really just spicy water. so if you swallow a monkey cube...

also: the suicide fails for species with TRAIT_NOHUNGER -- plasmamen, ethereals, skeletons, abductors, etc., since their biology doesn't involve stomach acid / saliva and thus they can't activate the monkey cube

## Why It's Good For The Game

suicides are nice flavor, and it felt weird that monkey cubes didn't have a fitting suicide

## Changelog
:cl:
add: Distraught employees on Nanotransen stations have been observed consuming monkey cubes as a means of suicide. Nanotransen reminds employees to remain upbeat, and to not use monkey cubes for anything but their intended purpose.
/:cl: