### PR TITLE
fixes a mispelling in taste description for lean

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -919,7 +919,7 @@
 	description = "The drank that makes you go wheezy."
 	color = "#DE55ED"
 	quality = DRINK_NICE
-	taste_description = "purple and a hint of opiod."
+	taste_description = "purple and a hint of opioid."
 	glass_icon_state = "lean"
 	glass_name = "Lean"
 	glass_desc = "A drink that makes your life less miserable."


### PR DESCRIPTION

## About The Pull Request

It's nothing major, its just fixes a spelling mistake for the taste description. I accidentally put opoid instead of opioid. 

## Why It's Good For The Game

Just a minor fix, it just fixes a spelling mistake for lean.

## Changelog
:cl:
spellcheck: fixes a spelling mistake in taste description for lean
/:cl: