### PR TITLE
movespeed_modification unlawful list modification fix

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -11,6 +11,7 @@
 
 #define LAZYINITLIST(L) if (!L) L = list()
 #define UNSETEMPTY(L) if (L && !length(L)) L = null
+#define LAZYCOPY(L) (L ? L.Copy() : list() )
 #define LAZYREMOVE(L, I) if(L) { L -= I; if(!length(L)) { L = null; } }
 #define LAZYADD(L, I) if(!L) { L = list(); } L += I;
 #define LAZYOR(L, I) if(!L) { L = list(); } L |= I;

--- a/code/modules/movespeed/_movespeed_modifier.dm
+++ b/code/modules/movespeed/_movespeed_modifier.dm
@@ -199,7 +199,7 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 
 /// Get the move speed modifiers list of the mob
 /mob/proc/get_movespeed_modifiers()
-	. = movespeed_modification
+	. = LAZYLEN(movespeed_modification) ? movespeed_modification.Copy() : list()
 	for(var/id in movespeed_mod_immunities)
 		. -= id
 

--- a/code/modules/movespeed/_movespeed_modifier.dm
+++ b/code/modules/movespeed/_movespeed_modifier.dm
@@ -199,7 +199,7 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 
 /// Get the move speed modifiers list of the mob
 /mob/proc/get_movespeed_modifiers()
-	. = LAZYLEN(movespeed_modification) ? movespeed_modification.Copy() : list()
+	. = LAZYCOPY(movespeed_modification)
 	for(var/id in movespeed_mod_immunities)
 		. -= id
 


### PR DESCRIPTION
Fixing a bug I introduced in #50095
Lists are passed by reference, so this would cause an unintended modification of the original list.
It may not be terribly noticeable right now because the list is being rebuilt periodically, but it will/would once/if we make it more static, reacting to events.