### PR TITLE
Reconnects Pubby Medbay to the power grid

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -24927,6 +24927,7 @@
 /obj/structure/sign/departments/psychology{
 	pixel_y = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/storage/emergency/port)
 "bmk" = (
@@ -25276,6 +25277,7 @@
 "bnw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
 /turf/closed/wall,
 /area/storage/emergency/port)
 "bnx" = (
@@ -25656,6 +25658,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/chair/sofa/left,
 /obj/item/toy/plush/moth,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "boy" = (
@@ -26092,6 +26095,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "bpB" = (
@@ -26766,6 +26770,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/psychology)
 "bqY" = (
@@ -26773,6 +26778,7 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/psychology)
 "bqZ" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Psychology office deleted the power cables.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't have to do this manually every pubby round
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Power has been restored to Pubby's Medbay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
