### PR TITLE
Fix instances of duplicate variable definitions in types

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -435,18 +435,15 @@
 		new /obj/item/reagent_containers/food/drinks/sillycup( src )
 
 /obj/item/storage/box/donkpockets
-    var/donktype = /obj/item/reagent_containers/food/snacks/donkpocket
-
-/obj/item/storage/box/donkpockets/PopulateContents()
-    for(var/i in 1 to 6)
-        new donktype(src)
-
-/obj/item/storage/box/donkpockets
 	name = "box of donk-pockets"
 	desc = "<B>Instructions:</B> <I>Heat in microwave. Product will cool if not eaten within seven minutes.</I>"
 	icon_state = "donkpocketbox"
 	illustration=null
-	donktype = /obj/item/reagent_containers/food/snacks/donkpocket
+	var/donktype = /obj/item/reagent_containers/food/snacks/donkpocket
+
+/obj/item/storage/box/donkpockets/PopulateContents()
+    for(var/i in 1 to 6)
+        new donktype(src)
 
 /obj/item/storage/box/donkpockets/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -856,7 +856,7 @@
 /obj/item/storage/box/beanbag
 	name = "box of beanbags"
 	desc = "A box full of beanbag shells."
-	illustration = "rubbershot_box"
+	icon_state = "rubbershot_box"
 	illustration = null
 
 /obj/item/storage/box/beanbag/PopulateContents()

--- a/code/modules/antagonists/gang/outfits.dm
+++ b/code/modules/antagonists/gang/outfits.dm
@@ -24,7 +24,6 @@
 	belt = /obj/item/gun/ballistic/automatic/pistol/m1911
 	r_pocket = /obj/item/lighter
 	l_pocket = /obj/item/restraints/handcuffs
-	back = /obj/item/storage/backpack/satchel/leather
 	id = /obj/item/card/id
 	backpack_contents = list(/obj/item/storage/box/handcuffs = 1,
 	/obj/item/storage/box/teargas = 1,

--- a/code/modules/cargo/exports/parts.dm
+++ b/code/modules/cargo/exports/parts.dm
@@ -50,7 +50,7 @@
 	include_subtypes = FALSE
 
 
-/datum/export/modular_part/battery
+/datum/export/modular_part/battery/upgraded
 	cost = 100
 	unit_name = "upgraded computer power cell"
 	export_types = list(/obj/item/stock_parts/cell/computer/micro)

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -3,7 +3,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass
 	name = "drinking glass"
 	desc = "Your standard drinking glass."
-	custom_price = 50
 	icon_state = "glass_empty"
 	amount_per_transfer_from_this = 10
 	volume = 50
@@ -44,7 +43,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass
 	name = "shot glass"
 	desc = "A shot glass - the universal symbol for bad decisions."
-	custom_price = 50
 	icon_state = "shotglass"
 	gulp_size = 15
 	amount_per_transfer_from_this = 15

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/king_of_goats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/king_of_goats.dm
@@ -55,7 +55,6 @@ Difficulty: Insanely Hard
 	robust_searching = TRUE
 	move_to_delay = 3
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
-	minbodytemp = 0
 	var/stun_chance = 5 //chance per attack to Weaken target
 
 /mob/living/simple_animal/hostile/megafauna/king/ex_act(severity, target)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -384,7 +384,7 @@
 	build_path = /obj/item/storage/bag/tray
 	category = list("initial","Dinnerware")
 
-/datum/design/tray
+/datum/design/cafeteria_tray
 	name = "Cafeteria Tray"
 	id = "foodtray"
 	build_type = AUTOLATHE

--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -103,4 +103,4 @@
 	product_slogans = "~Shake me up some of that Shambler's Juice!~"
 	product_ads = "Refreshing!;Jyrbv dv lg jfdv fw kyrk Jyrdscvi'j Alztv!;Over 1 trillion souls drank!;Thirsty? Nyp efk uizeb kyv uribevjj?;Kyv Jyrdscvi uizebj kyv ezxyk!;Drink up!;Krjkp."
 	light_mask = "shamblers-light-mask"
-	light_mask = "#e4005b"
+	light_color = "#e4005b"


### PR DESCRIPTION
## About The Pull Request
I'm removing bits of code that were defining the same variable inside a type multiple times.
It's like this PR: https://github.com/tgstation/tgstation/pull/46978


## Why It's Good For The Game
Cleans code and re-adds some things that were accidentally removed. I'll provide details:

- The box of beanbags (`/obj/item/storage/box/beanbag`) lost its icon at some point. It seems like this was a mistake, so I've re-added that and remove the duplicate vars.
![image](https://user-images.githubusercontent.com/1499676/80056291-c5f4fe00-851b-11ea-8c7f-a0dbee0e34df.png)
- The Shambler's Vendor had a typo leading to its `light_color` not being set. Now it's set (you'll have to squint):
![image](https://user-images.githubusercontent.com/1499676/80056375-f9d02380-851b-11ea-92eb-9fde80be15be.png)
- The cargo export for micro batteries was overriding the export for nano batteries. I fixed this, but there's another bug involving them (https://github.com/tgstation/tgstation/pull/50628) that makes testing this change awkward (I did test it though.)
- I also fixed the bag that cops in Families were spawning with being broken duped vars. @Iamgoofball says this change is the intended behaviour.

The rest is obvious enough.

## Changelog
:cl:
tweak: Beat cop in families now spawn with a cop dufflebag
fix: box of beanbags now has its correct icon instead of a generic box
fix: Shambler's Vendor now has correctly coloured ominous glow
fix: serving trays are no longer hidden from the autolathe
code: removed some instances of duplicate variables being defined in types
/:cl: