### PR TITLE
Reverts material datum item exports.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -294,13 +294,11 @@
 
 // /obj/item signals for economy
 #define COMSIG_ITEM_SOLD "item_sold"							//called when an item is sold by the exports subsystem
-#define COMSIG_ITEM_SOLD_MATERIAL "item_sold_material"			//called when an item is sold by the exports subsystem using material datums.
 #define COMSIG_STRUCTURE_UNWRAPPED "structure_unwrapped"		//called when a wrapped up structure is opened by hand
 #define COMSIG_ITEM_UNWRAPPED "item_unwrapped"					//called when a wrapped up item is opened by hand
 	#define COMSIG_ITEM_SPLIT_VALUE  1
 #define COMSIG_ITEM_SPLIT_PROFIT "item_split_profits"			//Called when getting the item's exact ratio for cargo's profit.
 #define COMSIG_ITEM_SPLIT_PROFIT_DRY "item_split_profits_dry"			//Called when getting the item's exact ratio for cargo's profit, without selling the item.
-#define COMSIG_ITEM_SPLIT_PROFIT_MATERIAL "item_split_material_profits"	//Called when getting an item's profit ratio, but when calculating wealth from material datums.
 
 
 // /obj/item/clothing signals

--- a/code/datums/components/pricetag.dm
+++ b/code/datums/components/pricetag.dm
@@ -8,9 +8,9 @@
 	owner = _owner
 	if(_profit_ratio)
 		profit_ratio = _profit_ratio
-	RegisterSignal(parent, list(COMSIG_ITEM_SOLD, COMSIG_ITEM_SOLD_MATERIAL), .proc/split_profit)
+	RegisterSignal(parent, list(COMSIG_ITEM_SOLD), .proc/split_profit)
 	RegisterSignal(parent, list(COMSIG_STRUCTURE_UNWRAPPED, COMSIG_ITEM_UNWRAPPED), .proc/Unwrapped)
-	RegisterSignal(parent, list(COMSIG_ITEM_SPLIT_PROFIT, COMSIG_ITEM_SPLIT_PROFIT_DRY, COMSIG_ITEM_SPLIT_PROFIT_MATERIAL), .proc/return_ratio)
+	RegisterSignal(parent, list(COMSIG_ITEM_SPLIT_PROFIT, COMSIG_ITEM_SPLIT_PROFIT_DRY), .proc/return_ratio)
 
 /datum/component/pricetag/proc/Unwrapped()
 	qdel(src) //Once it leaves it's wrapped container, the object in question should lose it's pricetag component.

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -56,11 +56,6 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 				if(!QDELETED(thing))
 					report.exported_atoms_ref += thing
 				break
-		if(!sold && thing.custom_materials)
-			var/datum/export/S = new /datum/export
-			if(S.get_material_cost(thing) && (!S.get_cost(thing, allowed_categories , apply_elastic)))
-				S.sell_material_item(thing, report, dry_run, apply_elastic, profit_ratio)
-				sold = TRUE
 		if(!dry_run && (sold || delete_unsold))
 			if(ismob(thing))
 				thing.investigate_log("deleted through cargo export",INVESTIGATE_CARGO)
@@ -196,51 +191,6 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	return msg
 
 GLOBAL_LIST_EMPTY(exports_list)
-
-/**
-  * Calculates the exact export value of the object based on the object's datum materials.
-  *
-  * loops through the atom's material datums and then multiplies that amount by it's relative worth, and sums the total.
-  */
-/datum/export/proc/get_material_cost(atom/movable/A)
-	for(var/i in A.custom_materials)
-		var/datum/material/M = i
-		. += M.value_per_unit * A.custom_materials[M]
-	. = round(.)  //floor of the value
-
-/**
-  * Sells an object using it's material cost.
-  *
-  * Works similarly to the sell object proc, but utilizes the get_material_cost proc in order to obtain it's raw value in terms of materials.
-  * Similarly checks for pricetags to split export profit the same way.
-  */
-/datum/export/proc/sell_material_item(obj/sold_object, datum/export_report/report, dry_run = TRUE, apply_elastic = TRUE)
-	///This is the value of the object, as derived from material datums.
-	var/material_cost = get_material_cost(sold_object)
-	///Quantity of the object in question.
-	var/amount = get_amount(sold_object)
-	///Utilized in the pricetag component. Splits the object's profit when it has a pricetag by the specified amount.
-	var/profit_ratio = 0
-
-	if(amount <= 0 || material_cost <= 0)
-		return FALSE
-	unit_name = "[sold_object.name]"
-	profit_ratio = SEND_SIGNAL(sold_object, COMSIG_ITEM_SPLIT_PROFIT_MATERIAL)
-	material_cost = material_cost * ((100 - profit_ratio) * 0.01)
-	if(dry_run == FALSE)
-		SEND_SIGNAL(sold_object, COMSIG_ITEM_SOLD_MATERIAL, item_value = material_cost)
-	report.total_value[src] += material_cost
-
-	if(istype(sold_object, /datum/export/material))
-		report.total_amount[src] += amount*MINERAL_MATERIAL_AMOUNT
-	else
-		report.total_amount[src] += amount
-
-	if(!dry_run)
-		if(apply_elastic)
-			cost *= NUM_E**(-1*k_elasticity*amount)		//marginal cost modifier
-		SSblackbox.record_feedback("nested tally", "export_sold_cost", 1, list("[sold_object.type]", "[material_cost]"))
-	return TRUE
 
 /proc/setupExports()
 	for(var/subtype in subtypesof(/datum/export))


### PR DESCRIPTION

## About The Pull Request
Long story short, oranges told me this PR was a bad idea about 30 minutes after it was merged, I had a good laugh, it couldn't possibly be that bad, antic ensue.

April 18th, The year of our lord 2020 rolls around.
My eyes have been open about how dumb-foundedly broken the material economy is vs the cash economy, and between metalgen, the new material datums that have been added, and all the things inbetween those issues that have come up, this is definitely NOT something I can make work alone, let alone with the way that won't enable an exponential number of issues as custom datum objects or custom material datums are expanded upon over time.

This doesn't fully revert the PR because A: Github is borked still and refuses to let me just revert the original PR, and B: There were some good code improvements in the other PR including documentation that have been left in.

## Why It's Good For The Game

As nice as this is and was, the material economy enabling infinite resources, infinite custom material exchange, and enabling otherwise intentionally worthless materials to generate near effortless infinite profit is endemic that branching the material economy and the cash economy was a step too far, too soon. It would be nice to see this back in the future, but this has brought forward a few endemic issues with materials that should be ironed out or designed around first.

## Changelog
:cl:
del: Non-sheet items can no longer be sold for their worth in materials.
/:cl:
