### PR TITLE
Silences proximity sensor runtime

### DIFF
--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -113,4 +113,4 @@
 /obj/effect/abstract/proximity_checker/Crossed(atom/movable/AM)
 	set waitfor = FALSE
 	. = ..()
-	monitor.hasprox_receiver.HasProximity(AM)
+	monitor.hasprox_receiver?.HasProximity(AM)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Some things that use proximity sensors don't actually care about HasProximity. Examples would be timestop or high gravity anomaly. These will no longer runtime.
```
[2020-05-07 08:41:45.655] runtime error: Cannot execute null.HasProximity().
 - proc name: Crossed (/obj/effect/abstract/proximity_checker/Crossed)
 -   source file: proximity.dm,116
 -   usr: 0
 -   src: the energy field (/obj/effect/abstract/proximity_checker/advanced/field_turf)
 -   src.loc: the floor (119,174,2) (/turf/open/floor/plasteel)
 -   call stack:
 - the energy field (/obj/effect/abstract/proximity_checker/advanced/field_turf): Crossed(the universal recorder (/obj/item/taperecorder))
 - the energy field (/obj/effect/abstract/proximity_checker/advanced/field_turf): Crossed(the universal recorder (/obj/item/taperecorder))
 - the universal recorder (/obj/item/taperecorder): Move(the floor (119,174,2) (/turf/open/floor/plasteel), 1)
 - the universal recorder (/obj/item/taperecorder): Move(the floor (119,174,2) (/turf/open/floor/plasteel), 1)
 - the universal recorder (/obj/item/taperecorder): Move(the floor (119,174,2) (/turf/open/floor/plasteel), 9)
 - the gravitational anomaly (/obj/effect/anomaly/grav/high): anomalyEffect()
 - the gravitational anomaly (/obj/effect/anomaly/grav/high): process(20)
 - Objects (/datum/controller/subsystem/processing/obj): fire(0)
 - Objects (/datum/controller/subsystem/processing/obj): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop()
 - Master (/datum/controller/master): StartProcessing(0)
```
It entire proximity field code is highly questionable but whatever works, I guess.