### PR TITLE
Fixes plumbing stuff ROTATING

### DIFF
--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -196,7 +196,7 @@
 	var/new_demand_connects
 	var/new_supply_connects
 	var/new_dir = AM.dir
-	var/angle = 180 - dir2angle(new_dir)
+	var/angle = 270 - dir2angle(new_dir) //it's 270 because of the way ducts are oriented, sorry
 
 	if(new_dir == SOUTH)
 		demand_connects = initial(demand_connects)


### PR DESCRIPTION
Only took me about 5 hours to fix

closes #50190

:cl:
fix: Plumbing stuff shouldnt have misleading directions and CONSTANTLY SPIN EVERYWHERE
/:cl:

I have no idea why this started now, apparently the direction tracking was off by 90 degrees since the very beginning