### PR TITLE
Nightmare now properly spawns with Lighteater

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -154,6 +154,11 @@
 		playsound(owner, 'sound/hallucinations/far_noise.ogg', 50, TRUE)
 		respawn_progress = 0
 
+/obj/item/organ/heart/nightmare/get_availability(datum/species/S)
+	if(istype(S,/datum/species/shadow/nightmare))
+		return TRUE
+	return ..()
+
 //Weapon
 
 /obj/item/light_eater


### PR DESCRIPTION
Nightmares use NOBLOOD and the default heart's `get_availability` checks for NOBLOOD so it didn't realize that the nightmare does in fact need the heart.

