### PR TITLE
Fixes the spray bottle suicide

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -180,7 +180,7 @@
 			return SHAME
 	else
 		user.visible_message("<span class='suicide'>[user] decided life was worth living.</span>")
-		return
+		return MANUAL_SUICIDE_NONLETHAL
 
 //spray tan
 /obj/item/reagent_containers/spray/spraytan


### PR DESCRIPTION
## About The Pull Request

Starting a suicide attempt with a spray bottle, then aborting it partway through because you had a revelation and decided that life was worth living after all currently causes you to commit suicide anyway.

Basically, because the spray bottle suicide was just returning 0 if it got interrupted instead of something like MANUAL_SUICIDE_NONLETHAL, the suicide verb would think that the spray bottle suicide had failed to kill you because the spray bottle had no unique suicide, and so it would cause your character to perform one of the generic/unarmed suicides immediately after their spray bottle suicide got interrupted.

This PR fixes that issue.

## Why It's Good For The Game

h

## Changelog
:cl: ATHATH
fix: Starting a suicide attempt with a spray bottle, then aborting it partway through because you had a revelation and decided that life was worth living after all no longer causes you to commit suicide anyway.
/:cl:
