### PR TITLE
Fixes "Show alerts" button/link in chat doing nothing for borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -189,6 +189,12 @@
 	cell = null
 	return ..()
 
+/mob/living/silicon/robot/Topic(href, href_list)
+	..()
+	//Show alerts window if user clicked on "Show alerts" in chat
+	if (href_list["showalerts"])
+		robot_alerts()
+
 /mob/living/silicon/robot/proc/pick_module()
 	if(module.type != /obj/item/robot_module)
 		return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -190,7 +190,7 @@
 	return ..()
 
 /mob/living/silicon/robot/Topic(href, href_list)
-	..()
+	. = ..()
 	//Show alerts window if user clicked on "Show alerts" in chat
 	if (href_list["showalerts"])
 		robot_alerts()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
AI has a topic proc that checks if showalerts is 1 (gets set by clicking the href) and if yes shows AI alerts. Works the same for borgs but they don't have a custom topic proc so showalerts is never 
getting evaluated and the alerts window is never getting shown
Fixes https://github.com/tgstation/tgstation/issues/50045
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Button/Href actually does what it says now, displaying alerts
## Changelog
:cl:
fix: Pressing "Show alerts" in chat now works for borgs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
