### PR TITLE
Fix attempting to load extools .dll on Linux

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -19,7 +19,7 @@ GLOBAL_VAR(restart_counter)
   *
   */
 /world/New()
-	var/extools = world.GetConfig("env", "EXTOOLS_DLL") || "./byond-extools.dll"
+	var/extools = world.GetConfig("env", "EXTOOLS_DLL") || (world.system_type == MS_WINDOWS ? "./byond-extools.dll" : "./libbyond-extools.so")
 	if (fexists(extools))
 		call(extools, "maptick_initialize")()
 	enable_debugger()


### PR DESCRIPTION
Now looks for the `.so` and moves along quietly if it's not there instead of runtiming