### PR TITLE
Speeds up /datum/light_source/proc/update_corners() by 16% or so

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -117,3 +117,27 @@
 #define EMISSIVE_BLOCK_GENERIC 1
 /// Uses a dedicated render_target object to copy the entire appearance in real time to the blocking layer. For things that can change in appearance a lot from the base state, like humans.
 #define EMISSIVE_BLOCK_UNIQUE 2
+
+/// Returns the red part of a RRGGBB hex sequence as number
+#define GETREDPART(hexa) text2num(copytext(hexa, 2, 4), 16)
+
+/// Returns the green part of a RRGGBB hex sequence as number
+#define GETGREENPART(hexa) text2num(copytext(hexa, 4, 6), 16)
+
+/// Returns the blue part of a RRGGBB hex sequence as number
+#define GETBLUEPART(hexa) text2num(copytext(hexa, 6, 8), 16)
+
+/// Parse the hexadecimal color into lumcounts of each perspective.
+#define PARSE_LIGHT_COLOR(source) \
+do { \
+	if (source.light_color) { \
+		var/__light_color = source.light_color; \
+		source.lum_r = GETREDPART(__light_color) / 255; \
+		source.lum_g = GETREDPART(__light_color) / 255; \
+		source.lum_b = GETREDPART(__light_color) / 255; \
+	} else { \
+		source.lum_r = 1; \
+		source.lum_g = 1; \
+		source.lum_b = 1; \
+	}; \
+} while (FALSE)

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -119,13 +119,13 @@
 #define EMISSIVE_BLOCK_UNIQUE 2
 
 /// Returns the red part of a RRGGBB hex sequence as number
-#define GETREDPART(hexa) text2num(copytext(hexa, 2, 4), 16)
+#define GETREDPART(hexa) hex2num(copytext(hexa, 2, 4))
 
 /// Returns the green part of a RRGGBB hex sequence as number
-#define GETGREENPART(hexa) text2num(copytext(hexa, 4, 6), 16)
+#define GETGREENPART(hexa) hex2num(copytext(hexa, 4, 6))
 
 /// Returns the blue part of a RRGGBB hex sequence as number
-#define GETBLUEPART(hexa) text2num(copytext(hexa, 6, 8), 16)
+#define GETBLUEPART(hexa) hex2num(copytext(hexa, 6, 8))
 
 /// Parse the hexadecimal color into lumcounts of each perspective.
 #define PARSE_LIGHT_COLOR(source) \
@@ -133,8 +133,8 @@ do { \
 	if (source.light_color) { \
 		var/__light_color = source.light_color; \
 		source.lum_r = GETREDPART(__light_color) / 255; \
-		source.lum_g = GETREDPART(__light_color) / 255; \
-		source.lum_b = GETREDPART(__light_color) / 255; \
+		source.lum_g = GETGREENPART(__light_color) / 255; \
+		source.lum_b = GETBLUEPART(__light_color) / 255; \
 	} else { \
 		source.lum_r = 1; \
 		source.lum_g = 1; \

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -118,13 +118,13 @@
 /// Uses a dedicated render_target object to copy the entire appearance in real time to the blocking layer. For things that can change in appearance a lot from the base state, like humans.
 #define EMISSIVE_BLOCK_UNIQUE 2
 
-/// Returns the red part of a RRGGBB hex sequence as number
+/// Returns the red part of a #RRGGBB hex sequence as number
 #define GETREDPART(hexa) hex2num(copytext(hexa, 2, 4))
 
-/// Returns the green part of a RRGGBB hex sequence as number
+/// Returns the green part of a #RRGGBB hex sequence as number
 #define GETGREENPART(hexa) hex2num(copytext(hexa, 4, 6))
 
-/// Returns the blue part of a RRGGBB hex sequence as number
+/// Returns the blue part of a #RRGGBB hex sequence as number
 #define GETBLUEPART(hexa) hex2num(copytext(hexa, 6, 8))
 
 /// Parse the hexadecimal color into lumcounts of each perspective.

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -527,15 +527,6 @@
 	var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
 	announcer.announce("ARRIVAL", character.real_name, rank, list()) //make the list empty to make it announce it in common
 
-/proc/GetRedPart(const/hexa)
-	return hex2num(copytext(hexa, 2, 4))
-
-/proc/GetGreenPart(const/hexa)
-	return hex2num(copytext(hexa, 4, 6))
-
-/proc/GetBluePart(const/hexa)
-	return hex2num(copytext(hexa, 6, 8))
-
 /proc/lavaland_equipment_pressure_check(turf/T)
 	. = FALSE
 	if(!istype(T))

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -163,6 +163,7 @@
 	APPLY_CORNER(C)
 	UNSETEMPTY(effect_str)
 
+
 /datum/light_source/proc/update_corners()
 	var/update = FALSE
 	var/atom/source_atom = src.source_atom
@@ -229,11 +230,16 @@
 	var/thing
 	var/datum/lighting_corner/C
 	var/turf/T
+
 	if (source_turf)
 		var/oldlum = source_turf.luminosity
 		source_turf.luminosity = CEILING(light_range, 1)
 		for(T in view(CEILING(light_range, 1), source_turf))
-			for (thing in T.get_corners(source_turf))
+			if((!IS_DYNAMIC_LIGHTING(T) && !T.light_sources) || T.has_opaque_atom)
+				continue
+			if (!T.lighting_corners_initialised)
+				T.generate_missing_corners()
+			for (thing in T.corners)
 				C = thing
 				corners[C] = 0
 			turfs += T

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -43,7 +43,7 @@
 	light_range = source_atom.light_range
 	light_color = source_atom.light_color
 
-	parse_light_color()
+	PARSE_LIGHT_COLOR(src)
 
 	update()
 
@@ -94,7 +94,6 @@
 /datum/light_source/proc/vis_update()
 	EFFECT_UPDATE(LIGHTING_VIS_UPDATE)
 
-// Decompile the hexadecimal colour into lumcounts of each perspective.
 /datum/light_source/proc/parse_light_color()
 	if (light_color)
 		lum_r = GetRedPart   (light_color) / 255
@@ -164,7 +163,156 @@
 	UNSETEMPTY(effect_str)
 
 
+/datum/light_source/proc/update_corners_new()
+	var/update = FALSE
+	var/atom/source_atom = src.source_atom
+
+	if (QDELETED(source_atom))
+		qdel(src)
+		return
+
+	if (source_atom.light_power != light_power)
+		light_power = source_atom.light_power
+		update = TRUE
+
+	if (source_atom.light_range != light_range)
+		light_range = source_atom.light_range
+		update = TRUE
+
+	if (!top_atom)
+		top_atom = source_atom
+		update = TRUE
+
+	if (!light_range || !light_power)
+		qdel(src)
+		return
+
+	if (isturf(top_atom))
+		if (source_turf != top_atom)
+			source_turf = top_atom
+			pixel_turf = source_turf
+			update = TRUE
+	else if (top_atom.loc != source_turf)
+		source_turf = top_atom.loc
+		pixel_turf = get_turf_pixel(top_atom)
+		update = TRUE
+	else
+		var/P = get_turf_pixel(top_atom)
+		if (P != pixel_turf)
+			pixel_turf = P
+			update = TRUE
+
+	if (!isturf(source_turf))
+		if (applied)
+			remove_lum()
+		return
+
+	if (light_range && light_power && !applied)
+		update = TRUE
+
+	if (source_atom.light_color != light_color)
+		light_color = source_atom.light_color
+		PARSE_LIGHT_COLOR(src)
+		update = TRUE
+
+	else if (applied_lum_r != lum_r || applied_lum_g != lum_g || applied_lum_b != lum_b)
+		update = TRUE
+
+	if (update)
+		needs_update = LIGHTING_CHECK_UPDATE
+		applied = TRUE
+	else if (needs_update == LIGHTING_CHECK_UPDATE)
+		return //nothing's changed
+
+	var/list/datum/lighting_corner/corners = list()
+	var/list/turf/turfs                    = list()
+	var/thing
+	var/datum/lighting_corner/C
+	var/turf/T
+
+	if (source_turf)
+		var/oldlum = source_turf.luminosity
+		source_turf.luminosity = CEILING(light_range, 1)
+		for(T in view(CEILING(light_range, 1), source_turf))
+			if((!IS_DYNAMIC_LIGHTING(T) && !T.light_sources) || T.has_opaque_atom)
+				continue
+			if (!T.lighting_corners_initialised)
+				T.generate_missing_corners()
+			for (thing in T.corners)
+				C = thing
+				corners[C] = 0
+			turfs += T
+		source_turf.luminosity = oldlum
+
+	LAZYINITLIST(affecting_turfs)
+	var/list/L = turfs - affecting_turfs // New turfs, add us to the affecting lights of them.
+	affecting_turfs += L
+	for (thing in L)
+		T = thing
+		LAZYADD(T.affecting_lights, src)
+
+	L = affecting_turfs - turfs // Now-gone turfs, remove us from the affecting lights.
+	affecting_turfs -= L
+	for (thing in L)
+		T = thing
+		LAZYREMOVE(T.affecting_lights, src)
+
+	LAZYINITLIST(effect_str)
+	if (needs_update == LIGHTING_VIS_UPDATE)
+		for (thing in  corners - effect_str) // New corners
+			C = thing
+			LAZYADD(C.affecting, src)
+			if (!C.active)
+				effect_str[C] = 0
+				continue
+			APPLY_CORNER(C)
+	else
+		L = corners - effect_str
+		for (thing in L) // New corners
+			C = thing
+			LAZYADD(C.affecting, src)
+			if (!C.active)
+				effect_str[C] = 0
+				continue
+			APPLY_CORNER(C)
+
+		for (thing in corners - L) // Existing corners
+			C = thing
+			if (!C.active)
+				effect_str[C] = 0
+				continue
+			APPLY_CORNER(C)
+
+	L = effect_str - corners
+	for (thing in L) // Old, now gone, corners.
+		C = thing
+		REMOVE_CORNER(C)
+		LAZYREMOVE(C.affecting, src)
+	effect_str -= L
+
+	applied_lum_r = lum_r
+	applied_lum_g = lum_g
+	applied_lum_b = lum_b
+
+	UNSETEMPTY(effect_str)
+	UNSETEMPTY(affecting_turfs)
+
+/turf/proc/get_corners()
+	if (!IS_DYNAMIC_LIGHTING(src) && !light_sources)
+		return null
+	if (!lighting_corners_initialised)
+		generate_missing_corners()
+	if (has_opaque_atom)
+		return null // Since this proc gets used in a for loop, null won't be looped though.
+
+	return corners
+
 /datum/light_source/proc/update_corners()
+	if (prob(100))
+		return update_corners_old()
+	return update_corners_new()
+
+/datum/light_source/proc/update_corners_old()
 	var/update = FALSE
 	var/atom/source_atom = src.source_atom
 
@@ -235,11 +383,7 @@
 		var/oldlum = source_turf.luminosity
 		source_turf.luminosity = CEILING(light_range, 1)
 		for(T in view(CEILING(light_range, 1), source_turf))
-			if((!IS_DYNAMIC_LIGHTING(T) && !T.light_sources) || T.has_opaque_atom)
-				continue
-			if (!T.lighting_corners_initialised)
-				T.generate_missing_corners()
-			for (thing in T.corners)
+			for (thing in T.get_corners())
 				C = thing
 				corners[C] = 0
 			turfs += T

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -110,16 +110,6 @@
 			else
 				lighting_clear_overlay()
 
-/turf/proc/get_corners()
-	if (!IS_DYNAMIC_LIGHTING(src) && !light_sources)
-		return null
-	if (!lighting_corners_initialised)
-		generate_missing_corners()
-	if (has_opaque_atom)
-		return null // Since this proc gets used in a for loop, null won't be looped though.
-
-	return corners
-
 /turf/proc/generate_missing_corners()
 	if (!IS_DYNAMIC_LIGHTING(src) && !light_sources)
 		return
@@ -132,5 +122,3 @@
 			continue
 
 		corners[i] = new/datum/lighting_corner(src, GLOB.LIGHTING_CORNER_DIAGONAL[i])
-
-

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -44,9 +44,9 @@
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		default_color = "#" + H.dna.features["ethcolor"]
-		r1 = GetRedPart(default_color)
-		g1 = GetGreenPart(default_color)
-		b1 = GetBluePart(default_color)
+		r1 = GETREDPART(default_color)
+		g1 = GETGREENPART(default_color)
+		b1 = GETBLUEPART(default_color)
 		spec_updatehealth(H)
 		RegisterSignal(C, COMSIG_ATOM_EMAG_ACT, .proc/on_emag_act)
 		RegisterSignal(C, COMSIG_ATOM_EMP_ACT, .proc/on_emp_act)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Just moving `/turf/proc/get_corners()` into its only caller, slightly shuffled. 

+ Also #defining `/proc/GetRedPart()` etc, which should flatten down to a copytext+text2num operation with #51005. Also defining `parse_light_color()` since it has two callers and does something trivial (splits #ff0000 into three luminance vars). 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
profile from first commit:
![image](https://user-images.githubusercontent.com/20017308/81459809-46695f00-91aa-11ea-8604-0ffa4f28b623.png)

## Changelog
:cl: Naksu
code: Lighting corner updates are ever so slightly faster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
