### PR TITLE
Update to spacemandmm 1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tgstation/byond:513.1508 as base
+FROM tgstation/byond:513.1514 as base
 
 FROM base as build_base
 

--- a/code/__DEFINES/spaceman_dmm.dm
+++ b/code/__DEFINES/spaceman_dmm.dm
@@ -7,13 +7,13 @@
 	#define SHOULD_CALL_PARENT(X) set SpacemanDMM_should_call_parent = X
 	#define UNLINT(X) SpacemanDMM_unlint(X)
 	#define SHOULD_NOT_OVERRIDE(X) set SpacemanDMM_should_not_override = X
-	#define SHOULD_NOT_SLEEP(X)
-	#define SHOULD_BE_PURE(X)
-	#define PRIVATE_PROC(X)
-	#define PROTECTED_PROC(X)
+	#define SHOULD_NOT_SLEEP(X) set SpacemanDMM_should_not_sleep = X
+	#define SHOULD_BE_PURE(X) set SpacemanDMM_should_be_pure = X
+	#define PRIVATE_PROC(X) set SpacemanDMM_private_proc = X
+	#define PROTECTED_PROC(X) set SpacemanDMM_protected_proc = X
 	#define VAR_FINAL var/SpacemanDMM_final
-	#define VAR_PRIVATE var
-	#define VAR_PROTECTED var
+	#define VAR_PRIVATE var/SpacemanDMM_private
+	#define VAR_PROTECTED var/SpacemanDMM_protected
 #else
 	#define RETURN_TYPE(X)
 	#define SHOULD_CALL_PARENT(X)

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -23,7 +23,4 @@ export NODE_VERSION=12
 export PHP_VERSION=5.6
 
 # SpacemanDMM git tag
-export SPACEMAN_DMM_VERSION=suite-1.3
-
-# SpacemanDMM commit hash
-export SPACEMAN_DMM_COMMIT_HASH=3cd3c402af04e6deedc9149caf5c5b0dfd44ad3b
+export SPACEMAN_DMM_VERSION=suite-1.4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
h

Dockerfile updated to 513.1514 because that's the version of byond that spacemandmm understands.  The difference from 1508 is the text2num/num2text parameters and the addition of flags to the outline filter