### PR TITLE
The Bogdanoffs have upgraded CRAB-17. You can't escape the dump.

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -257,8 +257,8 @@
 		set_new_account(user)
 		return
 
-	if (world.time < registered_account.withdrawDelay)
-		registered_account.bank_card_talk("<span class='warning'>ERROR: UNABLE TO LOGIN DUE TO SCHEDULED MAINTENANCE. MAINTENANCE IS SCHEDULED TO COMPLETE IN [(registered_account.withdrawDelay - world.time)/10] SECONDS.</span>", TRUE)
+	if (registered_account.being_dumped)
+		registered_account.bank_card_talk("<span class='warning'>内部服务器错误</span>", TRUE)
 		return
 
 	var/amount_to_remove =  FLOOR(input(user, "How much do you want to withdraw? Current Balance: [registered_account.account_balance]", "Withdraw Funds", 5) as num|null, 1)

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -71,7 +71,6 @@
 				return
 			to_chat(user, "<span class='warning'>You quickly cash out your funds to a more secure banking location. Funds are safu.</span>") // This is a reference and not a typo
 			card.registered_account.being_dumped = FALSE
-			card.registered_account.withdrawDelay = 0
 			if(check_if_finished())
 				qdel(src)
 				return

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -20,6 +20,12 @@
 		var/turf/targetturf = get_safe_random_station_turf()
 		if (!targetturf)
 			return FALSE
+		var/list/accounts_to_rob = SSeconomy.bank_accounts.Copy()
+		var/mob/living/carbon/human/H = user
+		accounts_to_rob -= H.get_bank_account()
+		for(var/i in accounts_to_rob)
+			var/datum/bank_account/B = i
+			B.being_dumped = TRUE
 		new /obj/effect/dumpeetTarget(targetturf, user)
 		dumped = TRUE
 

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -8,7 +8,6 @@
 	var/add_to_accounts = TRUE
 	var/account_id
 	var/being_dumped = FALSE //pink levels are rising
-	var/withdrawDelay = 0
 
 /datum/bank_account/New(newname, job)
 	if(add_to_accounts)
@@ -24,7 +23,6 @@
 
 /datum/bank_account/proc/dumpeet()
 	being_dumped = TRUE
-	withdrawDelay = world.time + DUMPTIME
 
 /datum/bank_account/proc/_adjust_money(amt)
 	account_balance += amt


### PR DESCRIPTION
## About The Pull Request

You can now no longer withdraw from the Spacecoin Market after CRAB-17 is enacted until you use your ID on the spacecoin market, the spacecoin market is destroyed, or the 8 minute timer elapses.

## Why It's Good For The Game

Being able to completely hose the whole point of CRAB-17 by alt-clicking your ID within the 10 second window is lame. Go swipe your ID if you want out of the space-coin market.

## Changelog
:cl:
balance: The Bogdanoffs have upgraded CRAB-17. You can't escape the dump.
/:cl: