### PR TITLE
gives the chaplain a shotgun

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -709,11 +709,20 @@
 /obj/item/nullrod/shotgun
 	name = "super shotgun replica"
 	desc = "Makes you want to shoot demons."
+	force = 12
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "dshotgun"
 	item_state = "shotgun_db"
 	lefthand_file = 'icons/mob/inhands/weapons/64x_guns_left.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/64x_guns_right.dmi'
+	inhand_x_dimension = 64
+	inhand_y_dimension = 64
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("struck", "hit", "bashed")
+	attack_verb = list("shot")
 	hitsound = 'sound/weapons/gun/shotgun/shot.ogg'
+
+/obj/item/nullrod/shotgun/attack(mob/living/target, mob/living/user)
+	. = ..()
+	var/atom/throw_target = get_edge_target_turf(target, user.dir)
+	if(!target.anchored)
+		target.throw_at(throw_target, rand(1,2), 7, user)

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -718,6 +718,7 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = ITEM_SLOT_BELT
 	attack_verb = list("shot")
 	hitsound = 'sound/weapons/gun/shotgun/shot.ogg'
 

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -705,3 +705,15 @@
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("stabbed", "poked", "slashed", "clocked")
 	hitsound = 'sound/weapons/bladeslice.ogg'
+
+/obj/item/nullrod/shotgun
+	name = "super shotgun replica"
+	desc = "Makes you want to shoot demons."
+	icon = 'icons/obj/guns/ballistic.dmi'
+	icon_state = "dshotgun"
+	item_state = "shotgun_db"
+	lefthand_file = 'icons/mob/inhands/weapons/64x_guns_left.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/64x_guns_right.dmi'
+	w_class = WEIGHT_CLASS_NORMAL
+	attack_verb = list("struck", "hit", "bashed")
+	hitsound = 'sound/weapons/gun/shotgun/shot.ogg'

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -709,7 +709,7 @@
 /obj/item/nullrod/shotgun
 	name = "super shotgun replica"
 	desc = "Makes you want to shoot demons."
-	icon = 'icons/obj/guns/ballistic.dmi'
+	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "dshotgun"
 	item_state = "shotgun_db"
 	lefthand_file = 'icons/mob/inhands/weapons/64x_guns_left.dmi'

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -717,7 +717,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/64x_guns_right.dmi'
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BELT
 	attack_verb = list("shot")
 	hitsound = 'sound/weapons/gun/shotgun/shot.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Chaplains now can reskin their null rod to the super shotgun replica! 
It does 12 damage instead of the usual null rod 18, but can throw away opponents like a baseball bat and makes FUN sounds!
(it doesn't shoot bullets)

## Why It's Good For The Game

fun stuff for chaplains with their deity being a gun god or for people who have doom religions

## Changelog
:cl:
add: Super Shotgun replica! now available as a null rod reskin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
