### PR TITLE
Removes certain warden locker and contraband locker spawns

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -46,29 +46,19 @@
 
 /obj/effect/spawner/lootdrop/armory_contraband
 	name = "armory contraband gun spawner"
+	lootcount = 3
 	lootdoubles = FALSE
 
 	loot = list(
-				/obj/item/gun/ballistic/automatic/pistol = 8,
-				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
-				/obj/item/gun/ballistic/automatic/pistol/deagle,
-				/obj/item/gun/ballistic/revolver/mateba
+				/obj/item/reagent_containers/food/snacks/donut/choco = 6,
+				/obj/item/reagent_containers/food/snacks/donut/blumpkin = 4,
+				/obj/item/reagent_containers/food/snacks/donut/berry = 2,
+				/obj/item/reagent_containers/food/snacks/donut/chaos = 1
 				)
 
 /obj/effect/spawner/lootdrop/armory_contraband/metastation
-	loot = list(/obj/item/gun/ballistic/automatic/pistol = 5,
-				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
-				/obj/item/gun/ballistic/automatic/pistol/deagle,
-				/obj/item/storage/box/syndie_kit/throwing_weapons = 3,
-				/obj/item/gun/ballistic/revolver/mateba)
 
 /obj/effect/spawner/lootdrop/armory_contraband/donutstation
-	loot = list(/obj/item/grenade/clusterbuster/teargas = 5,
-				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
-				/obj/item/bikehorn/golden,
-				/obj/item/grenade/clusterbuster,
-				/obj/item/storage/box/syndie_kit/throwing_weapons = 3,
-				/obj/item/gun/ballistic/revolver/mateba)
 
 /obj/effect/spawner/lootdrop/prison_contraband
 	name = "prison contraband loot spawner"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -120,7 +120,6 @@
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/clothing/gloves/krav_maga/sec(src)
 	new /obj/item/door_remote/head_of_security(src)
-	new /obj/item/gun/ballistic/shotgun/automatic/combat/compact(src)
 
 /obj/structure/closet/secure_closet/security
 	name = "security officer's locker"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR is a follow up to #50746. It retains the availability and functionality of the compact combat shotgun but removes it from the spawn table on the warden locker. Additionally, this removes the weapon spawns from the contraband locker which will now spawn various varieties of donuts.

## Why It's Good For The Game

"Super alpha strike compact shotgun is not really healthy for game balance." - Rohesie
The contraband locker has been subject to a lot of debate and controversy over the past and the previous removal PR showed that maintainers wanted the spawner removed, which I've done by replacing it with a funnier and tamer loot list.

## Changelog
:cl:angelstarri
del: MA Arms Inc. has initiated a product recall of all compact combat shotguns due to faulty internal magazines that cause the weapon to explode after firing. Unfortunately, all of the weapons in our stock have already exploded. We're not going to acquire any replacements.

balance: Nanotrasen Internal Security has cracked down on security personnel rummaging confiscated contraband items originally intended for safe storage. Rumor is that security is now using the locker to store high-value food items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
