### PR TITLE
[READY] Passive vents still mix gases when pressures are equal

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -192,7 +192,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	return removed
 
-/datum/gas_mixture/remove_specific(gas_id, amount)
+/datum/gas_mixture/proc/remove_specific(gas_id, amount)
 	var/list/cached_gases = gases
 	amount = min(amount, cached_gases[gas_id][MOLES])
 	if(amount <= 0)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -192,6 +192,21 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	return removed
 
+/datum/gas_mixture/remove_specific(gas_id, amount)
+	var/list/cached_gases = gases
+	amount = min(amount, cached_gases[gas_id][MOLES])
+	if(amount <= 0)
+		return null
+	var/datum/gas_mixture/removed = new type
+	var/list/removed_gases = removed.gases
+	removed.temperature = temperature
+	ADD_GAS(gas_id, removed.gases)
+	removed_gases[gas_id][MOLES] = amount
+	cached_gases[gas_id][MOLES] -= amount
+
+	garbage_collect()
+	return removed
+
 	///Creates new, identical gas mixture
 	///Returns: duplicate gas mixture
 /datum/gas_mixture/proc/copy()

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -75,7 +75,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	//PV = nRT
 
 	///joules per kelvin
-/datum/gas_mixture/proc/heat_capacity(data = MOLES) 
+/datum/gas_mixture/proc/heat_capacity(data = MOLES)
 	var/list/cached_gases = gases
 	. = 0
 	for(var/id in cached_gases)
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		. += gas_data[data] * gas_data[GAS_META][META_GAS_SPECIFIC_HEAT]
 
 	/// Same as above except vacuums return HEAT_CAPACITY_VACUUM
-/datum/gas_mixture/turf/heat_capacity(data = MOLES) 
+/datum/gas_mixture/turf/heat_capacity(data = MOLES)
 	var/list/cached_gases = gases
 	. = 0
 	for(var/id in cached_gases)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -192,6 +192,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	return removed
 
+	///Removes a amount of a specific gas from the gas_mixture.
+	///Returns: gas_mixture with the gas removed
 /datum/gas_mixture/proc/remove_specific(gas_id, amount)
 	var/list/cached_gases = gases
 	amount = min(amount, cached_gases[gas_id][MOLES])

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -209,7 +209,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	garbage_collect(list(gas_id))
 	return removed
 
-	///Distributes gases equally between two mixtures, as if they were connected by an open link
+	///Distributes the contents of two mixes equally between themselves
 	//Returns: bool indicating whether gases moved between the two mixes
 /datum/gas_mixture/proc/equalize(datum/gas_mixture/other)
 	. = FALSE

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -226,7 +226,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	for(var/gas_id in gas_list)
 		assert_gas(gas_id)
 		other.assert_gas(gas_id)
-		if(abs(gases[gas_id][MOLES] - other.gases[gas_id][MOLES]) > 0.001)
+		//math is under the assumption temperatures are equal
+		if(abs(gases[gas_id][MOLES] / volume - other.gases[gas_id][MOLES] / other.volume) > 0.1 / (R_IDEAL_GAS_EQUATION * temperature))
 			. = TRUE
 			var/total_moles = gases[gas_id][MOLES] + other.gases[gas_id][MOLES]
 			gases[gas_id][MOLES] = total_moles * (volume/total_volume)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -204,7 +204,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	removed_gases[gas_id][MOLES] = amount
 	cached_gases[gas_id][MOLES] -= amount
 
-	garbage_collect()
+	garbage_collect(list(gas_id))
 	return removed
 
 	///Creates new, identical gas mixture

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -213,7 +213,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	//Returns: bool indicating whether gases moved between the two mixes
 /datum/gas_mixture/proc/equalize(datum/gas_mixture/other)
 	. = FALSE
-	if(abs(return_temperature() - other.return_temperature()) > 1)
+	if(abs(return_temperature() - other.return_temperature()) > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
 		. = TRUE
 		var/self_heat_cap = heat_capacity()
 		var/other_heat_cap = other.heat_capacity()
@@ -221,13 +221,14 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		temperature = new_temp
 		other.temperature = new_temp
 
+	var/min_p_delta = 0.1
 	var/total_volume = volume + other.volume
 	var/list/gas_list = gases | other.gases
 	for(var/gas_id in gas_list)
 		assert_gas(gas_id)
 		other.assert_gas(gas_id)
 		//math is under the assumption temperatures are equal
-		if(abs(gases[gas_id][MOLES] / volume - other.gases[gas_id][MOLES] / other.volume) > 0.1 / (R_IDEAL_GAS_EQUATION * temperature))
+		if(abs(gases[gas_id][MOLES] / volume - other.gases[gas_id][MOLES] / other.volume) > min_p_delta / (R_IDEAL_GAS_EQUATION * temperature))
 			. = TRUE
 			var/total_moles = gases[gas_id][MOLES] + other.gases[gas_id][MOLES]
 			gases[gas_id][MOLES] = total_moles * (volume/total_volume)

--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -20,8 +20,6 @@
 /obj/machinery/atmospherics/components/unary/passive_vent/process_atmos()
 	..()
 
-	var/active = FALSE
-
 	var/datum/gas_mixture/external = loc.return_air()
 	var/datum/gas_mixture/internal = airs[1]
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -27,11 +27,7 @@
 
 	//is there a better way to do this in byond i.e. get the keys?
 	var/list/gas_list = new()
-	for(var/gas_id in internal.gases)
-		gas_list += gas_id
-	for(var/gas_id in external.gases)
-		gas_list += gas_id
-	gas_list = uniqueList(gas_list)
+	gas_list |= internal.gases | external.gases
 
 	//calculate delta of partial pressure for each gas, and do transfer for each gas individually
 	var/internal_pp_coeff = R_IDEAL_GAS_EQUATION * internal.temperature / internal.volume

--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -25,11 +25,8 @@
 
 	var/internal_volume_fraction = internal.volume/(internal.volume + external.volume)
 
-	var/datum/gas_mixture/holding = new
-	holding.merge(internal.remove_ratio(1))
-	holding.merge(external.remove_ratio(1))
-	internal.merge(holding.remove_ratio(internal_volume_fraction))
-	external.merge(holding)
+	external.merge(internal.remove_ratio(1))
+	internal.merge(external.remove_ratio(internal_volume_fraction))
 
 	air_update_turf()
 	update_parents()

--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -23,13 +23,9 @@
 	var/datum/gas_mixture/external = loc.return_air()
 	var/datum/gas_mixture/internal = airs[1]
 
-	var/internal_volume_fraction = internal.volume/(internal.volume + external.volume)
-
-	external.merge(internal.remove_ratio(1))
-	internal.merge(external.remove_ratio(internal_volume_fraction))
-
-	air_update_turf()
-	update_parents()
+	if(internal.equalize(external))
+		air_update_turf()
+		update_parents()
 
 /obj/machinery/atmospherics/components/unary/passive_vent/can_crawl_through()
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Changes passive vents so that rather than just moving gas from inside the vent to outside or vice versa based purely on the difference between internal and external pressure, they also merge and mix the gases. For example, if you have one passive vent in the nitrogen atmos tank connected to another in the oxygen atmos tank, previously nothing would happen as both their pressures are the same.  With this PR, the two gases will also mix until both tanks are 50/50 mix of oxygen and nitrogen, as you would intuitively expect to happen.

## Why It's Good For The Game

It's what you would expect to happen with a device that's just an open vent, and opens the door for cool things e.g. single tile SM setups.

## Changelog
:cl: Tetr4 and Dennok
tweak: Passive vents now transfer based on each individual gases partial pressure, i.e. they will now mix gases internally and externally if internal and external pressures are the same.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
