### PR TITLE
Spacemen finally learn what punctuation is by force

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -204,6 +204,13 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		spans |= SPAN_SINGING
 		message = "[randomnote] [message] [randomnote]"
 
+	///List of symbols that we dont want a dot after
+	var/list/punctuation = list("!","?",".")
+	///Last charachter in the message
+	var/last_charachter = copytext(message,length_char(message))
+	if(!(last_charachter in punctuation))
+		message += "."
+
 	var/radio_return = radio(message, message_mode, spans, language)
 	if(radio_return & ITALICS)
 		spans |= SPAN_ITALICS


### PR DESCRIPTION
## About The Pull Request

Test will now automatically get a dot, i.e. "hello" will be turned into "Hello."

## Why It's Good For The Game

GRAMMER

## Changelog
:cl:
add: Spacemen finally learned the art of "punctuation" and now put so called "dots" at the end of their said sentences
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
