### PR TITLE
Readding the same asset to the asset cache now logs to asset.log instead of runtime.log

### DIFF
--- a/code/modules/asset_cache/asset_cache.dm
+++ b/code/modules/asset_cache/asset_cache.dm
@@ -84,9 +84,15 @@ Note: If your code uses output() with assets you will need to call asset_flush o
 //icons and virtual assets get copied to the dyn rsc before use
 /proc/register_asset(asset_name, asset)
 	var/datum/asset_cache_item/ACI = new(asset_name, asset)
+	
+	//this is technically never something that was supported and i want metrics on how often it happens if at all.
 	if (SSassets.cache[asset_name])
 		var/datum/asset_cache_item/OACI = SSassets.cache[asset_name]
-		stack_trace("WARNING: dupe asset added to the asset cache: [asset_name] existing asset md5: [OACI.md5] new asset md5:[ACI.md5]") //this is technically never something that was supported and i want metrics on how often it happens if at all.
+		if (OACI.md5 != ACI.md5)
+			stack_trace("ERROR: new asset added to the asset cache with the same name as another asset: [asset_name] existing asset md5: [OACI.md5] new asset md5:[ACI.md5]")
+		else
+			var/list/stacktrace = gib_stack_trace()
+			log_asset("WARNING: dupe asset added to the asset cache: [asset_name] existing asset md5: [OACI.md5] new asset md5:[ACI.md5]\n[stacktrace.Join("\n")]")
 	SSassets.cache[asset_name] = ACI
 
 //Generated names do not include file extention.


### PR DESCRIPTION
How many of you forgot we had a way in game code to get the stack trace as a list.