### PR TITLE
Untrivializing AI upload boards/Ending the upload war meme

### DIFF
--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -5,6 +5,10 @@
 	icon_state = "command"
 	build_path = /obj/machinery/computer/upload/ai
 
+/obj/item/circuitboard/computer/aiupload/Initialize()
+	. = ..()
+	AddComponent(/datum/component/gps, "Inactive Encrypted Upload")
+
 /obj/item/circuitboard/computer/borgupload
 	name = "Cyborg Upload (Computer Board)"
 	icon_state = "command"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1430,6 +1430,15 @@
 	crate_name = "robotics assembly crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 
+/datum/supply_pack/science/aiupload
+	name = "AI Upload Board"
+	desc = "AI Upload Board to change the AIs laws. Garaunteed to purge 99% of fleshbags with just one swipe! Requires AI upload access to open."
+	cost = 7500
+	access = ACCESS_AI_UPLOAD
+	contains = list(/obj/item/circuitboard/computer/aiupload)
+	crate_name = "AI law Upload Board crate"
+	crate_type = /obj/structure/closet/crate/secure/science
+
 /datum/supply_pack/science/rped
 	name = "RPED crate"
 	desc = "Need to rebuild the ORM but science got annihialted after a bomb test? Buy this for the most advanced parts NT can give you."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1432,7 +1432,7 @@
 
 /datum/supply_pack/science/aiupload
 	name = "AI Upload Board"
-	desc = "AI Upload Board to change the AIs laws. Garaunteed to purge 99% of fleshbags with just one swipe! Requires AI upload access to open."
+	desc = "An AI Upload Board to change the AI's laws. Guaranteed to purge 99% of fleshbags with just one swipe! Requires AI Upload access to open."
 	cost = 7500
 	access = ACCESS_AI_UPLOAD
 	contains = list(/obj/item/circuitboard/computer/aiupload)

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -46,15 +46,6 @@
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/board/aiupload
-	name = "Computer Design (AI Upload)"
-	desc = "Allows for the construction of circuit boards used to build an AI Upload Console."
-	id = "aiupload"
-	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000, /datum/material/diamond = 2000, /datum/material/bluespace = 2000)
-	build_path = /obj/item/circuitboard/computer/aiupload
-	category = list("Computer Boards")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
-
 /datum/design/board/borgupload
 	name = "Computer Design (Cyborg Upload)"
 	desc = "Allows for the construction of circuit boards used to build a Cyborg Upload Console."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -338,7 +338,7 @@
 	prereq_ids = list("adv_robotics")
 	design_ids = list("aifixer", "aicore", "safeguard_module", "onehuman_module", "protectstation_module", "quarantine_module", "oxygen_module", "freeform_module",
 	"reset_module", "purge_module", "remove_module", "freeformcore_module", "asimov_module", "paladin_module", "tyrant_module", "overlord_module", "corporate_module",
-	"default_module", "borg_ai_control", "mecha_tracking_ai_control", "aiupload", "intellicard")
+	"default_module", "borg_ai_control", "mecha_tracking_ai_control", "intellicard")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
## About The Pull Request

You know those rounds where we get stuff like
AI law changes:40
And we all laugh and feel bad for the AI?
Yea well we should address that

Divina/Nist explains the issue better than I:
https://docs.google.com/document/d/1NVwuxMHPRKJVogR2P1l8a8LgrdUL-J3on-tGSHAu3GU/edit?usp=sharing

I'm open to rebalancing the specific cost for the board but it's set to 7500 for now

If you feel this nerfs traitors too much do propose alternatives please
## Why It's Good For The Game

Laws are gooder, spam is less
## Changelog
:cl:
add: AI uploads may be ordered in cargo for 7500 credits
balance: AI uploads may no longer be researched or printed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
