### PR TITLE
Nerfs timestop

### DIFF
--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -11,8 +11,8 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/list/immune = list() // the one who creates the timestop is immune, which includes wizards and the dead slime you murdered to make this chronofield
 	var/turf/target
-	var/freezerange = 2
-	var/duration = 140
+	var/freezerange = 1
+	var/duration = 30
 	var/datum/proximity_monitor/advanced/timestop/chronofield
 	alpha = 125
 	var/check_anti_magic = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes timestop freeze range from 5x5 to 3x3, plus decreases freeze time to 30.
Note: I haven't actually tested or compiled the code yet, but it _should_ work.

## Why It's Good For The Game

Timestop is unbalanced and unfun, decreasing freeze time and radius makes skill more important and prevents just running up to random people with a melee weapon and beating them to death while frozen as a wizard.

## Changelog
:cl:
balance: Decreased timestop/stop time freeze range and freeze time.
/:cl:
