### PR TITLE
The shuttle can no longer leave while the nuke is going off

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -425,6 +425,7 @@
 			S.switch_mode_to(TRACK_INFILTRATOR)
 		countdown.start()
 		set_security_level("delta")
+		SSshuttle.registerHostileEnvironment(src)
 	else
 		detonation_timer = null
 		set_security_level(previous_level)
@@ -432,6 +433,7 @@
 			S.switch_mode_to(initial(S.mode))
 			S.alert = FALSE
 		countdown.stop()
+		SSshuttle.clearHostileEnvironment(src)
 	update_icon()
 
 /obj/machinery/nuclearbomb/proc/get_time_left()


### PR DESCRIPTION
## About The Pull Request

It's dumb that every other delta event doesn't let you leave. Nukies would greentext anyway, it's just a more satisfying conclusion this way

## Why It's Good For The Game

This ones for that 2am loneop on manuel yesterday

## Changelog
:cl:
fix: Due to captains choosing to abandon ship during nuclear detonations, Nanotransen has installed their shuttles with patented ensurethecaptaingoesdownwithhisship(tm) engine clamps. Stop that nuke, lazy!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
