### PR TITLE
Vape fire stack issue fix

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -898,7 +898,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 					reagents.remove_any(REAGENTS_METABOLISM)
 				if(reagents.get_reagent_amount(/datum/reagent/fuel))
 					//HOT STUFF
-					C.fire_stacks += 2
+					C.adjust_fire_stacks(2)
 					C.IgniteMob()
 
 				if(reagents.get_reagent_amount(/datum/reagent/toxin/plasma)) // the plasma explodes when exposed to fire

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -898,7 +898,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 					reagents.remove_any(REAGENTS_METABOLISM)
 				if(reagents.get_reagent_amount(/datum/reagent/fuel))
 					//HOT STUFF
-					C.fire_stacks = 2
+					C.fire_stacks += 2
 					C.IgniteMob()
 
 				if(reagents.get_reagent_amount(/datum/reagent/toxin/plasma)) // the plasma explodes when exposed to fire


### PR DESCRIPTION
## About The Pull Request

Vapes loaded with welder fuel adjust firestacks instead of setting them

## Why It's Good For The Game

Vapes loaded with welding fuel shouldn't prevent you from burning alive via hellfoam

## Changelog
:cl:
fix: Vapes loaded with welding fuel no longer prevent you from being further set on fire from other sources.
/:cl: