### PR TITLE
Gives SWAT masks some armor

### DIFF
--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -70,6 +70,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	aggressiveness = AGGR_SHIT_COP
 	flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDEEYES | HIDEEARS | HIDEHAIR
 	visor_flags_inv = 0
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 0, "bio" = 50, "rad" = 0, "fire" = 20, "acid" = 40) //same amount of armor as an explorer gas mask
 
 /obj/item/clothing/mask/gas/sechailer/swat/spacepol
 	name = "spacepol mask"


### PR DESCRIPTION
## About The Pull Request

This PR gives SWAT masks (and their subtypes) an armor statline of: 
`armor = list("melee" = 10, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 0, "bio" = 50, "rad" = 0, "fire" = 20, "acid" = 40)`

## Why It's Good For The Game

This is the same armor statline that explorer gas mask's have, and I found it kind of odd that a SWAT-grade mask is currently less protective than an explorer gas mask. And before you suggest the idea of just giving explorer gas masks no armor instead of (or in addition to) buffing SWAT masks, I'd like to point out that explorer gas masks are explicitly stated to be "military-grade" in their descriptions, so I think that them having some armor is fine (and I ain't touchin' mining balance with a ten foot pole).

I decided to just buff SWAT masks (and their subtypes) here instead of buffing sechailers and all sechailer subtypes because I do actually kind of like that you can target a sec officer's head to face slightly less armor (as sec jumpsuits, which provide 10 melee armor, don't cover/protect your head). In fact, I think buffing sechailers instead of just SWAT masks would lead to a meta where you'd intentionally NOT shoot at a sec officer's head, because they'd have 5 more bullet, laser, and energy armor there). 

Still, I think the HoS can have a mask that's a tiny bit better than the masks of the common man, yeah?

## Changelog
:cl: ATHATH
balance: SWAT masks and their subtypes now have armor values equal to those of explorer masks.
/:cl: