### PR TITLE
[READY] Restore captain's ownership of own display case

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54657,10 +54657,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
 "bXg" = (
-/obj/structure/displaycase/captain{
-	req_access = null;
-	req_access_txt = "20"
-	},
+/obj/structure/displaycase/captain,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
 "bXh" = (

--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -88,7 +88,7 @@
 #define ACCESS_CENT_GENERAL 101
 /// Thunderdome.
 #define ACCESS_CENT_THUNDER 102
-/// Special Ops. Captain's display case, Marauder and Seraph mechs.
+/// Special Ops. Marauder and Seraph mechs.
 #define ACCESS_CENT_SPECOPS 103
 /// Medical/Research
 #define ACCESS_CENT_MEDICAL 104

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -249,7 +249,7 @@
 //The lab cage and captain's display case do not spawn with electronics, which is why req_access is needed.
 /obj/structure/displaycase/captain
 	start_showpiece_type = /obj/item/gun/energy/laser/captain
-	req_access = list(ACCESS_CENT_SPECOPS) //this was intentional, presumably to make it slightly harder for caps to grab their gun roundstart
+	req_access = list(ACCESS_CAPTAIN)
 
 /obj/structure/displaycase/labcage
 	name = "lab cage"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The captain now has ownership of their own glass case.

## Why It's Good For The Game

It makes no sense for the captain to be unable to open their own display case.

## Changelog
:cl:NewSta
tweak: The captain now finally has ownership of their own display case.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
