### PR TITLE
king of goat goats are now large mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/king_of_goats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/king_of_goats.dm
@@ -128,6 +128,7 @@ Difficulty: Insanely Hard
 	armour_penetration = 10
 	melee_damage_lower = 10
 	melee_damage_upper = 15
+	mob_size = MOB_SIZE_LARGE
 
 /mob/living/simple_animal/hostile/retaliate/goat/guard/master
 	name = "master of the guard"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this means that they can be attacked with the crusher for mark detonations

## Why It's Good For The Game

unlike all other lavaland boss enemies, the goats limit your crusher power to do nothing, which is kinda cringe

## Changelog
:cl:
balance: goats in the king of goats lair are now affected by kinetic crusher
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
