### PR TITLE
Fixes overlay subsystem being lenient on large amounts of overlays

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -56,3 +56,7 @@
 #ifdef TRAVISTESTING
 #define TESTING
 #endif
+
+// A reasonable number of maximum overlays an object needs
+// If you think you need more, rethink it
+#define MAX_ATOM_OVERLAYS 100

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -47,8 +47,13 @@ SUBSYSTEM_DEF(overlays)
 	for (var/thing in queue)
 		count++
 		if(thing)
-			STAT_START_STOPWATCH
 			var/atom/A = thing
+			if(A.overlays.len >= MAX_ATOM_OVERLAYS)
+				//Break it real GOOD
+				stack_trace("Too many overlays on [A.type] - [A.overlays.len], refusing to update and cutting")
+				A.overlays.Cut()
+				continue
+			STAT_START_STOPWATCH
 			COMPILE_OVERLAYS(A)
 			STAT_STOP_STOPWATCH
 			STAT_LOG_ENTRY(stats, A.type)


### PR DESCRIPTION
It will now cut the overlays entirely and dump a message to the runtime
logs

This will stop lag from broken items attaching hundreds of overlays, and should help us clean up such instances.