### PR TITLE
hop moves from supply positions to service positions

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -29,13 +29,13 @@ GLOBAL_LIST_INIT(science_positions, list(
 
 
 GLOBAL_LIST_INIT(supply_positions, list(
-	"Head of Personnel",
 	"Quartermaster",
 	"Cargo Technician",
 	"Shaft Miner"))
 
 
 GLOBAL_LIST_INIT(service_positions, list(
+	"Head of Personnel",
 	"Bartender",
 	"Botanist",
 	"Cook",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this is one thing i forgot in my civillian service merge pr, qm already somewhat rules over supply while service doesn't have any authority figure, so i figured that moving hop to service would be neat

## Why It's Good For The Game

i dont think this actually does anything ingame but i'd classify hop more as service than supply

## Changelog
is it even needed

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
