### PR TITLE
Fixes F.R.A.M.E. cartridge, and minor refactor.

### DIFF
--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -101,6 +101,7 @@
 			hidden_uplink.hidden_crystals += hidden_uplink.telecrystals //Temporarially hide the PDA's crystals, so you can't steal telecrystals.
 		hidden_uplink.telecrystals = telecrystals
 		telecrystals = 0
+		hidden_uplink.locked = FALSE
 		hidden_uplink.active = TRUE
 	else
 		to_chat(U, "<span class='alert'>PDA not found.</span>")

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -105,3 +105,14 @@
 		hidden_uplink.active = TRUE
 	else
 		to_chat(U, "<span class='alert'>PDA not found.</span>")
+		
+/obj/item/cartridge/virus/frame/attackby(obj/item/I, mob/user, params)
+	. = ..()
+	if(istype(I, /obj/item/stack/telecrystal))
+		if(!charges)
+			to_chat(user, "<span class='notice'>[src] is out of charges, it's refusing to accept [I].</span>")
+			return
+		var/obj/item/stack/telecrystal/telecrystalStack = I
+		telecrystals += telecrystalStack.amount
+		to_chat(user, "<span class='notice'>You slot [telecrystalStack] into [src]. The next time it's used, it will also give telecrystals.</span>")
+		telecrystalStack.use(telecrystalStack.amount)

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -21,19 +21,6 @@
 	else
 		return ..()
 
-/obj/item/stack/telecrystal/afterattack(obj/item/I, mob/user, proximity)
-	. = ..()
-	if(!proximity)
-		return
-	if(istype(I, /obj/item/cartridge/virus/frame))
-		var/obj/item/cartridge/virus/frame/cart = I
-		if(!cart.charges)
-			to_chat(user, "<span class='notice'>[cart] is out of charges, it's refusing to accept [src].</span>")
-			return
-		cart.telecrystals += amount
-		use(amount)
-		to_chat(user, "<span class='notice'>You slot [src] into [cart]. The next time it's used, it will also give telecrystals.</span>")
-
 /obj/item/stack/telecrystal/five
 	amount = 5
 


### PR DESCRIPTION
## About The Pull Request

The F.R.A.M.E. Cartridge now properly unlocks the target PDA, as expected.

Also slightly organizes the code, so that the F.R.A.M.E. cartridge handles telecrystal insertion, rather than the telecrystals.

## Why It's Good For The Game

The cartridge was always intended to make the target's PDA unlocked.  It did originally, then it broke with a revamp, requiring physical access to the PDA to actually frame a person.

Also organizes the code a little.

## Changelog
:cl:
fix: The F.R.A.M.E. cartridge once again creates an unlocked uplink.
/:cl: