### PR TITLE
Makes sm delams a little more... sparky (Tweaks the way h2o works in the engine)

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -19,7 +19,7 @@
 #define CO2_HEAT_PENALTY 0.1
 #define NITROGEN_HEAT_PENALTY -1.5
 #define BZ_HEAT_PENALTY 5
-#define H2O_HEAT_PENALTY 8  //still under testing, but should be enough to make a lot of heat
+#define H2O_HEAT_PENALTY 8
 #define FREON_HEAT_PENALTY -10 //very good heat absorbtion and less plasma and o2 generation
 #define HYDROGEN_HEAT_PENALTY 10 // similar heat penalty as tritium (dangerous)
 
@@ -31,14 +31,13 @@
 #define BZ_TRANSMIT_MODIFIER -2
 #define TRITIUM_TRANSMIT_MODIFIER 30 //We divide by 10, so this works out to 3
 #define PLUOXIUM_TRANSMIT_MODIFIER -5 //Should halve the power output
-#define H2O_TRANSMIT_MODIFIER -9
+#define H2O_TRANSMIT_MODIFIER 2
 #define HYDROGEN_TRANSMIT_MODIFIER 25 //increase the radiation emission, but less than the trit (2.5)
 
 #define BZ_RADIOACTIVITY_MODIFIER 5 //Improves the effect of transmit modifiers
 
 #define N2O_HEAT_RESISTANCE 6          //Higher == Gas makes the crystal more resistant against heat damage.
 #define PLUOXIUM_HEAT_RESISTANCE 3
-#define H2O_HEAT_RESISTANCE 10
 #define HYDROGEN_HEAT_RESISTANCE 2 // just a bit of heat resistance to spice it up
 
 #define POWERLOSS_INHIBITION_GAS_THRESHOLD 0.20         //Higher == Higher percentage of inhibitor gas needed before the charge inertia chain reaction effect starts.
@@ -157,10 +156,6 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/h2obonus = 0
 	///it allows us to remove the power generation while freon is inside the chamber
 	var/freonbonus = 1
-	///used when calculating if the h2o "malus" is applied, the malus is an increase in power, waste gases and heat (wich is bad if not ready) also now used when calculating amount of radiations
-	var/h2omalus = 1
-	///fix for the heat penalty, making it work differently at different %
-	var/h2ofixed = 0.5
 
 	///The last air sample's total molar count, will always be above or equal to 0
 	var/combined_gas = 0
@@ -361,6 +356,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			var/obj/singularity/energy_ball/E = new(T)
 			E.energy = power
 	investigate_log("has exploded.", INVESTIGATE_SUPERMATTER)
+	//Dear mappers, balance the sm max explosion radius to 17.5, 37, 39, 41
 	explosion(get_turf(T), explosion_power * max(gasmix_power_ratio, 0.205) * 0.5 , explosion_power * max(gasmix_power_ratio, 0.205) + 2, explosion_power * max(gasmix_power_ratio, 0.205) + 4 , explosion_power * max(gasmix_power_ratio, 0.205) + 6, 1, 1)
 	qdel(src)
 
@@ -480,34 +476,16 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		else
 			pluoxiumbonus = 0
 
-		if (h2ocomp >= 0.35 && h2ocomp <= 0.45) //heat protection from h2o only works when it's between 35 and 45%
-			h2obonus = 1
-		else
-			h2obonus = 0
-
 		if(freoncomp <= 0.03)
 			freonbonus = 1
 		else
 			freonbonus = 0 //stop any power generation by removing radiation output
 
-		switch(h2ocomp)
-			if (-INFINITY to 0.05) //non h2o delamination fix
-				h2omalus = 1
-			if(0.05 to 0.45) //the engine will stop producing power from 5% to 45% h2o (slow down the o2 and plasma generation too)
-				h2omalus = 0.05
-			if (0.45 to INFINITY)
-				h2omalus = 2  //when gas comp is above 0.45 the engine will start to freak out
-
-		switch(h2ocomp)  //variability in the h2o penalty calculation depending on the %
-			if(-INFINITY to 0.30)
-				h2ofixed = 1
-			if(0.30 to 0.50)
-				h2ofixed = 0.5
-			if(0.5 to INFINITY)
-				h2ofixed = 2
+		h2obonus = 1 - (h2ocomp * 0.25)//At max this value should be 0.75
 
 		//No less then zero, and no greater then one, we use this to do explosions and heat to power transfer
-		gasmix_power_ratio = min(max(((plasmacomp + o2comp + co2comp + h2ocomp + tritiumcomp + bzcomp + h2comp - pluoxiumcomp - n2comp - freoncomp) * h2omalus), 0), 1)
+		//Be very careful with modifing this var by large amounts, and for the love of god do not push it past 1
+		gasmix_power_ratio = min(max(((plasmacomp + o2comp + co2comp + h2ocomp + tritiumcomp + bzcomp + h2comp - pluoxiumcomp - n2comp - freoncomp)), 0), 1)
 		//Minimum value of 1.5, maximum value of 23
 		dynamic_heat_modifier = plasmacomp * PLASMA_HEAT_PENALTY
 		dynamic_heat_modifier += o2comp * OXYGEN_HEAT_PENALTY
@@ -518,21 +496,20 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		dynamic_heat_modifier += bzcomp * BZ_HEAT_PENALTY
 		dynamic_heat_modifier += freoncomp * FREON_HEAT_PENALTY
 		dynamic_heat_modifier += h2comp * HYDROGEN_HEAT_PENALTY
-		dynamic_heat_modifier *= h2omalus
-		dynamic_heat_modifier += h2ocomp * H2O_HEAT_PENALTY * h2ofixed
+		dynamic_heat_modifier += h2ocomp * H2O_HEAT_PENALTY
+		dynamic_heat_modifier *= h2obonus
 		dynamic_heat_modifier = max(dynamic_heat_modifier, 0.5)
 		//Value between 1 and 10
-		dynamic_heat_resistance = max((n2ocomp * N2O_HEAT_RESISTANCE) + ((h2ocomp * H2O_HEAT_RESISTANCE) * h2obonus) + ((pluoxiumcomp * PLUOXIUM_HEAT_RESISTANCE) * pluoxiumbonus) + (h2comp * HYDROGEN_HEAT_RESISTANCE), 1)
+		dynamic_heat_resistance = max((n2ocomp * N2O_HEAT_RESISTANCE) + ((pluoxiumcomp * PLUOXIUM_HEAT_RESISTANCE) * pluoxiumbonus) + (h2comp * HYDROGEN_HEAT_RESISTANCE), 1)
 		//Value between 30 and -5, used to determine radiation output as it concerns things like collectors
 		power_transmission_bonus = plasmacomp * gas_trans["PL"]
 		power_transmission_bonus += o2comp * gas_trans["O2"]
-		power_transmission_bonus += (h2ocomp * gas_trans["WV"])*h2obonus
+		power_transmission_bonus += (h2ocomp * gas_trans["WV"])
 		power_transmission_bonus += bzcomp * gas_trans["BZ"]
 		power_transmission_bonus += tritiumcomp * gas_trans["TRIT"]
 		power_transmission_bonus += (pluoxiumcomp * gas_trans["PLX"]) * pluoxiumbonus
 		power_transmission_bonus += h2comp * gas_trans["H2"]
-		power_transmission_bonus *= h2omalus
-
+		power_transmission_bonus *= h2obonus
 		//more moles of gases are harder to heat than fewer, so let's scale heat damage around them
 		mole_heat_penalty = max(combined_gas / MOLE_HEAT_PENALTY, 0.25)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes what was added in this pr #49624 to let the sm be a little more spicy.
H2O on the whole dampened delams a bit, and most of the time it neutered eer (power if you're a nerd) gain.

This was fine before, but now that h2o spawns in plasma fires, we gotta change things up. #50510 

I've changed the gas to be a median between plasma and o2 most of the time, excepting the fact that in high percentages it can stall rad/gas gen. The value for this is up for debate, currently it maxes out at 0.75x. 

Hopefully this gives engis something to deal with cascading o2 molar count delams. **Hint hint**

## Why It's Good For The Game

Should let delams be a little more hot, and attempts to keep h2o's uniqueness.

@Ghilker Let me know if I've made any unnecessary changes here, I'm attempting to preserve some of the intent I can glean behind the h2o interactions.

## Changelog
:cl:
tweak: Changed the way h2o interacts with the engine. It should acts similar to o2 normally, but in high concentrations it cools the engine down. Have fun :)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
