### PR TITLE
Empath quirk lets you check if others are burning/freezing

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -191,7 +191,7 @@
 
 /datum/mood_event/sad_empath
 	description = "<span class='warning'>Someone seems upset...</span>\n"
-	mood_change = -2
+	mood_change = -1
 	timeout = 60 SECONDS
 
 /datum/mood_event/sad_empath/add_effects(mob/sadtarget)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -287,6 +287,10 @@
 					msg += "[t_He] appear[p_s()] to be staring off into space.\n"
 				if (HAS_TRAIT(src, TRAIT_DEAF))
 					msg += "[t_He] appear[p_s()] to not be responding to noises.\n"
+				if (bodytemperature > dna.species.bodytemp_heat_damage_limit)
+					msg += "[t_He] [t_is] flushed and wheezing.\n"
+				if (bodytemperature < dna.species.bodytemp_cold_damage_limit)
+					msg += "[t_He] [t_is] shivering.\n"
 
 			msg += "</span>"
 


### PR DESCRIPTION
Body temperature is a more interesting mechanic nowadays, so with this you can more easily spot when your friends needs some hugs to warm/chill them up

I've also slightly lowered the mood loss from examining people with negative mood, I wanted it to be a fluff thing to nudge people to help others, but it was a bit too punishing for a 2 point quirk
:cl:
balance: empath quirk can now sense abnormal body temperature on examine
balance: lowered the mood malus from examining people with low sanity as an empath
/:cl: