### PR TITLE
Fixes goonchat link bug

### DIFF
--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -859,7 +859,6 @@ $(function() {
 		runByond('byond://winset?mapwindow.map.focus=true');
 	});
 
-	//Sends all inputs from here over to where they are needed.
 	$('body').on('keydown', function(e) {
 		if (e.target.nodeName == 'INPUT' || e.target.nodeName == 'TEXTAREA') {
 			return;

--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -856,76 +856,18 @@ $(function() {
 			href = escaper(href);
 			runByond('?action=openLink&link='+href);
 		}
+		runByond('byond://winset?mapwindow.map.focus=true');
 	});
 
-	//Fuck everything about this event. Will look into alternatives.
+	//Sends all inputs from here over to where they are needed.
 	$('body').on('keydown', function(e) {
 		if (e.target.nodeName == 'INPUT' || e.target.nodeName == 'TEXTAREA') {
 			return;
 		}
-
 		if (e.ctrlKey || e.altKey || e.shiftKey) { //Band-aid "fix" for allowing ctrl+c copy paste etc. Needs a proper fix.
 			return;
 		}
-
-		e.preventDefault()
-
-		var k = e.which;
-		// Hardcoded because else there would be no feedback message.
-		if (k == 113) { // F2
-			runByond('byond://winset?screenshot=auto');
-			internalOutput('Screenshot taken', 'internal');
-		}
-
-		var c = "";
-		switch (k) {
-			case 8:
-				c = 'BACK';
-			case 9:
-				c = 'TAB';
-			case 13:
-				c = 'ENTER';
-			case 19:
-				c = 'PAUSE';
-			case 27:
-				c = 'ESCAPE';
-			case 33: // Page up
-				c = 'NORTHEAST';
-			case 34: // Page down
-				c = 'SOUTHEAST';
-			case 35: // End
-				c = 'SOUTHWEST';
-			case 36: // Home
-				c = 'NORTHWEST';
-			case 37:
-				c = 'WEST';
-			case 38:
-				c = 'NORTH';
-			case 39:
-				c = 'EAST';
-			case 40:
-				c = 'SOUTH';
-			case 45:
-				c = 'INSERT';
-			case 46:
-				c = 'DELETE';
-			case 93: // That weird thing to the right of alt gr.
-				c = 'APPS';
-
-			default:
-				c = String.fromCharCode(k);
-		}
-
-		if (c.length == 0) {
-			if (!e.shiftKey) {
-				c = c.toLowerCase();
-			}
-			runByond('byond://winset?mapwindow.map.focus=true;mainwindow.input.text='+c);
-			return false;
-		} else {
-			runByond('byond://winset?mapwindow.map.focus=true');
-			return false;
-		}
+		runByond('byond://winset?mapwindow.map.focus=true');
 	});
 
 	//Mildly hacky fix for scroll issues on mob change (interface gets resized sometimes, messing up snap-scroll)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Clicking a goonchat link will now instantly return focus to the game map. This means that the game will no longer eat your next input after you clicked a link

## Why It's Good For The Game

This makes the game feel more responsive and with no downside. Also removes an ugly function that was supposed to implement this feature.
This function was also causing some other issues, for example, it could cause you to take a screenshot with f2 although you have rebound it.

## Changelog
:cl:
fix: Clicking links in goonchat will no longer eat your next input.
/:cl:
