### PR TITLE
Assorted defib mount logic fixes for #50880 and #50881

### DIFF
--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -73,12 +73,12 @@
 		if(defib)
 			to_chat(user, "<span class='warning'>There's already a defibrillator in [src]!</span>")
 			return
-		if(HAS_TRAIT(I, TRAIT_NODROP) || !user.transferItemToLoc(I, src))
-			to_chat(user, "<span class='warning'>[I] is stuck to your hand!</span>")
-			return
 		var/obj/item/defibrillator/D = I
 		if(!D.get_cell())
 			to_chat(user, "<span class='warning'>Only defibrilators containing a cell can be hooked up to [src]!</span>")
+			return
+		if(HAS_TRAIT(I, TRAIT_NODROP) || !user.transferItemToLoc(I, src))
+			to_chat(user, "<span class='warning'>[I] is stuck to your hand!</span>")
 			return
 		user.visible_message("<span class='notice'>[user] hooks up [I] to [src]!</span>", \
 		"<span class='notice'>You press [I] into the mount, and it clicks into place.</span>")
@@ -151,9 +151,11 @@
 		return
 	if(!user.put_in_hands(defib))
 		to_chat(user, "<span class='warning'>You need a free hand!</span>")
-		return
-	user.visible_message("<span class='notice'>[user] unhooks [defib] from [src].</span>", \
-	"<span class='notice'>You slide out [defib] from [src] and unhook the charging cables.</span>")
+		user.visible_message("<span class='notice'>[user] unhooks [defib] from [src], dropping it on the floor.</span>", \
+		"<span class='notice'>You slide out [defib] from [src] and unhook the charging cables, dropping it on the floor.</span>")
+	else
+		user.visible_message("<span class='notice'>[user] unhooks [defib] from [src].</span>", \
+		"<span class='notice'>You slide out [defib] from [src] and unhook the charging cables.</span>")
 	playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
 	// Make sure processing ends before the defib is nulled
 	end_processing()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bugs were probably introduced with my #50407 PR

Fixes #50880
Simple copy-paste job. I didn't understand how user.transferItemToLoc worked and I was calling it before checking if the defib had a cell. The cell check could then return early, leaving the defib in memory leak limbo - Not in the defib, not in the user's hands, not DEL'd. Logic is now in the correct order to prevent this.

Fixes #50881 
Similar issue. Didn't understand what user.put_in_hands did. If it fails and returns FALSE, it places the item on the floor instead of the users hands. When this returned FALSE, I actually ended up returning early, so a duplicate reference'd defib was placed on the floor while still in the mount. Logic changes (and some additional flavour text for the case where the defibs are dropped to the floor) should resolve this.

Both issues have been given some private server testing I can no longer replicate the bugs in the two linked PRs with my fixed logic.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Fixed various broken functionality between defibrilators and defibrilator mounts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
