### PR TITLE
fixing a few super small issues with usage of the & operator

### DIFF
--- a/code/datums/components/edible.dm
+++ b/code/datums/components/edible.dm
@@ -66,7 +66,7 @@ Behavior that's still missing from this component that original food items had t
 				owner.reagents.add_reagent(rid, amount)
 
 /datum/component/edible/proc/examine(datum/source, mob/user, list/examine_list)
-	if(!food_flags & FOOD_IN_CONTAINER)
+	if(!(food_flags & FOOD_IN_CONTAINER))
 		switch (bitecount)
 			if (0)
 				return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -651,7 +651,7 @@
 		else
 			. += "It looks very robust."
 
-	if(issilicon(user) && (!machine_stat & BROKEN))
+	if(issilicon(user) && !(machine_stat & BROKEN))
 		. += "<span class='notice'>Shift-click [src] to [ density ? "open" : "close"] it.</span>"
 		. += "<span class='notice'>Ctrl-click [src] to [ locked ? "raise" : "drop"] its bolts.</span>"
 		. += "<span class='notice'>Alt-click [src] to [ secondsElectrified ? "un-electrify" : "permanently electrify"] it.</span>"

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -829,7 +829,7 @@
 
 /obj/machinery/turretid/examine(mob/user)
 	. += ..()
-	if(issilicon(user) && (!machine_stat & BROKEN))
+	if(issilicon(user) && !(machine_stat & BROKEN))
 		. += {"<span class='notice'>Ctrl-click [src] to [ enabled ? "disable" : "enable"] turrets.</span>
 					<span class='notice'>Alt-click [src] to set turrets to [ lethal ? "stun" : "kill"].</span>"}
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -270,7 +270,7 @@
 	. = ..()
 
 /obj/item/stack/medical/mesh/attack_hand(mob/user)
-	if(!is_open & user.get_inactive_held_item() == src)
+	if(!is_open && user.get_inactive_held_item() == src)
 		to_chat(user, "<span class='warning'>You need to open [src] first.</span>")
 		return
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
This fixes a couple of instances of code matching the pattern `!x & y` where intended functionality would actually require the code to be `!(x & y)`

Also modified some medical mesh code to use `&&` instead of `&`. Although it technically works either way.

In the case of borg examine text, the current code actually works most of the time because the expression evaluates out to `!0 & 1` as machine_stat is usually 0 and BROKEN is 1. This'll fix the other cases, though.

## Why It's Good For The Game
correct code eases the soul

## Changelog
:cl:
fix: borg examine text describing hotkeys now always shows on non-broken doors/portable-turrets
code: cleans up some accidents around the & operator
/:cl:
