### PR TITLE
Revert "Changes icon state fallback order"

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -19,9 +19,8 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	var/righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 
 	///Icon file for mob worn overlays.
+	///no var for state because it should *always* be the same as icon_state
 	var/icon/mob_overlay_icon
-	///Icon state for mob worn overlays. If not set falls back to item_state, then icon_state
-	var/mob_overlay_state
 	///Forced mob worn layer instead of the standard preferred ssize.
 	var/alternate_worn_layer
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -499,9 +499,7 @@ generate/load female uniform sprites matching all previously decided variables
 	if(override_state)
 		t_state = override_state
 	else
-		if (!isinhands && mob_overlay_state)
-			t_state = mob_overlay_state
-		else if(item_state)
+		if(isinhands && item_state)
 			t_state = item_state
 		else
 			t_state = icon_state


### PR DESCRIPTION
should be testmerged for a bit, im pretty sure it breaks icons even further, causing things like hardsuits being black and pink and cloaks all being the qm cloak