### PR TITLE
Janitorial cart now uses a radial menu

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -100,47 +100,47 @@
 
 	var/list/items = list()
 	if(mybag)
-		items += list("trash bag" = image(icon = mybag.icon, icon_state = mybag.icon_state))
+		items += list("Trash bag" = image(icon = mybag.icon, icon_state = mybag.icon_state))
 	if(mymop)
-		items += list("mop" = image(icon = mymop.icon, icon_state = mymop.icon_state))
+		items += list("Mop" = image(icon = mymop.icon, icon_state = mymop.icon_state))
 	if(mybroom)
-		items += list("push broom" = image(icon = mybroom.icon, icon_state = mybroom.icon_state))
+		items += list("Broom" = image(icon = mybroom.icon, icon_state = mybroom.icon_state))
 	if(myspray)
-		items += list("spray bottle" = image(icon = myspray.icon, icon_state = myspray.icon_state))
+		items += list("Spray bottle" = image(icon = myspray.icon, icon_state = myspray.icon_state))
 	if(myreplacer)
-		items += list("light replacer" = image(icon = myreplacer.icon, icon_state = myreplacer.icon_state))
+		items += list("Light replacer" = image(icon = myreplacer.icon, icon_state = myreplacer.icon_state))
 	var/obj/item/clothing/suit/caution/sign = locate() in src
 	if(sign)
-		items += list("wet floor sign" = image(icon = sign.icon, icon_state = sign.icon_state))
+		items += list("Sign" = image(icon = sign.icon, icon_state = sign.icon_state))
 
 	if(!length(items))
 		return
 	items = sortList(items)
-	var/pick = show_radial_menu(user, src, items, custom_check = CALLBACK(src, .proc/check_menu, user, src), radius = 38, require_near = TRUE)
+	var/pick = show_radial_menu(user, src, items, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 38, require_near = TRUE)
 	if(!pick)
 		return
 	switch(pick)
-		if("trash bag")
+		if("Trash bag")
 			user.put_in_hands(mybag)
 			to_chat(user, "<span class='notice'>You take [mybag] from [src].</span>")
 			mybag = null
-		if("mop")
+		if("Mop")
 			user.put_in_hands(mymop)
 			to_chat(user, "<span class='notice'>You take [mymop] from [src].</span>")
 			mymop = null
-		if("push broom")
+		if("Broom")
 			user.put_in_hands(mybroom)
 			to_chat(user, "<span class='notice'>You take [mybroom] from [src].</span>")
 			mybroom = null
-		if("spray bottle")
+		if("Spray bottle")
 			user.put_in_hands(myspray)
 			to_chat(user, "<span class='notice'>You take [myspray] from [src].</span>")
 			myspray = null
-		if("light replacer")
+		if("Light replacer")
 			user.put_in_hands(myreplacer)
 			to_chat(user, "<span class='notice'>You take [myreplacer] from [src].</span>")
 			myreplacer = null
-		if("wet floor sign")
+		if("Sign")
 			if(signs <= 0)
 				return
 			user.put_in_hands(sign)
@@ -156,14 +156,11 @@
   *
   * Arguments:
   * * user The mob interacting with a menu
-  * * cart The cart used to interact with a menu
   */
-/obj/structure/janitorialcart/proc/check_menu(mob/living/user, obj/structure/janitorialcart/cart)
+/obj/structure/janitorialcart/proc/check_menu(mob/living/user)
 	if(!istype(user))
 		return FALSE
 	if(user.incapacitated())
-		return FALSE
-	if(!cart)
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -121,22 +121,32 @@
 		return
 	switch(pick)
 		if("Trash bag")
+			if(!mybag)
+				return
 			user.put_in_hands(mybag)
 			to_chat(user, "<span class='notice'>You take [mybag] from [src].</span>")
 			mybag = null
 		if("Mop")
+			if(!mymop)
+				return
 			user.put_in_hands(mymop)
 			to_chat(user, "<span class='notice'>You take [mymop] from [src].</span>")
 			mymop = null
 		if("Broom")
+			if(!mybroom)
+				return
 			user.put_in_hands(mybroom)
 			to_chat(user, "<span class='notice'>You take [mybroom] from [src].</span>")
 			mybroom = null
 		if("Spray bottle")
+			if(!myspray)
+				return
 			user.put_in_hands(myspray)
 			to_chat(user, "<span class='notice'>You take [myspray] from [src].</span>")
 			myspray = null
 		if("Light replacer")
+			if(!myreplacer)
+				return
 			user.put_in_hands(myreplacer)
 			to_chat(user, "<span class='notice'>You take [myreplacer] from [src].</span>")
 			myreplacer = null

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -34,7 +34,6 @@
 /obj/structure/janitorialcart/proc/put_in_cart(obj/item/I, mob/user)
 	if(!user.transferItemToLoc(I, src))
 		return
-	updateUsrDialog()
 	to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
 	return
 
@@ -98,70 +97,75 @@
 	. = ..()
 	if(.)
 		return
-	user.set_machine(src)
-	var/dat
+
+	var/list/items = list()
 	if(mybag)
-		dat += "<a href='?src=[REF(src)];garbage=1'>[mybag.name]</a><br>"
+		items += list("trash bag" = image(icon = mybag.icon, icon_state = mybag.icon_state))
 	if(mymop)
-		dat += "<a href='?src=[REF(src)];mop=1'>[mymop.name]</a><br>"
+		items += list("mop" = image(icon = mymop.icon, icon_state = mymop.icon_state))
 	if(mybroom)
-		dat += "<a href='?src=[REF(src)];broom=1'>[mybroom.name]</a><br>"
+		items += list("push broom" = image(icon = mybroom.icon, icon_state = mybroom.icon_state))
 	if(myspray)
-		dat += "<a href='?src=[REF(src)];spray=1'>[myspray.name]</a><br>"
+		items += list("spray bottle" = image(icon = myspray.icon, icon_state = myspray.icon_state))
 	if(myreplacer)
-		dat += "<a href='?src=[REF(src)];replacer=1'>[myreplacer.name]</a><br>"
-	if(signs)
-		dat += "<a href='?src=[REF(src)];sign=1'>[signs] sign\s</a><br>"
-	var/datum/browser/popup = new(user, "janicart", name, 240, 160)
-	popup.set_content(dat)
-	popup.open()
+		items += list("light replacer" = image(icon = myreplacer.icon, icon_state = myreplacer.icon_state))
+	var/obj/item/clothing/suit/caution/sign = locate() in src
+	if(sign)
+		items += list("wet floor sign" = image(icon = sign.icon, icon_state = sign.icon_state))
 
-
-/obj/structure/janitorialcart/Topic(href, href_list)
-	if(!in_range(src, usr))
+	if(!length(items))
 		return
-	if(!isliving(usr))
+	items = sortList(items)
+	var/pick = show_radial_menu(user, src, items, custom_check = CALLBACK(src, .proc/check_menu, user, src), radius = 38, require_near = TRUE)
+	if(!pick)
 		return
-	var/mob/living/user = usr
-	if(href_list["garbage"])
-		if(mybag)
+	switch(pick)
+		if("trash bag")
 			user.put_in_hands(mybag)
 			to_chat(user, "<span class='notice'>You take [mybag] from [src].</span>")
 			mybag = null
-	if(href_list["mop"])
-		if(mymop)
+		if("mop")
 			user.put_in_hands(mymop)
 			to_chat(user, "<span class='notice'>You take [mymop] from [src].</span>")
 			mymop = null
-	if(href_list["broom"])
-		if(mybroom)
+		if("push broom")
 			user.put_in_hands(mybroom)
 			to_chat(user, "<span class='notice'>You take [mybroom] from [src].</span>")
 			mybroom = null
-	if(href_list["spray"])
-		if(myspray)
+		if("spray bottle")
 			user.put_in_hands(myspray)
 			to_chat(user, "<span class='notice'>You take [myspray] from [src].</span>")
 			myspray = null
-	if(href_list["replacer"])
-		if(myreplacer)
+		if("light replacer")
 			user.put_in_hands(myreplacer)
 			to_chat(user, "<span class='notice'>You take [myreplacer] from [src].</span>")
 			myreplacer = null
-	if(href_list["sign"])
-		if(signs)
-			var/obj/item/clothing/suit/caution/Sign = locate() in src
-			if(Sign)
-				user.put_in_hands(Sign)
-				to_chat(user, "<span class='notice'>You take \a [Sign] from [src].</span>")
-				signs--
-			else
-				WARNING("Signs ([signs]) didn't match contents")
-				signs = 0
+		if("wet floor sign")
+			if(signs <= 0)
+				return
+			user.put_in_hands(sign)
+			to_chat(user, "<span class='notice'>You take \a [sign] from [src].</span>")
+			signs--
+		else
+			return
 
 	update_icon()
-	updateUsrDialog()
 
+/**
+  * check_menu: Checks if we are allowed to interact with a radial menu
+  *
+  * Arguments:
+  * * user The mob interacting with a menu
+  * * cart The cart used to interact with a menu
+  */
+/obj/structure/janitorialcart/proc/check_menu(mob/living/user, obj/structure/janitorialcart/cart)
+	if(!istype(user))
+		return FALSE
+	if(user.incapacitated())
+		return FALSE
+	if(!cart)
+		return FALSE
+	return TRUE
 
 /obj/structure/janitorialcart/update_overlays()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR replaces a janitorial cart HTML UI with a radial menu, which is used for taking various janitorial items out of it.

**BEFORE:**

![JanicartBefore](https://user-images.githubusercontent.com/43862960/80849857-6385b700-8c19-11ea-99aa-84d7750e0d7e.png)

**AFTER:**

![JanicartRadial](https://user-images.githubusercontent.com/43862960/80849806-26b9c000-8c19-11ea-89d1-652192124800.png)

## Why It's Good For The Game

Better handling of the janitorial cart.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Arkatos
add: Janitorial cart now uses a radial menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
