### PR TITLE
Adds turning on the spot to binoculars

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -26,16 +26,26 @@
 
 /obj/item/binoculars/proc/on_wield(obj/item/source, mob/user)
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/unwield)
+	RegisterSignal(user, COMSIG_ATOM_DIR_CHANGE, .proc/rotate)
 	listeningTo = user
 	user.visible_message("<span class='notice'>[user] holds [src] up to [user.p_their()] eyes.</span>", "<span class='notice'>You hold [src] up to your eyes.</span>")
 	item_state = "binoculars_wielded"
+	zoom(user, user.dir)
+
+/obj/item/binoculars/proc/rotate(atom/thing, old_dir, new_dir)
+	zoom(listeningTo, new_dir)
+
+/obj/item/binoculars/proc/zoom(mob/user, direction)
 	user.regenerate_icons()
 	if(!user?.client)
 		return
 	var/client/C = user.client
 	var/_x = 0
 	var/_y = 0
-	switch(user.dir)
+	C.change_view(CONFIG_GET(string/default_view))
+	C.pixel_x = 0
+	C.pixel_y = 0
+	switch(direction)
 		if(NORTH)
 			_y = zoom_amt
 		if(EAST)
@@ -47,12 +57,14 @@
 	C.change_view(world.view + zoom_out_amt)
 	C.pixel_x = world.icon_size*_x
 	C.pixel_y = world.icon_size*_y
+
 /obj/item/binoculars/proc/on_unwield(obj/item/source, mob/user)
 	unwield(user)
 
 /obj/item/binoculars/proc/unwield(mob/user)
 	if(listeningTo)
 		UnregisterSignal(listeningTo, COMSIG_MOVABLE_MOVED)
+		UnregisterSignal(user, COMSIG_ATOM_DIR_CHANGE)
 		listeningTo = null
 	user.visible_message("<span class='notice'>[user] lowers [src].</span>", "<span class='notice'>You lower [src].</span>")
 	item_state = "binoculars"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I hooked into the direction change signal to allow people using the binoculars to turn in place, and to make it actually work.

## Why It's Good For The Game

Spin spin

## Changelog
:cl:
add: You can now turn in place while using the binoculars, and it will behave as expected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
