### PR TITLE
Avoid loading double extools

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -19,8 +19,9 @@ GLOBAL_VAR(restart_counter)
   *
   */
 /world/New()
-	if(fexists("byond-extools.dll"))
-		call("byond-extools.dll", "maptick_initialize")()
+	var/extools = world.GetConfig("env", "EXTOOLS_DLL") || "./byond-extools.dll"
+	if (fexists(extools))
+		call(extools, "maptick_initialize")()
 	enable_debugger()
 
 	//Early profile for auto-profiler - will be stopped on profiler init if necessary.


### PR DESCRIPTION
Preventing debugger from working since #50594