### PR TITLE
Buffs Hierophant (melee range cheese begone edition)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -456,8 +456,7 @@ Difficulty: Hard
 				else
 					burst_range = 3
 					INVOKE_ASYNC(src, .proc/burst, get_turf(src), 0.25) //melee attacks on living mobs cause it to release a fast burst if on cooldown
-				if(L.stat == CONSCIOUS && L.health >= 30)
-					OpenFire()
+				OpenFire()
 			else
 				devour(L)
 		else

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -456,6 +456,8 @@ Difficulty: Hard
 				else
 					burst_range = 3
 					INVOKE_ASYNC(src, .proc/burst, get_turf(src), 0.25) //melee attacks on living mobs cause it to release a fast burst if on cooldown
+				if(L.stat == CONSCIOUS && L.health >= 30)
+					OpenFire()
 			else
 				devour(L)
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The hierophant's melee attack is now in addition to its main attack if you are in melee range, instead of skipping the main OpenFire() sequence.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I was told this was not resolved and people tanking it in melee and outhealing the bursts was still a thing.
This makes it not a thing, because the measly melee attack is not going to be the only thing it's going to toss at you and I'll be impressed if someone can outheal the normal burst attacks it does.
Megafauna fights should be skill based yadda yadda not standing still and hitting it with a crusher until it dies.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Hierophant now uses its ranged abilities in melee attacks, meaning the strategy of standing still and tanking the hits is no longer viable in 99% of circumstances.
/:cl:

99% because xenobiology + nanites exist :)
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
