### PR TITLE
reverts the cult stun change and nerfs barrier/final reckoning instead

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -81,7 +81,7 @@
 		..()
 
 /obj/structure/emergency_shield/cult/barrier/Destroy()
-	if(parent_rune)
+	if(parent_rune && !QDELETED(parent_rune))
 		parent_rune.visible_message("<span class='danger'>The [parent_rune] fades away as [src] is destroyed!</span>")
 		qdel(parent_rune)
 	..()
@@ -89,9 +89,9 @@
 /obj/structure/emergency_shield/cult/barrier/proc/Toggle()
 	density = !density
 	air_update_turf(1)
-	alpha = 255 //alpha instead of invisibility so that it doesnt mess with the conceal runes spell
+	invisibility = initial(invisibility)
 	if(!density)
-		alpha = 0
+		invisibility = INVISIBILITY_OBSERVER
 
 /obj/machinery/shieldgen
 	name = "anti-breach shielding projector"

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -43,16 +43,22 @@
 	if(.) //damage was dealt
 		new /obj/effect/temp_visual/impact_effect/ion(loc)
 
-/obj/structure/emergency_shield/sanguine
-	name = "sanguine barrier"
-	desc = "A potent shield summoned by cultists to defend their rites."
-	icon_state = "shield-red"
-	max_integrity = 60
 
-/obj/structure/emergency_shield/sanguine/emp_act(severity)
+/obj/structure/emergency_shield/cult
+	name = "cult barrier"
+	desc = "A shield summoned by cultists to keep heretics away."
+	max_integrity = 100
+	icon_state = "shield-red"
+
+/obj/structure/emergency_shield/cult/emp_act(severity)
 	return
 
-/obj/structure/emergency_shield/invoker
+/obj/structure/emergency_shield/cult/narsie
+	name = "sanguine barrier"
+	desc = "A potent shield summoned by cultists to defend their rites."
+	max_integrity = 60
+
+/obj/structure/emergency_shield/cult/weak
 	name = "Invoker's Shield"
 	desc = "A weak shield summoned by cultists to protect them while they carry out delicate rituals."
 	color = "#FF0000"
@@ -60,9 +66,32 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	layer = ABOVE_MOB_LAYER
 
-/obj/structure/emergency_shield/invoker/emp_act(severity)
-	return
+/obj/structure/emergency_shield/cult/barrier
+	var/obj/effect/rune/parent_rune // for deleting the barrier rune that created the barrier
+	density = FALSE //toggled on right away by the parent rune
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
+/obj/structure/emergency_shield/cult/barrier/attack_hand(mob/living/user)
+	parent_rune.attack_hand(user)
+
+/obj/structure/emergency_shield/cult/barrier/attack_animal(mob/living/simple_animal/user)
+	if(iscultist(user))
+		parent_rune.attack_animal(user)
+	else
+		..()
+
+/obj/structure/emergency_shield/cult/barrier/Destroy()
+	if(parent_rune)
+		parent_rune.visible_message("<span class='danger'>The [parent_rune] fades away as [src] is destroyed!</span>")
+		qdel(parent_rune)
+	..()
+
+/obj/structure/emergency_shield/cult/barrier/proc/Toggle()
+	density = !density
+	air_update_turf(1)
+	alpha = 255 //alpha instead of invisibility so that it doesnt mess with the conceal runes spell
+	if(!density)
+		alpha = 0
 
 /obj/machinery/shieldgen
 	name = "anti-breach shielding projector"

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -67,9 +67,10 @@
 	layer = ABOVE_MOB_LAYER
 
 /obj/structure/emergency_shield/cult/barrier
-	var/obj/effect/rune/parent_rune // for deleting the barrier rune that created the barrier
 	density = FALSE //toggled on right away by the parent rune
 	CanAtmosPass = ATMOS_PASS_DENSITY
+	///The rune that created the shield itself. Used to delete the rune when the shield is destroyed.
+	var/obj/effect/rune/parent_rune
 
 /obj/structure/emergency_shield/cult/barrier/attack_hand(mob/living/user)
 	parent_rune.attack_hand(user)
@@ -81,11 +82,18 @@
 		..()
 
 /obj/structure/emergency_shield/cult/barrier/Destroy()
-	if(parent_rune && !QDELETED(parent_rune))
+	if(parent_rune)
 		parent_rune.visible_message("<span class='danger'>The [parent_rune] fades away as [src] is destroyed!</span>")
-		qdel(parent_rune)
+		QDEL_NULL(parent_rune)
 	..()
 
+/**
+*Turns the shield on and off.
+*
+*The shield has 2 states: on and off. When on, it will block movement,projectiles, items, etc. and be clearly visible, and block atmospheric gases.
+*When off, the rune no longer blocks anything and turns invisible.
+*The barrier itself is not intended to interact with the conceal runes cult spell for balance purposes.
+*/
 /obj/structure/emergency_shield/cult/barrier/proc/Toggle()
 	density = !density
 	air_update_turf(1)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -447,7 +447,7 @@
 				C.silent += 6
 				C.stuttering += 15
 				C.cultslurring += 15
-				C.Jitter(15)
+				C.Jitter(1.5 SECONDS)
 		uses--
 	..()
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -438,7 +438,7 @@
 		else
 			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
 			L.Paralyze(160)
-			L.flash_act(1,1)
+			L.flash_act(1,TRUE)
 			if(issilicon(target))
 				var/mob/living/silicon/S = L
 				S.emp_act(EMP_HEAVY)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -437,7 +437,7 @@
 
 		else
 			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
-			L.Paralyze(160)
+			L.Paralyze(16 SECONDS)
 			L.flash_act(1,TRUE)
 			if(issilicon(target))
 				var/mob/living/silicon/S = L

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -436,28 +436,18 @@
 									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 
 		else
-			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+			L.Paralyze(160)
+			L.flash_act(1,1)
+			if(issilicon(target))
+				var/mob/living/silicon/S = L
+				S.emp_act(EMP_HEAVY)
+			else if(iscarbon(target))
 				var/mob/living/carbon/C = L
-				to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
-				C.stuttering += 8
-				C.dizziness += 30
-				C.Jitter(8)
-				C.drop_all_held_items()
-				C.bleed(40)
-				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
-			else
-				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
-				L.Paralyze(160)
-				L.flash_act(1,1)
-				if(issilicon(target))
-					var/mob/living/silicon/S = L
-					S.emp_act(EMP_HEAVY)
-				else if(iscarbon(target))
-					var/mob/living/carbon/C = L
-					C.silent += 6
-					C.stuttering += 15
-					C.cultslurring += 15
-					C.Jitter(15)
+				C.silent += 6
+				C.stuttering += 15
+				C.cultslurring += 15
+				C.Jitter(15)
 		uses--
 	..()
 

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -153,6 +153,11 @@
 	var/datum/antagonist/cult/antag = owner.mind.has_antag_datum(/datum/antagonist/cult,TRUE)
 	if(!antag)
 		return
+	var/place = get_area(owner)
+	var/datum/objective/eldergod/summon_objective = locate() in antag.cult_team.objectives
+	if(place in summon_objective.summon_spots)//cant do final reckoning in the summon area to prevent abuse, you'll need to get everyone to stand on the circle!
+		to_chat(owner, "<span class='cultlarge'>The veil is too weak here! Move to an area where it is strong enough to support this magic.</span>")
+		return
 	for(var/i in 1 to 4)
 		chant(i)
 		var/list/destinations = list()

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -803,7 +803,7 @@
 	if(do_after(user, 90, target = user))
 		firing = TRUE
 		INVOKE_ASYNC(src, .proc/pewpew, user, params)
-		var/obj/structure/emergency_shield/invoker/N = new(user.loc)
+		var/obj/structure/emergency_shield/cult/weak/N = new(user.loc)
 		if(do_after(user, 90, target = user))
 			user.Paralyze(40)
 			to_chat(user, "<span class='cult italic'>You have exhausted the power of this spell!</span>")

--- a/code/modules/antagonists/cult/ritual.dm
+++ b/code/modules/antagonists/cult/ritual.dm
@@ -115,7 +115,7 @@ This file contains the cult dagger and rune list code
 			return
 		priority_announce("Figments from an eldritch god are being summoned by [user] into [A.map_name] from an unknown dimension. Disrupt the ritual at all costs!","Central Command Higher Dimensional Affairs", 'sound/ai/spanomalies.ogg')
 		for(var/B in spiral_range_turfs(1, user, 1))
-			var/obj/structure/emergency_shield/sanguine/N = new(B)
+			var/obj/structure/emergency_shield/cult/narsie/N = new(B)
 			shields += N
 	user.visible_message("<span class='warning'>[user] [user.blood_volume ? "cuts open [user.p_their()] arm and begins writing in [user.p_their()] own blood":"begins sketching out a strange design"]!</span>", \
 						 "<span class='cult'>You [user.blood_volume ? "slice open your arm and ":""]begin drawing a sigil of the Geometer.</span>")
@@ -126,7 +126,7 @@ This file contains the cult dagger and rune list code
 		scribe_mod *= 0.5
 	if(!do_after(user, scribe_mod, target = get_turf(user)))
 		for(var/V in shields)
-			var/obj/structure/emergency_shield/sanguine/S = V
+			var/obj/structure/emergency_shield/cult/narsie/S = V
 			if(S && !QDELETED(S))
 				qdel(S)
 		return

--- a/code/modules/antagonists/cult/rune_spawn_action.dm
+++ b/code/modules/antagonists/cult/rune_spawn_action.dm
@@ -101,12 +101,6 @@
 	rune_center_type = /obj/effect/temp_visual/cult/rune_spawn/rune4/center
 	rune_color = RUNE_COLOR_DARKRED
 
-/datum/action/innate/cult/create_rune/wall/Activate()
-	. = ..()
-	var/obj/effect/rune/wall/W = locate(/obj/effect/rune/wall) in owner.loc
-	if(W)
-		W.spread_density()
-
 /datum/action/innate/cult/create_rune/revive
 	name = "Summon Revive Rune"
 	desc = "Summons a revive rune to your location, as though it has been there all along..."

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -610,79 +610,26 @@ structure_check() searches for nearby cultist structures required for the invoca
 	invocation = "Khari'd! Eske'te tannin!"
 	icon_state = "4"
 	color = RUNE_COLOR_DARKRED
-	CanAtmosPass = ATMOS_PASS_DENSITY
-	var/datum/timedevent/density_timer
-	var/recharging = FALSE
+	var/obj/structure/emergency_shield/cult/barrier/barrier //barrier is the path and variable name.... i am not a clever man
 
 /obj/effect/rune/wall/Initialize(mapload, set_keyword)
 	. = ..()
 	GLOB.wall_runes += src
 
-/obj/effect/rune/wall/examine(mob/user)
-	. = ..()
-	if(density && iscultist(user))
-		if(density_timer)
-			. += "<span class='cultitalic'>The air above this rune has hardened into a barrier that will last [DisplayTimeText(density_timer.timeToRun - world.time)].</span>"
-
 /obj/effect/rune/wall/Destroy()
 	GLOB.wall_runes -= src
 	return ..()
 
-/obj/effect/rune/wall/BlockSuperconductivity()
-	return density
-
 /obj/effect/rune/wall/invoke(var/list/invokers)
-	if(recharging)
-		return
 	var/mob/living/user = invokers[1]
 	..()
-	density = !density
-	update_state()
-	if(density)
-		spread_density()
-	var/carbon_user = iscarbon(user)
-	user.visible_message("<span class='warning'>[user] [carbon_user ? "places [user.p_their()] hands on":"stares intently at"] [src], and [density ? "the air above it begins to shimmer" : "the shimmer above it fades"].</span>", \
-						 "<span class='cult italic'>You channel [carbon_user ? "your life ":""]energy into [src], [density ? "temporarily preventing" : "allowing"] passage above it.</span>")
-	if(carbon_user)
+	if(!barrier)
+		barrier = new /obj/structure/emergency_shield/cult/barrier(src.loc)
+		barrier.parent_rune = src
+	barrier.Toggle()
+	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		C.apply_damage(2, BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
-
-/obj/effect/rune/wall/proc/spread_density()
-	for(var/R in GLOB.wall_runes)
-		var/obj/effect/rune/wall/W = R
-		if(W.z == z && get_dist(src, W) <= 2 && !W.density && !W.recharging)
-			W.density = TRUE
-			W.update_state()
-			W.spread_density()
-	density_timer = addtimer(CALLBACK(src, .proc/lose_density), 3000, TIMER_STOPPABLE)
-
-/obj/effect/rune/wall/proc/lose_density()
-	if(density)
-		recharging = TRUE
-		density = FALSE
-		update_state()
-		var/oldcolor = color
-		add_atom_colour("#696969", FIXED_COLOUR_PRIORITY)
-		animate(src, color = oldcolor, time = 50, easing = EASE_IN)
-		addtimer(CALLBACK(src, .proc/recharge), 50)
-
-/obj/effect/rune/wall/proc/recharge()
-	recharging = FALSE
-	add_atom_colour(RUNE_COLOR_MEDIUMRED, FIXED_COLOUR_PRIORITY)
-
-/obj/effect/rune/wall/proc/update_state()
-	deltimer(density_timer)
-	air_update_turf(1)
-	if(density)
-		var/mutable_appearance/shimmer = mutable_appearance('icons/effects/effects.dmi', "barriershimmer", ABOVE_MOB_LAYER)
-		shimmer.appearance_flags |= RESET_COLOR
-		shimmer.alpha = 60
-		shimmer.color = "#701414"
-		add_overlay(shimmer)
-		add_atom_colour(RUNE_COLOR_RED, FIXED_COLOUR_PRIORITY)
-	else
-		cut_overlays()
-		add_atom_colour(RUNE_COLOR_MEDIUMRED, FIXED_COLOUR_PRIORITY)
 
 //Rite of Joined Souls: Summons a single cultist.
 /obj/effect/rune/summon
@@ -861,7 +808,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		playsound(src, 'sound/magic/exit_blood.ogg', 50, TRUE)
 		visible_message("<span class='warning'>A cloud of red mist forms above [src], and from within steps... a [new_human.gender == FEMALE ? "wo":""]man.</span>")
 		to_chat(user, "<span class='cultitalic'>Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely...</span>")
-		var/obj/structure/emergency_shield/invoker/N = new(T)
+		var/obj/structure/emergency_shield/cult/weak/N = new(T)
 		new_human.key = ghost_to_spawn.key
 		SSticker.mode.add_cultist(new_human.mind, 0)
 		to_chat(new_human, "<span class='cultitalic'><b>You are a servant of the Geometer. You have been made semi-corporeal by the cult of Nar'Sie, and you are to serve them at all costs.</b></span>")

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -618,6 +618,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 
 /obj/effect/rune/wall/Destroy()
 	GLOB.wall_runes -= src
+	if(barrier && !QDELETED(barrier))
+		qdel(barrier)
 	return ..()
 
 /obj/effect/rune/wall/invoke(var/list/invokers)

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -610,6 +610,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	invocation = "Khari'd! Eske'te tannin!"
 	icon_state = "4"
 	color = RUNE_COLOR_DARKRED
+	///The barrier summoned by the rune when invoked. Tracked as a variable to prevent refreshing the barrier's integrity.
 	var/obj/structure/emergency_shield/cult/barrier/barrier //barrier is the path and variable name.... i am not a clever man
 
 /obj/effect/rune/wall/Initialize(mapload, set_keyword)
@@ -618,8 +619,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 
 /obj/effect/rune/wall/Destroy()
 	GLOB.wall_runes -= src
-	if(barrier && !QDELETED(barrier))
-		qdel(barrier)
+	if(barrier)
+		QDEL_NULL(barrier)
 	return ..()
 
 /obj/effect/rune/wall/invoke(var/list/invokers)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
cult code gave me a headache, give me an @ if you see something you dont like. this PR changes a lot of cult code
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
the cult stun nerf was really dumb and hamfisted by someone who didnt realize how cult actually wins after gaining a small foothold. with their nerf, cult is forced to avoid fighting mindshielded people at all costs(of which they cant even identify until AFTER they try to stun). The cult stun is balanced around the fact that cult is severely weak to ranged ballistics (read: the shotgun) and keeps cult able to take on security in melee. The previous nerf made cult weaker on BOTH fronts.

I made sure to play 2 rounds of cult before making this change, one as cult and one as non-cult. Not a large sample size but better than nothing. I was able to fight cult without even stunning them prior by just hitting them with a baseball bat, didnt even matter that i was an assistant with no other gear when the stunned me because i had gotten a mindshield from a crate outside of cargo. It was really dumb, and it felt like I cheated him out of a cult round.

Earlier, I had played as a cultist. After converting several non-implanted people and sacrificing our mindshielded target that a changeling had killed prior, I barrier'd myself into a room, scribed the narsie rune, and then used final reckoning as a horde of angry crewmembers lay staring dumbfounded at my omnipotent barrier rune. We straight up would have gotten overwhelmed if they could force past the barriers, as we were 100% outnumbered and outgunned. 

This PR reverts the stun change for the above mentioned reasons, and introduces 2 more severe nerfs that I argue will have a bigger effect on win rate while also making cult summon feel a LOT more fair by giving the crew a chance  to stop them.

Specifically, barrier rune can now be destroyed. It has 100 integrity, and erases the rune below it when it is broken. To prevent abuse, barrier runes cant be constantly invoked to replenish them, the integrity is persistent after lowering it. Clicking the barrier itself as a cult construct or cultist will invoke the rune to allow passage. Simple mobs that arent cultists are still able to smash the barrier.

Final reckoning has been limited to only areas that narsie cant be summoned in. This is to prevent the cheese/instant summons of the past which have often killed the mood as it removes the fight out of the final summon, usually combined with barrier runes. I have done this myself dozens of times. I did it earlier today even with the stun nerf to win. Masters will still be able to summon their cult outside of the summon location prior to get everyone near the location to prepare defending.

tl;dr removes the stun nerf, makes barrier runes breakable, cant final reckoning in summon locations
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:imsxz
balance: reverts the recent cult stun nerf, allowing mindshielded people to be stunned again
balance: cult barrier runes can be smashed until they break
balance: cult leaders can no longer use final reckoning in narsie summon locations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
