### PR TITLE
Makes the station more colorful...

### DIFF
--- a/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
+++ b/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
@@ -5,7 +5,8 @@
 	alpha = 110
 
 /obj/effect/turf_decal/tile/Initialize()
-	color = "#[random_short_color()]"
+	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
+		color = "#[random_short_color()]"
 	. = ..()
 
 /obj/effect/turf_decal/tile/blue
@@ -48,7 +49,8 @@
 	icon_state = "trimline_box"
 
 /obj/effect/turf_decal/trimline/Initialize()
-	color = "#[random_short_color()]"
+	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
+		color = "#[random_short_color()]"
 	. = ..()
 
 /obj/effect/turf_decal/trimline/white

--- a/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
+++ b/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
@@ -43,10 +43,6 @@
 	color = "#D4D4D4"
 	alpha = 50
 
-/obj/effect/turf_decal/tile/blue
-	name = "blue corner"
-	color = "#52B4E9"
-
 /obj/effect/turf_decal/tile/random // so many colors
 	name = "colorful corner"
 

--- a/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
+++ b/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
@@ -4,6 +4,10 @@
 	layer = TURF_PLATING_DECAL_LAYER
 	alpha = 110
 
+/obj/effect/turf_decal/tile/Initialize()
+	color = "#[random_short_color()]"
+	. = ..()
+
 /obj/effect/turf_decal/tile/blue
 	name = "blue corner"
 	color = "#52B4E9"
@@ -42,6 +46,10 @@
 	layer = TURF_PLATING_DECAL_LAYER
 	alpha = 110
 	icon_state = "trimline_box"
+
+/obj/effect/turf_decal/trimline/Initialize()
+	color = "#[random_short_color()]"
+	. = ..()
 
 /obj/effect/turf_decal/trimline/white
 	color = "#FFFFFF"

--- a/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
+++ b/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
@@ -43,6 +43,18 @@
 	color = "#D4D4D4"
 	alpha = 50
 
+/obj/effect/turf_decal/tile/blue
+	name = "blue corner"
+	color = "#52B4E9"
+
+/obj/effect/turf_decal/tile/random // so many colors
+	name = "colorful corner"
+
+/obj/effect/turf_decal/tile/random/Initialize()
+	color = "#[random_short_color()]"
+	. = ..()
+
+
 /obj/effect/turf_decal/trimline
 	layer = TURF_PLATING_DECAL_LAYER
 	alpha = 110

--- a/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
+++ b/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
@@ -45,6 +45,7 @@
 
 /obj/effect/turf_decal/tile/random // so many colors
 	name = "colorful corner"
+	color = "#E300FF" //bright pink as default for mapping
 
 /obj/effect/turf_decal/tile/random/Initialize()
 	color = "#[random_short_color()]"


### PR DESCRIPTION
...on april fools, and adds a randomly colored tile subtype for mapping

## Changelog
:cl:
tweak: Due to a new clause in the Crew Satisfaction Program, the clown has been given full control over station decorations during April Fools
tweak: Added randomly colored tile decals for mapping
/:cl:

![Screenshot_6](https://user-images.githubusercontent.com/38563876/77550174-0d528500-6eb1-11ea-92dd-a2b9ab883711.png)
