### PR TITLE
spoken_info builder-datum containing all the stuff for Hear()

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -148,8 +148,8 @@
 
 	friend_talk(message)
 
-/mob/camera/imaginary_friend/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
-	to_chat(src, compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode))
+/mob/camera/imaginary_friend/Hear(datum/spoken_info/info)
+	to_chat(src, info.getMsg())
 
 /mob/camera/imaginary_friend/proc/friend_talk(message)
 	message = capitalize(trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN)))

--- a/code/datums/spoken_info.dm
+++ b/code/datums/spoken_info.dm
@@ -1,0 +1,292 @@
+/**
+  * A solution to any amount of arguments passed into [/atom/movable/proc/Hear], and alike.
+  *
+  * This class should be used as a builder of sorts that is passed in all hearing-speaking related procs.
+  * This class expects "message" argument to be pre-sanitized.
+  */
+/datum/spoken_info
+	// What has sent us this message. Please set via [/datum/spoken_info/proc/setSource].
+	var/atom/movable/source
+	// Who is currently perceiving this info. Please set via [/datum/spoken_info/proc/setHearer].
+	var/atom/movable/hearer
+
+	// The range in which this message can be heard. Please set via [/datum/spoken_info/proc/setRawMessage].
+	var/message_range
+
+	// Not actually(assumingly) raw, a sanitized string of what was spoken.
+	var/raw_message
+
+	// In what was is the message conveyed.
+	var/message_mode
+
+	// The language in which this message was spoken. Please set via [/datum/spoken_info/proc/setLanguage].
+	var/datum/language/message_language
+
+	// What radio freq the message was sent on, if any. Please set via [/datum/spoken_info/proc/setRadioFreq].
+	var/radio_freq
+
+	// What spans should apply to this message.
+	var/list/spans
+
+	// The type of bubble to display above source. Please set via [/datum/spoken_info/proc/setBubbleType].
+	var/bubble_type
+
+	/*
+		All of the vars below are used in text rendering, and are saved for efficency.
+	*/
+	// Basic span
+	var/spanpart1 = "<span class='game say'>"
+	// Radio freq/name display
+	var/freqpart
+	//Speaker name
+	var/namepart
+
+	// How does a creature that *understands* the message perceive it.
+	var/comprehended_message
+	// How does a creature that doesn't understand the message perceive it.
+	var/scrambled_message
+
+	// The icon of message spoken.
+	var/languageicon = ""
+
+	// The bubble image displayed to all of those whom it may concern.
+	var/image/bubble_image
+
+/datum/spoken_info/New(message, message_range, message_mode, buble_type, atom/movable/source = null, atom/movable/hearer = null, datum/language/language = null, freq = null, list/spans = null)
+	src.message_mode = message_mode
+
+	setRawMessage(message)
+
+	setBubbleType(bubble_type)
+
+	if(language)
+		setLanguage(language)
+
+	if(source)
+		setSource(source)
+
+	if(hearer)
+		setHearer(hearer)
+
+	src.message_range = message_range
+
+	if(radio_freq)
+		setRadioFreq(freq)
+
+	src.spans = spans
+
+/datum/spoken_info/Destroy()
+	source = null
+	hearer = null
+	QDEL_NULL(bubble_image)
+	return ..()
+
+/**
+  * This proc sets the raw message, and updates contents for "processed" messages.
+  *
+  */
+/datum/spoken_info/proc/setRawMessage(message)
+	if(raw_message == message)
+		return
+
+	raw_message = message
+
+	updateBubble()
+	updatePerception()
+
+/**
+  * This proc updates the bubble image.
+  *
+  */
+/datum/spoken_info/proc/setBubbleType(new_bubble_type)
+	if(bubble_type == new_bubble_type)
+		return
+
+	bubble_type = new_bubble_type
+
+	updateBubble()
+
+/**
+  * This proc sets the source for src, and updates all required stuff.
+  *
+  */
+/datum/spoken_info/proc/setSource(atom/movable/new_source)
+	if(source == new_source)
+		return
+
+	source = new_source
+
+	var/namepart = "[source.GetVoice()][source.get_alt_name()]"
+	if(source.face_name && ishuman(source))
+		var/mob/living/carbon/human/H = source
+		namepart = "[H.get_face_name()]" //So "fake" speaking like in hallucinations does not give the speaker away if disguised
+
+	updateBubble()
+	updatePerception()
+
+/**
+  * This proc sets the hearer for src, and updates all required stuff.
+  *
+  */
+/datum/spoken_info/proc/setHearer(atom/movable/new_hearer)
+	if(hearer == new_hearer)
+		return
+
+	hearer = new_hearer
+	updateLangIcon()
+
+/**
+  * This proc sets the language of src, and updates all required stuff.
+  *
+  */
+/datum/spoken_info/proc/setLanguage(datum/language/L)
+	if(message_language == L)
+		return
+
+	message_language = L
+
+	updatePerception()
+	updateLangIcon()
+
+/datum/spoken_info/proc/setRadioFreq(freq)
+	radio_freq = freq
+	freqpart = radio_freq ? "\[[get_radio_name(radio_freq)]\] " : ""
+	spanpart1 = "<span class='[radio_freq ? get_radio_span(radio_freq) : "game say"]'>"
+
+/**
+  * This proc updates the message's contents on change of source, or language.
+  *
+  */
+/datum/spoken_info/proc/updatePerception()
+	if(!source)
+		return
+
+	if(!message_language)
+		comprehended_message = "makes a strange, yet familiar sound."
+		scrambled_message = "makes a strange sound."
+		return
+
+	var/datum/language/D = GLOB.language_datum_instances[message_language]
+	var/lang_mes = D.scramble(raw_message)
+
+	var/atom/movable/virtual_source = source.GetSource()
+	var/atom/movable/AM = virtual_source ? virtual_source : source
+
+	comprehended_message = AM.say_quote(raw_message, spans, message_mode)
+	scrambled_message = AM.say_quote(lang_mes, spans, message_mode)
+
+/**
+  * This proc updates language icon if new language is set, or a new hearer is set.
+  *
+  */
+/datum/spoken_info/proc/updateLangIcon()
+	if(!hearer || !message_language)
+		languageicon = ""
+		return
+
+	var/datum/language/D = GLOB.language_datum_instances[message_language]
+	if(istype(D) && D.display_icon(hearer))
+		languageicon = "[D.get_icon()]"
+
+/**
+  * This proc updates the speech bubble if a new source, or bubble type is set.
+  *
+  */
+/datum/spoken_info/proc/updateBubble()
+	if(!source || !bubble_type || !raw_message)
+		QDEL_NULL(bubble_image)
+		return
+
+	QDEL_NULL(bubble_image)
+
+	bubble_image = image('icons/mob/talk.dmi', source, "[bubble_type][say_test(raw_message)]", FLY_LAYER)
+	bubble_image.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+
+/**
+  * The proc used to merge two instances of spoken info, if conflicts arise.
+  * It intentionally ignores set-procs, as to allow for creating confusion by mingling directly with
+  * spanpart1, freqpart, endpart, etc.
+  *
+  * The procs assumes that the instance which other instance is merged into is "dominant"
+  * and all non-null fields are to be preserved, unless *forced* to not be.
+  * Arguments:
+  * * datum/spoken_info/new_info - the instance merged into src.
+  * * force - Whether to force all of fields to be passed onto src.
+  */
+/datum/spoken_info/proc/merge(datum/spoken_info/new_info, force = FALSE)
+	if(!source || force)
+		source = new_info.source
+
+	// isnull() is used since strings can be falsey.
+	if(isnull(raw_message) || force)
+		raw_message = new_info.raw_message
+
+	// isnull() is used since 0 is falsey.
+	if(isnull(message_range) || force)
+		message_range = new_info.message_range
+
+	if(isnull(message_mode) || force)
+		message_mode = new_info.message_mode
+
+	if(!message_language || force)
+		message_language = new_info.message_language
+
+	if(isnull(radio_freq) || force)
+		radio_freq = new_info.radio_freq
+
+	if(!spans || force)
+		spans = new_info.spans
+
+	if(isnull(spanpart1) || force)
+		spanpart1 = new_info.spanpart1
+
+	if(isnull(freqpart) || force)
+		freqpart = new_info.freqpart
+
+	if(isnull(namepart) || force)
+		namepart = new_info.namepart
+
+	if(isnull(comprehended_message) || force)
+		comprehended_message = new_info.comprehended_message
+
+	if(isnull(scrambled_message) || force)
+		scrambled_message = new_info.scrambled_message
+
+	if(!languageicon || force)
+		languageicon = new_info.languageicon
+
+	if(!bubble_image || force)
+		setBubbleType(new_info.bubble_type)
+
+/**
+  * This proc creates a copy of current spoken_info instance *correctly*.
+  *
+  */
+/datum/spoken_info/proc/getCopy()
+	var/datum/spoken_info/C = new
+	C.merge(src, TRUE)
+	return C
+
+/**
+  * This proc gets rendered message for current set of source-hearer, and all other related vars.
+  *
+  */
+/datum/spoken_info/proc/getMsg()
+	if(!hearer)
+		return "But if there was none to perceive it, was the message even really there?"
+
+	//Start name span
+	var/spanpart2 = "<span class='name'>"
+	//End name span.
+	var/endspanpart = "</span>"
+
+	var/messagepart = hearer.has_language(message_language) ? comprehended_message : scrambled_message
+
+	return "[spanpart1][spanpart2][freqpart][languageicon][hearer.compose_track_href(source, namepart)][namepart][hearer.compose_job(source, message_language, raw_message, radio_freq)][endspanpart][messagepart]"
+
+/**
+  * This proc shows hearer the bubble they ought to perceive.
+  *
+  */
+/datum/spoken_info/proc/showBubble()
+	return

--- a/code/game/machinery/doors/passworddoor.dm
+++ b/code/game/machinery/doors/passworddoor.dm
@@ -22,11 +22,11 @@
 	if(voice_activated)
 		flags_1 |= HEAR_1
 
-/obj/machinery/door/password/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
+/obj/machinery/door/password/Hear(datum/spoken_info/info)
 	. = ..()
 	if(!density || !voice_activated || radio_freq)
 		return
-	if(findtext(raw_message,password))
+	if(findtext(info.raw_message, password))
 		open()
 
 /obj/machinery/door/password/Bumped(atom/movable/AM)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -431,23 +431,23 @@ obj/machinery/holopad/secure/Initialize()
 
 /*This is the proc for special two-way communication between AI and holopad/people talking near holopad.
 For the other part of the code, check silicon say.dm. Particularly robot talk.*/
-/obj/machinery/holopad/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
+/obj/machinery/holopad/Hear(datum/spoken_info/info)
 	. = ..()
-	if(speaker && LAZYLEN(masters) && !radio_freq)//Master is mostly a safety in case lag hits or something. Radio_freq so AIs dont hear holopad stuff through radios.
+	if(info.source && LAZYLEN(masters) && !info.radio_freq)//Master is mostly a safety in case lag hits or something. Radio_freq so AIs dont hear holopad stuff through radios.
 		for(var/mob/living/silicon/ai/master in masters)
-			if(masters[master] && speaker != master)
+			if(masters[master] && info.source != master)
 				master.relay_speech(message, speaker, message_language, raw_message, radio_freq, spans, message_mode)
 
 	for(var/I in holo_calls)
 		var/datum/holocall/HC = I
-		if(HC.connected_holopad == src && speaker != HC.hologram)
-			HC.user.Hear(message, speaker, message_language, raw_message, radio_freq, spans, message_mode)
+		if(HC.connected_holopad == src && info.source != HC.hologram)
+			HC.user.Hear(info)
 
-	if(outgoing_call && speaker == outgoing_call.user)
-		outgoing_call.hologram.say(raw_message)
+	if(outgoing_call && info.source == outgoing_call.user)
+		outgoing_call.hologram.say(info.raw_message)
 
-	if(record_mode && speaker == record_user)
-		record_message(speaker,raw_message,message_language)
+	if(record_mode && info.source == record_user)
+		record_message(speaker, raw_message, message_language)
 
 /obj/machinery/holopad/proc/SetLightsAndPower()
 	var/total_users = LAZYLEN(masters) + LAZYLEN(holo_calls)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -449,9 +449,9 @@
 /obj/mecha/proc/drop_item()//Derpfix, but may be useful in future for engineering exosuits.
 	return
 
-/obj/mecha/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
+/obj/mecha/Hear(datum/spoken_info/info)
 	. = ..()
-	if(speaker == occupant)
+	if(info.source == occupant)
 		if(radio?.broadcasting)
 			radio.talk_into(speaker, text, , spans, message_language)
 		//flick speech bubble

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -280,9 +280,9 @@
 	signal.levels = list(T.z)
 	signal.broadcast()
 
-/obj/item/radio/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
+/obj/item/radio/Hear(datum/spoken_info/info)
 	. = ..()
-	if(radio_freq || !broadcasting || get_dist(src, speaker) > canhear_range)
+	if(info.radio_freq || !broadcasting || get_dist(src, info.source) > canhear_range)
 		return
 
 	if(message_mode == MODE_WHISPER || message_mode == MODE_WHISPER_CRIT)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -94,11 +94,12 @@
 		icon_state = "taperecorder_idle"
 
 
-/obj/item/taperecorder/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, spans, message_mode)
+/obj/item/taperecorder/Hear(datum/spoken_info/info)
 	. = ..()
 	if(mytape && recording)
+		// Taperecorder did this weird thing even before, that it heard whatever, and however the one recording did o_o.
 		mytape.timestamp += mytape.used_capacity
-		mytape.storedinfo += "\[[time2text(mytape.used_capacity * 10,"mm:ss")]\] [message]"
+		mytape.storedinfo += "\[[time2text(mytape.used_capacity * 10,"mm:ss")]\] [info.getMsg()]"
 
 /obj/item/taperecorder/verb/record()
 	set name = "Start Recording"

--- a/code/game/objects/items/eightball.dm
+++ b/code/game/objects/items/eightball.dm
@@ -153,9 +153,9 @@
 	interact(user)
 	return ..()
 
-/obj/item/toy/eightball/haunted/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, spans, message_mode)
+/obj/item/toy/eightball/haunted/Hear(datum/spoken_info/info)
 	. = ..()
-	last_message = raw_message
+	last_message = info.raw_message
 
 /obj/item/toy/eightball/haunted/start_shaking(mob/user)
 	// notify ghosts that someone's shaking a haunted eightball

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -26,19 +26,23 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	spans |= speech_span
 	if(!language)
 		language = get_selected_language()
-	send_speech(message, 7, src, , spans, message_language=language)
 
-/atom/movable/proc/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
+	var/datum/spoken_info/SI = new(message, 7, , , source = src, language = language, spans = spans)
+
+	send_speech(SI)
+
+/atom/movable/proc/Hear(datum/spoken_info/info)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)
 
 /atom/movable/proc/can_speak()
 	return 1
 
-/atom/movable/proc/send_speech(message, range = 7, obj/source = src, bubble_type, list/spans, datum/language/message_language = null, message_mode)
-	var/rendered = compose_message(src, message_language, message, , spans, message_mode)
-	for(var/_AM in get_hearers_in_view(range, source))
+/atom/movable/proc/send_speech(datum/spoken_info/info)
+	for(var/_AM in get_hearers_in_view(info.message_range, info.source))
 		var/atom/movable/AM = _AM
-		AM.Hear(rendered, src, message_language, message, , spans, message_mode)
+		// Changes the language icon and what text(comprehensive/uncomprehensive) should AM see, for more detail - see spoken_info.dm
+		info.setHearer(AM)
+		AM.Hear(info)
 
 /atom/movable/proc/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode, face_name = FALSE)
 	//This proc uses text() because it is faster than appending strings. Thanks BYOND.

--- a/code/modules/antagonists/disease/disease_mob.dm
+++ b/code/modules/antagonists/disease/disease_mob.dm
@@ -115,21 +115,19 @@ the new instance inside the host to be updated to the template's stats.
 			follow_next(Dir & NORTHWEST)
 			last_move_tick = world.time
 
-/mob/camera/disease/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
+/mob/camera/disease/Hear(datum/spoken_info/info)
 	. = ..()
-	var/atom/movable/to_follow = speaker
-	if(radio_freq)
-		var/atom/movable/virtualspeaker/V = speaker
+	var/atom/movable/to_follow = info.source
+	if(info.radio_freq)
+		var/atom/movable/virtualspeaker/V = info.source
 		to_follow = V.source
 	var/link
 	if(to_follow in hosts)
 		link = FOLLOW_LINK(src, to_follow)
 	else
 		link = ""
-	// Recompose the message, because it's scrambled by default
-	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode)
-	to_chat(src, "[link] [message]")
 
+	to_chat(src, "[link] [info.getMsg()]")
 
 /mob/camera/disease/mind_initialize()
 	. = ..()

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -27,12 +27,12 @@
 	. = ..()
 	. += "<span class='notice'>Use a multitool to swap between \"inclusive\", \"exclusive\", \"recognizer\", and \"voice sensor\" mode.</span>"
 
-/obj/item/assembly/voice/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
+/obj/item/assembly/voice/Hear(datum/spoken_info/info)
 	. = ..()
-	if(speaker == src)
+	if(info.source == src)
 		return
 
-	if(listening && !radio_freq)
+	if(listening && !info.radio_freq)
 		record_speech(speaker, raw_message, message_language)
 	else
 		if(check_activation(speaker, raw_message))

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -24,11 +24,11 @@
 
 	. = say_dead(message)
 
-/mob/dead/observer/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
+/mob/dead/observer/Hear(datum/spoken_info/info)
 	. = ..()
-	var/atom/movable/to_follow = speaker
-	if(radio_freq)
-		var/atom/movable/virtualspeaker/V = speaker
+	var/atom/movable/to_follow = info.source
+	if(info.radio_freq)
+		var/atom/movable/virtualspeaker/V = info.source
 
 		if(isAI(V.source))
 			var/mob/living/silicon/ai/S = V.source
@@ -37,6 +37,4 @@
 			to_follow = V.source
 	var/link = FOLLOW_LINK(src, to_follow)
 	// Recompose the message, because it's scrambled by default
-	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode)
-	to_chat(src, "[link] [message]")
-
+	to_chat(src, "[link] [info.getMsg()]")

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -230,26 +230,22 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	return 1
 
-/mob/living/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
+/mob/living/Hear(datum/spoken_info/info)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)
 	if(!client)
 		return
 
 	var/deaf_message
 	var/deaf_type
-	if(speaker != src)
-		if(!radio_freq) //These checks have to be seperate, else people talking on the radio will make "You can't hear yourself!" appear when hearing people over the radio while deaf.
-			deaf_message = "<span class='name'>[speaker]</span> [speaker.verb_say] something but you cannot hear [speaker.p_them()]."
+	if(info.source != src)
+		if(!info.radio_freq) //These checks have to be seperate, else people talking on the radio will make "You can't hear yourself!" appear when hearing people over the radio while deaf.
+			deaf_message = "<span class='name'>[info.source]</span> [info.source.verb_say] something but you cannot hear [info.source.p_them()]."
 			deaf_type = 1
 	else
 		deaf_message = "<span class='notice'>You can't hear yourself!</span>"
 		deaf_type = 2 // Since you should be able to hear yourself without looking
 
-	// Recompose message for AI hrefs, language incomprehension.
-	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode)
-
-	show_message(message, MSG_AUDIBLE, deaf_message, deaf_type)
-	return message
+	show_message(info.getMsg(), MSG_AUDIBLE, deaf_message, deaf_type)
 
 /mob/living/send_speech(message, message_range = 6, obj/source = src, bubble_type = bubble_icon, list/spans, datum/language/message_language=null, message_mode)
 	var/static/list/eavesdropping_modes = list(MODE_WHISPER = TRUE, MODE_WHISPER_CRIT = TRUE)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -192,9 +192,9 @@
 	acceleration = !acceleration
 	to_chat(usr, "Camera acceleration has been toggled [acceleration ? "on" : "off"].")
 
-/mob/camera/aiEye/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
+/mob/camera/aiEye/Hear(datum/spoken_info/info)
 	. = ..()
-	if(relay_speech && speaker && ai && !radio_freq && speaker != ai && near_camera(speaker))
+	if(relay_speech && info.source && ai && !info.radio_freq && info.source != ai && near_camera(info.source))
 		ai.relay_speech(message, speaker, message_language, raw_message, radio_freq, spans, message_mode)
 
 /obj/effect/overlay/ai_detect_hud

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -415,10 +415,10 @@ Difficulty: Very Hard
 		. += observer_desc
 		. += "It is activated by [activation_method]."
 
-/obj/machinery/anomalous_crystal/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, spans, message_mode)
+/obj/machinery/anomalous_crystal/Hear(datum/spoken_info/info)
 	..()
-	if(isliving(speaker))
-		ActivationReaction(speaker, ACTIVATE_SPEECH)
+	if(isliving(info.source))
+		ActivationReaction(info.source, ACTIVATE_SPEECH)
 
 /obj/machinery/anomalous_crystal/attack_hand(mob/user)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -147,15 +147,13 @@
 		stat("Held Item", held_item)
 		stat("Mode",a_intent)
 
-/mob/living/simple_animal/parrot/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, list/spans, message_mode)
+/mob/living/simple_animal/parrot/Hear(datum/spoken_info/info)
 	. = ..()
-	if(speaker != src && prob(50)) //Dont imitate ourselves
-		if(!radio_freq || prob(10))
+	if(info.source != src && prob(50)) //Dont imitate ourselves
+		if(!info.radio_freq || prob(10))
 			if(speech_buffer.len >= 500)
 				speech_buffer -= pick(speech_buffer)
-			speech_buffer |= html_decode(raw_message)
-	if(speaker == src && !client) //If a parrot squawks in the woods and no one is around to hear it, does it make a sound? This code says yes!
-		return message
+			speech_buffer |= html_decode(info.raw_message)
 
 /mob/living/simple_animal/parrot/radio(message, message_mode, list/spans, language) //literally copied from human/radio(), but there's no other way to do this. at least it's better than it used to be.
 	. = ..()

--- a/code/modules/mob/living/simple_animal/slime/say.dm
+++ b/code/modules/mob/living/simple_animal/slime/say.dm
@@ -1,7 +1,7 @@
-/mob/living/simple_animal/slime/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, spans, message_mode)
+/mob/living/simple_animal/slime/Hear(datum/spoken_info/info)
 	. = ..()
-	if(speaker != src && !radio_freq && !stat)
-		if (speaker in Friends)
+	if(info.source != src && !info.radio_freq && !stat)
+		if (info.source in Friends)
 			speech_buffer = list()
-			speech_buffer += speaker
-			speech_buffer += lowertext(html_decode(message))
+			speech_buffer += info.source
+			speech_buffer += lowertext(html_decode(info.getMsg()))

--- a/code/modules/research/nanites/nanite_programmer.dm
+++ b/code/modules/research/nanites/nanite_programmer.dm
@@ -131,8 +131,8 @@
 				program.timer_trigger_delay = timer
 			. = TRUE
 
-/obj/machinery/nanite_programmer/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
+/obj/machinery/nanite_programmer/Hear(datum/spoken_info/info)
 	. = ..()
 	var/static/regex/when = regex("(?:^\\W*when|when\\W*$)", "i") //starts or ends with when
-	if(findtext(raw_message, when) && !istype(speaker, /obj/machinery/nanite_programmer))
+	if(findtext(info.raw_message, when) && !istype(info.source, /obj/machinery/nanite_programmer))
 		say("When you code it!!")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -346,6 +346,7 @@
 #include "code\datums\shuttles.dm"
 #include "code\datums\soullink.dm"
 #include "code\datums\spawners_menu.dm"
+#include "code\datums\spoken_info.dm"
 #include "code\datums\verbs.dm"
 #include "code\datums\weakrefs.dm"
 #include "code\datums\world_topic.dm"


### PR DESCRIPTION
## About The Pull Request

This pull request merges all possible Hear()(and alike) proc arguments into a single instance, which then can be passed anywhere, and changed from any point for every (next) hearer.

I am heavily doubtful about whether this is really needed, but with this I could then make "memes" that influence the way people perceive all messages easily, and stuff like that.

!!! NB !!!
This PR is in heavy need of critique as to it's usefulness, and the way I achieve my goal.

TO-DO:
- [ ] Convert all places into the new system.
- [ ] Remove(?) all previous ways of "compiling" the message.

## Why It's Good For The Game

code improvements?
