### PR TITLE
Fixes a speling error in the description for the lisence plate press

### DIFF
--- a/code/game/machinery/prisonlabor.dm
+++ b/code/game/machinery/prisonlabor.dm
@@ -1,6 +1,6 @@
 /obj/machinery/plate_press
 	name = "license plate press"
-	desc = "You know, we're making a lot of license plates for a station with literaly no cars in it."
+	desc = "You know, we're making a lot of license plates for a station with literally no cars in it."
 	icon = 'icons/obj/machines/prison.dmi'
 	icon_state = "offline"
 	use_power = IDLE_POWER_USE


### PR DESCRIPTION
## About The Pull Request
Thunks better about how this game does word stuff
## Why It's Good For The Game
Uhh, I can't think of any reason why it would make the game worse? I guess correcting spelling errors helps present a better image to new players?
:cl:
spellcheck: corrects literaly to literally in the description for the Permabrig's plate press
/:cl: