### PR TITLE
[Ready] Policy config refactor for Forgottenship ruin.

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -663,7 +663,7 @@
 	new_spawn.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
 	var/policy = get_policy(ROLE_SYNDICATE_CYBERSUN)
 	if(policy)
-		to_chat(new_spawn, "<span class='warning'>[policy]</span>")
+		to_chat(new_spawn, "<span class='bold'>[policy]</span>")
 
 /obj/effect/mob_spawn/human/syndicatespace/captain
 	name = "Syndicate Ship Captain"
@@ -677,7 +677,7 @@
 	new_spawn.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
 	var/policy = get_policy(ROLE_SYNDICATE_CYBERSUN_CAPTAIN)
 	if(policy)
-		to_chat(new_spawn, "<span class='warning'>[policy]</span>")
+		to_chat(new_spawn, "<span class='bold'>[policy]</span>")
 
 /datum/outfit/syndicatespace/syndicaptain/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -673,12 +673,6 @@
 	outfit = /datum/outfit/syndicatespace/syndicaptain
 	assignedrole = ROLE_SYNDICATE_CYBERSUN_CAPTAIN
 
-/obj/effect/mob_spawn/human/syndicatespace/captain/special(mob/living/new_spawn)
-	new_spawn.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
-	var/policy = get_policy(assignedrole)
-	if(policy)
-		to_chat(new_spawn, "<span class='bold'>[policy]</span>")
-
 /datum/outfit/syndicatespace/syndicaptain/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE
 
@@ -703,18 +697,9 @@
 
 /datum/outfit/syndicatespace/syndicaptain
 	name = "Syndicate Ship Captain"
-	uniform = /obj/item/clothing/under/syndicate/combat
 	suit = /obj/item/clothing/suit/armor/vest/capcarapace/syndicate
-	glasses = /obj/item/clothing/glasses/night
-	mask = /obj/item/clothing/mask/gas/syndicate
 	head = /obj/item/clothing/head/HoS/beret/syndicate
 	ears = /obj/item/radio/headset/syndicate/alt/leader
-	shoes = /obj/item/clothing/shoes/combat
-	gloves = /obj/item/clothing/gloves/combat
-	back = /obj/item/storage/backpack
 	l_pocket = /obj/item/gun/ballistic/automatic/pistol/APS
-	r_pocket = /obj/item/kitchen/knife/combat/survival
-	belt = /obj/item/storage/belt/military/assault
 	id = /obj/item/card/id/syndicate_command/captain_id
 	backpack_contents = list(/obj/item/documents/syndicate/red, /obj/item/paper/fluff/ruins/forgottenship/password)
-	implants = list(/obj/item/implant/weapons_auth)

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -654,14 +654,14 @@
 	flavour_text = "Your ship docks after a long time somewhere in hostile space, reporting a malfunction. You are stuck here, with Nanotrasen station nearby. Fix the ship, find a way to power it and follow your captain's orders."
 	important_info = "Obey orders given by your captain. DO NOT let the ship fall into enemy hands."
 	outfit = /datum/outfit/syndicatespace/syndicrew
-	assignedrole = "Cybersun Space Syndicate"
+	assignedrole = ROLE_SYNDICATE_CYBERSUN
 
 /datum/outfit/syndicatespace/syndicrew/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE
 
 /obj/effect/mob_spawn/human/syndicatespace/special(mob/living/new_spawn)
 	new_spawn.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
-	var/policy = get_policy(ROLE_SYNDICATE_CYBERSUN)
+	var/policy = get_policy(assignedrole)
 	if(policy)
 		to_chat(new_spawn, "<span class='bold'>[policy]</span>")
 
@@ -671,11 +671,11 @@
 	flavour_text = "Your ship docks after a long time somewhere in hostile space, reporting a malfunction. You are stuck here, with Nanotrasen station nearby. Command your crew and turn your ship into the most protected fortress."
 	important_info = "Protect the ship and secret documents in your backpack with your own life."
 	outfit = /datum/outfit/syndicatespace/syndicaptain
-	assignedrole = "Cybersun Space Syndicate Captain"
+	assignedrole = ROLE_SYNDICATE_CYBERSUN_CAPTAIN
 
 /obj/effect/mob_spawn/human/syndicatespace/captain/special(mob/living/new_spawn)
 	new_spawn.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
-	var/policy = get_policy(ROLE_SYNDICATE_CYBERSUN_CAPTAIN)
+	var/policy = get_policy(assignedrole)
 	if(policy)
 		to_chat(new_spawn, "<span class='bold'>[policy]</span>")
 

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -654,7 +654,7 @@
 	flavour_text = "Your ship docks after a long time somewhere in hostile space, reporting a malfunction. You are stuck here, with Nanotrasen station nearby. Fix the ship, find a way to power it and follow your captain's orders."
 	important_info = "Obey orders given by your captain. DO NOT let the ship fall into enemy hands."
 	outfit = /datum/outfit/syndicatespace/syndicrew
-	assignedrole = "Cybersun Crewmember"
+	assignedrole = "Cybersun Space Syndicate"
 
 /datum/outfit/syndicatespace/syndicrew/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE
@@ -671,7 +671,7 @@
 	flavour_text = "Your ship docks after a long time somewhere in hostile space, reporting a malfunction. You are stuck here, with Nanotrasen station nearby. Command your crew and turn your ship into the most protected fortress."
 	important_info = "Protect the ship and secret documents in your backpack with your own life."
 	outfit = /datum/outfit/syndicatespace/syndicaptain
-	assignedrole = "Cybersun Captain"
+	assignedrole = "Cybersun Space Syndicate Captain"
 
 /obj/effect/mob_spawn/human/syndicatespace/captain/special(mob/living/new_spawn)
 	new_spawn.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -647,6 +647,7 @@
 	name = "Syndicate Ship Crew Member"
 	roundstart = FALSE
 	death = FALSE
+	show_flavour = FALSE
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper_s"
 	short_desc = "You are a syndicate operative on old ship, stuck in hostile space."
@@ -655,35 +656,28 @@
 	outfit = /datum/outfit/syndicatespace/syndicrew
 	assignedrole = "Cybersun Crewmember"
 
-/obj/effect/mob_spawn/human/syndicatespace/Initialize(mapload)
-	. = ..()
-	var/policy = get_policy(ROLE_SYNDICATE_CYBERSUN)
-	if(policy)
-		important_info = policy
-
 /datum/outfit/syndicatespace/syndicrew/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE
 
 /obj/effect/mob_spawn/human/syndicatespace/special(mob/living/new_spawn)
 	new_spawn.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
+	var/policy = get_policy(ROLE_SYNDICATE_CYBERSUN)
+	if(policy)
+		to_chat(new_spawn, "<span class='warning'>[policy]</span>")
 
 /obj/effect/mob_spawn/human/syndicatespace/captain
 	name = "Syndicate Ship Captain"
-	roundstart = FALSE
-	death = FALSE
-	icon = 'icons/obj/machines/sleeper.dmi'
-	icon_state = "sleeper_s"
 	short_desc = "You are the captain of an old ship, stuck in hostile space."
 	flavour_text = "Your ship docks after a long time somewhere in hostile space, reporting a malfunction. You are stuck here, with Nanotrasen station nearby. Command your crew and turn your ship into the most protected fortress."
-	important_info = "Protect the ship and secret documents in your backpack with your own life. DO NOT let the ship fall into enemy hands."
+	important_info = "Protect the ship and secret documents in your backpack with your own life."
 	outfit = /datum/outfit/syndicatespace/syndicaptain
 	assignedrole = "Cybersun Captain"
 
-/obj/effect/mob_spawn/human/syndicatespace/syndicaptain/Initialize(mapload)
-	. = ..()
+/obj/effect/mob_spawn/human/syndicatespace/captain/special(mob/living/new_spawn)
+	new_spawn.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
 	var/policy = get_policy(ROLE_SYNDICATE_CYBERSUN_CAPTAIN)
 	if(policy)
-		important_info = policy
+		to_chat(new_spawn, "<span class='warning'>[policy]</span>")
 
 /datum/outfit/syndicatespace/syndicaptain/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE


### PR DESCRIPTION
## About The Pull Request

Policy config isn't replacing "important_info" in ghost-role spawner objects now, but instead, it will be showing up as the only, smaller text you see once you spawned in.
It also sets "show_flavour" to 'false' so you don't have to read 2 text walls, focusing your attention on policy.

## Why It's Good For The Game

You can put large walls of text in config, so people will know every single detail of it.

![Screenshot_85](https://user-images.githubusercontent.com/53223414/80411944-171b3e00-88de-11ea-81a1-886e035e835f.png)

## Changelog
:cl: EgorDinamit
tweak: Policy config for cybersun ship ruin is now the only text you will see when you spawn as its crew.
/:cl: