### PR TITLE
Removes opening doors with the cryptographic sequencer. Aka, removes the 6 tc tax.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1159,22 +1159,6 @@
 //Airlock is passable if it is open (!density), bot has access, and is not bolted shut or powered off)
 	return !density || (check_access(ID) && !locked && hasPower())
 
-/obj/machinery/door/airlock/emag_act(mob/user)
-	if(!operating && density && hasPower() && !(obj_flags & EMAGGED))
-		operating = TRUE
-		update_icon(AIRLOCK_EMAG, 1)
-		sleep(6)
-		if(QDELETED(src))
-			return
-		operating = FALSE
-		if(!open())
-			update_icon(AIRLOCK_CLOSED, 1)
-		obj_flags |= EMAGGED
-		lights = FALSE
-		locked = TRUE
-		loseMainPower()
-		loseBackupPower()
-
 /obj/machinery/door/airlock/attack_alien(mob/living/carbon/alien/humanoid/user)
 	if(isElectrified())
 		add_fingerprint(user)


### PR DESCRIPTION
## About The Pull Request

Removes opening doors with emags.

## Why It's Good For The Game

The six TC tax has been a huge issue for traitors for ages. You have to buy the emag because the emag is how you get access.

Except that's not the case anymore. Much like cloning, there's hundreds of ways to get access to a room you don't have access to nowadays that are much more interesting than magic swipe card.

This change allows the emag to be focused more on hacking shit than being a free all access ID.

## Changelog
:cl:
balance: E-mags no longer open doors.
/:cl: