### PR TITLE
Fixed bug in Tea Aspera leaves

### DIFF
--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -14,6 +14,7 @@
 	icon_dead = "tea-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/tea/astra)
+	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/toxin/teapowder = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/tea
 	seed = /obj/item/seeds/tea


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There was a missing line (line 17) that outlined what reagents are produced by dried Tea Aspera leaves when ground.  With the code added back, dried Tea Aspera will now produce 4% vitamins and 10% Tea Leaves in relation to their potency, which is in line with the stats I could find listed on the /tg/station wiki and the reagent list for the Tea Astera.

## Why It's Good For The Game

I suspect that the missing line was just an oversight.  Without it, Tea Aspera crops are literally worthless, and it would require botanists to mutate their plants to Tea Astera to produce any Tea Powder.  Without Tea Powder, many drinks and food items are uncraftable.  Fixing this bug would restore these options.

## Changelog
:cl:
add: reagant_add line to line 17, allowing Tea Aspera to produce tea powder and vitamins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
