### PR TITLE
Fixes bug with malf AI camera upgrade module

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -727,7 +727,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 	unlock_sound = 'sound/items/rped.ogg'
 
 /datum/AI_Module/upgrade/upgrade_cameras/upgrade(mob/living/silicon/ai/AI)
-	AI.see_override = SEE_INVISIBLE_MINIMUM //Night-vision, without which X-ray would be very limited in power.
+	AI.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE //Night-vision, without which X-ray would be very limited in power.
 	AI.update_sight()
 
 	var/upgraded_cameras = 0


### PR DESCRIPTION
## About The Pull Request

Changes a see_invisible value that was being adjusted to be a lighting_alpha value that is adjusted when a malf AI uses the camera upgrades so that it no longer effectively blinds them.

The lighting_alpha value is the same value that nightvision goggles use, so players should be familiar with how things look with it, so that they will still be able to discern lighting levels in an area.


## Why It's Good For The Game

This is what it looks like when a malf AI upgrades their cameras, ruining the round for them.
![image](https://user-images.githubusercontent.com/51932756/77726042-a15d4300-6fbc-11ea-8682-5d7fd86a9132.png)

Here's what it looks like with this change
![image](https://user-images.githubusercontent.com/51932756/77726147-db2e4980-6fbc-11ea-9cc2-7378e5867e74.png)



## Changelog
:cl:
fix: Malfunctioning AIs will no longer be effectively blinded when choosing to use the camera upgrade module.
/:cl: