### PR TITLE
Replaces plurality voting with approval voting for some votes

### DIFF
--- a/code/__DEFINES/vote.dm
+++ b/code/__DEFINES/vote.dm
@@ -1,0 +1,7 @@
+#define PLURALITY_VOTING 0
+#define APPROVAL_VOTING 1
+
+GLOBAL_LIST_INIT(vote_type_names,list(\
+"Plurality (can only vote one option)" = PLURALITY_VOTING,\
+"Approval (can vote any amount)" = APPROVAL_VOTING,\
+))

--- a/code/__DEFINES/vote.dm
+++ b/code/__DEFINES/vote.dm
@@ -1,7 +1,2 @@
 #define PLURALITY_VOTING 0
 #define APPROVAL_VOTING 1
-
-GLOBAL_LIST_INIT(vote_type_names,list(\
-"Plurality (can only vote one option)" = PLURALITY_VOTING,\
-"Approval (can vote any amount)" = APPROVAL_VOTING,\
-))

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -345,7 +345,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		return
 	if(SSvote.mode) //Theres already a vote running, default to rotation.
 		maprotate()
-	SSvote.initiate_vote("map", "automatic map rotation")
+	SSvote.initiate_vote("map", "automatic map rotation", voting_system = APPROVAL_VOTING)
 
 /datum/controller/subsystem/mapping/proc/changemap(var/datum/map_config/VM)
 	if(!VM.MakeNextMap())

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -157,11 +157,18 @@ SUBSYSTEM_DEF(vote)
 	if(mode)
 		if(CONFIG_GET(flag/no_dead_vote) && usr.stat == DEAD && !usr.client.holder)
 			return FALSE
-		if(!(usr.ckey in voted))
-			if(vote && 1<=vote && vote<=choices.len)
-				voted += usr.ckey
-				choices[choices[vote]]++	//check this
-				return vote
+		if(usr.ckey in voted)
+			if(vote in voted[usr.ckey])
+				voted[usr.ckey] -= vote
+				choices[choices[vote]]--
+			else
+				voted[usr.ckey] += vote
+				choices[choices[vote]]++
+		else
+			voted += usr.ckey
+			voted[usr.ckey] = list(vote)
+			choices[choices[vote]]++
+			return vote
 	return FALSE
 
 /datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -226,8 +226,9 @@ SUBSYSTEM_DEF(vote)
 				question = stripped_input(usr,"What is the vote for?")
 				if(!question)
 					return 0
-				var/system_string = input(usr,"Which voting type?",GLOB.vote_type_names[1]) in GLOB.vote_type_names
-				vote_system = GLOB.vote_type_names[system_string]
+				var/list/vote_type_names = list("Plurality (can only vote one option)" = PLURALITY_VOTING,"Approval (can vote any amount)" = APPROVAL_VOTING)
+				var/system_string = input(usr,"Which voting type?",vote_type_names[1]) in vote_type_names
+				vote_system = vote_type_names[system_string]
 				for(var/i=1,i<=10,i++)
 					var/option = capitalize(stripped_input(usr,"Please enter an option or hit cancel to finish"))
 					if(!option || mode || !usr.client)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -110,6 +110,7 @@
 #include "code\__DEFINES\turf_flags.dm"
 #include "code\__DEFINES\typeids.dm"
 #include "code\__DEFINES\vehicles.dm"
+#include "code\__DEFINES\vote.dm"
 #include "code\__DEFINES\vv.dm"
 #include "code\__DEFINES\wall_dents.dm"
 #include "code\__DEFINES\wires.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As the title: replaces the [first past the post](https://en.wikipedia.org/wiki/First-past-the-post_voting) voting method used in the codebase right now with [approval voting](https://en.wikipedia.org/wiki/Approval_voting).

## Why It's Good For The Game

First past the post sucks. I mean, it's just awful. Sometimes the winner is someone who the actual majority of voters doesn't want, it's highly susceptible to strategic voting, it leads to a massive amount of similar perverse results...

Approval voting is simple: you can vote for as many options as you want. For two-choice votes, it's identical, as long as there's one winner; voting both options is the same as voting one option. For multi-winner votes, it's *still* better, because voting both makes the vote closer, which is what you'd *want*.

And if you want to know why approval over IRV: well, [see this article, if you have the time](https://www.electionscience.org/library/approval-voting-versus-irv/). That, plus it's much, much easier to implement approval (see how small this change is!)

## Changelog
:cl:
tweak: Voting now uses approval instead of first-past-the-post
/:cl: