### PR TITLE
Krok Addict Species Name Fix

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -323,6 +323,40 @@
 		update_body_parts()
 		update_mutations_overlay()// no lizard with human hulk overlay please.
 
+/mob/proc/set_limb_id(datum/species/target_species, icon_update = 1) //Code for just changing limp id and appearance, not species
+	return
+
+/mob/living/carbon/set_limb_id(datum/species/target_species, icon_update = TRUE, pref_load = FALSE, change_voice = TRUE) //Voice mod can be toggled
+	if(target_species && has_dna())
+		var/datum/species/new_limb_id
+		if(ispath(target_species))
+			new_limb_id = new target_species
+		else if(istype(target_species))
+			new_limb_id = target_species
+		else
+			return
+		dna.species.limbs_id = new_limb_id.limbs_id //changes limb id
+		if(change_voice == TRUE)//toggable when calling the proc, default true
+			dna.species.say_mod = new_limb_id.say_mod //changes voice
+		if(ishuman(src))
+			qdel(language_holder)
+			var/species_holder = initial(new_limb_id.species_language_holder)
+			language_holder = new species_holder(src)
+		update_atom_languages()
+
+		if(new_limb_id.limbs_id == "zombie")
+			dna.species.use_skintones = FALSE //prevent sprite turning transparent
+			dna.species.species_traits -= MUTCOLORS
+			dna.species.species_traits -= DYNCOLORS
+
+/mob/living/carbon/human/set_limb_id(datum/species/target_species, icon_update = TRUE, pref_load = FALSE)
+	..()
+	if(icon_update)
+		update_body()
+		update_hair()
+		update_body_parts()
+		update_mutations_overlay()
+
 
 /mob/proc/has_dna()
 	return

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -88,7 +88,7 @@
 
 // Your skin falls off
 /datum/species/krokodil_addict
-	name = "Human"
+	name = "Krokodil Addict"
 	id = "goofzombies"
 	limbs_id = "zombie" //They look like zombies
 	sexes = 0

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -87,13 +87,14 @@
 		infection.Insert(C)
 
 // Your skin falls off
+/* his species is only left in to be targeted by set_limb_id(), which reads limbs_id and applies the respective sprite, Addicts WONT change species by this and only gain visual effects */
 /datum/species/krokodil_addict
 	name = "Krokodil Addict"
 	id = "goofzombies"
 	limbs_id = "zombie" //They look like zombies
 	sexes = 0
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie
-	mutanttongue = /obj/item/organ/tongue/zombie
+	say_mod = "moans"
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
 
 #undef REGENERATION_DELAY

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -161,10 +161,10 @@
 
 /datum/reagent/drug/krokodil/addiction_act_stage4(mob/living/carbon/human/M)
 	CHECK_DNA_AND_SPECIES(M)
-	if(!istype(M.dna.species, /datum/species/krokodil_addict))
-		to_chat(M, "<span class='userdanger'>Your skin falls off easily! You feel like you have changed.</span>") // Alert user of species change
+	if(M.mob_biotypes & MOB_ORGANIC)
+		to_chat(M, "<span class='userdanger'>Your skin falls off easily and you feel rotten!</span>") // Alert user injury
 		M.adjustBruteLoss(50*REM, 0) // holy shit your skin just FELL THE FUCK OFF
-		M.set_species(/datum/species/krokodil_addict)
+		M.set_limb_id(/datum/species/krokodil_addict) // Apply krok addict zombie sprites and say_mod, doesnt mutate
 	else
 		M.adjustBruteLoss(5*REM, 0)
 	..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -162,7 +162,7 @@
 /datum/reagent/drug/krokodil/addiction_act_stage4(mob/living/carbon/human/M)
 	CHECK_DNA_AND_SPECIES(M)
 	if(!istype(M.dna.species, /datum/species/krokodil_addict))
-		to_chat(M, "<span class='userdanger'>Your skin falls off easily!</span>")
+		to_chat(M, "<span class='userdanger'>Your skin falls off easily! You feel like you have changed.</span>") // Alert user of species change
 		M.adjustBruteLoss(50*REM, 0) // holy shit your skin just FELL THE FUCK OFF
 		M.set_species(/datum/species/krokodil_addict)
 	else


### PR DESCRIPTION
## About The Pull Request
Tweaks #50949. Krokodil Addicts were incorrectly displayed as "Humans" in medical scanners leading some players of non-human chars to believe they were turned into humans. Now, getting addicted to Krok only leads to visual change, as only the respective limbs_id is applied, with a say_mod instead of a zombie tounge. Thus, characters retain their species specific properties.

Krok Addict species is still in the code, but is only used to fetch the appropriate limbs_id/say_mod.

PR now provides a proc that only changes sprite to any given species, instead of mutating the player, with a toggable say_mod. (set_limb_id())

**Thanks a bunch @XDTM for helping a baby coder, would have never found the mistake witout you!**

## Why It's Good For The Game

- Fixes a consistency issue. (Krok Addicts should be less likely to be mistaken for real zombies)
- Adds an easy way to apply visual changes without mutating chars to a different species

## Changelog
:cl:
rcsdel: Krok Addiction does not change species anymore, only applies visual change
tweak: Changed krokodil addict species to be more consistent 
/:cl: