### PR TITLE
Changes icon state fallback order

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -19,8 +19,9 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	var/righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 
 	///Icon file for mob worn overlays.
-	///no var for state because it should *always* be the same as icon_state
 	var/icon/mob_overlay_icon
+	///Icon state for mob worn overlays. If not set falls back to item_state, then icon_state
+	var/mob_overlay_state
 	///Forced mob worn layer instead of the standard preferred ssize.
 	var/alternate_worn_layer
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -499,7 +499,9 @@ generate/load female uniform sprites matching all previously decided variables
 	if(override_state)
 		t_state = override_state
 	else
-		if(isinhands && item_state)
+		if (!isinhands && mob_overlay_state)
+			t_state = mob_overlay_state
+		else if(item_state)
 			t_state = item_state
 		else
 			t_state = icon_state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new `mob_overlay_state` var which is used to explicitly define unique/shared mob overlays.

mob overlays now fallback in the order of mob_overlay_state -> item_state -> icon_state

This matches behavior prior to the removal of item_color which accidentally broke some old on mob overlays.

## Changelog
:cl:
fix: Fallback order of on mob icons was changed to match older versions, correcting some issues with missing sprites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
