### PR TITLE
Octet separators in DNA Console genome sequencer.

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -257,7 +257,7 @@
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 
 	if(!ui)
-		ui = new(user, src, ui_key, "scan_consolenew", name, 515, 710, master_ui, state)
+		ui = new(user, src, ui_key, "scan_consolenew", name, 539, 710, master_ui, state)
 		ui.open()
 
 /obj/machinery/computer/scan_consolenew/ui_data(mob/user)

--- a/tgui/packages/tgui/interfaces/DnaConsole.js
+++ b/tgui/packages/tgui/interfaces/DnaConsole.js
@@ -1004,9 +1004,10 @@ const GenomeSequencer = props => {
       </Box>
     );
 
-    if (((i % 8) === 0) && (i !== 0)) {
+    if ((i % 8 === 0) && (i !== 0)) {
       pairs.push(
         <Box
+          key={`${i}_divider`}
           inline
           position="relative"
           top="-17px"

--- a/tgui/packages/tgui/interfaces/DnaConsole.js
+++ b/tgui/packages/tgui/interfaces/DnaConsole.js
@@ -7,10 +7,8 @@ import { useBackend } from '../backend';
 import { Box, Button, Collapsible, Dimmer, Divider, Dropdown, Flex, Icon, LabeledList, NumberInput, ProgressBar, Section } from '../components';
 import { createLogger } from '../logging';
 
-// TODO: Combining mutations (E.g. Radioactive + Strength = Hulk)
-// https://tgstation13.org/wiki/Guide_to_genetics#List_of_Mutations
-
-const logger = createLogger('DnaConsole');
+// IN CASE OF DEBUGGING, BREAK GLASS.
+// const logger = createLogger('DnaConsole');
 
 const SUBJECT_CONCIOUS = 0;
 const SUBJECT_SOFT_CRIT = 1;
@@ -1005,7 +1003,22 @@ const GenomeSequencer = props => {
         {buttons[i + 1]}
       </Box>
     );
+
+    if (((i % 8) === 0) && (i !== 0)) {
+      pairs.push(
+        <Box
+          inline
+          position="relative"
+          top="-17px"
+          left="-1px"
+          width="8px"
+          height="2px"
+          backgroundColor="label" />,
+      );
+    }
+
     pairs.push(pair);
+
   }
   return (
     <Fragment>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds seperators between gene sequencer octets.

![image](https://user-images.githubusercontent.com/24975989/79609103-0f91b300-80ee-11ea-9e73-9a5c7a1cf658.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Commonly asked tweak from genetics mains following the new DNA Console overhaul.

Promised I'd add it back in as soon as the GitHub came back to life.

Delivering on said promise.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
None needed.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
