### PR TITLE
Radial menu tweaks

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -255,6 +255,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	current_user = M.client
 	//Blank
 	menu_holder = image(icon='icons/effects/effects.dmi',loc=anchor,icon_state="nothing",layer = ABOVE_HUD_LAYER)
+	menu_holder.plane = ABOVE_HUD_PLANE
 	menu_holder.appearance_flags |= KEEP_APART
 	menu_holder.vis_contents += elements + close_button
 	current_user.images += menu_holder
@@ -311,4 +312,9 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	var/answer = menu.selected_choice
 	qdel(menu)
 	GLOB.radial_menus -= uniqueid
+	if(require_near && !in_range(anchor, user))
+		return
+	if(menu.custom_check_callback)
+		if(!menu.custom_check_callback.Invoke())
+			return
 	return answer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

**Extremely boring stuff, skip to next PR.**

This PR fixes two issues regarding radial menus:

1) Firstly, radial menus are affected by the lighting, which means options they offer may not be always clearly visible to the user, and may sometimes even be cut in half if the turf the option is on is not visible to the user. 

Solved by setting plane of the radial menu holder to ABOVE_HUD_PLANE (which is also the same plane as radial screen objects themselves are on!).

2) Secondly, radials have two types of additional checks - optional require_near check, and custom check callback. These checks are, to save performance, called in intervals. If the checks are not met (for example, if user goes too far from the anchor of the radial menu), the menu automatically closes. Problem is, if the user is faster than the check interval, he is able to bypass these checks completely. For example, user goes away from the anchor of the radial menu, and clicks on some option before regular interval, the menu does not close fast enough and option goes through. This causes teleporting items, pseudo telekinesis and more. 

Solved by doing one last check after the option is chosen.

## Why It's Good For The Game

More reliable radial menu behavior.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
tweak: Radial menu options will now always be clearly visible to the user.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
