### PR TITLE
Makes the hypnoflash and hypnoflashbang role-restricted to the Psychologist.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1373,18 +1373,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/aiModule/syndicate
 	cost = 9
 
-/datum/uplink_item/device_tools/hypnotic_flash
-	name = "Hypnotic Flash"
-	desc = "A modified flash able to hypnotize targets. If the target is not in a mentally vulnerable state, it will only confuse and pacify them temporarily."
-	item = /obj/item/assembly/flash/hypnotic
-	cost = 7
-
-/datum/uplink_item/device_tools/hypnotic_grenade
-	name = "Hypnotic Grenade"
-	desc = "A modified flashbang grenade able to hypnotize targets. The sound portion of the flashbang causes hallucinations, and will allow the flash to induce a hypnotic trance to viewers."
-	item = /obj/item/grenade/hypnotic
-	cost = 12
-
 /datum/uplink_item/device_tools/medgun
 	name = "Medbeam Gun"
 	desc = "A wonder of Syndicate engineering, the Medbeam gun, or Medi-Gun enables a medic to keep his fellow \
@@ -1676,6 +1664,20 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/disk/surgery/brainwashing
 	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Roboticist")
 	cost = 5
+
+/datum/uplink_item/role_restricted/hypnotic_flash
+	name = "Hypnotic Flash"
+	desc = "A modified flash able to hypnotize targets. If the target is not in a mentally vulnerable state, it will only confuse and pacify them temporarily."
+	item = /obj/item/assembly/flash/hypnotic
+	cost = 7
+	restricted_roles = list("Psychologist")
+
+/datum/uplink_item/role_restricted/hypnotic_grenade
+	name = "Hypnotic Grenade"
+	desc = "A modified flashbang grenade able to hypnotize targets. The sound portion of the flashbang causes hallucinations, and will allow the flash to induce a hypnotic trance to viewers."
+	item = /obj/item/grenade/hypnotic
+	cost = 12
+	restricted_roles = list("Psychologist")
 
 /datum/uplink_item/role_restricted/clown_bomb
 	name = "Clown Bomb"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This role-restricts the hypnoflash and hypnoflashbang to the Psychologist in the traitor uplink.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The hypnoflash is not a very commonly purchased item, in large part I assume because it's not an efficient killing tool. It's a liability and a bit of monkeying around to even try hypnoflashing somebody, and if you succeed it's a further liability on if the person you flashed will actually play along and obey or just rat you out, or screw up your plan/be incompetent if they do obey. If your objective is greentexting at all cost or murderboning, chances are you will not touch this item with a ten foot pole.

What the hypnoflash IS great for, is memes, funny things, and roleplay. And so, who better to give this item to than an RP job which attracts those type of players to begin with? In particular one for who it makes perfect RP sense for them to be hypnotizing people. I feel this makes at least as much sense as the current role-restrictions on the brainwashing surgery disk.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The hypnotic flash and hypnotic flashbang are now role-restricted to traitor Psychologists.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
