### PR TITLE
Remove exploity way of using pumps and scrubbers

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -392,7 +392,7 @@
 	var/temperature = air_contents.return_temperature()
 	///function used to check the limit of the canisters and also set the amount of damage that the canister can recieve, if the heat and pressure are way higher than the limit the more damage will be done
 	if(temperature > heat_limit || pressure > pressure_limit)
-		take_damage(min(((temperature/heat_limit) * (pressure/pressure_limit)), 50), BURN, 0)
+		take_damage(clamp((temperature/heat_limit) * (pressure/pressure_limit), 5, 50), BURN, 0)
 		return
 
 /obj/machinery/portable_atmospherics/canister/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -242,7 +242,7 @@
 	pressure_limit = 1e14
 	volume = 5000
 	max_integrity = 500
-	can_max_release_pressure = (ONE_ATMOSPHERE * 50)
+	can_max_release_pressure = (ONE_ATMOSPHERE * 30)
 	can_min_release_pressure = (ONE_ATMOSPHERE / 50)
 	mode = CANISTER_TIER_3
 

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -11,11 +11,11 @@
 	ui_x = 300
 	ui_y = 315
 
+	max_integrity = 250
 	///Max amount of heat allowed inside of the canister before it starts to melt (different tiers have different limits)
 	var/heat_limit = 5000
 	///Max amount of pressure allowed inside of the canister before it starts to break (different tiers have different limits)
 	var/pressure_limit = 50000
-	max_integrity = 250
 
 	var/on = FALSE
 	var/direction = PUMP_OUT
@@ -52,7 +52,7 @@
 
 	var/pressure = air_contents.return_pressure()
 	var/temperature = air_contents.return_temperature()
-	///function used to check the limit of the canisters and also set the amount of damage that the pump can recieve, if the heat and pressure are way higher than the limit the more damage will be done
+	///function used to check the limit of the pumps and also set the amount of damage that the pump can recieve, if the heat and pressure are way higher than the limit the more damage will be done
 	if(temperature > heat_limit || pressure > pressure_limit)
 		take_damage(min(((temperature/heat_limit) * (pressure/pressure_limit)), 50), BURN, 0)
 		return

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -54,7 +54,7 @@
 	var/temperature = air_contents.return_temperature()
 	///function used to check the limit of the pumps and also set the amount of damage that the pump can recieve, if the heat and pressure are way higher than the limit the more damage will be done
 	if(temperature > heat_limit || pressure > pressure_limit)
-		take_damage(min(((temperature/heat_limit) * (pressure/pressure_limit)), 50), BURN, 0)
+		take_damage(clamp((temperature/heat_limit) * (pressure/pressure_limit), 5, 50), BURN, 0)
 		return
 
 	if(!on)

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -48,6 +48,11 @@
 		pump.airs[2] = null
 		return
 
+	var/temp = air_contents.temperature
+	if(temp > 5000)
+		Destroy()
+		return
+
 	var/turf/T = get_turf(src)
 	if(direction == PUMP_OUT) // Hook up the internal pump.
 		pump.airs[1] = holding ? holding.air_contents : air_contents

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -11,6 +11,12 @@
 	ui_x = 300
 	ui_y = 315
 
+	///Max amount of heat allowed inside of the canister before it starts to melt (different tiers have different limits)
+	var/heat_limit = 5000
+	///Max amount of pressure allowed inside of the canister before it starts to break (different tiers have different limits)
+	var/pressure_limit = 50000
+	max_integrity = 250
+
 	var/on = FALSE
 	var/direction = PUMP_OUT
 	var/obj/machinery/atmospherics/components/binary/pump/pump
@@ -43,14 +49,17 @@
 
 /obj/machinery/portable_atmospherics/pump/process_atmos()
 	..()
+
+	var/pressure = air_contents.return_pressure()
+	var/temperature = air_contents.return_temperature()
+	///function used to check the limit of the canisters and also set the amount of damage that the pump can recieve, if the heat and pressure are way higher than the limit the more damage will be done
+	if(temperature > heat_limit || pressure > pressure_limit)
+		take_damage(min(((temperature/heat_limit) * (pressure/pressure_limit)), 50), BURN, 0)
+		return
+
 	if(!on)
 		pump.airs[1] = null
 		pump.airs[2] = null
-		return
-
-	var/temp = air_contents.temperature
-	if(temp > 5000)
-		Destroy()
 		return
 
 	var/turf/T = get_turf(src)

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -44,7 +44,7 @@
 	var/temperature = air_contents.return_temperature()
 	///function used to check the limit of the scrubbers and also set the amount of damage that the scrubber can recieve, if the heat and pressure are way higher than the limit the more damage will be done
 	if(temperature > heat_limit || pressure > pressure_limit)
-		take_damage(min(((temperature/heat_limit) * (pressure/pressure_limit)), 50), BURN, 0)
+		take_damage(clamp((temperature/heat_limit) * (pressure/pressure_limit), 5, 50), BURN, 0)
 		return
 
 	if(!on)

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -5,11 +5,11 @@
 	ui_x = 320
 	ui_y = 335
 
+	max_integrity = 250
 	///Max amount of heat allowed inside of the canister before it starts to melt (different tiers have different limits)
 	var/heat_limit = 5000
 	///Max amount of pressure allowed inside of the canister before it starts to break (different tiers have different limits)
 	var/pressure_limit = 50000
-	max_integrity = 250
 
 	var/on = FALSE
 	var/volume_rate = 1000
@@ -42,7 +42,7 @@
 
 	var/pressure = air_contents.return_pressure()
 	var/temperature = air_contents.return_temperature()
-	///function used to check the limit of the canisters and also set the amount of damage that the pump can recieve, if the heat and pressure are way higher than the limit the more damage will be done
+	///function used to check the limit of the scrubbers and also set the amount of damage that the scrubber can recieve, if the heat and pressure are way higher than the limit the more damage will be done
 	if(temperature > heat_limit || pressure > pressure_limit)
 		take_damage(min(((temperature/heat_limit) * (pressure/pressure_limit)), 50), BURN, 0)
 		return

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -5,6 +5,12 @@
 	ui_x = 320
 	ui_y = 335
 
+	///Max amount of heat allowed inside of the canister before it starts to melt (different tiers have different limits)
+	var/heat_limit = 5000
+	///Max amount of pressure allowed inside of the canister before it starts to break (different tiers have different limits)
+	var/pressure_limit = 50000
+	max_integrity = 250
+
 	var/on = FALSE
 	var/volume_rate = 1000
 	var/overpressure_m = 80
@@ -33,6 +39,14 @@
 
 /obj/machinery/portable_atmospherics/scrubber/process_atmos()
 	..()
+
+	var/pressure = air_contents.return_pressure()
+	var/temperature = air_contents.return_temperature()
+	///function used to check the limit of the canisters and also set the amount of damage that the pump can recieve, if the heat and pressure are way higher than the limit the more damage will be done
+	if(temperature > heat_limit || pressure > pressure_limit)
+		take_damage(min(((temperature/heat_limit) * (pressure/pressure_limit)), 50), BURN, 0)
+		return
+
 	if(!on)
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I added to portable pumps and scrubbers the same limit t1 canisters have in terms of heat and pressure (5000 K and 50000 Kpa). In hindsight i should've added this in the same PR as the canisters but i forgot about those and i see people use those instead of making t2 and t3 canisters.
Edit: i changed how the damage is calculated, it now uses a clamp() between 5 and 50 so that there will be no more instances where the damage is so low that is discarded and no damage is done
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Add the intended behaviour for all gas containers thinked in the Tiered Canisters PR to Portable Pumps and Scrubbers
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added heat and pressure limit to portable pumps and scrubbers
tweak: changed the damage calculation from a max() to a clamp() between 5 and 50
tweak: reduced max pressure output of t3 canisters to the same as t2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
