### PR TITLE
Fireman carry exploit fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1001,7 +1001,7 @@
 		//(Using your gloves' nanochips, you/You) ( /quickly/expertly) start to lift Grey Tider onto your back(, while assisted by the nanochips in your gloves../...)
 		if(do_after(src, carrydelay, TRUE, target))
 			//Second check to make sure they're still valid to be carried
-			if(can_be_firemanned(target) && !incapacitated(FALSE, TRUE))
+			if(can_be_firemanned(target) && !incapacitated(FALSE, TRUE) && !target.buckled)
 				buckle_mob(target, TRUE, TRUE, 90, 1, 0)
 				return
 		visible_message("<span class='warning'>[src] fails to fireman carry [target]!</span>")


### PR DESCRIPTION
## About The Pull Request

Makes you fail when attempting to fireman's carry someone when they are buckled to an object, so that you cannot get the off-hand placeholder item to enable unintended interactions.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/51932756/78323227-6dd76700-752e-11ea-8bec-ce24bc63cb1e.png)

No more long-range body throwing, people teleporting through bluespace to the individual with the off-hand placeholder to be slammed onto a table, or tabling without needing to regrab the individual

## Changelog
:cl:
fix: Attempting to fireman's carry someone that is buckled to an object will fail.
/:cl:
