### PR TITLE
Changes the sprite of the Clarke's ore storage equipment

### DIFF
--- a/code/game/mecha/working/clarke.dm
+++ b/code/game/mecha/working/clarke.dm
@@ -54,7 +54,8 @@
 /obj/item/mecha_parts/mecha_equipment/orebox_manager
 	name = "ore storage module"
 	desc = "An automated ore box management device."
-	icon_state = "mecha_clamp" //None of this should matter, this shouldn't ever exist outside a mech anyway.
+	icon = 'icons/obj/mining.dmi'
+	icon_state = "bin"
 	selectable = FALSE
 	detachable = FALSE
 	salvageable = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the ore manager (equipment exclusively used by the Clarke) to use the bin sprite of icon/obj/mining.dmi instead of the mecha clamp.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When I coded the ore box manager, I just gave it the clamp for an icon, since I figured it wouldn't matter if the equipment cannot exist outside the mech. Apparently you can just examine the mech and see the equipment sprites, though.

![image](https://user-images.githubusercontent.com/37497534/77237151-e0396600-6b82-11ea-9433-1afe10f260b1.png)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
imageadd: Sprite change for the Clarke's ore manager
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

For the record, the sprite that will be used;
![image](https://user-images.githubusercontent.com/37497534/77237125-a2d4d880-6b82-11ea-9b0a-b5b57124ef01.png)

