### PR TITLE
Purge Medicine Buff (Multiver and Calomel no longer suck!)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -307,14 +307,14 @@
 		var/datum/reagent/the_reagent = r
 		if(istype(the_reagent, /datum/reagent/medicine))
 			medibonus += 1
-	M.adjustToxLoss(-0.5 * min(medibonus, 3))
-	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, 0.5)
+	M.adjustToxLoss(-0.5 * min(medibonus, 3)) //It ain't great at healing, but if you've got nothing else it'll work
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, 0.5) //Kills at 40u
 	for(var/r2 in M.reagents.reagent_list)
 		var/datum/reagent/the_reagent2 = r2
 		if(the_reagent2 == src)
 			continue
 		var/amount2purge = 3
-		if(medibonus >= 3 && istype(the_reagent2, /datum/reagent/medicine)) //3 unique meds (3+multiver) will make it not purge medicines
+		if(medibonus >= 3 && istype(the_reagent2, /datum/reagent/medicine)) //3 unique meds (2+multiver) will make it not purge medicines
 			continue
 		M.reagents.remove_reagent(the_reagent2.type, amount2purge)
 	..()

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -307,16 +307,14 @@
 		var/datum/reagent/the_reagent = r
 		if(istype(the_reagent, /datum/reagent/medicine))
 			medibonus += 1
-	M.adjustToxLoss(-0.2 * medibonus)
-	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, medibonus ? 1.5/medibonus : 1)
+	M.adjustToxLoss(-1 * min(medibonus, 3))
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, 0.5)
 	for(var/r2 in M.reagents.reagent_list)
 		var/datum/reagent/the_reagent2 = r2
 		if(the_reagent2 == src)
 			continue
-		var/amount2purge = 0.1
-		if(istype(the_reagent2,/datum/reagent/toxin) || istype(the_reagent2,/datum/reagent/consumable/ethanol/))
-			amount2purge *= (5*medibonus) //very good antitox and antidrink (well just removing them) for roundstart availability
-		else if(medibonus >= 5 && istype(the_reagent2, /datum/reagent/medicine)) //5 unique meds (4+multiver) will make it not purge medicines
+		var/amount2purge = 3
+		if(medibonus >= 3 && istype(the_reagent2, /datum/reagent/medicine)) //3 unique meds (3+multiver) will make it not purge medicines
 			continue
 		M.reagents.remove_reagent(the_reagent2.type, amount2purge)
 	..()

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -307,8 +307,8 @@
 		var/datum/reagent/the_reagent = r
 		if(istype(the_reagent, /datum/reagent/medicine))
 			medibonus += 1
-	M.adjustToxLoss(-0.5 * min(medibonus, 3)) //It ain't great at healing, but if you've got nothing else it'll work
-	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, 0.5) //Kills at 40u
+	M.adjustToxLoss(-0.5 * min(medibonus, 3)) //not great at healing but if you have nothing else it will work
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, 0.5) //kills at 40u
 	for(var/r2 in M.reagents.reagent_list)
 		var/datum/reagent/the_reagent2 = r2
 		if(the_reagent2 == src)

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -307,7 +307,7 @@
 		var/datum/reagent/the_reagent = r
 		if(istype(the_reagent, /datum/reagent/medicine))
 			medibonus += 1
-	M.adjustToxLoss(-1 * min(medibonus, 3))
+	M.adjustToxLoss(-0.5 * min(medibonus, 3))
 	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, 0.5)
 	for(var/r2 in M.reagents.reagent_list)
 		var/datum/reagent/the_reagent2 = r2

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -379,11 +379,10 @@
 	taste_description = "acid"
 
 /datum/reagent/medicine/calomel/on_mob_life(mob/living/carbon/M)
-	for(var/datum/reagent/R in M.reagents.reagent_list)
-		if(R != src)
-			M.reagents.remove_reagent(R.type,2.5)
+	for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
+		M.reagents.remove_reagent(R.type,3)
 	if(M.health > 20)
-		M.adjustToxLoss(2.5*REM, 0)
+		M.adjustToxLoss(1*REM, 0)
 		. = 1
 	..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR aims to buff Multiver and Calomel, two sorely underused medicines (at least for actual doctoring). Compared to other early-game cat2s such as Libital and Aiuri, these two are sorely underwhelming as medicines, where they have been used more often as gimmick poisons than to actually help people. These changes should hopefully make them a viable treatment.

MULTIVER
Toxin healing changed from 0.2 per unique medicine to 0.5 per unique medicine (capped at 1.5)
Units purged changed from 0.1 per unique medicine (0.5 if toxin) to a static 3 units per tick
Multiver now stops purging medicines at 3 unique medicines (from 5).
Lung damage reduced from 1.5 to 0.5 (now kills at 40u, from 13.4u)

Out of all the CobbyChems, this one is the most infamous. Intended to encourage chem stacking and using a variety of meds for a treatment, this chem more often than not found itself used as a spectacularly lethal poison on par with Lexorin, depending on how you applied it, rather than its intended purpose of purging toxins. Its gimmick made it hard to fully utilize without filling your patient with junk, so doctors would often just default to pentetic acid. Multiver should be easier to bring to full potential and hopefully will see more use among skilled MDs.

CALOMEL
Calomel now only purges toxins.
Units purged buffed slightly from 2.5 to 3
Toxin damage reduced from 2.5 to 1

Calomel has always been the redheaded stepchild of chemistry. Also intended as a purging chem, it often hindered treatments more than it helped due to its relatively high damage output. While it still deals toxin damage to encourage players to use other medicines to outpace it, since Calomel now only purges toxins, it can be used as a "smart purger" in mixes that trades healing output for the ability to quickly get rid of poisons (and keep your other meds too).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You can no longer kill someone with a syringe full of Multiver. Cat2s should be medicines first, weapons second. Purge medications are now better at purging toxins without being spectacularly lethal poisons

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

balance: Multiver now heals 0.5 toxin per unique medicine (capped at 1.5), purges 3u of reagents a tick, stops purging medicines at 2 unique medicines (along with multiver), and deals 0.5 lung damage per tick (kills at 40u, from 13.4u).
balance: Calomel now only purges toxins, purges 3u per tick, and only deals 1 toxin damage per tick.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
