### PR TITLE
Adds some more uses for plastic to the autolathe

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2309,7 +2309,7 @@
 /datum/supply_pack/costumes_toys/randomised/toys
 	name = "Toy Crate"
 	desc = "Who cares about pride and accomplishment? Skip the gaming and get straight to the sweet rewards with this product! Contains five random toys. Warranty void if used to prank research directors."
-	cost = 5000 // or play the arcade machines ya lazy bum
+	cost = 4000 // or play the arcade machines ya lazy bum
 	num_contained = 5
 	contains = list()
 	crate_name = "toy crate"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1067,6 +1067,30 @@
 	build_path = /obj/item/toy/ammo/gun
 	category = list("hacked", "Misc")
 
+/datum/design/toy_balloon
+	name = "Plastic Balloon"
+	id = "toy_balloon"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/plastic = 1200)
+	build_path = /obj/item/toy/balloon
+	category = list("hacked", "Misc")
+
+/datum/design/toy_meteor
+	name = "Plastic Toy Meteor"
+	id = "toy_meteor"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/plastic = 1000)
+	build_path = /obj/item/toy/minimeteor
+	category = list("hacked", "Misc")
+
+/datum/design/toy_armblade
+	name = "Plastic Armblade"
+	id = "toy_armblade"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/plastic = 2000)
+	build_path = /obj/item/toy/foamblade
+	category = list("hacked", "Misc")
+
 /datum/design/plastic_tree
 	name = "Plastic Potted Plant"
 	id = "plastic_trees"

--- a/tools/CreditsTool/remappings.txt
+++ b/tools/CreditsTool/remappings.txt
@@ -18,3 +18,13 @@ PraiseRatvar Frozenguy5
 FuryMcFlurry Fury McFlurry
 vuonojenmustaturska Naksu
 praisenarsie Frozenguy5
+MrDoomBringer Mr. DoomBringer
+Fikou Dr. Fikou
+TiviPlus Tivi Plus
+tralezab Trale Zab
+Iamgoofball goofball
+Tharcoonvagh Tharcoon
+Rectification itseasytosee
+ATHATH ATH1909
+trollbreeder troll breeder
+BuffEngineering Buff Engineering


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds balloons, foam armblades, and toy meteors to the autolathe
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I didn't want to add too many toys as that's the whole point of arcade machines, but I thought it would be nice if there were some more fun uses for plastic. I feel like miscreants faking a huge bombing with the toy meteors or a ling army with the foam armblades could be a pretty funny gimmick. Balloons were underused anywhere else in the code so I figured i'd toss em in too.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: MrDoomBringer
add: More toys are available from the Autolathe's contraband selection.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
