### PR TITLE
Remove Donut and Kilo from maps.txt

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -34,16 +34,6 @@ map deltastation
 	votable
 endmap
 
-map donutstation
-	minplayers 50
-	votable
-endmap
-
-map kilostation
-	minplayers 25
-	votable
-endmap
-
 map runtimestation
 endmap
 


### PR DESCRIPTION
Fixes a warning on server startup because `_maps/X.json` does not exist for these