### PR TITLE
Prevents acid from spawning 100's of overlays

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -168,14 +168,13 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 ///the obj's reaction when touched by acid
 /obj/acid_act(acidpwr, acid_volume)
 	if(!(resistance_flags & UNACIDABLE) && acid_volume)
-
-		if(!acid_level)
+		if(!acid_level && SSacid.processing[src] != src)
 			SSacid.processing[src] = src
 			add_overlay(GLOB.acid_overlay, TRUE)
 		var/acid_cap = acidpwr * 300 //so we cannot use huge amounts of weak acids to do as well as strong acids.
 		if(acid_level < acid_cap)
 			acid_level = min(acid_level + acidpwr * acid_volume, acid_cap)
-		return 1
+		return TRUE
 
 ///the proc called by the acid subsystem to process the acid that's on the obj
 /obj/proc/acid_processing()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Basically the way acid code worked was to check to see if there wasn't an `acid_level` then the `src` object would add itself to the acid processing subsystem and add an overlay. The problem is that acid level actually gets it's variable set sometime further down in `acid_act` and could allow dozens if not 100's of overlays to appear and never be removed since the acid subsystem is only responsible for removing 1 acid overlay when done processing. This basically checks to make sure the object is not already processing in the acid subsystem then add itself and the overlay.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less bugs and probably less lag from having 100's of acid overlays that you would have to manually clear by an admin.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Acid should no longer spawn 100's of overlays unchecked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
