### PR TITLE
Lizards X Autohiss: Ecks', Z's and Kss's. 

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -59,14 +59,20 @@
 /obj/item/organ/tongue/lizard/handle_speech(datum/source, list/speech_args)
 	var/static/regex/lizard_hiss = new("s+", "g")
 	var/static/regex/lizard_hiSS = new("S+", "g")
-	var/static/regex/lizard_kss = new("x+", "g")
-	var/static/regex/lizard_kSS = new("X+", "g")
+	var/static/regex/lizard_kss = new(@"(\w)x", "g")
+	var/static/regex/lizard_kSS = new(@"(\w)X", "g")
+	var/static/regex/lizard_ecks = new(@"\bx([\-|r|R]|\b)", "g")
+	var/static/regex/lizard_eckS = new(@"\bX([\-|r|R]|\b)", "g")
+	var/static/regex/lizard_hizz = new(@"\bx(\w)", "g")//This chunk checks for X's the sounds like Z's. Xeno >> (Z)eno
+	var/static/regex/lizard_hiZZ = new(@"\bX(\w)", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = lizard_hiss.Replace(message, "sss")
 		message = lizard_hiSS.Replace(message, "SSS")
-		message = lizard_kss.Replace(message, "kss")
-		message = lizard_kSS.Replace(message, "KSS")
+		message = lizard_kss.Replace(message, "$1kss")
+		message = lizard_kSS.Replace(message, "$1KSS")
+		message = lizard_ecks.Replace(message, "ecks$1")
+		message = lizard_eckS.Replace(message, "ECKS$1")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/fly

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -63,8 +63,6 @@
 	var/static/regex/lizard_kSS = new(@"(\w)X", "g")
 	var/static/regex/lizard_ecks = new(@"\bx([\-|r|R]|\b)", "g")
 	var/static/regex/lizard_eckS = new(@"\bX([\-|r|R]|\b)", "g")
-	var/static/regex/lizard_hizz = new(@"\bx(\w)", "g")//This chunk checks for X's the sounds like Z's. Xeno >> (Z)eno
-	var/static/regex/lizard_hiZZ = new(@"\bX(\w)", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = lizard_hiss.Replace(message, "sss")


### PR DESCRIPTION
## About The Pull Request

Iterates upon ideas established in #50698 and makes general improvements.

## Why It's Good For The Game

While lizards hissing on X is an understandable and welcome addition to the lizard autohiss mechanic, this made it harder to understand lizardhiss when using certain words containing X. By utilizing the powers of regex, phonetic intent can be determined and actualized. Simply put, lizards will now properly enunciate their X's properly. No more "Kssenomporhs", and "xray" will be said as "ecksray". This will make lizards understandable at a glance while maintaining the hiss-feeling.

![image](https://user-images.githubusercontent.com/33048583/80652214-b8b4a380-8a34-11ea-884d-0a8ce379407a.png)

We can jumble speech all we like and still understand it while maintaining phonetic similarities.


## Changelog
:cl:
tweak: Added Regex to account for variations on X within the English language
tweak: Added The ability for lizards to use the word X at the beginning of a word again.
tweak: Doesn't make every" X" into "KSS"
tweak: Adjusts lizard Autohissing on "X" to be more phonetically accurate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
