### PR TITLE
Adds foreign calendar datum and fixes Ramadan holidays

### DIFF
--- a/code/modules/holiday/foreign_calendar.dm
+++ b/code/modules/holiday/foreign_calendar.dm
@@ -1,21 +1,48 @@
 #define BYOND_EPOCH 2451544.5
 #define HEBREW_EPOCH 347995.5
+#define ISLAMIC_EPOCH 1948439.5
 
 /*
 Source for the method of calcuation
 https://www.fourmilab.ch/documents/calendar/
 by John Walker 2015, released under public domain
 */
-/datum/hebrew_calendar
-	var/dd
-	var/mm
+/datum/foreign_calendar
+	var/static/jd
 	var/yy
+	var/mm
+	var/dd
 
-/datum/hebrew_calendar/New()
-	var/julian = realtime_to_jd()
-	set_date(julian)
+/datum/foreign_calendar/New()
+	if (!jd)
+		jd = realtime_to_jd()
+	set_date(jd)
 
-/datum/hebrew_calendar/proc/hebrew_leap(year)
+/datum/foreign_calendar/proc/set_date()
+	return
+
+/datum/foreign_calendar/proc/realtime_to_jd()
+	return round(world.realtime / 864000) + BYOND_EPOCH
+
+//////////////////////////////
+//     Islamic Calendar     //
+//////////////////////////////
+/datum/foreign_calendar/islamic/proc/leap_islamic(yr)
+	return ((yr * 11 + 14) % 30) < 11
+
+/datum/foreign_calendar/islamic/set_date()
+	var/jd_adj = round(jd) + 0.5 // adjust julian date so it ends in .5
+	yy = round(((30 * (jd_adj - ISLAMIC_EPOCH)) + 10646) / 10631)
+	mm = min(12, CEILING(((jd - (29 + islamic_to_jd(yy, 1, 1))) / 29.5) + 1, 1))
+	dd = jd - islamic_to_jd(yy, mm, 1) + 1
+
+/datum/foreign_calendar/islamic/proc/islamic_to_jd(year, month, day)
+	return day + CEILING(29.5 * (month - 1), 1) + (year - 1) * 354 + round((3 + (11 * year)) / 30) + ISLAMIC_EPOCH - 1
+
+//////////////////////////////
+//      Hebrew Calendar     //
+//////////////////////////////
+/datum/foreign_calendar/hebrew/proc/hebrew_leap(year)
 	switch (year % 19)
 		if (0, 3, 6, 8, 11, 14, 17)
 			return TRUE
@@ -23,7 +50,7 @@ by John Walker 2015, released under public domain
 			return FALSE
 
 // Hebrew to Julian
-/datum/hebrew_calendar/proc/hebrew_to_jd(year, month, day)
+/datum/foreign_calendar/hebrew/proc/hebrew_to_jd(year, month, day)
 	var/months = hebrew_year_months(year)
 	var/jd = HEBREW_EPOCH + hebrew_delay_1(year) + hebrew_delay_2(year) + day + 1
 	if (month < 7)
@@ -38,7 +65,9 @@ by John Walker 2015, released under public domain
 
 
 // Julian to Hebrew
-/datum/hebrew_calendar/proc/set_date(jd)
+/datum/foreign_calendar/hebrew/set_date(jd)
+	if (yy && mm && dd)
+		return
 	jd = round(jd) + 0.5
 	var/count = round(((jd - HEBREW_EPOCH) * 98496) / 35975351)
 	var/year = count - 1
@@ -52,14 +81,14 @@ by John Walker 2015, released under public domain
 	mm = month
 	dd = day
 
-/datum/hebrew_calendar/proc/hebrew_year_months(year)
+/datum/foreign_calendar/hebrew/proc/hebrew_year_months(year)
 	if (hebrew_leap(year))
 		return 13
 	else
 		return 12
 
 // Delay based on starting day of the year
-/datum/hebrew_calendar/proc/hebrew_delay_1(year)
+/datum/foreign_calendar/hebrew/proc/hebrew_delay_1(year)
 	var/months = round(((235 * year) - 234) / 19)
 	var/parts = 12084 + (13753 * months)
 	var/day = (months * 29) + round(parts / 25920)
@@ -68,7 +97,7 @@ by John Walker 2015, released under public domain
 	return day
 
 // Delay based on length of adjacent years
-/datum/hebrew_calendar/proc/hebrew_delay_2(year)
+/datum/foreign_calendar/hebrew/proc/hebrew_delay_2(year)
 	var/last = hebrew_delay_1(year - 1)
 	var/present = hebrew_delay_1(year)
 	var/next = hebrew_delay_1(year + 1)
@@ -79,10 +108,10 @@ by John Walker 2015, released under public domain
 	else
 		return 0
 
-/datum/hebrew_calendar/proc/hebrew_year_days(year)
+/datum/foreign_calendar/hebrew/proc/hebrew_year_days(year)
 	return hebrew_to_jd(year + 1, 7, 1) - hebrew_to_jd(year, 7, 1)
 
-/datum/hebrew_calendar/proc/hebrew_month_days(year, month)
+/datum/foreign_calendar/hebrew/proc/hebrew_month_days(year, month)
 	switch (month)
 		//  First of all, dispose of fixed-length 29 day months
 		if (2, 4, 6, 10, 13)
@@ -102,8 +131,6 @@ by John Walker 2015, released under public domain
 	//  Nope, it's a 30 day month
 	return 30
 
-/datum/hebrew_calendar/proc/realtime_to_jd()
-	return round(world.realtime / 864000) + BYOND_EPOCH
-
+#undef ISLAMIC_EPOCH
 #undef BYOND_EPOCH
 #undef HEBREW_EPOCH

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -462,36 +462,27 @@
 /datum/holiday/moth/getStationPrefix()
 	return pick("Mothball","Lepidopteran","Lightbulb","Moth","Giant Atlas","Twin-spotted Sphynx","Madagascan Sunset","Luna","Death's Head","Emperor Gum","Polyphenus","Oleander Hawk","Io","Rosy Maple","Cecropia","Noctuidae","Giant Leopard","Dysphania Militaris","Garden Tiger")
 
-/datum/holiday/ramadan
+/datum/holiday/islamic
+	name = "Islamic calendar code broken"
+
+/datum/holiday/islamic/shouldCelebrate(dd, mm, yy, ww, ddd)
+	var/datum/foreign_calendar/islamic/cal = new
+	return ..(cal.dd, cal.mm, cal.yy, ww, ddd)
+
+/datum/holiday/islamic/ramadan
 	name = "Start of Ramadan"
-
-/*
-
-For anyone who stumbles on this some time in the future: this was calibrated to 2017
-Calculated based on the start and end of Ramadan in 2000 (First year of the Gregorian Calendar supported by BYOND)
-This is going to be accurate for at least a decade, likely a lot longer
-Since the date fluctuates, it may be inaccurate one year and then accurate for several after
-Inaccuracies will never be by more than one day for at least a hundred years
-Finds the number of days since the day in 2000 and gets the modulo of that and the average length of a Muslim year since the first one (622 AD, Gregorian)
-Since Ramadan is an entire month that lasts 29.5 days on average, the start and end are holidays and are calculated from the two dates in 2000
-
-*/
-
-/datum/holiday/ramadan/shouldCelebrate(dd, mm, yy, ww, ddd)
-	if (round(((world.realtime - 285984000) / 864000) % 354.373435326843) == 0)
-		return TRUE
-	return FALSE
+	begin_month = 9
+	begin_day = 1
+	end_day = 3
 
 /datum/holiday/ramadan/getStationPrefix()
-	return pick("Harm","Halaal","Jihad","Muslim")
+	return pick("Haram","Halaal","Jihad","Muslim")
 
 /datum/holiday/ramadan/end
 	name = "End of Ramadan"
-
-/datum/holiday/ramadan/end/shouldCelebrate(dd, mm, yy, ww, ddd)
-	if (round(((world.realtime - 312768000) / 864000) % 354.373435326843) == 0)
-		return TRUE
-	return FALSE
+	end_month = 10
+	begin_day = 28
+	end_day = 1
 
 /datum/holiday/lifeday
 	name = "Life Day"
@@ -625,7 +616,7 @@ Since Ramadan is an entire month that lasts 29.5 days on average, the start and 
 	name = "If you see this the Hebrew holiday calendar code is broken"
 
 /datum/holiday/hebrew/shouldCelebrate(dd, mm, yy, ww, ddd)
-	var/datum/hebrew_calendar/cal = new /datum/hebrew_calendar()
+	var/datum/foreign_calendar/hebrew/cal = new
 	return ..(cal.dd, cal.mm, cal.yy, ww, ddd)
 
 /datum/holiday/hebrew/hanukkah

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1895,7 +1895,7 @@
 #include "code\modules\games\kotahi.dm"
 #include "code\modules\goonchat\browserOutput.dm"
 #include "code\modules\holiday\easter.dm"
-#include "code\modules\holiday\hebrew_calendar.dm"
+#include "code\modules\holiday\foreign_calendar.dm"
 #include "code\modules\holiday\holidays.dm"
 #include "code\modules\holodeck\area_copy.dm"
 #include "code\modules\holodeck\computer.dm"


### PR DESCRIPTION
The game said it was Ramadan like last week. Ramadan is in like 5 days. This should fix it so it will be accurate. Note: Ramadan officially starts when someone sees the new moon, so this is predicting that. It will be way more accurate than before but never 100% accurate.

I think I will add Mayan calendar next.

## Changelog
:cl: That REALLY Good Soda Flavor
fix: Fix Ramadan so it won't be a week off anymore.
refactor: Replaced Hebrew calendar datum with a more generic foreign calendar datum. New calendar types can easily be added.
/:cl: