### PR TITLE
fix for diseases sometimes being unable to infect anybody

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -45,16 +45,16 @@
 #define BLOODCRAWL_EAT 2 /// crawling+mob devour
 
 //Mob bio-types flags
-#define MOB_ORGANIC 	1 << 0
-#define MOB_MINERAL		1 << 1
-#define MOB_ROBOTIC 	1 << 2
-#define MOB_UNDEAD		1 << 3
-#define MOB_HUMANOID 	1 << 4
-#define MOB_BUG 		1 << 5
-#define MOB_BEAST		1 << 6
-#define MOB_EPIC		1 << 7 //megafauna
-#define MOB_REPTILE		1 << 8
-#define MOB_SPIRIT		1 << 9
+#define MOB_ORGANIC 	(1 << 0)
+#define MOB_MINERAL		(1 << 1)
+#define MOB_ROBOTIC 	(1 << 2)
+#define MOB_UNDEAD		(1 << 3)
+#define MOB_HUMANOID 	(1 << 4)
+#define MOB_BUG 		(1 << 5)
+#define MOB_BEAST		(1 << 6)
+#define MOB_EPIC		(1 << 7) //megafauna
+#define MOB_REPTILE		(1 << 8)
+#define MOB_SPIRIT		(1 << 9)
 
 //Organ defines for carbon mobs
 #define ORGAN_ORGANIC   1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Yes, this is the fix. The operator precedence was fucking up on the following lines:
https://github.com/tgstation/tgstation/blob/448216574e9a65de23e6169c42f3e0bc4b47b359/code/datums/diseases/advance/symptoms/species.dm#L17
https://github.com/tgstation/tgstation/blob/448216574e9a65de23e6169c42f3e0bc4b47b359/code/datums/diseases/advance/symptoms/species.dm#L33

I checked out all the uses of these enums and didn't see anywhere that the current precedence would matter.

The following reports of this bug aren't 100% confirmed to be caused by this, but I'ma put 'em here anyway:
fixes https://github.com/tgstation/tgstation/issues/51150
fixes https://github.com/tgstation/tgstation/issues/51128
fixes https://github.com/tgstation/tgstation/issues/50663
fixes https://github.com/tgstation/tgstation/issues/50641
fixes https://github.com/tgstation/tgstation/issues/50641
fixes https://github.com/tgstation/tgstation/issues/50607
fixes https://github.com/tgstation/tgstation/issues/46408
fixes https://github.com/tgstation/tgstation/issues/47359

## Changelog
:cl:
fix: diseases now retain the ability to infect people after having 'inorganic biology' or 'necrotic metabolism' removed from them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
