### PR TITLE
Small fix for Forgottenship ruin.

### DIFF
--- a/code/modules/ruins/spaceruin_code/forgottenship.dm
+++ b/code/modules/ruins/spaceruin_code/forgottenship.dm
@@ -78,6 +78,7 @@ GLOBAL_VAR_INIT(fscpassword, generate_password())
 /obj/structure/fluff/empty_sleeper/syndicate/captain
 	icon_state = "sleeper_s-open"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	deconstructible = FALSE
 
 /obj/structure/fluff/empty_sleeper/syndicate/captain/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

_"deconstructible = FALSE"_ for fluff object that emits GPS signal, so you cannot actually remove it to hide your location.

## Why It's Good For The Game

It was intended to be indestructible, but I forgot to remove the ability to deconstruct it with a wrench.

## Changelog
:cl:
fix: captain's empty sleeper, on cybersun ship space ruin, cannot be deconstructed with a wrench now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
