### PR TITLE
Unjanks macrobomb implants

### DIFF
--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -54,7 +54,7 @@
 
 /obj/item/implant/explosive/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
 	for(var/X in target.implants)
-		if(istype(X, type))
+		if(istype(X, /obj/item/implant/explosive)) //we don't use our own type here, because macrobombs inherit this proc and need to be able to upgrade microbombs
 			var/obj/item/implant/explosive/imp_e = X
 			imp_e.heavy += heavy
 			imp_e.medium += medium
@@ -87,28 +87,10 @@
 	name = "macrobomb implant"
 	desc = "And boom goes the weasel. And everything else nearby."
 	icon_state = "explosive"
-	weak = 16
+	weak = 20 //the strength and delay of 10 microbombs
 	medium = 8
 	heavy = 4
 	delay = 70
-
-/obj/item/implant/explosive/macro/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
-	for(var/X in target.implants)
-		if(istype(X, type))
-			return 0
-
-	for(var/Y in target.implants)
-		if(istype(Y, /obj/item/implant/explosive))
-			var/obj/item/implant/explosive/imp_e = Y
-			heavy += imp_e.heavy
-			medium += imp_e.medium
-			weak += imp_e.weak
-			delay += imp_e.delay
-			qdel(imp_e)
-			break
-
-	return ..()
-
 
 /obj/item/implanter/explosive
 	name = "implanter (microbomb)"


### PR DESCRIPTION
## About The Pull Request

Macrobomb implants now have a weak explosion radius of 20 (up from 16).

Macrobomb implants will now no longer refuse to implant themselves in someone that already has a macrobomb implant, and instead will add their stats to that existing macrobomb implant, as they would to a microbomb implant.

## Why It's Good For The Game

In our current system, the explosion stats of macrobomb implants (including their delay) are equivalent to those of 10 stacked microbomb implants in every way... except for their weak explosion radius, which is 4 less than the equivalent weak radius of 10 stacked microbomb implants (which cost the same amount of TC as a macrobomb implant). This means that it's TECHNICALLY more TC-efficient to buy 10 microbomb implants and implant them into yourself one at a time instead of just buying a single macrobomb implant, which kind of invalidates the main point of macrobomb implants (being a time-saver for if you want to implant yourself with a ton of microbomb implants). Plus, it was triggering my OCD.

As for the second change, basically, under our current system, for some inexplicable reason, if you implant yourself with a macrobomb implant first, then try to implant yourself with another macrobomb implant, they'll refuse to combine with each other. However, if you implant yourself with a MICROBOMB implant first (second won't do), THEN implant yourself with two macrobomb implants, they'll stack with each other (and the microbomb implant) just fine. This PR fixes that pointless (especially since you can just buy 10 microbomb implants instead of another macrobomb implant) jank.

## Changelog
:cl: ATHATH
balance: Macrobomb implants now have a weak explosion radius of 20 (up from 16).
fix: Macrobomb implants will now no longer refuse to implant themselves in someone that already has a macrobomb implant, and instead will add their stats to that existing macrobomb implant, as they would to a microbomb implant.
/:cl: