### PR TITLE
Sets bodypart throw force to zero

### DIFF
--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -3,7 +3,7 @@
 	name = "limb"
 	desc = "Why is it detached..."
 	force = 3
-	throwforce = 3
+	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/mob/human_parts.dmi'
 	icon_state = ""


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Limbs do no damage while being flung at people.

## Why It's Good For The Game

This change is intended to make mechanics such as ashwalker sacrificing less annoying as you get hit with a leg to the head. I believe organs were already given a throwing force of zero for this purpose.

## Changelog
:cl:
tweak: limbs no longer do damage when thrown at people
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
