### PR TITLE
[READY] Lavaland Elite Buffs and QoL Changes

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -173,7 +173,7 @@
 
 /datum/mood_event/hope_lavaland
 	description = "<span class='nicegreen'>What a peculiar emblem.  It makes me feel hopeful for my future.</span>\n"
-	mood_change = 5
+	mood_change = 10
 
 /datum/mood_event/nanite_happiness
 	description = "<span class='nicegreen robot'>+++++++HAPPINESS ENHANCEMENT+++++++</span>\n"

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -728,6 +728,8 @@
 		user.changeNext_move(CLICK_CD_MELEE * 0.5) //when closed, it attacks very rapidly
 
 /obj/item/melee/transforming/cleaving_saw/nemesis_effects(mob/living/user, mob/living/target)
+	if(istype(target, /mob/living/simple_animal/hostile/asteroid/elite))
+		return
 	var/datum/status_effect/stacking/saw_bleed/B = target.has_status_effect(STATUS_EFFECT_SAWBLEED)
 	if(!B)
 		target.apply_status_effect(STATUS_EFFECT_SAWBLEED,bleed_stacks_per_hit)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -41,7 +41,7 @@
 		var/obj/structure/elite_tumor/T = target
 		if(T.mychild == src && T.activity == TUMOR_PASSIVE)
 			var/elite_remove = alert("Re-enter the tumor?", "Despawn yourself?", "Yes", "No")
-			if(elite_remove == "No" || !src || get_dist(src, T) > 1 || QDELETED(src))
+			if(elite_remove == "No" || QDELETED(src) || !Adjacent(T))
 				return
 			T.mychild = null
 			T.activity = TUMOR_INACTIVE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -188,8 +188,6 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	. = ..()
 	if(istype(I, /obj/item/organ/regenerative_core) && activity == TUMOR_INACTIVE && !boosted)
 		var/obj/item/organ/regenerative_core/core = I
-		if(!core.preserved)
-			return
 		visible_message("<span class='boldwarning'>As [user] drops the core into [src], [src] appears to swell.</span>")
 		icon_state = "advanced_tumor"
 		boosted = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -11,10 +11,10 @@
 	robust_searching = TRUE
 	ranged_ignores_vision = TRUE
 	ranged = TRUE
-	obj_damage = 5
+	obj_damage = 30
 	vision_range = 6
 	aggro_vision_range = 18
-	environment_smash = ENVIRONMENT_SMASH_NONE  //This is to prevent elites smashing up the mining station, we'll make sure they can smash minerals fine below.
+	environment_smash = ENVIRONMENT_SMASH_NONE  //This is to prevent elites smashing up the mining station (entirely), we'll make sure they can smash minerals fine below.
 	harm_intent_damage = 0 //Punching elites gets you nowhere
 	stat_attack = UNCONSCIOUS
 	layer = LARGE_MOB_LAYER
@@ -41,7 +41,7 @@
 		var/obj/structure/elite_tumor/T = target
 		if(T.mychild == src && T.activity == TUMOR_PASSIVE)
 			var/elite_remove = alert("Re-enter the tumor?", "Despawn yourself?", "Yes", "No")
-			if(elite_remove == "No" || !src || QDELETED(src))
+			if(elite_remove == "No" || !src || get_dist(src, T) > 1 || QDELETED(src))
 				return
 			T.mychild = null
 			T.activity = TUMOR_INACTIVE
@@ -52,6 +52,9 @@
 	if(ismineralturf(target))
 		var/turf/closed/mineral/M = target
 		M.gets_drilled()
+	if(istype(target, /obj/mecha))
+		var/obj/mecha/M = target
+		M.take_damage(50, BRUTE, "melee", 1)
 
 //Elites can't talk (normally)!
 /mob/living/simple_animal/hostile/asteroid/elite/say(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
@@ -256,7 +259,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	mychild.revive(full_heal = TRUE, admin_revive = TRUE)
 	if(boosted)
 		times_won++
-		mychild.maxHealth = mychild.maxHealth * 0.5
+		mychild.maxHealth = mychild.maxHealth * 0.4
 		mychild.health = mychild.maxHealth
 	if(times_won == 1)
 		mychild.playsound_local(get_turf(mychild), 'sound/effects/magic.ogg', 40, 0)
@@ -284,13 +287,13 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		if(E.stat != DEAD || E.sentience_type != SENTIENCE_BOSS || !E.key)
 			user.visible_message("<span class='notice'>It appears [E] is unable to be revived right now.  Perhaps try again later.</span>")
 			return
-		E.faction = list("neutral")
+		E.faction = list("[REF(user)]")
 		E.revive(full_heal = TRUE, admin_revive = TRUE)
 		user.visible_message("<span class='notice'>[user] stabs [E] with [src], reviving it.</span>")
 		E.playsound_local(get_turf(E), 'sound/effects/magic.ogg', 40, 0)
 		to_chat(E, "<span class='userdanger'>You have been revived by [user].  While you can't speak to them, you owe [user] a great debt.  Assist [user.p_them()] in achieving [user.p_their()] goals, regardless of risk.</span")
 		to_chat(E, "<span class='big bold'>Note that you now share the loyalties of [user].  You are expected not to intentionally sabotage their faction unless commanded to!</span>")
-		E.maxHealth = E.maxHealth * 0.5
+		E.maxHealth = E.maxHealth * 0.4
 		E.health = E.maxHealth
 		E.desc = "[E.desc]  However, this one appears appears less wild in nature, and calmer around people."
 		E.sentience_type = SENTIENCE_ORGANIC

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -232,7 +232,7 @@
 // Broodmother's loot: Broodmother Tongue
 /obj/item/crusher_trophy/broodmother_tongue
 	name = "broodmother tongue"
-	desc = "The tongue of a broodmother.  If attached a certain way, makes for a suitable crusher trophy.  It also feels very spongey, I wonder what would happen if you squeezed it?..."
+	desc = "The tongue of a broodmother. If attached a certain way, makes for a suitable crusher trophy.  It also feels very spongey, I wonder what would happen if you squeezed it?..."
 	icon = 'icons/obj/lavaland/elite_trophies.dmi'
 	icon_state = "broodmother_tongue"
 	denied_type = /obj/item/crusher_trophy/broodmother_tongue

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -237,6 +237,7 @@
 	icon_state = "broodmother_tongue"
 	denied_type = /obj/item/crusher_trophy/broodmother_tongue
 	bonus_value = 10
+	/// Time at which the item becomes usable again
 	var/use_time
 
 /obj/item/crusher_trophy/broodmother_tongue/effect_desc()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -251,7 +251,7 @@
 		return
 	var/mob/living/L = user
 	if(use_time > world.time)
-		to_chat(L, "<b>The tongue looks dried out.  You'll need to wait longer to use it again.</b>")
+		to_chat(L, "<b>The tongue looks dried out. You'll need to wait longer to use it again.</b>")
 		return
 	else if("lava" in L.weather_immunities)
 		to_chat(L, "<b>You stare at the tongue.  You don't think this is any use to you.</b>")

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -250,17 +250,17 @@
 /obj/item/crusher_trophy/broodmother_tongue/attack_self(mob/user)
 	if(!isliving(user))
 		return
-	var/mob/living/L = user
+	var/mob/living/living_user = user
 	if(use_time > world.time)
-		to_chat(L, "<b>The tongue looks dried out. You'll need to wait longer to use it again.</b>")
+		to_chat(living_user, "<b>The tongue looks dried out. You'll need to wait longer to use it again.</b>")
 		return
-	else if("lava" in L.weather_immunities)
-		to_chat(L, "<b>You stare at the tongue. You don't think this is any use to you.</b>")
+	else if("lava" in living_user.weather_immunities)
+		to_chat(living_user, "<b>You stare at the tongue. You don't think this is any use to you.</b>")
 		return
-	L.weather_immunities |= "lava"
-	to_chat(L, "<b>You squeeze the tongue, and some transluscent liquid shoots out all over you.</b>")
-	addtimer(CALLBACK(src, .proc/remove_lavaproofing, L), 100)
+	living_user.weather_immunities |= "lava"
+	to_chat(living_user, "<b>You squeeze the tongue, and some transluscent liquid shoots out all over you.</b>")
+	addtimer(CALLBACK(src, .proc/remove_lavaproofing, living_user), 10 SECONDS)
 	use_time = world.time + 60 SECONDS
 	
-/obj/item/crusher_trophy/broodmother_tongue/proc/remove_lavaproofing(mob/living/L)
-	L.weather_immunities -= "lava"
+/obj/item/crusher_trophy/broodmother_tongue/proc/remove_lavaproofing(mob/living/user)
+	user.weather_immunities -= "lava"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -26,8 +26,8 @@
 	icon_dead = "egg_sac"
 	icon_gib = "syndicate_gib"
 	health_doll_icon = "broodmother"
-	maxHealth = 800
-	health = 800
+	maxHealth = 1000
+	health = 1000
 	melee_damage_lower = 30
 	melee_damage_upper = 30
 	armour_penetration = 30
@@ -232,11 +232,12 @@
 // Broodmother's loot: Broodmother Tongue
 /obj/item/crusher_trophy/broodmother_tongue
 	name = "broodmother tongue"
-	desc = "The tongue of a broodmother.  If attached a certain way, makes for a suitable crusher trophy."
+	desc = "The tongue of a broodmother.  If attached a certain way, makes for a suitable crusher trophy.  It also feels very spongey, I wonder what would happen if you squeezed it?..."
 	icon = 'icons/obj/lavaland/elite_trophies.dmi'
 	icon_state = "broodmother_tongue"
 	denied_type = /obj/item/crusher_trophy/broodmother_tongue
 	bonus_value = 10
+	var/use_time
 
 /obj/item/crusher_trophy/broodmother_tongue/effect_desc()
 	return "mark detonation to have a <b>[bonus_value]%</b> chance to summon a patch of goliath tentacles at the target's location"
@@ -244,3 +245,22 @@
 /obj/item/crusher_trophy/broodmother_tongue/on_mark_detonation(mob/living/target, mob/living/user)
 	if(rand(1, 100) <= bonus_value && target.stat != DEAD)
 		new /obj/effect/temp_visual/goliath_tentacle/broodmother/patch(get_turf(target), user)
+		
+/obj/item/crusher_trophy/broodmother_tongue/attack_self(mob/user)
+	if(!isliving(user))
+		return
+	var/mob/living/L = user
+	if(use_time > world.time)
+		to_chat(L, "<b>The tongue looks dried out.  You'll need to wait longer to use it again.</b>")
+		return
+	else if("lava" in L.weather_immunities)
+		to_chat(L, "<b>You stare at the tongue.  You don't think this is any use to you.</b>")
+		return
+	L.weather_immunities |= "lava"
+	to_chat(L, "<b>You squeeze the tongue, and some transluscent liquid shoots out all over you.</b>")
+	addtimer(CALLBACK(src, .proc/remove_lavaproofing, L), 100)
+	use_time = world.time + 600
+	
+/obj/item/crusher_trophy/broodmother_tongue/proc/remove_lavaproofing(mob/living/L)
+	L.weather_immunities -= "lava"
+	

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -260,7 +260,7 @@
 	L.weather_immunities |= "lava"
 	to_chat(L, "<b>You squeeze the tongue, and some transluscent liquid shoots out all over you.</b>")
 	addtimer(CALLBACK(src, .proc/remove_lavaproofing, L), 100)
-	use_time = world.time + 600
+	use_time = world.time + 60 SECONDS
 	
 /obj/item/crusher_trophy/broodmother_tongue/proc/remove_lavaproofing(mob/living/L)
 	L.weather_immunities -= "lava"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -254,7 +254,7 @@
 		to_chat(L, "<b>The tongue looks dried out. You'll need to wait longer to use it again.</b>")
 		return
 	else if("lava" in L.weather_immunities)
-		to_chat(L, "<b>You stare at the tongue.  You don't think this is any use to you.</b>")
+		to_chat(L, "<b>You stare at the tongue. You don't think this is any use to you.</b>")
 		return
 	L.weather_immunities |= "lava"
 	to_chat(L, "<b>You squeeze the tongue, and some transluscent liquid shoots out all over you.</b>")

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -263,4 +263,3 @@
 	
 /obj/item/crusher_trophy/broodmother_tongue/proc/remove_lavaproofing(mob/living/L)
 	L.weather_immunities -= "lava"
-	

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -25,8 +25,8 @@
 	icon_dead = "herald_dying"
 	icon_gib = "syndicate_gib"
 	health_doll_icon = "herald"
-	maxHealth = 800
-	health = 800
+	maxHealth = 1000
+	health = 1000
 	melee_damage_lower = 20
 	melee_damage_upper = 20
 	attack_verb_continuous = "preaches to"
@@ -123,7 +123,7 @@
 		if(HERALD_MIRROR)
 			herald_mirror()
 
-/mob/living/simple_animal/hostile/asteroid/elite/herald/proc/shoot_projectile(turf/marker, set_angle, var/is_teleshot)
+/mob/living/simple_animal/hostile/asteroid/elite/herald/proc/shoot_projectile(turf/marker, set_angle, var/is_teleshot, var/is_trishot)
 	var/turf/startloc = get_turf(src)
 	var/obj/projectile/herald/H = null
 	if(!is_teleshot)
@@ -135,25 +135,28 @@
 	if(target)
 		H.original = target
 	H.fire(set_angle)
+	if(is_trishot)
+		shoot_projectile(marker, set_angle + 15, FALSE, FALSE)
+		shoot_projectile(marker, set_angle - 15, FALSE, FALSE)
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/proc/herald_trishot(target)
 	ranged_cooldown = world.time + 30
 	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 	var/target_turf = get_turf(target)
 	var/angle_to_target = Get_Angle(src, target_turf)
-	shoot_projectile(target_turf, angle_to_target, FALSE)
-	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE), 2)
-	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE), 4)
+	shoot_projectile(target_turf, angle_to_target, FALSE, TRUE)
+	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 2)
+	addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 4)
 	if(health < maxHealth * 0.5)
 		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
-		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE), 10)
-		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE), 12)
-		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE), 14)
+		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 10)
+		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 12)
+		addtimer(CALLBACK(src, .proc/shoot_projectile, target_turf, angle_to_target, FALSE, TRUE), 14)
 
-/mob/living/simple_animal/hostile/asteroid/elite/herald/proc/herald_circleshot()
+/mob/living/simple_animal/hostile/asteroid/elite/herald/proc/herald_circleshot(offset)
 	var/static/list/directional_shot_angles = list(0, 45, 90, 135, 180, 225, 270, 315)
 	for(var/i in directional_shot_angles)
-		shoot_projectile(get_turf(src), i, FALSE)
+		shoot_projectile(get_turf(src), i + offset, FALSE, FALSE)
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/proc/unenrage()
 	if(stat == DEAD || is_mirror)
@@ -165,10 +168,10 @@
 	if(!is_mirror)
 		icon_state = "herald_enraged"
 	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
-	addtimer(CALLBACK(src, .proc/herald_circleshot), 5)
+	addtimer(CALLBACK(src, .proc/herald_circleshot, 0), 5)
 	if(health < maxHealth * 0.5)
 		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
-		addtimer(CALLBACK(src, .proc/herald_circleshot), 15)
+		addtimer(CALLBACK(src, .proc/herald_circleshot, 22.5), 15)
 	addtimer(CALLBACK(src, .proc/unenrage), 20)
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/proc/herald_teleshot(target)
@@ -176,7 +179,7 @@
 	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
 	var/target_turf = get_turf(target)
 	var/angle_to_target = Get_Angle(src, target_turf)
-	shoot_projectile(target_turf, angle_to_target, TRUE)
+	shoot_projectile(target_turf, angle_to_target, TRUE, FALSE)
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/proc/herald_mirror()
 	ranged_cooldown = world.time + 40
@@ -250,7 +253,7 @@
 	icon = 'icons/obj/lavaland/elite_trophies.dmi'
 	icon_state = "herald_cloak"
 	body_parts_covered = CHEST|GROIN|ARMS
-	hit_reaction_chance = 10
+	hit_reaction_chance = 20
 
 /obj/item/clothing/neck/cloak/herald_cloak/proc/reactionshot(mob/living/carbon/owner)
 	var/static/list/directional_shot_angles = list(0, 45, 90, 135, 180, 225, 270, 315)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -113,7 +113,7 @@
 		myhead.Goto(T, myhead.move_to_delay)
 		
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/legionnaire_charge(target)
-	ranged_cooldown = world.time + 35
+	ranged_cooldown = world.time + 3.5 SECONDS
 	charging = TRUE
 	var/dir_to_target = get_dir(get_turf(src), get_turf(target))
 	var/turf/T = get_step(get_turf(src), dir_to_target)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -106,7 +106,7 @@
 	. = ..()
 	if(myhead != null)
 		var/turf/T = get_turf(A)
-		if(T != null)
+		if(T)
 			myhead.LoseTarget()
 			myhead.Goto(T, myhead.move_to_delay)
 		

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -301,7 +301,7 @@
 
 /obj/item/crusher_trophy/legionnaire_spine
 	name = "legionnaire spine"
-	desc = "The spine of a legionnaire.  With some creativity, you could use it as a crusher trophy.  Alternatively, shaking it might do something as well."
+	desc = "The spine of a legionnaire. With some creativity, you could use it as a crusher trophy. Alternatively, shaking it might do something as well."
 	icon = 'icons/obj/lavaland/elite_trophies.dmi'
 	icon_state = "legionnaire_spine"
 	denied_type = /obj/item/crusher_trophy/legionnaire_spine

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -101,7 +101,7 @@
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/Move()
 	if(charging)
 		return
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/MiddleClickOn(atom/A)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -49,7 +49,7 @@
 	var/obj/structure/legionnaire_bonfire/mypile = null
 	var/has_head = TRUE
 	/// Whether or not the legionnaire is currently charging, used to deny movement input if he is
-	var/charging
+	var/charging = FALSE
 
 /datum/action/innate/elite_attack/legionnaire_charge
 	name = "Legionnaire Charge"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -48,6 +48,7 @@
 	var/mob/living/simple_animal/hostile/asteroid/elite/legionnairehead/myhead = null
 	var/obj/structure/legionnaire_bonfire/mypile = null
 	var/has_head = TRUE
+	/// Whether or not the legionnaire is currently charging, used to deny movement input if he is
 	var/charging
 
 /datum/action/innate/elite_attack/legionnaire_charge
@@ -306,6 +307,7 @@
 	icon_state = "legionnaire_spine"
 	denied_type = /obj/item/crusher_trophy/legionnaire_spine
 	bonus_value = 20
+	/// Time at which the item becomes usable again
 	var/use_time
 
 /obj/item/crusher_trophy/legionnaire_spine/effect_desc()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -104,7 +104,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/MiddleClickOn(atom/A)
 	. = ..()
-	if(myhead != null)
+	if(myhead)
 		var/turf/T = get_turf(A)
 		if(T)
 			myhead.LoseTarget()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -99,19 +99,21 @@
 			spew_smoke()
 			
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/Move()
-	if(!charging)
-		..()
+	if(charging)
+		return
+	..()
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/MiddleClickOn(atom/A)
 	. = ..()
-	if(myhead)
-		var/turf/T = get_turf(A)
-		if(T)
-			myhead.LoseTarget()
-			myhead.Goto(T, myhead.move_to_delay)
+	if(!myhead)
+		return
+	var/turf/T = get_turf(A)
+	if(T)
+		myhead.LoseTarget()
+		myhead.Goto(T, myhead.move_to_delay)
 		
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/legionnaire_charge(target)
-	ranged_cooldown = world.time + 50
+	ranged_cooldown = world.time + 35
 	charging = TRUE
 	var/dir_to_target = get_dir(get_turf(src), get_turf(target))
 	var/turf/T = get_step(get_turf(src), dir_to_target)
@@ -167,7 +169,6 @@
 		icon_aggro = "legionnaire_headless"
 		visible_message("<span class='boldwarning'>[src]'s head flies off!</span>")
 		var/mob/living/simple_animal/hostile/asteroid/elite/legionnairehead/newhead = new /mob/living/simple_animal/hostile/asteroid/elite/legionnairehead(loc)
-		newhead.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
 		newhead.GiveTarget(target)
 		newhead.faction = faction.Copy()
 		myhead = newhead
@@ -317,9 +318,8 @@
 	if(!rand(1, 100) <= bonus_value || target.stat == DEAD)
 		return
 	var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/A = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion(user.loc)
-	A.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
 	A.GiveTarget(target)
-	A.friends = user
+	A.friends += user
 	A.faction = user.faction.Copy()
 	
 /obj/item/crusher_trophy/legionnaire_spine/attack_self(mob/user)
@@ -332,7 +332,6 @@
 		return
 	L.visible_message("<span class='boldwarning'>[L] shakes the [src] and summons a legion skull!</span>")
 	var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/A = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion(L.loc)
-	A.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
-	A.friends = L
+	A.friends += L
 	A.faction = L.faction.Copy()
-	use_time = world.time + 40
+	use_time = world.time + 4 SECONDS

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -100,7 +100,7 @@
 			
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/Move()
 	if(charging)
-		return
+		return FALSE
 	return ..()
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/MiddleClickOn(atom/A)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -309,7 +309,7 @@
 	denied_type = /obj/item/crusher_trophy/legionnaire_spine
 	bonus_value = 20
 	/// Time at which the item becomes usable again
-	var/use_time
+	var/next_use_time
 
 /obj/item/crusher_trophy/legionnaire_spine/effect_desc()
 	return "mark detonation to have a <b>[bonus_value]%</b> chance to summon a loyal legion skull"
@@ -325,13 +325,13 @@
 /obj/item/crusher_trophy/legionnaire_spine/attack_self(mob/user)
 	if(!isliving(user))
 		return
-	var/mob/living/L = user
-	if(use_time > world.time)
-		L.visible_message("<span class='warning'>[L] shakes the [src], but nothing happens...</span>")
-		to_chat(L, "<b>You need to wait longer to use this again.</b>")
+	var/mob/living/LivingUser = user
+	if(next_use_time > world.time)
+		LivingUser.visible_message("<span class='warning'>[LivingUser] shakes the [src], but nothing happens...</span>")
+		to_chat(LivingUser, "<b>You need to wait longer to use this again.</b>")
 		return
-	L.visible_message("<span class='boldwarning'>[L] shakes the [src] and summons a legion skull!</span>")
-	var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/A = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion(L.loc)
-	A.friends += L
-	A.faction = L.faction.Copy()
-	use_time = world.time + 4 SECONDS
+	LivingUser.visible_message("<span class='boldwarning'>[LivingUser] shakes the [src] and summons a legion skull!</span>")
+	var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/LegionSkull = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion(LivingUser.loc)
+	LegionSkull.friends += LivingUser
+	LegionSkull.faction = LivingUser.faction.Copy()
+	next_use_time = world.time + 4 SECONDS

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
@@ -25,8 +25,8 @@
 	icon_dead = "pandora_dead"
 	icon_gib = "syndicate_gib"
 	health_doll_icon = "pandora"
-	maxHealth = 800
-	health = 800
+	maxHealth = 1000
+	health = 1000
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	attack_verb_continuous = "smashes into the side of"
@@ -128,7 +128,7 @@
 			new /obj/effect/temp_visual/hierophant/blast/pandora(t, src)
 
 /mob/living/simple_animal/hostile/asteroid/elite/pandora/proc/pandora_teleport(target)
-	ranged_cooldown = world.time + cooldown_time
+	ranged_cooldown = world.time + (cooldown_time * 2)
 	var/turf/T = get_turf(target)
 	var/turf/source = get_turf(src)
 	new /obj/effect/temp_visual/hierophant/telegraph(T, src)


### PR DESCRIPTION
## About The Pull Request

Resolves #49814

This pull request makes some changes to the Lavaland Elites in order to make fighting as and against them a more enjoyable experience.  Also removes a number of cheese strats used to easily kill the elites, along with some changes to the elite's loot.  The changes are as follows:

**ALL ELITES**

- Health buffed from 800 to 1000 (Health is still 400 when enslaved or away from tumor)
- Object damage buffed from 5 to 30
- Elites re-entering their tumor must be next to it in order to do so
- Elites are now immune to the effects of BDM's cleaver bleed
- Elites' melee attacks now do substantial damage against mechs
- Tamed elites are now only loyal to their master, meaning friendly fire is enabled for anyone else
- The tumor can be boosted using an unpreserved core now

**BROODMOTHER**

- Loot drop of Broodmother's Tongue now has an additional use in hand.  Allows the user to become immune to lava for 10 seconds.  60 second cooldown

**PANDORA**

- Time until next attack penalty from using Teleport increased by double across all health states.  This means Pandora's teleport has the same attack "lag" on it at below 25% health now as it did at 100% health prior to this update.  This change is mostly to prevent Pandoras who get on station from tele-spamming the crew to death

- Loot drop Hope mood buff increased from 5 to 10

**LEGIONNAIRE**

- Is now locked in place during a charge.  Charge performs faster and travels a longer distance to compensate, along with a shorter cooldown
- Head health buffed from 80 to 200
- Head damage buffed from 10, 20, and 30 at various health percentages to 20, 30, and 40
- Can now move their head around manually by middle-clicking
- Loot drop Legionnaire's Spine now has an additional use.  Can be shook to summon legion skulls with a 4 second cooldown between skulls
- Is no longer stopped when charging through open doors

**HERALD**

- Tri-shot now fires projectiles to the left and right of the one directly aimed at the target
- Herald's additional directional shot when below 50% health is now offset to fire the second set of projectile in between the first set
- Loot drop Cloak of the Prophet now activates 20% of the time instead of 10%

## Why It's Good For The Game

The lavaland elites have been around long enough for people to get a feel for them, along with developing some rather nasty cheese strats.  This update attempts to patch those up, along with buffing them in general to make the fights more interesting along with their loot to make them more desirable to go fight in the first place

## Changelog
:cl:
add: Lavaland elite loot drops for Broodmother and Legionnaire now have in-hand use functions
balance: Lavaland elites now have more health in their arena fights, along with several other balance changes
fix: Fixed lavaland elites not being able to damage mechs

/:cl: