### PR TITLE
Add look up verb for multi-z

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -57,6 +57,7 @@
 #define CLICK_CD_HANDCUFFED 10
 #define CLICK_CD_RESIST 20
 #define CLICK_CD_GRABBING 10
+#define CLICK_CD_LOOK_UP 5
 
 //Cuff resist speeds
 #define FAST_CUFFBREAK 1

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -214,6 +214,7 @@
 
 // /mob/living signals
 #define COMSIG_LIVING_RESIST "living_resist"					//from base of mob/living/resist() (/mob/living)
+#define COMSIG_LIVING_LOOK_UP "living_look_up"					//from base of mob/living/look_up() (/mob/living)
 #define COMSIG_LIVING_IGNITED "living_ignite"					//from base of mob/living/IgniteMob() (/mob/living)
 #define COMSIG_LIVING_EXTINGUISHED "living_extinguished"		//from base of mob/living/ExtinguishMob() (/mob/living)
 #define COMSIG_LIVING_ELECTROCUTE_ACT "living_electrocute_act"		//from base of mob/living/electrocute_act(): (shock_damage, source, siemens_coeff, flags)

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -41,6 +41,8 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 
 #define isplatingturf(A) (istype(A, /turf/open/floor/plating))
 
+#define isopenspace(A) (istype(A, /turf/open/openspace))
+
 //Mobs
 #define isliving(A) (istype(A, /mob/living))
 

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -26,3 +26,8 @@
 	var/mob/living/L = user.mob
 	L.look_up()
 	return TRUE
+
+/datum/keybinding/living/look_up/up(client/user)
+	var/mob/living/L = user.mob
+	L.stop_look_up()
+	return TRUE

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -15,3 +15,14 @@
 	var/mob/living/L = user.mob
 	L.resist()
 	return TRUE
+
+/datum/keybinding/living/look_up
+	hotkey_keys = list("L")
+	name = "look up"
+	full_name = "Look Up"
+	description = ""
+
+/datum/keybinding/living/look_up/down(client/user)
+	var/mob/living/L = user.mob
+	L.look_up()
+	return TRUE

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -20,7 +20,7 @@
 	hotkey_keys = list("L")
 	name = "look up"
 	full_name = "Look Up"
-	description = ""
+	description = "Look up at the next z-level.  Only works if directly below open space."
 
 /datum/keybinding/living/look_up/down(client/user)
 	var/mob/living/L = user.mob

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1522,7 +1522,6 @@
 		return
 
 	changeNext_move(CLICK_CD_LOOK_UP)
-	SEND_SIGNAL(src, COMSIG_LIVING_LOOK_UP)
 	reset_perspective(ceiling)
 	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, .proc/stop_look_up) //We stop looking up if we move.
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1496,7 +1496,8 @@
 		return BODYTEMP_NORMAL
 	return BODYTEMP_NORMAL + get_body_temp_normal_change()
 
-/mob/living/proc/can_look_up() //Checks if the user is incapacitated.
+///Checks if the user is incapacitated or on cooldown.
+/mob/living/proc/can_look_up()
 	return !((next_move > world.time) || incapacitated(ignore_restraints = TRUE))
 
 /**

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1515,15 +1515,15 @@
 		return
 	if(!can_look_up())
 		return
-	var/turf/above_turf = get_step_multiz(src, UP)
-	if(!above_turf) //We are at the highest z-level.
-		to_chat(src, "<span class='warning'>You're already at the highest floor.</span>")
+	var/turf/ceiling= get_step_multiz(src, UP)
+	if(!ceiling) //We are at the highest z-level.
+		to_chat(src, "<span class='warning'>You can't see through the ceiling above you.</span>")
 		return
-	else if(!isopenspace(above_turf)) //There is no openspace turf above us.
+	else if(!isopenspace(ceiling)) //There is no openspace turf above us.
 		to_chat(src, "<span class='warning'>You can't see through the floor above you.</span>")
 		return
 
 	changeNext_move(CLICK_CD_LOOK_UP)
 	SEND_SIGNAL(src, COMSIG_LIVING_LOOK_UP, src)
-	reset_perspective(above_turf)
+	reset_perspective(ceiling)
 	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, .proc/reset_perspective) //We stop looking up if we move.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1521,7 +1521,7 @@
 		return
 
 	changeNext_move(CLICK_CD_LOOK_UP)
-	SEND_SIGNAL(src, COMSIG_LIVING_LOOK_UP, src)
+	SEND_SIGNAL(src, COMSIG_LIVING_LOOK_UP)
 	reset_perspective(ceiling)
 	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, .proc/stop_look_up) //We stop looking up if we move.
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1513,7 +1513,7 @@
 		return
 	if(!can_look_up())
 		return
-	var/turf/ceiling= get_step_multiz(src, UP)
+	var/turf/ceiling = get_step_multiz(src, UP)
 	if(!ceiling) //We are at the highest z-level.
 		to_chat(src, "<span class='warning'>You can't see through the ceiling above you.</span>")
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1505,13 +1505,10 @@
  * This also checks if an openspace turf is above the mob before looking up or resets the perspective if already looking up
  *
  */
-/mob/living/verb/look_up()
-	set name = "Look Up"
-	set category = "IC"
+/mob/living/proc/look_up()
 
 	if(client.perspective != MOB_PERSPECTIVE) //We are already looking up.
-		reset_perspective()
-		UnregisterSignal(src, COMSIG_MOVABLE_PRE_MOVE)
+		stop_look_up()
 		return
 	if(!can_look_up())
 		return
@@ -1526,4 +1523,8 @@
 	changeNext_move(CLICK_CD_LOOK_UP)
 	SEND_SIGNAL(src, COMSIG_LIVING_LOOK_UP, src)
 	reset_perspective(ceiling)
-	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, .proc/reset_perspective) //We stop looking up if we move.
+	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, .proc/stop_look_up) //We stop looking up if we move.
+
+/mob/living/proc/stop_look_up()
+	reset_perspective()
+	UnregisterSignal(src, COMSIG_MOVABLE_PRE_MOVE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR adds a new feature for a (hopefully) better multi-z experience.

The look_up verb allows the play to see the z-level above them if the following conditions are met:
1, The turf directly above the player is openspace.
2, The player is not already on the highest z-level
3, The player is not incapacitated.

It's currently implemented as a hotkey bound to "L".  If you're already looking up, the perspective of the player will be reset back to their mob (which is essentially lookin back down).  The perspective also resets if the player moves.

https://imgur.com/a/RRtxuJd

A GUI button, like the one used for resist, could be added later if this proves popular enough.

If people are interested, I could also look into adding the ability to look up ladders as well.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It increases player awareness on multi-z maps, removes a visual disconnect between z-levels (you could look down but not up), and may even be a basis in the future for players being able to throw things up z-levels and other interactions.

## Changelog
:cl:
add: Look up verb

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
