### PR TITLE
Clarke mech now damages floor tiles

### DIFF
--- a/code/game/mecha/working/clarke.dm
+++ b/code/game/mecha/working/clarke.dm
@@ -72,8 +72,7 @@
 /obj/item/mecha_parts/mecha_equipment/orebox_manager
 	name = "ore storage module"
 	desc = "An automated ore box management device."
-	icon = 'icons/obj/mining.dmi'
-	icon_state = "bin"
+	icon_state = "mecha_clamp" //None of this should matter, this shouldn't ever exist outside a mech anyway.
 	selectable = FALSE
 	detachable = FALSE
 	salvageable = FALSE

--- a/code/game/mecha/working/clarke.dm
+++ b/code/game/mecha/working/clarke.dm
@@ -48,13 +48,32 @@
 		var/mob/living/brain/B = M.brainmob
 		hud.add_hud_to(B)
 
+/obj/mecha/working/clarke/play_stepsound(direction)
+	if(prob(30))
+		floor_damage()
+	. = ..()
+
+/obj/mecha/working/clarke/mechturn(direction)
+	if(prob(80))
+		floor_damage()
+	. = ..()
+
+/obj/mecha/working/clarke/proc/floor_damage()
+	var/turf/open/floor/tile = get_turf(src)
+	if(!istype(tile, /turf/open/floor))
+		return
+	if(tile.icon_plating == "basalt") //Find me a better way to tell a tile is basalt, and I'll use it
+		return
+	tile.break_tile()
+
 //Ore Box Controls
 
 ///Special equipment for the Clarke mech, handles moving ore without giving the mech a hydraulic clamp and cargo compartment.
 /obj/item/mecha_parts/mecha_equipment/orebox_manager
 	name = "ore storage module"
 	desc = "An automated ore box management device."
-	icon_state = "mecha_clamp" //None of this should matter, this shouldn't ever exist outside a mech anyway.
+	icon = 'icons/obj/mining.dmi'
+	icon_state = "bin"
 	selectable = FALSE
 	detachable = FALSE
 	salvageable = FALSE

--- a/code/game/mecha/working/clarke.dm
+++ b/code/game/mecha/working/clarke.dm
@@ -51,7 +51,7 @@
 /obj/mecha/working/clarke/play_stepsound(direction)
 	if(prob(30))
 		floor_damage()
-	. = ..()
+	return ..()
 
 /obj/mecha/working/clarke/mechturn(direction)
 	if(prob(80))

--- a/code/game/mecha/working/clarke.dm
+++ b/code/game/mecha/working/clarke.dm
@@ -56,7 +56,7 @@
 /obj/mecha/working/clarke/mechturn(direction)
 	if(prob(80))
 		floor_damage()
-	. = ..()
+	return ..()
 
 /obj/mecha/working/clarke/proc/floor_damage()
 	var/turf/open/floor/tile = get_turf(src)

--- a/code/game/mecha/working/clarke.dm
+++ b/code/game/mecha/working/clarke.dm
@@ -48,23 +48,23 @@
 		var/mob/living/brain/B = M.brainmob
 		hud.add_hud_to(B)
 
-/obj/mecha/working/clarke/play_stepsound(direction)
-	if(prob(30))
-		floor_damage()
-	return ..()
+/obj/mecha/working/clarke/domove(direction)
+	. = ..()
+	if (.)
+		if(prob(30))
+			crush_floor()
 
 /obj/mecha/working/clarke/mechturn(direction)
 	if(prob(80))
-		floor_damage()
+		crush_floor()
 	return ..()
 
-/obj/mecha/working/clarke/proc/floor_damage()
+///Damages floor tiles and plating as the Clarke moves over them with its tracks. Damage is superficial, will not create hull breaches.
+/obj/mecha/working/clarke/proc/crush_floor()
 	var/turf/open/floor/tile = get_turf(src)
 	if(!istype(tile, /turf/open/floor))
 		return
-	if(tile.icon_plating == "basalt") //Find me a better way to tell a tile is basalt, and I'll use it
-		return
-	tile.break_tile()
+	tile.crush()
 
 //Ore Box Controls
 

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -134,6 +134,10 @@
 /turf/open/floor/proc/make_plating()
 	return ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 
+///For when the floor is placed under heavy load. Calls break_tile(), but exists to be overridden by floor types that should resist crushing force.
+/turf/open/floor/proc/crush()
+	break_tile()
+
 /turf/open/floor/ChangeTurf(path, new_baseturf, flags)
 	if(!isfloorturf(src))
 		return ..() //fucking turfs switch the fucking src of the fucking running procs

--- a/code/game/turfs/open/floor/plating/asteroid.dm
+++ b/code/game/turfs/open/floor/plating/asteroid.dm
@@ -53,6 +53,9 @@
 /turf/open/floor/plating/asteroid/MakeDry()
 	return
 
+/turf/open/floor/plating/asteroid/crush()
+	return
+
 /turf/open/floor/plating/asteroid/attackby(obj/item/W, mob/user, params)
 	. = ..()
 	if(!.)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Clarke mech now causes damage to floor tiles (or hull tiles) as it moves over them. 30% chance for each movement, 80% chance when it turns. Does not actually break tiles or hull, and will not cause a hull breach.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives some flavor to the Clarke mech, and is a good indicator of why the other mechs don't use tracks.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The Clarke mech's tracks now slightly damage floor tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
