### PR TITLE
Cryo-syringes now can only hold 10u

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -252,8 +252,8 @@
 
 /obj/item/reagent_containers/syringe/noreact
 	name = "cryo syringe"
-	desc = "An advanced syringe that stops reagents inside from reacting. It can hold up to 20 units."
-	volume = 20
+	desc = "An advanced syringe that stops reagents inside from reacting. It can only hold  to 10 units."
+	volume = 10
 	reagent_flags = TRANSPARENT | NO_REACT
 
 /obj/item/reagent_containers/syringe/piercing

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -252,7 +252,7 @@
 
 /obj/item/reagent_containers/syringe/noreact
 	name = "cryo syringe"
-	desc = "An advanced syringe that stops reagents inside from reacting. It can only hold  to 10 units."
+	desc = "An advanced syringe that stops reagents inside from reacting. It can hold up to 10 units."
 	volume = 10
 	reagent_flags = TRANSPARENT | NO_REACT
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alternative to #50471 
10u is not gibbable in a single shot. They can be heavy for some high-level explosions but poisons and acid combos are about on par. Darts could never hold enough to gib in the first place
## Why It's Good For The Game
Improve don't remove. This is the best solution I know of to the current issue. There may be better ones.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: cryo syringes are now only capable of holding 10 units
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
