### PR TITLE
Runechat messages now get deleted as intended when their owning client gets deleted.

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -68,7 +68,7 @@
 /datum/chatmessage/proc/generate_image(text, atom/target, mob/owner, list/extra_classes, lifespan)
 	// Register client who owns this message
 	owned_by = owner.client
-	RegisterSignal(owned_by, COMSIG_PARENT_QDELETING, .proc/qdel, src)
+	RegisterSignal(owned_by, COMSIG_PARENT_QDELETING, .proc/on_ownedby_deleting)
 
 	// Clip message
 	var/maxlen = owned_by.prefs.max_chat_length
@@ -153,6 +153,12 @@
 /datum/chatmessage/proc/end_of_life(fadetime = CHAT_MESSAGE_EOL_FADE)
 	animate(message, alpha = 0, time = fadetime, flags = ANIMATION_PARALLEL)
 	QDEL_IN(src, fadetime)
+
+/**
+  * Deletes the message when the owners client gets deleted.
+  */
+/datum/chatmessage/proc/on_ownedby_deleting()
+	qdel(src)
 
 /**
   * Creates a message overlay at a defined location for a given speaker


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As far as I'm aware you can't register to global procs, hence the wrapper.

Relevant error:
```
[2020-05-02 10:07:05.659] runtime error: undefined proc or verb /datum/chatmessage/qdel().
 - 
 - proc name: CallAsync (/proc/CallAsync)
 -   source file: unsorted.dm,1530
 -   usr: (src)
 -   src: null
 -   call stack:
 - CallAsync(/datum/chatmessage (/datum/chatmessage), /proc/qdel (/proc/qdel), /list (/list))
 - Timonk (/client):  SendSignal("parent_qdeleting", /list (/list))
 - qdel(Timonk (/client), 0)
 - /datum/callback (/datum/callback): InvokeAsync()
 - Timer (/datum/controller/subsystem/timer): fire(0)
 - Timer (/datum/controller/subsystem/timer): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop()
 - Master (/datum/controller/master): StartProcessing(0)
```
