### PR TITLE
Makes Pestles Small Items

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -286,6 +286,7 @@
 /obj/item/pestle
 	name = "pestle"
 	desc = "An ancient, simple tool used in conjunction with a mortar to grind or juice items."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "pestle"
 	force = 7


### PR DESCRIPTION

pestles are now small items as they always should have been.
Part 2 coming this spring to theaters near you.

## Changelog
:cl: itseasytosee
tweak: pestles are now small items
/:cl:

