### PR TITLE
Adds the ability for players to craft sign backings.

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -80,6 +80,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("light fixture frame", /obj/item/wallframe/light_fixture, 2), \
 	new/datum/stack_recipe("small light fixture frame", /obj/item/wallframe/light_fixture/small, 1), \
 	null, \
+	new/datum/stack_recipe("sign backing", /obj/item/sign_backing, 2), \
 	new/datum/stack_recipe("apc frame", /obj/item/wallframe/apc, 2), \
 	new/datum/stack_recipe("air alarm frame", /obj/item/wallframe/airalarm, 2), \
 	new/datum/stack_recipe("fire alarm frame", /obj/item/wallframe/firealarm, 2), \

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -46,7 +46,7 @@
 			qdel(src)
 		return
 	else if(istype(I, /obj/item/pen) && buildable_sign)
-		var/list/sign_types = list("Secure Area", "Biohazard", "High Voltage", "Radiation", "Hard Vacuum Ahead", "Disposal: Leads To Space", "Danger: Fire", "No Smoking", "Medbay", "Science", "Chemistry", \
+		var/list/sign_types = list("Secure Area", "Biohazard", "High Voltage", "Radiation", "Hard Vacuum Ahead", "Disposal: Leads To Space", "Danger: Fire", "No Smoking", "Medbay", "Psychology", "Science", "Chemistry", \
 		"Hydroponics", "Xenobiology", "Test Chamber","Firing Range", "Extreme Cold", "Extreme Heat", "Gas Mask", "Nanites Lab", "Maintenance", "Reactive Chemicals")
 		var/obj/structure/sign/sign_type
 		switch(input(user, "Select a sign type.", "Sign Customization") as null|anything in sortList(sign_types))
@@ -82,6 +82,8 @@
 				sign_type = /obj/structure/sign/warning/chemdiamond
 			if("Medbay")
 				sign_type = /obj/structure/sign/departments/medbay/alt
+			if("Psychology")
+				sign_type = /obj/structure/sign/departments/psychology
 			if("Science")
 				sign_type = /obj/structure/sign/departments/science
 			if("Chemistry")

--- a/code/game/objects/structures/signs/signs_departments.dm
+++ b/code/game/objects/structures/signs/signs_departments.dm
@@ -90,6 +90,7 @@
 	name = "\improper NANITE LAB"
 	desc = "A sign labelling an area where testing and development of nanites is performed."
 	icon_state = "nanites"
+	
 /obj/structure/sign/departments/psychology
 	name = "\improper PSYCHOLOGY"
 	desc = "A sign labelling where the Psychologist works, they can probably help you get your head straight."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For some reason, sign backings (obj\item\sign_backing) have been in the code for god only knows how long, and there's even a fancy feature where you can use a pen to label a new sign backing or relabel an existing sign to a list of various department and other assorted signs. This PR allows you to craft new sign backings using a stack of at least two metal sheets in hand, and adds them to the stack crafting section with APC, air alarm, fire alarm, and button frames. Again, for whatever reason, crafting these was previously seemingly impossible.

So now you can simply craft one with two metal sheets, stick it on a wall, use a pen on it, and tah dah! Your very own sign. You can make it a medbay sign, a sec sign, a biohazard sign, a maint sign, anything your heart desires. Great for autism projects, fun roleplay rooms, and repairing cosmetic features of departments after big booms and fires.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Signs are fun.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the ability to craft sign backings using metal in hand. Once made and placed on a wall, use a pen on them to choose from various existing departmental, warning, etc sign designs.
tweak: Added the Psychology department sign to _signs.dm, so you can now change new or existing signs with a pen to Psychology signs, if you want.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
