### PR TITLE
Strength and stimmed buff 2: Chemical Strongaloo

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -224,17 +224,37 @@
 
 /datum/mutation/human/strong
 	name = "Strength"
-	desc = "The user's muscles slightly expand."
+	desc = "The user's muscles slightly expand, allowing them to move heavy objects easily."
 	quality = POSITIVE
-	text_gain_indication = "<span class='notice'>You feel strong.</span>"
+	text_gain_indication = "<span class='notice'>You feel strong!</span>"
 	difficulty = 16
+	instability = 25
+
+/datum/mutation/human/strong/on_acquiring(mob/living/carbon/human/owner)
+	. = ..()
+	if(.)
+		return
+	owner.add_movespeed_mod_immunities(type, list(/datum/movespeed_modifier/bulky_drag, /datum/movespeed_modifier/human_carry))
+
+/datum/mutation/human/strong/on_losing(mob/living/carbon/human/owner)
+	. = ..()
+	if(.)
+		return
+	owner.remove_movespeed_mod_immunities(type, list(/datum/movespeed_modifier/bulky_drag, /datum/movespeed_modifier/human_carry))
+
+ ///Amount of units of toxin reagents to remove while having the stimmed mutation
+ #define STIMMED_PURGE_AMOUNT 0.25
 
 /datum/mutation/human/stimmed
 	name = "Stimmed"
-	desc = "The user's chemical balance is more robust."
+	desc = "The user's chemical balance is more robust, allowing them to quickly remove toxins from their body."
 	quality = POSITIVE
-	text_gain_indication = "<span class='notice'>You feel stimmed.</span>"
+	text_gain_indication = "<span class='notice'>You feel relaxed.</span>"
 	difficulty = 16
+	instability = 30 // the purging is quite powerful
+
+/datum/mutation/human/stimmed/on_life()
+	owner.reagents.remove_all_type(/datum/reagent/toxin, STIMMED_PURGE_AMOUNT, FALSE, TRUE)
 
 /datum/mutation/human/insulated
 	name = "Insulated"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -228,7 +228,7 @@
 	quality = POSITIVE
 	text_gain_indication = "<span class='notice'>You feel strong!</span>"
 	difficulty = 16
-	instability = 25
+	instability = 20
 
 /datum/mutation/human/strong/on_acquiring(mob/living/carbon/human/owner)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Second attempt at PRing this. See #50149 

This adds functionality to strength and stimmed, so they're not just craftgenes.
Strength allows you to carry and drag mobs and lockers without being slowed down. Very useful for would-be paramedics, as long as you stop the bleeding. Nyoom.
Stimmed is what i hope will become used often, maybe even a must-have like space adap. It removes toxic reagents slowly but consistently from the user. Dap on the chemist as you shrug off their chloral hydrate cyanide nitric acid fluorosulfuric acid lexorin deathmix! Drink sulfonal as a party trick! Etc etc..

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fun new mutations to play with, no more throwing away these craftgenes after being used to make a better mutation. Now they have actual purpose to be injected into you, which is good.

## Changelog
:cl:
add: The strength mutation now allows dragging heavy objects with ease.
add: The stimmed mutation now slowly purges toxic reagents.
balance: Stimmed and strength have been given instability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
