### PR TITLE
Moved glowshrooms to regular products

### DIFF
--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -21,6 +21,7 @@
 					/obj/item/seeds/corn = 3,
 					/obj/item/seeds/eggplant = 3,
 					/obj/item/seeds/garlic = 3,
+					/obj/item/seeds/glowshroom = 2,
 					/obj/item/seeds/grape = 3,
 					/obj/item/seeds/grass = 3,
 					/obj/item/seeds/lemon = 3,
@@ -43,7 +44,6 @@
 					/obj/item/seeds/wheat = 3,
 					/obj/item/seeds/whitebeet = 3)
 	contraband = list(/obj/item/seeds/amanita = 2,
-					/obj/item/seeds/glowshroom = 2,
 					/obj/item/seeds/liberty = 2,
 					/obj/item/seeds/nettle = 2,
 					/obj/item/seeds/plump = 2,


### PR DESCRIPTION
## About The Pull Request
Moved glowshroom seeds from the contraband list in the megaseed vending machine into the regular products list.

## Why It's Good For The Game
This will allow for production of regenerative jelly without having to hack the vending machine in advance. I don't think there really is a point in putting one of the more valuable and harmless plants botany can grow behind such a pointless (and, really, mostly symbolic, since oftentimes the machine gets hacked for cannabis anyway) barrier.  

## Changelog
:cl:
tweak: tweaked contents of vending machine
balance: makes it easier to get glowcaps and regenerative jelly early on
/:cl: