### PR TITLE
Fixes a runtime with RSFs

### DIFF
--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -47,6 +47,7 @@ RSF
 /obj/item/rsf/Initialize()
 	. = ..()
 	to_dispense = cost_by_item[1]
+	dispense_cost = cost_by_item[to_dispense]
 
 /obj/item/rsf/examine(mob/user)
 	. = ..()
@@ -148,7 +149,7 @@ RSF
 	icon_state = "rcd"
 	spent_icon_state = "rcd"
 	max_matter = 10
-	cost_by_item = list()
+	cost_by_item = list(/obj/item/reagent_containers/food/snacks/cookie = 100)
 	dispense_cost = 100
 	discriptor = "cookie-units"
 	action_type = "Fabricates"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I swear it's not my fault I prom-

cost_by_item should always have a value, or it runtimes.
Oh and we should set the cost based on the initial item.

Thanks for poking me bee.

## Why It's Good For The Game
Runtime man bad.

## Changelog
:cl:
fix: fixes a runtime in the rsf
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
