### PR TITLE
Fixes circlegame qdel + emote logic

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -684,10 +684,14 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/circlegame/Destroy()
 	var/mob/owner = loc
-	if(!istype(owner))
-		return
-	UnregisterSignal(owner, COMSIG_PARENT_EXAMINE)
-	. = ..()
+	if(istype(owner))
+		UnregisterSignal(owner, COMSIG_PARENT_EXAMINE)
+	return ..()
+
+/obj/item/circlegame/dropped()
+	UnregisterSignal(owner, COMSIG_PARENT_EXAMINE)		//loc will have changed by the time this is called, so Destroy() can't catch it
+	// this is a dropdel item.
+	return ..()
 
 /// Stage 1: The mistake is made
 /obj/item/circlegame/proc/ownerExamined(mob/living/owner, mob/living/sucker)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -688,8 +688,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		UnregisterSignal(owner, COMSIG_PARENT_EXAMINE)
 	return ..()
 
-/obj/item/circlegame/dropped()
-	UnregisterSignal(owner, COMSIG_PARENT_EXAMINE)		//loc will have changed by the time this is called, so Destroy() can't catch it
+/obj/item/circlegame/dropped(mob/user)
+	UnregisterSignal(user, COMSIG_PARENT_EXAMINE)		//loc will have changed by the time this is called, so Destroy() can't catch it
 	// this is a dropdel item.
 	return ..()
 

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -115,12 +115,12 @@
 
 /datum/emote/living/carbon/circle/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
+	if(!length(user.get_empty_held_indexes()))
+		to_chat(user, "<span class='warning'>You don't have any free hands to make a circle with.</span>")
+		return
 	var/obj/item/circlegame/N = new(user)
 	if(user.put_in_hands(N))
 		to_chat(user, "<span class='notice'>You make a circle with your hand.</span>")
-	else
-		qdel(N)
-		to_chat(user, "<span class='warning'>You don't have any free hands to make a circle with.</span>")
 
 /datum/emote/living/carbon/slap
 	key = "slap"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes circlegame items not properly deleting.
drop location forcemove is called before dropped
qdel happens in dropped by dropdel flag
by the time qdel fires, it'll no longer be on a mob, resulting in it not being moved to nullspace and staying on the floor and not being garbage collected
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

help please stop filling the station with circlegames this kills the garbage machine!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Circlegame items now properly delete on drop and can't be made with full hands.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
