### PR TITLE
Projectiles embed their shrapnel in the locations they hit

### DIFF
--- a/code/datums/elements/embed.dm
+++ b/code/datums/elements/embed.dm
@@ -168,7 +168,7 @@
   * If we hit a valid target (carbon or closed turf), we create the shrapnel_type object and immediately call tryEmbed() on it, targeting what we impacted. That will lead
   *	it to call tryForceEmbed() on its own embed element (it's out of our hands here, our projectile is done), where it will run through all the checks it needs to.
   */
-/datum/element/embed/proc/checkEmbedProjectile(obj/projectile/P, atom/movable/firer, atom/hit)
+/datum/element/embed/proc/checkEmbedProjectile(obj/projectile/P, atom/movable/firer, atom/hit, angle, hit_zone)
 	if(!iscarbon(hit) && !isclosedturf(hit))
 		Detach(P)
 		return // we don't care
@@ -177,7 +177,10 @@
 	var/did_embed
 	if(iscarbon(hit))
 		var/mob/living/carbon/C = hit
-		var/obj/item/bodypart/limb = C.get_bodypart(C.check_limb_hit(P.def_zone))
+		var/obj/item/bodypart/limb
+		limb = C.get_bodypart(hit_zone)
+		if(!limb)
+			limb = C.get_bodypart()
 		did_embed = payload.tryEmbed(limb)
 	else
 		did_embed = payload.tryEmbed(hit)
@@ -213,6 +216,7 @@
 			hit_zone = limb.body_zone
 	else if(isbodypart(target))
 		limb = target
+		hit_zone = limb.body_zone
 		C = limb.owner
 	else if(isclosedturf(target))
 		T = target

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -163,7 +163,11 @@
 		SEND_SIGNAL(fired_from, COMSIG_PROJECTILE_ON_HIT, firer, target, Angle)
 	// i know that this is probably more with wands and gun mods in mind, but it's a bit silly that the projectile on_hit signal doesn't ping the projectile itself.
 	// maybe we care what the projectile thinks! See about combining these via args some time when it's not 5AM
-	SEND_SIGNAL(src, COMSIG_PROJECTILE_SELF_ON_HIT, firer, target, Angle)
+	var/obj/item/bodypart/hit_limb
+	if(isliving(target))
+		var/mob/living/L = target
+		hit_limb = L.check_limb_hit(def_zone)
+	SEND_SIGNAL(src, COMSIG_PROJECTILE_SELF_ON_HIT, firer, target, Angle, hit_limb)
 	var/turf/target_loca = get_turf(target)
 
 	var/hitx
@@ -206,7 +210,7 @@
 			new impact_effect_type(target_loca, hitx, hity)
 
 		var/organ_hit_text = ""
-		var/limb_hit = L.check_limb_hit(def_zone)//to get the correct message info.
+		var/limb_hit = hit_limb
 		if(limb_hit)
 			organ_hit_text = " in \the [parse_zone(limb_hit)]"
 		if(suppressed==SUPPRESSED_VERY)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Projectiles with shrapnel currently embed their shrapnel somewhere random on the body. This PR changes it so shrapnel embeds on the same bodypart they hit
[![dreamseeker_2020-05-08_10-47-01.png](https://i.imgur.com/UU3mk5Kl.jpg)](https://i.imgur.com/UU3mk5K.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix for floyd so he can use shrapnel for something else, consistency
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Projectiles with shrapnel now embed in the same limb they hit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
