### PR TITLE
You can no longer view the AI's laws as a ghost.

### DIFF
--- a/code/modules/mob/living/silicon/examine.dm
+++ b/code/modules/mob/living/silicon/examine.dm
@@ -1,6 +1,0 @@
-/mob/living/silicon/examine(mob/user) //Displays a silicon's laws to ghosts
-	. = ..()
-	if(laws && isobserver(user))
-		. += "<b>[src] has the following laws:</b>"
-		for(var/law in laws.get_law_list(include_zeroth = TRUE))
-			. += law


### PR DESCRIPTION
## About The Pull Request
Prevents metagaming malf AIs. Admins can still view them.
## Why It's Good For The Game
Players were bragging about using it to metagame in the discord. Prepare for a bunch of angry people insisting they totally didn't use this for reals or whatever, despite the fact there's too much plausible deniability available for this.

## Changelog
:cl:
del: You can no longer view the AI's laws as a non-admin ghost.
/:cl:
