### PR TITLE
Makes crematorium actually burn stuff instead of deleting it

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -267,10 +267,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 		audible_message("<span class='hear'>You hear a roar as [src] activates.</span>")
 		return
 	if(!cremating && set_cremate != FALSE)
-		if(user)
-			last_user = user
-		else
-			last_user = null //let's not blame the previous guy
+		last_user = user
 		cremating = TRUE
 		first_cremation_tick = TRUE
 		locked = TRUE
@@ -294,6 +291,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 				log_combat(last_user, L, "cremated")
 			else
 				L.log_message("was cremated", LOG_ATTACK)
+			first_cremation_tick = FALSE
 		var/heat_resistant = HAS_TRAIT(L, TRAIT_RESISTHEAT)
 		L.apply_damage(heat_resistant ? 90 : 25, BURN, spread_damage = TRUE)
 		L.adjust_fire_stacks(10)
@@ -308,8 +306,6 @@ GLOBAL_LIST_EMPTY(crematoriums)
 		if(!(O.resistance_flags & FIRE_PROOF))
 			O.fire_act()
 			O.take_damage(50, BURN, null, FALSE)
-
-	first_cremation_tick = FALSE
 
 /*
  * Generic Tray

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -299,6 +299,11 @@ GLOBAL_LIST_EMPTY(crematoriums)
 		L.adjust_fire_stacks(10)
 		L.IgniteMob()
 
+		//Artificially speed up the cremation process
+		if(iscarbon(L))
+			var/mob/living/carbon/C = L
+			C.adjust_cremation(25)
+
 	for(var/obj/O in conts) //conts defined above, ignores crematorium and tray
 		O.fire_act()
 		O.take_damage(50, BURN, null, FALSE)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -294,8 +294,8 @@ GLOBAL_LIST_EMPTY(crematoriums)
 				log_combat(last_user, L, "cremated")
 			else
 				L.log_message("was cremated", LOG_ATTACK)
-
-		L.apply_damage(90, BURN, spread_damage = TRUE)
+		var/heat_resistant = HAS_TRAIT(L, TRAIT_RESISTHEAT)
+		L.apply_damage(heat_resistant ? 90 : 25, BURN, spread_damage = TRUE)
 		L.adjust_fire_stacks(10)
 		L.IgniteMob()
 
@@ -305,8 +305,9 @@ GLOBAL_LIST_EMPTY(crematoriums)
 			C.adjust_cremation(25)
 
 	for(var/obj/O in conts) //conts defined above, ignores crematorium and tray
-		O.fire_act()
-		O.take_damage(50, BURN, null, FALSE)
+		if(!(O.resistance_flags & FIRE_PROOF))
+			O.fire_act()
+			O.take_damage(50, BURN, null, FALSE)
 
 	first_cremation_tick = FALSE
 

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -143,6 +143,6 @@
 	cooldown = TRUE
 	for (var/obj/structure/bodycontainer/crematorium/C in GLOB.crematoriums)
 		if (C.id == id)
-			C.toggle_cremation(usr)
+			C.toggle_cremation(null, usr)
 
 	addtimer(VARSET_CALLBACK(src, cooldown, FALSE), 30)

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -143,6 +143,6 @@
 	cooldown = TRUE
 	for (var/obj/structure/bodycontainer/crematorium/C in GLOB.crematoriums)
 		if (C.id == id)
-			C.cremate(usr)
+			C.toggle_cremation(usr)
 
-	addtimer(VARSET_CALLBACK(src, cooldown, FALSE), 50)
+	addtimer(VARSET_CALLBACK(src, cooldown, FALSE), 30)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -730,7 +730,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if(!limb_list)
 		limb_list = list(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 	for(var/zone in limb_list)
-		limb = get_bodypart(zone)
+		var/obj/item/bodypart/limb = get_bodypart(zone)
 		if(limb)
 			limb.cremation_progress = max(limb.cremation_progress + amount, 0)
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -724,6 +724,16 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /////////////
 //CREMATION//
 /////////////
+
+///Manually adjusts the cremation counter for the selected limbs (all limbs if left null)
+/mob/living/carbon/proc/adjust_cremation(amount, list/limb_list)
+	if(!limb_list)
+		limb_list = list(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+	for(var/zone in limb_list)
+		limb = get_bodypart(zone)
+		if(limb)
+			limb.cremation_progress = max(limb.cremation_progress + amount, 0)
+
 /mob/living/carbon/proc/check_cremation()
 	//Only cremate while actively on fire
 	if(!on_fire)

--- a/code/modules/mob/living/silicon/damage_procs.dm
+++ b/code/modules/mob/living/silicon/damage_procs.dm
@@ -1,5 +1,5 @@
 
-/mob/living/silicon/apply_damage(damage = 0,damagetype = BRUTE, def_zone = null, blocked = FALSE, forced = FALSE)
+/mob/living/silicon/apply_damage(damage = 0,damagetype = BRUTE, def_zone = null, blocked = FALSE, forced = FALSE, spread_damage = FALSE)
 	var/hit_percent = (100-blocked)/100
 	if((!damage || (!forced && hit_percent <= 0)))
 		return 0

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -178,14 +178,14 @@
 	var/total_damage = brute + burn
 
 	if(total_damage > can_inflict)
-		brute = round(brute * (can_inflict / total_damage),DAMAGE_PRECISION)
-		burn = round(burn * (can_inflict / total_damage),DAMAGE_PRECISION)
+		brute = CEILING(brute * (can_inflict / total_damage),DAMAGE_PRECISION)
+		burn = CEILING(burn * (can_inflict / total_damage),DAMAGE_PRECISION)
 
 	brute_dam += brute
 	burn_dam += burn
 
 	//We've dealt the physical damages, if there's room lets apply the stamina damage.
-	stamina_dam += round(clamp(stamina, 0, max_stamina_damage - stamina_dam), DAMAGE_PRECISION)
+	stamina_dam += CEILING(clamp(stamina, 0, max_stamina_damage - stamina_dam), DAMAGE_PRECISION)
 
 
 	if(owner && updating_health)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the behaviour of the crematorium.
Now, instead of instantly deleting all its contents, it will process while it remains on.

On every process tick, it will deal 90 burn damage (25 with the RESISTHEAT trait) and 10 firestacks (+ignite) to all mobs, and 50 burn damage(+regular burning) to all other non-fireproof objects.
On top of that mobs will have a greatly accelerated limb cremation process compared to regular burning, although they still need to be on fire for the actual dusting to take place.

**Note: i've not been able to compile or test this yet, putting the PR up early for feedback/opinions/kneejerk reactions. Will test as soon as i can work on a pc with byond on.**

## Why It's Good For The Game

Allows the crematorius to interact more consistently, especially when facing other game mechanics.
You could cremate something for three seconds and have it come out somewhat intact, although still badly burned (and still burning). With enough time everything will burn to ash anyway, of course, but you can now enjoy hearing every bit crumbling into dust inside the crematorium.

Fire immunity now prevents the crematorium from fully dusting a body, although the extreme heat will still deal some burn damage.

As another bonus, after the cremation you can easily collect any fireproof gear left over from the victims!

## Changelog
:cl: XDTM
balance: Crematoriums no longer instantly delete their contents upon activation. Instead, they can be toggled on or off, and will rapidly burn their contents into ash over time while active, unless completely fireproof.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
