### PR TITLE
Fixes some misnamed cameras (and other stuff) on Kilo Station.

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -10150,6 +10150,12 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/leafybush,
+/obj/machinery/camera{
+	c_tag = "Genetics Monkey Pen";
+	dir = 4;
+	name = "science camera";
+	network = list("ss13","rd")
+	},
 /turf/open/floor/grass,
 /area/science/genetics)
 "aqr" = (
@@ -31692,7 +31698,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/flora/ausbushes/fernybush,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/grass,
 /area/science/genetics)
@@ -35982,6 +35987,7 @@
 	name = "Monkey Pen";
 	req_access_txt = "9, 7"
 	},
+/obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/grass,
 /area/science/genetics)
 "bdc" = (
@@ -36008,11 +36014,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bde" = (
-/obj/machinery/camera{
-	c_tag = "Genetics Monkey Pen";
-	name = "science camera";
-	network = list("ss13","rd")
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -19703,7 +19703,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Sleepers";
+	c_tag = "Medbay Stasis Beds";
 	name = "medical camera";
 	network = list("ss13","medical")
 	},
@@ -36008,11 +36008,8 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bde" = (
-/obj/structure/sign/warning/fire{
-	pixel_y = 32
-	},
 /obj/machinery/camera{
-	c_tag = "Experimenter Chamber";
+	c_tag = "Genetics Monkey Pen";
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -38275,7 +38272,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Experimenter Lab";
+	c_tag = "Genetics Lab";
 	dir = 8;
 	name = "science camera";
 	network = list("ss13","rd")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Renames these cameras:
"Medbay Sleepers" to "Medbay Stasis Beds"
"Experimenter Lab" to "Genetics Lab"
"Experimenter Chamber" to "Genetics Monkey Pen"

Additionally, deletes an old fire warning sign from the monkey pen, moves some shrubbery that was covering a vent there, and moves the camera so it is no longer hidden behind a tree.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Kilo Station? More like _Best Station..._

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Kilo Station now has properly named cameras next to the medbay stasis beds, the genetics lab and monkey pen, and the monkey pen has been deemed not to be a fire hazard any longer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
