### PR TITLE
neckgrab table slamming deals less damage, doesn't stamcrit in 2

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -138,8 +138,8 @@
 
 /obj/structure/table/proc/tableheadsmash(mob/living/user, mob/living/pushed_mob)
 	pushed_mob.Knockdown(30)
-	pushed_mob.apply_damage(40, BRUTE, BODY_ZONE_HEAD)
-	pushed_mob.apply_damage(60, STAMINA)
+	pushed_mob.apply_damage(30, BRUTE, BODY_ZONE_HEAD)
+	pushed_mob.apply_damage(40, STAMINA)
 	take_damage(50)
 	if(user.mind?.martial_art.smashes_tables && user.mind?.martial_art.can_use(user))
 		deconstruct(FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

tableslams now take three hits to crit + stamcrit

## Why It's Good For The Game

nothing huge but gives more chances to resist an aggressive grab upgrading. disarm to cuffing is guaranteed fastkill with one item and if you have rng they can only resist out of grab upgrading once. if you need two hits to stamcrit, they get a total of two chances to escape a grab.

## Changelog
:cl:
balance: tableslam now crits in three hits instead of two
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
