### PR TITLE
Removes sleeping carp's hidden damage resistance + 40 brute crit punches, lowers price

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -23,26 +23,18 @@
 		return TRUE
 	return FALSE
 
-///Gnashing Teeth: Harm Harm, consistent 20 force punch on every second harm punch, has a chance to crit
+///Gnashing Teeth: Harm Harm, consistent 20 force punch on every second harm punch
 /datum/martial_art/the_sleeping_carp/proc/strongPunch(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	///this var is so that the strong punch is always aiming for the body part the user is targeting and not trying to apply to the chest before deviating
 	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
 	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
 	var/atk_verb = pick("precisely kick", "brutally chop", "cleanly hit", "viciously slam")
-	///this is the critical hit damage added to the attack if it rolls, it starts at 0 because it'll be changed when rolled
-	var/crit_damage = 0
 	D.visible_message("<span class='danger'>[A] [atk_verb]s [D]!</span>", \
 					"<span class='userdanger'>[A] [atk_verb]s you!</span>", null, null, A)
 	to_chat(A, "<span class='danger'>You [atk_verb] [D]!</span>")
-	if(prob(10))
-		crit_damage += 20
-		playsound(get_turf(D), 'sound/weapons/bite.ogg', 50, TRUE, -1)
-		D.visible_message("<span class='warning'>[D] is sent reeling as the blow strikes them with inhuman force!</span>", "<span class='userdanger'>You are struck with incredible precision by [A]!</span>")
-		log_combat(A, D, "critcal strong punched (Sleeping Carp)")//log it here because a critical can swing for 40 force and it's important for the sake of how hard they hit
-	else
-		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
-		log_combat(A, D, "strong punched (Sleeping Carp)")//so as to not double up on logging
-	D.apply_damage(20 + crit_damage, A.dna.species.attack_type, affecting)
+	playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
+	log_combat(A, D, "strong punched (Sleeping Carp)")//so as to not double up on logging
+	D.apply_damage(20, A.dna.species.attack_type, affecting)
 	return
 
 ///Crashing Wave Kick: Harm Disarm combo, throws people seven tiles backwards
@@ -129,31 +121,14 @@
 		return
 	ADD_TRAIT(H, TRAIT_NOGUNS, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(H, TRAIT_PIERCEIMMUNE, SLEEPING_CARP_TRAIT)
-	ADD_TRAIT(H, TRAIT_STUNRESISTANCE, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
-	H.physiology.brute_mod *= 0.4 //brute is really not gonna cut it
-	H.physiology.burn_mod *= 0.7 //burn is distinctly more useful against them than brute but they're still resistant
-	H.physiology.stamina_mod *= 0.5 //stun batons prove to be one of the few ways to fight them. They have stun resistance already, so I think doubling down too hard on this resistance is a bit much.
-	H.physiology.stun_mod *= 0.3 //for those rare stuns
-	H.physiology.pressure_mod *= 0.3 //go hang out with carp
-	H.physiology.cold_mod *= 0.3 //cold mods are different to burn mods, they do stack however
-	H.physiology.heat_mod *= 2 //this is mostly so sleeping carp has a viable weakness. Cooking them alive. Setting them on fire and heating them will be their biggest weakness. The reason for this is....filet jokes.
-
 	H.faction |= "carp" //:D
 
 /datum/martial_art/the_sleeping_carp/on_remove(mob/living/carbon/human/H)
 	. = ..()
 	REMOVE_TRAIT(H, TRAIT_NOGUNS, SLEEPING_CARP_TRAIT)
 	REMOVE_TRAIT(H, TRAIT_PIERCEIMMUNE, SLEEPING_CARP_TRAIT)
-	REMOVE_TRAIT(H, TRAIT_STUNRESISTANCE, SLEEPING_CARP_TRAIT)
 	REMOVE_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
-	H.physiology.brute_mod = initial(H.physiology.brute_mod)
-	H.physiology.burn_mod = initial(H.physiology.burn_mod)
-	H.physiology.stamina_mod = initial(H.physiology.stamina_mod)
-	H.physiology.stun_mod = initial(H.physiology.stun_mod)
-	H.physiology.pressure_mod = initial(H.physiology.pressure_mod) //no more carpies
-	H.physiology.cold_mod = initial(H.physiology.cold_mod)
-	H.physiology.heat_mod = initial(H.physiology.heat_mod)
 
 	H.faction -= "carp" //:(
 

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -33,7 +33,7 @@
 					"<span class='userdanger'>[A] [atk_verb]s you!</span>", null, null, A)
 	to_chat(A, "<span class='danger'>You [atk_verb] [D]!</span>")
 	playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
-	log_combat(A, D, "strong punched (Sleeping Carp)")//so as to not double up on logging
+	log_combat(A, D, "strong punched (Sleeping Carp)")
 	D.apply_damage(20, A.dna.species.attack_type, affecting)
 	return
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -584,10 +584,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/stealthy_weapons/martialarts
 	name = "Martial Arts Scroll"
-	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat, \
-			gain skin as hard as steel and swat bullets from the air, but you also refuse to use dishonorable ranged weaponry."
+	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat \
+			and the ability swat bullets from the air, but you also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/book/granter/martial/carp
-	cost = 17
+	cost = 12
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -585,7 +585,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/stealthy_weapons/martialarts
 	name = "Martial Arts Scroll"
 	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat \
-			and the ability swat bullets from the air, but you also refuse to use dishonorable ranged weaponry."
+			and gain the ability to swat bullets from the air, but you will also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/book/granter/martial/carp
 	cost = 12
 	surplus = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hi all, usually I stay far away from balance memes and all that, but during my work on wounds I was made aware that sleeping carp was completely broken with wounds, since it dealt so much damage. I went in to see if I needed to make adjustments for balance, and was shocked at what I found. Apparently sleeping carp has had lots of changes since I last saw it.

For the uninitiated, sleeping carp grants:

- 60% global brute resist
- 30% global burn resist (which the code tries to play off as a "lesser" strength)
- 50% global stamina resist (I should point out the author to these changes is adamantly trying to change stunbatons to do solely stamina damage)
- 70% global stun resist
- 70% global pressure resist
- 70% global cold resist
- Immunity to dismemberment
- Immunity to all embedding, injections, and caltrops
- Ability to deflect all projectiles while throw mode is enabled

with no visible tell. The only thing that sleeping carp users are actually hurt more by is being on fire, though that's reduced of course by the burn mod (x2 * x0.3 = 1.4x damage from fire), and maybe pressure mod too. I'd also like to point out that all of these incredible resistances are before armor is even applied, so you can easily push those all up by like 20-30 percentage points if they get their hands on armor.

I'm not really interested in arguments about whether or not there's a specific set of counters that are actually effective to this, because a few people have offered very long lists of very specific ways that sleeping carp can be defeated, I'm removing the resistances because it's bad gameplay and the ultimate in munchkinry. All of those buffs above come before armor is applied, before stims and meds are applied, and again are totally invisible to the vast majority of players who don't specifically follow the meta or randomly code dive to learn that there are only certain very specific counters to it and if you don't have that plan already worked out then you're just screwed.

This also removes the 10% chance to do 20 extra brute damage for a total of 40 with every second punch because what the hell is that
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
At least back when sleeping carp was first added and your only defensive buff was deflecting bullets you could recognize that pretty quickly and move in with a baton instead. Even after it was explained to me like thrice how you're supposed to counter a carp user I still couldn't tell you what you're supposed to do, so there's no point in subjecting normal players to this mess.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
del: Sleeping carp no longer grants outright damage resistances to all forms of damage. Its price has been decreased to 12TC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
