### PR TITLE
Lavaland Chems Booster Pack I: More chems edition

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -90,6 +90,17 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = IS_SHARP
 
+/obj/item/clothing/glasses/meson/science
+	name = "science meson goggles"
+	desc = "Used by mining staff to see basic structural and terrain layouts through walls, and scan reagents regardless of lighting conditions."
+	clothing_flags = SCAN_REAGENTS //You can see reagents while wearing science goggles
+	actions_types = list(/datum/action/item_action/toggle_research_scanner)
+	glass_colour_type = /datum/client_colour/glass_colour/purple
+
+/obj/item/clothing/glasses/meson/science/item_action_slot_check(slot)
+	if(slot == ITEM_SLOT_EYES)
+		return TRUE
+
 /obj/item/clothing/glasses/science
 	name = "science goggles"
 	desc = "A pair of snazzy goggles used to protect against chemical spills. Fitted with an analyzer for scanning items and reagents."

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -58,7 +58,7 @@
 	new /obj/item/storage/bag/ore(src)
 	new /obj/item/t_scanner/adv_mining_scanner/lesser(src)
 	new /obj/item/gun/energy/kinetic_accelerator(src)
-	new /obj/item/clothing/glasses/meson(src)
+	new /obj/item/clothing/glasses/meson/science(src)
 	new /obj/item/survivalcapsule(src)
 	new /obj/item/assault_pod/mining(src)
 

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -78,7 +78,8 @@
 		/datum/reagent/medicine/mine_salve,
 		/datum/reagent/medicine/morphine,
 		/datum/reagent/drug/space_drugs,
-		/datum/reagent/toxin
+		/datum/reagent/toxin,
+		/datum/reagent/plasma_oxide
 	)
 
 	var/list/recording_recipe

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -71,7 +71,7 @@
 	. = 1
 
 /datum/reagent/drug/crank
-	name = "Lavacrank"
+	name = "Crank"
 	description = "Reduces stun times by about 400%. If overdosed or addicted it will deal significant Toxin, Brute and Brain damage."
 	reagent_state = LIQUID
 	color = "#fa0000"

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -71,16 +71,16 @@
 	. = 1
 
 /datum/reagent/drug/crank
-	name = "Crank"
-	description = "Reduces stun times by about 200%. If overdosed or addicted it will deal significant Toxin, Brute and Brain damage."
+	name = "Lavacrank"
+	description = "Reduces stun times by about 400%. If overdosed or addicted it will deal significant Toxin, Brute and Brain damage."
 	reagent_state = LIQUID
-	color = "#FA00C8"
+	color = "#fa0000"
 	overdose_threshold = 20
 	addiction_threshold = 10
 
 /datum/reagent/drug/crank/on_mob_life(mob/living/carbon/M)
 	if(prob(5))
-		var/high_message = pick("You feel jittery.", "You feel like you gotta go fast.", "You feel like you need to step it up.")
+		var/high_message = pick("You feel the scorch in your veins", "You feel flames engulfing you.", "You feel like you need to step it up.")
 		to_chat(M, "<span class='notice'>[high_message]</span>")
 	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "tweaking", /datum/mood_event/stimulant_medium, name)
 	M.adjustStaminaLoss(-4, 0)
@@ -89,36 +89,31 @@
 	M.AdjustUnconscious(-60, FALSE)
 	M.AdjustImmobilized(-60, FALSE)
 	M.AdjustParalyzed(-60, FALSE)
-	..()
-	. = 1
+	. = ..()
 
 /datum/reagent/drug/crank/overdose_process(mob/living/M)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2*REM)
 	M.adjustToxLoss(2*REM, 0)
-	M.adjustBruteLoss(2*REM, FALSE, FALSE, BODYPART_ORGANIC)
-	..()
-	. = 1
+	M.adjustFireLoss(2*REM, FALSE, FALSE, BODYPART_ORGANIC)
+	. = ..()
 
 /datum/reagent/drug/crank/addiction_act_stage1(mob/living/M)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5*REM)
-	..()
+	. = ..()
 
 /datum/reagent/drug/crank/addiction_act_stage2(mob/living/M)
-	M.adjustToxLoss(5*REM, 0)
-	..()
-	. = 1
+	M.adjustFireLoss(4*REM, 0)
+	. = ..()
 
 /datum/reagent/drug/crank/addiction_act_stage3(mob/living/M)
-	M.adjustBruteLoss(5*REM, 0)
-	..()
-	. = 1
+	M.adjustFireLoss(5*REM, 0)
+	. = ..()
 
 /datum/reagent/drug/crank/addiction_act_stage4(mob/living/M)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3*REM)
 	M.adjustToxLoss(5*REM, 0)
-	M.adjustBruteLoss(5*REM, 0)
-	..()
-	. = 1
+	M.adjustFireLoss(7*REM, 0)
+	. = ..()
 
 /datum/reagent/drug/krokodil
 	name = "Krokodil"

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -83,11 +83,12 @@
 		var/high_message = pick("You feel jittery.", "You feel like you gotta go fast.", "You feel like you need to step it up.")
 		to_chat(M, "<span class='notice'>[high_message]</span>")
 	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "tweaking", /datum/mood_event/stimulant_medium, name)
-	M.AdjustStun(-20, FALSE)
-	M.AdjustKnockdown(-20, FALSE)
-	M.AdjustUnconscious(-20, FALSE)
-	M.AdjustImmobilized(-20, FALSE)
-	M.AdjustParalyzed(-20, FALSE)
+	M.adjustStaminaLoss(-4, 0)
+	M.AdjustStun(-60, FALSE)
+	M.AdjustKnockdown(-60, FALSE)
+	M.AdjustUnconscious(-60, FALSE)
+	M.AdjustImmobilized(-60, FALSE)
+	M.AdjustParalyzed(-60, FALSE)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -370,6 +370,32 @@
 	color = "#d8c7b7"
 	healing = 0.2
 
+/datum/reagent/medicine/omnizine/alphazine
+	name = "Alphazine"
+	description = "Experimental mixture of hyper-plasmium oxide , protozine and wittel. This inorganic slurry seems to be better than homeworld omnizine."
+	reagent_state = LIQUID
+	color = "#460000"
+	metabolization_rate = 0.2
+	healing = 0.7
+
+/datum/reagent/medicine/alphazine/on_mob_add(mob/living/L)
+	. = ..()
+	if(!iscarbon(L))
+		return
+	var/mob/living/carbon/C = L
+	C.adjustStaminaLoss(min(-volume*2,60))
+
+/datum/reagent/medicine/alphazine/on_mob_end_metabolize(mob/living/L)
+	. = ..()
+	if(!iscarbon(L))
+		return
+	var/mob/living/carbon/C = L
+	C.adjustToxLoss(-current_cycle/5, 0)
+	C.adjustOxyLoss(-current_cycle/5, 0)
+	C.adjustBruteLoss(-current_cycle/5, 0)
+	C.adjustFireLoss(-current_cycle/5, 0)
+
+
 /datum/reagent/medicine/calomel
 	name = "Calomel"
 	description = "Quickly purges the body of all chemicals. Toxin damage is dealt if the patient is in good condition."
@@ -1334,3 +1360,5 @@
 	L.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 	L.Dizzy(0)
 	L.Jitter(0)
+
+

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -376,6 +376,7 @@
 	reagent_state = LIQUID
 	color = "#460000"
 	metabolization_rate = 0.2
+	overdose_threshold = 60
 	healing = 0.7
 
 /datum/reagent/medicine/alphazine/on_mob_add(mob/living/L)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -372,21 +372,21 @@
 
 /datum/reagent/medicine/omnizine/alphazine
 	name = "Alphazine"
-	description = "Experimental mixture of hyper-plasmium oxide , protozine and wittel. This inorganic slurry seems to be better than homeworld omnizine."
+	description = "Experimental mixture of hyper-plasmium oxide and protozine. This inorganic slurry seems to be better than homeworld omnizine."
 	reagent_state = LIQUID
 	color = "#460000"
 	metabolization_rate = 0.2
 	overdose_threshold = 60
 	healing = 0.7
 
-/datum/reagent/medicine/alphazine/on_mob_add(mob/living/L)
+/datum/reagent/medicine/omnizine/alphazine/on_mob_add(mob/living/L)
 	. = ..()
 	if(!iscarbon(L))
 		return
 	var/mob/living/carbon/C = L
 	C.adjustStaminaLoss(min(-volume*2,60))
 
-/datum/reagent/medicine/alphazine/on_mob_end_metabolize(mob/living/L)
+/datum/reagent/medicine/omnizine/alphazine/on_mob_end_metabolize(mob/living/L)
 	. = ..()
 	if(!iscarbon(L))
 		return

--- a/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
+++ b/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
@@ -60,6 +60,4 @@
 	results = list(/datum/reagent/medicine/C2/syriniver = 5)
 	required_reagents = list(/datum/reagent/sulfur = 1, /datum/reagent/fluorine = 1, /datum/reagent/toxin = 1, /datum/reagent/nitrous_oxide = 2)
 
-/datum/chemical_reaction/penthrite
-	results = list(/datum/reagent/medicine/C2/penthrite = 3)
-	required_reagents = list(/datum/reagent/pentaerythritol = 1, /datum/reagent/acetone = 1,  /datum/reagent/toxin/acid/nitracid = 1 , /datum/reagent/wittel = 1)
+

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -4,7 +4,7 @@
 
 /datum/chemical_reaction/crank
 	results = list(/datum/reagent/drug/crank = 5)
-	required_reagents = list(/datum/reagent/medicine/diphenhydramine = 1, /datum/reagent/ammonia = 1, /datum/reagent/lithium = 1,/datum/reagent/medicine/omnizine/protozine)
+	required_reagents = list(/datum/reagent/medicine/diphenhydramine = 1, /datum/reagent/ammonia = 1, /datum/reagent/lithium = 1,/datum/reagent/medicine/omnizine/protozine = 1)
 	mix_message = "The mixture violently reacts, leaving behind a few crystalline shards."
 	required_temp = 390
 

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -4,10 +4,9 @@
 
 /datum/chemical_reaction/crank
 	results = list(/datum/reagent/drug/crank = 5)
-	required_reagents = list(/datum/reagent/medicine/diphenhydramine = 1, /datum/reagent/ammonia = 1, /datum/reagent/lithium = 1, /datum/reagent/toxin/acid = 1, /datum/reagent/fuel = 1)
+	required_reagents = list(/datum/reagent/medicine/diphenhydramine = 1, /datum/reagent/ammonia = 1, /datum/reagent/lithium = 1,/datum/reagent/medicine/omnizine/protozine)
 	mix_message = "The mixture violently reacts, leaving behind a few crystalline shards."
 	required_temp = 390
-
 
 /datum/chemical_reaction/krokodil
 	results = list(/datum/reagent/drug/krokodil = 6)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -170,6 +170,6 @@
 	for(var/i = 1, i <= created_volume, i++)
 		new /obj/item/stack/medical/mesh/advanced(location)
 
-/datum/chemical_reaction/psicodine
-	results = list(/datum/reagent/medicine/omnizine/alphazine = 4)
-	required_reagents = list( /datum/reagent/medicine/omnizine/protozine = 1, /datum/reagent/plasma_oxide = 1, /datum/reagent/wittel = 1)
+/datum/chemical_reaction/alphazine
+	results = list(/datum/reagent/medicine/omnizine/alphazine = 3)
+	required_reagents = list( /datum/reagent/medicine/omnizine/protozine = 1, /datum/reagent/plasma_oxide = 1)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -170,3 +170,6 @@
 	for(var/i = 1, i <= created_volume, i++)
 		new /obj/item/stack/medical/mesh/advanced(location)
 
+/datum/chemical_reaction/psicodine
+	results = list(/datum/reagent/medicine/omnizine/alphazine = 4)
+	required_reagents = list( /datum/reagent/medicine/omnizine/protozine = 1, /datum/reagent/plasma_oxide = 1, /datum/reagent/wittel = 1)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -115,6 +115,18 @@
 /datum/chemical_reaction/reagent_explosion/tatp_explosion/update_info()
 	required_temp = 550 + rand(-49,49)
 
+/datum/chemical_reaction/reagent_explosion/penthrite
+	results = list(/datum/reagent/medicine/C2/penthrite = 3)
+	required_reagents = list(/datum/reagent/pentaerythritol = 1, /datum/reagent/acetone = 1,  /datum/reagent/toxin/acid/nitracid = 1)
+	strengthdiv = 5
+
+/datum/chemical_reaction/reagent_explosion/penthrite/on_reaction(datum/reagents/holder, created_volume)
+
+	if(holder.has_reagent(/datum/reagent/exotic_stabilizer,round(created_volume / 100, CHEMICAL_QUANTISATION_LEVEL)))
+		return
+	holder.remove_reagent(/datum/reagent/medicine/C2/penthrite, created_volume*3)
+	..()
+
 /datum/chemical_reaction/reagent_explosion/penthrite_explosion_epinephrine
 	required_reagents = list(/datum/reagent/medicine/C2/penthrite = 1, /datum/reagent/medicine/epinephrine = 1)
 	strengthdiv = 5

--- a/code/modules/reagents/chemistry/recipes/special.dm
+++ b/code/modules/reagents/chemistry/recipes/special.dm
@@ -207,3 +207,21 @@ GLOBAL_LIST_INIT(food_reagents, build_reagents_to_food()) //reagentid = related 
 	dat += "."
 	info = dat.Join("")
 	update_icon()
+
+/datum/chemical_reaction/randomized/maint_mixture1
+	persistent = TRUE
+	persistence_period = 1 //Resets every day
+	randomize_req_temperature = TRUE
+	results = list(/datum/reagent/drug/maint_mixture/slurry=1)
+
+/datum/chemical_reaction/randomized/maint_mixture2
+	persistent = TRUE
+	persistence_period = 5 //Reset every 5 days
+	randomize_req_temperature = TRUE
+	results = list(/datum/reagent/drug/maint_mixture/powder=1)
+
+/datum/chemical_reaction/randomized/maint_mixture3
+	persistent = TRUE
+	persistence_period = 7 //Reset every week
+	randomize_req_temperature = TRUE
+	results = list(/datum/reagent/drug/maint_mixture/tar=1)

--- a/code/modules/reagents/chemistry/recipes/special.dm
+++ b/code/modules/reagents/chemistry/recipes/special.dm
@@ -208,20 +208,3 @@ GLOBAL_LIST_INIT(food_reagents, build_reagents_to_food()) //reagentid = related 
 	info = dat.Join("")
 	update_icon()
 
-/datum/chemical_reaction/randomized/maint_mixture1
-	persistent = TRUE
-	persistence_period = 1 //Resets every day
-	randomize_req_temperature = TRUE
-	results = list(/datum/reagent/drug/maint_mixture/slurry=1)
-
-/datum/chemical_reaction/randomized/maint_mixture2
-	persistent = TRUE
-	persistence_period = 5 //Reset every 5 days
-	randomize_req_temperature = TRUE
-	results = list(/datum/reagent/drug/maint_mixture/powder=1)
-
-/datum/chemical_reaction/randomized/maint_mixture3
-	persistent = TRUE
-	persistence_period = 7 //Reset every week
-	randomize_req_temperature = TRUE
-	results = list(/datum/reagent/drug/maint_mixture/tar=1)


### PR DESCRIPTION
## About The Pull Request
This PR changes a few things, first of all miners now recieve special meson scanners that can also function as science goggles, so they can scan what's inside geysers, making cooperation easier.

Secondly it adds a few chems that can be considered very good, but since they require you to go to lavaland and look for geysers, it balances out, since chemists have no incentive to go to lavaland as is, locking op shit behind geysers will force at least some of them to go there, which is my goal.

Chems:
- Penthrite now requires plasmium oxide instead of wittel

- Alphazine - a lot better omnizine crafted with lavaland chems

- Crank - crank now requires lavaland chems to be crafter, but i buffed it to be 50% better meth

Plasmium oxide can now also be aquired from emagged chem dispenser. Honestly emagged chem dispensers are useless, more reasons for emagging something is good, since we nerfed emag already im not considering this bloat.

## Why It's Good For The Game

Lavaland chems should be better than standard chems. Effort = OP chems. I'm just adding more 
chems so that there is more incentive to actually going to lavaland.
## Changelog
:cl:
add: Miners are outfitted with specialized science meson goggles, to identify geysers
add: Alphazine has been added, as a much better omnizine alternative that requires lavaland chems
tweak: Crank now requires protozine, but acts like 50% better meth.
tweak: Penthrite now requires plasmium oxide.
add: Plasmium oxide can now be aquired from emagged chem dispenser
/:cl:
