### PR TITLE
Fix adding sheets to machine frames when holding the perfect amount of sheets

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -321,7 +321,7 @@
 		return FALSE
 	amount -= used
 	if(check && zero_amount())
-		return FALSE
+		return TRUE
 	if(length(mats_per_unit))
 		var/temp_materials = custom_materials.Copy()
 		for(var/i in mats_per_unit)


### PR DESCRIPTION
## About The Pull Request
I added this return in https://github.com/tgstation/tgstation/pull/50832 but neglected to use the correct return value, so machines would receive an entire sheet and assume they didn't get enough mats because of this FALSE.

## Why It's Good For The Game
bug fix bug fix
fixes https://github.com/tgstation/tgstation/issues/50948
fixes https://github.com/tgstation/tgstation/issues/50958

## Changelog
:cl:
fix: fixed issue where inserting sheets into machine frames does not always work
/:cl: