### PR TITLE
Changes the foam application cycle

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -141,8 +141,7 @@
 	for(var/obj/O in range(0,src))
 		if(O.type == src.type)
 			continue
-		if(lifetime % reagent_divisor)
-			reagents.reaction(O, VAPOR, fraction)
+		reagents.reaction(O, VAPOR, fraction)
 	var/hit = 0
 	for(var/mob/living/L in range(0,src))
 		hit += foam_mob(L)
@@ -162,8 +161,7 @@
 	if(!istype(L))
 		return 0
 	var/fraction = 1/initial(reagent_divisor)
-	if(lifetime % reagent_divisor)
-		reagents.reaction(L, VAPOR, fraction)
+	reagents.reaction(L, VAPOR, fraction)
 	lifetime--
 	return 1
 


### PR DESCRIPTION
When goof added this in 2016, the intent was to have it apply 1/7th of the reagents
dose every cycle divisible by 7, however, the way the if was implemented, it applied
a dose every single cycle, except where the cycle was a multiple of 7

Given this has been the case for quite some time now, I have changed it
to simply apply a 1/7th dose every cycle of the process.

This only adds a maximum of 5 extra doses per foam at the current lifetime of
40, so should not be overly troublesome.

There are arguments to be made that we should apply a much smaller
multiple, or rationalise it to work like goof originally intended, but
I'm not sure if they add any particular value

## Changelog

:cl: oranges
tweak: Foam now applies 1/7th of it's reagent volume on every cycle, previously this applied 1/7th every cycle except when the foam lifetime was a multiple of 7
/:cl:
