### PR TITLE
Gives clown, mime, and tiki masks radial menus

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -219,7 +219,16 @@
 	max_integrity = 100
 	actions_types = list(/datum/action/item_action/adjust)
 	dog_fashion = null
+	var/list/tikimask_designs = list()
 
+/obj/item/clothing/mask/gas/tiki_mask/Initialize(mapload)
+	.=..()
+	tikimask_designs = list(
+		"Original Tiki" = image(icon = src.icon, icon_state = "tiki_eyebrow"),
+		"Happy Tiki" = image(icon = src.icon, icon_state = "tiki_happy"),
+		"Confused Tiki" = image(icon = src.icon, icon_state = "tiki_confused"),
+		"Angry Tiki" = image(icon = src.icon, icon_state = "tiki_angry")
+		)
 
 /obj/item/clothing/mask/gas/tiki_mask/ui_action_click(mob/user)
 	var/mob/M = usr
@@ -229,7 +238,9 @@
 	options["Confused Tiki"] = "tiki_confused"
 	options["Angry Tiki"] ="tiki_angry"
 
-	var/choice = input(M,"To what form do you wish to change this mask?","Morph Mask") in sortList(options)
+	var/choice = show_radial_menu(user,src, tikimask_designs, custom_check = FALSE, radius = 36, require_near = TRUE)
+	if(!choice)
+		return FALSE
 
 	if(src && choice && !M.stat && in_range(M,src))
 		icon_state = options[choice]

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -91,8 +91,8 @@
 		"True Form" = image(icon = src.icon, icon_state = "clown"),
 		"The Feminist" = image(icon = src.icon, icon_state = "sexyclown"),
 		"The Madman" = image(icon = src.icon, icon_state = "joker"),
-		"The Rainbow Color" = image(icon = src.icon, icon_state = "rainbow"),
-		"The Jester" = image(icon = src.icon, icon_state = "chaos")
+		"The Jester" = image(icon = src.icon, icon_state = "chaos"),
+		"The Rainbow Color" = image(icon = src.icon, icon_state = "rainbow")
 		)
 
 /obj/item/clothing/mask/gas/clown_hat/ui_action_click(mob/user)

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -83,6 +83,17 @@
 	resistance_flags = FLAMMABLE
 	actions_types = list(/datum/action/item_action/adjust)
 	dog_fashion = /datum/dog_fashion/head/clown
+	var/list/clownmask_designs = list()
+
+/obj/item/clothing/mask/gas/clown_hat/Initialize(mapload)
+	.=..()
+	clownmask_designs = list(
+		"True Form" = image(icon = src.icon, icon_state = "clown"),
+		"The Feminist" = image(icon = src.icon, icon_state = "sexyclown"),
+		"The Madman" = image(icon = src.icon, icon_state = "joker"),
+		"The Rainbow Color" = image(icon = src.icon, icon_state = "rainbow"),
+		"The Jester" = image(icon = src.icon, icon_state = "chaos")
+		)
 
 /obj/item/clothing/mask/gas/clown_hat/ui_action_click(mob/user)
 	if(!istype(user) || user.incapacitated())
@@ -95,7 +106,9 @@
 	options["The Rainbow Color"] ="rainbow"
 	options["The Jester"] ="chaos" //Nepeta33Leijon is holding me captive and forced me to help with this please send help
 
-	var/choice = input(user,"To what form do you wish to Morph this mask?","Morph Mask") in sortList(options)
+	var/choice = show_radial_menu(user,src, clownmask_designs, custom_check = FALSE, radius = 36, require_near = TRUE)
+	if(!choice)
+		return FALSE
 
 	if(src && choice && !user.incapacitated() && in_range(user,src))
 		icon_state = options[choice]
@@ -104,7 +117,7 @@
 			var/datum/action/A = X
 			A.UpdateButtonIcon()
 		to_chat(user, "<span class='notice'>Your Clown Mask has now morphed into [choice], all praise the Honkmother!</span>")
-		return 1
+		return TRUE
 
 /obj/item/clothing/mask/gas/sexyclown
 	name = "sexy-clown wig and mask"
@@ -125,7 +138,16 @@
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
 	actions_types = list(/datum/action/item_action/adjust)
+	var/list/mimemask_designs = list()
 
+/obj/item/clothing/mask/gas/mime/Initialize(mapload)
+	.=..()
+	mimemask_designs = list(
+		"Blanc" = image(icon = src.icon, icon_state = "mime"),
+		"Excité" = image(icon = src.icon, icon_state = "sexymime"),
+		"Triste" = image(icon = src.icon, icon_state = "sadmime"),
+		"Effrayé" = image(icon = src.icon, icon_state = "scaredmime")
+		)
 
 /obj/item/clothing/mask/gas/mime/ui_action_click(mob/user)
 	if(!istype(user) || user.incapacitated())
@@ -137,7 +159,9 @@
 	options["Effrayé"] = "scaredmime"
 	options["Excité"] ="sexymime"
 
-	var/choice = input(user,"To what form do you wish to Morph this mask?","Morph Mask") in sortList(options)
+	var/choice = show_radial_menu(user,src, mimemask_designs, custom_check = FALSE, radius = 36, require_near = TRUE)
+	if(!choice)
+		return FALSE
 
 	if(src && choice && !user.incapacitated() && in_range(user,src))
 		icon_state = options[choice]
@@ -146,7 +170,7 @@
 			var/datum/action/A = X
 			A.UpdateButtonIcon()
 		to_chat(user, "<span class='notice'>Your Mime Mask has now morphed into [choice]!</span>")
-		return 1
+		return TRUE
 
 /obj/item/clothing/mask/gas/monkeymask
 	name = "monkey mask"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -90,8 +90,8 @@
 	clownmask_designs = list(
 		"True Form" = image(icon = src.icon, icon_state = "clown"),
 		"The Feminist" = image(icon = src.icon, icon_state = "sexyclown"),
-		"The Madman" = image(icon = src.icon, icon_state = "joker"),
 		"The Jester" = image(icon = src.icon, icon_state = "chaos"),
+		"The Madman" = image(icon = src.icon, icon_state = "joker"),
 		"The Rainbow Color" = image(icon = src.icon, icon_state = "rainbow")
 		)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Clown, mime, and tiki mask options are now displayed in a radial menu
![image](https://user-images.githubusercontent.com/3204033/80081920-73f6ad00-8508-11ea-9c85-a31ca00a4c9b.png)
![image](https://user-images.githubusercontent.com/3204033/80079106-af8f7800-8504-11ea-8524-ef6b444776ab.png)
![image](https://user-images.githubusercontent.com/3204033/80080349-57f20c00-8506-11ea-8176-365556721e86.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes some pop-up menus in favor of something that looks and feels better
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Clown, Mime, and Tiki masks now use radial menus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
