### PR TITLE
Fixes Null Reference + Qdel Issue in Runechat

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -56,6 +56,12 @@
 	return ..()
 
 /**
+  * Calls qdel on the chatmessage when its parent is deleted, used to register qdel signal
+  */
+/datum/chatmessage/proc/parent_qdel()
+	qdel(src)
+
+/**
   * Generates a chat message image representation
   *
   * Arguments:
@@ -68,7 +74,7 @@
 /datum/chatmessage/proc/generate_image(text, atom/target, mob/owner, list/extra_classes, lifespan)
 	// Register client who owns this message
 	owned_by = owner.client
-	RegisterSignal(owned_by, COMSIG_PARENT_QDELETING, .proc/qdel, src)
+	RegisterSignal(owned_by, COMSIG_PARENT_QDELETING, .proc/parent_qdel)
 
 	// Clip message
 	var/maxlen = owned_by.prefs.max_chat_length

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -102,19 +102,19 @@
 		extra_classes |= "small"
 
 	// Append radio icon if from a virtual speaker
-	if (extra_classes?.Find("virtual-speaker"))
+	if (extra_classes.Find("virtual-speaker"))
 		var/image/r_icon = image('icons/UI_Icons/chat/chat_icons.dmi', icon_state = "radio")
 		text =  "\icon[r_icon]&nbsp;" + text
 
 	// We dim italicized text to make it more distinguishable from regular text
-	var/tgt_color = extra_classes?.Find("italics") ? target.chat_color_darkened : target.chat_color
+	var/tgt_color = extra_classes.Find("italics") ? target.chat_color_darkened : target.chat_color
 
 	// Approximate text height
 	// Note we have to replace HTML encoded metacharacters otherwise MeasureText will return a zero height
 	// BYOND Bug #2563917
 	// Construct text
 	var/static/regex/html_metachars = new(@"&[A-Za-z]{1,7};", "g")
-	var/complete_text = "<span class='center maptext [extra_classes != null ? extra_classes.Join(" ") : ""]' style='color: [tgt_color]'>[text]</span>"
+	var/complete_text = "<span class='center maptext [extra_classes.Join(" ")]' style='color: [tgt_color]'>[text]</span>"
 	var/mheight = WXH_TO_HEIGHT(owned_by.MeasureText(replacetext(complete_text, html_metachars, "m"), null, CHAT_MESSAGE_WIDTH))
 	approx_lines = max(1, mheight / CHAT_MESSAGE_APPROX_LHEIGHT)
 

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -35,7 +35,7 @@
   * * extra_classes - Extra classes to apply to the span that holds the text
   * * lifespan - The lifespan of the message in deciseconds
   */
-/datum/chatmessage/New(text, atom/target, mob/owner, list/extra_classes = null, lifespan = CHAT_MESSAGE_LIFESPAN)
+/datum/chatmessage/New(text, atom/target, mob/owner, list/extra_classes = list(), lifespan = CHAT_MESSAGE_LIFESPAN)
 	. = ..()
 	if (!istype(target))
 		CRASH("Invalid target given for chatmessage")

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -93,8 +93,6 @@
 
 	// Non mobs speakers can be small
 	if (!ismob(target))
-		if (!extra_classes)
-			extra_classes = list()
 		extra_classes |= "small"
 
 	// Append radio icon if from a virtual speaker
@@ -168,13 +166,11 @@
   */
 /mob/proc/create_chat_message(atom/movable/speaker, datum/language/message_language, raw_message, list/spans, message_mode)
 	// Ensure the list we are using, if present, is a copy so we don't modify the list provided to us
-	spans = spans?.Copy()
+	spans = spans ? spans.Copy() : list()
 
 	// Check for virtual speakers (aka hearing a message through a radio)
 	var/atom/movable/originalSpeaker = speaker
 	if (istype(speaker, /atom/movable/virtualspeaker))
-		if (!spans)
-			spans = list()
 		var/atom/movable/virtualspeaker/v = speaker
 		speaker = v.source
 		spans |= "virtual-speaker"

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -58,7 +58,7 @@
 /**
   * Calls qdel on the chatmessage when its parent is deleted, used to register qdel signal
   */
-/datum/chatmessage/proc/parent_qdel()
+/datum/chatmessage/proc/on_parent_qdel()
 	qdel(src)
 
 /**
@@ -74,7 +74,7 @@
 /datum/chatmessage/proc/generate_image(text, atom/target, mob/owner, list/extra_classes, lifespan)
 	// Register client who owns this message
 	owned_by = owner.client
-	RegisterSignal(owned_by, COMSIG_PARENT_QDELETING, .proc/parent_qdel)
+	RegisterSignal(owned_by, COMSIG_PARENT_QDELETING, .proc/on_parent_qdel)
 
 	// Clip message
 	var/maxlen = owned_by.prefs.max_chat_length

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -93,15 +93,17 @@
 
 	// Non mobs speakers can be small
 	if (!ismob(target))
+		if (!extra_classes)
+			extra_classes = list()
 		extra_classes |= "small"
 
 	// Append radio icon if from a virtual speaker
-	if (extra_classes.Find("virtual-speaker"))
+	if (extra_classes?.Find("virtual-speaker"))
 		var/image/r_icon = image('icons/UI_Icons/chat/chat_icons.dmi', icon_state = "radio")
 		text =  "\icon[r_icon]&nbsp;" + text
 
 	// We dim italicized text to make it more distinguishable from regular text
-	var/tgt_color = extra_classes.Find("italics") ? target.chat_color_darkened : target.chat_color
+	var/tgt_color = extra_classes?.Find("italics") ? target.chat_color_darkened : target.chat_color
 
 	// Approximate text height
 	// Note we have to replace HTML encoded metacharacters otherwise MeasureText will return a zero height
@@ -171,6 +173,8 @@
 	// Check for virtual speakers (aka hearing a message through a radio)
 	var/atom/movable/originalSpeaker = speaker
 	if (istype(speaker, /atom/movable/virtualspeaker))
+		if (!spans)
+			spans = list()
 		var/atom/movable/virtualspeaker/v = speaker
 		speaker = v.source
 		spans |= "virtual-speaker"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixed a runtime that could occur in runechat if the spans list / extra classes list was null.
Fixed an issue with signal registration that would cause a runtime when trying to qdel self after parent is qdeling.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
no runtimes

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
fix: Fixed unstyled messages potentially causing null reference exceptions in runechat.
fix: Fixed a client's qdeletion causing runtimes on chat messages they see.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
