### PR TITLE
Material wall/floor and floor tile name/desc changes

### DIFF
--- a/code/__DEFINES/materials.dm
+++ b/code/__DEFINES/materials.dm
@@ -9,6 +9,5 @@
 #define MATERIAL_ADD_PREFIX (1<<1)
 #define MATERIAL_NO_EFFECTS (1<<2)
 #define MATERIAL_AFFECT_STATISTICS (1<<3)
-#define MATERIAL_UPDATE_DESC (1<<4)
 
 #define MATERIAL_SOURCE(mat) "[mat.name]_material"

--- a/code/__DEFINES/materials.dm
+++ b/code/__DEFINES/materials.dm
@@ -9,5 +9,6 @@
 #define MATERIAL_ADD_PREFIX (1<<1)
 #define MATERIAL_NO_EFFECTS (1<<2)
 #define MATERIAL_AFFECT_STATISTICS (1<<3)
+#define MATERIAL_UPDATE_DESC (1<<4)
 
 #define MATERIAL_SOURCE(mat) "[mat.name]_material"

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -70,10 +70,9 @@
 			out += "[length(out) ? " and it " : "[master] "]seems to be glowing a bit."
 		if(RAD_AMOUNT_HIGH to INFINITY) //At this level the object can contaminate other objects
 			out += "[length(out) ? " and it " : "[master] "]hurts to look at."
-	if(LAZYLEN(out))
-		out += "."
-	else
+	if(!LAZYLEN(out))
 		return
+	out += "."
 	to_chat(user, "<span class ='warning'>[out.Join()]</span>")
 
 /datum/component/radioactive/proc/rad_attack(datum/source, atom/movable/target, mob/living/user)

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -70,9 +70,11 @@
 			out += "[length(out) ? " and it " : "[master] "]seems to be glowing a bit."
 		if(RAD_AMOUNT_HIGH to INFINITY) //At this level the object can contaminate other objects
 			out += "[length(out) ? " and it " : "[master] "]hurts to look at."
-		else
-			out += "."
-	to_chat(user, out.Join())
+	if(LAZYLEN(out))
+		out += "."
+	else
+		return
+	to_chat(user, "<span class ='warning'>[out.Join()]</span>")
 
 /datum/component/radioactive/proc/rad_attack(datum/source, atom/movable/target, mob/living/user)
 	radiation_pulse(parent, strength/20)

--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -68,8 +68,7 @@ Simple datum which is instanced once per type and is used for every object of sa
 	if(istype(source, /turf)) //turfs
 		on_applied_turf(source, amount, material_flags)
 
-	if(material_flags & MATERIAL_UPDATE_DESC)
-		source.mat_update_desc(src)
+	source.mat_update_desc(src)
 
 ///This proc is called when a material updates an object's description
 /atom/proc/mat_update_desc(/datum/material/mat)

--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -68,6 +68,13 @@ Simple datum which is instanced once per type and is used for every object of sa
 	if(istype(source, /turf)) //turfs
 		on_applied_turf(source, amount, material_flags)
 
+	if(material_flags & MATERIAL_UPDATE_DESC)
+		source.mat_update_desc(src)
+
+///This proc is called when a material updates an object's description
+/atom/proc/mat_update_desc(/datum/material/mat)
+	return
+
 ///This proc is called when the material is added to an object specifically.
 /datum/material/proc/on_applied_obj(obj/o, amount, material_flags)
 	if(material_flags & MATERIAL_AFFECT_STATISTICS)

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -20,6 +20,11 @@
 	pixel_x = rand(-3, 3)
 	pixel_y = rand(-3, 3) //randomize a little
 
+/obj/item/stack/tile/examine(mob/user)
+	..()
+	if(throwforce >= 10)
+		to_chat(user, "Those could work as a pretty decent throwing weapon.")
+
 /obj/item/stack/tile/attackby(obj/item/W, mob/user, params)
 
 	if (W.tool_behaviour == TOOL_WELDER)
@@ -308,7 +313,6 @@
 /obj/item/stack/tile/plasteel
 	name = "floor tile"
 	singular_name = "floor tile"
-	desc = "Those could work as a pretty decent throwing weapon."
 	icon_state = "tile"
 	item_state = "tile"
 	force = 6
@@ -337,17 +341,10 @@
 /obj/item/stack/tile/material
 	name = "floor tile"
 	singular_name = "floor tile"
-	desc = "Those could work as a pretty decent throwing weapon."
 	throwforce = 10
 	icon_state = "material_tile"
 	turf_type = /turf/open/floor/material
 	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-
-/obj/item/stack/tile/material/mat_update_desc(mat)
-	if(throwforce >= 10)
-		desc = "Those could work as a pretty decent throwing weapon."
-	else
-		desc = "Those wouldn't make a very good throwing weapon."
 
 /obj/item/stack/tile/eighties
 	name = "retro tile"

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -340,7 +340,7 @@
 	throwforce = 5
 	icon_state = "material_tile"
 	turf_type = /turf/open/floor/material
-	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS | MATERIAL_UPDATE_DESC
+	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_UPDATE_DESC | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 
 /obj/item/stack/tile/material/mat_update_desc(mat)
 	switch(throwforce)

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/obj/tiles.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 1
-	throwforce = 5
+	throwforce = 1
 	throw_speed = 3
 	throw_range = 7
 	max_amount = 60
@@ -337,6 +337,7 @@
 /obj/item/stack/tile/material
 	name = "floor tile"
 	singular_name = "floor tile"
+	throwforce = 5
 	icon_state = "material_tile"
 	turf_type = /turf/open/floor/material
 	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS | MATERIAL_UPDATE_DESC

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -14,6 +14,7 @@
 	var/turf_type = null
 	var/mineralType = null
 	novariants = TRUE
+	var/human_maxHealth = 100
 
 /obj/item/stack/tile/Initialize(mapload, amount)
 	. = ..()
@@ -22,8 +23,18 @@
 
 /obj/item/stack/tile/examine(mob/user)
 	..()
-	if(throwforce >= 10)
-		to_chat(user, "Those could work as a pretty decent throwing weapon.")
+	if(throwforce) //do not want to divide by zero
+		switch(CEILING(human_maxHealth / throwforce)) //amount of throws to crit
+			if(1 to 3)
+				to_chat(user, "Those could work as a spectacular throwing weapon.")
+			if(4 to 6)
+				to_chat(user, "Those could work as a fantastic throwing weapon.")				
+			if(7 to 9)
+				to_chat(user, "Those could work as a great throwing weapon.")
+			if(10)
+				to_chat(user, "Those could work as a fairly decent throwing weapon.")
+			if(11 to 13)
+				to_chat(user, "Those could work as a mediocre throwing weapon.")
 
 /obj/item/stack/tile/attackby(obj/item/W, mob/user, params)
 

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -335,9 +335,8 @@
 	turf_type = /turf/open/floor/plastic
 
 /obj/item/stack/tile/material
-	name = "tile"
+	name = "floor tile"
 	singular_name = "floor tile"
-	desc = "A tile of flooring."
 	icon_state = "material_tile"
 	turf_type = /turf/open/floor/material
 	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -24,17 +24,21 @@
 /obj/item/stack/tile/examine(mob/user)
 	..()
 	if(throwforce) //do not want to divide by zero
-		switch(CEILING(human_maxHealth / throwforce)) //amount of throws to crit
+		var/verb
+		switch(CEILING(human_maxHealth / throwforce, 1)) //amount of throws to crit a human
 			if(1 to 3)
-				to_chat(user, "Those could work as a spectacular throwing weapon.")
+				verb = "superb"
 			if(4 to 6)
-				to_chat(user, "Those could work as a fantastic throwing weapon.")				
+				verb = "great"
 			if(7 to 9)
-				to_chat(user, "Those could work as a great throwing weapon.")
-			if(10)
-				to_chat(user, "Those could work as a fairly decent throwing weapon.")
-			if(11 to 13)
-				to_chat(user, "Those could work as a mediocre throwing weapon.")
+				verb = "good"
+			if(10 to 12)
+				verb = "fairly decent"
+			if(13 to 15)
+				verb = "mediocre"
+		if(!verb)
+			return
+		to_chat(user, "<span class='notice'>Those could work as a [verb] throwing weapon.</span>")
 
 /obj/item/stack/tile/attackby(obj/item/W, mob/user, params)
 

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/obj/tiles.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 1
-	throwforce = 1
+	throwforce = 5
 	throw_speed = 3
 	throw_range = 7
 	max_amount = 60
@@ -339,7 +339,16 @@
 	singular_name = "floor tile"
 	icon_state = "material_tile"
 	turf_type = /turf/open/floor/material
-	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
+	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS | MATERIAL_UPDATE_DESC
+
+/obj/item/stack/tile/material/mat_update_desc(mat)
+	switch(throwforce)
+		if (6 to 8)
+			desc = "Those could make an okay throwing weapon."
+		if(9 to INFINITY)
+			desc = "Those could work as a pretty decent throwing weapon."
+		else
+			desc = "Those would make a lousy throwing weapon."
 
 /obj/item/stack/tile/eighties
 	name = "retro tile"

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -22,10 +22,10 @@
 	pixel_y = rand(-3, 3) //randomize a little
 
 /obj/item/stack/tile/examine(mob/user)
-	..()
-	if(throwforce) //do not want to divide by zero
+	. = ..()
+	if(throwforce && !is_cyborg) //do not want to divide by zero or show the message to borgs who can't throw
 		var/verb
-		switch(CEILING(human_maxHealth / throwforce, 1)) //amount of throws to crit a human
+		switch(CEILING(human_maxHealth / throwforce, 1)) //throws to crit a human
 			if(1 to 3)
 				verb = "superb"
 			if(4 to 6)
@@ -38,7 +38,7 @@
 				verb = "mediocre"
 		if(!verb)
 			return
-		to_chat(user, "<span class='notice'>Those could work as a [verb] throwing weapon.</span>")
+		. += "<span class='notice'>Those could work as a [verb] throwing weapon.</span>"
 
 /obj/item/stack/tile/attackby(obj/item/W, mob/user, params)
 
@@ -328,6 +328,7 @@
 /obj/item/stack/tile/plasteel
 	name = "floor tile"
 	singular_name = "floor tile"
+	desc = "The ground you walk on."
 	icon_state = "tile"
 	item_state = "tile"
 	force = 6
@@ -340,7 +341,6 @@
 	resistance_flags = FIRE_PROOF
 
 /obj/item/stack/tile/plasteel/cyborg
-	desc = "The ground you walk on." //Not the usual floor tile desc as that refers to throwing, Cyborgs can't do that - RR
 	custom_materials = null // All other Borg versions of items have no Metal or Glass - RR
 	is_cyborg = 1
 	cost = 125
@@ -356,6 +356,7 @@
 /obj/item/stack/tile/material
 	name = "floor tile"
 	singular_name = "floor tile"
+	desc = "The ground you walk on."
 	throwforce = 10
 	icon_state = "material_tile"
 	turf_type = /turf/open/floor/material

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -337,19 +337,17 @@
 /obj/item/stack/tile/material
 	name = "floor tile"
 	singular_name = "floor tile"
-	throwforce = 5
+	desc = "Those could work as a pretty decent throwing weapon."
+	throwforce = 10
 	icon_state = "material_tile"
 	turf_type = /turf/open/floor/material
-	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_UPDATE_DESC | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
+	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 
 /obj/item/stack/tile/material/mat_update_desc(mat)
-	switch(throwforce)
-		if (6 to 8)
-			desc = "Those could make an okay throwing weapon."
-		if(9 to INFINITY)
-			desc = "Those could work as a pretty decent throwing weapon."
-		else
-			desc = "Those would make a lousy throwing weapon."
+	if(throwforce >= 10)
+		desc = "Those could work as a pretty decent throwing weapon."
+	else
+		desc = "Those wouldn't make a very good throwing weapon."
 
 /obj/item/stack/tile/eighties
 	name = "retro tile"

--- a/code/game/turfs/closed/wall/material_walls.dm
+++ b/code/game/turfs/closed/wall/material_walls.dm
@@ -5,7 +5,7 @@
 	icon_state = "wall"
 	canSmoothWith = list(/turf/closed/wall/material)
 	smooth = SMOOTH_TRUE
-	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
+	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_UPDATE_DESC | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 
 /turf/closed/wall/material/break_wall()
 	for(var/i in custom_materials)
@@ -17,3 +17,7 @@
 	for(var/i in custom_materials)
 		var/datum/material/M = i
 		new M.sheet_type(src, FLOOR(custom_materials[M] / MINERAL_MATERIAL_AMOUNT, 1))
+
+/turf/closed/wall/material/mat_update_desc(mat)
+	desc = "A huge chunk of [mat] used to separate rooms."
+

--- a/code/game/turfs/closed/wall/material_walls.dm
+++ b/code/game/turfs/closed/wall/material_walls.dm
@@ -5,7 +5,7 @@
 	icon_state = "wall"
 	canSmoothWith = list(/turf/closed/wall/material)
 	smooth = SMOOTH_TRUE
-	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_UPDATE_DESC | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
+	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 
 /turf/closed/wall/material/break_wall()
 	for(var/i in custom_materials)

--- a/code/game/turfs/closed/wall/material_walls.dm
+++ b/code/game/turfs/closed/wall/material_walls.dm
@@ -1,6 +1,6 @@
 /turf/closed/wall/material
 	name = "wall"
-	desc = "A solid wall made out of a certain material"
+	desc = "A huge chunk of material used to separate rooms."
 	icon = 'icons/turf/walls/materialwall.dmi'
 	icon_state = "wall"
 	canSmoothWith = list(/turf/closed/wall/material)

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -294,8 +294,7 @@
 	return FALSE
 
 /turf/open/floor/material
-	name = "plating"
-	desc = "A flooring made out of a certain material"
+	name = "floor"
 	icon_state = "materialfloor"
 	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Renames material floors to floor instead of plating
2. Removes placeholdery material floor description to make them consistent with regular metal floors which don't have one
3. Changes material wall description to name the material used, to mirror the description of regular metal walls
4. Changes material tiles' name to "floor tile" to be consistent with regular floor tiles
5. Adds custom examine to floor tiles based on their throwforce
5. Buffs material floor tiles' throwforces from 1 to 10 to better showcase the difference between certain materials (e.g. meat, titanium)
5. Radioactive items no longer output a single full stop when examined at a distance
6. Adds warning span to radioactive item message
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Polish, consistency, fixes the mistake of calling material floors plating.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
fix: Material floors are now correctly called floors and not plating
balance: Buffs material floor tiles' throwforces from 1 to 10 (same as iron) to better showcase the effect of different materials (e.g. meat vs. titanium)
fix: Radioactive items no longer output a single . when examined at a distance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
