### PR TITLE
Adds another roundstart prisoner job slot

### DIFF
--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -5,7 +5,7 @@
 	department_flag = CIVILIAN
 	faction = "Station"
 	total_positions = 0
-	spawn_positions = 4
+	spawn_positions = 3
 	supervisors = "the security team"
 	selection_color = "#ffe1c3"
 

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -5,7 +5,7 @@
 	department_flag = CIVILIAN
 	faction = "Station"
 	total_positions = 0
-	spawn_positions = 2
+	spawn_positions = 4
 	supervisors = "the security team"
 	selection_color = "#ffe1c3"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just as the title says, increases default prisoner job slots from 2 to 3.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Since prisoner is a roundstart-only role, I figured that adding another job slot would allow more people who want to spend their shift in perma to actually get that. In addition to this, the permabrig on any station is meant to handle at least three people.

(I was going to increase the job slots from 2 to 4, but then remembered that box and meta are the only two stations that have more than 3 perma cells so far, so 3 seems like a good compromise)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Amount of roundstart prisoner jobs changed from 2 to 3.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
