### PR TITLE
laughter demons now use the honk demon sprite on april fools

### DIFF
--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -150,6 +150,11 @@
 	released and fully healed, because in the end it's just a jape, \
 	sibling!</B>"
 
+/mob/living/simple_animal/slaughter/laughter/Initialize()
+	. = ..()
+	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
+		icon_state = "honkmon"
+
 /mob/living/simple_animal/slaughter/laughter/Destroy()
 	release_friends()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

on april fools now laughter demons use the clown demon sprite
its basically a slaughter demon with a clown outfit

## Why It's Good For The Game

fun

## Changelog
:cl:
add: on april fools laughter demons embrace their clown nature to the fullest degree
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
