### PR TITLE
Fixes "thats" in a few item descriptions.

### DIFF
--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -635,13 +635,8 @@
 /obj/structure/closet/crate/miningcar{
 	name = "Mining cart"
 	},
-/obj/item/pickaxe{
-	attack_verb = list("ineffectively hit");
-	desc = "A pickaxe that's been left to rust.";
-	force = 1;
-	name = "rusty pickaxe";
-	pixel_x = 5;
-	throwforce = 1
+/obj/item/pickaxe/rusted{
+	pixel_x = 5
 	},
 /turf/open/floor/plating/asteroid/basalt{
 	initial_gas_mix = "n2=23;o2=14"
@@ -895,13 +890,8 @@
 	},
 /area/awaymission/caves/research)
 "cQ" = (
-/obj/item/pickaxe{
-	attack_verb = list("ineffectively hit");
-	desc = "A pickaxe that's been left to rust.";
-	force = 1;
-	name = "rusty pickaxe";
-	pixel_x = 5;
-	throwforce = 1
+/obj/item/pickaxe/rusted{
+	pixel_x = 5
 	},
 /turf/open/floor/plating/asteroid/basalt{
 	initial_gas_mix = "n2=23;o2=14"
@@ -1097,13 +1087,8 @@
 /area/awaymission/caves/BMP_asteroid/level_two)
 "ds" = (
 /obj/structure/closet/secure_closet/personal,
-/obj/item/pickaxe{
-	attack_verb = list("ineffectively hit");
-	desc = "A pickaxe that's been left to rust.";
-	force = 1;
-	name = "rusty pickaxe";
-	pixel_x = 5;
-	throwforce = 1
+/obj/item/pickaxe/rusted{
+	pixel_x = 5
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/caves/BMP_asteroid/level_two)
@@ -1492,21 +1477,11 @@
 /area/awaymission/caves/listeningpost)
 "eP" = (
 /obj/structure/table,
-/obj/item/pickaxe{
-	attack_verb = list("ineffectively hit");
-	desc = "A pickaxe that's been left to rust.";
-	force = 1;
-	name = "rusty pickaxe";
-	pixel_x = 5;
-	throwforce = 1
+/obj/item/pickaxe/rusted{
+	pixel_x = 5
 	},
-/obj/item/pickaxe{
-	attack_verb = list("ineffectively hit");
-	desc = "A pickaxe that's been left to rust.";
-	force = 1;
-	name = "rusty pickaxe";
-	pixel_x = 5;
-	throwforce = 1
+/obj/item/pickaxe/rusted{
+	pixel_x = 5
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/caves/listeningpost)
@@ -1872,13 +1847,8 @@
 /obj/structure/closet/crate/miningcar{
 	name = "Mining cart"
 	},
-/obj/item/pickaxe{
-	attack_verb = list("ineffectively hit");
-	desc = "A pickaxe that's been left to rust.";
-	force = 1;
-	name = "rusty pickaxe";
-	pixel_x = 5;
-	throwforce = 1
+/obj/item/pickaxe/rusted{
+	pixel_x = 5
 	},
 /obj/item/stack/sheet/mineral/adamantine{
 	amount = 15

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -637,7 +637,7 @@
 	},
 /obj/item/pickaxe{
 	attack_verb = list("ineffectively hit");
-	desc = "A pickaxe thats been left to rust.";
+	desc = "A pickaxe that's been left to rust.";
 	force = 1;
 	name = "rusty pickaxe";
 	pixel_x = 5;
@@ -897,7 +897,7 @@
 "cQ" = (
 /obj/item/pickaxe{
 	attack_verb = list("ineffectively hit");
-	desc = "A pickaxe thats been left to rust.";
+	desc = "A pickaxe that's been left to rust.";
 	force = 1;
 	name = "rusty pickaxe";
 	pixel_x = 5;
@@ -1099,7 +1099,7 @@
 /obj/structure/closet/secure_closet/personal,
 /obj/item/pickaxe{
 	attack_verb = list("ineffectively hit");
-	desc = "A pickaxe thats been left to rust.";
+	desc = "A pickaxe that's been left to rust.";
 	force = 1;
 	name = "rusty pickaxe";
 	pixel_x = 5;
@@ -1494,7 +1494,7 @@
 /obj/structure/table,
 /obj/item/pickaxe{
 	attack_verb = list("ineffectively hit");
-	desc = "A pickaxe thats been left to rust.";
+	desc = "A pickaxe that's been left to rust.";
 	force = 1;
 	name = "rusty pickaxe";
 	pixel_x = 5;
@@ -1502,7 +1502,7 @@
 	},
 /obj/item/pickaxe{
 	attack_verb = list("ineffectively hit");
-	desc = "A pickaxe thats been left to rust.";
+	desc = "A pickaxe that's been left to rust.";
 	force = 1;
 	name = "rusty pickaxe";
 	pixel_x = 5;
@@ -1874,7 +1874,7 @@
 	},
 /obj/item/pickaxe{
 	attack_verb = list("ineffectively hit");
-	desc = "A pickaxe thats been left to rust.";
+	desc = "A pickaxe that's been left to rust.";
 	force = 1;
 	name = "rusty pickaxe";
 	pixel_x = 5;

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -24,6 +24,13 @@
 	user.visible_message("<span class='suicide'>[user] couldn't do it!</span>")
 	return SHAME
 
+/obj/item/pickaxe/rusted
+	name = "rusty pickaxe"
+	desc = "A pickaxe that's been left to rust."
+	attack_verb = list("ineffectively hit")
+	force = 1
+	throwforce = 1
+
 /obj/item/pickaxe/mini
 	name = "compact pickaxe"
 	desc = "A smaller, compact version of the standard pickaxe."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes "thats" to "that's" on some descriptions of pickaxes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

"Thats" is not a word.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: Changes "thats" to "that's" on some descriptions of pickaxes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
