### PR TITLE
Fixes Maint Hole that Magically Appeared in #50601

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -68249,10 +68249,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"dCl" = (
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/maintenance/port/fore)
 "dCn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -98264,7 +98260,7 @@ aAN
 aDl
 aEv
 doJ
-dCl
+doJ
 aRG
 dnZ
 aHm

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -13001,11 +13001,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/item/dice/d6{
-	pixel_y = 5;
-	pixel_x = 7
-	},
-/obj/item/dice/d6,
+/obj/item/storage/pill_bottle/dice,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aBZ" = (
@@ -98260,7 +98256,7 @@ aAN
 aDl
 aEv
 doJ
-doJ
+aRG
 aRG
 dnZ
 aHm

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -97480,7 +97480,7 @@ aqN
 ask
 dpG
 auI
-aok
+atu
 dne
 aBZ
 dpG


### PR DESCRIPTION
Please speedmerge : (

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a hole that spontaneously appeared in #50601 (likely a map editor error)

## Why It's Good For The Game

We don't want maintenance to be depressurized.

## Changelog
:cl:
fix: Maintenance will not be depressurized above cargo on MetaStation
/:cl:
