### PR TITLE
Fixes manually attached barcodes

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -128,6 +128,9 @@
 			to_chat(user, "<span class='warning'>For some reason, you can't attach [W]!</span>")
 			return
 		sticker = stickerA
+		var/list/wrap_contents = src.GetAllContents()
+		for(var/obj/I in wrap_contents)
+			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, sticker.percent_cut)
 		var/overlaystring = "[icon_state]_tag"
 		if(giftwrapped)
 			overlaystring = copytext_char(overlaystring, 5) //5 == length("gift") + 1
@@ -306,6 +309,9 @@
 			to_chat(user, "<span class='warning'>For some reason, you can't attach [W]!</span>")
 			return
 		sticker = stickerA
+		var/list/wrap_contents = src.GetAllContents()
+		for(var/obj/I in wrap_contents)
+			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, sticker.percent_cut)
 		var/overlaystring = "[icon_state]_tag"
 		if(giftwrapped)
 			overlaystring = copytext_char(overlaystring, 5) //5 == length("gift") + 1
@@ -398,14 +404,16 @@
 	if(istype(I, /obj/item/card/id))
 		var/obj/item/card/id/potential_acc = I
 		if(potential_acc.registered_account)
-			payments_acc = potential_acc.registered_account
-			playsound(src, 'sound/machines/ping.ogg', 40, TRUE)
-			to_chat(user, "<span class='notice'>[src] registers the ID card. Tag a wrapped item to create a barcode.</span>")
+			if(payments_acc == potential_acc.registered_account)
+				to_chat(user, "<span class='notice'>ID card already registered.</span>")
+				return
+			else
+				payments_acc = potential_acc.registered_account
+				playsound(src, 'sound/machines/ping.ogg', 40, TRUE)
+				to_chat(user, "<span class='notice'>[src] registers the ID card. Tag a wrapped item to create a barcode.</span>")
 		else if(!potential_acc.registered_account)
 			to_chat(user, "<span class='warning'>This ID card has no account registered!</span>")
 			return
-		else if(payments_acc != potential_acc.registered_account)
-			to_chat(user, "<span class='notice'>ID card already registered.</span>")
 	if(istype(I, /obj/item/paper))
 		if (!(paper_count >=  max_paper_count))
 			paper_count += 10
@@ -432,7 +440,8 @@
 	playsound(src, 'sound/machines/click.ogg', 40, TRUE)
 	to_chat(user, "<span class='notice'>You print a new barcode.</span>")
 	var/obj/item/barcode/new_barcode = new /obj/item/barcode(src)
-	new_barcode.payments_acc = payments_acc		//The sticker gets the scanner's registered account.
+	new_barcode.payments_acc = payments_acc		// The sticker gets the scanner's registered account.
+	new_barcode.percent_cut = percent_cut		// Also the registered percent cut.
 	user.put_in_hands(new_barcode)
 
 /obj/item/sales_tagger/CtrlClick(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes barcodes/price tags: manually attached ones weren't setting the price tags on the wrapped contents AFAIK. Also, manually printed barcodes didn't copy the registered _percent_cut_ set in the sales tagger.
And you could spam the ID on the sales tagger cause of a bad check.

Fixes #50998 , already tested. Sold 4 packages (2 large, 2 small), 2 of them with a printed barcode, 2 using the price tagger, got credits for all of them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Doesn't force you to tag packages always with the sales tagger. Also, working as intended now I guess.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Manually printed barcodes are now working correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
