### PR TITLE
An attempt to clean up tesla code

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -752,6 +752,14 @@
 	return FALSE
 
 /**
+  * Respond to a electric bolt action on our item
+  *
+  * Default behaviour is to return, we define here to allow for cleaner code later on
+  */
+/atom/proc/zap_act(power, zap_flags, shocked_targets)
+	return
+
+/**
   * Implement the behaviour for when a user click drags a storage object to your atom
   *
   * This behaviour is usually to mass transfer, but this is no longer a used proc as it just

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -222,7 +222,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		SSfire_burning.processing -= src
 
 ///Called when the obj is hit by a tesla bolt.
-/obj/proc/zap_act(power, zap_flags, shocked_targets)
+/obj/zap_act(power, zap_flags, shocked_targets)
 	if(QDELETED(src))
 		return 0
 	obj_flags |= BEING_SHOCKED

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -737,7 +737,7 @@
 
 /obj/machinery/light/zap_act(power, zap_flags)
 	if(zap_flags & ZAP_MACHINE_EXPLOSIVE)
-		explosion(src,0,0,0,flame_range = 5, adminlog = 0)
+		explosion(src,0,0,0,flame_range = 5, adminlog = FALSE)
 		qdel(src)
 	else
 		return ..()

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -920,7 +920,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	if(zap_str < zap_cutoff)
 		return
 	var/atom/target
-	var/target_type = 0
+	var/target_type = LOWEST
 	var/list/arctargets = list()
 	//Making a new copy so additons further down the recursion do not mess with other arcs
 	//Lets put this ourself into the do not hit list, so we don't curve back to hit the same thing twice with one arc

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -919,8 +919,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	//If the strength of the zap decays past the cutoff, we stop
 	if(zap_str < zap_cutoff)
 		return
-	var/datum/target
-	var/target_type = (LOWEST)
+	var/atom/target
+	var/target_type = 0
 	var/list/arctargets = list()
 	//Making a new copy so additons further down the recursion do not mess with other arcs
 	//Lets put this ourself into the do not hit list, so we don't curve back to hit the same thing twice with one arc
@@ -1007,8 +1007,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		//Going boom should be rareish
 		if(prob(80))
 			zap_flags &= ~ZAP_MACHINE_EXPLOSIVE
-		if(istype(target, /obj/machinery/power/tesla_coil))
-			var/obj/machinery/power/tesla_coil/coil = target
+		if(target_type == COIL)
 			//In the best situation we can expect this to grow up to 2120kw before a delam/IT'S GONE TOO FAR FRED SHUT IT DOWN
 			//The formula for power gen is zap_str * zap_mod / 2 * capacitor rating, between 1 and 4
 			var/multi = 10
@@ -1017,33 +1016,29 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 					multi = 20
 				if(CRITICAL_POWER_PENALTY_THRESHOLD to INFINITY)
 					multi = 40
-			coil.zap_act(zap_str * multi, zap_flags, list())
+			target.zap_act(zap_str * multi, zap_flags, list())
 			zap_str /= 3 //Coils should take a lot out of the power of the zap
 
-		else if(istype(target, /obj/machinery/power/grounding_rod))
-			var/obj/machinery/power/grounding_rod/rod = target
+		else if(target_type == ROD)
 			//We can expect this to do very little, maybe shock the poor soul buckled to it, but that's all.
 			//This is one of our endpoints, if the bolt hits a grounding rod, it stops jumping
-			rod.zap_act(zap_str, zap_flags, list())
+			target.zap_act(zap_str, zap_flags, list())
 			return
 
 		else if(isliving(target))//If we got a fleshbag on our hands
-			var/mob/living/mob = target
-			mob.set_shocked()
-			addtimer(CALLBACK(mob, /mob/living/proc/reset_shocked), 10)
+			var/mob/living/creature = target
+			creature.set_shocked()
+			addtimer(CALLBACK(creature, /mob/living/proc/reset_shocked), 10)
 			//3 shots a human with no resistance. 2 to crit, one to death. This is at at least 10000 power.
 			//There's no increase after that because the input power is effectivly capped at 10k
 			//Does 1.5 damage at the least
 			var/shock_damage = ((zap_flags & ZAP_MOB_DAMAGE) ? (power / 200) - 10 : rand(5,10))
-			mob.electrocute_act(shock_damage, "Supermatter Discharge Bolt", 1,  ((zap_flags & ZAP_MOB_STUN) ? SHOCK_TESLA : SHOCK_NOSTUN))
+			creature.electrocute_act(shock_damage, "Supermatter Discharge Bolt", 1,  ((zap_flags & ZAP_MOB_STUN) ? SHOCK_TESLA : SHOCK_NOSTUN))
 			zap_str /= 1.5 //Meatsacks are conductive, makes working in pairs more destructive
 
-		else if(isobj(target))
-			var/obj/junk = target
-			junk.zap_act(zap_str, zap_flags, list())
-			zap_str /= 2 // worse then living things, better then coils
 		else
-			zap_str = 0
+			target.zap_act(zap_str, zap_flags, list())
+			zap_str /= 2 // worse then living things, better then coils
 		//This gotdamn variable is a boomer and keeps giving me problems
 		var/turf/T = get_turf(target)
 		var/pressure = 1

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -221,7 +221,8 @@
 
 	//Darkness fucks oview up hard. I've tried dview() but it doesn't seem to work
 	//I hate existance
-	for(var/atom/A in typecache_filter_multi_list_exclusion(oview(zap_range+2, source), things_to_shock, blacklisted_tesla_types))
+	for(var/a in typecache_filter_multi_list_exclusion(oview(zap_range+2, source), things_to_shock, blacklisted_tesla_types))
+		var/atom/A = a
 		if(!(zap_flags & ZAP_ALLOW_DUPLICATES) && LAZYACCESS(shocked_targets, A))
 			continue
 		if(closest_type >= BIKE)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -1,5 +1,14 @@
 #define TESLA_DEFAULT_POWER 1738260
 #define TESLA_MINI_POWER 869130
+//Zap constants, speeds up targeting
+#define BIKE (COIL + 1)
+#define COIL (ROD + 1)
+#define ROD (RIDE + 1)
+#define RIDE (LIVING + 1)
+#define LIVING (MACHINERY + 1)
+#define MACHINERY (BLOB + 1)
+#define BLOB (STRUCTURE + 1)
+#define STRUCTURE (1)
 
 /obj/singularity/energy_ball
 	name = "energy ball"
@@ -30,6 +39,9 @@
 		set_light(10, 7, "#EEEEFF")
 
 /obj/singularity/energy_ball/ex_act(severity, target)
+	return
+
+/obj/singularity/energy_ball/consume(severity, target)
 	return
 
 /obj/singularity/energy_ball/Destroy()
@@ -143,8 +155,8 @@
 		target.orbiting_balls += src
 		GLOB.poi_list -= src
 		target.dissipate_strength = target.orbiting_balls.len
-
 	. = ..()
+
 /obj/singularity/energy_ball/stop_orbit()
 	if (orbiting && istype(orbiting.parent, /obj/singularity/energy_ball))
 		var/obj/singularity/energy_ball/orbitingball = orbiting.parent
@@ -178,16 +190,8 @@
 	/*
 	THIS IS SO FUCKING UGLY AND I HATE IT, but I can't make it nice without making it slower, check*N rather then n. So we're stuck with it.
 	*/
-	var/closest_dist = 0
-	var/closest_atom
-	var/obj/vehicle/ridden/bicycle/closest_million_dollar_baby
-	var/obj/machinery/power/tesla_coil/closest_tesla_coil
-	var/obj/machinery/power/grounding_rod/closest_grounding_rod
-	var/obj/vehicle/ridden/closest_rideable
-	var/mob/living/closest_mob
-	var/obj/machinery/closest_machine
-	var/obj/structure/closest_structure
-	var/obj/structure/blob/closest_blob
+	var/atom/closest_atom
+	var/closest_type = 0
 	var/static/things_to_shock = typecacheof(list(/obj/machinery, /mob/living, /obj/structure, /obj/vehicle/ridden))
 	var/static/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 										/obj/machinery/power/emitter,
@@ -211,123 +215,104 @@
 										/obj/structure/grille,
 										/obj/structure/frame/machine))
 
-	for(var/A in typecache_filter_multi_list_exclusion(oview(source, zap_range+2), things_to_shock, blacklisted_tesla_types))
+	//Ok so we are making an assumption here. We assume that view() still calculates from the center out.
+	//This means that if we find an object we can assume it is the closest one of its type. This is somewhat of a speed increase.
+	//This also means we have no need to track distance, as the doview() proc does it all for us.
+
+	//Darkness fucks oview up hard. I've tried dview() but it doesn't seem to work
+	//I hate existance
+	for(var/atom/A in typecache_filter_multi_list_exclusion(oview(zap_range+2, source), things_to_shock, blacklisted_tesla_types))
 		if(!(zap_flags & ZAP_ALLOW_DUPLICATES) && LAZYACCESS(shocked_targets, A))
 			continue
+		if(closest_type >= BIKE)
+			break
 
-		if(istype(A, /obj/vehicle/ridden/bicycle))//God's not on our side cause he hates idiots.
-			var/dist = get_dist(source, A)
+		else if(istype(A, /obj/vehicle/ridden/bicycle))//God's not on our side cause he hates idiots.
 			var/obj/vehicle/ridden/bicycle/B = A
-			if(dist <= zap_range && (dist < closest_dist || !closest_million_dollar_baby) && !(B.obj_flags & BEING_SHOCKED) && B.can_buckle)//Gee goof thanks for the boolean
-				closest_dist = dist
+			if(!(B.obj_flags & BEING_SHOCKED) && B.can_buckle)//Gee goof thanks for the boolean
 				//we use both of these to save on istype and typecasting overhead later on
 				//while still allowing common code to run before hand
-				closest_million_dollar_baby = B
+				closest_type = BIKE
 				closest_atom = B
 
-		else if(closest_million_dollar_baby)
+		else if(closest_type >= COIL)
 			continue //no need checking these other things
 
 		else if(istype(A, /obj/machinery/power/tesla_coil))
-			var/dist = get_dist(source, A)
 			var/obj/machinery/power/tesla_coil/C = A
-			if(dist <= zap_range && (dist < closest_dist || !closest_tesla_coil) && !(C.obj_flags & BEING_SHOCKED))
-				closest_dist = dist
-				closest_tesla_coil = C
+			if(!(C.obj_flags & BEING_SHOCKED))
+				closest_type = COIL
 				closest_atom = C
 
-		else if(closest_tesla_coil)
+		else if(closest_type >= ROD)
 			continue
 
 		else if(istype(A, /obj/machinery/power/grounding_rod))
-			var/dist = get_dist(source, A)-2
-			if(dist <= zap_range && (dist < closest_dist || !closest_grounding_rod))
-				closest_grounding_rod = A
-				closest_atom = A
-				closest_dist = dist
+			closest_type = ROD
+			closest_atom = A
 
-		else if(closest_grounding_rod)
+		else if(closest_type >= RIDE)
 			continue
 
 		else if(istype(A,/obj/vehicle/ridden))
-			var/dist = get_dist(source, A)
 			var/obj/vehicle/ridden/R = A
-			if(dist <= zap_range && (dist < closest_dist || !closest_rideable) && R.can_buckle && !(R.obj_flags & BEING_SHOCKED))
-				closest_rideable = R
+			if(R.can_buckle && !(R.obj_flags & BEING_SHOCKED))
+				closest_type = RIDE
 				closest_atom = A
-				closest_dist = dist
 
-		else if(closest_rideable)
+		else if(closest_type >= LIVING)
 			continue
 
 		else if(isliving(A))
-			var/dist = get_dist(source, A)
 			var/mob/living/L = A
-			if(dist <= zap_range && (dist < closest_dist || !closest_mob) && L.stat != DEAD && !(HAS_TRAIT(L, TRAIT_TESLA_SHOCKIMMUNE)) && !(L.flags_1 & SHOCKED_1))
-				closest_mob = L
+			if(L.stat != DEAD && !(HAS_TRAIT(L, TRAIT_TESLA_SHOCKIMMUNE)) && !(L.flags_1 & SHOCKED_1))
+				closest_type = LIVING
 				closest_atom = A
-				closest_dist = dist
 
-		else if(closest_mob)
+		else if(closest_type >= MACHINERY)
 			continue
 
 		else if(ismachinery(A))
 			var/obj/machinery/M = A
-			var/dist = get_dist(source, A)
-			if(dist <= zap_range && (dist < closest_dist || !closest_machine) && !(M.obj_flags & BEING_SHOCKED))
-				closest_machine = M
+			if(!(M.obj_flags & BEING_SHOCKED))
+				closest_type = MACHINERY
 				closest_atom = A
-				closest_dist = dist
 
-		else if(closest_machine)
+		else if(closest_type >= BLOB)
 			continue
 
 		else if(istype(A, /obj/structure/blob))
 			var/obj/structure/blob/B = A
-			var/dist = get_dist(source, A)
-			if(dist <= zap_range && (dist < closest_dist || !closest_blob) && !(B.obj_flags & BEING_SHOCKED))
-				closest_blob = B
+			if(!(B.obj_flags & BEING_SHOCKED))
+				closest_type = BLOB
 				closest_atom = A
-				closest_dist = dist
 
-		else if(closest_blob)
+		else if(closest_type >= STRUCTURE)
 			continue
 
 		else if(isstructure(A))
 			var/obj/structure/S = A
-			var/dist = get_dist(source, A)
-			//There's no closest_structure here because there are no checks below this one, re-add it if that changes
-			if(dist <= zap_range && (dist < closest_dist) && !(S.obj_flags & BEING_SHOCKED))
-				closest_structure = S
+			if(!(S.obj_flags & BEING_SHOCKED))
+				closest_type = STRUCTURE
 				closest_atom = A
-				closest_dist = dist
 
 	//Alright, we've done our loop, now lets see if was anything interesting in range
-	if(closest_atom)
-		//common stuff
-		source.Beam(closest_atom, icon_state="lightning[rand(1,12)]", time=5, maxdistance = INFINITY)
-		if(!(zap_flags & ZAP_ALLOW_DUPLICATES))
-			LAZYSET(shocked_targets, closest_atom, TRUE)
-		var/zapdir = get_dir(source, closest_atom)
-		if(zapdir)
-			. = zapdir
+	if(!closest_atom)
+		return
+	//common stuff
+	source.Beam(closest_atom, icon_state="lightning[rand(1,12)]", time=5, maxdistance = INFINITY)
+	if(!(zap_flags & ZAP_ALLOW_DUPLICATES))
+		LAZYSET(shocked_targets, closest_atom, TRUE)
+	var/zapdir = get_dir(source, closest_atom)
+	if(zapdir)
+		. = zapdir
 
-	//per type stuff:
-	var/range = 3
-	if(!QDELETED(closest_million_dollar_baby))
-		power = closest_million_dollar_baby.zap_act(power, zap_flags, shocked_targets)
+	var/next_range = 3
+	if(closest_type == COIL)
+		next_range = 5
 
-	else if(!QDELETED(closest_tesla_coil))
-		power = closest_tesla_coil.zap_act(power, zap_flags, shocked_targets)
-		range = 5
-
-	else if(!QDELETED(closest_grounding_rod))
-		power = closest_grounding_rod.zap_act(power, zap_flags, shocked_targets)
-
-	else if(!QDELETED(closest_rideable))
-		power = closest_rideable.zap_act(power, zap_flags, shocked_targets)
-
-	else if(!QDELETED(closest_mob))
+	if(closest_type == LIVING)
+		var/mob/living/closest_mob = closest_atom
 		closest_mob.set_shocked()
 		addtimer(CALLBACK(closest_mob, /mob/living/proc/reset_shocked), 10)
 		var/shock_damage = (zap_flags & ZAP_MOB_DAMAGE) ? (min(round(power/600), 90) + rand(-5, 5)) : 0
@@ -336,20 +321,24 @@
 			var/mob/living/silicon/S = closest_mob
 			if((zap_flags & ZAP_MOB_STUN) && (zap_flags & ZAP_MOB_DAMAGE))
 				S.emp_act(EMP_LIGHT)
-			range = 7 // metallic folks bounce it further
+			next_range = 7 // metallic folks bounce it further
 		else
-			range = 5
+			next_range = 5
 		power /= 1.5
 
-	else if(!QDELETED(closest_machine))
-		power = closest_machine.zap_act(power, zap_flags, shocked_targets)
-
-	else if(!QDELETED(closest_blob))
-		power = closest_blob.zap_act(power, zap_flags, shocked_targets)
-
-	else if(!QDELETED(closest_structure))
-		power = closest_structure.zap_act(power, zap_flags, shocked_targets)
-
-	tesla_zap(closest_mob, range, power, zap_flags, shocked_targets)
+	else
+		power = closest_atom.zap_act(power, zap_flags, shocked_targets)
 	if(prob(20))//I know I know
-		tesla_zap(closest_mob, range, power / 2, zap_flags, shocked_targets)
+		tesla_zap(closest_atom, next_range, power * 0.5, zap_flags, shocked_targets)
+		tesla_zap(closest_atom, next_range, power * 0.5, zap_flags, shocked_targets)
+	else
+		tesla_zap(closest_atom, next_range, power, zap_flags, shocked_targets)
+
+#undef BIKE
+#undef COIL
+#undef ROD
+#undef RIDE
+#undef LIVING
+#undef MACHINERY
+#undef BLOB
+#undef STRUCTURE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds an override to tesla's consume() to prevent the tesla from calling consume() on what seems to be it's own energy balls, blowing up the containment.
Refactors the way tesla_zap deals with type, instead of dealing with type with a var for each type, we store the type integer, so we can clean up the zap_act part and something something lower the amount of vats we have to create on each zap.
Moves the base of zap_act to /atom so we don't need to type the default target var on most zaps.
Uses this in the same manner in supermatter_zap
*Should* make power output of tesla zaps more sane, mostly from tesla coils. I'll go into this more in future.

Now onto the more interesting changes.
We no longer track the closest object. We can do this because of how byond outputs objects with range()/view().
It outputs things in a spiral, starting from the center. [See](https://tgstation13.org/phpBB/viewtopic.php?f=5&t=25922)
Let me know if you want me to change this. It should speed up things slightly, it's mostly a cleanliness thing at this point.

And finally onto what I didn't change.
oview() for some insane reason cares about darkness. I've tried dview() and a modified version of that doview(), and neither worked. It didn't seem to return any objects from the for loop.  I plan on doing more testing on this in future.

## Why It's Good For The Game

Fixes #50506 
Cleans some stuff up, fixes some fucking weird shit. Documents some strange behavior.
Maybe now b**mer st##ion feature coders will stop being toxic towards my code.

## Changelog
:cl:
fix: Fixes teslas not containing properly sometimes
fix: Maybe makes tesla coil power output more sane, not totally sure myself
refactor: Refactored tesla code a bit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
