### PR TITLE
[READY]Major explosive rebalanance and changes patch: Edge strikes back

### DIFF
--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -44,7 +44,7 @@
 
 /obj/structure/geyser/random
 	erupting_state = null
-	var/list/options = list(/datum/reagent/clf3 = 10, /datum/reagent/water/hollowwater = 10, /datum/reagent/medicine/omnizine/protozine = 6, /datum/reagent/wittel = 1)
+	var/list/options = list(/datum/reagent/clf3 = 10, /datum/reagent/water/hollowwater = 10,/datum/reagent/plasma_oxide = 8, /datum/reagent/medicine/omnizine/protozine = 6, /datum/reagent/wittel = 1)
 
 /obj/structure/geyser/random/Initialize()
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2174,6 +2174,18 @@
 	taste_description = "bananas"
 	can_synth = TRUE
 
+/datum/reagent/plasma_oxide
+	name = "Hyper-Plasmium Oxide"
+	description = "Compound created deep in the cores of demon-class planets. Commonly found through deep geysers."
+	color = "#470750" // rgb: 255, 255, 255
+	taste_description = "hell"
+
+/datum/reagent/exotic_stabilizer
+	name = "Exotic Stabilizer"
+	description = "Advanced compound created by mixing stabilizing agent and hyper-plasmium oxide."
+	color = "#180000" // rgb: 255, 255, 255
+	taste_description = "blood"
+
 /datum/reagent/wittel
 	name = "Wittel"
 	description = "An extremely rare metallic-white substance only found on demon-class planets."

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -115,6 +115,10 @@
 	e.start()
 	holder.clear_reagents()
 
+/datum/reagent/gunpowder/ghetto
+	name = "Improvised Gunpowder"
+	description = "Better than nothing i guess."
+
 /datum/reagent/rdx
 	name = "RDX"
 	description = "Military grade explosive"

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -115,10 +115,6 @@
 	e.start()
 	holder.clear_reagents()
 
-/datum/reagent/gunpowder/ghetto
-	name = "Improvised Gunpowder"
-	description = "Better than nothing i guess."
-
 /datum/reagent/rdx
 	name = "RDX"
 	description = "Military grade explosive"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -852,7 +852,7 @@
 		mytray.adjustWeeds(-rand(1,4))
 
 /datum/reagent/toxin/acid/fluacid/on_mob_life(mob/living/carbon/M)
-	M.adjustFireLoss(current_cycle/10, 0)
+	M.adjustFireLoss(current_cycle/15, 0)
 	. = 1
 	..()
 
@@ -864,7 +864,7 @@
 	acidpwr = 5.0
 
 /datum/reagent/toxin/acid/nitracid/on_mob_life(mob/living/carbon/M)
-	M.adjustFireLoss(current_cycle/15, FALSE) //here you go nervar
+	M.adjustFireLoss(volume/10, FALSE) //here you go nervar
 	. = TRUE
 	..()
 

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -15,7 +15,7 @@
 
 	// Both of these variables are mostly going to be used with slime cores - but if you want to, you can use them for other things
 	/// the exact container path required for the reaction to happen
-	var/required_container = null
+	var/required_container
 	/// an integer required for the reaction to happen
 	var/required_other = 0
 
@@ -24,7 +24,7 @@
 	///Required temperature for the reaction to begin
 	var/required_temp = 0
 	/// Set to TRUE if you want the recipe to only react when it's BELOW the required temp.
-	var/is_cold_recipe = 0
+	var/is_cold_recipe = FALSE
 	///The message shown to nearby people upon mixing, if applicable
 	var/mix_message = "The solution begins to bubble."
 	///The sound played upon mixing, if applicable

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -1,23 +1,74 @@
+/**
+  * #Chemical Reaction
+  *
+  * Datum that makes the magic between reagents happen.
+  *
+  * Chemical reactions is a class that is instantiated and stored in a global list 'chemical_reactions_list'
+  */
 /datum/chemical_reaction
+	///Results of the chemical reactions
 	var/list/results = new/list()
+	///Required chemicals that are USED in the reaction
 	var/list/required_reagents = new/list()
+	///Required chemicals that must be present in the container but are not USED.
 	var/list/required_catalysts = new/list()
 
 	// Both of these variables are mostly going to be used with slime cores - but if you want to, you can use them for other things
-	var/required_container = null // the exact container path required for the reaction to happen
-	var/required_other = 0 // an integer required for the reaction to happen
+	/// the exact container path required for the reaction to happen
+	var/required_container = null
+	/// an integer required for the reaction to happen
+	var/required_other = 0
 
-	var/mob_react = TRUE //Determines if a chemical reaction can occur inside a mob
-
+	///Determines if a chemical reaction can occur inside a mob
+	var/mob_react = TRUE
+	///Required temperature for the reaction to begin
 	var/required_temp = 0
-	var/is_cold_recipe = 0 // Set to 1 if you want the recipe to only react when it's BELOW the required temp.
-	var/mix_message = "The solution begins to bubble." //The message shown to nearby people upon mixing, if applicable
-	var/mix_sound = 'sound/effects/bubbles.ogg' //The sound played upon mixing, if applicable
+	/// Set to TRUE if you want the recipe to only react when it's BELOW the required temp.
+	var/is_cold_recipe = 0
+	///The message shown to nearby people upon mixing, if applicable
+	var/mix_message = "The solution begins to bubble."
+	///The sound played upon mixing, if applicable
+	var/mix_sound = 'sound/effects/bubbles.ogg'
 
+/datum/chemical_reaction/New()
+	. = ..()
+	SSticker.OnRoundstart(CALLBACK(src,.proc/update_info))
+
+/**
+  * Updates information during the roundstart
+  *
+  * This proc is mainly used by explosives but can be used anywhere else
+  * You should generally use the special reactions in [/datum/chemical_reaction/randomized]
+  * But for simple variable edits, like changing the temperature or adding/subtracting required reagents it is better to use this.
+  */
+/datum/chemical_reaction/proc/update_info()
+	return
+
+/**
+  * Shit that happens on reaction
+  *
+  * Proc where the additional magic happens.
+  * You dont want to handle mob spawning in this since there is a dedicated proc for that.client
+  * Arguments:
+  * * holder - the datum that holds this reagent, be it a beaker or anything else
+  * * created_volume - volume created when this is mixed. look at 'var/list/results'.
+  */
 /datum/chemical_reaction/proc/on_reaction(datum/reagents/holder, created_volume)
 	return
 	//I recommend you set the result amount to the total volume of all components.
 
+/**
+  * Magical mob spawning when chemicals react
+  *
+  * Your go to proc when you want to create new mobs from chemicals. please dont use on_reaction.
+  * Arguments:
+  * * holder - the datum that holds this reagent, be it a beaker or anything else
+  * * amount_to_spawn - how much /mob to spawn
+  * * reaction_name - what is the name of this reaction. be creative, the world is your oyster after all!
+  * * mob_class - determines if the mob will be friendly, neutral or hostile
+  * * mob_faction - used in determining targets, mobs from the same faction wont harm eachother.
+  * * random - creates random mobs. self explanatory.
+  */
 /datum/chemical_reaction/proc/chemical_mob_spawn(datum/reagents/holder, amount_to_spawn, reaction_name, mob_class = HOSTILE_SPAWN, mob_faction = "chemicalsummon", random = TRUE)
 	if(holder && holder.my_atom)
 		var/atom/A = holder.my_atom
@@ -50,7 +101,16 @@
 				for(var/j = 1, j <= rand(1, 3), j++)
 					step(S, pick(NORTH,SOUTH,EAST,WEST))
 
-///Simulates a vortex that moves nearby movable atoms towards or away from the turf T. Range also determines the strength of the effect. High values cause nearby objects to be thrown.
+/**
+  * Magical move-wooney that happens sometimes.
+  *
+  * Simulates a vortex that moves nearby movable atoms towards or away from the turf T.
+  * Range also determines the strength of the effect. High values cause nearby objects to be thrown.
+  * Arguments:
+  * * T - turf where it happens
+  * * setting_type - does it suck or does it blow?
+  * * range - range.
+  */
 /proc/goonchem_vortex(turf/T, setting_type, range)
 	for(var/atom/movable/X in orange(range, T))
 		if(X.anchored)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -578,3 +578,6 @@
 	results = list(/datum/reagent/consumable/gravy = 3)
 	required_reagents = list(/datum/reagent/consumable/milk = 1, /datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/flour = 1)
 
+/datum/chemical_reaction/exotic_stabilizer
+	results = list(/datum/reagent/exotic_stabilizer = 2)
+	required_reagents = list(/datum/reagent/plasma_oxide = 1,/datum/reagent/stabilizing_agent = 1)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -169,25 +169,6 @@
 	sleep(rand(50,100))
 	..()
 
-/datum/chemical_reaction/ghetto_gunpowder
-	results = list(/datum/reagent/gunpowder/ghetto = 2)
-	required_reagents = list(/datum/reagent/phosphorus = 1,/datum/reagent/nitrogen = 1, /datum/reagent/carbon = 1, /datum/reagent/sulfur = 1)
-
-/datum/chemical_reaction/reagent_explosion/ghetto_gunpowder_explosion
-	required_reagents = list(/datum/reagent/gunpowder/ghetto = 1)
-	strengthdiv = 10
-	required_temp = 474
-	///Amplitude of time
-	var/time_amplitude = 100
-
-/datum/chemical_reaction/reagent_explosion/ghetto_gunpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
-	sleep(rand(time_amplitude,time_amplitude*2))
-	..()
-
-/datum/chemical_reaction/reagent_explosion/ghetto_gunpowder_explosion/update_info()
-	required_temp += rand(-30,30)
-	time_amplitude += rand(-50,50)
-
 /datum/chemical_reaction/thermite
 	results = list(/datum/reagent/thermite = 3)
 	required_reagents = list(/datum/reagent/aluminium = 1, /datum/reagent/iron = 1, /datum/reagent/oxygen = 1)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -43,6 +43,7 @@
 /datum/chemical_reaction/reagent_explosion/rdx
 	results = list(/datum/reagent/rdx= 2)
 	required_reagents = list(/datum/reagent/phenol = 2, /datum/reagent/toxin/acid/nitracid = 1, /datum/reagent/acetone_oxide = 1 )
+	required_catalysts = list(/datum/reagent/gold) //royal explosive
 	required_temp = 404
 	strengthdiv = 8
 
@@ -55,12 +56,12 @@
 /datum/chemical_reaction/reagent_explosion/rdx_explosion
 	required_reagents = list(/datum/reagent/rdx = 1)
 	required_temp = 474
-	strengthdiv = 8
+	strengthdiv = 7
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion2 //makes rdx unique , on its own it is a good bomb, but when combined with liquid electricity it becomes truly destructive
 	required_reagents = list(/datum/reagent/rdx = 1 , /datum/reagent/consumable/liquidelectricity = 1)
-	strengthdiv = 4
-	modifier = 3
+	strengthdiv = 3.5 //actually a decrease of 1 becaused of how explosions are calculated. This is due to the fact we require 2 reagents
+	modifier = 2
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion2/on_reaction(datum/reagents/holder, created_volume)
 	var/fire_range = round(created_volume/50)
@@ -72,8 +73,9 @@
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion3
 	required_reagents = list(/datum/reagent/rdx = 1 , /datum/reagent/teslium = 1)
-	modifier = 5
-	strengthdiv = 4
+	strengthdiv = 3.5 //actually a decrease of 1 becaused of how explosions are calculated. This is due to the fact we require 2 reagents
+	modifier = 4
+
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion3/on_reaction(datum/reagents/holder, created_volume)
 	var/fire_range = round(created_volume/30)
@@ -106,13 +108,12 @@
 
 /datum/chemical_reaction/reagent_explosion/tatp_explosion/on_reaction(datum/reagents/holder, created_volume)
 	var/strengthdiv_adjust = created_volume / ( 2100 / initial(strengthdiv))
-	strengthdiv = max(initial(strengthdiv) - strengthdiv_adjust + 0.25 ,0.25) //small scale explosions are weak, but at the higher end it becomes a true force of nature
+	strengthdiv = max(initial(strengthdiv) - strengthdiv_adjust + 1.5 ,1.5) //Slightly better than nitroglycerin
 	. = ..()
 	return
 
 /datum/chemical_reaction/reagent_explosion/tatp_explosion/update_info()
 	required_temp = 550 + rand(-49,49)
-
 
 /datum/chemical_reaction/reagent_explosion/penthrite_explosion_epinephrine
 	required_reagents = list(/datum/reagent/medicine/C2/penthrite = 1, /datum/reagent/medicine/epinephrine = 1)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -96,7 +96,7 @@
 	required_temp = 450 + rand(-49,49)  //this gets loaded only on round start
 
 /datum/chemical_reaction/reagent_explosion/tatp/on_reaction(datum/reagents/holder, created_volume)
-	if(holder.has_reagent(/datum/reagent/exotic_stabilizer,round(created_volume / 50, CHEMICAL_QUANTISATION_LEVEL)))
+	if(holder.has_reagent(/datum/reagent/exotic_stabilizer,round(created_volume / 50, CHEMICAL_QUANTISATION_LEVEL))) // we like exotic stabilizer
 		return
 	holder.remove_reagent(/datum/reagent/tatp, created_volume)
 	..()

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -72,8 +72,8 @@
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion3
 	required_reagents = list(/datum/reagent/rdx = 1 , /datum/reagent/teslium = 1)
-	modifier = 4
-	strengthdiv = 5
+	modifier = 5
+	strengthdiv = 4
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion3/on_reaction(datum/reagents/holder, created_volume)
 	var/fire_range = round(created_volume/30)
@@ -89,10 +89,7 @@
 	required_temp = 450
 	strengthdiv = 3
 
-/datum/chemical_reaction/reagent_explosion/tatp/New()
-	SSticker.OnRoundstart(CALLBACK(src,.proc/UpdateInfo)) //method used by secret sauce.
-
-/datum/chemical_reaction/reagent_explosion/tatp/proc/UpdateInfo()
+/datum/chemical_reaction/reagent_explosion/tatp/update_info()
 	required_temp = 450 + rand(-49,49)  //this gets loaded only on round start
 
 
@@ -107,16 +104,13 @@
 	required_temp = 550 // this makes making tatp before pyro nades, and extreme pain in the ass to make
 	strengthdiv = 3
 
-/datum/chemical_reaction/reagent_explosion/tatp_explosion/New()
-	SSticker.OnRoundstart(CALLBACK(src,.proc/UpdateInfo))
-
 /datum/chemical_reaction/reagent_explosion/tatp_explosion/on_reaction(datum/reagents/holder, created_volume)
 	var/strengthdiv_adjust = created_volume / ( 2100 / initial(strengthdiv))
 	strengthdiv = max(initial(strengthdiv) - strengthdiv_adjust + 0.25 ,0.25) //small scale explosions are weak, but at the higher end it becomes a true force of nature
 	. = ..()
 	return
 
-/datum/chemical_reaction/reagent_explosion/tatp_explosion/proc/UpdateInfo()
+/datum/chemical_reaction/reagent_explosion/tatp_explosion/update_info()
 	required_temp = 550 + rand(-49,49)
 
 
@@ -183,16 +177,14 @@
 	required_reagents = list(/datum/reagent/gunpowder/ghetto = 1)
 	strengthdiv = 10
 	required_temp = 474
+	///Amplitude of time
 	var/time_amplitude = 100
-
-/datum/chemical_reaction/reagent_explosion/ghetto_gunpowder_explosion/New()
-	SSticker.OnRoundstart(CALLBACK(src,.proc/UpdateInfo))
 
 /datum/chemical_reaction/reagent_explosion/ghetto_gunpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
 	sleep(rand(time_amplitude,time_amplitude*2))
 	..()
 
-/datum/chemical_reaction/reagent_explosion/ghetto_gunpowder_explosion/proc/UpdateInfo()
+/datum/chemical_reaction/reagent_explosion/ghetto_gunpowder_explosion/update_info()
 	required_temp += rand(-30,30)
 	time_amplitude += rand(-50,50)
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -60,7 +60,7 @@
 /datum/chemical_reaction/reagent_explosion/rdx_explosion2 //makes rdx unique , on its own it is a good bomb, but when combined with liquid electricity it becomes truly destructive
 	required_reagents = list(/datum/reagent/rdx = 1 , /datum/reagent/consumable/liquidelectricity = 1)
 	strengthdiv = 4
-	modifier = 2
+	modifier = 3
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion2/on_reaction(datum/reagents/holder, created_volume)
 	var/fire_range = round(created_volume/50)
@@ -73,7 +73,7 @@
 /datum/chemical_reaction/reagent_explosion/rdx_explosion3
 	required_reagents = list(/datum/reagent/rdx = 1 , /datum/reagent/teslium = 1)
 	modifier = 4
-	strengthdiv = 4
+	strengthdiv = 5
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion3/on_reaction(datum/reagents/holder, created_volume)
 	var/fire_range = round(created_volume/30)
@@ -131,7 +131,7 @@
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/potassium = 1)
-	strengthdiv = 18
+	strengthdiv = 20
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion/holyboom
 	required_reagents = list(/datum/reagent/water/holywater = 1, /datum/reagent/potassium = 1)
@@ -167,13 +167,34 @@
 /datum/chemical_reaction/reagent_explosion/gunpowder_explosion
 	required_reagents = list(/datum/reagent/gunpowder = 1)
 	required_temp = 474
-	strengthdiv = 6
-	modifier = 2
+	strengthdiv = 10
+	modifier = 5
 	mix_message = "<span class='boldannounce'>Sparks start flying around the gunpowder!</span>"
 
 /datum/chemical_reaction/reagent_explosion/gunpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
 	sleep(rand(50,100))
 	..()
+
+/datum/chemical_reaction/ghetto_gunpowder
+	results = list(/datum/reagent/gunpowder/ghetto = 2)
+	required_reagents = list(/datum/reagent/phosphorus = 1,/datum/reagent/nitrogen = 1, /datum/reagent/carbon = 1, /datum/reagent/sulfur = 1)
+
+/datum/chemical_reaction/reagent_explosion/ghetto_gunpowder_explosion
+	required_reagents = list(/datum/reagent/gunpowder/ghetto = 1)
+	strengthdiv = 10
+	required_temp = 474
+	var/time_amplitude = 100
+
+/datum/chemical_reaction/reagent_explosion/ghetto_gunpowder_explosion/New()
+	SSticker.OnRoundstart(CALLBACK(src,.proc/UpdateInfo))
+
+/datum/chemical_reaction/reagent_explosion/ghetto_gunpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
+	sleep(rand(time_amplitude,time_amplitude*2))
+	..()
+
+/datum/chemical_reaction/reagent_explosion/ghetto_gunpowder_explosion/proc/UpdateInfo()
+	required_temp += rand(-30,30)
+	time_amplitude += rand(-50,50)
 
 /datum/chemical_reaction/thermite
 	results = list(/datum/reagent/thermite = 3)
@@ -229,8 +250,8 @@
 /datum/chemical_reaction/reagent_explosion/methsplosion
 	required_temp = 380 //slightly above the meth mix time.
 	required_reagents = list(/datum/reagent/drug/methamphetamine = 1)
-	strengthdiv = 9
-	modifier = 1
+	strengthdiv = 12
+	modifier = 5
 	mob_react = FALSE
 
 /datum/chemical_reaction/reagent_explosion/methsplosion/on_reaction(datum/reagents/holder, created_volume)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -63,7 +63,7 @@
 	modifier = 2
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion2/on_reaction(datum/reagents/holder, created_volume)
-	var/fire_range = round(created_volume/100)
+	var/fire_range = round(created_volume/50)
 	var/turf/T = get_turf(holder.my_atom)
 	for(var/turf/turf in range(fire_range,T))
 		new /obj/effect/hotspot(turf)
@@ -76,7 +76,7 @@
 	strengthdiv = 4
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion3/on_reaction(datum/reagents/holder, created_volume)
-	var/fire_range = round(created_volume/50)
+	var/fire_range = round(created_volume/30)
 	var/turf/T = get_turf(holder.my_atom)
 	for(var/turf/turf in range(fire_range,T))
 		new /obj/effect/hotspot(turf)
@@ -110,6 +110,11 @@
 /datum/chemical_reaction/reagent_explosion/tatp_explosion/New()
 	SSticker.OnRoundstart(CALLBACK(src,.proc/UpdateInfo))
 
+/datum/chemical_reaction/reagent_explosion/tatp_explosion/on_reaction(datum/reagents/holder, created_volume)
+	var/strengthdiv_adjust = created_volume / ( 2100 / initial(strengthdiv))
+	strengthdiv = max(initial(strengthdiv) - strengthdiv_adjust + 0.25 ,0.25) //small scale explosions are weak, but at the higher end it becomes a true force of nature
+	. = ..()
+	return
 
 /datum/chemical_reaction/reagent_explosion/tatp_explosion/proc/UpdateInfo()
 	required_temp = 550 + rand(-49,49)
@@ -126,7 +131,7 @@
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/potassium = 1)
-	strengthdiv = 20
+	strengthdiv = 18
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion/holyboom
 	required_reagents = list(/datum/reagent/water/holywater = 1, /datum/reagent/potassium = 1)
@@ -163,7 +168,7 @@
 	required_reagents = list(/datum/reagent/gunpowder = 1)
 	required_temp = 474
 	strengthdiv = 6
-	modifier = 1
+	modifier = 2
 	mix_message = "<span class='boldannounce'>Sparks start flying around the gunpowder!</span>"
 
 /datum/chemical_reaction/reagent_explosion/gunpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
@@ -224,7 +229,7 @@
 /datum/chemical_reaction/reagent_explosion/methsplosion
 	required_temp = 380 //slightly above the meth mix time.
 	required_reagents = list(/datum/reagent/drug/methamphetamine = 1)
-	strengthdiv = 6
+	strengthdiv = 9
 	modifier = 1
 	mob_react = FALSE
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -30,7 +30,8 @@
 	strengthdiv = 2
 
 /datum/chemical_reaction/reagent_explosion/nitroglycerin/on_reaction(datum/reagents/holder, created_volume)
-	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
+
+	if(holder.has_reagent(/datum/reagent/exotic_stabilizer,round(created_volume / 25, CHEMICAL_QUANTISATION_LEVEL)))
 		return
 	holder.remove_reagent(/datum/reagent/nitroglycerin, created_volume*2)
 	..()
@@ -94,9 +95,8 @@
 /datum/chemical_reaction/reagent_explosion/tatp/update_info()
 	required_temp = 450 + rand(-49,49)  //this gets loaded only on round start
 
-
 /datum/chemical_reaction/reagent_explosion/tatp/on_reaction(datum/reagents/holder, created_volume)
-	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
+	if(holder.has_reagent(/datum/reagent/exotic_stabilizer,round(created_volume / 50, CHEMICAL_QUANTISATION_LEVEL)))
 		return
 	holder.remove_reagent(/datum/reagent/tatp, created_volume)
 	..()


### PR DESCRIPTION
## About The Pull Request

This PR rebalances the explosives. 

Changes:
- TaTP - TaTP is now the most powerful **large scale** (>1000 u) explosive chemical. The more units you use the lower strengthdivider becomes, topping off at 1.5 at around 2100u. Which is 25% better than nitroglycerin.

- RDX - RDX now produces a slightly bigger fire wave. I felt like the chem needed a small buff due to it being hard to craft. It now requires gold as a catalyst to craft. Prevents the use of macros since you now gotta get some gold.

- Methamphetamine - Meth was nerfed from strengthdiv of 6 to 12, modifier changed from 1 to 5. This won't affect small scale explosions that much, it will still destroy your meth lab, but bigger explosions will be underwhelming. I felt like meth was the go-to braindead explosive, since pretty much everyone has macro's for it.

- Blackpowder - nerfed strengthdiv from 6 to 8, buffed modifier from 2 to 5. Same reason as Meth, it is very easy to craft , so it will be weaker.

- Nitric acid - I have recently checkced the formula and noticed that fluorosulphuric acid is better than nitric acid in every single way! I have decided to move some power from facid to nacid, because nacid is an upgrade, so it should be better. Nerfed facid's fireloss power and moved it to nitric acid. Death syringes are still not possible.

- Exotic Stabilizer - created with stabilizing agent and hyper-plasmium oxide

- Hyper-plasmium oxide - commonly found on lavaland in geysers.

Additionally i made chemical_reactions AUTODOC compliant.

## Why It's Good For The Game

I felt like explosives were too easy to craft. With this rebalance i made a big seperation - higher tier explosives that can really deal a lot of damage should be hard to create or require cross-dep collaboration. Lower tier explosives should be a lot weaker, to prohibit people from abusing macro's to pump out tons of high-tier explosives.

Availability of high-tier explosives should be limited to chemists.

TL;DR meth is now worse, tatp is better, you can now make ghetto blackpowder.

## Changelog
:cl:
balance: Nitroglycerin : You now have to use exotic stabilizer.
balance: TaTP : The more you use it, the more powerful it becomes. You now have to stabilize it with exotic stabilizer
balance: RDX : produces slightly bigger heatwave and slightly bigger shockwave. Now requires gold.
balance: Gunpowder : strengthdiv 8 - > 10 (nerf), modifier 2 - > 5 (buff).
balance: Methamphetamine : strengthdiv 6 -> 12 (nerf), modifier 1 - > 5 (buff).
balance: Moved some power from facid to nitric acid.
add: Hyper-plasmium oxide can be commonly found in lavaland geysers
add: Exotic stabilizer can now be crafted with hyper-plasmium oxide and stabilizing agent
/:cl:

 