### PR TITLE
Fixes being unable to store gum in gum boxes

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1283,7 +1283,7 @@
 /obj/item/storage/box/gum/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.set_holdable(list(/obj/item/storage/box/gum))
+	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/chewable/bubblegum))
 	STR.max_items = 4
 
 /obj/item/storage/box/gum/PopulateContents()


### PR DESCRIPTION
How embarassing

:cl:
fix: bubblegum can correctly be stored in gum boxes
/:cl:
