### PR TITLE
The Grand Stun Baton/Flash Double Nerf: Stamina Drain Edition

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -76,6 +76,8 @@
 
 #define STATUS_EFFECT_CONVULSING /datum/status_effect/convulsing
 
+#define STATUS_EFFECT_STAMDRAIN /datum/status_effect/stamdrain
+
 #define STATUS_EFFECT_NECROPOLIS_CURSE /datum/status_effect/necropolis_curse
 #define STATUS_EFFECT_HIVEMIND_CURSE /datum/status_effect/necropolis_curse/hivemind
 #define CURSE_BLINDING	1 //makes the edges of the target's screen obscured

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -575,11 +575,9 @@
 	status_type = STATUS_EFFECT_REFRESH
 
 /datum/status_effect/stamdrain/tick()
-	if(iscarbon(owner) && !HAS_TRAIT(owner, TRAIT_STUNRESISTANCE))
+	if(iscarbon(owner))
 		var/mob/living/carbon/H = owner
 		H.adjustStaminaLoss(3)
-	else
-		qdel(src)
 
 /datum/status_effect/dna_melt
 	id = "dna_melt"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -201,19 +201,6 @@
 			to_chat(owner, "<span class='notice'>You succesfuly remove the durathread strand.</span>")
 			L.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
 
-
-/datum/status_effect/pacify/on_creation(mob/living/new_owner, set_duration)
-	if(isnum(set_duration))
-		duration = set_duration
-	. = ..()
-
-/datum/status_effect/pacify/on_apply()
-	ADD_TRAIT(owner, TRAIT_PACIFISM, "status_effect")
-	return ..()
-
-/datum/status_effect/pacify/on_remove()
-	REMOVE_TRAIT(owner, TRAIT_PACIFISM, "status_effect")
-
 //OTHER DEBUFFS
 /datum/status_effect/pacify
 	id = "pacify"
@@ -579,6 +566,20 @@
 	name = "Shaky Hands"
 	desc = "You've been zapped with something and your hands can't stop shaking! You can't seem to hold on to anything."
 	icon_state = "convulsing"
+
+//Stamina drain associated with stun batons and flashes when used on carbons
+/datum/status_effect/stamdrain
+	id = "stamdrain"
+	duration = 50
+	alert_type = null
+	status_type = STATUS_EFFECT_REFRESH
+
+/datum/status_effect/stamdrain/tick()
+	if(iscarbon(owner) && !HAS_TRAIT(owner, TRAIT_STUNRESISTANCE))
+		var/mob/living/carbon/H = owner
+		H.adjustStaminaLoss(3)
+	else
+		qdel(src)
 
 /datum/status_effect/dna_melt
 	id = "dna_melt"

--- a/code/game/objects/items/teleprod.dm
+++ b/code/game/objects/items/teleprod.dm
@@ -13,11 +13,11 @@
 							"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
 		if(do_teleport(user, get_turf(user), 50, channel = TELEPORT_CHANNEL_BLUESPACE))//honk honk
 			SEND_SIGNAL(user, COMSIG_LIVING_MINOR_SHOCK)
-			user.Paralyze(stun_time*3)
+			user.Paralyze(15 SECONDS)
 			deductcharge(cell_hit_cost)
 		else
 			SEND_SIGNAL(user, COMSIG_LIVING_MINOR_SHOCK)
-			user.Paralyze(stun_time*3)
+			user.Paralyze(15 SECONDS)
 			deductcharge(cell_hit_cost/4)
 		return
 	else

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -119,6 +119,8 @@
 			if(M.confused < power)
 				var/diff = power * CONFUSION_STACK_MAX_MULTIPLIER - M.confused
 				M.confused += min(power, diff)
+			if(!HAS_TRAIT(M, TRAIT_STUNRESISTANCE))
+				M.apply_status_effect(STATUS_EFFECT_STAMDRAIN)
 			if(user)
 				terrible_conversion_proc(M, user)
 				visible_message("<span class='danger'>[user] blinds [M] with the flash!</span>")
@@ -126,7 +128,7 @@
 				to_chat(M, "<span class='userdanger'>[user] blinds you with the flash!</span>")
 			else
 				to_chat(M, "<span class='userdanger'>You are blinded by [src]!</span>")
-			M.Paralyze(rand(80,120))
+			M.Knockdown(8 SECONDS)
 		else if(user)
 			visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>")
 			to_chat(user, "<span class='warning'>You fail to blind [M] with the flash!</span>")

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -14,9 +14,9 @@
 	var/flashing_overlay = "flash-f"
 	var/times_used = 0 //Number of times it's been used.
 	var/burnt_out = FALSE     //Is the flash burnt out?
-	var/burnout_resistance = 0
+	var/burnout_resistance = 0 //How resistant to burning out is the flash? Affects probability for burnout.
 	var/last_used = 0 //last world.time it was used.
-	var/cooldown = 0
+	var/cooldown = 0 //Cooldown between flashes. Only relevant on some flashes like the hypnoflash.
 	var/last_trigger = 0 //Last time it was successfully triggered.
 
 /obj/item/assembly/flash/suicide_act(mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes how many standard security weapons work. This is in an effort to make batons a little closer to traditional melee weapons, and retaining the powerful use flashes have as a self defense tool while removing their hard stun.

**Stun Batons**
They respect armor for their damage. It inflicts this damage against the chest and checks for chest armor.

The stun baton inflicts a delated burst of stamina damage after about a second from the hit. The baton also does less upfront damage but only has an attack cooldown of 1.5. This means you're hitting more frequently with your baton but doing less upfront damage. The baton also inflicts a stamina drain.

The stun effects of a stun baton is not negated by armor, but is partially stopped by stun resistance. The stamina drain cannot be removed except waiting out the 5 second duration. The upfront damage a stun baton inflicts is not negated by stun resistance.

Stun prods have an attack cooldown of 2.5 and after effect of 10 stamina damage.

**Classic Batons**
Only the contractor baton will cause a knockdown. All classic batons inflict confusion on the target. Because you smacked them on the head. Their damage is reduced by armor, much like the standard baton.

Contractor Batons have armor penetration which works for both their stamina damage and standard force. They are however weaker than before when attacking anyone in armor unless you're trying to use the baton as a lethal weapon, in which case it is stronger.

**Flashes**
These now cause a knockdown instead of a hard stun and also cause stamina drain. This is an 8 second knockdown. This means security would be better to start with flashing their target before moving to other weapons. 

Stun Resistance
Stun resistance prevents the stamina draining effect from flashes and the delayed stamina damage from batons. It does not affect the knockdown of flashes or the damage of batons.

## Why It's Good For The Game

Stun batons kind of invalidate melee weapons as a whole due to both doing stamina damage, disarming someone and also knocking them to the ground, which is usually a loss anyway because of shoves. Classic batons were no better either. But I really liked the idea of a delayed effect from being hit with a baton, so I have given them a different effect that still retains some of that disarming power.

This also makes stun resistance actually somewhat meaningful for stopping some of the nastier effects of stun batons without strictly making you immune to their effects.

Flashes were just kind of a gear check. They still ARE a gear check but on a much less severe level. They still can be useful as self defense tools. Their direct counters are still their counters.

## Changelog
:cl:
balance: Batons now respect armor as a whole.
balance: Stun batons now inflict a delayed hit of stamina damage after the initial hit. The baton also inflicts a stamina drain over time. This is an effective netgain on stamina damage per hit, but obviously is far slower for application.
balance: Stun batons have a lower cooldown but lower upfront stamina damage.
balance: Classic batons (like telebatons) confuse people on hit instead of knocking down.
balance: Contractor batons have armor penetration and retain the knockdown.
balance: Flashes cause an 8 second knockdown and stamina drain.
balance: Stun resistance protects from stun baton after effects entirely and remove stamina drain.
fix: Deleted copypasted code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
