### PR TITLE
Cobbduceus: Multiver Rebalance

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -363,7 +363,7 @@
 
 		if(C && R)
 			if(C.reagent_check(R) != TRUE)
-				if((liverless && !R.self_consuming) || R.overrides_processing) //need to be metabolized or we're specifically overriding it's processing.
+				if((liverless && !R.self_consuming) || R.overrides_processing) //need to be metabolized or we're specifically overriding its processing.
 					continue
 				if(!R.metabolizing)
 					R.metabolizing = TRUE

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -363,7 +363,7 @@
 
 		if(C && R)
 			if(C.reagent_check(R) != TRUE)
-				if(liverless && !R.self_consuming) //need to be metabolized
+				if((liverless && !R.self_consuming) || R.overrides_processing) //need to be metabolized or we're specifically overriding it's processing.
 					continue
 				if(!R.metabolizing)
 					R.metabolizing = TRUE

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -50,8 +50,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/can_synth = TRUE
 	///how fast the reagent is metabolized by the mob
 	var/metabolization_rate = REAGENTS_METABOLISM
-	/// appears unused
-	var/overrides_metab = 0
+	/// Overrides processing, preventing on_mob_life and on_mob_metabolize from occurring
+	var/overrides_processing = FALSE
 	/// above this overdoses happen
 	var/overdose_threshold = 0
 	/// above this amount addictions start

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -319,7 +319,7 @@
 			multibonus += 0.1
 
 	M.adjustToxLoss(-0.1 * multibonus)
-	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, min(CEILING(multibonus*0.3,0.1),1)
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, CEILING((min(multibonus*0.3,1)),0.1)
 
 	// purging magic
 	for(var/r2 in M.reagents.reagent_list)

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -362,6 +362,7 @@
 	. = ..()
 	mytray.adjustToxic(-round(chems.get_reagent_amount(type) * 2))
 
+#undef MULTIVER_TOXINBTFO
 #define issyrinormusc(A)	(istype(A,/datum/reagent/medicine/C2/syriniver) || istype(A,/datum/reagent/medicine/C2/musiver)) //musc is metab of syrin so let's make sure we're not purging either
 
 /datum/reagent/medicine/C2/syriniver //Inject >> SYRINge

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -319,7 +319,7 @@
 			multibonus += 0.1
 
 	M.adjustToxLoss(-0.1 * multibonus)
-	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, max(3-multibonus, 0.5))
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, max(2-(multibonus*0.5), 0.5))
 
 	// purging magic
 	for(var/r2 in M.reagents.reagent_list)

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -319,7 +319,7 @@
 			multibonus += 0.1
 
 	M.adjustToxLoss(-0.1 * multibonus)
-	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, max(3-multibonus, 0.3))
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, max(3-multibonus, 0.5))
 
 	// purging magic
 	for(var/r2 in M.reagents.reagent_list)

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -301,7 +301,7 @@
 
 /datum/reagent/medicine/C2/multiver //enhanced with MULTIple medicines
 	name = "Multiver"
-	description = "A chem-purger that becomes more effective and less damaging the more unique reagents (preferably medicines) present in the bloodstream, but incurs lung damage. Having several reagents in the system act as a catalyst for Multiver to actively inhibit toxins, dissallowing their effects to manifest."
+	description = "A chem-purger that becomes more effective the more unique reagents (preferably medicines) present in the bloodstream, but incurs lung damage relative to efficacy. Having several reagents in the system act as a catalyst for Multiver to actively inhibit toxins, dissallowing their effects to manifest."
 	///List of chems currently being shut off by multiver
 	var/list/inhibited_toxins
 
@@ -319,7 +319,7 @@
 			multibonus += 0.1
 
 	M.adjustToxLoss(-0.1 * multibonus)
-	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, max(3-multibonus, 0.5))
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, min(CEILING(multibonus*0.3,0.1),1)
 
 	// purging magic
 	for(var/r2 in M.reagents.reagent_list)

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -319,7 +319,7 @@
 			multibonus += 0.1
 
 	M.adjustToxLoss(-0.1 * multibonus)
-	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, CEILING((min(multibonus*0.3,1)),0.1)
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, CEILING((min(multibonus*0.3,1)),0.1))
 
 	// purging magic
 	for(var/r2 in M.reagents.reagent_list)

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -297,7 +297,7 @@
 	..()
 	return TRUE
 
-#define MULTIVER_TOXINBTFO	3 //magic number that thresholds toxin shutdown.
+#define MULTIVER_TOXINBTFO	5 //magic number that thresholds toxin shutdown.
 
 /datum/reagent/medicine/C2/multiver //enhanced with MULTIple medicines
 	name = "Multiver"
@@ -314,26 +314,25 @@
 		if(istype(the_reagent, /datum/reagent/medicine))
 			multibonus += 1
 		else if(istype(the_reagent, /datum/reagent/toxin))
-			multibonus += 0.5
+			multibonus += 0.2
 		else
 			multibonus += 0.1
 
 	M.adjustToxLoss(-0.1 * multibonus)
-	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, max(2-(multibonus*0.5), 0.5))
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, max(3-multibonus, 0.5))
 
 	// purging magic
 	for(var/r2 in M.reagents.reagent_list)
 		var/datum/reagent/the_reagent2 = r2
 		if(the_reagent2 == src)
 			continue
-		var/amount2purge = 0.1
+		var/amount2purge = 0.1*multibonus
 		if(istype(the_reagent2,/datum/reagent/toxin))
-			amount2purge *= (2*multibonus) //very good antitox
+			amount2purge *= 2
 			if(multibonus >= MULTIVER_TOXINBTFO)
 				the_reagent2.overrides_processing = TRUE
 				LAZYOR(inhibited_toxins, the_reagent2)
-
-		else if(multibonus >= 5 && istype(the_reagent2, /datum/reagent/medicine)) //5 unique meds (4+multiver) will make it not purge medicines
+		else if(istype(the_reagent2, /datum/reagent/medicine) && multibonus >= (MULTIVER_TOXINBTFO*1.5)) // we don't purge meds unless we have a TON of uniques in our system
 			continue
 		M.reagents.remove_reagent(the_reagent2.type, amount2purge)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

`feedback` commit and recent commit changes:

Uniques required to inhibit increased
Toxin's unique score counts less (0.5 > 0.2)
Organ damage goes up to max 1 instead of down to min 0.3
Uniques affect all reagent purging, but still does bonus against tox
Uniques required to stop meds from purging increased and is relative to the toxin BTFO (5 > 7.5)


## About The Pull Request
Multiver has been rebalanced!

- Unique Non-medicines will now contribute to multiver's efficacy, albeit at a lower rate compared to medicine (half for toxins, tenth for everything else)
- Less toxin damage healing per unique because of this
- Lung damage now starts at 1.5 (2-0.5) and goes down in a linear fashion instead of diminishing returns. Caps at 0.5 damage, which is 3 unique meds.
- No longer specializes in purging alcohol (use antihol)
- **Multiver now completely disables toxins so long as you have a sufficient amount of unique reagents in your system**. Purging is **NOT** affected (see where I'm getting at?).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Multiver was not seen really anywhere outside of the antag arsenal. Given it's gimmick requires reagent dumps of valuable medicine that could be used elsewhere, it really inhibits (hehe) its usage in core play, especially when compared to Pacid or even Syrin.

Hopefully now it will see a lot more play and effectively establish itself as the C2 toxin purger. Advanced antag strategies could still use this as a way to delay effects of poisons at the cost of losing quite a bit to the purging effects, but you're probably better off just filling up on lexorin still 😏.

I would say this might hit kill syringes, but people are still racking up lung damage and are having to dump reagents they could be using later to save themselves to contain the kill syringe chem(s) so your chems aren't entirely in vain!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Multiverbby
balance: Multiver does less toxin healing per unique (see above) and no longer specializes as an anti-booze.
balance: Multiver's lung damage no longer gives diminishing returns for uniques.
add: Multiver now scales with unique reagents, instead of unique medicines. Medicines are still the best at helping multiver though!
add: Multiver now shuts off toxins if there's enough uniques present.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
