### PR TITLE
tgui: Find BYOND cache via Windows Registry

### DIFF
--- a/tgui/packages/tgui-dev-server/reloader.js
+++ b/tgui/packages/tgui-dev-server/reloader.js
@@ -4,6 +4,7 @@ import os from 'os';
 import { basename } from 'path';
 import { promisify } from 'util';
 import { resolveGlob, resolvePath } from './util.js';
+import { regQuery } from './winreg.js';
 
 const logger = createLogger('reloader');
 
@@ -36,6 +37,21 @@ export const findCacheRoot = async () => {
     const paths = await resolveGlob(pattern);
     if (paths.length > 0) {
       cacheRoot = paths[0];
+      logger.log(`found cache at '${cacheRoot}'`);
+      return cacheRoot;
+    }
+  }
+  // Query the Windows Registry
+  if (process.platform === 'win32') {
+    logger.log('querying windows registry');
+    let userpath = await regQuery(
+      'HKCU\\Software\\Dantom\\BYOND',
+      'userpath');
+    if (userpath) {
+      cacheRoot = userpath
+        .replace(/\\$/, '')
+        .replace(/\\/g, '/')
+        + '/cache';
       logger.log(`found cache at '${cacheRoot}'`);
       return cacheRoot;
     }

--- a/tgui/packages/tgui-dev-server/winreg.js
+++ b/tgui/packages/tgui-dev-server/winreg.js
@@ -1,0 +1,43 @@
+/**
+ * @file
+ * Tools for dealing with Windows Registry bullshit.
+ */
+import { exec } from 'child_process';
+import { createLogger } from 'common/logging.js';
+import { promisify } from 'util';
+
+const logger = createLogger('winreg');
+
+export const regQuery = async (path, key) => {
+  if (process.platform !== 'win32') {
+    return null;
+  }
+  try {
+    const command = `reg query "${path}" /v ${key}`;
+    const { stdout } = await promisify(exec)(command);
+    const keyPattern = `    ${key}    `;
+    const indexOfKey = stdout.indexOf(keyPattern);
+    if (indexOfKey === -1) {
+      logger.error('could not find the registry key');
+      return null;
+    }
+    const indexOfEol = stdout.indexOf('\r\n', indexOfKey);
+    if (indexOfEol === -1) {
+      logger.error('could not find the end of the line');
+      return null;
+    }
+    const indexOfValue = stdout.indexOf(
+      '    ',
+      indexOfKey + keyPattern.length);
+    if (indexOfValue === -1) {
+      logger.error('could not find the start of the key value');
+      return null;
+    }
+    const value = stdout.substring(indexOfValue + 4, indexOfEol);
+    return value;
+  }
+  catch (err) {
+    logger.error(err);
+    return null;
+  }
+};


### PR DESCRIPTION
## About The Pull Request

This finally makes tgui-dev-server aware of custom BYOND cache locations by querying BYOND settings in Windows Registry in `HKCU\Software\Dantom\BYOND`,

There were too many weird chaps with their BYOND folder located in something liek:

- `~/OneDrive/Documents/BYOND`
- `E:/Libraries/Documents/BYOND`

It runs `reg query` in a child process, so has a chance of breaking, so here's a usual disclaimer:

![image](https://forthebadge.com/images/badges/60-percent-of-the-time-works-every-time.svg)