### PR TITLE
Allows prisoners to retract skin and manipulate organs

### DIFF
--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -8,7 +8,7 @@
 //extract implant
 /datum/surgery_step/extract_implant
 	name = "extract implant"
-	implements = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 65)
+	implements = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 65, /obj/item/kitchen/fork = 35)
 	time = 64
 	experience_given = MEDICAL_SKILL_MEDIUM
 	var/obj/item/implant/I = null

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -69,7 +69,7 @@
 	name = "manipulate organs"
 	repeatable = TRUE
 	implements = list(/obj/item/organ = 100, /obj/item/organ_storage = 100)
-	var/implements_extract = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 55)
+	var/implements_extract = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 55, /obj/item/kitchen/fork = 10)
 	var/current_type
 	var/obj/item/organ/I = null
 

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -69,7 +69,7 @@
 	name = "manipulate organs"
 	repeatable = TRUE
 	implements = list(/obj/item/organ = 100, /obj/item/organ_storage = 100)
-	var/implements_extract = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 55, /obj/item/kitchen/fork = 10)
+	var/implements_extract = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 55, /obj/item/kitchen/fork = 35)
 	var/current_type
 	var/obj/item/organ/I = null
 

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -61,7 +61,7 @@
 //retract skin
 /datum/surgery_step/retract_skin
 	name = "retract skin"
-	implements = list(TOOL_RETRACTOR = 100, TOOL_SCREWDRIVER = 45, TOOL_WIRECUTTER = 35)
+	implements = list(TOOL_RETRACTOR = 100, TOOL_SCREWDRIVER = 45, TOOL_WIRECUTTER = 35, /obj/item/stack/rods = 35)
 	time = 24
 
 /datum/surgery_step/retract_skin/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -126,7 +126,7 @@
 //drill bone
 /datum/surgery_step/drill
 	name = "drill bone"
-	implements = list(TOOL_DRILL = 100, /obj/item/screwdriver/power = 80, /obj/item/pickaxe/drill = 60, TOOL_SCREWDRIVER = 20)
+	implements = list(TOOL_DRILL = 100, /obj/item/screwdriver/power = 80, /obj/item/pickaxe/drill = 60, TOOL_SCREWDRIVER = 20, /obj/item/kitchen/spoon = 5)
 	time = 30
 
 /datum/surgery_step/drill/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -126,7 +126,7 @@
 //drill bone
 /datum/surgery_step/drill
 	name = "drill bone"
-	implements = list(TOOL_DRILL = 100, /obj/item/screwdriver/power = 80, /obj/item/pickaxe/drill = 60, TOOL_SCREWDRIVER = 20, /obj/item/kitchen/spoon = 5)
+	implements = list(TOOL_DRILL = 100, /obj/item/screwdriver/power = 80, /obj/item/pickaxe/drill = 60, TOOL_SCREWDRIVER = 25, /obj/item/kitchen/spoon = 20)
 	time = 30
 
 /datum/surgery_step/drill/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
and extract organs
## About The Pull Request
Due to the only alternatives to retractors being engineering tools, inmates were barred from most round start surgeries, this PR adds the ability to use metal rods(the same way you would use a screwdriver) to complete the skin retraction step, allowing prisoners access to the following surgeries
- Organ manipulation, taking out organs may now be done using a fork
- Lobectomies
- Coronary Bypasses
- Hepatectomies
- Cavity implants
- Implant Removal, ditto, forks are the poor surgeon's best friend and can now remove implants
- Eye Surgery
and Fat Removal surgeries with varying levels of success. In testing i found that you will fail skin retraction almost every time unless you use sterilizer(see; alcohol) and work on a table.
Dental implants(though useless without pills) are now possible as you may now use a spoon to drill into teeth
## Why It's Good For The Game
 Though it doesn't help you escape, and botched surgeries may be fatal, ghetto surgery is the only way to heal yourself after a failed attempt at escape. Tracking implants may now, riskily, be removed in perma, and plastic surgery may help in escape if security cares about who should be behind bars 
## Changelog
:cl:
tweak: You can now use metal rods to retract skin during surgery if you are that desperate
tweak: forks are now viable alternatives to surgical instruments when extracting organs and implants
/:cl: