### PR TITLE
Mining and Service borgs now use a radial menu to choose their skins

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -139,46 +139,6 @@ GLOBAL_LIST_INIT(ai_core_display_screens, sortList(list(
 			input = pick(GLOB.ai_core_display_screens - "Random")
 		return "ai-[lowertext(input)]"
 
-GLOBAL_LIST_INIT(miner_robot_icons, sortList(list(
-	"Lavaland Miner",
-	"Asteroid Miner",
-	"Spider Miner")))
-
-/proc/resolve_miner_robot_icon(input)
-	if(!input || !(input in GLOB.miner_robot_icons))
-		return "miner"
-	else
-		switch(input)
-			if("Lavaland Miner")
-				return "miner"
-			if("Asteroid Miner")
-				return "minerOLD"
-			if("Spider Miner")
-				return "spidermin"
-
-GLOBAL_LIST_INIT(service_robot_icons, sortList(list(
-	"Waitress",
-	"Butler",
-	"Bro",
-	"Kent",
-	"Tophat")))
-
-/proc/resolve_service_robot_icon(input)
-	if(!input || !(input in GLOB.service_robot_icons))
-		return "service_m"
-	else
-		switch(input)
-			if("Waitress")
-				return "service_f"
-			if("Butler")
-				return "service_m"
-			if("Bro")
-				return "brobot"
-			if("Kent")
-				return "kent"
-			if("Tophat")
-				return "tophat"
-
 GLOBAL_LIST_INIT(security_depts_prefs, sortList(list(SEC_DEPT_RANDOM, SEC_DEPT_NONE, SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, SEC_DEPT_SCIENCE, SEC_DEPT_SUPPLY)))
 
 	//Backpacks

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -139,6 +139,46 @@ GLOBAL_LIST_INIT(ai_core_display_screens, sortList(list(
 			input = pick(GLOB.ai_core_display_screens - "Random")
 		return "ai-[lowertext(input)]"
 
+GLOBAL_LIST_INIT(miner_robot_icons, sortList(list(
+	"Lavaland Miner",
+	"Asteroid Miner",
+	"Spider Miner")))
+
+/proc/resolve_miner_robot_icon(input)
+	if(!input || !(input in GLOB.miner_robot_icons))
+		return "miner"
+	else
+		switch(input)
+			if("Lavaland Miner")
+				return "miner"
+			if("Asteroid Miner")
+				return "minerOLD"
+			if("Spider Miner")
+				return "spidermin"
+
+GLOBAL_LIST_INIT(service_robot_icons, sortList(list(
+	"Waitress",
+	"Butler",
+	"Bro",
+	"Kent",
+	"Tophat")))
+
+/proc/resolve_service_robot_icon(input)
+	if(!input || !(input in GLOB.service_robot_icons))
+		return "service_m"
+	else
+		switch(input)
+			if("Waitress")
+				return "service_f"
+			if("Butler")
+				return "service_m"
+			if("Bro")
+				return "brobot"
+			if("Kent")
+				return "kent"
+			if("Tophat")
+				return "tophat"
+
 GLOBAL_LIST_INIT(security_depts_prefs, sortList(list(SEC_DEPT_RANDOM, SEC_DEPT_NONE, SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, SEC_DEPT_SCIENCE, SEC_DEPT_SUPPLY)))
 
 	//Backpacks

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -227,6 +227,19 @@
 		R.hud_used.update_robot_modules_display()
 	SSblackbox.record_feedback("tally", "cyborg_modules", 1, R.module)
 
+/**
+  * check_menu: Checks if we are allowed to interact with a radial menu
+  *
+  * Arguments:
+  * * user The mob interacting with a menu
+  */
+/obj/item/robot_module/proc/check_menu(mob/user)
+	if(!istype(user))
+		return FALSE
+	if(user.incapacitated() || !user.Adjacent(src))
+		return FALSE
+	return TRUE
+
 /obj/item/robot_module/standard
 	name = "Standard"
 	basic_modules = list(
@@ -477,7 +490,7 @@
 		"Kent" = image(icon = R.icon, icon_state = "kent"),
 		"Tophat" = image(icon = R.icon, icon_state = "tophat")
 		))
-	var/service_robot_icon = show_radial_menu(R, R , service_icons, radius = 42, require_near = TRUE)
+	var/service_robot_icon = show_radial_menu(R, R , service_icons, custom_check = CALLBACK(src, .proc/check_menu, R), radius = 42, require_near = TRUE)
 	switch(service_robot_icon)
 		if("Waitress")
 			cyborg_base_icon = "service_f"
@@ -525,7 +538,7 @@
 		"Asteroid Miner" = image(icon = R.icon, icon_state = "minerOLD"),
 		"Spider Miner" = image(icon = R.icon, icon_state = "spidermin")
 		))
-	var/miner_robot_icon = show_radial_menu(R, R , miner_icons, radius = 42, require_near = TRUE)
+	var/miner_robot_icon = show_radial_menu(R, R , miner_icons, custom_check = CALLBACK(src, .proc/check_menu, R), radius = 42, require_near = TRUE)
 	switch(miner_robot_icon)
 		if("Lavaland Miner")
 			cyborg_base_icon = "miner"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -484,11 +484,11 @@
 /obj/item/robot_module/butler/be_transformed_to(obj/item/robot_module/old_module)
 	var/mob/living/silicon/robot/R = loc
 	var/list/service_icons = sortList(list(
-		"Waitress" = image(icon = R.icon, icon_state = "service_f"),
-		"Butler" = image(icon = R.icon, icon_state = "service_m"),
-		"Bro" = image(icon = R.icon, icon_state = "brobot"),
-		"Kent" = image(icon = R.icon, icon_state = "kent"),
-		"Tophat" = image(icon = R.icon, icon_state = "tophat")
+		"Waitress" = image(icon = 'icons/mob/robots.dmi', icon_state = "service_f"),
+		"Butler" = image(icon = 'icons/mob/robots.dmi', icon_state = "service_m"),
+		"Bro" = image(icon = 'icons/mob/robots.dmi', icon_state = "brobot"),
+		"Kent" = image(icon = 'icons/mob/robots.dmi', icon_state = "kent"),
+		"Tophat" = image(icon = 'icons/mob/robots.dmi', icon_state = "tophat")
 		))
 	var/service_robot_icon = show_radial_menu(R, R , service_icons, custom_check = CALLBACK(src, .proc/check_menu, R), radius = 42, require_near = TRUE)
 	switch(service_robot_icon)
@@ -534,9 +534,9 @@
 /obj/item/robot_module/miner/be_transformed_to(obj/item/robot_module/old_module)
 	var/mob/living/silicon/robot/R = loc
 	var/list/miner_icons = sortList(list(
-		"Lavaland Miner" = image(icon = R.icon, icon_state = "miner"),
-		"Asteroid Miner" = image(icon = R.icon, icon_state = "minerOLD"),
-		"Spider Miner" = image(icon = R.icon, icon_state = "spidermin")
+		"Lavaland Miner" = image(icon = 'icons/mob/robots.dmi', icon_state = "miner"),
+		"Asteroid Miner" = image(icon = 'icons/mob/robots.dmi', icon_state = "minerOLD"),
+		"Spider Miner" = image(icon = 'icons/mob/robots.dmi', icon_state = "spidermin")
 		))
 	var/miner_robot_icon = show_radial_menu(R, R , miner_icons, custom_check = CALLBACK(src, .proc/check_menu, R), radius = 42, require_near = TRUE)
 	switch(miner_robot_icon)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -470,24 +470,31 @@
 
 /obj/item/robot_module/butler/be_transformed_to(obj/item/robot_module/old_module)
 	var/mob/living/silicon/robot/R = loc
-
-	var/list/iconstates = GLOB.service_robot_icons
-	for(var/option in iconstates)
-		iconstates[option] = image(icon = R.icon, icon_state = resolve_service_robot_icon(option))
-
-	var/service_robot_icon = show_radial_menu(R, R , iconstates, radius = 42)
-	if(!service_robot_icon)
-		return FALSE
-
-	cyborg_base_icon = resolve_service_robot_icon(service_robot_icon)
-	switch(cyborg_base_icon)
-		if("tophat")
-			special_light_key = null
-			hat_offset = INFINITY //He is already wearing a hat
-		if("kent")
+	var/list/service_icons = sortList(list(
+		"Waitress" = image(icon = R.icon, icon_state = "service_f"),
+		"Butler" = image(icon = R.icon, icon_state = "service_m"),
+		"Bro" = image(icon = R.icon, icon_state = "brobot"),
+		"Kent" = image(icon = R.icon, icon_state = "kent"),
+		"Tophat" = image(icon = R.icon, icon_state = "tophat")
+		))
+	var/service_robot_icon = show_radial_menu(R, R , service_icons, radius = 42, require_near = TRUE)
+	switch(service_robot_icon)
+		if("Waitress")
+			cyborg_base_icon = "service_f"
+		if("Butler")
+			cyborg_base_icon = "service_m"
+		if("Bro")
+			cyborg_base_icon = "brobot"
+		if("Kent")
+			cyborg_base_icon = "kent"
 			special_light_key = "medical"
 			hat_offset = 3
-
+		if("Tophat")
+			cyborg_base_icon = "tophat"
+			special_light_key = null
+			hat_offset = INFINITY //He is already wearing a hat
+		else
+			return FALSE
 	return ..()
 
 /obj/item/robot_module/miner
@@ -513,19 +520,22 @@
 
 /obj/item/robot_module/miner/be_transformed_to(obj/item/robot_module/old_module)
 	var/mob/living/silicon/robot/R = loc
-
-	var/list/iconstates = GLOB.miner_robot_icons
-	for(var/option in iconstates)
-		iconstates[option] = image(icon = R.icon, icon_state = resolve_miner_robot_icon(option))
-
-	var/miner_robot_icon = show_radial_menu(R, R , iconstates, radius = 42)
-	if(!miner_robot_icon)
-		return FALSE
-
-	cyborg_base_icon = resolve_miner_robot_icon(miner_robot_icon)
-	if(cyborg_base_icon == "minerOLD")
-		special_light_key = "miner"
-
+	var/list/miner_icons = sortList(list(
+		"Lavaland Miner" = image(icon = R.icon, icon_state = "miner"),
+		"Asteroid Miner" = image(icon = R.icon, icon_state = "minerOLD"),
+		"Spider Miner" = image(icon = R.icon, icon_state = "spidermin")
+		))
+	var/miner_robot_icon = show_radial_menu(R, R , miner_icons, radius = 42, require_near = TRUE)
+	switch(miner_robot_icon)
+		if("Lavaland Miner")
+			cyborg_base_icon = "miner"
+		if("Asteroid Miner")
+			cyborg_base_icon = "minerOLD"
+			special_light_key = "miner"
+		if("Spider Miner")
+			cyborg_base_icon = "spidermin"
+		else
+			return FALSE
 	return ..()
 
 /obj/item/robot_module/miner/rebuild_modules()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -470,24 +470,24 @@
 
 /obj/item/robot_module/butler/be_transformed_to(obj/item/robot_module/old_module)
 	var/mob/living/silicon/robot/R = loc
-	var/borg_icon = input(R, "Select an icon!", "Robot Icon", null) as null|anything in sortList(list("Waitress", "Butler", "Tophat", "Kent", "Bro"))
-	if(!borg_icon)
+
+	var/list/iconstates = GLOB.service_robot_icons
+	for(var/option in iconstates)
+		iconstates[option] = image(icon = R.icon, icon_state = resolve_service_robot_icon(option))
+
+	var/service_robot_icon = show_radial_menu(R, R , iconstates, radius = 42)
+	if(!service_robot_icon)
 		return FALSE
-	switch(borg_icon)
-		if("Waitress")
-			cyborg_base_icon = "service_f"
-		if("Butler")
-			cyborg_base_icon = "service_m"
-		if("Bro")
-			cyborg_base_icon = "brobot"
-		if("Kent")
-			cyborg_base_icon = "kent"
-			special_light_key = "medical"
-			hat_offset = 3
-		if("Tophat")
-			cyborg_base_icon = "tophat"
+
+	cyborg_base_icon = resolve_service_robot_icon(service_robot_icon)
+	switch(cyborg_base_icon)
+		if("tophat")
 			special_light_key = null
 			hat_offset = INFINITY //He is already wearing a hat
+		if("kent")
+			special_light_key = "medical"
+			hat_offset = 3
+
 	return ..()
 
 /obj/item/robot_module/miner
@@ -513,17 +513,19 @@
 
 /obj/item/robot_module/miner/be_transformed_to(obj/item/robot_module/old_module)
 	var/mob/living/silicon/robot/R = loc
-	var/borg_icon = input(R, "Select an icon!", "Robot Icon", null) as null|anything in sortList(list("Lavaland Miner", "Asteroid Miner", "Spider Miner"))
-	if(!borg_icon)
+
+	var/list/iconstates = GLOB.miner_robot_icons
+	for(var/option in iconstates)
+		iconstates[option] = image(icon = R.icon, icon_state = resolve_miner_robot_icon(option))
+
+	var/miner_robot_icon = show_radial_menu(R, R , iconstates, radius = 42)
+	if(!miner_robot_icon)
 		return FALSE
-	switch(borg_icon)
-		if("Lavaland Miner")
-			cyborg_base_icon = "miner"
-		if("Asteroid Miner")
-			cyborg_base_icon = "minerOLD"
-			special_light_key = "miner"
-		if("Spider Miner")
-			cyborg_base_icon = "spidermin"
+
+	cyborg_base_icon = resolve_miner_robot_icon(miner_robot_icon)
+	if(cyborg_base_icon == "minerOLD")
+		special_light_key = "miner"
+
 	return ..()
 
 /obj/item/robot_module/miner/rebuild_modules()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes Mining and Service cyborgs use a radial menu to choose their module skin, instead of swimming in the input menu with no preview of how given skin even looks like.

Example image:

![RadialMining](https://user-images.githubusercontent.com/43862960/77956987-12f60380-72d3-11ea-9424-db0fa3b20647.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better cyborg skin choosing method.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
add: Mining and service borgs now use a radial menu to select their module skins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
