### PR TITLE
Refactors eyestabbing, allows scalpels and surgical drills to eyestab

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -87,7 +87,7 @@
 		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
 		return
 
-	if(user.zone_selected == BODY_ZONE_PRECISE_EYES && eyestab == 1)
+	if(user.zone_selected == BODY_ZONE_PRECISE_EYES && can_eyestab == TRUE)
 		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 			M = user
 		return eyestab(M,user)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -87,6 +87,11 @@
 		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
 		return
 
+	if(user.zone_selected == BODY_ZONE_PRECISE_EYES && eyestab == 1)
+		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
+			M = user
+		return eyestab(M,user)
+
 	if(!force)
 		playsound(loc, 'sound/weapons/tap.ogg', get_clamped_volume(), TRUE, -1)
 	else if(hitsound)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -87,11 +87,6 @@
 		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
 		return
 
-	if(user.zone_selected == BODY_ZONE_PRECISE_EYES && can_eyestab == TRUE)
-		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
-			M = user
-		return eyestab(M,user)
-
 	if(!force)
 		playsound(loc, 'sound/weapons/tap.ogg', get_clamped_volume(), TRUE, -1)
 	else if(hitsound)

--- a/code/datums/elements/eyestab.dm
+++ b/code/datums/elements/eyestab.dm
@@ -1,13 +1,19 @@
-// It an item has the eyestab element, when you hit someone while targetting their eyes it stabs them in the eyes
+/// It an item has the eyestab element, when you hit someone while targetting their eyes it stabs them in the eyes
+/datum/element/eyestab
+
+///Register the attack signal to call eyestab()
 /datum/element/eyestab/Attach(datum/target)
 	if(!isatom(target))
 		return ELEMENT_INCOMPATIBLE
 	RegisterSignal(target, COMSIG_ITEM_ATTACK, .proc/eyestab)
 
+
+///Unregister the attack signal
 /datum/element/dunkable/Detach(datum/target)
 	. = ..()
 	UnregisterSignal(target, COMSIG_ITEM_ATTACK)
 
+///Check if the victim's eyes can be stabbed, and if so stab them
 /datum/element/eyestab/proc/eyestab(obj/item/source, mob/living/carbon/M, mob/living/carbon/user)
 	if(user.zone_selected != BODY_ZONE_PRECISE_EYES)
 		return

--- a/code/datums/elements/eyestab.dm
+++ b/code/datums/elements/eyestab.dm
@@ -1,0 +1,87 @@
+// It an item has the eyestab element, when you hit someone while targetting their eyes it stabs them in the eyes
+/datum/element/eyestab/Attach(datum/target)
+	if(!isatom(target))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_ITEM_ATTACK, .proc/eyestab)
+
+/datum/element/dunkable/Detach(datum/target)
+	. = ..()
+	UnregisterSignal(target, COMSIG_ITEM_ATTACK)
+
+/datum/element/eyestab/proc/eyestab(obj/item/source, mob/living/carbon/M, mob/living/carbon/user)
+	if(user.zone_selected != BODY_ZONE_PRECISE_EYES)
+		return
+	if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
+		M = user
+	var/is_human_victim
+	var/obj/item/bodypart/affecting = M.get_bodypart(BODY_ZONE_HEAD)
+	if(ishuman(M))
+		if(!affecting) //no head!
+			return
+		is_human_victim = TRUE
+
+	if(source.force && HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
+		return COMPONENT_ITEM_NO_ATTACK
+
+	if(M.is_eyes_covered())
+		// you can't stab someone in the eyes wearing a mask!
+		to_chat(user, "<span class='warning'>You're going to need to remove [M.p_their()] eye protection first!</span>")
+		return
+
+	if(isalien(M))//Aliens don't have eyes./N     slimes also don't have eyes!
+		to_chat(user, "<span class='warning'>You cannot locate any eyes on this creature!</span>")
+		return
+
+	if(isbrain(M))
+		to_chat(user, "<span class='warning'>You cannot locate any organic eyes on this brain!</span>")
+		return
+
+	source.add_fingerprint(user)
+
+	playsound(source.loc, source.hitsound, 30, TRUE, -1)
+
+	user.do_attack_animation(M)
+
+	if(M != user)
+		M.visible_message("<span class='danger'>[user] stabs [M] in the eye with [source]!</span>", \
+							"<span class='userdanger'>[user] stabs you in the eye with [source]!</span>")
+	else
+		user.visible_message( \
+			"<span class='danger'>[user] stabs [user.p_them()]self in the eyes with [source]!</span>", \
+			"<span class='userdanger'>You stab yourself in the eyes with [source]!</span>" \
+		)
+	if(is_human_victim)
+		var/mob/living/carbon/human/U = M
+		U.apply_damage(7, BRUTE, affecting)
+
+	else
+		M.take_bodypart_damage(7)
+
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "eye_stab", /datum/mood_event/eye_stab)
+
+	log_combat(user, M, "attacked", "[source.name]", "(INTENT: [uppertext(user.a_intent)])")
+
+	var/obj/item/organ/eyes/eyes = M.getorganslot(ORGAN_SLOT_EYES)
+	if (!eyes)
+		return
+	M.adjust_blurriness(3)
+	eyes.applyOrganDamage(rand(2,4))
+	if(eyes.damage >= 10)
+		M.adjust_blurriness(15)
+		if(M.stat != DEAD)
+			to_chat(M, "<span class='danger'>Your eyes start to bleed profusely!</span>")
+		if(!(M.is_blind() || HAS_TRAIT(M, TRAIT_NEARSIGHT)))
+			to_chat(M, "<span class='danger'>You become nearsighted!</span>")
+		M.become_nearsighted(EYE_DAMAGE)
+		if(prob(50))
+			if(M.stat != DEAD)
+				if(M.drop_all_held_items())
+					to_chat(M, "<span class='danger'>You drop what you're holding and clutch at your eyes!</span>")
+			M.adjust_blurriness(10)
+			M.Unconscious(20)
+			M.Paralyze(40)
+		if (prob(eyes.damage - 10 + 1))
+			M.become_blind(EYE_DAMAGE)
+			to_chat(M, "<span class='danger'>You go blind!</span>")
+	return COMPONENT_ITEM_NO_ATTACK

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -127,9 +127,6 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	///All items with sharpness of IS_SHARP or higher will automatically get the butchering component.
 	var/sharpness = IS_BLUNT
 
-	///All items with eyestab of TRUE can be used to poke someone's eyes out
-	var/can_eyestab = FALSE
-
 	///How a tool acts when you use it on something, such as wirecutters cutting wires while multitools measure power
 	var/tool_behaviour = NONE
 	///How fast does the tool work
@@ -534,76 +531,6 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 ///This proc determines if and at what an object will reflect energy projectiles if it's in l_hand,r_hand or wear_suit
 /obj/item/proc/IsReflect(var/def_zone)
 	return FALSE
-
-/obj/item/proc/eyestab(mob/living/carbon/M, mob/living/carbon/user)
-
-	var/is_human_victim
-	var/obj/item/bodypart/affecting = M.get_bodypart(BODY_ZONE_HEAD)
-	if(ishuman(M))
-		if(!affecting) //no head!
-			return
-		is_human_victim = TRUE
-
-	if(M.is_eyes_covered())
-		// you can't stab someone in the eyes wearing a mask!
-		to_chat(user, "<span class='warning'>You're going to need to remove [M.p_their()] eye protection first!</span>")
-		return
-
-	if(isalien(M))//Aliens don't have eyes./N     slimes also don't have eyes!
-		to_chat(user, "<span class='warning'>You cannot locate any eyes on this creature!</span>")
-		return
-
-	if(isbrain(M))
-		to_chat(user, "<span class='warning'>You cannot locate any organic eyes on this brain!</span>")
-		return
-
-	src.add_fingerprint(user)
-
-	playsound(loc, src.hitsound, 30, TRUE, -1)
-
-	user.do_attack_animation(M)
-
-	if(M != user)
-		M.visible_message("<span class='danger'>[user] stabs [M] in the eye with [src]!</span>", \
-							"<span class='userdanger'>[user] stabs you in the eye with [src]!</span>")
-	else
-		user.visible_message( \
-			"<span class='danger'>[user] stabs [user.p_them()]self in the eyes with [src]!</span>", \
-			"<span class='userdanger'>You stab yourself in the eyes with [src]!</span>" \
-		)
-	if(is_human_victim)
-		var/mob/living/carbon/human/U = M
-		U.apply_damage(7, BRUTE, affecting)
-
-	else
-		M.take_bodypart_damage(7)
-
-	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "eye_stab", /datum/mood_event/eye_stab)
-
-	log_combat(user, M, "attacked", "[src.name]", "(INTENT: [uppertext(user.a_intent)])")
-
-	var/obj/item/organ/eyes/eyes = M.getorganslot(ORGAN_SLOT_EYES)
-	if (!eyes)
-		return
-	M.adjust_blurriness(3)
-	eyes.applyOrganDamage(rand(2,4))
-	if(eyes.damage >= 10)
-		M.adjust_blurriness(15)
-		if(M.stat != DEAD)
-			to_chat(M, "<span class='danger'>Your eyes start to bleed profusely!</span>")
-		if(!(M.is_blind() || HAS_TRAIT(M, TRAIT_NEARSIGHT)))
-			to_chat(M, "<span class='danger'>You become nearsighted!</span>")
-		M.become_nearsighted(EYE_DAMAGE)
-		if(prob(50))
-			if(M.stat != DEAD)
-				if(M.drop_all_held_items())
-					to_chat(M, "<span class='danger'>You drop what you're holding and clutch at your eyes!</span>")
-			M.adjust_blurriness(10)
-			M.Unconscious(20)
-			M.Paralyze(40)
-		if (prob(eyes.damage - 10 + 1))
-			M.become_blind(EYE_DAMAGE)
-			to_chat(M, "<span class='danger'>You go blind!</span>")
 
 /obj/item/singularity_pull(S, current_size)
 	..()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -127,8 +127,8 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	///All items with sharpness of IS_SHARP or higher will automatically get the butchering component.
 	var/sharpness = IS_BLUNT
 
-	///All items with eyestab of 1 can be used to poke someone's eyes out
-	var/eyestab = 0
+	///All items with eyestab of TRUE can be used to poke someone's eyes out
+	var/can_eyestab = FALSE
 
 	///How a tool acts when you use it on something, such as wirecutters cutting wires while multitools measure power
 	var/tool_behaviour = NONE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -127,6 +127,9 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	///All items with sharpness of IS_SHARP or higher will automatically get the butchering component.
 	var/sharpness = IS_BLUNT
 
+	///All items with eyestab of 1 can be used to poke someone's eyes out
+	var/eyestab = 0
+
 	///How a tool acts when you use it on something, such as wirecutters cutting wires while multitools measure power
 	var/tool_behaviour = NONE
 	///How fast does the tool work

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -27,6 +27,7 @@
 	flags_1 = CONDUCT_1
 	attack_verb = list("attacked", "stabbed", "poked")
 	hitsound = 'sound/weapons/bladeslice.ogg'
+	eyestab = 1
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
 	var/datum/reagent/forkload //used to eat omelette
 
@@ -49,10 +50,6 @@
 		icon_state = "fork"
 		forkload = null
 
-	else if(user.zone_selected == BODY_ZONE_PRECISE_EYES)
-		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
-			M = user
-		return eyestab(M,user)
 	else
 		return ..()
 
@@ -88,6 +85,7 @@
 	custom_materials = list(/datum/material/iron=12000)
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = IS_SHARP_ACCURATE
+	eyestab = 1
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	var/bayonet = FALSE	//Can this be attached to a gun?
 	custom_price = 250
@@ -99,14 +97,6 @@
 ///Adds the butchering component, used to override stats for special cases
 /obj/item/kitchen/knife/proc/set_butchering()
 	AddComponent(/datum/component/butchering, 80 - force, 100, force - 10) //bonus chance increases depending on force
-
-/obj/item/kitchen/knife/attack(mob/living/carbon/M, mob/living/carbon/user)
-	if(user.zone_selected == BODY_ZONE_PRECISE_EYES)
-		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
-			M = user
-		return eyestab(M,user)
-	else
-		return ..()
 
 /obj/item/kitchen/knife/suicide_act(mob/user)
 	user.visible_message(pick("<span class='suicide'>[user] is slitting [user.p_their()] wrists with the [src.name]! It looks like [user.p_theyre()] trying to commit suicide.</span>", \

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -27,7 +27,7 @@
 	flags_1 = CONDUCT_1
 	attack_verb = list("attacked", "stabbed", "poked")
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	eyestab = 1
+	can_eyestab = TRUE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
 	var/datum/reagent/forkload //used to eat omelette
 
@@ -85,7 +85,7 @@
 	custom_materials = list(/datum/material/iron=12000)
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = IS_SHARP_ACCURATE
-	eyestab = 1
+	can_eyestab = TRUE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	var/bayonet = FALSE	//Can this be attached to a gun?
 	custom_price = 250

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -27,7 +27,6 @@
 	flags_1 = CONDUCT_1
 	attack_verb = list("attacked", "stabbed", "poked")
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	can_eyestab = TRUE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
 	var/datum/reagent/forkload //used to eat omelette
 
@@ -35,6 +34,10 @@
 	user.visible_message("<span class='suicide'>[user] stabs \the [src] into [user.p_their()] chest! It looks like [user.p_theyre()] trying to take a bite out of [user.p_them()]self!</span>")
 	playsound(src, 'sound/items/eatfood.ogg', 50, TRUE)
 	return BRUTELOSS
+
+/obj/item/kitchen/fork/Initialize()
+	. = ..()
+	AddElement(/datum/element/eyestab)
 
 /obj/item/kitchen/fork/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!istype(M))
@@ -85,7 +88,6 @@
 	custom_materials = list(/datum/material/iron=12000)
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = IS_SHARP_ACCURATE
-	can_eyestab = TRUE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	var/bayonet = FALSE	//Can this be attached to a gun?
 	custom_price = 250
@@ -93,6 +95,10 @@
 /obj/item/kitchen/knife/ComponentInitialize()
 	. = ..()
 	set_butchering()
+
+/obj/item/kitchen/knife/Initialize()
+	. = ..()
+	AddElement(/datum/element/eyestab)
 
 ///Adds the butchering component, used to override stats for special cases
 /obj/item/kitchen/knife/proc/set_butchering()

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -19,6 +19,7 @@
 	usesound = list('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg')
 	tool_behaviour = TOOL_SCREWDRIVER
 	toolspeed = 1
+	eyestab = 1
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
 	drop_sound = 'sound/items/handling/screwdriver_drop.ogg'
 	pickup_sound =  'sound/items/handling/screwdriver_pickup.ogg'
@@ -71,18 +72,6 @@
 		return head
 	else
 		return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', icon_state)
-
-/obj/item/screwdriver/attack(mob/living/carbon/M, mob/living/carbon/user)
-	if(!istype(M))
-		return ..()
-	if(user.zone_selected != BODY_ZONE_PRECISE_EYES && user.zone_selected != BODY_ZONE_HEAD)
-		return ..()
-	if(HAS_TRAIT(user, TRAIT_PACIFISM))
-		to_chat(user, "<span class='warning'>You don't want to harm [M]!</span>")
-		return
-	if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
-		M = user
-	return eyestab(M,user)
 
 /obj/item/screwdriver/abductor
 	name = "alien screwdriver"

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -19,7 +19,7 @@
 	usesound = list('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg')
 	tool_behaviour = TOOL_SCREWDRIVER
 	toolspeed = 1
-	eyestab = 1
+	can_eyestab = TRUE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
 	drop_sound = 'sound/items/handling/screwdriver_drop.ogg'
 	pickup_sound =  'sound/items/handling/screwdriver_pickup.ogg'

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -19,7 +19,6 @@
 	usesound = list('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg')
 	tool_behaviour = TOOL_SCREWDRIVER
 	toolspeed = 1
-	can_eyestab = TRUE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
 	drop_sound = 'sound/items/handling/screwdriver_drop.ogg'
 	pickup_sound =  'sound/items/handling/screwdriver_pickup.ogg'
@@ -47,6 +46,7 @@
 		update_icon()
 	if(prob(75))
 		pixel_y = rand(0, 16)
+	AddElement(/datum/element/eyestab)
 
 /obj/item/screwdriver/update_overlays()
 	. = ..()

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -74,7 +74,7 @@
 	force = 15
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("drilled")
-	eyestab = 1
+	can_eyestab = TRUE
 	tool_behaviour = TOOL_DRILL
 	toolspeed = 1
 
@@ -112,7 +112,7 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = IS_SHARP_ACCURATE
-	eyestab = 1
+	can_eyestab = TRUE
 	tool_behaviour = TOOL_SCALPEL
 	toolspeed = 1
 

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -74,6 +74,7 @@
 	force = 15
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("drilled")
+	eyestab = 1
 	tool_behaviour = TOOL_DRILL
 	toolspeed = 1
 
@@ -111,6 +112,7 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = IS_SHARP_ACCURATE
+	eyestab = 1
 	tool_behaviour = TOOL_SCALPEL
 	toolspeed = 1
 

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -74,7 +74,6 @@
 	force = 15
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("drilled")
-	can_eyestab = TRUE
 	tool_behaviour = TOOL_DRILL
 	toolspeed = 1
 
@@ -84,6 +83,10 @@
 	user.SpinAnimation(3, 10)
 	playsound(user, 'sound/machines/juicer.ogg', 20, TRUE)
 	return (MANUAL_SUICIDE)
+
+/obj/item/surgicaldrill/Initialize()
+	. = ..()
+	AddElement(/datum/element/eyestab)
 
 /obj/item/surgicaldrill/augment
 	desc = "Effectively a small power drill contained within your arm, edges dulled to prevent tissue damage. May or may not pierce the heavens."
@@ -112,13 +115,13 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = IS_SHARP_ACCURATE
-	can_eyestab = TRUE
 	tool_behaviour = TOOL_SCALPEL
 	toolspeed = 1
 
 /obj/item/scalpel/Initialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 80 * toolspeed, 100, 0)
+	AddElement(/datum/element/eyestab)
 
 /obj/item/scalpel/augment
 	desc = "Ultra-sharp blade attached directly to your bone for extra-accuracy."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -532,6 +532,7 @@
 #include "code\datums\elements\dunkable.dm"
 #include "code\datums\elements\earhealing.dm"
 #include "code\datums\elements\embed.dm"
+#include "code\datums\elements\eyestab.dm"
 #include "code\datums\elements\firestacker.dm"
 #include "code\datums\elements\forced_gravity.dm"
 #include "code\datums\elements\selfknockback.dm"


### PR DESCRIPTION
## About The Pull Request
See title

## Why It's Good For The Game
Scalpels and drills both seem like reasonable items to stab people in the eyes with, and moving eyestabbing to an element makes it more versatile and avoids copypasted code.

## Changelog
:cl: Thunder12345 and Fikou
balance: Scalpels and surgical drills can be used to eye stab.
refactor: Eye stabbing is now an element instead of being hardcoded.
/:cl:

closes #50476 
