### PR TITLE
Guns that init with magazines now start chambered with full magazines

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -95,7 +95,7 @@
 		return
 	if (!magazine)
 		magazine = new mag_type(src)
-	chamber_round(chamber_round)
+	chamber_round(TRUE)
 	update_icon()
 
 /obj/item/gun/ballistic/update_icon_state()

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -95,7 +95,7 @@
 		return
 	if (!magazine)
 		magazine = new mag_type(src)
-	chamber_round()
+	chamber_round(chamber_round)
 	update_icon()
 
 /obj/item/gun/ballistic/update_icon_state()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Relevant snippets of code:
`/obj/item/gun/ballistic/proc/chamber_round(keep_bullet = FALSE)`
`chambered = magazine.get_round(keep_bullet || bolt_type == BOLT_TYPE_NO_BOLT)`
`/obj/item/ammo_box/proc/get_round(keep = FALSE)`
`    if (keep)`
`      stored_ammo.Insert(1,b)`

Someone complained that guns spawned on round start (for example, the warden shotgun) were missing bullets.

Turns out that guns spawn, generate a magazine if applicable then chamber a round from that magazine, giving the appearance of all guns missing a bullet from the magazine.

It looks like, from code, there's actually a path already in to allow chambering a round without removing a bullet from the magazine.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It makes @uomo91 happy.

If ALL guns have to init with a chambered round, it makes sense that said chambered round would have been done either by hand or the magazine would have then been refilled. Probably. It's literally one word I've added. It took me longer to write this sentence. HELP ME.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Weapons should now spawn chambered and with full magazines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
