### PR TITLE
buffs the lord singulo syndie kit

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -90,6 +90,7 @@
 			new /obj/item/storage/toolbox/syndicate(src)
 			new /obj/item/card/mining_access_card(src)
 			new /obj/item/stack/spacecash/c10000(src)
+			new /obj/item/toy/spinningtoy(src) //lol
 
 		if("sabotage")
 			/obj/item/storage/backpack/duffelbag/syndie/sabotage

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -88,6 +88,8 @@
 			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
 			new /obj/item/card/emag(src)
 			new /obj/item/storage/toolbox/syndicate(src)
+			new /obj/item/card/mining_access_card(src)
+			new /obj/item/stack/spacecash/c10000(src)
 
 		if("sabotage")
 			/obj/item/storage/backpack/duffelbag/syndie/sabotage


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the lord singulo kit now in addition to having a singulo beacon, spacesuit, emag and toolbox gives you a 10000 credits stack of money and a mining id upgrade card (same as from mining conscription kits)

## Why It's Good For The Game

since singulos aren't the main engine anymore and you need to buy them from cargo, this is nice to actually let whoever gets this kit to not just use it as "emag and a few practically useless things"
imo the only way to save this kit that isn't this is deleting it
also the kit's value was 19 tc, so you were paying to get normal uplink items but costing you 1 more tc, now its worth 21 tc + an access upgrade, making it adhere to the standards

## Changelog
:cl:
balance: the lord singulo syndie kit now has a mining id upgrade and a 10000 credits so you can actually bother with getting a singulo running
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
