### PR TITLE
Makes the required version more obvious

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -37,7 +37,7 @@
 #if DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 513.1508 or higher
+#error You need version 513.1514 or higher
 #endif
 
 //Additional code for the above flags.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The num_to_hex pr #51005 updated the required version without updating the error message _sweep sweep sweep_

## Why It's Good For The Game

This looks like a bug at first glance, let's fix that.
## Changelog
:cl:
fix: Dear out of date coders, you will now be yelled at to update to the correct version of byond, rather then an unsupported one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
