### PR TITLE
Chapel Equality! Improves the chapel on all maps

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12071,12 +12071,7 @@
 /area/chapel/main)
 "aFA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/computer/pod/old{
-	density = 0;
-	icon = 'icons/obj/airlock_machines.dmi';
-	icon_state = "airlock_control_standby";
-	id = "chapelgun";
-	name = "Mass Driver Controller";
+/obj/machinery/computer/pod/wall{
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/dark,
@@ -13868,6 +13863,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/item/soulstone/anybody/chaplain,
+/obj/item/book/granter/spell/smoke/lesser{
+	name = "mysterious old book of cloud-chasing"
+	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "aJN" = (
@@ -13919,6 +13918,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/item/organ/heart,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "aJV" = (
@@ -16172,8 +16172,9 @@
 	},
 /area/chapel/main)
 "aQw" = (
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/dark,
+/obj/structure/altar_of_gods,
+/obj/item/storage/book/bible,
+/turf/open/floor/carpet,
 /area/chapel/main)
 "aQx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -109367,9 +109367,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "ebi" = (
-/obj/structure/table/wood/fancy,
 /obj/item/storage/book/bible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "ebj" = (
@@ -110468,6 +110468,7 @@
 /obj/item/nullrod,
 /obj/item/organ/heart,
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
+/obj/item/soulstone/anybody/chaplain,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "edn" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -364,6 +364,9 @@
 /obj/machinery/camera{
 	c_tag = "Civilian - Chapel Cremator"
 	},
+/obj/item/book/granter/spell/smoke/lesser{
+	name = "mysterious old book of cloud-chasing"
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aaV" = (
@@ -1360,8 +1363,8 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "adu" = (
-/obj/structure/table/wood,
 /obj/item/storage/book/bible,
+/obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
@@ -1529,11 +1532,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "adR" = (
-/obj/machinery/button/massdriver{
-	id = "chapelgun";
-	pixel_x = 8;
-	pixel_y = 24
-	},
 /obj/structure/table/wood,
 /obj/structure/sign/plaques/kiddie/badger{
 	pixel_x = -32
@@ -1549,6 +1547,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Chapel Mass Driver"
+	},
+/obj/machinery/computer/pod/wall{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -2553,6 +2554,7 @@
 "agq" = (
 /obj/structure/table/wood,
 /obj/item/storage/book/bible,
+/obj/item/organ/heart,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "agr" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -14251,7 +14251,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "awA" = (
-/obj/structure/table/wood/fancy,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -14263,15 +14262,12 @@
 	dir = 4
 	},
 /obj/item/storage/book/bible{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/item/storage/book/bible{
 	pixel_y = 2
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "awB" = (
@@ -47212,6 +47208,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/computer/pod/wall{
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "bsT" = (
@@ -47322,15 +47321,17 @@
 /area/chapel/office)
 "bta" = (
 /obj/structure/table/wood/fancy,
-/obj/item/book/granter/spell/smoke/lesser{
-	pixel_y = 4
-	},
 /obj/item/nullrod{
 	pixel_x = 4;
 	pixel_y = 4
 	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/item/soulstone/anybody/chaplain,
+/obj/item/organ/heart,
+/obj/item/book/granter/spell/smoke/lesser{
+	name = "mysterious old book of cloud-chasing"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -47366,12 +47367,6 @@
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
-	},
-/obj/machinery/button/massdriver{
-	id = "chapelgun";
-	name = "Chapel Mass Driver";
-	pixel_x = -24;
-	pixel_y = -24
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -47414,10 +47409,6 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
-/area/chapel/office)
-"btg" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
 /area/chapel/office)
 "bth" = (
 /obj/effect/turf_decal/tile/red,
@@ -116278,7 +116269,7 @@ adQ
 akf
 cAU
 aWG
-btg
+aWG
 aTb
 aNu
 aNu

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -63081,7 +63081,7 @@
 /area/chapel/main)
 "cQG" = (
 /obj/item/storage/book/bible,
-/obj/structure/table/wood,
+/obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "cQH" = (
@@ -63572,12 +63572,6 @@
 /obj/item/reagent_containers/food/snacks/grown/harebell,
 /obj/item/reagent_containers/food/snacks/grown/harebell,
 /obj/item/reagent_containers/food/snacks/grown/harebell,
-/obj/machinery/button/massdriver{
-	id = "chapelgun";
-	name = "Chapel Mass Driver";
-	pixel_x = -4;
-	pixel_y = -26
-	},
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -63588,6 +63582,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/computer/pod/wall{
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -46436,6 +46436,10 @@
 /obj/structure/table/wood/fancy,
 /obj/item/folder,
 /obj/item/pen,
+/obj/item/book/granter/spell/smoke/lesser{
+	name = "mysterious old book of cloud-chasing"
+	},
+/obj/item/organ/heart,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cru" = (
@@ -46503,6 +46507,7 @@
 "crD" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/box/bodybags,
+/obj/item/soulstone/anybody/chaplain,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "crE" = (
@@ -47821,9 +47826,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/button/massdriver{
-	id = "chapelgun";
-	pixel_x = 28
+/obj/machinery/computer/pod/wall{
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -51263,6 +51267,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "hYm" = (

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -131,3 +131,11 @@
 /obj/machinery/computer/pod/old/swf
 	name = "\improper Magix System IV"
 	desc = "An arcane artifact that holds much magic. Running E-Knock 2.2: Sorcerer's Edition."
+
+/obj/machinery/computer/pod/wall
+	icon = 'icons/obj/airlock_machines.dmi'
+	icon_state = "airlock_control_standby"
+	density = FALSE
+	icon_screen = null
+	icon_keyboard = null
+	id = "chapelgun"

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -138,4 +138,5 @@
 	density = FALSE
 	icon_screen = null
 	icon_keyboard = null
+	req_access = list(ACCESS_CHAPEL_OFFICE)
 	id = "chapelgun"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

replaces all chapel mass driver buttons with wall mounted mass driver consoles from boxstation
all chapels now share the same loot as meta, rod, shard, smoke, water and heart
the altar of gods no longer has to be ahelped to get, @ExcessiveUseOfCobblestone didnt want to put it in because of map conflicts i think so now the chance to add it

## Why It's Good For The Game

more fun for chaplains to not be limited in what they can do based on what map they are on
also altar of gods is an unused mechanic so it should be mapped somewhere

## Changelog
:cl:
add: The altar of gods is now available on all maps!
tweak: Chapel mass driver buttons have been replaced with wall mounted consoles, the loot in all chapels is now the same as meta loot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
