### PR TITLE
Minor cleanup on plant analyzer modes and fixes plant instability loss

### DIFF
--- a/code/__DEFINES/botany.dm
+++ b/code/__DEFINES/botany.dm
@@ -1,0 +1,9 @@
+
+#define TRAY_NAME_UPDATE name = myseed ? "[initial(name)] ([myseed.plantname])" : initial(name)
+#define YIELD_WEED_MINIMUM 3
+#define YIELD_WEED_MAXIMUM 10
+#define STATIC_NUTRIENT_CAPACITY 10
+
+//Both available scanning modes for the plant analyzer.
+#define PLANT_SCANMODE_STATS		0
+#define PLANT_SCANMODE_CHEMICALS 	1

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -68,10 +68,10 @@
 	if (istype(O, /obj/item/plant_analyzer))
 		var/obj/item/plant_analyzer/P_analyzer = O
 		var/msg = "<span class='info'>*---------*\n This is \a <span class='name'>[src]</span>.\n"
-		if(seed && P_analyzer.scan_mode == 0)
+		if(seed && P_analyzer.scan_mode == PLANT_SCANMODE_STATS)
 			msg += seed.get_analyzer_text()
 		var/reag_txt = ""
-		if(seed && P_analyzer.scan_mode == 1)
+		if(seed && P_analyzer.scan_mode == PLANT_SCANMODE_CHEMICALS)
 			msg += "<br><span class='info'>*Plant Reagents:*</span>"
 			for(var/reagent_id in seed.reagents_add)
 				var/datum/reagent/R  = GLOB.chemical_reagents_list[reagent_id]

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -1,6 +1,3 @@
-//Both available scanning modes for the plant analyzer.
-#define SCANMODE_STATS		0
-#define SCANMODE_CHEMICALS 	1
 
 // Plant analyzer
 /obj/item/plant_analyzer
@@ -14,12 +11,12 @@
 	w_class = WEIGHT_CLASS_TINY
 	slot_flags = ITEM_SLOT_BELT
 	custom_materials = list(/datum/material/iron=30, /datum/material/glass=20)
-	var/scan_mode = SCANMODE_STATS
+	var/scan_mode = PLANT_SCANMODE_STATS
 
 /obj/item/plant_analyzer/attack_self(mob/user)
 	. = ..()
 	scan_mode = !scan_mode
-	to_chat(user, "<span class='notice'>You switch [src] to [scan_mode == SCANMODE_CHEMICALS ? "scan for chemical reagents and traits" : "scan for plant growth statistics"].</span>")
+	to_chat(user, "<span class='notice'>You switch [src] to [scan_mode == PLANT_SCANMODE_CHEMICALS ? "scan for chemical reagents and traits" : "scan for plant growth statistics"].</span>")
 
 // *************************************
 // Hydroponics Tools

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1,8 +1,3 @@
-#define TRAY_NAME_UPDATE name = myseed ? "[initial(name)] ([myseed.plantname])" : initial(name)
-#define YIELD_WEED_MINIMUM 3
-#define YIELD_WEED_MAXIMUM 10
-#define STATIC_NUTRIENT_CAPACITY 10
-
 
 /obj/machinery/hydroponics
 	name = "hydroponics tray"

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -263,7 +263,7 @@
 			if(myseed.instability >= 80)
 				mutate(0, 0, 0, 0, 0, 0, 0, 5, 0) //Exceedingly low odds of gaining a trait.
 			if(myseed.instability >= 60)
-				if(prob((myseed.instability)/2) && !self_sustaining) //Minimum 30%, Maximum 50% chance of mutating every age tick when not on autogrow.
+				if(prob((myseed.instability)/2) && !self_sustaining && length(myseed.mutatelist)) //Minimum 30%, Maximum 50% chance of mutating every age tick when not on autogrow.
 					mutatespecie()
 					myseed.instability = myseed.instability/2
 			if(myseed.instability >= 40)
@@ -647,14 +647,14 @@
 	else if(istype(O, /obj/item/plant_analyzer))
 		var/obj/item/plant_analyzer/P_analyzer = O
 		if(myseed)
-			if(P_analyzer.scan_mode == 0)
+			if(P_analyzer.scan_mode == PLANT_SCANMODE_STATS)
 				to_chat(user, "*** <B>[myseed.plantname]</B> ***" )
 				to_chat(user, "- Plant Age: <span class='notice'>[age]</span>")
 				var/list/text_string = myseed.get_analyzer_text()
 				if(text_string)
 					to_chat(user, text_string)
 					to_chat(user, "*---------*")
-			if(myseed.reagents_add && P_analyzer.scan_mode == 1)
+			if(myseed.reagents_add && P_analyzer.scan_mode == PLANT_SCANMODE_CHEMICALS)
 				to_chat(user, "- <B>Plant Reagents</B> -")
 				to_chat(user, "*---------*")
 				for(var/datum/plant_gene/reagent/G in myseed.genes)

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -432,9 +432,7 @@
 			continue
 		all_traits += " [traits.get_name()]"
 	text += "- Plant Traits:[all_traits]\n"
-
 	text += "*---------*"
-
 	return text
 
 /obj/item/seeds/proc/on_chem_reaction(datum/reagents/S)  //in case seeds have some special interaction with special chems
@@ -445,11 +443,11 @@
 		to_chat(user, "<span class='info'>*---------*\n This is \a <span class='name'>[src]</span>.</span>")
 		var/text
 		var/obj/item/plant_analyzer/P_analyzer = O
-		if(P_analyzer.scan_mode == 0)
+		if(P_analyzer.scan_mode == PLANT_SCANMODE_STATS)
 			text = get_analyzer_text()
 			if(text)
 				to_chat(user, "<span class='notice'>[text]</span>")
-		if(reagents_add && P_analyzer.scan_mode == 1)
+		if(reagents_add && P_analyzer.scan_mode == PLANT_SCANMODE_CHEMICALS)
 			to_chat(user, "<span class='notice'>- Plant Reagents -</span>")
 			to_chat(user, "<span class='notice'>*---------*</span>")
 			for(var/datum/plant_gene/reagent/G in genes)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -26,6 +26,7 @@
 #include "code\__DEFINES\atmospherics.dm"
 #include "code\__DEFINES\atom_hud.dm"
 #include "code\__DEFINES\blackmarket.dm"
+#include "code\__DEFINES\botany.dm"
 #include "code\__DEFINES\bsql.config.dm"
 #include "code\__DEFINES\bsql.dm"
 #include "code\__DEFINES\callbacks.dm"


### PR DESCRIPTION

## About The Pull Request

Includes several bits of code cleanup for plant analyzers from review of #50513 that were missed before merge. Included was defines for botany and hydroponics trays being moved to their own define file, those defines being applied to most locations, and a fix for plant mutations above 60 instability halving instability from mutating when they had nothing else to mutate into.

## Why It's Good For The Game

Fixes a bug, and improves readability of botany code while decreasing the number of magic numbers.

## Changelog
:cl:
fix: Plants above 60 instability with no new mutations will no longer halve their instability if they would otherwise mutate.
/:cl: