### PR TITLE
Fixes explosions damaging the contents of atoms with the PREVENT_CONTENTS_EXPLOSION_1 flag

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -480,7 +480,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 			processing += A.contents
 			. += A
 
-//Gets all contents except those with the specified flag_1
+//Gets all contents of contents but ignores those of atoms with the specified flag_1 (ex. atoms that protect their contents from explosions)
 /atom/proc/GetAllContentsIgnoreFlag(var/T, flag)
 	var/list/processing_list = list(src)
 	if(T)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -449,7 +449,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 	Gets all contents of contents and returns them all in a list.
 */
 
-/atom/proc/GetAllContents(var/T, ignore_flag)
+/atom/proc/GetAllContents(var/T, ignore_flag_1)
 	var/list/processing_list = list(src)
 	if(T)
 		. = list()
@@ -458,7 +458,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 			var/atom/A = processing_list[++i]
 			//Byond does not allow things to be in multiple contents, or double parent-child hierarchies, so only += is needed
 			//This is also why we don't need to check against assembled as we go along
-			if (!(A.flags_1 & ignore_flag))
+			if (!(A.flags_1 & ignore_flag_1))
 				processing_list += A.contents
 				if(istype(A,T))
 					. += A
@@ -466,7 +466,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 		var/i = 0
 		while(i < length(processing_list))
 			var/atom/A = processing_list[++i]
-			if (!(A.flags_1 & ignore_flag))
+			if (!(A.flags_1 & ignore_flag_1))
 				processing_list += A.contents
 		return processing_list
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -480,6 +480,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 			processing += A.contents
 			. += A
 
+//Gets all contents except those with the specified flag_1
 /atom/proc/GetAllContentsIgnoreFlag(var/T, flag)
 	var/list/processing_list = list(src)
 	if(T)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -480,6 +480,25 @@ Turf and target are separate in case you want to teleport some distance from a t
 			processing += A.contents
 			. += A
 
+/atom/proc/GetAllContentsIgnoreFlag(var/T, flag)
+	var/list/processing_list = list(src)
+	if(T)
+		. = list()
+		var/i = 0
+		while(i < length(processing_list))
+			var/atom/A = processing_list[++i]
+			if (!(A.flags_1 & flag))
+				processing_list += A.contents
+				if(istype(A,T))
+					. += A
+	else
+		var/i = 0
+		while(i < length(processing_list))
+			var/atom/A = processing_list[++i]
+			if (!(A.flags_1 & flag))
+				processing_list += A.contents
+		return processing_list
+
 //Step-towards method of determining whether one atom can see another. Similar to viewers()
 /proc/can_see(atom/source, atom/target, length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.
 	var/turf/current = get_turf(source)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -449,7 +449,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 	Gets all contents of contents and returns them all in a list.
 */
 
-/atom/proc/GetAllContents(var/T)
+/atom/proc/GetAllContents(var/T, ignore_flag)
 	var/list/processing_list = list(src)
 	if(T)
 		. = list()
@@ -458,14 +458,16 @@ Turf and target are separate in case you want to teleport some distance from a t
 			var/atom/A = processing_list[++i]
 			//Byond does not allow things to be in multiple contents, or double parent-child hierarchies, so only += is needed
 			//This is also why we don't need to check against assembled as we go along
-			processing_list += A.contents
-			if(istype(A,T))
-				. += A
+			if (!(A.flags_1 & ignore_flag))
+				processing_list += A.contents
+				if(istype(A,T))
+					. += A
 	else
 		var/i = 0
 		while(i < length(processing_list))
 			var/atom/A = processing_list[++i]
-			processing_list += A.contents
+			if (!(A.flags_1 & ignore_flag))
+				processing_list += A.contents
 		return processing_list
 
 /atom/proc/GetAllContentsIgnoring(list/ignore_typecache)
@@ -479,26 +481,6 @@ Turf and target are separate in case you want to teleport some distance from a t
 		if(!ignore_typecache[A.type])
 			processing += A.contents
 			. += A
-
-//Gets all contents of contents but ignores those of atoms with the specified flag_1 (ex. atoms that protect their contents from explosions)
-/atom/proc/GetAllContentsIgnoreFlag(var/T, flag)
-	var/list/processing_list = list(src)
-	if(T)
-		. = list()
-		var/i = 0
-		while(i < length(processing_list))
-			var/atom/A = processing_list[++i]
-			if (!(A.flags_1 & flag))
-				processing_list += A.contents
-				if(istype(A,T))
-					. += A
-	else
-		var/i = 0
-		while(i < length(processing_list))
-			var/atom/A = processing_list[++i]
-			if (!(A.flags_1 & flag))
-				processing_list += A.contents
-		return processing_list
 
 //Step-towards method of determining whether one atom can see another. Similar to viewers()
 /proc/can_see(atom/source, atom/target, length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -199,7 +199,7 @@ GLOBAL_LIST_EMPTY(explosions)
 			for(var/I in T)
 				var/atom/A = I
 				if (!(A.flags_1 & PREVENT_CONTENTS_EXPLOSION_1))
-					items += A.GetAllContents(ignore_flag = PREVENT_CONTENTS_EXPLOSION_1)
+					items += A.GetAllContents(ignore_flag_1 = PREVENT_CONTENTS_EXPLOSION_1)
 			for(var/O in items)
 				var/atom/A = O
 				if(!QDELETED(A))

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -198,7 +198,7 @@ GLOBAL_LIST_EMPTY(explosions)
 			var/list/items = list()
 			for(var/I in T)
 				var/atom/A = I
-				if (!(A.flags_1 & PREVENT_CONTENTS_EXPLOSION_1)) //The atom/contents_explosion() proc returns null if the contents ex_acting has been handled by the atom, and TRUE if it hasn't.
+				if (!(A.flags_1 & PREVENT_CONTENTS_EXPLOSION_1))
 					items += A.GetAllContentsIgnoreFlag(flag = PREVENT_CONTENTS_EXPLOSION_1)
 			for(var/O in items)
 				var/atom/A = O

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -199,7 +199,7 @@ GLOBAL_LIST_EMPTY(explosions)
 			for(var/I in T)
 				var/atom/A = I
 				if (!(A.flags_1 & PREVENT_CONTENTS_EXPLOSION_1))
-					items += A.GetAllContentsIgnoreFlag(flag = PREVENT_CONTENTS_EXPLOSION_1)
+					items += A.GetAllContents(ignore_flag = PREVENT_CONTENTS_EXPLOSION_1)
 			for(var/O in items)
 				var/atom/A = O
 				if(!QDELETED(A))

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -199,7 +199,7 @@ GLOBAL_LIST_EMPTY(explosions)
 			for(var/I in T)
 				var/atom/A = I
 				if (!(A.flags_1 & PREVENT_CONTENTS_EXPLOSION_1)) //The atom/contents_explosion() proc returns null if the contents ex_acting has been handled by the atom, and TRUE if it hasn't.
-					items += A.GetAllContents()
+					items += A.GetAllContentsIgnoreFlag(flag = PREVENT_CONTENTS_EXPLOSION_1)
 			for(var/O in items)
 				var/atom/A = O
 				if(!QDELETED(A))


### PR DESCRIPTION
Fixes #49986
Fixes #49232

:cl:
fix: Being at the epicenter of explosions no longer damage the contents of storage that is meant to prevent it (most commonly photos inside photo albums)
/:cl:
