### PR TITLE
Fixes access on two doors in Delta's service hall.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -20813,8 +20813,8 @@
 "aRW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Theatre Backstage";
-	req_access_txt = "46"
+	name = "Service Hall";
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -25205,8 +25205,8 @@
 /area/maintenance/port/fore)
 "aYz" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
+	name = "Service Hallway Maintenance Hatch";
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes two small changes to Delta Station.
It removes regular maintenance access from the side maintenance door in the service hall on Delta, and gives all the service jobs access to it instead. Also it is now named accordingly to the other maintenance door there.
It renames the door in the theater to "Service Hall", and gives all service jobs access to it, instead of just the clown and mime.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If assistants want to print bear traps they better be prepared to hack in or make a false wall, not just waltz right in.
And, the theater's door to the service hall being labeled "Theater Backstage" seems odd, seeing as it doesn't lead (directly) to the theater backstage, it leads to the Service Hall! May as well label it as such and let the rest of service use it, since the theater is an otherwise public area anyway.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: A maintenance door in Delta's Service Hall has been changed from general maintenance access, to service job access, and renamed accordingly.
tweak: On Delta, the door leading to the Service Hall from the theater is now labeled "Service Hall" instead of "Theater Backstage", and all of service is now able to use it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
