### PR TITLE
[APRIL FOOLS] Adds ultra-moths as a roundstart race

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -20,6 +20,7 @@
 #define RACEMUT		/datum/mutation/human/race
 #define BADSIGHT	/datum/mutation/human/nearsight
 #define LASEREYES	/datum/mutation/human/laser_eyes
+#define LASEREYESNOBLIND /datum/mutation/human/laser_eyes/noblind
 #define CHAMELEON	/datum/mutation/human/chameleon
 #define WACKY		/datum/mutation/human/wacky
 #define MUT_MUTE	/datum/mutation/human/mute

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -296,6 +296,7 @@
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4)	// By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism
 
 // Eye protection
+#define FLASH_PROTECTION_ULTRAMOTH -10
 #define FLASH_PROTECTION_SENSITIVE -1
 #define FLASH_PROTECTION_NONE 0
 #define FLASH_PROTECTION_FLASH 1

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -76,6 +76,7 @@
 	text_gain_indication = "<span class='notice'>You feel pressure building up behind your eyes.</span>"
 	layer_used = FRONT_MUTATIONS_LAYER
 	limb_req = BODY_ZONE_HEAD
+	var/requires_sight = FALSE //can you fire lasers with this mutation while blind?
 
 /datum/mutation/human/laser_eyes/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
 	..()
@@ -101,6 +102,8 @@
 /datum/mutation/human/laser_eyes/proc/on_ranged_attack(mob/living/carbon/human/source, atom/target, mouseparams)
 	if(source.a_intent != INTENT_HARM)
 		return
+	if(requires_sight && source.is_blind())
+		return
 	to_chat(source, "<span class='warning'>You shoot with your laser eyes!</span>")
 	source.changeNext_move(CLICK_CD_RANGE)
 	source.newtonian_move(get_dir(target, source))
@@ -110,6 +113,9 @@
 	LE.preparePixelProjectile(target, source, mouseparams)
 	LE.fire()
 	playsound(source, 'sound/weapons/taser2.ogg', 75, TRUE)
+
+/datum/mutation/human/laser_eyes/noblind
+	requires_sight = TRUE
 
 ///Projectile type used by laser eyes
 /obj/projectile/beam/laser_eyes

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -61,3 +61,14 @@
 		var/datum/gas_mixture/current = H.loc.return_air()
 		if(current && (current.return_pressure() >= ONE_ATMOSPHERE*0.85)) //as long as there's reasonable pressure and no gravity, flight is possible
 			return TRUE
+
+/datum/species/moth/ultra
+	name = "Ultra-Mothman"
+	mutanteyes = /obj/item/organ/eyes/moth/ultra
+	changesource_flags = MIRROR_BADMIN //admin-only
+
+/datum/species/moth/ultra/check_roundstart_eligible()
+	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS]) //... unless it's Aprils Fools' Day
+		return TRUE
+	return ..()
+

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -615,7 +615,9 @@
 
 /datum/reagent/medicine/oculine/on_mob_life(mob/living/carbon/M)
 	var/obj/item/organ/eyes/eyes = M.getorganslot(ORGAN_SLOT_EYES)
-	if (!eyes)
+	if(!eyes)
+		return
+	if(!eyes.oculine_compatible)
 		return
 	eyes.applyOrganDamage(-2)
 	if(HAS_TRAIT_FROM(M, TRAIT_BLIND, EYE_DAMAGE))
@@ -624,7 +626,6 @@
 			M.cure_blind(EYE_DAMAGE)
 			M.cure_nearsighted(EYE_DAMAGE)
 			M.blur_eyes(35)
-
 	else if(HAS_TRAIT_FROM(M, TRAIT_NEARSIGHT, EYE_DAMAGE))
 		to_chat(M, "<span class='warning'>The blackness in your peripheral vision fades.</span>")
 		M.cure_nearsighted(EYE_DAMAGE)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -30,6 +30,7 @@
 	var/lighting_alpha
 	var/no_glasses
 	var/damaged	= FALSE	//damaged indicates that our eyes are undergoing some level of negative effect
+	var/oculine_compatible = TRUE //can oculine heal these eyes?
 
 /obj/item/organ/eyes/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE, initialising)
 	. = ..()
@@ -379,6 +380,38 @@
 	name = "moth eyes"
 	desc = "These eyes seem to have increased sensitivity to bright light, with no improvement to low light vision."
 	flash_protect = FLASH_PROTECTION_SENSITIVE
+
+/obj/item/organ/eyes/moth/ultra
+	name = "ultra-moth eyes" //for the admin/April Fools Day-only ultra-moth race
+	desc = "These incredibly delicate eyes are incredibly sensitive to bright light (and damage in general) and can't be healed by oculine, but can shoot lasers if functional."
+	flash_protect = FLASH_PROTECTION_ULTRAMOTH //these have a flash_protect of -10; you are FUCKED if you get flashed or eyestabbed
+	high_threshold_passed = "<span class='userdanger'>HOLY SHIT YOUR RETINAS ARE FUCKING GONE OH GOD THE PAIN</span>" //the lack of punctuation is intentional
+	oculine_compatible = FALSE //you can't just cheese these by chugging 500u of oculine
+
+/obj/item/organ/eyes/moth/ultra/applyOrganDamage(d, maximum = maxHealth)
+	if(d > 0)
+		d = 100 //any amount of organ damage to your eyes will be turned into enough damage to blind you
+		if(owner && !owner.is_blind())
+			owner.emote("scream")
+			owner.apply_damage(10, BURN, BODY_ZONE_HEAD) //the pain is so great that your eyes literally burn (yes, even if you get eyestabbed)
+			owner.Paralyze(rand(80,120)) //same length as a stun from a handheld flash
+			owner.say("AAAAAAHHHHH!! MY RETINAS, MY PRECIOUS RETINAS!!", forced = "ultra-moth eyes") //I debated whether or not to make this make you say "MY EYES!! MY EYES!!" as a Spongebob reference, but I eventually went with this because I thought it was funnier
+	..()
+
+/obj/item/organ/eyes/moth/ultra/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
+	. = ..()
+	if(M.dna)
+		M.dna.add_mutation(LASEREYESNOBLIND) //even plasmamen and such should be allowed to have this mutation if they get ulta-moth eyes implanted in them
+
+/obj/item/organ/eyes/moth/ultra/Remove(mob/living/carbon/M, special = FALSE)
+	. = ..()
+	if(M.dna)
+		M.dna.remove_mutation(LASEREYESNOBLIND)
+
+/obj/item/organ/eyes/moth/ultra/Destroy()
+	if(owner.dna)
+		owner.dna.remove_mutation(LASEREYESNOBLIND)
+	return ..()
 
 /obj/item/organ/eyes/snail
 	name = "snail eyes"


### PR DESCRIPTION
## About The Pull Request

During the April Fools' Day holiday period, ultra-moths will be available as a roundstart race. Outside of the April Fools' Day holiday, admins can spawn them in, but wizard mirrors, pride mirrors, mutation toxins, etc. can't turn you into an ultra-moth.

Ultra-moths are like normal moths, except they start the round with ulta-moth eyes, which are even more sensitive than normal moth eyes. The flash_protection value of a pair of ultra-moth eyes is -10, and any amount of eye damage dealt to a pair of ultra-moth eyes (even eye damage from, say, a handheld flash's AoE flash or a screwdriver's eyestab) will burn out their retinas, instantly ruining the ultra-moth eyes (resulting in permanent blindness unless medical treatment is received), dealing a bit of burn damage to their owner, and stunning their owner. A few funny messages are also sent when this happens.

Ultra-moth eyes can't be healed by oculine, but they can be healed by eye surgery, sensory restoration viruses, etc. I've added a special variable for that feature in case someone in the future wants to make robotic eyes immune to oculine or something (which I think is a bad idea, but hey, people will PR what they want to PR).

In exchange for all of these downsides, while inside of your head, ultra-moth eyes grant you access to a special subtype of the laser eyes mutation that doesn't let you fire lasers if you're blind.

## Why It's Good For The Game

https://youtu.be/ADkLBtSGKMo?t=7

## Changelog
:cl: ATHATH
add: Ultra-moths are now available as a roundstart race during the April Fools' Day holiday. They can shoot lasers from their eyes (while not blind), but they have a crippling weakness to flashes. Try them out!
/:cl: