### PR TITLE
Fixes ORM scooping bugs.

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -16,7 +16,7 @@
 
 /obj/machinery/mineral/Initialize(mapload)
 	. = ..()
-	if(needs_item_input)
+	if(needs_item_input && anchored)
 		register_input_turf()
 
 /// Gets the turf in the `input_dir` direction adjacent to the machine, and registers signals for ATOM_ENTERED and ATOM_CREATED. Calls the `pickup_item()` proc when it recieves these signals.

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -30,6 +30,13 @@
 	if(input_turf)
 		UnregisterSignal(input_turf, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_CREATED))
 
+/obj/machinery/mineral/Moved()
+	. = ..()
+	if(!needs_item_input || !anchored)
+		return
+	unregister_input_turf()
+	register_input_turf()
+
 /**
 	Base proc for all `/mineral` subtype machines to use. Place your item pickup behavior in this proc when you override it for your specific machine.
 

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -160,7 +160,7 @@
 
 /obj/machinery/mineral/ore_redemption/default_unfasten_wrench(mob/user, obj/item/I)
 	. = ..()
-	if(!.)
+	if(. != SUCCESSFUL_UNFASTEN)
 		return
 	if(anchored)
 		register_input_turf() // someone just wrenched us down, re-register the turf

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -160,6 +160,8 @@
 
 /obj/machinery/mineral/ore_redemption/default_unfasten_wrench(mob/user, obj/item/I)
 	. = ..()
+	if(!.)
+		return
 	if(anchored)
 		register_input_turf() // someone just wrenched us down, re-register the turf
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changelog says it all.
First bug gets caused by constructing a ORM with an unanchored frame.
Second bug can occour through movement while the ORM is anchored. This could be caused by meteorshot or singulos, for example.
EDIT: Third bug would occour if you failed to unwrench the ORM (for example because of movement). It would cause the machine to try to register/unregister a second time although it's not required. This did bug does not have any gameplay implications beyond an ugly runtime error.

## Changelog
:cl:
fix: Fixes a bug that could cause the ORM to scoop up ores although it was not anchored.
fix: The ORM will now always scoop up from the correct turf.
/:cl:
