### PR TITLE
Adds the crew manifest program to security's PDAs

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -83,7 +83,7 @@
 /obj/item/cartridge/security
 	name = "\improper R.O.B.U.S.T. cartridge"
 	icon_state = "cart-s"
-	access = CART_SECURITY
+	access = CART_SECURITY | CART_MANIFEST
 	bot_access_flags = SEC_BOT
 
 /obj/item/cartridge/detective


### PR DESCRIPTION

## About The Pull Request

Adds the crew manifest program to security PDA's that allows them to see a list of the entire crew. 

## Why It's Good For The Game

After just getting back into security after a long hiatus, I have once again come to realize how much security needs a way of sorting through the crew by jobs, instead of by names like the messenger. It is not only tedious but a consuming task to find the job you are looking for instead of the person. This would make it so much easier. I would hardly consider this to be a major buff and I don't see many reasons to oppose it. 

## Changelog
:cl:
add: Security PDA's now come with the Crew Manifest Program
/:cl:

