### PR TITLE
Silences proximity sensor runtime

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -241,6 +241,7 @@
 
 	targeted_by = null
 	QDEL_NULL(light)
+	QDEL_NULL(proximity_monitor)
 
 	return ..()
 

--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -20,13 +20,26 @@
 	if(host)
 		UnregisterSignal(host, COMSIG_MOVABLE_MOVED)
 	if(R)
-		hasprox_receiver = R
+		set_prox_receiver(R)
 	else if(hasprox_receiver == host) //Default case
-		hasprox_receiver = H
+		set_prox_receiver(H)
 	host = H
 	RegisterSignal(host, COMSIG_MOVABLE_MOVED, .proc/HandleMove)
 	last_host_loc = host.loc
 	SetRange(current_range,TRUE)
+
+/// Sets signal callbacks for crossed
+/datum/proximity_monitor/proc/set_prox_receiver(atom/R)
+	if(hasprox_receiver)
+		for(var/i in checkers)
+			UnregisterSignal(i, COMSIG_MOVABLE_CROSSED)
+	hasprox_receiver = R
+	for(var/i in checkers)
+		RegisterSignal(i, COMSIG_MOVABLE_CROSSED, .proc/crossed_callback)
+
+/// Callback for crossing of effects
+/datum/proximity_monitor/proc/crossed_callback(/obj/effect/abstract/proximity_checker/source, atom/movable/AM)
+	hasprox_receiver.HasProximity(AM)
 
 /datum/proximity_monitor/Destroy()
 	host = null
@@ -109,8 +122,3 @@
 /obj/effect/abstract/proximity_checker/Destroy()
 	monitor = null
 	return ..()
-
-/obj/effect/abstract/proximity_checker/Crossed(atom/movable/AM)
-	set waitfor = FALSE
-	. = ..()
-	monitor.hasprox_receiver.HasProximity(AM)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
#50965 done properly
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

the prox datum will cause qdel on the atom to fail and force a hard del, leaving a dangling datum kept alive by the /obj/effects that still exist in the map and when something crosses them they try to call a proc on the atom that was harddelled