### PR TITLE
Revert "Makes compile changelogs action only run if secret is present."

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -8,7 +8,6 @@ jobs:
   compile:
     name: "Compile changelogs"
     runs-on: ubuntu-latest
-    if: secrets.CompileChangelogs == true
     steps:
       - name: "Setup python"
         uses: actions/setup-python@v1


### PR DESCRIPTION
Reverts tgstation/tgstation#50112

Github docs failed to mention limitations on secrets use.