### PR TITLE
RnD Console list view no longer displays BEPIS-only nodes

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -674,7 +674,7 @@ Nothing else in the console has ID requirements.
 		for(var/v in stored_research.researched_nodes)
 			res += SSresearch.techweb_node_by_id(v)
 		for(var/v in stored_research.available_nodes)
-			if(stored_research.researched_nodes[v])
+			if(stored_research.researched_nodes[v] || stored_research.hidden_nodes[v])
 				continue
 			avail += SSresearch.techweb_node_by_id(v)
 		for(var/v in stored_research.visible_nodes)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

RnD Console technology research list view mode now has a check to continue over hidden nodes in the for loop that populates the list of available nodes for research.

Tested locally including using the BEPIS to unlock hidden research nodes. Everything is exactly how it was before, only BEPIS-only "hidden" research doesn't appear as a possible option in list view.

Note that this bug didn't allow people to actually UNLOCK BEPIS research nodes. There was at least some sanity check elsewhere that would error out before that happened.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/24975989/80921147-7230b300-8d6c-11ea-9a33-24007966df1b.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: RnD Consoles will no longer list BEPIS-exclusive research nodes in list view as available for research.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
