### PR TITLE
Felinids don't like being sprayed with water, but aren't degenerates who hate showers

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -245,3 +245,8 @@
 /datum/mood_event/bald
 	description ="<span class='warning'>I need something to cover my head...</span>\n"
 	mood_change = -3
+
+/datum/mood_event/sadcat
+	description = "<span class='warning'>I've been a bad cat...</span>\n"
+	mood_change = -15
+	timeout = 10 SECONDS

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -247,6 +247,6 @@
 	mood_change = -3
 
 /datum/mood_event/sadcat
-	description = "<span class='warning'>I've been a bad cat...</span>\n"
+	description = "<span class='warning'>I've been reprimanded with water!</span>\n"
 	mood_change = -15
 	timeout = 10 SECONDS

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -196,6 +196,8 @@
 /datum/reagent/water/reaction_mob(mob/living/M, method=TOUCH, reac_volume)//Splashing people with water can help put them out!
 	if(!istype(M))
 		return
+	if(isfelinid(M) && !(M.on_fire) && (method == TOUCH || method == VAPOR)) //if someone sprays you with water while you're on fire, they're not trying to reprimand you, they're trying to save your life
+		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "water", /datum/mood_event/sadcat) //Cats don't like being sprayed (or splashed) with water! Showers and the like are an exception to this, however, since washing yourself off in them is usually voluntary.
 	if(method == TOUCH)
 		M.adjust_fire_stacks(-(reac_volume / 10))
 		M.ExtinguishMob()


### PR DESCRIPTION
## About The Pull Request

This PR is an alternative to https://github.com/tgstation/tgstation/pull/50635.

Being sprayed or splashed by water while you are not on fire as a felinid will give you a -15 moodlet for 10 seconds. Showers will not cause apply this negative moodlet, though, and that is intentional. And yes, this SHOULD work with water from fire extinguishers, if I've read the code for fire extinguishers correctly.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/42606352/80272672-10e45200-8691-11ea-86b4-fc867b9e6027.png)

## Changelog
:cl: ATHATH
balance: Felinids don't like to be sprayed with water. Showering is fine, though, and so is being sprayed with water while you're on fire.
/:cl: