### PR TITLE
Sets the default PRELOAD_RSC to 0 to match the servers

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -23,7 +23,7 @@
 //#define UNIT_TESTS			//Enables unit tests via TEST_RUN_PARAMETER
 
 #ifndef PRELOAD_RSC				//set to:
-#define PRELOAD_RSC	2			//	0 to allow using external resources or on-demand behaviour;
+#define PRELOAD_RSC	0			//	0 to allow using external resources or on-demand behaviour;
 #endif							//	1 to use the default behaviour;
 								//	2 for preloading absolutely everything;
 


### PR DESCRIPTION
epic shit blocked me from getting a fucking testmerge because I didn't know a glob was hidden behind this being 0 and it was a fucking compiler def