### PR TITLE
Boxstation Firelocks Electric Boogaloo

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12469,18 +12469,6 @@
 /obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"aGt" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"aGu" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aGv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -14509,10 +14497,6 @@
 "aLE" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aLF" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "aLG" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/port";
@@ -14618,7 +14602,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aLT" = (
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -15059,13 +15042,6 @@
 /area/hallway/primary/port)
 "aNl" = (
 /obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
-"aNp" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aNq" = (
@@ -15551,13 +15527,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aOC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "aOD" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=QM";
@@ -20996,13 +20965,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"bdx" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bdy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29925,25 +29887,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"bAN" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bAO" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bAP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bAR" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/rxglasses,
@@ -71686,9 +71629,9 @@ vyA
 aHz
 aIS
 aKn
-aLF
-aLF
-aLF
+aLE
+aLE
+aLE
 aPz
 aQL
 aSg
@@ -79911,8 +79854,8 @@ aHL
 aJi
 aKB
 aLT
-aNp
-aOC
+aMS
+aOz
 aPQ
 nTU
 aTL
@@ -84532,7 +84475,7 @@ azZ
 azZ
 azZ
 azZ
-aGt
+azZ
 aHQ
 aJr
 aJq
@@ -84569,7 +84512,7 @@ bwa
 bAg
 bBq
 bCu
-bAO
+bFd
 bFd
 bFd
 bFj
@@ -84789,7 +84732,7 @@ anz
 anz
 anz
 anz
-apj
+anz
 aHP
 aJq
 aJq
@@ -84826,7 +84769,7 @@ bvW
 bAf
 bBp
 aHP
-bAN
+bQg
 bQg
 bQg
 bFh
@@ -85046,7 +84989,7 @@ aBu
 aAa
 aAa
 aAa
-aGu
+aAa
 aHR
 aJt
 aJq
@@ -85083,7 +85026,7 @@ bwh
 bAh
 bBs
 bzG
-bAP
+bFq
 bCp
 bDp
 bFq
@@ -89688,9 +89631,9 @@ aXi
 aQc
 baa
 aJC
-bcq
-bcq
-bcq
+aYV
+aYV
+aYV
 bfF
 nQI
 bio
@@ -103566,9 +103509,9 @@ aXz
 aZg
 aFz
 bbF
-bcq
-bdx
-bcq
+aYV
+aXq
+aYV
 bgc
 bgc
 biX


### PR DESCRIPTION
Does the same thing as my last PR https://github.com/tgstation/tgstation/pull/49949 but only the firelock portion of it. 

Removes the double firelocks in the: arrivals, sec , escape, engineering, and medical/bar hallways. (central hallway apc not moved)

![1](https://user-images.githubusercontent.com/8175582/77794629-765d0880-7029-11ea-81eb-956b70444134.png)
![2](https://user-images.githubusercontent.com/8175582/77794630-76f59f00-7029-11ea-9dfc-912a8a9948f0.png)
![3](https://user-images.githubusercontent.com/8175582/77794633-76f59f00-7029-11ea-9cde-46b775981e58.png)
![4](https://user-images.githubusercontent.com/8175582/77794636-778e3580-7029-11ea-8982-9fb1d40a83af.png)
![5](https://user-images.githubusercontent.com/8175582/77794637-778e3580-7029-11ea-82e0-0dac6a829f4c.png)

