### PR TITLE
Quick one-line fix for two war buttons

### DIFF
--- a/code/game/gamemodes/clown_ops/clown_ops.dm
+++ b/code/game/gamemodes/clown_ops/clown_ops.dm
@@ -53,5 +53,4 @@
 	name = "Clown Operative Leader - Basic"
 	id = /obj/item/card/id/syndicate/nuke_leader
 	gloves = /obj/item/clothing/gloves/krav_maga/combatglovesplus
-	r_hand = /obj/item/nuclear_challenge/clownops
 	command_radio = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes clown op leaders spawning with two declare war buttons

## Why It's Good For The Game

Clown operatives can have little a war, as a treat

fixes #50499

## Changelog
:cl:
fix: fixed clown op leaders getting two declare war buttons
/:cl: