### PR TITLE
Caltrop effects require standing

### DIFF
--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -31,6 +31,8 @@
 			return							//gravity checking only our parent would prevent us from triggering they're using magboots / other gravity assisting items that would cause them to still touch us.
 		if(H.buckled) //if they're buckled to something, that something should be checked instead.
 			return
+		if(!(H.mobility_flags & MOBILITY_STAND)) //if were not standing we cant step on the caltrop
+			return
 
 		var/picked_def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 		var/obj/item/bodypart/O = H.get_bodypart(picked_def_zone)


### PR DESCRIPTION
## About The Pull Request

Caltrop effects such as stepping on broken glass without shoes now require the person to be standing to take effect.

## Why It's Good For The Game

People can drag someone who isn't wearing shoes over glass shards repeatedly to perma stun them and kill them rather quickly without any way for the person to counteract it, this PR makes it no longer possible to do that.

## Changelog
:cl:
balance: Caltrop effects such as stepping on broken glass without shoes now require the person to be standing to take effect.
/:cl:
