### PR TITLE
Makes railings craftable and rotatable, again.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1297,6 +1297,10 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 			var/obj/structure/window/W = O
 			if(W.ini_dir == dir_to_check || W.ini_dir == FULLTILE_WINDOW_DIR || dir_to_check == FULLTILE_WINDOW_DIR)
 				return FALSE
+		if(istype(O, /obj/structure/railing))
+			var/obj/structure/railing/rail = O
+			if(rail.ini_dir == dir_to_check || rail.ini_dir == FULLTILE_WINDOW_DIR || dir_to_check == FULLTILE_WINDOW_DIR)
+				return FALSE
 	return TRUE
 
 #define UNTIL(X) while(!(X)) stoplag()

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -3,6 +3,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	new/datum/stack_recipe("table frame", /obj/structure/table_frame, 2, time = 10, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("scooter frame", /obj/item/scooter_frame, 10, time = 25, one_per_turf = 0), \
 	new/datum/stack_recipe("linen bin", /obj/structure/bedsheetbin/empty, 2, time = 5, one_per_turf = 0), \
+	new/datum/stack_recipe("railing", /obj/structure/railing, 3, time = 18, window_checks = TRUE), \
 	))
 
 /obj/item/stack/rods

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -6,11 +6,21 @@
 	density = TRUE
 	anchored = TRUE
 	climbable = TRUE
+	///Initial direction of the railing.
+	var/ini_dir
 
 /obj/structure/railing/corner //aesthetic corner sharp edges hurt oof ouch
 	icon_state = "railing_corner"
 	density = FALSE
 	climbable = FALSE
+
+/obj/structure/railing/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS ,null,CALLBACK(src, .proc/can_be_rotated),CALLBACK(src,.proc/after_rotation))
+
+/obj/structure/railing/Initialize()
+	. = ..()
+	ini_dir = dir
 
 /obj/structure/railing/attackby(obj/item/I, mob/living/user, params)
 	..()
@@ -29,6 +39,22 @@
 			to_chat(user, "<span class='warning'>[src] is already in good condition!</span>")
 		return
 
+/obj/structure/railing/wirecutter_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(!anchored)
+		to_chat(user, "<span class='warning'>You cut apart the railing.</span>")
+		I.play_tool_sound(src, 100)
+		deconstruct()
+		return TRUE
+
+/obj/structure/railing/deconstruct(disassembled)
+	. = ..()
+	if(!loc) //quick check if it's qdeleted already.
+		return
+	if(!(flags_1 & NODECONSTRUCT_1))
+		var/obj/item/stack/rods/rod = new /obj/item/stack/rods(drop_location(), 3)
+		transfer_fingerprints_to(rod)
+		qdel(src)
 ///Implements behaviour that makes it possible to unanchor the railing.
 /obj/structure/railing/wrench_act(mob/living/user, obj/item/I)
 	. = ..()
@@ -39,10 +65,6 @@
 		setAnchored(!anchored)
 		to_chat(user, "<span class='notice'>You [anchored ? "fasten the railing to":"unfasten the railing from"] the floor.</span>")
 	return TRUE
-
-/obj/structure/railing/proc/check_anchored(checked_anchored)
-	if(anchored == checked_anchored)
-		return TRUE
 
 /obj/structure/railing/CanPass(atom/movable/mover, turf/target)
 	..()
@@ -63,3 +85,24 @@
 
 /obj/structure/railing/corner/CheckExit()
 	return TRUE
+
+/obj/structure/railing/proc/can_be_rotated(mob/user,rotation_type)
+	if(anchored)
+		to_chat(user, "<span class='warning'>[src] cannot be rotated while it is fastened to the floor!</span>")
+		return FALSE
+
+	var/target_dir = turn(dir, rotation_type == ROTATION_CLOCKWISE ? -90 : 90)
+
+	if(!valid_window_location(loc, target_dir)) //Expanded to include rails, as well!
+		to_chat(user, "<span class='warning'>[src] cannot be rotated in that direction!</span>")
+		return FALSE
+	return TRUE
+
+/obj/structure/railing/proc/check_anchored(checked_anchored)
+	if(anchored == checked_anchored)
+		return TRUE
+
+/obj/structure/railing/proc/after_rotation(mob/user,rotation_type)
+	air_update_turf(1)
+	ini_dir = dir
+	add_fingerprint(user)


### PR DESCRIPTION

## About The Pull Request
Remake of  #50470 on a working branch. So recap, Metal railings are craftable with rods, can be rotated with alt-click, and can be constructed with wrench - > wirecutters. See the original PR for more context.

## Why It's Good For The Game

Makes it more consistant, and good for construction on multiz stations.

## Changelog
:cl:
add: Railings can now be crafted with metal rods, and deconstructed with wirecutters when unwrenched.
tweak: Railings can now be rotated with Alt Click.
/:cl: