### PR TITLE
Fix some of the .travis.yml lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: generic
+os: linux
 dist: xenial
-sudo: false
 
 branches:
   except:
   - ___TGS3TempBranch
   - ___TGSTempBranch
 
-matrix:
+jobs:
   include:
     - name: "Run Linters"
       addons:
@@ -97,5 +97,5 @@ matrix:
         provider: pages
         skip_cleanup: true
         local_dir: dmdoc
-        github_token: $DMDOC_GITHUB_TOKEN
+        token: $DMDOC_GITHUB_TOKEN
         fqdn: codedocs.tgstation13.org


### PR DESCRIPTION
Fixes:
* root: deprecated key sudo (The key `sudo` has no effect anymore.)
* root: missing os, using the default linux
* jobs.include.deploy: key github_token is an alias for token, using token
* root: key matrix is an alias for jobs, using jobs

Ignores deploy lints because I don't want to break anything:
* jobs.include.deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)
* jobs.include.deploy: missing strategy, using the default git

Ignores this because it's just informational:
* jobs.include: skipping job #​1, because its condition does not match: branch = master AND head_branc ... 