### PR TITLE
Removes a method to raid centcom

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -29,7 +29,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/machinery/disposal,
 		/obj/structure/disposalpipe,
 		/obj/item/hilbertshotel,
-		/obj/machinery/camera
+		/obj/machinery/camera,
+		/obj/item/gps
 	)))
 
 /obj/docking_port/mobile/supply

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -28,7 +28,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/machinery/launchpad,
 		/obj/machinery/disposal,
 		/obj/structure/disposalpipe,
-		/obj/item/hilbertshotel
+		/obj/item/hilbertshotel,
+		/obj/machinery/camera
 	)))
 
 /obj/docking_port/mobile/supply


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

you can no send cameras and gps on the supply shuttle

## Why It's Good For The Game

jesus christ how horrifying

## Changelog
:cl:
fix: you can no longer put cameras and gps on the supply shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
