### PR TITLE
Fixes a small mapping oversight on Delta near Psych's office.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -87241,7 +87241,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "12"
+	req_one_access_txt = "5;12"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -89915,6 +89915,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/chair{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -113455,7 +113458,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "12"
+	req_one_access_txt = "5;12"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This enables medbay staff who lack maintenance access to use the two maint doors outside of the Psych's office, between the office and the medbay hallway. Also adds a chair, which might make that area seem more like a little waiting room.

![delt](https://user-images.githubusercontent.com/51800976/78464722-6214ad80-76b2-11ea-816b-70b8eefff1d0.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Medbay staff should probably have access to any maint doors directly leading into/out of their department.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: On Delta station, the two maintenance doors near the Psychology office now permit medbay staff to access them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
