### PR TITLE
Lighttile Multitool Fix

### DIFF
--- a/code/game/turfs/open/floor/light_floor.dm
+++ b/code/game/turfs/open/floor/light_floor.dm
@@ -69,13 +69,13 @@
 	set_light(0)
 	return ..()
 
-/turf/open/floor/light/multitool_act(mob/living/user, obj/item/I, obj/item/multitool/multitool)
+/turf/open/floor/light/multitool_act(mob/living/user, obj/item/I)
 	. = ..()
 	if(.)
 		return
 	if(!can_modify_colour)
 		return
-	var/choice = show_radial_menu(user,src, lighttile_designs, custom_check = CALLBACK(src, .proc/check_menu, user, multitool), radius = 36, require_near = TRUE)
+	var/choice = show_radial_menu(user,src, lighttile_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
 	if(!choice)
 		return FALSE
 	currentcolor = choice
@@ -123,11 +123,11 @@
   * * user The mob interacting with a menu
   * * multitool The multitool used to interact with a menu
   */
-/turf/open/floor/light/proc/check_menu(mob/living/user, obj/item/multitool/multitool)
+/turf/open/floor/light/proc/check_menu(mob/living/user, obj/item/multitool/)
 	if(!istype(user))
 		return FALSE
 	if(user.incapacitated())
 		return FALSE
-	if(!user.is_holding(multitool))
+	if(!multitool || !user.is_holding(multitool))
 		return FALSE
 	return TRUE

--- a/code/game/turfs/open/floor/light_floor.dm
+++ b/code/game/turfs/open/floor/light_floor.dm
@@ -123,7 +123,7 @@
   * * user The mob interacting with a menu
   * * multitool The multitool used to interact with a menu
   */
-/turf/open/floor/light/proc/check_menu(mob/living/user, obj/item/multitool/)
+/turf/open/floor/light/proc/check_menu(mob/living/user, obj/item/multitool)
 	if(!istype(user))
 		return FALSE
 	if(user.incapacitated())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I jumbled implementation of the callback menu for light tiles so you can only adjust them when you're only holding a multitool and nothing else.

This PR fixes that.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: light tiles are less picky about how you hold the multitool
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
