### PR TITLE
Gastrectomy, a stomach-healing surgery

### DIFF
--- a/code/modules/surgery/gastrectomy.dm
+++ b/code/modules/surgery/gastrectomy.dm
@@ -1,0 +1,48 @@
+/datum/surgery/gastrectomy
+	name = "Gastrectomy"
+	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	possible_locs = list(BODY_ZONE_CHEST)
+	requires_real_bodypart = TRUE
+	steps = list(/datum/surgery_step/incise,
+		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/saw,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/incise,
+		/datum/surgery_step/gastrectomy,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/close
+		)
+
+/datum/surgery/gastrectomy/can_start(mob/user, mob/living/carbon/target)
+	var/obj/item/organ/liver/L = target.getorganslot(ORGAN_SLOT_STOMACH)
+	if(L?.damage > 50 && !(L.organ_flags & ORGAN_FAILING))
+		return TRUE
+
+////Gastrectomy, because we truly needed a way to repair stomachs.
+//95% chance of success to be consistent with most organ-repairing surgeries.
+/datum/surgery_step/gastrectomy
+	name = "remove lower duodenum"
+	implements = list(TOOL_SCALPEL = 95, /obj/item/melee/transforming/energy/sword = 65, /obj/item/kitchen/knife = 45,
+		/obj/item/shard = 35)
+	time = 52
+	experience_given = (MEDICAL_SKILL_ORGAN_FIX*0.8) //for consistency across organ surgeries
+
+/datum/surgery_step/gastrectomy/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(user, target, "<span class='notice'>You begin to cut out a damaged piece of [target]'s stomach...</span>",
+		"<span class='notice'>[user] begins to make an incision in [target].</span>",
+		"<span class='notice'>[user] begins to make an incision in [target].</span>")
+
+/datum/surgery_step/gastrectomy/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
+	var/mob/living/carbon/human/H = target
+	H.setOrganLoss(ORGAN_SLOT_STOMACH, 20) // Stomachs have a threshold for being able to even digest food, so I might tweak this number
+	display_results(user, target, "<span class='notice'>You successfully remove the damaged part of [target]'s stomach.</span>",
+		"<span class='notice'>[user] successfully removes the damaged part of [target]'s stomach.</span>",
+		"<span class='notice'>[user] successfully removes the damaged part of [target]'s stomach.</span>")
+	return ..()
+
+/datum/surgery_step/hepatectomy/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery)
+	var/mob/living/carbon/human/H = target
+	H.adjustOrganLoss(ORGAN_SLOT_STOMACH, 15)
+	display_results(user, target, "<span class='warning'>You cut the wrong part of [target]'s stomach!</span>",
+		"<span class='warning'>[user] cuts the wrong part of [target]'s stomach!</span>",
+		"<span class='warning'>[user] cuts the wrong part of [target]'s stomach!</span>")

--- a/code/modules/surgery/gastrectomy.dm
+++ b/code/modules/surgery/gastrectomy.dm
@@ -14,7 +14,7 @@
 		)
 
 /datum/surgery/gastrectomy/can_start(mob/user, mob/living/carbon/target)
-	var/obj/item/organ/liver/L = target.getorganslot(ORGAN_SLOT_STOMACH)
+	var/obj/item/organ/stomach/L = target.getorganslot(ORGAN_SLOT_STOMACH)
 	if(L?.damage > 50 && !(L.organ_flags & ORGAN_FAILING))
 		return TRUE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2933,6 +2933,7 @@
 #include "code\modules\surgery\dental_implant.dm"
 #include "code\modules\surgery\experimental_dissection.dm"
 #include "code\modules\surgery\eye_surgery.dm"
+#include "code\modules\surgery\gastrectomy.dm"
 #include "code\modules\surgery\healing.dm"
 #include "code\modules\surgery\hepatectomy.dm"
 #include "code\modules\surgery\implant_removal.dm"


### PR DESCRIPTION
## About The Pull Request

Why was every organ "repairable" through surgery except the stomach? Let's fix that! Adds Gastrectomy, another organ healing surgery aimed directly to remove a portion of your duodenum to make food digesting be more appealing after being dead for quite a while.

## Why It's Good For The Game

Currently, there is no way to heal a stomach other than using strange reagent, and the only way to have your organs heal naturally is staying healthy and well fed, something impossible with a damaged stomach that makes you puke/dry heave every time you get even a whiff of food. This surgery is another step towards recovery of an individual rather than outright requiring stomach pumps to be researched to circumvent such a problem.

## Changelog
:cl:DimmaDunk
add: Adds Gastrectomy, a surgery for healing damaged stomachs.
/:cl:
