### PR TITLE
Adds a sci wardrobe vendor to meta.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -48233,6 +48233,7 @@
 /obj/structure/noticeboard{
 	pixel_y = 31
 	},
+/obj/item/radio/headset/headset_sci,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "chj" = (
@@ -49452,6 +49453,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/radio/headset/headset_sci,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "ckd" = (
@@ -50068,6 +50070,16 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 30
 	},
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stock_parts/scanning_module{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/stock_parts/scanning_module{
+	pixel_x = 2;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "clF" = (
@@ -50500,11 +50512,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cmG" = (
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 6
-	},
 /obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cmH" = (
@@ -50537,13 +50548,10 @@
 	pixel_x = 27
 	},
 /obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 2;
-	pixel_y = 3
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 6
 	},
-/obj/item/stock_parts/scanning_module,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cmK" = (
@@ -52386,9 +52394,6 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cqz" = (
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
@@ -52396,10 +52401,10 @@
 	pixel_y = -30;
 	receive_ore_updates = 1
 	},
-/obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cqA" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Meta didn't have one, lost in the genetics department move, this fixes that. It's in R&D.
Also adds two science headsets.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Wardrobe vendors are the only place to get certain things and every map should have one.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Metastation now has a science wardrobe vendor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
