### PR TITLE
Tweaks helbital's more unique effects a bit, and buffs the chem in general

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -19,12 +19,8 @@
 /datum/reagent/medicine/C2/helbital/on_mob_life(mob/living/carbon/M)
 	. = TRUE
 	var/death_is_coming = (M.getToxLoss() + M.getOxyLoss() + M.getFireLoss() + M.getBruteLoss())
-	switch(M.stat)
-		if(CONSCIOUS) //bad
-			M.adjustOxyLoss(2, TRUE)
-		if(SOFT_CRIT) //meh convert
-			M.adjustOxyLoss(1, TRUE)
-	//no (further) oxyloss damage if you're not conscious or in soft crit
+	if(!(M.stat)) //deals oxyloss to you if you're conscious
+		M.adjustOxyLoss(2, TRUE)
 	M.adjustBruteLoss(-(round(death_is_coming/50,0.1)+0.5), FALSE) //heals you more the closer you are to death
 
 	if(M.stat && !reaping && prob(0.1)) //janken with the grim reaper!

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -25,7 +25,7 @@
 		if(SOFT_CRIT) //meh convert
 			M.adjustOxyLoss(1, TRUE)
 	//no (further) oxyloss damage if you're not conscious or in soft crit
-	M.adjustBruteLoss(-(round(death_is_coming/50,0.1)+1), FALSE) //heals you more the closer you are to death
+	M.adjustBruteLoss(-(round(death_is_coming/50,0.1)+0.5), FALSE) //heals you more the closer you are to death
 
 	if(M.stat && !reaping && prob(0.1)) //janken with the grim reaper!
 		reaping = TRUE

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -65,9 +65,9 @@
 	..()
 	return TRUE
 
-/datum/reagent/medicine/C2/helbital/on_mob_end_metabolize(mob/living/L)
+/datum/reagent/medicine/C2/helbital/on_mob_end_metabolize(mob/living/carbon/M)
 	if(overdosed) //the spirits will bother to remove your curses if they gave you one earlier, but if they didn't, your curses are YOUR problem, not theirs (this also keeps people from curing their own curses with just 0.1u of helbital; you gotta WORK for that shit)
-		L.remove_status_effect(STATUS_EFFECT_NECROPOLIS_CURSE) //this will remove existing curses, but there's not much I can really do to get around it. consider it a feature instead of a bug, since we don't really have many other ways to remove curses right now (other than just waiting them out).
+		M.remove_status_effect(STATUS_EFFECT_NECROPOLIS_CURSE) //this will remove existing curses, but there's not much I can really do to get around it. consider it a feature instead of a bug, since we don't really have many other ways to remove curses right now (other than just waiting them out).
 	..()
 
 /datum/reagent/medicine/C2/libital //messes with your liber

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -21,14 +21,11 @@
 	var/death_is_coming = (M.getToxLoss() + M.getOxyLoss() + M.getFireLoss() + M.getBruteLoss())
 	switch(M.stat)
 		if(CONSCIOUS) //bad
-			thou_shall_heal = death_is_coming/50
 			M.adjustOxyLoss(2, TRUE)
 		if(SOFT_CRIT) //meh convert
-			thou_shall_heal = round(death_is_coming/47,0.1)
 			M.adjustOxyLoss(1, TRUE)
-		else //no convert
-			thou_shall_heal = round(death_is_coming/45,0.1)
-	M.adjustBruteLoss(-thou_shall_heal, FALSE)
+	//no (further) oxyloss damage if you're not conscious or in soft crit
+	M.adjustBruteLoss(-(round(death_is_coming/50,0.1)+1), FALSE) //heals you more the closer you are to death
 
 	if(M.stat && !reaping && prob(0.1)) //janken with the grim reaper!
 		reaping = TRUE
@@ -47,13 +44,17 @@
 		if(grim == RPSchoice) //You Tied!
 			to_chat(M, "<span class='hierophant'>You tie, and the malevolent spirits disappear... for now.</span>")
 			reaping = FALSE
+			if(helbent)
+				M.remove_status_effect(STATUS_EFFECT_NECROPOLIS_CURSE) //they disappeared, so they're no longer causing the OD effect
 		else if(RockPaperScissors[RPSchoice] == grim) //You lost!
 			to_chat(M, "<span class='hierophant'>You lose, and the malevolent spirits smirk eerily as they surround your body.</span>")
 			M.dust()
 			return
 		else //VICTORY ROYALE
-			to_chat(M, "<span class='hierophant'>You win, and the malevolent spirits fade away as well as your wounds.</span>")
+			to_chat(M, "<span class='hierophant'>You win, and the malevolent spirits fade away... and so do your wounds!</span>")
 			M.client.give_award(/datum/award/achievement/misc/helbitaljanken, M)
+			if(helbent)
+				M.remove_status_effect(STATUS_EFFECT_NECROPOLIS_CURSE) //they faded away, so they're no longer causing the OD effect
 			M.revive(full_heal = TRUE, admin_revive = FALSE)
 			M.reagents.del_reagent(type)
 			return

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -13,8 +13,8 @@
 	taste_description = "cold and lifeless"
 	overdose_threshold = 35
 	reagent_state = SOLID
-	var/reaping = FALSE
 	var/helbent = FALSE
+	var/reaping = FALSE
 
 /datum/reagent/medicine/C2/helbital/on_mob_life(mob/living/carbon/M)
 	. = TRUE

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -13,14 +13,12 @@
 	taste_description = "cold and lifeless"
 	overdose_threshold = 35
 	reagent_state = SOLID
-	var/helbent = FALSE
 	var/reaping = FALSE
+	var/helbent = FALSE
 
 /datum/reagent/medicine/C2/helbital/on_mob_life(mob/living/carbon/M)
 	. = TRUE
 	var/death_is_coming = (M.getToxLoss() + M.getOxyLoss() + M.getFireLoss() + M.getBruteLoss())
-	var/thou_shall_heal = 0
-	var/good_kind_of_healing = FALSE
 	switch(M.stat)
 		if(CONSCIOUS) //bad
 			thou_shall_heal = death_is_coming/50
@@ -30,17 +28,14 @@
 			M.adjustOxyLoss(1, TRUE)
 		else //no convert
 			thou_shall_heal = round(death_is_coming/45,0.1)
-			good_kind_of_healing = TRUE
 	M.adjustBruteLoss(-thou_shall_heal, FALSE)
 
-	if(good_kind_of_healing && !reaping && prob(0.0001)) //janken with the grim reaper!
+	if(M.stat && !reaping && prob(0.1)) //janken with the grim reaper!
 		reaping = TRUE
 		var/list/RockPaperScissors = list("rock" = "paper", "paper" = "scissors", "scissors" = "rock") //choice = loses to
-		if(M.apply_status_effect(/datum/status_effect/necropolis_curse,CURSE_BLINDING))
-			helbent = TRUE
 		to_chat(M, "<span class='hierophant'>Malevolent spirits appear before you, bartering your life in a 'friendly' game of rock, paper, scissors. Which do you choose?</span>")
 		var/timeisticking = world.time
-		var/RPSchoice = input(M, "Janken Time! You have 60 Seconds to Choose!", "Rock Paper Scissors",null) as null|anything in RockPaperScissors
+		var/RPSchoice = input(M, "Janken time! You have 60 seconds to choose!", "Rock Paper Scissors",null) as null|anything in RockPaperScissors
 		if(QDELETED(M) || (timeisticking+(1.1 MINUTES) < world.time))
 			reaping = FALSE
 			return //good job, you ruined it

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -63,6 +63,7 @@
 
 /datum/reagent/medicine/C2/helbital/overdose_process(mob/living/carbon/M)
 	if(!helbent)
+		to_chat(M, "<span class='hierophant'>Malevolent spirits swirl around you, searing your flesh and impeding your vision!</span>")
 		M.apply_necropolis_curse(CURSE_WASTING | CURSE_BLINDING)
 		helbent = TRUE
 	..()


### PR DESCRIPTION
## About The Pull Request

The chance per tick of helbital's special "janken" effect occurring is now 1/1000, instead of one in a million.

Helbital's "janken" effect no longer blinds you until either the chem leaves your system or 10 MINUTES pass when it triggers (the blindness caused by a helbital OD is still there, though).

Helbital's "janken" effect now rolls its chance to occur each chem tick while you're in crit, instead of while you have brute damage.

Helbital's brute healing formula has been tweaked to be less JANKy (heh), and it also (approximately) heals an extra 0.5 points of brute damage per tick over what it healed before this PR.

Helbital now deals no oxyloss damage to you while you're in soft crit.

You now get a special message indicating how helbital's OD effect is blinding you and dealing burn damage to you when the curse it gets applied.

Tying or winning a game of RPS with the malevolent spirits from its "janken" effect (which causes those spirits to "disappear" and "fade away", respectively) now clears the curse from helbital's OD effect.

Update: Also, epic gamers can no longer just inject themselves with 1000u of helbital, then wait out the curse from its OD effect. You also can't cure your other curses with a 0.1u dose helbital anymore; you gotta OD on it first. Also, the stuff that used to be in on_mob_delete() is now in on_mob_end_metabolize().

## Why It's Good For The Game

Getting helbital's "janken" effect to trigger on a chem tick shouldn't be as likely to happen as winning a pulse rifle from a single game at an arcade machine (which is also a one in a million chance), especially given the extra conditions that are attached to when that janken effect can appear and how rarely people actually use/bother to make helbital.

## Changelog
:cl: ATHATH
balance: The brute healing rate of helbital has been increased.
balance: Helbital no longer deals oxyloss damage to you while you're in soft crit.
balance: Helbital's "janken" effect can no longer trigger while you're conscious, but the chance for it to trigger has been GREATLY increased (to 1/1000 each chem tick, up from one in a million each chem tick), and you no longer need brute damage (before helbital heals you that chem tick) for it to have a chance to trigger.
/:cl:
