### PR TITLE
Mad Scientist Special kit now has a functioning Wormhole Gun

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -165,7 +165,7 @@
 			new /obj/item/assembly/signaler(src) // 0 tc
 			new /obj/item/storage/toolbox/syndicate(src) // 1 tc
 			new /obj/item/pen/edagger(src)
-			new /obj/item/gun/energy/wormhole_projector(src)
+			new /obj/item/gun/energy/wormhole_projector/core_inserted(src)
 			new /obj/item/gun/energy/decloner/unrestricted(src)
 
 		if("bee")

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -278,6 +278,9 @@
 		p_blue = P
 	crosslink()
 
+/obj/item/gun/energy/wormhole_projector/core_inserted
+    firing_core = TRUE
+
 /* 3d printer 'pseudo guns' for borgs */
 
 /obj/item/gun/energy/printer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Created a wormhole projector that has an anomaly core already inside. 
Replaced the un-loaded wormhole projector with the new one in the Mad Scientist Syndie Kit Special.
Fixes #50437

## Why It's Good For The Game

Bug bad -Fikou 

## Changelog
:cl:
fix: Mad Scientist Wormhole Projector no longer requires an anomaly core. 
/:cl: