### PR TITLE
Use /tg/'s Discord UserID wiki page over Discord's because Discord's guide sucks.

### DIFF
--- a/code/modules/discord/accountlink.dm
+++ b/code/modules/discord/accountlink.dm
@@ -21,7 +21,7 @@
 	if(!stored_id) // Account is not linked
 		var/know_how = alert("Do you know how to get a Discord user ID? This ID is NOT your Discord username and numbers! (Pressing NO will open a guide.)","Question","Yes","No","Cancel Linking")
 		if(know_how == "No") // Opens discord support on how to collect IDs
-			src << link("https://support.discordapp.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID")
+			src << link("https://tgstation13.org/wiki/How_to_find_your_Discord_User_ID")
 		if(know_how == "Cancel Linking")
 			return
 		var/entered_id = input("Please enter your Discord ID (18-ish digits)", "Enter Discord ID", null, null) as text|null
@@ -32,8 +32,8 @@
 		var/choice = alert("You already have the Discord Account [stored_id] linked to [usr.ckey]. Would you like to link a different account?","Already Linked","Yes","No")
 		if(choice == "Yes")
 			var/know_how = alert("Do you know how to get a Discord user ID? This ID is NOT your Discord username and numbers! (Pressing NO will open a guide.)","Question","Yes","No", "Cancel Linking")
-			if(know_how == "No") // Opens discord support on how to collect IDs
-				src << link("https://support.discordapp.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID")
+			if(know_how == "No")
+				src << link("https://tgstation13.org/wiki/How_to_find_your_Discord_User_ID")
 
 			if(know_how == "Cancel Linking")
 				return


### PR DESCRIPTION
https://tgstation13.org/wiki/How_to_find_your_Discord_User_ID

Somebody who is an experienced discord user will likely already know how to find this, and somebody who is not may not be conformable enabling dev mode to get it. The bot command method is good for people who are on their phone, the url method is good for people on web discord, and desktop app users are likely to already have dev mode on.
