### PR TITLE
Fixes right pew name

### DIFF
--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -41,7 +41,7 @@
 	update_leftpewarmrest()
 
 /obj/structure/chair/pew/right
-	name = "left wooden pew end"
+	name = "right wooden pew end"
 	icon_state = "pewend_right"
 	var/mutable_appearance/rightpewarmrest
 


### PR DESCRIPTION
## About The Pull Request

Fixes the right wooden pew end name

## Why It's Good For The Game

discrepancy detected

## Changelog
:cl:
fix: right pews are no longer left pews.
/:cl: