### PR TITLE
Updates dynamic restricted roles after loading config

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -82,11 +82,6 @@
 
 /datum/dynamic_ruleset/New()
 	..()
-	if(CONFIG_GET(flag/protect_roles_from_antagonist))
-		restricted_roles += protected_roles
-	if(CONFIG_GET(flag/protect_assistant_from_antagonist))
-		restricted_roles += "Assistant"
-
 	if (istype(SSticker.mode, /datum/game_mode/dynamic))
 		mode = SSticker.mode
 	else if (GLOB.master_mode != "dynamic") // This is here to make roundstart forced ruleset function.
@@ -144,6 +139,11 @@
 /// Do everything you need to do before job is assigned here.
 /// IMPORTANT: ASSIGN special_role HERE
 /datum/dynamic_ruleset/proc/pre_execute()
+	SHOULD_CALL_PARENT(TRUE)
+	if(CONFIG_GET(flag/protect_roles_from_antagonist))
+		restricted_roles += protected_roles
+	if(CONFIG_GET(flag/protect_assistant_from_antagonist))
+		restricted_roles += "Assistant"
 	return TRUE
 
 /// Called on post_setup on roundstart and when the rule executes on midround and latejoin.

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -23,6 +23,7 @@
 	var/autotraitor_cooldown = 450 // 15 minutes (ticks once per 2 sec)
 
 /datum/dynamic_ruleset/roundstart/traitor/pre_execute()
+	. = ..()
 	var/num_traitors = antag_cap[indice_pop] * (scaled_times + 1)
 	for (var/i = 1 to num_traitors)
 		var/mob/M = pick_n_take(candidates)
@@ -64,6 +65,7 @@
 	var/const/min_team_size = 2
 
 /datum/dynamic_ruleset/roundstart/traitorbro/pre_execute()
+	. = ..()
 	var/num_teams = (antag_cap[indice_pop]/min_team_size) * (scaled_times + 1) // 1 team per scaling
 	for(var/j = 1 to num_teams)
 		if(candidates.len < min_team_size || candidates.len < required_candidates)
@@ -113,6 +115,7 @@
 	var/team_mode_probability = 30
 
 /datum/dynamic_ruleset/roundstart/changeling/pre_execute()
+	. = ..()
 	var/num_changelings = antag_cap[indice_pop] * (scaled_times + 1)
 	for (var/i = 1 to num_changelings)
 		var/mob/M = pick_n_take(candidates)
@@ -170,6 +173,7 @@
 	return ..()
 
 /datum/dynamic_ruleset/roundstart/wizard/pre_execute()
+	. = ..()
 	if(GLOB.wizardstart.len == 0)
 		return FALSE
 	mode.antags_rolled += 1
@@ -213,6 +217,7 @@
 	. = ..()
 
 /datum/dynamic_ruleset/roundstart/bloodcult/pre_execute()
+	. = ..()
 	var/cultists = antag_cap[indice_pop]
 	mode.antags_rolled += cultists
 	for(var/cultists_number = 1 to cultists)
@@ -272,6 +277,7 @@
 	. = ..()
 
 /datum/dynamic_ruleset/roundstart/nuclear/pre_execute()
+	. = ..()
 	// If ready() did its job, candidates should have 5 or more members in it
 	var/operatives = antag_cap[indice_pop]
 	mode.antags_rolled += operatives
@@ -359,6 +365,7 @@
 	var/finished = FALSE
 
 /datum/dynamic_ruleset/roundstart/revs/pre_execute()
+	. = ..()
 	var/max_candidates = antag_cap[indice_pop]
 	mode.antags_rolled += max_candidates
 	for(var/i = 1 to max_candidates)
@@ -474,6 +481,7 @@
 	high_population_requirement = 101
 
 /datum/dynamic_ruleset/roundstart/extended/pre_execute()
+	. = ..()
 	message_admins("Starting a round of extended.")
 	log_game("Starting a round of extended.")
 	mode.spend_threat(mode.threat)
@@ -524,6 +532,7 @@
 	antag_cap = list(1,1,1,2,2,2,3,3,3,4)
 
 /datum/dynamic_ruleset/roundstart/devil/pre_execute()
+	. = ..()
 	var/num_devils = antag_cap[indice_pop]
 	mode.antags_rolled += num_devils
 
@@ -581,6 +590,7 @@
 	var/datum/team/monkey/monkey_team
 
 /datum/dynamic_ruleset/roundstart/monkey/pre_execute()
+	. = ..()
 	var/carriers_to_make = max(round(mode.roundstart_pop_ready / players_per_carrier, 1), 1)
 	mode.antags_rolled += carriers_to_make
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes rulesets update the restricted roles list just before executing, these were previously overwritten by loading the values from the dynamic config.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #51025
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Dynamic config no longer overwrites ruleset restricted roles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
