### PR TITLE
Shrapnel mines no longer crash server, cleans up pellets a bit, take 2

### DIFF
--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -92,6 +92,8 @@
 	if(!weapon.isEmbedHarmless())
 		harmful = TRUE
 
+	weapon.embedded(parent)
+
 	if(iscarbon(parent))
 		initCarbon()
 	else if(isclosedturf(parent))

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -126,6 +126,12 @@
   * Note we track anyone who's alive and client'd when they get shredded in var/list/purple_hearts, for achievement checking later
   */
 /datum/component/pellet_cloud/proc/handle_martyrs()
+	var/obj/temp_parent = parent
+	var/mob/living/idiot_holding_grenade = temp_parent.loc
+	if(istype(idiot_holding_grenade))
+		for(var/i in 1 to radius * 2)
+			pew(idiot_holding_grenade) // free shrapnel if it goes off in your hand, and it doesn't even count towards the absorbed. fun!
+
 	var/list/martyrs = list()
 	for(var/mob/living/body in get_turf(parent))
 		if(!(body in bodies))

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -280,7 +280,7 @@
 	return TRUE
 
 /// Someone who was originally "under" the grenade has moved off the tile and is now eligible for being a martyr and "covering" it
-/datum/component/pellet_cloud/proc/target_qdel(atom/target)
+/datum/component/pellet_cloud/proc/on_target_qdel(atom/target)
 	UnregisterSignal(target, COMSIG_PARENT_QDELETING)
 	targets_hit -= target
 	bodies -= target

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -72,27 +72,27 @@
   * Honestly this is mostly just a rehash of [/obj/item/ammo_casing/proc/fire_casing()] for pellet counts > 1, except this lets us tamper with the pellets and hook onto them for tracking purposes.
   * The arguments really don't matter, this proc is triggered by COMSIG_PELLET_CLOUD_INIT which is only for this really, it's just a big mess of the state vars we need for doing the stuff over here.
   */
-/datum/component/pellet_cloud/proc/create_casing_pellets(obj/item/ammo_casing/A, atom/target, mob/living/user, fired_from, randomspread, spread, zone_override, params, distro)
+/datum/component/pellet_cloud/proc/create_casing_pellets(obj/item/ammo_casing/shell, atom/target, mob/living/user, fired_from, randomspread, spread, zone_override, params, distro)
 	shooter = user
 	var/targloc = get_turf(target)
 	if(!zone_override)
 		zone_override = shooter.zone_selected
 
 	for(var/i in 1 to num_pellets)
-		A.ready_proj(target, user, SUPPRESSED_VERY, zone_override, fired_from)
+		shell.ready_proj(target, user, SUPPRESSED_VERY, zone_override, fired_from)
 		if(distro)
 			if(randomspread)
 				spread = round((rand() - 0.5) * distro)
 			else //Smart spread
 				spread = round((i / num_pellets - 0.5) * distro)
 
-		RegisterSignal(A.BB, COMSIG_PROJECTILE_SELF_ON_HIT, .proc/pellet_hit)
-		RegisterSignal(A.BB, list(COMSIG_PROJECTILE_RANGE_OUT, COMSIG_PARENT_QDELETING), .proc/pellet_range)
-		pellets += A.BB
-		if(!A.throw_proj(target, targloc, shooter, params, spread))
+		RegisterSignal(shell.BB, COMSIG_PROJECTILE_SELF_ON_HIT, .proc/pellet_hit)
+		RegisterSignal(shell.BB, list(COMSIG_PROJECTILE_RANGE_OUT, COMSIG_PARENT_QDELETING), .proc/pellet_range)
+		pellets += shell.BB
+		if(!shell.throw_proj(target, targloc, shooter, params, spread))
 			return
 		if(i != num_pellets)
-			A.newshot()
+			shell.newshot()
 
 /**
   * create_blast_pellets() is for when we have a central point we want to shred the surroundings of with a ring of shrapnel, namely frag grenades and landmines.
@@ -208,7 +208,7 @@
 			to_chat(target, "<span class='userdanger'>You're hit by [num_hits] [proj_name]s!</span>")
 		else
 			target.visible_message("<span class='danger'>[target] is hit by a [proj_name]!</span>", null, null, COMBAT_MESSAGE_RANGE, target)
-			to_chat(target, "<span class='userdanger'>You're hit by [num_hits] [proj_name]s!</span>")
+			to_chat(target, "<span class='userdanger'>You're hit by a [proj_name]!</span>")
 
 	for(var/M in purple_hearts)
 		var/mob/living/martyr = M

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -178,6 +178,7 @@
 
 		if(martyr.stat != DEAD && martyr.client)
 			LAZYADD(purple_hearts, martyr)
+			RegisterSignal(martyr, COMSIG_PARENT_QDELETING, .proc/target_qdel, override=TRUE)
 
 		for(var/i in 1 to round(pellets_absorbed * 0.5))
 			pew(martyr)
@@ -192,7 +193,7 @@
 	hits++
 	targets_hit[target]++
 	if(targets_hit[target] == 1)
-		RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/target_qdel)
+		RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/target_qdel, override=TRUE)
 	UnregisterSignal(P, list(COMSIG_PARENT_QDELETING, COMSIG_PROJECTILE_RANGE_OUT, COMSIG_PROJECTILE_SELF_ON_HIT))
 	if(terminated == num_pellets)
 		finalize()
@@ -264,6 +265,7 @@
 /datum/component/pellet_cloud/proc/grenade_moved()
 	LAZYCLEARLIST(bodies)
 	for(var/mob/living/L in get_turf(parent))
+		RegisterSignal(L, COMSIG_PARENT_QDELETING, .proc/target_qdel, override=TRUE)
 		bodies += L
 
 /// Someone who was originally "under" the grenade has moved off the tile and is now eligible for being a martyr and "covering" it
@@ -281,3 +283,5 @@
 /datum/component/pellet_cloud/proc/target_qdel(atom/target)
 	UnregisterSignal(target, COMSIG_PARENT_QDELETING)
 	targets_hit -= target
+	bodies -= target
+	purple_hearts -= target

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -114,7 +114,7 @@
   *
   * Note that grenades have extra handling for someone throwing themselves/being thrown on top of it, while landmines do not (obviously, it's a landmine!). See [/datum/component/pellet_cloud/proc/handle_martyrs()]
   */
-/datum/component/pellet_cloud/proc/create_blast_pellets(obj/O, mob/living/lanced_by=NONE)
+/datum/component/pellet_cloud/proc/create_blast_pellets(obj/O, mob/living/lanced_by)
 	var/atom/A = parent
 
 	if(isgrenade(parent)) // handle_martyrs can reduce the radius and thus the number of pellets we produce if someone dives on top of a frag grenade

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -178,7 +178,7 @@
 
 		if(martyr.stat != DEAD && martyr.client)
 			LAZYADD(purple_hearts, martyr)
-			RegisterSignal(martyr, COMSIG_PARENT_QDELETING, .proc/target_qdel, override=TRUE)
+			RegisterSignal(martyr, COMSIG_PARENT_QDELETING, .proc/on_target_qdel, override=TRUE)
 
 		for(var/i in 1 to round(pellets_absorbed * 0.5))
 			pew(martyr)
@@ -193,7 +193,7 @@
 	hits++
 	targets_hit[target]++
 	if(targets_hit[target] == 1)
-		RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/target_qdel, override=TRUE)
+		RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/on_target_qdel, override=TRUE)
 	UnregisterSignal(P, list(COMSIG_PARENT_QDELETING, COMSIG_PROJECTILE_RANGE_OUT, COMSIG_PROJECTILE_SELF_ON_HIT))
 	if(terminated == num_pellets)
 		finalize()
@@ -265,7 +265,7 @@
 /datum/component/pellet_cloud/proc/grenade_moved()
 	LAZYCLEARLIST(bodies)
 	for(var/mob/living/L in get_turf(parent))
-		RegisterSignal(L, COMSIG_PARENT_QDELETING, .proc/target_qdel, override=TRUE)
+		RegisterSignal(L, COMSIG_PARENT_QDELETING, .proc/on_target_qdel, override=TRUE)
 		bodies += L
 
 /// Someone who was originally "under" the grenade has moved off the tile and is now eligible for being a martyr and "covering" it

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -287,6 +287,8 @@
 	sharpness = IS_SHARP
 	custom_materials = list(/datum/material/biomass = 500)
 	var/mob/living/carbon/human/fired_by
+	/// if we missed our target
+	var/missed = TRUE
 
 /obj/item/hardened_spike/Initialize(mapload, firedby)
 	. = ..()
@@ -294,13 +296,12 @@
 	addtimer(CALLBACK(src, .proc/checkembedded), 5 SECONDS)
 
 /obj/item/hardened_spike/proc/checkembedded()
-	if(ishuman(loc))
-		var/mob/living/carbon/human/embedtest = loc
-		for(var/l in embedtest.bodyparts)
-			var/obj/item/bodypart/limb = l
-			if(src in limb.embedded_objects)
-				return limb
-	unembedded()
+	if(missed)
+		unembedded()
+
+/obj/item/hardened_spike/embedded(atom/target)
+	if(isbodypart(target))
+		missed = FALSE
 
 /obj/item/hardened_spike/unembedded()
 	var/turf/T = get_turf(src)

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -206,7 +206,7 @@
 	icon_state = "moustacheg"
 	clumsy_check = GRENADE_NONCLUMSY_FUMBLE
 
-/obj/item/grenade/chem_grenade/teargas/moustache/prime()
+/obj/item/grenade/chem_grenade/teargas/moustache/prime(lance=FALSE)
 	var/myloc = get_turf(src)
 	. = ..()
 	for(var/mob/living/carbon/M in view(6, myloc))

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -206,7 +206,7 @@
 	icon_state = "moustacheg"
 	clumsy_check = GRENADE_NONCLUMSY_FUMBLE
 
-/obj/item/grenade/chem_grenade/teargas/moustache/prime(lanced_by)
+/obj/item/grenade/chem_grenade/teargas/moustache/prime(mob/living/lanced_by)
 	var/myloc = get_turf(src)
 	. = ..()
 	for(var/mob/living/carbon/M in view(6, myloc))

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -206,7 +206,7 @@
 	icon_state = "moustacheg"
 	clumsy_check = GRENADE_NONCLUMSY_FUMBLE
 
-/obj/item/grenade/chem_grenade/teargas/moustache/prime(lance=FALSE)
+/obj/item/grenade/chem_grenade/teargas/moustache/prime(lanced_by)
 	var/myloc = get_turf(src)
 	. = ..()
 	for(var/mob/living/carbon/M in view(6, myloc))

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -167,7 +167,7 @@
 
 	to_chat(user, "<span class='notice'>[src] is now in [mode] mode.</span>")
 
-/obj/item/grenade/barrier/prime(lanced_by)
+/obj/item/grenade/barrier/prime(mob/living/lanced_by)
 	. = ..()
 	new /obj/structure/barricade/security(get_turf(src.loc))
 	switch(mode)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -167,7 +167,7 @@
 
 	to_chat(user, "<span class='notice'>[src] is now in [mode] mode.</span>")
 
-/obj/item/grenade/barrier/prime()
+/obj/item/grenade/barrier/prime(lance=FALSE)
 	. = ..()
 	new /obj/structure/barricade/security(get_turf(src.loc))
 	switch(mode)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -167,7 +167,7 @@
 
 	to_chat(user, "<span class='notice'>[src] is now in [mode] mode.</span>")
 
-/obj/item/grenade/barrier/prime(lance=FALSE)
+/obj/item/grenade/barrier/prime(lanced_by)
 	. = ..()
 	new /obj/structure/barricade/security(get_turf(src.loc))
 	switch(mode)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -6,8 +6,6 @@
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "uglymine"
 	var/triggered = FALSE
-	/// whether we're deleting ourself or if we're just nullspacing ourself and letting something else delete us (shrapnel mines)
-	var/del_self = TRUE
 
 /obj/effect/mine/proc/mineEffect(mob/victim)
 	to_chat(victim, "<span class='danger'>*click*</span>")
@@ -36,10 +34,7 @@
 	mineEffect(victim)
 	triggered = TRUE
 	SEND_SIGNAL(src, COMSIG_MINE_TRIGGERED)
-	if(del_self)
-		qdel(src)
-	else
-		moveToNullspace()
+	qdel(src)
 
 /obj/effect/mine/explosive
 	name = "explosive mine"
@@ -59,7 +54,6 @@
 	name = "shrapnel mine"
 	var/shrapnel_type = /obj/projectile/bullet/shrapnel
 	var/shrapnel_magnitude = 3
-	del_self = FALSE
 
 /obj/effect/mine/shrapnel/mineEffect(mob/victim)
 	AddComponent(/datum/component/pellet_cloud, projectile_type=shrapnel_type, magnitude=shrapnel_magnitude)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -5,20 +5,26 @@
 	anchored = TRUE
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "uglymine"
-	var/triggered = 0
+	var/triggered = FALSE
+	/// whether we're deleting ourself or if we're just nullspacing ourself and letting something else delete us (shrapnel mines)
+	var/del_self = TRUE
 
 /obj/effect/mine/proc/mineEffect(mob/victim)
 	to_chat(victim, "<span class='danger'>*click*</span>")
 
-/obj/effect/mine/Crossed(AM as mob|obj)
+/obj/effect/mine/Crossed(atom/movable/AM)
+	if(triggered || !isturf(loc))
+		return
 	. = ..()
-	if(isturf(loc))
-		if(ismob(AM))
-			var/mob/MM = AM
-			if(!(MM.movement_type & FLYING))
-				triggermine(AM)
-		else
-			triggermine(AM)
+
+	if(AM.movement_type & FLYING)
+		return
+
+	triggermine(AM)
+
+/obj/effect/mine/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir)
+	. = ..()
+	triggermine()
 
 /obj/effect/mine/proc/triggermine(mob/victim)
 	if(triggered)
@@ -28,10 +34,12 @@
 	s.set_up(3, 1, src)
 	s.start()
 	mineEffect(victim)
+	triggered = TRUE
 	SEND_SIGNAL(src, COMSIG_MINE_TRIGGERED)
-	triggered = 1
-	qdel(src)
-
+	if(del_self)
+		qdel(src)
+	else
+		moveToNullspace()
 
 /obj/effect/mine/explosive
 	name = "explosive mine"
@@ -51,6 +59,7 @@
 	name = "shrapnel mine"
 	var/shrapnel_type = /obj/projectile/bullet/shrapnel
 	var/shrapnel_magnitude = 3
+	del_self = FALSE
 
 /obj/effect/mine/shrapnel/mineEffect(mob/victim)
 	AddComponent(/datum/component/pellet_cloud, projectile_type=shrapnel_type, magnitude=shrapnel_magnitude)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -5,6 +5,7 @@
 	anchored = TRUE
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "uglymine"
+	/// We manually check to see if we've been triggered in case multiple atoms cross us in the time between the mine being triggered and it actually deleting, to avoid a race condition with multiple detonations
 	var/triggered = FALSE
 
 /obj/effect/mine/proc/mineEffect(mob/victim)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -912,11 +912,6 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 			dropped(M, FALSE)
 	return ..()
 
-/obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=TRUE, diagonals_first = FALSE, datum/callback/callback, gentle = FALSE)
-	if(HAS_TRAIT(src, TRAIT_NODROP))
-		return
-	return ..()
-
 /obj/item/proc/embedded(atom/embedded_target)
 	return
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -912,7 +912,12 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 			dropped(M, FALSE)
 	return ..()
 
-/obj/item/proc/embedded(mob/living/carbon/human/embedded_mob)
+/obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=TRUE, diagonals_first = FALSE, datum/callback/callback, gentle = FALSE)
+	if(HAS_TRAIT(src, TRAIT_NODROP))
+		return
+	return ..()
+
+/obj/item/proc/embedded(atom/embedded_target)
 	return
 
 /obj/item/proc/unembedded()

--- a/code/game/objects/items/grenades/antigravity.dm
+++ b/code/game/objects/items/grenades/antigravity.dm
@@ -7,7 +7,7 @@
 	var/forced_value = 0
 	var/duration = 300
 
-/obj/item/grenade/antigravity/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/antigravity/prime(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 

--- a/code/game/objects/items/grenades/antigravity.dm
+++ b/code/game/objects/items/grenades/antigravity.dm
@@ -7,7 +7,7 @@
 	var/forced_value = 0
 	var/duration = 300
 
-/obj/item/grenade/antigravity/prime()
+/obj/item/grenade/antigravity/prime(mob/living/lanced_by = NONE)
 	. = ..()
 	update_mob()
 
@@ -15,4 +15,4 @@
 		T.AddElement(/datum/element/forced_gravity, forced_value)
 		addtimer(CALLBACK(T, /datum/.proc/_RemoveElement, list(forced_value)), duration)
 
-	resolve()
+	qdel(src)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -174,7 +174,7 @@
 	active = TRUE
 	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
 
-/obj/item/grenade/chem_grenade/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/chem_grenade/prime(mob/living/lanced_by)
 	if(stage != GRENADE_READY)
 		return
 
@@ -213,7 +213,7 @@
 	ignition_temp = 25 // Large grenades are slightly more effective at setting off heat-sensitive mixtures than smaller grenades.
 	threatscale = 1.1	// 10% more effective.
 
-/obj/item/grenade/chem_grenade/large/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/chem_grenade/large/prime(mob/living/lanced_by)
 	if(stage != GRENADE_READY)
 		return
 
@@ -280,7 +280,7 @@
 			to_chat(user, "<span class='notice'>The new value is out of bounds. Minimum spread is 5 units, maximum is 100 units.</span>")
 	..()
 
-/obj/item/grenade/chem_grenade/adv_release/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/chem_grenade/adv_release/prime(mob/living/lanced_by)
 	if(stage != GRENADE_READY)
 		return
 

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -174,7 +174,7 @@
 	active = TRUE
 	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
 
-/obj/item/grenade/chem_grenade/prime()
+/obj/item/grenade/chem_grenade/prime(mob/living/lanced_by = NONE)
 	if(stage != GRENADE_READY)
 		return
 
@@ -213,7 +213,7 @@
 	ignition_temp = 25 // Large grenades are slightly more effective at setting off heat-sensitive mixtures than smaller grenades.
 	threatscale = 1.1	// 10% more effective.
 
-/obj/item/grenade/chem_grenade/large/prime()
+/obj/item/grenade/chem_grenade/large/prime(mob/living/lanced_by = NONE)
 	if(stage != GRENADE_READY)
 		return
 
@@ -280,7 +280,7 @@
 			to_chat(user, "<span class='notice'>The new value is out of bounds. Minimum spread is 5 units, maximum is 100 units.</span>")
 	..()
 
-/obj/item/grenade/chem_grenade/adv_release/prime()
+/obj/item/grenade/chem_grenade/adv_release/prime(mob/living/lanced_by = NONE)
 	if(stage != GRENADE_READY)
 		return
 

--- a/code/game/objects/items/grenades/clusterbuster.dm
+++ b/code/game/objects/items/grenades/clusterbuster.dm
@@ -14,7 +14,7 @@
 	var/max_spawned = 8
 	var/segment_chance = 35
 
-/obj/item/grenade/clusterbuster/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/clusterbuster/prime(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	var/numspawned = rand(min_spawned,max_spawned)
@@ -60,7 +60,7 @@
 		step_away(src,loc)
 	addtimer(CALLBACK(src, .proc/prime), rand(15,60))
 
-/obj/item/grenade/clusterbuster/segment/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/clusterbuster/segment/prime(mob/living/lanced_by)
 	new payload_spawner(drop_location(), payload, rand(min_spawned,max_spawned))
 	playsound(src, prime_sound, 75, TRUE, -3)
 	qdel(src)

--- a/code/game/objects/items/grenades/clusterbuster.dm
+++ b/code/game/objects/items/grenades/clusterbuster.dm
@@ -14,7 +14,7 @@
 	var/max_spawned = 8
 	var/segment_chance = 35
 
-/obj/item/grenade/clusterbuster/prime()
+/obj/item/grenade/clusterbuster/prime(mob/living/lanced_by = NONE)
 	. = ..()
 	update_mob()
 	var/numspawned = rand(min_spawned,max_spawned)
@@ -30,7 +30,7 @@
 
 	new payload_spawner(drop_location(), payload, numspawned)//Launches payload
 	playsound(src, prime_sound, 75, TRUE, -3)
-	resolve()
+	qdel(src)
 
 //////////////////////
 //Clusterbang segment
@@ -60,10 +60,10 @@
 		step_away(src,loc)
 	addtimer(CALLBACK(src, .proc/prime), rand(15,60))
 
-/obj/item/grenade/clusterbuster/segment/prime()
+/obj/item/grenade/clusterbuster/segment/prime(mob/living/lanced_by = NONE)
 	new payload_spawner(drop_location(), payload, rand(min_spawned,max_spawned))
 	playsound(src, prime_sound, 75, TRUE, -3)
-	resolve()
+	qdel(src)
 
 //////////////////////////////////
 //The payload spawner effect

--- a/code/game/objects/items/grenades/emgrenade.dm
+++ b/code/game/objects/items/grenades/emgrenade.dm
@@ -4,7 +4,7 @@
 	icon_state = "emp"
 	item_state = "emp"
 
-/obj/item/grenade/empgrenade/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/empgrenade/prime(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	empulse(src, 4, 10)

--- a/code/game/objects/items/grenades/emgrenade.dm
+++ b/code/game/objects/items/grenades/emgrenade.dm
@@ -4,8 +4,8 @@
 	icon_state = "emp"
 	item_state = "emp"
 
-/obj/item/grenade/empgrenade/prime()
+/obj/item/grenade/empgrenade/prime(mob/living/lanced_by = NONE)
 	. = ..()
 	update_mob()
 	empulse(src, 4, 10)
-	resolve()
+	qdel(src)

--- a/code/game/objects/items/grenades/festive.dm
+++ b/code/game/objects/items/grenades/festive.dm
@@ -108,7 +108,7 @@ obj/item/grenade/firecracker/preprime(mob/user, delayoverride, msg = TRUE, volum
 	icon_state = initial(icon_state) + "_active"
 	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
 
-/obj/item/grenade/firecracker/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/firecracker/prime(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	var/explosion_loc = get_turf(src)

--- a/code/game/objects/items/grenades/festive.dm
+++ b/code/game/objects/items/grenades/festive.dm
@@ -108,11 +108,11 @@ obj/item/grenade/firecracker/preprime(mob/user, delayoverride, msg = TRUE, volum
 	icon_state = initial(icon_state) + "_active"
 	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
 
-/obj/item/grenade/firecracker/prime()
+/obj/item/grenade/firecracker/prime(mob/living/lanced_by = NONE)
 	. = ..()
 	update_mob()
 	var/explosion_loc = get_turf(src)
-	resolve()
+	qdel(src)
 	explosion(explosion_loc,-1,-1,2)
 
 

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -6,7 +6,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	var/flashbang_range = 7 //how many tiles away the mob will be stunned.
 
-/obj/item/grenade/flashbang/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/flashbang/prime(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	var/flashbang_turf = get_turf(src)
@@ -57,7 +57,7 @@
 	shrapnel_type = /obj/projectile/bullet/pellet/stingball/mega
 	shrapnel_radius = 12
 
-/obj/item/grenade/stingbang/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/stingbang/prime(mob/living/lanced_by)
 	if(iscarbon(loc))
 		var/mob/living/carbon/C = loc
 		var/obj/item/bodypart/B = C.get_holding_bodypart_of_item(src)
@@ -118,7 +118,7 @@
 		rots++
 		user.changeNext_move(CLICK_CD_RAPID)
 
-/obj/item/grenade/primer/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/primer/prime(mob/living/lanced_by)
 	shrapnel_radius = round(rots / rots_per_mag)
 	. = ..()
 	qdel(src)

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -58,14 +58,15 @@
 	shrapnel_radius = 12
 
 /obj/item/grenade/stingbang/prime()
-	var/atom/initial_loc = loc
-	. = ..()
-	if(iscarbon(initial_loc))
-		var/mob/living/carbon/C = initial_loc
+	if(iscarbon(loc))
+		var/mob/living/carbon/C = loc
 		var/obj/item/bodypart/B = C.get_holding_bodypart_of_item(src)
 		if(B)
+			forceMove(get_turf(C))
 			C.visible_message("<b><span class='danger'>[src] goes off in [C]'s hand, blowing [C.p_their()] [B.name] to bloody shreds!</span></b>", "<span class='userdanger'>[src] goes off in your hand, blowing your [B.name] to bloody shreds!</span>")
 			B.dismember()
+
+	. = ..()
 
 	update_mob()
 	var/flashbang_turf = get_turf(src)

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -6,7 +6,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	var/flashbang_range = 7 //how many tiles away the mob will be stunned.
 
-/obj/item/grenade/flashbang/prime()
+/obj/item/grenade/flashbang/prime(mob/living/lanced_by = NONE)
 	. = ..()
 	update_mob()
 	var/flashbang_turf = get_turf(src)
@@ -17,7 +17,7 @@
 	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_WHITE, (flashbang_range + 2), 4, 2)
 	for(var/mob/living/M in get_hearers_in_view(flashbang_range, flashbang_turf))
 		bang(get_turf(M), M)
-	resolve()
+	qdel(src)
 
 /obj/item/grenade/flashbang/proc/bang(turf/T , mob/living/M)
 	if(M.stat == DEAD)	//They're dead!
@@ -57,7 +57,7 @@
 	shrapnel_type = /obj/projectile/bullet/pellet/stingball/mega
 	shrapnel_radius = 12
 
-/obj/item/grenade/stingbang/prime()
+/obj/item/grenade/stingbang/prime(mob/living/lanced_by = NONE)
 	if(iscarbon(loc))
 		var/mob/living/carbon/C = loc
 		var/obj/item/bodypart/B = C.get_holding_bodypart_of_item(src)
@@ -77,7 +77,7 @@
 	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_WHITE, (flashbang_range + 2), 2, 1)
 	for(var/mob/living/M in get_hearers_in_view(flashbang_range, flashbang_turf))
 		pop(get_turf(M), M)
-	resolve()
+	qdel(src)
 
 /obj/item/grenade/stingbang/proc/pop(turf/T , mob/living/M)
 	if(M.stat == DEAD)	//They're dead!
@@ -118,10 +118,10 @@
 		rots++
 		user.changeNext_move(CLICK_CD_RAPID)
 
-/obj/item/grenade/primer/prime()
+/obj/item/grenade/primer/prime(mob/living/lanced_by = NONE)
 	shrapnel_radius = round(rots / rots_per_mag)
 	. = ..()
-	resolve()
+	qdel(src)
 
 /obj/item/grenade/primer/stingbang
 	name = "rotsting"

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -58,14 +58,15 @@
 	shrapnel_radius = 12
 
 /obj/item/grenade/stingbang/prime()
-	if(iscarbon(loc))
-		var/mob/living/carbon/C = loc
+	var/atom/initial_loc = loc
+	. = ..()
+	if(iscarbon(initial_loc))
+		var/mob/living/carbon/C = initial_loc
 		var/obj/item/bodypart/B = C.get_holding_bodypart_of_item(src)
 		if(B)
 			C.visible_message("<b><span class='danger'>[src] goes off in [C]'s hand, blowing [C.p_their()] [B.name] to bloody shreds!</span></b>", "<span class='userdanger'>[src] goes off in your hand, blowing your [B.name] to bloody shreds!</span>")
 			B.dismember()
 
-	. = ..()
 	update_mob()
 	var/flashbang_turf = get_turf(src)
 	if(!flashbang_turf)
@@ -88,7 +89,7 @@
 		M.Knockdown(max(100/max(1,distance), 60))
 
 //Bang
-	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
+	if(!distance || loc == M || loc == M.loc)
 		M.Paralyze(20)
 		M.Knockdown(200)
 		M.soundbang_act(1, 200, 10, 15)

--- a/code/game/objects/items/grenades/ghettobomb.dm
+++ b/code/game/objects/items/grenades/ghettobomb.dm
@@ -63,7 +63,7 @@
 			cut_overlay("improvised_grenade_filled")
 			preprime(user, null, FALSE)
 
-/obj/item/grenade/iedcasing/prime(mob/living/lanced_by = NONE) //Blowing that can up
+/obj/item/grenade/iedcasing/prime(mob/living/lanced_by) //Blowing that can up
 	. = ..()
 	update_mob()
 	explosion(src.loc,-1,-1,2, flame_range = 4)	// small explosion, plus a very large fireball.

--- a/code/game/objects/items/grenades/ghettobomb.dm
+++ b/code/game/objects/items/grenades/ghettobomb.dm
@@ -63,11 +63,11 @@
 			cut_overlay("improvised_grenade_filled")
 			preprime(user, null, FALSE)
 
-/obj/item/grenade/iedcasing/prime() //Blowing that can up
+/obj/item/grenade/iedcasing/prime(mob/living/lanced_by = NONE) //Blowing that can up
 	. = ..()
 	update_mob()
 	explosion(src.loc,-1,-1,2, flame_range = 4)	// small explosion, plus a very large fireball.
-	resolve()
+	qdel(src)
 
 /obj/item/grenade/iedcasing/change_det_time()
 	return //always be random.

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -105,7 +105,7 @@
 	SEND_SIGNAL(src, COMSIG_GRENADE_ARMED, det_time, delayoverride)
 	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
 
-/obj/item/grenade/proc/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/proc/prime(mob/living/lanced_by)
 	if(shrapnel_type && shrapnel_radius && !shrapnel_initialized) // add a second check for adding the component in case whatever triggered the grenade went straight to prime (badminnery for example)
 		shrapnel_initialized = TRUE
 		AddComponent(/datum/component/pellet_cloud, projectile_type=shrapnel_type, magnitude=shrapnel_radius)

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -105,12 +105,12 @@
 	SEND_SIGNAL(src, COMSIG_GRENADE_ARMED, det_time, delayoverride)
 	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
 
-/obj/item/grenade/proc/prime()
+/obj/item/grenade/proc/prime(mob/living/lanced_by = NONE)
 	if(shrapnel_type && shrapnel_radius && !shrapnel_initialized) // add a second check for adding the component in case whatever triggered the grenade went straight to prime (badminnery for example)
 		shrapnel_initialized = TRUE
 		AddComponent(/datum/component/pellet_cloud, projectile_type=shrapnel_type, magnitude=shrapnel_radius)
 
-	SEND_SIGNAL(src, COMSIG_GRENADE_PRIME)
+	SEND_SIGNAL(src, COMSIG_GRENADE_PRIME, lanced_by)
 	if(ex_dev || ex_heavy || ex_light || ex_flame)
 		explosion(loc, ex_dev, ex_heavy, ex_light, flame_range = ex_flame)
 
@@ -170,10 +170,3 @@
 	. = ..()
 	if(active)
 		user.throw_item(target)
-
-/// Don't call qdel() directly on the grenade after it booms, call this instead so it can still resolve its pellet_cloud component if it has shrapnel, then the component will qdel it
-/obj/item/grenade/proc/resolve()
-	if(shrapnel_type)
-		moveToNullspace()
-	else
-		qdel(src)

--- a/code/game/objects/items/grenades/hypno.dm
+++ b/code/game/objects/items/grenades/hypno.dm
@@ -7,7 +7,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	var/flashbang_range = 7
 
-/obj/item/grenade/hypnotic/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/hypnotic/prime(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	var/flashbang_turf = get_turf(src)

--- a/code/game/objects/items/grenades/hypno.dm
+++ b/code/game/objects/items/grenades/hypno.dm
@@ -7,7 +7,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	var/flashbang_range = 7
 
-/obj/item/grenade/hypnotic/prime()
+/obj/item/grenade/hypnotic/prime(mob/living/lanced_by = NONE)
 	. = ..()
 	update_mob()
 	var/flashbang_turf = get_turf(src)
@@ -18,7 +18,7 @@
 	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_PURPLE, (flashbang_range + 2), 4, 2)
 	for(var/mob/living/M in get_hearers_in_view(flashbang_range, flashbang_turf))
 		bang(get_turf(M), M)
-	resolve()
+	qdel(src)
 
 /obj/item/grenade/hypnotic/proc/bang(turf/T, mob/living/M)
 	if(M.stat == DEAD)	//They're dead!

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -41,7 +41,7 @@
 	else
 		return ..()
 
-/obj/item/grenade/c4/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/c4/prime(mob/living/lanced_by)
 	if(QDELETED(src))
 		return
 

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -41,7 +41,7 @@
 	else
 		return ..()
 
-/obj/item/grenade/c4/prime()
+/obj/item/grenade/c4/prime(mob/living/lanced_by = NONE)
 	if(QDELETED(src))
 		return
 
@@ -61,7 +61,7 @@
 			explosion(get_step(T, aim_dir), boom_sizes[1], boom_sizes[2], boom_sizes[3])
 		else
 			explosion(location, boom_sizes[1], boom_sizes[2], boom_sizes[3])
-	resolve()
+	qdel(src)
 
 //assembly stuff
 /obj/item/grenade/c4/receive_signal()
@@ -149,7 +149,7 @@
 	shout_syndicate_crap(user)
 	explosion(user,0,2,0) //Cheap explosion imitation because putting prime() here causes runtimes
 	user.gib(1, 1)
-	resolve()
+	qdel(src)
 
 // X4 is an upgraded directional variant of c4 which is relatively safe to be standing next to. And much less safe to be standing on the other side of.
 // C4 is intended to be used for infiltration, and destroying tech. X4 is intended to be used for heavy breaching and tight spaces.

--- a/code/game/objects/items/grenades/smokebomb.dm
+++ b/code/game/objects/items/grenades/smokebomb.dm
@@ -19,7 +19,7 @@
 	desc = "The word '[pick(bruh_moment)]' is scribbled on it in crayon."
 
 ///Here we generate some smoke and also damage blobs??? for some reason. Honestly not sure why we do that.
-/obj/item/grenade/smokebomb/prime()
+/obj/item/grenade/smokebomb/prime(mob/living/lanced_by = NONE)
 	. = ..()
 	update_mob()
 	playsound(src, 'sound/effects/smoke.ogg', 50, TRUE, -3)
@@ -30,4 +30,4 @@
 	for(var/obj/structure/blob/B in view(8,src))
 		var/damage = round(30/(get_dist(B,src)+1))
 		B.take_damage(damage, BURN, "melee", 0)
-	resolve()
+	qdel(src)

--- a/code/game/objects/items/grenades/smokebomb.dm
+++ b/code/game/objects/items/grenades/smokebomb.dm
@@ -19,7 +19,7 @@
 	desc = "The word '[pick(bruh_moment)]' is scribbled on it in crayon."
 
 ///Here we generate some smoke and also damage blobs??? for some reason. Honestly not sure why we do that.
-/obj/item/grenade/smokebomb/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/smokebomb/prime(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	playsound(src, 'sound/effects/smoke.ogg', 50, TRUE, -3)

--- a/code/game/objects/items/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/grenades/spawnergrenade.dm
@@ -7,7 +7,7 @@
 	var/spawner_type = null // must be an object path
 	var/deliveryamt = 1 // amount of type to deliver
 
-/obj/item/grenade/spawnergrenade/prime(mob/living/lanced_by = NONE)			// Prime now just handles the two loops that query for people in lockers and people who can see it.
+/obj/item/grenade/spawnergrenade/prime(mob/living/lanced_by)			// Prime now just handles the two loops that query for people in lockers and people who can see it.
 	. = ..()
 	update_mob()
 	if(spawner_type && deliveryamt)

--- a/code/game/objects/items/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/grenades/spawnergrenade.dm
@@ -7,7 +7,7 @@
 	var/spawner_type = null // must be an object path
 	var/deliveryamt = 1 // amount of type to deliver
 
-/obj/item/grenade/spawnergrenade/prime()			// Prime now just handles the two loops that query for people in lockers and people who can see it.
+/obj/item/grenade/spawnergrenade/prime(mob/living/lanced_by = NONE)			// Prime now just handles the two loops that query for people in lockers and people who can see it.
 	. = ..()
 	update_mob()
 	if(spawner_type && deliveryamt)
@@ -21,7 +21,7 @@
 		var/list/spawned = spawn_and_random_walk(spawner_type, T, deliveryamt, walk_chance=50, admin_spawn=((flags_1 & ADMIN_SPAWNED_1) ? TRUE : FALSE))
 		afterspawn(spawned)
 
-	resolve()
+	qdel(src)
 
 /obj/item/grenade/spawnergrenade/proc/afterspawn(list/mob/spawned)
 	return

--- a/code/game/objects/items/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/grenades/syndieminibomb.dm
@@ -9,7 +9,7 @@
 	ex_light = 4
 	ex_flame = 2
 
-/obj/item/grenade/syndieminibomb/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/syndieminibomb/prime(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	qdel(src)
@@ -38,7 +38,7 @@
 	shrapnel_type = /obj/projectile/bullet/shrapnel/mega
 	shrapnel_radius = 12
 
-/obj/item/grenade/frag/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/frag/prime(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	qdel(src)
@@ -53,7 +53,7 @@
 	var/rad_damage = 350
 	var/stamina_damage = 30
 
-/obj/item/grenade/gluon/prime(mob/living/lanced_by = NONE)
+/obj/item/grenade/gluon/prime(mob/living/lanced_by)
 	. = ..()
 	update_mob()
 	playsound(loc, 'sound/effects/empulse.ogg', 50, TRUE)

--- a/code/game/objects/items/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/grenades/syndieminibomb.dm
@@ -9,10 +9,10 @@
 	ex_light = 4
 	ex_flame = 2
 
-/obj/item/grenade/syndieminibomb/prime()
+/obj/item/grenade/syndieminibomb/prime(mob/living/lanced_by = NONE)
 	. = ..()
 	update_mob()
-	resolve()
+	qdel(src)
 
 /obj/item/grenade/syndieminibomb/concussion
 	name = "HE Grenade"
@@ -38,10 +38,10 @@
 	shrapnel_type = /obj/projectile/bullet/shrapnel/mega
 	shrapnel_radius = 12
 
-/obj/item/grenade/frag/prime()
+/obj/item/grenade/frag/prime(mob/living/lanced_by = NONE)
 	. = ..()
 	update_mob()
-	resolve()
+	qdel(src)
 
 /obj/item/grenade/gluon
 	desc = "An advanced grenade that releases a harmful stream of gluons inducing radiation in those nearby. These gluon streams will also make victims feel exhausted, and induce shivering. This extreme coldness will also likely wet any nearby floors."
@@ -53,7 +53,7 @@
 	var/rad_damage = 350
 	var/stamina_damage = 30
 
-/obj/item/grenade/gluon/prime()
+/obj/item/grenade/gluon/prime(mob/living/lanced_by = NONE)
 	. = ..()
 	update_mob()
 	playsound(loc, 'sound/effects/empulse.ogg', 50, TRUE)
@@ -65,4 +65,4 @@
 			for(var/mob/living/carbon/L in T)
 				L.adjustStaminaLoss(stamina_damage)
 				L.adjust_bodytemperature(-230)
-	resolve()
+	qdel(src)

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -122,7 +122,7 @@
 	if(wielded)
 		user.say("[war_cry]", forced="spear warcry")
 		explosive.forceMove(AM)
-		explosive.prime()
+		explosive.prime(lanced_by=user)
 		qdel(src)
 
 //GREY TIDE

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -252,7 +252,7 @@
 
 /datum/supply_pack/security
 	group = "Security"
-	access_any = ACCESS_FORENSICS_LOCKERS //| ACCESS_SECURITY
+	access = ACCESS_SECURITY
 	crate_type = /obj/structure/closet/crate/secure/gear
 
 /datum/supply_pack/security/ammo

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -135,7 +135,7 @@
 /obj/item/reagent_containers/food/snacks/grown/firelemon/ex_act(severity)
 	qdel(src) //Ensuring that it's deleted by its own explosion
 
-/obj/item/reagent_containers/food/snacks/grown/firelemon/proc/prime(lanced_by)
+/obj/item/reagent_containers/food/snacks/grown/firelemon/proc/prime(mob/living/lanced_by)
 	switch(seed.potency) //Combustible lemons are alot like IEDs, lots of flame, very little bang.
 		if(0 to 30)
 			update_mob()

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -135,7 +135,7 @@
 /obj/item/reagent_containers/food/snacks/grown/firelemon/ex_act(severity)
 	qdel(src) //Ensuring that it's deleted by its own explosion
 
-/obj/item/reagent_containers/food/snacks/grown/firelemon/proc/prime()
+/obj/item/reagent_containers/food/snacks/grown/firelemon/proc/prime(lance=FALSE)
 	switch(seed.potency) //Combustible lemons are alot like IEDs, lots of flame, very little bang.
 		if(0 to 30)
 			update_mob()

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -135,7 +135,7 @@
 /obj/item/reagent_containers/food/snacks/grown/firelemon/ex_act(severity)
 	qdel(src) //Ensuring that it's deleted by its own explosion
 
-/obj/item/reagent_containers/food/snacks/grown/firelemon/proc/prime(lance=FALSE)
+/obj/item/reagent_containers/food/snacks/grown/firelemon/proc/prime(lanced_by)
 	switch(seed.potency) //Combustible lemons are alot like IEDs, lots of flame, very little bang.
 		if(0 to 30)
 			update_mob()

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -228,7 +228,7 @@
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/ex_act(severity)
 	qdel(src) //Ensuring that it's deleted by its own explosion. Also prevents mass chain reaction with piles of cherry bombs
 
-/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime(lanced_by)
+/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime(mob/living/lanced_by)
 	icon_state = "cherry_bomb_lit"
 	playsound(src, 'sound/effects/fuse.ogg', seed.potency, FALSE)
 	reagents.chem_temp = 1000 //Sets off the gunpowder

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -228,7 +228,7 @@
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/ex_act(severity)
 	qdel(src) //Ensuring that it's deleted by its own explosion. Also prevents mass chain reaction with piles of cherry bombs
 
-/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime()
+/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime(lance=FALSE)
 	icon_state = "cherry_bomb_lit"
 	playsound(src, 'sound/effects/fuse.ogg', seed.potency, FALSE)
 	reagents.chem_temp = 1000 //Sets off the gunpowder

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -228,7 +228,7 @@
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/ex_act(severity)
 	qdel(src) //Ensuring that it's deleted by its own explosion. Also prevents mass chain reaction with piles of cherry bombs
 
-/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime(lance=FALSE)
+/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime(lanced_by)
 	icon_state = "cherry_bomb_lit"
 	playsound(src, 'sound/effects/fuse.ogg', seed.potency, FALSE)
 	reagents.chem_temp = 1000 //Sets off the gunpowder

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -1,5 +1,5 @@
 
-/mob/living/proc/run_armor_check(def_zone = null, attack_flag = "melee", absorb_text = null, soften_text = null, silent=FALSE, armour_penetration, penetrated_text)
+/mob/living/proc/run_armor_check(def_zone = null, attack_flag = "melee", absorb_text = null, soften_text = null, armour_penetration, penetrated_text, silent=FALSE)
 	var/armor = getarmor(def_zone, attack_flag)
 
 	if(armor <= 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Remake of #50459 because of the git reforking

Groups of shrapnel mines no longer crash the server with a giant mess of recursion from bad trigger logic. Flying objects also no longer trigger mines while passing through, though sparks from nearby igniting mines and damaging them directly will still trigger them. Note flying things not setting off mines isn't the fix, that's just a side effect to neatening some landmine code. You can set off a 6x6-ish square of shrapnel mines without killing the server though i obviously don't offer warranties on anything above that

Priming a shrapnel grenade and dropping it will no longer make the shrapnel ignore you

Also I accidentally made security cargo packs require forensics access with the shrapnel PR, this fixes that.

Lastly I realized that I was deleting all pellet ammo casings like buckshot shells after the pellets resolved, and no one noticed the lack of spent buckshot shells somehow! Fascinating! I fixed that too.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixe
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Clusters of shrapnel mines will no longer kill the server when set off together.
tweak: Shooting over landmines will no longer trigger them
fix: security crates briefly required forensics access instead of proper security access, this has been fixed
fix: Buckshot shells no longer disappear into the void after being fired
fix: Priming shrapnel grenades and then dropping them will no longer exempt you from being shredded by the shrapnel, nor will using shrapnel grenades on explosive lances
fix: Armor penetration works again! Oops!! Turns out that's been broken for a bit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
