### PR TITLE
removing some duplicated proc definitions

### DIFF
--- a/code/datums/components/plumbing/reaction_chamber.dm
+++ b/code/datums/components/plumbing/reaction_chamber.dm
@@ -7,7 +7,7 @@
 	if(!istype(parent, /obj/machinery/plumbing/reaction_chamber))
 		return COMPONENT_INCOMPATIBLE
 
-/datum/component/plumbing/reaction_chamber/can_give(amount, reagent)
+/datum/component/plumbing/reaction_chamber/can_give(amount, reagent, datum/ductnet/net)
 	. = ..()
 	var/obj/machinery/plumbing/reaction_chamber/RC = parent
 	if(!. || !RC.emptying)
@@ -36,13 +36,3 @@
 	RC.emptying = TRUE //If we move this up, it'll instantly get turned off since any reaction always sets the reagent_total to zero. Other option is make the reaction update
 	//everything for every chemical removed, wich isn't a good option either.
 	RC.on_reagent_change() //We need to check it now, because some reactions leave nothing left.
-
-/datum/component/plumbing/reaction_chamber/can_give(amount, reagent, datum/ductnet/net)
-	. = ..()
-	var/obj/machinery/plumbing/reaction_chamber/RC = parent
-	if(!. || !RC.emptying)
-		return FALSE
-
-
-
-

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -201,19 +201,6 @@
 			to_chat(owner, "<span class='notice'>You succesfuly remove the durathread strand.</span>")
 			L.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
 
-
-/datum/status_effect/pacify/on_creation(mob/living/new_owner, set_duration)
-	if(isnum(set_duration))
-		duration = set_duration
-	. = ..()
-
-/datum/status_effect/pacify/on_apply()
-	ADD_TRAIT(owner, TRAIT_PACIFISM, "status_effect")
-	return ..()
-
-/datum/status_effect/pacify/on_remove()
-	REMOVE_TRAIT(owner, TRAIT_PACIFISM, "status_effect")
-
 //OTHER DEBUFFS
 /datum/status_effect/pacify
 	id = "pacify"

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -66,7 +66,7 @@
 	chameleon_action.chameleon_name = "Belt"
 	chameleon_action.initialize_disguises()
 
-/obj/item/storage/belt/chameleon/ComponentInitialize()
+/obj/item/storage/belt/holster/chameleon/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.silent = TRUE

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -55,9 +55,6 @@
 /obj/structure/reflector/setDir(new_dir)
 	return ..(NORTH)
 
-/obj/structure/reflector/proc/dir_map_to_angle(dir)
-	return 0
-
 /obj/structure/reflector/bullet_act(obj/projectile/P)
 	var/pdir = P.dir
 	var/pangle = P.Angle
@@ -252,9 +249,6 @@
 		return
 	else
 		return ..()
-
-/obj/structure/reflector/dir_map_to_angle(dir)
-	return dir2angle(dir)
 
 /obj/structure/reflector/singularity_act()
 	if(admin)

--- a/code/modules/antagonists/cult/cult_turf_overlay.dm
+++ b/code/modules/antagonists/cult/cult_turf_overlay.dm
@@ -12,10 +12,8 @@
 
 /obj/effect/cult_turf/overlay/singularity_act()
 	return
-/obj/effect/cult_turf/overlay/singularity_pull()
-	return
 
-/obj/effect/cult_turf/overlay/singularity_pull(S, current_size)
+/obj/effect/cult_turf/overlay/singularity_pull()
 	return
 
 /obj/effect/cult_turf/overlay/Destroy()

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -66,7 +66,7 @@
 	else
 		return ..()
 
-/obj/effect/rend/singularity_pull()
+/obj/effect/rend/singularity_act()
 	return
 
 /obj/effect/rend/singularity_pull()

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -188,7 +188,7 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 				return 1
 	return 0
 
-/obj/effect/extraction_holder/singularity_pull()
+/obj/effect/extraction_holder/singularity_act()
 	return
 
 /obj/effect/extraction_holder/singularity_pull()

--- a/code/modules/mob/living/simple_animal/bot/hygienebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/hygienebot.dm
@@ -87,12 +87,6 @@
 	walk_to(src,0)
 	last_found = world.time
 
-
-/mob/living/simple_animal/bot/hygienebot/Crossed(atom/movable/AM)
-	. = ..()
-	if(washing)
-		do_wash(AM)
-
 /mob/living/simple_animal/bot/hygienebot/Moved()
 	. = ..()
 	if(washing && isturf(loc) && !emagged)


### PR DESCRIPTION
##  About The Pull Request
These are some simple cases of procs that were defined multiple times. I've just removed the duplicate in most cases as it was either leading to the code running twice unexpectedly or made no difference at all during runtime.

In a couple of cases I've renamed the duplicate procs to what they were obviously intended to be, such as:
1) Some singularity_pull procs that were meant to be singularity_act procs
2) The syndicate holster's ComponentInitialize proc

For reflectors I have entirely deleted the dir_map_to_angle proc because it was left unused after a change a few years ago.

The functional changes are in the changelog.

## Why It's Good For The Game
🧹cleaner code

## Changelog
:cl:
code: removed some duplicate proc definitions
fix: syndicate holster now properly sets itself as silent
fix: rend tears and temporary object used by fulton extraction can no longer be eaten by singularity
fix: hygiene bot no longer cleans objects twice when passed over
/:cl: