### PR TITLE
Fixes painting icon bug

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -286,14 +286,6 @@
 	if(!C.painting_name)
 		C.try_rename(user)
 
-/obj/structure/sign/painting/update_icon_state()
-	. = ..()
-	if(C && C.generated_icon)
-		icon_state = null
-	else
-		icon_state = "frame-empty"
-
-
 /obj/structure/sign/painting/update_overlays()
 	. = ..()
 	if(C && C.generated_icon)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #50883
Removes a block of code that just sets the icon_state to null if a painting is in the frame, which isn't necessary since the painting covers the frame anyway. Someone please stop me if I missed something and this proc is actually useful.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Paintings are more enjoyable without distracting error signs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
