### PR TITLE
Makes rapid service fabricators modular

### DIFF
--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -71,7 +71,6 @@ RSF
 	if(!user)
 		return
 	playsound(src.loc, 'sound/effects/pop.ogg', 50, FALSE)
-	var/list/item_list
 	var/atom/target = cost_by_item
 	var/cost = 0
 	//Warning, prepare for bodgecode
@@ -91,17 +90,19 @@ RSF
 	dispense_cost = cost
 	// Change mode
 
+///Extracts the related object from a associated list of objects and values, or lists and objects.
 /obj/item/rsf/proc/extractObject(from, input)
 	var/atom/test
 	if(istype(input, /list/))
-		var/temp = target[input]//If it's a list we should use its associated object
+		var/temp = from[input]//If it's a list we should use its associated object
 		test = new temp()
 	else
 		test = new input()
 	return test
 
+///Forms a radial menu based off an object in a list, or a list's associated object
 /obj/item/rsf/proc/formRadial(from)
-	radial_list = list()
+	var/list/radial_list = list()
 	for(var/meme in from)//We iterate through all of targets entrys
 		var/atom/test = extractObject(from, meme)
 		//We then add their data into the radial menu

--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -8,6 +8,7 @@ RSF
 	desc = "A device used to rapidly deploy service items."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rsf"
+	///The icon state to revert to when the tool is empty
 	var/spent_icon_state = "rsf_empty"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
@@ -16,20 +17,29 @@ RSF
 	anchored = FALSE
 	item_flags = NOBLUDGEON
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	///The current matter count
 	var/matter = 0
+	///The max amount of matter in the device
 	var/max_matter = 30
+	///The type of the object we are going to despense
 	var/to_despense
+	///The cost of the object we are going to despense
 	var/despense_cost = 0
 	w_class = WEIGHT_CLASS_NORMAL
+	///An associated list of atoms and charge costs. This can contain a seperate list, as long as it's associated item is an object
 	var/list/cost_by_item = list(/obj/item/reagent_containers/food/drinks/drinkingglass = 20,
 								/obj/item/paper = 10,
 								/obj/item/storage/pill_bottle/dice = 200,
 								/obj/item/pen = 50,
 								/obj/item/clothing/mask/cigarette = 10,
 								)
+	///An associated list of fuel and it's value
 	var/list/matter_by_item = list(/obj/item/rcd_ammo = 10,)
+	///A list of surfaces that we are allowed to place things on.
 	var/list/allowed_surfaces = list(/turf/open/floor, /obj/structure/table)
+	///The unit of mesure of the matter, for use in text
 	var/discriptor = "fabrication-units"
+	///The verb that describes what we're doing, for use in text
 	var/action_type = "Dispensing"
 
 /obj/item/rsf/Initialize()
@@ -44,17 +54,17 @@ RSF
 	matter = 30
 
 /obj/item/rsf/attackby(obj/item/W, mob/user, params)
-	if(is_type_in_list(W,matter_by_item))
+	if(is_type_in_list(W,matter_by_item))//If the thing we got hit by is in our matter list
 		if(matter > max_matter)
 			to_chat(user, "<span class='warning'>\The [src] can't hold any more [discriptor]!</span>")
 			return
 		qdel(W)
-		matter += matter_by_item[W.type]
+		matter += matter_by_item[W.type]//We add its value
 		if(matter > max_matter)
 			matter = max_matter
 		playsound(src.loc, 'sound/machines/click.ogg', 10, TRUE)
 		to_chat(user, "<span class='notice'>\The [src] now holds [matter]/[max_matter] [discriptor].</span>")
-		icon_state = initial(icon_state)
+		icon_state = initial(icon_state)//and set the icon state to the initial value it had
 	else
 		return ..()
 
@@ -65,32 +75,35 @@ RSF
 	var/list/item_list
 	var/atom/target = cost_by_item
 	var/cost = 0
-	while(istype(target, /list/))
+	//Warning, prepare for bodgecode
+	while(istype(target, /list/))//While target is a list we continue the loop
 		item_list = list()
-		for(var/meme in target)
+		for(var/meme in target)//We iterate through all of targets entrys
 			var/atom/test
 			if(istype(meme, /list/))//If it's a list let's use its associated object
 				var/temp = target[meme]
 				test = new temp()
 			else
 				test = new meme()
+			//We then add their data into the radial menu
 			item_list[test.name] = image(icon = test.icon, icon_state = test.icon_state)
 			qdel(test)
 		var/picked = show_radial_menu(user, src, item_list, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE)
 		if(!check_menu(user) || picked == null)
 			return
-		for(var/emem in target)
+		for(var/emem in target)//Back through target agian
 			var/atom/test
 			if(istype(emem, /list/))
 				var/temp = target[emem]//If it's a list we should use its associated object
 				test = new temp()
 			else
 				test = new emem()
-			if(picked == test.name)
-				cost = target[emem]
+			if(picked == test.name)//We try and find the entry that matches the radial selection
+				cost = target[emem]//We cash the cost
 				target = emem
 				break
 			qdel(test)
+		//If we found a list we start it all again, this time looking through its contents.
 	to_despense = target
 	despense_cost = cost
 	// Change mode
@@ -108,11 +121,12 @@ RSF
 		return
 	if(!is_allowed(A))
 		return
-	if(use_matter(despense_cost, user))
+	if(use_matter(despense_cost, user))//If we can charge that amount of charge, we do so and return true
 		playsound(src.loc, 'sound/machines/click.ogg', 10, TRUE)
 		var/atom/meme = new to_despense(get_turf(A))
 		to_chat(user, "<span class='notice'>[action_type] [meme.name]...</span>")
 
+///A helper proc. checks to see if we can afford the amount of charge that is passed, and if we can docs the charge from our base, and returns TRUE. If we can't we return FALSE
 /obj/item/rsf/proc/use_matter(charge, mob/user)
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/R = user
@@ -130,6 +144,7 @@ RSF
 	icon_state = spent_icon_state
 	return FALSE
 
+///Helper proc that iterates through all the things we are allowed to spawn on, and sees if the passed atom is one of them
 /obj/item/rsf/proc/is_allowed(atom/to_check)
 	for(var/sort in allowed_surfaces)
 		if(istype(to_check, sort))

--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -29,7 +29,7 @@ RSF
 								)
 	var/list/matter_by_item = list(/obj/item/rcd_ammo = 10,)
 	var/list/allowed_surfaces = list(/turf/open/floor, /obj/structure/table)
-	var/discriptor = "matter"
+	var/discriptor = "fabrication-units"
 	var/action_type = "Dispensing"
 
 /obj/item/rsf/Initialize()
@@ -139,15 +139,11 @@ RSF
 /obj/item/rsf/cookiesynth
 	name = "Cookie Synthesizer"
 	desc = "A self-recharging device used to rapidly deploy cookies."
-	icon = 'icons/obj/tools.dmi'
 	icon_state = "rcd"
 	spent_icon_state = "rcd"
-	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	var/toxin = FALSE
 	var/cooldown = 0
 	var/cooldowndelay = 10
-	w_class = WEIGHT_CLASS_NORMAL
 	max_matter = 10
 	cost_by_item = list(/obj/item/reagent_containers/food/snacks/cookie = 100,)
 	discriptor = "cookie-units"

--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -8,6 +8,7 @@ RSF
 	desc = "A device used to rapidly deploy service items."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rsf"
+	var/spent_icon_state = "rsf_empty"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	opacity = 0
@@ -18,14 +19,18 @@ RSF
 	var/matter = 0
 	var/max_matter = 30
 	var/to_despense
+	var/despense_cost = 0
 	w_class = WEIGHT_CLASS_NORMAL
 	var/list/cost_by_item = list(/obj/item/reagent_containers/food/drinks/drinkingglass = 20,
 								/obj/item/paper = 10,
-								/obj/item/pen = 50,
 								/obj/item/storage/pill_bottle/dice = 200,
+								/obj/item/pen = 50,
 								/obj/item/clothing/mask/cigarette = 10,
 								)
 	var/list/matter_by_item = list(/obj/item/rcd_ammo = 10,)
+	var/list/allowed_surfaces = list(/turf/open/floor, /obj/structure/table)
+	var/discriptor = "matter"
+	var/action_type = "Dispensing"
 
 /obj/item/rsf/Initialize()
 	. = ..()
@@ -33,7 +38,7 @@ RSF
 
 /obj/item/rsf/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>It currently holds [(matter/max_matter) * 100]% matter.</span>"
+	. += "<span class='notice'>It currently holds [matter]/[max_matter] [discriptor].</span>"
 
 /obj/item/rsf/cyborg
 	matter = 30
@@ -41,15 +46,15 @@ RSF
 /obj/item/rsf/attackby(obj/item/W, mob/user, params)
 	if(is_type_in_list(W,matter_by_item))
 		if(matter > max_matter)
-			to_chat(user, "<span class='warning'>The RSF can't hold any more matter!</span>")
+			to_chat(user, "<span class='warning'>\The [src] can't hold any more [discriptor]!</span>")
 			return
 		qdel(W)
 		matter += matter_by_item[W.type]
 		if(matter > max_matter)
 			matter = max_matter
 		playsound(src.loc, 'sound/machines/click.ogg', 10, TRUE)
-		to_chat(user, "<span class='notice'>The RSF now holds [(matter/max_matter) * 100]% matter.</span>")
-		icon_state = "rsf"
+		to_chat(user, "<span class='notice'>\The [src] now holds [matter]/[max_matter] [discriptor].</span>")
+		icon_state = initial(icon_state)
 	else
 		return ..()
 
@@ -57,15 +62,37 @@ RSF
 	if(!user)
 		return
 	playsound(src.loc, 'sound/effects/pop.ogg', 50, FALSE)
-	var/list/item_list = list()
-	for(var/meme in cost_by_item)
-		message_admins(meme)
-		var/atom/test = new meme()
-		item_list[test.name] = image(icon = test.icon, icon_state = test.icon_state)
-	var/atom/item_result = show_radial_menu(user, src, item_list, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE)
-	if(!check_menu(user))
-		return
-	to_despense = item_result
+	var/list/item_list
+	var/atom/target = cost_by_item
+	var/cost = 0
+	while(istype(target, /list/))
+		item_list = list()
+		for(var/meme in target)
+			var/atom/test
+			if(istype(meme, /list/))//If it's a list let's use its associated object
+				var/temp = target[meme]
+				test = new temp()
+			else
+				test = new meme()
+			item_list[test.name] = image(icon = test.icon, icon_state = test.icon_state)
+			qdel(test)
+		var/picked = show_radial_menu(user, src, item_list, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE)
+		if(!check_menu(user) || picked == null)
+			return
+		for(var/emem in target)
+			var/atom/test
+			if(istype(emem, /list/))
+				var/temp = target[emem]//If it's a list we should use its associated object
+				test = new temp()
+			else
+				test = new emem()
+			if(picked == test.name)
+				cost = target[emem]
+				target = emem
+				break
+			qdel(test)
+	to_despense = target
+	despense_cost = cost
 	// Change mode
 
 /obj/item/rsf/proc/check_menu(mob/user)
@@ -79,16 +106,14 @@ RSF
 	. = ..()
 	if(!proximity)
 		return
-	if (!(istype(A, /obj/structure/table) || isfloorturf(A)))
+	if(!is_allowed(A))
 		return
-	message_admins("I'm in [to_despense] [cost_by_item[to_despense]]")
-	if(use_matter(cost_by_item[to_despense], user))
+	if(use_matter(despense_cost, user))
 		playsound(src.loc, 'sound/machines/click.ogg', 10, TRUE)
-		to_chat(user, "<span class='notice'>Dispensing [to_despense.name]...</span>")
 		var/atom/meme = new to_despense(get_turf(A))
+		to_chat(user, "<span class='notice'>[action_type] [meme.name]...</span>")
 
 /obj/item/rsf/proc/use_matter(charge, mob/user)
-	message_admins("Using [charge]")
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/R = user
 		var/end_charge = R.cell.charge - charge
@@ -99,10 +124,16 @@ RSF
 	else
 		if(matter - 1 >= 0)
 			matter--
-			to_chat(user, "<span class='notice'>The RSF now holds [(matter/max_matter) * 100]% matter.</span>")
+			to_chat(user, "<span class='notice'>\The [src] now holds [matter]/[max_matter] [discriptor].</span>")
 			return TRUE
-		to_chat(user, "<span class='warning'>\The [src] doesn't have enough matter left.</span>")
-	icon_state = "rsf_empty"
+		to_chat(user, "<span class='warning'>\The [src] doesn't have enough [discriptor] left.</span>")
+	icon_state = spent_icon_state
+	return FALSE
+
+/obj/item/rsf/proc/is_allowed(atom/to_check)
+	for(var/sort in allowed_surfaces)
+		if(istype(to_check, sort))
+			return TRUE
 	return FALSE
 
 /obj/item/rsf/cookiesynth
@@ -110,17 +141,25 @@ RSF
 	desc = "A self-recharging device used to rapidly deploy cookies."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rcd"
+	spent_icon_state = "rcd"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	var/toxin = FALSE
 	var/cooldown = 0
 	var/cooldowndelay = 10
 	w_class = WEIGHT_CLASS_NORMAL
+	max_matter = 10
 	cost_by_item = list(/obj/item/reagent_containers/food/snacks/cookie = 100,)
+	discriptor = "cookie-units"
+	action_type = "Fabricates"
 
-/obj/item/rsf/cookiesynth/examine(mob/user)
+/obj/item/rsf/cookiesynth/Initialize()
 	. = ..()
-	. += "<span class='notice'>It currently holds [matter]/10 cookie-units.</span>"
+	START_PROCESSING(SSprocessing, src)
+
+/obj/item/rsf/cookiesynth/Destroy()
+	STOP_PROCESSING(SSprocessing, src)
+	return ..()
 
 /obj/item/rsf/cookiesynth/attackby()
 	return
@@ -131,51 +170,26 @@ RSF
 		to_chat(user, "<span class='warning'>You short out [src]'s reagent safety checker!</span>")
 	else
 		to_chat(user, "<span class='warning'>You reset [src]'s reagent safety checker!</span>")
-		toxin = 0
 
 /obj/item/rsf/cookiesynth/attack_self(mob/user)
 	var/mob/living/silicon/robot/P = null
 	if(iscyborg(user))
 		P = user
-	if((obj_flags & EMAGGED)&&!toxin)
-		toxin = 1
-		to_chat(user, "<span class='alert'>Cookie Synthesizer hacked.</span>")
-	else if(P.emagged&&!toxin)
-		toxin = 1
+	if(((obj_flags & EMAGGED) || (P && P.emagged)) && toxin)
+		toxin = TRUE
+		cost_by_item = list(/obj/item/reagent_containers/food/snacks/cookie/sleepy = 100,)
 		to_chat(user, "<span class='alert'>Cookie Synthesizer hacked.</span>")
 	else
-		toxin = 0
+		toxin = FALSE
+		cost_by_item = list(/obj/item/reagent_containers/food/snacks/cookie = 100,)
 		to_chat(user, "<span class='notice'>Cookie Synthesizer reset.</span>")
 
 /obj/item/rsf/cookiesynth/process()
-	if(matter < 10)
+	if(matter < max_matter)
 		matter++
 
 /obj/item/rsf/cookiesynth/afterattack(atom/A, mob/user, proximity)
-	. = ..()
 	if(cooldown > world.time)
 		return
-	if(!proximity)
-		return
-	if (!(istype(A, /obj/structure/table) || isfloorturf(A)))
-		return
-	if(matter < 1)
-		to_chat(user, "<span class='warning'>[src] doesn't have enough matter left. Wait for it to recharge!</span>")
-		return
-	if(iscyborg(user))
-		var/mob/living/silicon/robot/R = user
-		if(!R.cell || R.cell.charge < 400)
-			to_chat(user, "<span class='warning'>You do not have enough power to use [src].</span>")
-			return
-	var/turf/T = get_turf(A)
-	playsound(src.loc, 'sound/machines/click.ogg', 10, TRUE)
-	to_chat(user, "<span class='notice'>Fabricating Cookie...</span>")
-	var/obj/item/reagent_containers/food/snacks/cookie/S = new /obj/item/reagent_containers/food/snacks/cookie(T)
-	if(toxin)
-		S.reagents.add_reagent(/datum/reagent/toxin/chloralhydrate, 10)
-	if (iscyborg(user))
-		var/mob/living/silicon/robot/R = user
-		R.cell.charge -= 100
-	else
-		matter--
+	. = ..()
 	cooldown = world.time + cooldowndelay

--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -145,7 +145,8 @@ RSF
 	var/cooldown = 0
 	var/cooldowndelay = 10
 	max_matter = 10
-	cost_by_item = list(/obj/item/reagent_containers/food/snacks/cookie = 100,)
+	cost_by_item = list()
+	despense_cost = 100
 	discriptor = "cookie-units"
 	action_type = "Fabricates"
 
@@ -171,13 +172,13 @@ RSF
 	var/mob/living/silicon/robot/P = null
 	if(iscyborg(user))
 		P = user
-	if(((obj_flags & EMAGGED) || (P && P.emagged)) && toxin)
+	if(((obj_flags & EMAGGED) || (P && P.emagged)) && !toxin)
 		toxin = TRUE
-		cost_by_item = list(/obj/item/reagent_containers/food/snacks/cookie/sleepy = 100,)
+		to_despense = /obj/item/reagent_containers/food/snacks/cookie/sleepy
 		to_chat(user, "<span class='alert'>Cookie Synthesizer hacked.</span>")
 	else
 		toxin = FALSE
-		cost_by_item = list(/obj/item/reagent_containers/food/snacks/cookie = 100,)
+		to_despense = /obj/item/reagent_containers/food/snacks/cookie
 		to_chat(user, "<span class='notice'>Cookie Synthesizer reset.</span>")
 
 /obj/item/rsf/cookiesynth/process()

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -560,6 +560,9 @@
 	. = ..()
 	AddElement(/datum/element/dunkable, 10)
 
+/obj/item/reagent_containers/food/snacks/cookie/sleepy
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin/chloralhydrate, 10)
+
 /obj/item/reagent_containers/food/snacks/fortunecookie
 	name = "fortune cookie"
 	desc = "A true prophecy in each cookie!"

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -561,7 +561,7 @@
 	AddElement(/datum/element/dunkable, 10)
 
 /obj/item/reagent_containers/food/snacks/cookie/sleepy
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin/chloralhydrate, 10)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin/chloralhydrate = 10)
 
 /obj/item/reagent_containers/food/snacks/fortunecookie
 	name = "fortune cookie"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -344,7 +344,7 @@
 	name = "Peacekeeper"
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
-		/obj/item/cookiesynth,
+		/obj/item/rsf/cookiesynth,
 		/obj/item/harmalarm,
 		/obj/item/reagent_containers/borghypo/peace,
 		/obj/item/holosign_creator/cyborg,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds radial menus to the RSF.
Makes RSF's modular to allow for better use. I may apply this to RCD's and the like at a later date.
Makes RCF's a subtype of RSF's, because that's dumb.
Allows for RSF's to radial menu into sublists. Code docs to come when I'm not nightcoding.

## Why It's Good For The Game

Makes code better(?), allows for modular expansion on the tool.

## Changelog
:cl:
add: RSF's now have a radial menu
balance: You can now kill yourself by dispensing cookies
refactor: RSF's are now modular
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
