### PR TITLE
Fix runtime on cable bridge mapload initialization

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -558,17 +558,18 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 	anchored = TRUE
 	obj_flags = CAN_BE_HIT | ON_BLUEPRINTS
 
-/obj/structure/cable_bridge/Initialize()
+/obj/structure/cable_bridge/Initialize(mapload)
 	. = ..()
-	var/first = TRUE
-	var/datum/powernet/PN
-	for(var/obj/structure/cable/C in get_turf(src))
-		C.update_icon()
-		if(first == TRUE)
-			first = FALSE
-			PN = C.powernet
-			continue
-		propagate_network(C, PN)
+	if (!mapload)
+		var/first = TRUE
+		var/datum/powernet/PN
+		for(var/obj/structure/cable/C in get_turf(src))
+			C.update_icon()
+			if(first == TRUE)
+				first = FALSE
+				PN = C.powernet
+				continue
+			propagate_network(C, PN)
 
 /obj/structure/cable_bridge/wirecutter_act(mob/living/user, obj/item/I)
 	. = ..()


### PR DESCRIPTION
Mapped cable bridges runtime on init because the cables don't have powernets yet.

Cable powernets will flow through the bridge when they init the because it is present; no need to manually link the nets in this case.

There is still a bug where deleting cable bridges does not split powernets, but I'm not sure how best to fix it.