### PR TITLE
Fixes med record population

### DIFF
--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -94,7 +94,7 @@
 					dat += medical ? T.medical_record_text : T.name
 	if(!dat.len)
 		return medical ? "No issues have been declared." : "None"
-	return medical ?  dat.Join("<br> ") : dat.Join(", ")
+	return medical ?  dat.Join("<br>") : dat.Join(", ")
 
 /mob/living/proc/cleanse_trait_datums() //removes all trait datums
 	for(var/V in roundstart_quirks)

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -74,37 +74,27 @@
 				dat += medical ? T.medical_record_text : T.name
 				if(!dat.len)
 					return "None"
-			return medical ?  dat.Join("<br>") : dat.Join(",")
-
 		//Major Disabilities
 		if(CAT_QUIRK_MAJOR_DISABILITY)
 			for(var/V in roundstart_quirks)
 				var/datum/quirk/T = V
 				if(T.value < -1)
 					dat += medical ? T.medical_record_text : T.name
-				if(!dat.len)
-					return medical ? "No major disabilities have been declared." : "None"
-			return medical ?  dat.Join("<br>") : dat.Join(",")
-
 		//Minor Disabilities
 		if(CAT_QUIRK_MINOR_DISABILITY)
 			for(var/V in roundstart_quirks)
 				var/datum/quirk/T = V
 				if(T.value == -1)
 					dat += medical ? T.medical_record_text : T.name
-				if(!dat.len)
-					return medical ? "No minor disabilities have been declared." : "None"
-			return medical ?  dat.Join("<br>") : dat.Join(",")
-
 		//Neutral and Positive quirks
 		if(CAT_QUIRK_NOTES)
 			for(var/V in roundstart_quirks)
 				var/datum/quirk/T = V
 				if(T.value > -1)
 					dat += medical ? T.medical_record_text : T.name
-				if(!dat.len)
-					return "None"
-			return medical ?  dat.Join("<br>") : dat.Join(",")
+	if(!dat.len)
+		return medical ? "No issues have been declared." : "None"
+	return medical ?  dat.Join("<br> ") : dat.Join(", ")
 
 /mob/living/proc/cleanse_trait_datums() //removes all trait datums
 	for(var/V in roundstart_quirks)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I nested (!dat.len) in the for loops and it made it all return early, causing only one category to be populated. This is fixed
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Med records populate full from your quirk list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
