### PR TITLE
You can eat as fast as you can click, but eating too fast makes you choke

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -697,7 +697,7 @@
 				C.vomit(force=TRUE)
 			else if(prob(50))
 				C.losebreath += 2
-				C.visible_message("<span class='danger'>[C]'s eyes water as they try desperately to clear [C.p_their()] throat!</span>", "<span class='userdanger'>You try fruitlessly to clear the blockage in your throat, but it's not working!</span>", "<span class='danger'>You hear a disgusting splat followed by hacking!</span>")
+				C.visible_message("<span class='danger'>[C]'s eyes water as they try desperately to clear [C.p_their()] throat!</span>", "<span class='userdanger'>You try fruitlessly to clear the blockage in your throat, but it's not working!</span>", "<span class='danger'>You hear a rapid series of half-gasps!</span>")
 			else
 				C.losebreath++
 		if(11 to INFINITY)
@@ -706,11 +706,11 @@
 				C.vomit(force=TRUE)
 			else if(prob(50))
 				C.losebreath += 3
-				C.visible_message("<span class='danger'>[C]'s eyes seem to darken noticeably as [C.p_their()] flailing begins to die down!</span>", "<span class='userdanger'>CAN'T- BREATHE- IS THIS- IT?!</span>", "<span class='danger'>You hear a disgusting splat followed by hacking!</span>")
+				C.visible_message("<span class='danger'>[C]'s eyes seem to darken noticeably as [C.p_their()] flailing begins to die down!</span>", "<span class='userdanger'>CAN'T- BREATHE- IS THIS- IT?!</span>", "<span class='danger'>You hear the wheezing embodiment of despair!</span>")
 			else
 				C.losebreath += 4
 
 /obj/screen/alert/status_effect/choking
 	name = "Choking"
-	desc = "You're choking! Find someone to apply the heimlich maneuver!"
+	desc = "You're choking! Find someone to apply the Heimlich Maneuver!"
 	icon_state = "gross3"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -655,3 +655,62 @@
 		to_chat(owner, fake_msg)
 
 	msg_stage++
+
+/datum/status_effect/choking
+	id = "choking"
+	status_type = STATUS_EFFECT_UNIQUE
+	tick_interval = 10
+	alert_type = /obj/screen/alert/status_effect/choking
+	var/choking_ticks = 0
+
+/datum/status_effect/choking/on_apply()
+	RegisterSignal(owner, COMSIG_MOB_SAY, .proc/sputter)
+	owner.visible_message("<span class='danger'>[owner] grasps frantically at [owner.p_their()] windpipe, clutching helplessly as [owner.p_their()] eyes widen in fear!</span>", "<span class='userdanger'>You can't breathe! You're choking on all the food you ate!</span>", "<span class='danger'>You hear horrible wheezing and hacking!</span>")
+	return TRUE
+
+/datum/status_effect/choking/on_remove()
+	UnregisterSignal(owner, COMSIG_MOB_SAY)
+	return ..()
+
+/datum/status_effect/choking/proc/sputter(mob/living/carbon/speaker, list/speech_args)
+	var/message = speech_args[SPEECH_MESSAGE]
+	var/static/regex/tongueless_lower = new("\[gdntke]+", "g")
+	var/static/regex/tongueless_upper = new("\[GDNTKE]+", "g")
+	if(message[1] != "*")
+		message = tongueless_lower.Replace(message, pick("aa","oo","'"))
+		message = tongueless_upper.Replace(message, pick("AA","OO","'"))
+		speech_args[SPEECH_MESSAGE] = "[copytext(message, 1, 5)] GHKK--"
+
+/datum/status_effect/choking/tick()
+	var/mob/living/carbon/C = owner
+	choking_ticks++
+	switch(choking_ticks)
+		if(1 to 5)
+			if(prob(8))
+				C.visible_message("<span class='danger'>[C] manages to vomit everywhere, successfully clearing [C.p_their()] windpipe!</span>", "<span class='userdanger'>Your stomach manages to propel all the food out of your mouth! Hooray!</span>", "<span class='danger'>You hear a disgusting splat followed by hacking!</span>")
+				C.vomit(force=TRUE)
+			else
+				C.losebreath += 2
+		if(6 to 10)
+			if(prob(4))
+				C.visible_message("<span class='danger'>[C] manages to vomit everywhere, successfully clearing [C.p_their()] windpipe!</span>", "<span class='userdanger'>Your stomach manages to propel all the food out of your mouth! Hooray!</span>", "<span class='danger'>You hear a disgusting splat followed by hacking!</span>")
+				C.vomit(force=TRUE)
+			else if(prob(50))
+				C.losebreath += 2
+				C.visible_message("<span class='danger'>[C]'s eyes water as they try desperately to clear [C.p_their()] throat!</span>", "<span class='userdanger'>You try fruitlessly to clear the blockage in your throat, but it's not working!</span>", "<span class='danger'>You hear a disgusting splat followed by hacking!</span>")
+			else
+				C.losebreath++
+		if(11 to INFINITY)
+			if(prob(2))
+				C.visible_message("<span class='danger'>[C] manages to vomit everywhere, successfully clearing [C.p_their()] windpipe!</span>", "<span class='userdanger'>Your stomach manages to propel all the food out of your mouth! Hooray!</span>", "<span class='danger'>You hear a disgusting splat followed by hacking!</span>")
+				C.vomit(force=TRUE)
+			else if(prob(50))
+				C.losebreath += 3
+				C.visible_message("<span class='danger'>[C]'s eyes seem to darken noticeably as [C.p_their()] flailing begins to die down!</span>", "<span class='userdanger'>CAN'T- BREATHE- IS THIS- IT?!</span>", "<span class='danger'>You hear a disgusting splat followed by hacking!</span>")
+			else
+				C.losebreath += 4
+
+/obj/screen/alert/status_effect/choking
+	name = "Choking"
+	desc = "You're choking! Find someone to apply the heimlich maneuver!"
+	icon_state = "gross3"

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -116,8 +116,7 @@ All foods are distributed among various categories. Use common sense.
 			else if(fullness > (600 * (1 + M.overeatduration / 2000)))	// The more you eat - the more you can eat
 				user.visible_message("<span class='warning'>[user] cannot force any more of \the [src] to go down [user.p_their()] throat!</span>", "<span class='warning'>You cannot force any more of \the [src] to go down your throat!</span>")
 				return FALSE
-			if(HAS_TRAIT(M, TRAIT_VORACIOUS))
-				M.changeNext_move(CLICK_CD_MELEE * 0.5) //nom nom nom
+			M.changeNext_move(CLICK_CD_RAPID) //nom nom nom
 		else
 			if(!isbrain(M))		//If you're feeding it to someone else.
 				if(fullness <= (600 * (1 + M.overeatduration / 1000)))
@@ -147,6 +146,11 @@ All foods are distributed among various categories. Use common sense.
 				var/fraction = min(bitesize / reagents.total_volume, 1)
 				reagents.trans_to(M, bitesize, transfered_by = user, method = INGEST)
 				bitecount++
+				if(iscarbon(M))
+					var/mob/living/carbon/C = M
+					var/obj/item/bodypart/head/hed = C.get_bodypart(BODY_ZONE_HEAD)
+					if(hed)
+						hed.mouthful += bitesize
 				On_Consume(M)
 				checkLiked(fraction, M)
 				return TRUE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -454,10 +454,9 @@
 				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "vomit", /datum/mood_event/vomit)
 
 	var/obj/item/bodypart/head/hed = get_bodypart(BODY_ZONE_HEAD)
-	if(hed)
-		if(!has_status_effect(/datum/status_effect/choking) || force)
-			hed.mouthful = 0
-			remove_status_effect(/datum/status_effect/choking)
+	if(hed && (!has_status_effect(/datum/status_effect/choking) || force)) // we check if we're not choking OR if it's forced so people can't manually vomit somehow to clear the choking
+		hed.mouthful = 0
+		remove_status_effect(/datum/status_effect/choking)
 
 	if(stun)
 		Paralyze(80)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -453,6 +453,12 @@
 			if(!isflyperson(src))
 				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "vomit", /datum/mood_event/vomit)
 
+	var/obj/item/bodypart/head/hed = get_bodypart(BODY_ZONE_HEAD)
+	if(hed)
+		if(!has_status_effect(/datum/status_effect/choking) || force)
+			hed.mouthful = 0
+			remove_status_effect(/datum/status_effect/choking)
+
 	if(stun)
 		Paralyze(80)
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -112,6 +112,18 @@
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /mob/living/carbon/attack_hand(mob/living/carbon/human/user)
+	if(has_status_effect(/datum/status_effect/choking) && user.pulling == src && user.grab_state >= GRAB_AGGRESSIVE)
+		user.visible_message("<span class='danger'>[user] pumps [src]'s stomach from behind with the Heimlich Maneuver!</span>", "<span class='danger'>You pump [src]'s stomach from behind with the Heimlich Maneuver!</span>", ignored_mobs=src)
+		to_chat(src, "<span class='userdanger'>[user] pumps squeezes your stomach tight from behind with the Heimlich Maneuver!</span>")
+		if(do_after(user, 0.5 SECONDS, TRUE, src))
+			if(!has_status_effect(/datum/status_effect/choking))
+				return
+			if(prob(25))
+				user.visible_message("<span class='danger'>[user] manages to force [src] to vomit, clearing [src.p_their()] windpipe!</span>", "<span class='danger'>You manage to force [src] to vomit, clearing [src.p_their()] windpipe!</span>", ignored_mobs=src)
+				to_chat(src, "<span class='userdanger'>The food blocking your throat comes shooting up, along with all the food that wasn't blocking your throat!</span>")
+				vomit(force=TRUE)
+				return
+			attack_hand(user)
 
 	for(var/thing in diseases)
 		var/datum/disease/D = thing

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -113,8 +113,8 @@
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /mob/living/carbon/attack_hand(mob/living/carbon/human/user)
 	if(has_status_effect(/datum/status_effect/choking) && user.pulling == src && user.grab_state >= GRAB_AGGRESSIVE)
-		user.visible_message("<span class='danger'>[user] pumps [src]'s stomach from behind with the Heimlich Maneuver!</span>", "<span class='danger'>You pump [src]'s stomach from behind with the Heimlich Maneuver!</span>", ignored_mobs=src)
-		to_chat(src, "<span class='userdanger'>[user] pumps squeezes your stomach tight from behind with the Heimlich Maneuver!</span>")
+		user.visible_message("<span class='danger'>[user] pumps [src]'s diaphragm from behind with the Heimlich Maneuver!</span>", "<span class='danger'>You pump [src]'s diaphragm from behind with the Heimlich Maneuver!</span>", ignored_mobs=src)
+		to_chat(src, "<span class='userdanger'>[user] pumps squeezes your diaphragm tight from behind with the Heimlich Maneuver!</span>")
 		if(do_after(user, 0.5 SECONDS, TRUE, src))
 			if(!has_status_effect(/datum/status_effect/choking))
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This idea has made me giggle for a while now, so I may as well make the PR since it's pretty simple.

https://cdn.discordapp.com/attachments/326831214667235328/708298898485018645/Space_Station_13_2020-05-08_08-45-46.mp4

There is no cooldown when eating food on yourself, but however much you bite out of the food is placed in your head to chew and swallow. If you eat too much food too quick, you can start choking. If you're lucky, you'll automatically vomit up the food blocking your throat, but otherwise you'll need someone to apply the Heimlich Maneuver by aggro grabbing you, and interacting with you on a non-grab intent. Failing to clear the blockage may lead to suffocation!

The voracious trait has also been changed to make you chew food 1.5x faster.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds mechanical depth to eating, raises the skill ceiling of not dying to a plate of chicken tenders, baits assistants into suffocating themselves for the vine
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
add: You can now eat food as fast as you can click!
add: Just because you CAN doesn't mean you should though!
tweak: The voracious perk now makes you chew food 50% faster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
