### PR TITLE
Fix asset cache verification

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -115,6 +115,7 @@ window "mainwindow"
 		anchor1 = none
 		anchor2 = none
 		is-visible = false
+		auto-format = false
 		saved-params = ""
 	elem "tooltip"
 		type = BROWSER


### PR DESCRIPTION
byond is injecting html to load js shims into json files returned by xhr. this will get fixed in a later byond release, but this disables the functionality for the asset cache skin control today
