### PR TITLE
Fix hardsuit cell draining even when thermals are off

### DIFF
--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -76,12 +76,14 @@
 	if(!user || !ishuman(user) || !(user.wear_suit == src))
 		return
 
+	// Do nothing if thermal regulators are off
 	if(!thermal_on)
 		return
 
+	// If we got here, thermal regulators are on. If there's no cell, turn them
+	// off
 	if(!cell)
-		if(thermal_on)
-			toggle_spacesuit()
+		toggle_spacesuit()
 		update_hud_icon(user)
 		return
 
@@ -91,6 +93,8 @@
 		update_hud_icon(user)
 		return
 
+	// If we got here, it means thermals are on, the cell is in and the cell has
+	// just had enough charge subtracted from it to power the thermal regulator
 	user.adjust_bodytemperature((temperature_setting - user.bodytemperature), use_steps=TRUE, capped=FALSE)
 	update_hud_icon(user)
 

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -76,6 +76,9 @@
 	if(!user || !ishuman(user) || !(user.wear_suit == src))
 		return
 
+	if(!thermal_on)
+		return
+
 	if(!cell)
 		if(thermal_on)
 			toggle_spacesuit()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Two lines of code I erroneously left out of #50728 that actually check if thermals are on before draining cell charge.

With these lines added, hardsuits no longer drain cell charge all the time while worn regardless of the thermal regulator setting.

Oof question mark?

Fixes #50820

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Hardsuits now no longer drain cell charge when thermal regulators are off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
