### PR TITLE
Completely disables papercode

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -250,6 +250,7 @@
 
 
 /obj/item/paper/Topic(href, href_list)
+	return
 	..()
 	var/literate = usr.is_literate()
 	if(!usr.canUseTopic(src, BE_CLOSE, literate))
@@ -288,7 +289,7 @@
 
 /obj/item/paper/attackby(obj/item/P, mob/living/carbon/human/user, params)
 	..()
-
+	return
 	if(resistance_flags & ON_FIRE)
 		return
 


### PR DESCRIPTION
This shit can go die in a fire.

I will allow paper to be readded when

ONE - the rich text markup is done entireyl clientside in JS

TWO - the paper code is stored as markdown on the server side.

I am done with this stupid ass crap forever