### PR TITLE
Makes storage bags box-sized instead of bag-sized

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -18,7 +18,7 @@
 //  Generic non-item
 /obj/item/storage/bag
 	slot_flags = ITEM_SLOT_BELT
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/storage/bag/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Basically just https://github.com/tgstation/tgstation/pull/50292, but the bags are WEIGHT_CLASS_NORMAL now instead of WEIGHT_CLASS_BULKY.

## Why It's Good For The Game

I do agree that most bags being WEIGHT_CLASS_TINY/able to fit in your pocket(s) was kind of bullshit. However, I believe that https://github.com/tgstation/tgstation/pull/50292 went too far in making them bulky items. IMO, bags should be a niche alternative to boxes; you can store far more items in a bag than you can store in a box, but the list of what KINDS of items you can store in a bag is far more restrictive than the list of what kinds of items you can store in a box is.

## Changelog
:cl: ATHATH
balance: Most storage bags can be stored inside of backpacks again, but they're box-sized items now, not coin-sized items.
/:cl: