### PR TITLE
fixes the targeting of the cortex bioware surgeries

### DIFF
--- a/code/modules/surgery/advanced/bioware/cortex_folding.dm
+++ b/code/modules/surgery/advanced/bioware/cortex_folding.dm
@@ -10,7 +10,7 @@
 				/datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_HEAD)
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
-	bioware_target = BIOWARE_LIGAMENTS
+	bioware_target = BIOWARE_CORTEX
 
 /datum/surgery/advanced/bioware/cortex_folding/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)

--- a/code/modules/surgery/advanced/bioware/cortex_imprint.dm
+++ b/code/modules/surgery/advanced/bioware/cortex_imprint.dm
@@ -1,6 +1,6 @@
 /datum/surgery/advanced/bioware/cortex_imprint
 	name = "Cortex Imprint"
-	desc = "A surgical procedure which modifies the cerebral cortex into a redundant neural pattern, making the brain able to bypass damage caused by minor brain traumas."
+	desc = "A surgical procedure which modifies the cerebral cortex into a redundant neural pattern, making the brain able to bypass impediments caused by minor brain traumas."
 	steps = list(/datum/surgery_step/incise,
 				/datum/surgery_step/retract_skin,
 				/datum/surgery_step/clamp_bleeders,
@@ -10,7 +10,7 @@
 				/datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_HEAD)
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
-	bioware_target = BIOWARE_LIGAMENTS
+	bioware_target = BIOWARE_CORTEX
 
 /datum/surgery/advanced/bioware/cortex_imprint/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)
@@ -49,7 +49,7 @@
 
 /datum/bioware/cortex_imprint
 	name = "Cortex Imprint"
-	desc = "The cerebral cortex has been reshaped into a redundant neural pattern, making the brain able to bypass damage caused by minor brain traumas."
+	desc = "The cerebral cortex has been reshaped into a redundant neural pattern, making the brain able to bypass impedements caused by minor brain traumas."
 	mod_type = BIOWARE_CORTEX
 	can_process = TRUE
 

--- a/code/modules/surgery/advanced/bioware/cortex_imprint.dm
+++ b/code/modules/surgery/advanced/bioware/cortex_imprint.dm
@@ -49,10 +49,9 @@
 
 /datum/bioware/cortex_imprint
 	name = "Cortex Imprint"
-	desc = "The cerebral cortex has been reshaped into a redundant neural pattern, making the brain able to bypass impedements caused by minor brain traumas."
+	desc = "The cerebral cortex has been reshaped into a redundant neural pattern, making the brain able to bypass impediments caused by minor brain traumas."
 	mod_type = BIOWARE_CORTEX
 	can_process = TRUE
 
 /datum/bioware/cortex_imprint/process()
 	owner.cure_trauma_type(resilience = TRAUMA_RESILIENCE_BASIC)
-


### PR DESCRIPTION
## About The Pull Request

The cortex folding and cortex imprint surgeries now check the BIOWARE_CORTEX slot (which is where they actually install their corresponding pieces of bioware) for competing pieces of bioware instead of the BIOWARE_LIGAMENTS slot, as almost certainly intended.

## Why It's Good For The Game

![N](https://user-images.githubusercontent.com/42606352/80401097-67b07e00-8881-11ea-9cfa-ee86c9ed4853.jpeg)

## Changelog
:cl: ATHATH
fix: The cortex folding and cortex imprint surgeries now check the BIOWARE_CORTEX slot (which is where they actually install their corresponding pieces of bioware) for competing pieces of bioware instead of the BIOWARE_LIGAMENTS slot, as almost certainly intended.
/:cl:
