### PR TITLE
Fixes roundstart AT on Donutstation

### DIFF
--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -31540,7 +31540,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "bsj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -31600,7 +31600,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "bsp" = (
 /obj/structure/closet,
@@ -31701,7 +31701,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "bsz" = (
 /obj/effect/turf_decal/tile/bar,
@@ -31734,7 +31734,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "bsC" = (
 /obj/structure/closet/crate{
@@ -31764,7 +31764,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "bsF" = (
 /obj/effect/mapping_helpers/airlock_note_placer{

--- a/_maps/map_files/Donutstation/Donutstation_LVL2.dmm
+++ b/_maps/map_files/Donutstation/Donutstation_LVL2.dmm
@@ -4704,7 +4704,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/upper)
 "ko" = (
-/turf/open/openspace/airless,
+/turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "kp" = (
 /obj/machinery/light{
@@ -4716,7 +4716,7 @@
 	dir = 2;
 	network = list("AISat")
 	},
-/turf/open/openspace/airless,
+/turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "kq" = (
 /obj/structure/cable,
@@ -4747,7 +4747,7 @@
 	pixel_x = -32
 	},
 /obj/structure/lattice,
-/turf/open/openspace/airless,
+/turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "kt" = (
 /obj/machinery/porta_turret/ai,
@@ -4825,7 +4825,7 @@
 	pixel_x = 32
 	},
 /obj/structure/lattice,
-/turf/open/openspace/airless,
+/turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "kC" = (
 /obj/structure/cable,
@@ -4846,7 +4846,7 @@
 /area/ai_monitored/turret_protected/ai)
 "kE" = (
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless,
+/turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "kF" = (
 /turf/open/floor/circuit,
@@ -5184,7 +5184,7 @@
 	pixel_x = -32
 	},
 /obj/structure/lattice,
-/turf/open/openspace/airless,
+/turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "lj" = (
 /obj/machinery/porta_turret/ai,
@@ -5239,7 +5239,7 @@
 	pixel_x = 32
 	},
 /obj/structure/lattice,
-/turf/open/openspace/airless,
+/turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "lm" = (
 /obj/machinery/light{
@@ -5251,7 +5251,7 @@
 	dir = 2;
 	network = list("AISat")
 	},
-/turf/open/openspace/airless,
+/turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "ln" = (
 /obj/machinery/airalarm{
@@ -5274,7 +5274,7 @@
 	dir = 1;
 	network = list("AISat")
 	},
-/turf/open/openspace/airless,
+/turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "lq" = (
 /obj/machinery/light,
@@ -5284,7 +5284,7 @@
 	dir = 1;
 	network = list("AISat")
 	},
-/turf/open/openspace/airless,
+/turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "lr" = (
 /obj/machinery/camera/motion{
@@ -5338,13 +5338,12 @@
 /turf/open/openspace/airless,
 /area/space/nearstation)
 "lx" = (
-/obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Chamber Exterior South";
 	dir = 2;
 	network = list("AISat")
 	},
-/turf/open/openspace/airless,
+/turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "ly" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -20824,22 +20823,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"Ug" = (
-/obj/machinery/door/firedoor,
-/obj/structure/lattice/catwalk,
-/turf/open/openspace/airless,
-/area/hallway/primary/upper)
+"Tl" = (
+/turf/open/openspace/airless{
+	initial_gas_mix = "n2=100000;TEMP=293.15"
+	},
+/area/space/nearstation)
+"TU" = (
+/turf/open/openspace/airless{
+	initial_gas_mix = "o2=100000;TEMP=293.15"
+	},
+/area/space/nearstation)
+"Uu" = (
+/turf/open/openspace/airless{
+	initial_gas_mix = "n2o=6000;TEMP=293.15"
+	},
+/area/space/nearstation)
 "UI" = (
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"Vy" = (
-/obj/machinery/light{
-	dir = 8
+"Wl" = (
+/turf/open/openspace/airless{
+	initial_gas_mix = "plasma=70000;TEMP=293.15"
 	},
-/turf/open/openspace/airless,
-/area/hallway/primary/upper)
+/area/space/nearstation)
 "Ya" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -20851,9 +20859,11 @@
 /obj/structure/closet/secure_closet/exile,
 /turf/open/floor/plasteel,
 /area/gateway)
-"YH" = (
-/turf/open/openspace/airless,
-/area/hallway/primary/upper)
+"Yc" = (
+/turf/open/openspace/airless{
+	initial_gas_mix = "co2=50000;TEMP=293.15"
+	},
+/area/space/nearstation)
 "ZS" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/dark,
@@ -55520,7 +55530,7 @@ jQ
 ko
 jQ
 jQ
-cn
+be
 be
 ac
 mt
@@ -56034,7 +56044,7 @@ jQ
 ko
 jQ
 jQ
-cn
+be
 be
 ac
 mt
@@ -56501,9 +56511,9 @@ Bk
 Bk
 Bk
 eH
-aG
-aG
-aG
+Tl
+Tl
+Tl
 eH
 fY
 be
@@ -56758,9 +56768,9 @@ Bs
 Bs
 Bs
 Bt
-aG
-aG
-aG
+Tl
+Tl
+Tl
 eH
 fY
 be
@@ -57015,9 +57025,9 @@ Bq
 Bq
 Bq
 eH
-aG
-aG
-aG
+Tl
+Tl
+Tl
 eH
 fY
 be
@@ -57529,9 +57539,9 @@ Bk
 Bk
 Bk
 eH
-aG
-aG
-aG
+TU
+TU
+TU
 eH
 fY
 be
@@ -57786,9 +57796,9 @@ Bs
 Bs
 Bs
 Bt
-aG
-aG
-aG
+TU
+TU
+TU
 eH
 fY
 be
@@ -58043,9 +58053,9 @@ Bq
 Bq
 Bq
 eH
-aG
-aG
-aG
+TU
+TU
+TU
 eH
 fY
 be
@@ -60084,17 +60094,17 @@ Ax
 AH
 AR
 lZ
-aG
-aG
-aG
+Uu
+Uu
+Uu
 eH
-aG
-aG
-aG
+Wl
+Wl
+Wl
 eH
-aG
-aG
-aG
+Yc
+Yc
+Yc
 eH
 bd
 bd
@@ -60341,17 +60351,17 @@ Ay
 Ay
 Ay
 lZ
-aG
-aG
-aG
+Uu
+Uu
+Uu
 eH
-aG
-aG
-aG
+Wl
+Wl
+Wl
 eH
-aG
-aG
-aG
+Yc
+Yc
+Yc
 eH
 bd
 bd
@@ -60598,17 +60608,17 @@ Ay
 AI
 AS
 lZ
-aG
-aG
-aG
+Uu
+Uu
+Uu
 eH
-aG
-aG
-aG
+Wl
+Wl
+Wl
 eH
-aG
-aG
-aG
+Yc
+Yc
+Yc
 eH
 bd
 bd
@@ -61351,10 +61361,10 @@ lC
 lC
 bv
 bv
-Ug
-Ug
-YH
-YH
+hy
+hy
+fm
+fm
 tt
 dA
 fm
@@ -61607,10 +61617,10 @@ bd
 bd
 bd
 bv
-YH
-YH
-Ug
-Ug
+fm
+fm
+hy
+hy
 tj
 tN
 Hz
@@ -61864,10 +61874,10 @@ bd
 bd
 bd
 bv
-YH
-YH
-YH
-YH
+fm
+fm
+fm
+fm
 sm
 xF
 Rg
@@ -62121,10 +62131,10 @@ bd
 bv
 bv
 bv
-YH
-YH
-YH
-YH
+fm
+fm
+fm
+fm
 sm
 Hv
 bv
@@ -62376,12 +62386,12 @@ bd
 bd
 bd
 bv
-YH
-YH
-YH
-YH
-YH
-YH
+fm
+fm
+fm
+fm
+fm
+fm
 sm
 Hv
 bv
@@ -62633,12 +62643,12 @@ bd
 bd
 bv
 bv
-YH
-YH
-YH
-YH
-YH
-YH
+fm
+fm
+fm
+fm
+fm
+fm
 sm
 Hy
 bv
@@ -62889,11 +62899,11 @@ bd
 bd
 bv
 bv
-YH
-YH
-YH
-YH
-YH
+fm
+fm
+fm
+fm
+fm
 rX
 tc
 so
@@ -63145,12 +63155,12 @@ rF
 bv
 bv
 bv
-Vy
-YH
-YH
-YH
-YH
-YH
+lU
+fm
+fm
+fm
+fm
+fm
 sm
 xF
 Eb
@@ -63402,11 +63412,11 @@ aM
 fm
 fm
 fm
-YH
-YH
-YH
-YH
-YH
+fm
+fm
+fm
+fm
+fm
 rX
 so
 Hv
@@ -63659,10 +63669,10 @@ fm
 fm
 fm
 fm
-YH
-YH
-YH
-YH
+fm
+fm
+fm
+fm
 ry
 si
 Hs
@@ -63916,8 +63926,8 @@ fm
 fm
 fm
 fm
-YH
-YH
+fm
+fm
 ry
 qY
 rE


### PR DESCRIPTION
This by extent effectively doubles the amount of gas in the atmos tanks since the above openspace needs the same initial gas mix to prevent roundstart AT, but that probably isn't a big issue. Everything else was just bits I missed on my first pass-through and wouldn't of had any effects on a round.