### PR TITLE
New Defines Now Require Documentation (Similarly to Variables)

### DIFF
--- a/.github/AUTODOC_GUIDE.md
+++ b/.github/AUTODOC_GUIDE.md
@@ -73,8 +73,8 @@ Finally we give a longer multi paragraph description of the class and it's detai
   */
 ```
 
-### Documenting a variable
-Give a short explanation of what the variable is in the context of the class.
+### Documenting a variable/define
+Give a short explanation of what the variable, in the context of the class, or define is. 
 ```
 /// Type path of item to go in suit slot
 var/suit = null


### PR DESCRIPTION
Requires documentation for any new defines created.

Since there was no section for defines, the implication was that defines did not need to be documented.

Please delete branch on merge/close.