### PR TITLE
Fixes runtime upon deleting borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -872,7 +872,8 @@
 /mob/living/silicon/robot/Exited(atom/A)
 	if(hat && hat == A)
 		hat = null
-	update_icons()
+		if(!QDELETED(src)) //Don't update icons if we are deleted.
+			update_icons()
 	. = ..()
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Borgs no longer runtime when deleted.

And here's the glorious runtime error this fixes:
```
[2020-04-30 03:19:35.354] runtime error: Cannot read null.cyborg_base_icon
 - proc name: update icons (/mob/living/silicon/robot/update_icons)
 -   source file: robot.dm,424
 -   usr: Orlando Smith (/mob/living/carbon/human)
 -   src: Unformatted Cyborg-381 (/mob/living/silicon/robot/shell)
 -   usr.loc: the floor (115,83,2) (/turf/open/floor/plasteel)
 -   src.loc: the floor (114,83,2) (/turf/open/floor/plasteel)
 -   call stack:
 - Unformatted Cyborg-381 (/mob/living/silicon/robot/shell): update icons()
 - Unformatted Cyborg-381 (/mob/living/silicon/robot/shell): Exited(the cyborg radio (/obj/item/radio/borg), null)
 - the cyborg radio (/obj/item/radio/borg): doMove(null)
 - the cyborg radio (/obj/item/radio/borg): doMove(null)
 - the cyborg radio (/obj/item/radio/borg): moveToNullspace()
 - the cyborg radio (/obj/item/radio/borg): Destroy(0)
 - the cyborg radio (/obj/item/radio/borg): Destroy(0)
 - the cyborg radio (/obj/item/radio/borg): Destroy(0)
 - the cyborg radio (/obj/item/radio/borg): Destroy(0)
 - the cyborg radio (/obj/item/radio/borg): Destroy(0)
 - qdel(the cyborg radio (/obj/item/radio/borg), 0)
 - Unformatted Cyborg-381 (/mob/living/silicon/robot/shell): Destroy(0)
 - Unformatted Cyborg-381 (/mob/living/silicon/robot/shell): Destroy(0)
 - qdel(Unformatted Cyborg-381 (/mob/living/silicon/robot/shell), 0)
 - Unformatted Cyborg-381 (/mob/living/silicon/robot/shell): deconstruct()
 - Unformatted Cyborg-381 (/mob/living/silicon/robot/shell): attackby(the wrench (/obj/item/wrench), Orlando Smith (/mob/living/carbon/human), "icon-x=15;icon-y=11;left=1;scr...")
 - the wrench (/obj/item/wrench): melee attack chain(Orlando Smith (/mob/living/carbon/human), Unformatted Cyborg-381 (/mob/living/silicon/robot/shell), "icon-x=15;icon-y=11;left=1;scr...")
 - Orlando Smith (/mob/living/carbon/human): ClickOn(Unformatted Cyborg-381 (/mob/living/silicon/robot/shell), "icon-x=15;icon-y=11;left=1;scr...")
 - Unformatted Cyborg-381 (/mob/living/silicon/robot/shell): Click(the floor (114,83,2) (/turf/open/floor/plasteel), "mapwindow.map", "icon-x=15;icon-y=11;left=1;scr...")
```
