### PR TITLE
Plantbags, Fridges, and Aprons hold Plant Grafts, Aprons also hold Secateurs.

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -200,6 +200,7 @@
 		/obj/item/seeds,
 		/obj/item/grown,
 		/obj/item/reagent_containers/honeycomb,
+		/obj/item/graft,
 		))
 ////////
 

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -10,7 +10,7 @@
 	item_state = "apron"
 	blood_overlay_type = "armor"
 	body_parts_covered = CHEST|GROIN
-	allowed = list(/obj/item/reagent_containers/spray/plantbgone, /obj/item/plant_analyzer, /obj/item/seeds, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/glass/beaker, /obj/item/cultivator, /obj/item/reagent_containers/spray/pestspray, /obj/item/hatchet, /obj/item/storage/bag/plants)
+	allowed = list(/obj/item/reagent_containers/spray/plantbgone, /obj/item/plant_analyzer, /obj/item/seeds, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/glass/beaker, /obj/item/cultivator, /obj/item/reagent_containers/spray/pestspray, /obj/item/hatchet, /obj/item/storage/bag/plants, /obj/item/graft, /obj/item/secateurs)
 
 /obj/item/clothing/suit/apron/waders
 	name = "horticultural waders"

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -136,7 +136,7 @@
 
 
 /obj/machinery/smartfridge/proc/accept_check(obj/item/O)
-	if(istype(O, /obj/item/reagent_containers/food/snacks/grown/) || istype(O, /obj/item/seeds/) || istype(O, /obj/item/grown/))
+	if(istype(O, /obj/item/reagent_containers/food/snacks/grown/) || istype(O, /obj/item/seeds/) || istype(O, /obj/item/grown/) || istype(O, /obj/item/graft/))
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Self Explanatory title, gives Plant Grafts consistant behavior with regular grown produce, as well as makes secateurs consistant with other botany tools by making it storable within an apron.

## Why It's Good For The Game

Helps to prevent the trash and item management in botany from getting to bad for the most part. Fridges and Bags make for efficient storage, and having a tool in an apron is always helpful for inventory management, so this brings secateurs up to speed.

## Changelog
:cl:
balance: Plant Grafts and Secateurs are now storable within plant bags and smartfridges. Secateurs can be stored in aprons.
/:cl: