### PR TITLE
Fixes changelog compile action changing line endings of changelog file

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pyyaml
+          sudo apt-get install  dos2unix
       - name: "Checkout"
         uses: actions/checkout@v1
         with:
@@ -24,6 +25,9 @@ jobs:
       - name: "Compile"
         run: |
           python tools/ss13_genchangelog.py html/changelog.html html/changelogs
+      - name: "Convert Lineendings"
+        run: |
+          unix2dos html/changelogs/.all_changelog.yml
       - name: Commit
         run: |
           git config --local user.email "action@github.com"


### PR DESCRIPTION
This conflicts with the tg tools version, which means the diff of the
entire file changes each time they step across each other.

This just installs dos2unix and uses the unix2dos version to fix the
lineendings