### PR TITLE
If a client is online when they link accounts, also verify them

### DIFF
--- a/code/modules/discord/accountlink.dm
+++ b/code/modules/discord/accountlink.dm
@@ -59,35 +59,5 @@
 	if(!SSdiscord)
 		to_chat(src, "<span class='notice'>The server is still starting up. Please wait before attempting to link your account!</span>")
 		return
-
-	// check that tgs is alive and well
-	if(!SSdiscord.enabled)
-		to_chat(src, "<span class='warning'>This feature requires the server is running on the TGS toolkit.</span>")
-		return
-
-	// check that this is not an IDIOT mistaking us for an attack vector
-	if(SSdiscord.reverify_cache[usr.ckey] == TRUE)
-		to_chat(src, "<span class='warning'>Thou can only do this once a round, if you're stuck seek help.</span>")
-		return
-	SSdiscord.reverify_cache[usr.ckey] = TRUE
-
-	// check that account is linked with discord
-	var/stored_id = SSdiscord.lookup_id(usr.ckey)
-	if(!stored_id) // Account is not linked
-		to_chat(usr, "Link your discord account via the linkdiscord verb in the OOC tab first");
-		return
-
-	// check for living hours requirement
-	var/required_living_minutes = CONFIG_GET(number/required_living_hours) * 60
-	var/living_minutes = usr.client ? usr.client.get_exp_living(TRUE) : 0
-	if(required_living_minutes <= 0)
-		CRASH("The discord verification system is setup to require zero hours or less, this is likely a configuration bug")
-		
-	if(living_minutes < required_living_minutes)
-		to_chat(usr, "<span class='warning'>You must have at least [required_living_minutes] minutes of living " \
-			+ "playtime in a round to verify. You have [living_minutes] minutes. Play more!</span>")
-		return
-
-	// honey its time for your role flattening
-	to_chat(usr, "<span class='notice'>Discord verified</span>")
-	SSdiscord.grant_role(stored_id)
+	//Do the work
+	SSdiscord.verify_client_in_discord(src)

--- a/code/modules/discord/tgs_commands.dm
+++ b/code/modules/discord/tgs_commands.dm
@@ -19,12 +19,19 @@
 	help_text = "Verifies your discord account and your BYOND account linkage"
 
 /datum/tgs_chat_command/verify/Run(datum/tgs_chat_user/sender, params)
-	var/lowerparams = replacetext(lowertext(params), " ", "") // Fuck spaces
+	var/ckey = replacetext(lowertext(params), " ", "") // Fuck spaces
 	var/discordid = SSdiscord.id_clean(sender.mention)
-	if(SSdiscord.account_link_cache[lowerparams]) // First if they are in the list, then if the ckey matches
-		if(SSdiscord.account_link_cache[lowerparams] == discordid) // If the associated ID is the correct one
+	if(SSdiscord.account_link_cache[ckey]) // First if they are in the list, then if the ckey matches
+		if(SSdiscord.account_link_cache[ckey] == discordid) // If the associated ID is the correct one
 			// Link the account in the DB table
-			SSdiscord.link_account(lowerparams)
+			SSdiscord.link_account(ckey, discordid)
+			//Try to find the client online (we assume this is possible)
+			var/verifying_client = GLOB.directory[ckey]
+			if(verifying_client)
+				//We want to unset the cache in case they pushed the verify in discord verb first
+				SSdiscord.reverify_cache[ckey] = FALSE;
+				//Also dole out the verified role in discord if they're eligible
+				SSdiscord.verify_client_in_discord(verifying_client);
 			return "Successfully linked accounts"
 		else
 			return "That ckey is not associated to this discord account. If someone has used your ID, please inform an administrator"


### PR DESCRIPTION
This saves having to do a two step process, but only works if the user
is online so we can grab their prefs datum for their living hours.

Given a user has to login to do the link step, we can usually assume
this is true
