### PR TITLE
The clown now bleeds colorful reagent on April Fools.

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -227,6 +227,8 @@
 /mob/living/carbon/human/get_blood_id()
 	if(HAS_TRAIT(src, TRAIT_HUSK))
 		return
+	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS] && mind && mind.assigned_role == "Clown")
+		return /datum/reagent/colorful_reagent
 	if(dna.species.exotic_blood)
 		return dna.species.exotic_blood
 	else if((NOBLOOD in dna.species.species_traits))


### PR DESCRIPTION
## About The Pull Request

The clown now bleeds colorful reagent on April Fools.

## Why It's Good For The Game

This will increase the party potential of clowns during April Fools.

## Changelog
:cl: Iamgoofball
add: The clown now bleeds Colorful Reagent on April Fools.
/:cl: