### PR TITLE
Removes GPS Signal From Comms Agents

### DIFF
--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -161,9 +161,5 @@
 /datum/outfit/lavaland_syndicate/comms
 	name = "Lavaland Syndicate Comms Agent"
 	r_hand = /obj/item/melee/transforming/energy/sword/saber
-	mask = /obj/item/clothing/mask/chameleon/gps
+	mask = /obj/item/clothing/mask/chameleon/
 	suit = /obj/item/clothing/suit/armor/vest
-
-/obj/item/clothing/mask/chameleon/gps/Initialize()
-	. = ..()
-	AddComponent(/datum/component/gps, "Encrypted Signal")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Due to some Manuel commentary on the subject, this reverts #35078 by removing the GPS component from the Lavaland Comms Agent Chameleon Mask and thus removes the Encrypted Signal.

If this falls under the Off-Station Content Freeze then blast this to the trashcan where it belongs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

**I don't personally have any opinion on it one way or the other. I'm making this PR on behalf of THE PEOPLE.**

**If THE PEOPLE are infact raving lunatics, consign this to the trashcan.**

**I'm hoping this opens up some constructive discussion on the Comms Agent role and whether it still needs the GPS signal attached to it.**

OOC: NikoTheGuyDude: REMOVE THE GODDAMN COMMS AGENT ENCRYPTED SIGNAL DAMMIT
OOC: NikoTheGuyDude: i read the original pr to add the encrypted signal
OOC: NikoTheGuyDude: its full of "I DED PLS NERF"

OOC: Ivuchnu: https://github.com/tgstation/tgstation/pull/35078 - CRINGE PR
OOC: Ivuchnu: cooms agent also fucks over syndicate scientists just trying to have fun with chem/virology by existing

OOC: RuneQuester: ah yes
OOC: RuneQuester: lets give a signal so miners can get free traitor gear
OOC: RuneQuester: MINERS ARE HERE WITH THE FUNNY STAFF

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The Syndicate have decided that equipping their top secret Comms Agents with unique encrypted GPS signals that aren't actually encrypted, can be tracked, traced and broadcast the location of the top secret Comms Agent and their probable base is a bad idea.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
