### PR TITLE
scalpels and surgical drills can now eyestab people

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -91,6 +91,13 @@
 	w_class = WEIGHT_CLASS_SMALL
 	toolspeed = 0.5
 
+/obj/item/surgicaldrill/attack(mob/living/carbon/M, mob/living/carbon/user)
+	if(user.zone_selected == BODY_ZONE_PRECISE_EYES)
+		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
+			M = user
+		return eyestab(M,user)
+	else
+		return ..()
 
 /obj/item/scalpel
 	name = "scalpel"
@@ -126,6 +133,13 @@
 	user.visible_message("<span class='suicide'>[user] is slitting [user.p_their()] [pick("wrists", "throat", "stomach")] with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return (BRUTELOSS)
 
+/obj/item/scalpel/attack(mob/living/carbon/M, mob/living/carbon/user)
+	if(user.zone_selected == BODY_ZONE_PRECISE_EYES)
+		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
+			M = user
+		return eyestab(M,user)
+	else
+		return ..()
 
 /obj/item/circular_saw
 	name = "circular saw"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

what the title says

## Why It's Good For The Game

knives can eyestab so it would make sense for scalpels
and its a reason to use surgical drills over circular saws and also gruesome and fuck yeah

## Changelog
:cl:
balance: scalpels and surgical drills can now eyestab people
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
