### PR TITLE
Adds panic bunker config to the world status topic

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -179,7 +179,7 @@
 	.["hard_popcap"] = CONFIG_GET(number/hard_popcap) || 0
 	.["extreme_popcap"] = CONFIG_GET(number/extreme_popcap) || 0
 	.["popcap"] = max(CONFIG_GET(number/soft_popcap), CONFIG_GET(number/hard_popcap), CONFIG_GET(number/extreme_popcap)) //generalized field for this concept for use across ss13 codebases
-	
+	.["bunkered"] = CONFIG_GET(flag/panic_bunker) || FALSE
 	if(SSshuttle && SSshuttle.emergency)
 		.["shuttle_mode"] = SSshuttle.emergency.mode
 		// Shuttle status, see /__DEFINES/stat.dm


### PR DESCRIPTION
In theory this can then be exposed to TGS and the status banners.