### PR TITLE
Adds all plane masters to the camera console.

### DIFF
--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -24,8 +24,8 @@
 	blend_mode = BLEND_MULTIPLY
 	alpha = 255
 
-/obj/screen/plane_master/openspace/backdrop(mob/mymob)
-	filters = list()
+/obj/screen/plane_master/openspace/Initialize()
+	. = ..()
 	filters += filter(type = "drop_shadow", color = "#04080FAA", size = -10)
 	filters += filter(type = "drop_shadow", color = "#04080FAA", size = -15)
 	filters += filter(type = "drop_shadow", color = "#04080FAA", size = -20)
@@ -72,6 +72,10 @@
 	plane = LIGHTING_PLANE
 	blend_mode = BLEND_MULTIPLY
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/obj/screen/plane_master/lighting/backdrop(mob/mymob)
+	mymob.overlay_fullscreen("lighting_backdrop_lit", /obj/screen/fullscreen/lighting_backdrop/lit)
+	mymob.overlay_fullscreen("lighting_backdrop_unlit", /obj/screen/fullscreen/lighting_backdrop/unlit)
 
 /obj/screen/plane_master/lighting/Initialize()
 	. = ..()
@@ -128,10 +132,6 @@
 /obj/screen/plane_master/parallax_white
 	name = "parallax whitifier plane master"
 	plane = PLANE_SPACE
-
-/obj/screen/plane_master/lighting/backdrop(mob/mymob)
-	mymob.overlay_fullscreen("lighting_backdrop_lit", /obj/screen/fullscreen/lighting_backdrop/lit)
-	mymob.overlay_fullscreen("lighting_backdrop_unlit", /obj/screen/fullscreen/lighting_backdrop/unlit)
 
 /obj/screen/plane_master/camera_static
 	name = "camera static plane master"

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -16,7 +16,8 @@
 	var/map_name
 	var/const/default_map_size = 15
 	var/obj/screen/map_view/cam_screen
-	var/obj/screen/plane_master/lighting/cam_plane_master
+	/// All the plane masters that need to be applied.
+	var/list/cam_plane_masters
 	var/obj/screen/background/cam_background
 
 /obj/machinery/computer/security/Initialize()
@@ -35,18 +36,20 @@
 	cam_screen.assigned_map = map_name
 	cam_screen.del_on_map_removal = FALSE
 	cam_screen.screen_loc = "[map_name]:1,1"
-	cam_plane_master = new
-	cam_plane_master.name = "plane_master"
-	cam_plane_master.assigned_map = map_name
-	cam_plane_master.del_on_map_removal = FALSE
-	cam_plane_master.screen_loc = "[map_name]:CENTER"
+	cam_plane_masters = list()
+	for(var/plane in subtypesof(/obj/screen/plane_master))
+		var/obj/screen/instance = new plane()
+		instance.assigned_map = map_name
+		instance.del_on_map_removal = FALSE
+		instance.screen_loc = "[map_name]:CENTER"
+		cam_plane_masters += instance
 	cam_background = new
 	cam_background.assigned_map = map_name
 	cam_background.del_on_map_removal = FALSE
 
 /obj/machinery/computer/security/Destroy()
 	qdel(cam_screen)
-	qdel(cam_plane_master)
+	QDEL_LIST(cam_plane_masters)
 	qdel(cam_background)
 	return ..()
 
@@ -76,7 +79,8 @@
 			use_power(active_power_usage)
 		// Register map objects
 		user.client.register_map_obj(cam_screen)
-		user.client.register_map_obj(cam_plane_master)
+		for(var/plane in cam_plane_masters)
+			user.client.register_map_obj(plane)
 		user.client.register_map_obj(cam_background)
 		// Open UI
 		ui = new(user, src, ui_key, "CameraConsole", name, ui_x, ui_y, master_ui, state)

--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -14,7 +14,8 @@
 		return
 	user.client.setup_popup("spypopup", 3, 3, 2)
 	user.client.register_map_obj(linked_bug.cam_screen)
-	user.client.register_map_obj(linked_bug.cam_plane_master)
+	for(var/plane in linked_bug.cam_plane_masters)
+		user.client.register_map_obj(plane)
 	linked_bug.update_view()
 
 /obj/item/clothing/glasses/regular/spy/equipped(mob/user, slot)
@@ -47,7 +48,7 @@
 
 	var/obj/item/clothing/glasses/regular/spy/linked_glasses
 	var/obj/screen/map_view/cam_screen
-	var/obj/screen/plane_master/lighting/cam_plane_master
+	var/list/cam_plane_masters
 	// Ranges higher than one can be used to see through walls.
 	var/cam_range = 1
 	var/datum/movement_detector/tracker
@@ -62,23 +63,23 @@
 	cam_screen.del_on_map_removal = FALSE
 	cam_screen.set_position(1, 1)
 
-	// We need to add a lighting planesmaster to the popup, otherwise
+	// We need to add planesmasters to the popup, otherwise
 	// blending fucks up massively. Any planesmaster on the main screen does
 	// NOT apply to map popups. If there's ever a way to make planesmasters
 	// omnipresent, then this wouldn't be needed.
-	cam_plane_master = new
-	// Not stored on the client, but instead on the bug, therefore, there's
-	// no need to delete this object.
-	cam_plane_master.del_on_map_removal = FALSE
-	cam_plane_master.assigned_map = "spypopup_map"
-	// We are using set_screen_loc due to it being a non-standard placement.
-	cam_plane_master.screen_loc = "spypopup_map:CENTER"
+	cam_plane_masters = list()
+	for(var/plane in subtypesof(/obj/screen/plane_master))
+		var/obj/screen/instance = new plane()
+		instance.assigned_map = "spypopup_map"
+		instance.del_on_map_removal = FALSE
+		instance.screen_loc = "spypopup_map:CENTER"
+		cam_plane_masters += instance
 
 /obj/item/spy_bug/Destroy()
 	if(linked_glasses)
 		linked_glasses.linked_bug = null
 	qdel(cam_screen)
-	qdel(cam_plane_master)
+	QDEL_LIST(cam_plane_masters)
 	qdel(tracker)
 	. = ..()
 

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -10,6 +10,8 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 	plane           = OPENSPACE_BACKDROP_PLANE
 	mouse_opacity 	= MOUSE_OPACITY_TRANSPARENT
 	layer           = SPLASHSCREEN_LAYER
+	//I don't know why the others are aligned but I shall do the same.
+	vis_flags		= VIS_INHERIT_ID
 
 /turf/open/transparent/openspace
 	name = "open space"

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 	var/tiled_dirt = FALSE // use smooth tiled dirt decal
 
-	vis_flags = VIS_INHERIT_PLANE|VIS_INHERIT_ID	//when this be added to vis_contents of something it inherit something.plane and be associated with something on clicking, important for visualisation of turf in openspace and interraction with openspace that show you turf.
+	vis_flags = VIS_INHERIT_ID|VIS_INHERIT_PLANE	// Important for interaction with and visualization of openspace.
 
 /turf/vv_edit_var(var_name, new_value)
 	var/static/list/banned_edits = list("x", "y", "z")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Emissive stuff now gets displayed on cameras.
No more spooky emissive blocking visual overlays on potted plants.
Openspace now gets displayed properly on cameras.
Did no proper testing but the initial time it took to open wasn't noticeably longer. We only have around 9 plane masters in total so our servers should survive.
Fixes https://github.com/tgstation/tgstation/issues/51180

## Changelog
:cl:
add: The camera console looks fancier now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
