### PR TITLE
you can no longer privately pay for stuff with departmental budgets

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -723,3 +723,6 @@ update_label()
 	department_ID = ACCOUNT_CAR
 	department_name = ACCOUNT_CAR_NAME
 	icon_state = "car_budget" //saving up for a new tesla
+
+/obj/item/card/id/departmental_budget/AltClick(mob/living/user)
+	registered_account.bank_card_talk("<span class='warning'>Withdrawing is not compatible with this card design.</span>", TRUE) //prevents the vault bank machine being useless and putting money from the budget to your card to go over personal crates

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -196,6 +196,9 @@
 				if(!istype(id_card))
 					say("No ID card detected.")
 					return
+				if(istype(id_card, /obj/item/card/id/departmental_budget))
+					say("The [src] rejects [id_card].")
+					return
 				account = id_card.registered_account
 				if(!istype(account))
 					say("Invalid bank account.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this is a bandaid for cargo being able to buy whatever they want without a care in the world by buying privately with the cargo budget
oranges does not want to prevent people from buying private crates without access for whatever stupid reason: #41686 so cargo can literally buy whatever they want, no need for any head of staff, anyone's help, they dont even have to break the crates, just buy with cargo budget and open the crate without restrictions
yes this can be worked around but its the best i can think of since orange man doesnt want the actual fix

## Why It's Good For The Game

we have limitations on cargo but they are invalidated by cargo budget private purchases
also it makes no sense that you buy something privately with the same budget that you buy stuff with normally

## Changelog
:cl:
balance: you can no longer privately pay for stuff with departmental budgets and cant withdraw money, just deposit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
