### PR TITLE
Fix a rare edgecase with explosions and shuttles

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -74,6 +74,12 @@ SUBSYSTEM_DEF(explosions)
 /datum/controller/subsystem/explosions/proc/is_exploding()
 	return (lowturf.len || medturf.len || highturf.len || flameturf.len || throwturf.len || lowobj.len || medobj.len || highobj.len)
 
+/datum/controller/subsystem/explosions/proc/wipe_turf(turf/T)
+	lowturf -= T
+	medturf -= T
+	highturf -= T
+	flameturf -= T
+	throwturf -= T
 
 /client/proc/check_bomb_impacts()
 	set name = "Check Bomb Impact"

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -71,6 +71,8 @@ All ShuttleMove procs go here
 /turf/proc/afterShuttleMove(turf/oldT, rotation)
 	//Dealing with the turf we left behind
 	oldT.TransferComponents(src)
+
+	SSexplosions.wipe_turf(src)
 	var/shuttle_boundary = baseturfs.Find(/turf/baseturf_skipover/shuttle)
 	if(shuttle_boundary)
 		oldT.ScrapeAway(baseturfs.len - shuttle_boundary + 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
shuttles moving into explosions probably shouldnt have explosions on their turfs that started before the shuttle moved