### PR TITLE
[READY] Carp Rift Bugfix and QOL

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -351,7 +351,7 @@ mob/living/simple_animal/hostile/space_dragon/proc/dragon_fire_line(turf/T)
 	sleep(100)
 	priority_announce("A large amount of lifeforms have been detected approaching [station_name()] at extreme speeds.  Evacuation of the remamining crew will begin immediately.", "Central Command Spacial Corps")
 	for(var/obj/structure/carp_rift/rift in rift_list)
-		rift.carp_stored = INFINITY
+		rift.carp_stored = 999999
 	sleep(50)
 	SSshuttle.emergency.request(null, set_coefficient = 0.3)
 

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -350,6 +350,8 @@ mob/living/simple_animal/hostile/space_dragon/proc/dragon_fire_line(turf/T)
 	sound_to_playing_players('sound/machines/alarm.ogg')
 	sleep(100)
 	priority_announce("A large amount of lifeforms have been detected approaching [station_name()] at extreme speeds.  Evacuation of the remamining crew will begin immediately.", "Central Command Spacial Corps")
+	for(var/obj/structure/carp_rift/rift in rift_list)
+		rift.carp_stored = INFINITY
 	sleep(50)
 	SSshuttle.emergency.request(null, set_coefficient = 0.3)
 

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -423,6 +423,7 @@ mob/living/simple_animal/hostile/space_dragon/proc/dragon_fire_line(turf/T)
 	light_range = 10
 	anchored = TRUE
 	density = FALSE
+	layer = MASSIVE_OBJ_LAYER
 	/// The amount of time the rift has charged for.
 	var/time_charged = 0
 	/// The maximum charge the rift can have.  It actually goes to max_charge + 1, as to prevent constantly retriggering the effects on full charge.


### PR DESCRIPTION
## About The Pull Request

Fixes carp rifts not spawning in infinite carps upon Space Dragon completing his objective.  Also renders the carp rift above things like doors, as per request.

## Why It's Good For The Game

It not already doing this was an oversight, and gives Space Dragon winning some weight.  Also makes it easier for ghosts to use the rift if it shares a tile with something else.

## Changelog
:cl:
fix: Carp Rifts now allow infinite carp spawns upon a Space Dragon completing his objective.
/:cl: