### PR TITLE
Fixes gamer skill exploit

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -792,6 +792,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 				event = null
 
 				if(killed_crew >= 4)
+					xp_gained -= 15//no cheating by spamming game overs
 					report_player(usr)
 			else if(obj_flags & EMAGGED)
 				if(usr.name == sheriff)


### PR DESCRIPTION
## About The Pull Request

I recently learned people were STEALING the title of legendary gamer by simply mashing the "shoot crew" button in orion trail. This fixes that by adding a 15 XP penalty if you game-over by way of mass suicide, counteracting the 14 XP you get from turns played + pity points.

## Why It's Good For The Game

No cheating!

## Changelog
:cl:
fix: You can no longer cheat at becoming a legendary gamer by committing suicide a lot in Orion Trail.
/:cl:
