### PR TITLE
Some minor cleanup around the verification system and jobexp

### DIFF
--- a/code/modules/discord/accountlink.dm
+++ b/code/modules/discord/accountlink.dm
@@ -80,7 +80,10 @@
 	// check for living hours requirement
 	var/required_living_minutes = CONFIG_GET(number/required_living_hours) * 60
 	var/living_minutes = usr.client ? usr.client.get_exp_living(TRUE) : 0
-	if(required_living_minutes > 0 && living_minutes < required_living_minutes)
+	if(required_living_minutes <= 0)
+		CRASH("The discord verification system is setup to require zero hours or less, this is likely a configuration bug")
+		
+	if(living_minutes < required_living_minutes)
 		to_chat(usr, "<span class='warning'>You must have at least [required_living_minutes] minutes of living " \
 			+ "playtime in a round to verify. You have [living_minutes] minutes. Play more!</span>")
 		return

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -123,7 +123,7 @@ GLOBAL_PROTECT(exp_to_update)
 
 
 /client/proc/get_exp_living(pure_numeric = FALSE)
-	if(!prefs.exp)
+	if(!prefs.exp || !prefs.exp[EXP_TYPE_LIVING])
 		return pure_numeric ? 0 : "No data"
 	var/exp_living = text2num(prefs.exp[EXP_TYPE_LIVING])
 	return pure_numeric ? exp_living : get_exp_format(exp_living)


### PR DESCRIPTION
Job exp now checks there is a living hours value, so as to avoid
returning a null unexpectedly.

Discord verification system now assumes you want at least 1 or more
hours of verification time, as it's value is limited otherwise
