### PR TITLE
Rebalanced timestop

### DIFF
--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -11,8 +11,8 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/list/immune = list() // the one who creates the timestop is immune, which includes wizards and the dead slime you murdered to make this chronofield
 	var/turf/target
-	var/freezerange = 2
-	var/duration = 140
+	var/freezerange = 5
+	var/duration = 80
 	var/datum/proximity_monitor/advanced/timestop/chronofield
 	alpha = 125
 	var/check_anti_magic = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases timestop freeze range to 11x11, but decreases freeze time to 8s.
Note: I haven't actually tested or compiled the code yet, but it _should_ work, since it's just a minor value change.

## Why It's Good For The Game

Timestop breaks the current direction for combat. We're supposed to be moving away from instant stuns, not towards, right?
So, basically, this changes timestop into more of an area denial and getaway spell, with the long freeze range allowing use during a chase, and the short freeze length making offensive use less viable.

## Changelog
:cl:
tweak: Increased timestop freeze range, decreased timestop freeze length..
/:cl:

