### PR TITLE
Relax air alarm pressure alarm thresholds

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -87,7 +87,7 @@
 	var/datum/radio_frequency/radio_connection
 
 	var/list/TLV = list( // Breathable air.
-		"pressure"					= new/datum/tlv(ONE_ATMOSPHERE * 0.8, ONE_ATMOSPHERE*  0.9, ONE_ATMOSPHERE * 1.1, ONE_ATMOSPHERE * 1.2), // kPa. Values are min2, min1, max1, max2
+		"pressure"					= new/datum/tlv(HAZARD_LOW_PRESSURE, WARNING_LOW_PRESSURE, WARNING_HIGH_PRESSURE, HAZARD_HIGH_PRESSURE), // kPa. Values are min2, min1, max1, max2
 		"temperature"				= new/datum/tlv(T0C, T0C+10, T0C+40, T0C+66),
 		/datum/gas/oxygen			= new/datum/tlv(16, 19, 135, 140), // Partial pressure, kpa
 		/datum/gas/nitrogen			= new/datum/tlv(-1, -1, 1000, 1000),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the air alarm alert thresholdsfrom being too conservative (warning thresholds were 90kpa and 110kpa, danger thresholds were 80kpa and 120kpa), to being the same as the HAZARD defines used by ui pressure warnings (50 and 325) and when damage actually occurs (20 and 550).

Might need to make the new values a bit more conservative, but I'd argue that's why the warning values exist in the first place.

## Why It's Good For The Game

Stops air alarm alerts occuring for safe pressures, e.g. after a draught to cool a hallway the pressure might be 115kpa, which will then trigger air alarm warnings, and requires siphoning to correct.  Main benefit is AI and borgs don't see a ton of alerts for trivial deviances from room temp and pressure (alert fatigue bad).

## Changelog
:cl: Tetr4
tweak: Air alarm alert thresholds are more generous
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
