### PR TITLE
Summon Events Tweak

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -533,6 +533,8 @@
 /datum/spellbook_entry/summon/events
 	name = "Summon Events"
 	desc = "Give Murphy's law a little push and replace all events with special wizard ones that will confound and confuse everyone. Multiple castings increase the rate of these events."
+	cost = 2 
+	limit = 1
 	var/times = 0
 
 /datum/spellbook_entry/summon/events/IsAvailible()


### PR DESCRIPTION
## About The Pull Request
Just re-opening Buggy123's PR, props to them and those who contributed there: https://github.com/tgstation/tgstation/pull/49365

Tweaks summon events to have one use at a cost of 2 points. Approved by headmins.

## Why It's Good For The Game

Summon events won't be able to cause quite as much insanity with an event happening every minute. 

## Changelog
:cl:
tweak: Summon events now has only one use at a cost of 2 points.
/:cl: