### PR TITLE
fix message when plastic spoons/forks break

### DIFF
--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -63,7 +63,7 @@
 	custom_price = 50
 	var/break_chance = 25
 
-/obj/item/kitchen/fork/plastic/afterattack(mob/living/carbon/user)
+/obj/item/kitchen/fork/plastic/afterattack(atom/target, mob/user)
 	.=..()
 	if(prob(break_chance))
 		user.visible_message("<span class='danger'>[user]'s fork snaps into tiny pieces in their hand.</span>")
@@ -247,7 +247,7 @@
 	custom_price = 50
 	var/break_chance = 25
 
-/obj/item/kitchen/spoon/plastic/afterattack(mob/living/carbon/user)
+/obj/item/kitchen/spoon/plastic/afterattack(atom/target, mob/user)
 	.=..()
 	if(prob(break_chance))
 		user.visible_message("<span class='danger'>[user]'s spoon snaps into tiny pieces in their hand.</span>")

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -247,7 +247,7 @@
 	custom_price = 50
 	var/break_chance = 25
 
-/obj/item/kitchen/knife/plastic/afterattack(mob/living/carbon/user)
+/obj/item/kitchen/spoon/plastic/afterattack(mob/living/carbon/user)
 	.=..()
 	if(prob(break_chance))
 		user.visible_message("<span class='danger'>[user]'s spoon snaps into tiny pieces in their hand.</span>")


### PR DESCRIPTION
## About The Pull Request
The spoon's proc was mistakenly using the fork's path and so never broke.
The messages when stuff broke were outputting the targeted object's name rather than the user's.

## Why It's Good For The Game
bad messages are bad

## Changelog
:cl:
fix: Plastic spoons can now break when hitting things
fix: Plastic spoons/forks breaking now shows the correct name of whoever broke them
/:cl:
