### PR TITLE
Prevent server from crashing due to writing on paper

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -37,6 +37,7 @@
 	var/spam_flag = 0
 	var/contact_poison // Reagent ID to transfer on contact
 	var/contact_poison_volume = 0
+	var/next_write_time = 0
 
 
 /obj/item/paper/pickup(user)
@@ -250,6 +251,8 @@
 
 
 /obj/item/paper/Topic(href, href_list)
+	if(next_write_time > world.time)
+		return
 	..()
 	var/literate = usr.is_literate()
 	if(!usr.canUseTopic(src, BE_CLOSE, literate))
@@ -259,6 +262,7 @@
 		openhelp(usr)
 		return
 	if(href_list["write"])
+		next_write_time = world.time + 1 SECONDS
 		var/id = href_list["write"]
 		var/t =  stripped_multiline_input("Enter what you want to write:", "Write", no_trim=TRUE)
 		if(!t || !usr.canUseTopic(src, BE_CLOSE, literate))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See: https://github.com/yogstation13/Yogstation/pull/8427
https://github.com/BeeStation/NSV13/pull/574

Apparently you can crash the server by writing on paper too often.

## Why It's Good For The Game

Well, one less exploit that can crash the server.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Kmc2000
tweak: Reduced rate at which you can write things on paper. You probably won't notice this unless you're trying to crash the server.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
