### PR TITLE
Increases the maximum number of bluespace anomalies per round

### DIFF
--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -2,7 +2,7 @@
 	name = "Anomaly: Bluespace"
 	typepath = /datum/round_event/anomaly/anomaly_bluespace
 
-	max_occurrences = 1
+	max_occurrences = 8
 	weight = 15
 
 /datum/round_event/anomaly/anomaly_bluespace


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Someone capped these at one for some reason? If we're going to require them for BoH, nobody's going to use the one core to make one of those over a Phazon.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I reckon the BoH changes were good, but only having one per round seems maybe a bit too rare, especially when you aren't going to get Bluespace anomalies every round.

## Changelog
:cl:
tweak: Increased the maximum number of Bluespace anomalies per round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
