### PR TITLE
Delays loading of random books

### DIFF
--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -538,7 +538,7 @@
 /area/awaymission/wildwest/mines)
 "cm" = (
 /obj/structure/bookcase/random{
-	book_count = 5
+	books_to_load = 5
 	},
 /turf/open/floor/wood,
 /area/awaymission/wildwest/gov)
@@ -654,7 +654,7 @@
 /area/awaymission/wildwest/gov)
 "cI" = (
 /obj/structure/bookcase/random{
-	book_count = 5
+	books_to_load = 5
 	},
 /turf/open/floor/wood,
 /area/awaymission/wildwest/mines)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2472,13 +2472,15 @@
 
 /datum/supply_pack/misc/book_crate
 	name = "Book Crate"
-	desc = "Surplus from the Nanotrasen Archives, these five books are sure to be good reads."
+	desc = "Surplus from the Nanotrasen Archives, these seven books are sure to be good reads."
 	cost = 1500
 	contains = list(/obj/item/book/codex_gigas,
 					/obj/item/book/manual/random/,
 					/obj/item/book/manual/random/,
 					/obj/item/book/manual/random/,
-					/obj/item/book/random/triple)
+					/obj/item/book/random,
+					/obj/item/book/random,
+					/obj/item/book/random)
 	crate_type = /obj/structure/closet/crate/wooden
 
 /datum/supply_pack/misc/paper

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -23,6 +23,9 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)
 	var/state = 0
 	var/list/allowed_books = list(/obj/item/book, /obj/item/spellbook, /obj/item/storage/book) //Things allowed in the bookcase
+	var/load_random_books = FALSE
+	var/random_category = null
+	var/books_to_load = 0
 
 /obj/structure/bookcase/examine(mob/user)
 	. = ..()
@@ -119,6 +122,9 @@
 		return
 	if(!istype(user))
 		return
+	if(load_random_books)
+		create_random_books(books_to_load, src, FALSE, random_category)
+		load_random_books = FALSE
 	if(contents.len)
 		var/obj/item/book/choice = input(user, "Which book would you like to remove from the shelf?") as null|obj in sortNames(contents.Copy())
 		if(choice)
@@ -140,8 +146,11 @@
 
 
 /obj/structure/bookcase/update_icon_state()
-	if(contents.len < 5)
-		icon_state = "book-[contents.len]"
+	var/amount = contents.len
+	if(load_random_books)
+		amount += books_to_load
+	if(amount < 5)
+		icon_state = "book-[amount]"
 	else
 		icon_state = "book-5"
 

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -23,8 +23,11 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)
 	var/state = 0
 	var/list/allowed_books = list(/obj/item/book, /obj/item/spellbook, /obj/item/storage/book) //Things allowed in the bookcase
+	/// When enabled, books_to_load number of random books will be generated for this bookcase when first interacted with.
 	var/load_random_books = FALSE
+	/// The category of books to pick from when populating random books.
 	var/random_category = null
+	/// How many random books to generate.
 	var/books_to_load = 0
 
 /obj/structure/bookcase/examine(mob/user)
@@ -149,10 +152,7 @@
 	var/amount = contents.len
 	if(load_random_books)
 		amount += books_to_load
-	if(amount < 5)
-		icon_state = "book-[amount]"
-	else
-		icon_state = "book-5"
+	icon_state = "book-[amount < 5 ? amount : 5]"
 
 
 /obj/structure/bookcase/manuals/engineering

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -10,82 +10,80 @@
 
 /obj/item/book/random
 	icon_state = "random_book"
-	var/amount = 1
-	var/category = null
+	var/random_category = null
+	var/random_loaded = FALSE
 
-/obj/item/book/random/Initialize()
+/obj/item/book/random/Initialize(mapload)
+	. = ..()
+	icon_state = "book[rand(1,8)]"
+
+/obj/item/book/random/attack_self()
+	if(!random_loaded)
+		create_random_books(1, loc, TRUE, random_category, src)
+		random_loaded = TRUE
 	..()
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/item/book/random/LateInitialize()
-	create_random_books(amount, src.loc, TRUE, category)
-	qdel(src)
-
-/obj/item/book/random/triple
-	amount = 3
 
 /obj/structure/bookcase/random
-	var/category = null
-	var/book_count = 2
+	load_random_books = TRUE
+	books_to_load = 2
 	icon_state = "random_bookcase"
-	anchored = TRUE
-	state = 2
 
 /obj/structure/bookcase/random/Initialize(mapload)
 	. = ..()
-	if(book_count && isnum(book_count))
-		book_count += pick(-1,-1,0,1,1)
-		. = INITIALIZE_HINT_LATELOAD
-
-/obj/structure/bookcase/random/LateInitialize()
-	create_random_books(book_count, src, FALSE, category)
+	if(books_to_load && isnum(books_to_load))
+		books_to_load += pick(-1,-1,0,1,1)
 	update_icon()
 
-/proc/create_random_books(amount = 2, location, fail_loud = FALSE, category = null)
+/proc/create_random_books(amount, location, fail_loud = FALSE, category = null, obj/item/book/existing_book)
 	. = list()
 	if(!isnum(amount) || amount<1)
 		return
 	if (!SSdbcore.Connect())
-		if(fail_loud || prob(5))
-			var/obj/item/paper/P = new(location)
-			P.info = "There once was a book from Nantucket<br>But the database failed us, so f*$! it.<br>I tried to be good to you<br>Now this is an I.O.U<br>If you're feeling entitled, well, stuff it!<br><br><font color='gray'>~</font>"
-			P.update_icon()
+		if(existing_book && (fail_loud || prob(5)))
+			existing_book.author = "???"
+			existing_book.title = "Strange book"
+			existing_book.name = "Strange book"
+			existing_book.dat = "There once was a book from Nantucket<br>But the database failed us, so f*$! it.<br>I tried to be good to you<br>Now this is an I.O.U<br>If you're feeling entitled, well, stuff it!<br><br><font color='gray'>~</font>"
 		return
 	if(prob(25))
 		category = null
-	var/c = category? " AND category='[sanitizeSQL(category)]'" :""
-	var/datum/DBQuery/query_get_random_books = SSdbcore.NewQuery("SELECT * FROM [format_table_name("library")] WHERE isnull(deleted)[c] GROUP BY title ORDER BY rand() LIMIT [amount];") // isdeleted copyright (c) not me
+	var/sql_category = category? " AND category='[sanitizeSQL(category)]'" :""
+	var/datum/DBQuery/query_get_random_books = SSdbcore.NewQuery("SELECT author, title, content FROM [format_table_name("library")] WHERE isnull(deleted)[sql_category] ORDER BY rand() LIMIT [amount];") // isdeleted copyright (c) not me
 	if(query_get_random_books.Execute())
 		while(query_get_random_books.NextRow())
-			var/obj/item/book/B = new(location)
-			. += B
-			B.author	=	query_get_random_books.item[2]
-			B.title		=	query_get_random_books.item[3]
-			B.dat		=	query_get_random_books.item[4]
+			var/obj/item/book/B
+			if(existing_book)
+				B = existing_book
+			else
+				B = new(location)
+			B.author	=	query_get_random_books.item[1]
+			B.title		=	query_get_random_books.item[2]
+			B.dat		=	query_get_random_books.item[3]
 			B.name		=	"Book: [B.title]"
-			B.icon_state=	"book[rand(1,8)]"
+			if(!existing_book)
+				B.icon_state=	"book[rand(1,8)]"
 	qdel(query_get_random_books)
 
 /obj/structure/bookcase/random/fiction
 	name = "bookcase (Fiction)"
-	category = "Fiction"
+	random_category = "Fiction"
 /obj/structure/bookcase/random/nonfiction
 	name = "bookcase (Non-Fiction)"
-	category = "Non-fiction"
+	random_category = "Non-fiction"
 /obj/structure/bookcase/random/religion
 	name = "bookcase (Religion)"
-	category = "Religion"
+	random_category = "Religion"
 /obj/structure/bookcase/random/adult
 	name = "bookcase (Adult)"
-	category = "Adult"
+	random_category = "Adult"
 
 /obj/structure/bookcase/random/reference
 	name = "bookcase (Reference)"
-	category = "Reference"
+	random_category = "Reference"
 	var/ref_book_prob = 20
 
 /obj/structure/bookcase/random/reference/Initialize(mapload)
 	. = ..()
-	while(book_count > 0 && prob(ref_book_prob))
-		book_count--
+	while(books_to_load > 0 && prob(ref_book_prob))
+		books_to_load--
 		new /obj/item/book/manual/random(src)

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -10,7 +10,9 @@
 
 /obj/item/book/random
 	icon_state = "random_book"
+	/// The category of books to pick from when creating this book.
 	var/random_category = null
+	/// If this book has already been 'generated' yet.
 	var/random_loaded = FALSE
 
 /obj/item/book/random/Initialize(mapload)
@@ -52,10 +54,7 @@
 	if(query_get_random_books.Execute())
 		while(query_get_random_books.NextRow())
 			var/obj/item/book/B
-			if(existing_book)
-				B = existing_book
-			else
-				B = new(location)
+			B = existing_book ? existing_book : new(location)
 			B.author	=	query_get_random_books.item[1]
 			B.title		=	query_get_random_books.item[2]
 			B.dat		=	query_get_random_books.item[3]

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -23,7 +23,7 @@
 	if(!random_loaded)
 		create_random_books(1, loc, TRUE, random_category, src)
 		random_loaded = TRUE
-	..()
+	return ..()
 
 /obj/structure/bookcase/random
 	load_random_books = TRUE


### PR DESCRIPTION
Instead of running a query at roundstart for every bookcase and random content book in the world when both are unlikely to get looked at, bookcases and books will only populate their contents once interacted with.

Bookcases store the number of books they want to load for use of update_icon but only actually query the database to create books in them once a player clicks on the bookshelf.

Removed the use of GROUP BY in book query as while we do have duplicate books, this also precludes selecting different books which have the same title.