### PR TITLE
Fixes a runtime relating to the new explosions

### DIFF
--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -72,7 +72,7 @@
 // Pipenet stuff; housekeeping
 
 /obj/machinery/atmospherics/components/nullifyNode(i)
-	if(nodes[i])
+	if(parents[i])
 		nullifyPipenet(parents[i])
 		QDEL_NULL(airs[i])
 	..()


### PR DESCRIPTION
## About The Pull Request

This does not make any claim towards fixing any lag whatsoever.
It merely fixes a mistake that COULD happen when trying to rebuild pipelines.
The first runtime does to my knowledge not cause any bugs.
The second one prevents the machine's air from properly detaching itself from a previously attached pipeline
```
[2020-05-01 02:29:34.424] runtime error: nullifyPipenet(null) called by /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos on (130,83,2)
 - proc name: nullifyPipenet (/obj/machinery/atmospherics/components/proc/nullifyPipenet)
 -   source file: components_base.dm,93
 -   usr: null
 -   src: the large dual-port air vent (/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos)
 -   src.loc: space (130,83,2) (/turf/open/space)
 -   call stack:
 - the large dual-port air vent (/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos): nullifyPipenet(null)
 - the large dual-port air vent (/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos): nullifyNode(2)
 - the large dual-port air vent (/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos): Destroy(0)
 - the large dual-port air vent (/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos): Destroy(0)
 - qdel(the large dual-port air vent (/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos), 0)
 - the large dual-port air vent (/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos): deconstruct(0)
 - the large dual-port air vent (/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos): deconstruct(0)
 - the large dual-port air vent (/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos): obj destruction("bomb")
 - the large dual-port air vent (/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos): take damage(1e+031, "brute", "bomb", 0, null, 0)
 - the large dual-port air vent (/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos): ex act(1, null)
 - Explosions (/datum/controller/subsystem/explosions): fire(0)
 - Explosions (/datum/controller/subsystem/explosions): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop()
 - Master (/datum/controller/master): StartProcessing(0)
```
```
[2020-05-01 02:29:34.657] runtime error: list index out of bounds
 - proc name: nullifyPipenet (/obj/machinery/atmospherics/components/proc/nullifyPipenet)
 -   source file: components_base.dm,95
 -   usr: null
 -   src: the Atmospherics vent pump #2 (/obj/machinery/atmospherics/components/unary/vent_pump/on)
 -   src.loc: the plating (141,98,2) (/turf/open/floor/plating)
 -   call stack:
 - the Atmospherics vent pump #2 (/obj/machinery/atmospherics/components/unary/vent_pump/on): nullifyPipenet(/datum/pipeline (/datum/pipeline))
 - /datum/pipeline (/datum/pipeline): Destroy(0)
 - qdel(/datum/pipeline (/datum/pipeline), 0)
 - the pipe (/obj/machinery/atmospherics/pipe/simple/cyan/visible): Destroy(0)
 - qdel(the pipe (/obj/machinery/atmospherics/pipe/simple/cyan/visible), 0)
 - the pipe (/obj/machinery/atmospherics/pipe/simple/cyan/visible): deconstruct(0)
 - the pipe (/obj/machinery/atmospherics/pipe/simple/cyan/visible): deconstruct(0)
 - the pipe (/obj/machinery/atmospherics/pipe/simple/cyan/visible): obj destruction("bomb")
 - the pipe (/obj/machinery/atmospherics/pipe/simple/cyan/visible): take damage(1e+031, "brute", "bomb", 0, null, 0)
 - the pipe (/obj/machinery/atmospherics/pipe/simple/cyan/visible): ex act(1, null)
 - Explosions (/datum/controller/subsystem/explosions): fire(0)
 - Explosions (/datum/controller/subsystem/explosions): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop()
 - Master (/datum/controller/master): StartProcessing(0)
```