### PR TITLE
Fixes icon fallback order.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -19,8 +19,9 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	var/righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 
 	///Icon file for mob worn overlays.
-	///no var for state because it should *always* be the same as icon_state
 	var/icon/mob_overlay_icon
+	///Item state for mob worn overlays
+	var/mob_overlay_state
 	///Forced mob worn layer instead of the standard preferred ssize.
 	var/alternate_worn_layer
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -499,7 +499,9 @@ generate/load female uniform sprites matching all previously decided variables
 	if(override_state)
 		t_state = override_state
 	else
-		if(isinhands && item_state)
+		if (mob_overlay_state)
+			t_state = mob_overlay_state
+		else if(isinhands && item_state)
 			t_state = item_state
 		else
 			t_state = icon_state

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -499,10 +499,10 @@ generate/load female uniform sprites matching all previously decided variables
 	if(override_state)
 		t_state = override_state
 	else
-		if (mob_overlay_state)
-			t_state = mob_overlay_state
-		else if(isinhands && item_state)
+		if(isinhands && item_state)
 			t_state = item_state
+		else if(mob_overlay_state)
+			t_state = mob_overlay_state
 		else
 			t_state = icon_state
 	var/t_icon = mob_overlay_icon

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -499,10 +499,10 @@ generate/load female uniform sprites matching all previously decided variables
 	if(override_state)
 		t_state = override_state
 	else
-		if(isinhands && item_state)
-			t_state = item_state
-		else if(mob_overlay_state)
+		if (mob_overlay_state)
 			t_state = mob_overlay_state
+		else if(isinhands && item_state)
+			t_state = item_state
 		else
 			t_state = icon_state
 	var/t_icon = mob_overlay_icon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Yall don't understand simple logic.
Makes redundant https://github.com/tgstation/tgstation/pull/51051

## Why It's Good For The Game

item_state is only supposed to be used for inhands. Anything else breaks shit.
Fallback order is now as follows
if inhand: mob_overlay_state > item_state > icon_state
if not inhand: mob_overlay_state > icon_state

## Changelog
:cl:
fix: Fixed a lot of broken sprites.
/:cl: