### PR TITLE
Fixes scrubber cooling

### DIFF
--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -79,6 +79,10 @@
 /turf/open/space/Assimilate_Air()
 	return
 
+//IT SHOULD RETURN NULL YOU MONKEY, WHY IN TARNATION WHAT THE FUCKING FUCK
+/turf/open/space/remove_air(amount)
+	return null
+
 /turf/open/space/proc/update_starlight()
 	if(CONFIG_GET(flag/starlight))
 		for(var/t in RANGE_TURFS(1,src)) //RANGE_TURFS is in code\__HELPERS\game.dm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can currently cool a pipenet by scrubbing space. Shoot me.
This is because the bit that stops heat share in scrubber code relies on a null check. And fortunately for us, for some ungodly reason, 
![image](https://user-images.githubusercontent.com/58055496/81792988-9f443a80-94bd-11ea-962e-12daaeaa2a0f.png)
returns nonnull on a space gasmix. And so, we force the null return.

## Why It's Good For The Game
Something something scrubbers should not be better coolers then fucking freezers.

## Changelog
:cl: LemonInTheDark, with thanks to ArcaneDefence for the pointer
fix: Scrubbers no longer cool pipenets attached to them when scrubbing space
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
