### PR TITLE
Adds a pulse rifle to the Warden's locker.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -120,6 +120,7 @@
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/clothing/gloves/krav_maga/sec(src)
 	new /obj/item/door_remote/head_of_security(src)
+	new /obj/item/gun/energy/pulse/destroyer(src)
 
 /obj/structure/closet/secure_closet/security
 	name = "security officer's locker"


### PR DESCRIPTION
## About The Pull Request

Adds the destroyer-variant pulse rifle to the Warden's locker. It has infinite ammo and has three modes (all of them are DESTROY).

## Why It's Good For The Game

As decided in #50764, the compact combat shotgun was far too powerful for the Warden to be simply given. However, the Warden now finds himself without an adequate armory-guarding weapon, making him unable to competently act out his job. Owing to its decreased damage-per-shot and the irrelevancies of max ammo counts in most encounters (as reported by Shadowflame909), the pulse rifle is a weapon that maintains usability while being less meta-altering than the compact combat shotgun. I believe this compromise will satisfy both parties.

## Changelog
:cl:
add: In the wake of a rash of armory heists resulting from the compact combat shotgun recall, the Warden has been supplied with a replacement firearm, albeit a less lethal one.
/:cl: