### PR TITLE
Readds the gulag consoles and teleporter to Metastation.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3092,9 +3092,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agU" = (
@@ -8072,6 +8069,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aqZ" = (
@@ -8098,6 +8096,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "ara" = (
@@ -9347,7 +9346,10 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "atK" = (
-/turf/open/space/basic,
+/obj/machinery/computer/security/labor{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "atL" = (
 /obj/structure/table,
@@ -9779,6 +9781,9 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
+	},
+/obj/machinery/computer/shuttle/labor{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -70134,6 +70139,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"gXz" = (
+/obj/machinery/computer/prisoner/gulag_teleporter_computer{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gXY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -75637,6 +75648,16 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qGv" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/box/prisoner{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qGP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -76164,6 +76185,7 @@
 /area/maintenance/starboard)
 "rDc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/gulag_teleporter,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "rFa" = (
@@ -77227,6 +77249,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tCp" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tCB" = (
 /obj/structure/closet/secure_closet/bar{
 	pixel_x = -3;
@@ -77532,6 +77560,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -104223,7 +104254,7 @@ anf
 aop
 xke
 aqY
-ahx
+qGv
 atK
 ajo
 avk
@@ -104480,8 +104511,8 @@ ang
 aoq
 gEY
 aqZ
-ahx
-ahx
+tCp
+gXz
 ahx
 avZ
 ahx

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6273,10 +6273,11 @@
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
-/obj/item/reagent_containers/spray/cleaner,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
+/obj/item/surgical_drapes,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "ane" = (
@@ -8056,7 +8057,6 @@
 /area/security/brig)
 "aqY" = (
 /obj/structure/bed,
-/obj/item/bedsheet,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Meta's recent perma rework removed the gulag consoles (teleporter, monitoring, shuttle) as well as the teleporter itself and a box of prisoner IDs from the brig, rendering the gulag essentially unusable.
This readds them.
I'm not super thrilled with how this worked out mapping wise, as it adds a bit of congestion to one of the brig's hallways, but there simply isn't an inch of room at present to do this any other way without majorly restructuring things.

![1](https://user-images.githubusercontent.com/51800976/81108137-da52d680-8edd-11ea-8759-56691948b28b.png)

![2](https://user-images.githubusercontent.com/51800976/81108143-dde65d80-8edd-11ea-8219-c6aecc886d88.png)

**If you have a better idea, please leave feedback or feel free to push to my branch or open a new PR.**

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The gulag is a nice thing for security to be able to use.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Metastation now has gulag equipment again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

