### PR TITLE
Unborks sensory restoration and makes some tweaks to how oculine works

### DIFF
--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -47,7 +47,7 @@ Bonus
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	var/list/healthy_messages = list("Your lungs feel great.", "You realize you haven't been breathing.", "You don't feel the need to breathe.",\
-					"Your eyes feel great.", "You are now blinking manually.", "You don't feel the need to blink.")
+					"Your eyes feel great.", "Your ears feel great.", "You don't feel the need to blink.")
 	switch(A.stage)
 		if(1, 2)
 			if(prob(base_message_chance))

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -80,30 +80,25 @@
 	if(!..())
 		return
 	var/mob/living/M = A.affected_mob
-	var/obj/item/organ/eyes/eyes = M.getorganslot(ORGAN_SLOT_EYES)
-	if (!eyes)
-		return
 	switch(A.stage)
 		if(4, 5)
-			M.restoreEars()
-
+			M.restoreEars() //this is mostly just copy+pasted from oculine and inacusiate
+			M.adjust_blindness(-2)
+			M.adjust_blurriness(-2)
+			var/obj/item/organ/eyes/eyes = M.getorganslot(ORGAN_SLOT_EYES)
+			if(!eyes)
+				return
+			eyes.applyOrganDamage(-2)
 			if(HAS_TRAIT_FROM(M, TRAIT_BLIND, EYE_DAMAGE))
 				if(prob(20))
-					to_chat(M, "<span class='notice'>Your vision slowly returns...</span>")
+					to_chat(M, "<span class='warning'>Your vision slowly returns...</span>")
 					M.cure_blind(EYE_DAMAGE)
 					M.cure_nearsighted(EYE_DAMAGE)
 					M.blur_eyes(35)
-
-				else if(HAS_TRAIT_FROM(M, TRAIT_NEARSIGHT, EYE_DAMAGE))
-					to_chat(M, "<span class='notice'>You can finally focus your eyes on distant objects.</span>")
-					M.cure_nearsighted(EYE_DAMAGE)
-					M.blur_eyes(10)
-
-				else if(M.eye_blind || M.eye_blurry)
-					M.set_blindness(0)
-					M.set_blurriness(0)
-				else if(eyes.damage > 0)
-					eyes.applyOrganDamage(-1)
+			else if(HAS_TRAIT_FROM(M, TRAIT_NEARSIGHT, EYE_DAMAGE))
+				to_chat(M, "<span class='warning'>The blackness in your peripheral vision fades.</span>")
+				M.cure_nearsighted(EYE_DAMAGE)
+				M.blur_eyes(10)
 		else
 			if(prob(base_message_chance))
-				to_chat(M, "<span class='notice'>[pick("Your eyes feel great.","You feel like your eyes can focus more clearly.", "You don't feel the need to blink.","Your ears feel great.","Your healing feels more acute.")]</span>")
+				to_chat(M, "<span class='notice'>[pick("Your eyes feel great.","You feel like your eyes can focus more clearly.", "You don't feel the need to blink.","Your ears feel great.","Your hearing feels more acute.")]</span>")

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -639,6 +639,8 @@
 
 /datum/reagent/medicine/oculine/on_mob_life(mob/living/carbon/M)
 	var/obj/item/organ/eyes/eyes = M.getorganslot(ORGAN_SLOT_EYES)
+	M.adjust_blindness(-2)
+	M.adjust_blurriness(-2)
 	if (!eyes)
 		return
 	eyes.applyOrganDamage(-2)
@@ -648,19 +650,15 @@
 			M.cure_blind(EYE_DAMAGE)
 			M.cure_nearsighted(EYE_DAMAGE)
 			M.blur_eyes(35)
-
 	else if(HAS_TRAIT_FROM(M, TRAIT_NEARSIGHT, EYE_DAMAGE))
 		to_chat(M, "<span class='warning'>The blackness in your peripheral vision fades.</span>")
 		M.cure_nearsighted(EYE_DAMAGE)
 		M.blur_eyes(10)
-	else if(M.eye_blind || M.eye_blurry)
-		M.set_blindness(0)
-		M.set_blurriness(0)
 	..()
 
 /datum/reagent/medicine/inacusiate
 	name = "Inacusiate"
-	description = "Instantly restores all hearing to the patient, but does not cure deafness."
+	description = "Instantly restores all hearing to the patient, but does not work on patients without ears, cure genetic deafness, or cure chronic deafness." //by "chronic" deafness, we mean people with the "deaf" quirk
 	color = "#606060" // ditto
 
 /datum/reagent/medicine/inacusiate/on_mob_life(mob/living/carbon/M)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/50587 by basically copy+pasting the code from oculine into the code for sensory restoration (and keeping the copy+pasted code from inacusiate that was already in there).

Also fixes sensory restoration not trying to heal your ears if you didn't have eyes.

Oculine no longer instantly heals the eye blurriness it causes on the tick after it causes it. Instead of healing all stacks of eye_blurry and eye_blind (not to be confused with blindness from blindness traits (it still has a chance per tick to instantly heal blindness from eye damage)) instantly, oculine now just greatly accelerates the rate at which those debuffs are healed at.

One of the hallucigen symptom's fake positive symptom messages ("You are now blinking manually.") wasn't actually given by any other symptom, so it's been replaced with another symptom message from the sensory restoration symptom ("Your ears feel great."). Also, a typo in one of the messages from the sensory restoration symptom has been fixed.

Finally, inacusiate's description has been modified to reflect the fact that it DOES heal deafness, just not certain KINDS of deafness.

## Why It's Good For The Game

Less jank/misleading information good, unga dunga.

Also, sensory restoration currently isn't doing what it's supposed to be able to do, and is currently basically just "ear restoration and sometimes you get unblinded".

## Changelog
:cl: ATHATH
fix: Unborks the sensory restoration symptom. It should work like having oculine and inacusiate in your system now.
fix: Adjusts inacusiate's description to more accurately reflect what it actually does.
fix: The eye_blind and eye_blurry healing from oculine is no longer instant, although oculine still has its 20% chance per chem tick to instantly remove the TRAIT_BLIND trait from you (if it was caused by eye damage).
fix: Replaces the "You are now blinking manually." fake positive message from the hallucigen symptom with a "Your ears feel great." message.
fix: Fixes a typo in one of the messages from the sensory restoration symptom.
/:cl: