### PR TITLE
Remove multilayer cable hub coloring

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -625,15 +625,6 @@ GLOBAL_LIST(cable_radial_layer_list)
 	return
 
 /obj/structure/cable/multilayer/update_icon()
-	var/R = 50
-	var/G = 50
-	var/B = 50
-
-	R += cable_layer & CABLE_LAYER_1 ? 150 : 0
-	G += cable_layer & CABLE_LAYER_2 ? 150 : 0
-	B += cable_layer & CABLE_LAYER_3 ? 150 : 0
-
-	color = rgb(R, G, B)
 
 	machinery_node?.alpha = machinery_layer & MACHINERY_LAYER_1 ? 255 : 0
 	


### PR DESCRIPTION
## About The Pull Request

Remove hub color layer indication

## Why It's Good For The Game

i see it redundant after i add cable visualization

## Changelog
:cl:
del: Hub layer related coloring
/:cl: