### PR TITLE
TEMPORARILY Revert "Moves all RnD's core consoles to the bridge."

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -16498,6 +16498,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRo" = (
+/obj/machinery/modular_computer/console/preset/command,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -16505,7 +16506,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/computer/rdconsole/core,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aRp" = (
@@ -22588,7 +22588,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bhw" = (
-/obj/machinery/computer/rdconsole/production,
+/obj/machinery/computer/rdconsole/robotics,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bhx" = (
@@ -24939,7 +24939,7 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "bnn" = (
-/obj/machinery/computer/rdconsole/production{
+/obj/machinery/computer/rdconsole/core{
 	dir = 4
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -39349,6 +39349,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "byo" = (
+/obj/machinery/computer/station_alert,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -39356,7 +39357,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/computer/rdconsole/core,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "byp" = (
@@ -86507,11 +86507,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "deh" = (
+/obj/machinery/computer/rdconsole/core{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
-	},
-/obj/machinery/computer/rdconsole/production{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
@@ -98677,13 +98677,13 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dEO" = (
+/obj/machinery/computer/rdconsole/robotics{
+	dir = 8
+	},
 /obj/structure/sign/departments/medbay/alt{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/computer/rdconsole/production{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dEP" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -1472,7 +1472,7 @@
 	},
 /area/science/explab)
 "adH" = (
-/obj/machinery/computer/rdconsole/production,
+/obj/machinery/computer/rdconsole/experiment,
 /turf/open/floor/plasteel/white/corner,
 /area/science/explab)
 "adI" = (
@@ -4497,11 +4497,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "akV" = (
+/obj/machinery/computer/rdconsole/core{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/machinery/computer/rdconsole/production{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
@@ -40152,13 +40152,13 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bJD" = (
+/obj/machinery/computer/shuttle/mining{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/computer/rdconsole/core{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bJE" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -33954,6 +33954,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/theatre)
 "bad" = (
+/obj/machinery/computer/rdconsole/robotics{
+	dir = 8
+	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -33968,9 +33971,6 @@
 	name = "Robotics RC";
 	pixel_x = 30;
 	receive_ore_updates = 1
-	},
-/obj/machinery/computer/rdconsole/production{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -36409,6 +36409,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/mixing)
 "bdG" = (
+/obj/machinery/computer/rdconsole/core{
+	dir = 4
+	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -36421,9 +36424,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/computer/rdconsole/production{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "bdH" = (
@@ -48714,6 +48714,9 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "bvh" = (
+/obj/machinery/computer/prisoner{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -48727,9 +48730,6 @@
 	pixel_x = -30
 	},
 /obj/structure/cable,
-/obj/machinery/computer/rdconsole/core{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bvi" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -26968,6 +26968,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bhr" = (
+/obj/machinery/computer/prisoner/management,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -26975,7 +26976,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/computer/rdconsole/core,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bht" = (
@@ -50604,10 +50604,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
 "cjX" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/computer/rdconsole/production{
+/obj/machinery/computer/rdconsole/core{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cjY" = (
@@ -58817,6 +58817,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cGa" = (
+/obj/machinery/computer/rdconsole/robotics{
+	dir = 4
+	},
 /obj/machinery/requests_console{
 	department = "Robotics";
 	departmentType = 2;
@@ -58825,9 +58828,6 @@
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/computer/rdconsole/production{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cGb" = (
@@ -77792,7 +77792,7 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/machinery/computer/rdconsole/production,
+/obj/machinery/computer/rdconsole/experiment,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "xgL" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6639,6 +6639,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arR" = (
+/obj/machinery/computer/prisoner/management,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -6646,7 +6647,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/computer/rdconsole/core,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arS" = (
@@ -25919,6 +25919,9 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boX" = (
+/obj/machinery/computer/rdconsole/robotics{
+	dir = 4
+	},
 /obj/machinery/button/door{
 	id = "robotics";
 	name = "Shutters Control Button";
@@ -25929,9 +25932,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -25;
 	pixel_y = -8
-	},
-/obj/machinery/computer/rdconsole/production{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -26006,6 +26006,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpe" = (
+/obj/machinery/computer/rdconsole/experiment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -26020,7 +26021,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/computer/rdconsole/production,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpf" = (
@@ -28658,10 +28658,10 @@
 /turf/closed/wall,
 /area/maintenance/department/engine)
 "bvw" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/computer/rdconsole/production{
+/obj/machinery/computer/rdconsole/core{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "bvx" = (


### PR DESCRIPTION
Reverts tgstation/tgstation#49899

So here's the realistic problem with this.

As much as I like it, all this has caused is two things: people complaining every round about it and an extra thirty seconds of work to dismantle the console in Science, screwdriver it, and put it back. If we're going to do this, we need to not half ass it and do it when everything else is ready, or at least put an R&D console in every head's office.

So my proposal is this: We shelve this for a short period while I finish working on departmental tech node (I'm relatively close, I'm just having trouble with a few small things), then we bring it back when there's actually a reason to do so.