### PR TITLE
Adjust payday payout for most species (un-Fairer paydays)

### DIFF
--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -2,24 +2,21 @@
 
 /datum/bank_account
 	var/account_holder = "Rusty Venture"
-	var/mob/living/carbon/human/account_holder_mob
 	var/account_balance = 0
+	var/payday_modifier
 	var/datum/job/account_job
 	var/list/bank_cards = list()
 	var/add_to_accounts = TRUE
 	var/account_id
 	var/being_dumped = FALSE //pink levels are rising
 
-/datum/bank_account/New(newname, job)
+/datum/bank_account/New(newname, job, modifier = 1)
 	if(add_to_accounts)
 		SSeconomy.bank_accounts += src
 	account_holder = newname
-	for (var/i in GLOB.human_list)
-		var/mob/living/carbon/human/H = i
-		if (H.real_name == newname)
-			account_holder_mob = H
 	account_job = job
 	account_id = rand(111111,999999)
+	payday_modifier = modifier
 
 /datum/bank_account/Destroy()
 	if(add_to_accounts)
@@ -53,9 +50,7 @@
 	return FALSE
 
 /datum/bank_account/proc/payday(amt_of_paychecks, free = FALSE)
-	var/money_to_transfer = account_job.paycheck * amt_of_paychecks
-	if (account_holder_mob.dna.species.id != "human")
-		money_to_transfer = money_to_transfer * 0.75
+	var/money_to_transfer = account_job.paycheck * payday_modifier * amt_of_paychecks
 	if(free)
 		adjust_money(money_to_transfer)
 		SSblackbox.record_feedback("amount", "free_income", money_to_transfer)

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -2,6 +2,7 @@
 
 /datum/bank_account
 	var/account_holder = "Rusty Venture"
+	var/mob/living/carbon/human/account_holder_mob
 	var/account_balance = 0
 	var/datum/job/account_job
 	var/list/bank_cards = list()
@@ -13,6 +14,10 @@
 	if(add_to_accounts)
 		SSeconomy.bank_accounts += src
 	account_holder = newname
+	for (var/i in GLOB.human_list)
+		var/mob/living/carbon/human/H = i
+		if (H.real_name == newname)
+			account_holder_mob = H
 	account_job = job
 	account_id = rand(111111,999999)
 
@@ -49,6 +54,8 @@
 
 /datum/bank_account/proc/payday(amt_of_paychecks, free = FALSE)
 	var/money_to_transfer = account_job.paycheck * amt_of_paychecks
+	if (account_holder_mob.dna.species.id != "human")
+		money_to_transfer = money_to_transfer * 0.75
 	if(free)
 		adjust_money(money_to_transfer)
 		SSblackbox.record_feedback("amount", "free_income", money_to_transfer)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -102,7 +102,7 @@
 			H.set_species(/datum/species/human)
 			H.apply_pref_name("human", preference_source)
 	if(!visualsOnly)
-		var/datum/bank_account/bank_account = new(H.real_name, src)
+		var/datum/bank_account/bank_account = new(H.real_name, src, H.dna.species.payday_modifier)
 		bank_account.payday(STARTING_PAYCHECKS, TRUE)
 		H.account_id = bank_account.account_id
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -74,6 +74,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/heatmod = 1
 	///multiplier for stun durations
 	var/stunmod = 1
+	///multiplier for money paid at payday
+	var/payday_modifier = 1
 	///Type of damage attack does. Ethereals attack with burn damage for example.
 	var/attack_type = BRUTE
 	///Lowest possible punch damage this species can give. If this is set to 0, punches will always miss.

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -12,6 +12,7 @@
 	exotic_blood = /datum/reagent/consumable/liquidelectricity //Liquid Electricity. fuck you think of something better gamer
 	siemens_coeff = 0.5 //They thrive on energy
 	brutemod = 1.25 //They're weak to punches
+	payday_modifier = 0.75
 	attack_type = BURN //burn bish
 	damage_overlay_type = "" //We are too cool for regular damage overlays
 	species_traits = list(DYNCOLORS, AGENDER, NO_UNDERWEAR, HAIR)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -12,6 +12,7 @@
 	mutant_organs = list(/obj/item/organ/tail/cat)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	var/original_felinid = TRUE //set to false for felinids created by mass-purrbation
+	payday_modifier = 0.75
 
 /datum/species/human/felinid/qualifies_for_rank(rank, list/features)
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -12,6 +12,7 @@
 	liked_food = GROSS
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/fly
+	payday_modifier = 0.75
 
 /datum/species/fly/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.type == /datum/reagent/toxin/pestkiller)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -7,6 +7,7 @@
 	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL
 	mutant_organs = list(/obj/item/organ/adamantine_resonator)
 	speedmod = 2
+	payday_modifier = 0.75
 	armor = 55
 	siemens_coeff = 0
 	punchdamagelow = 5

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -9,6 +9,7 @@
 	disliked_food = GROSS | RAW
 	liked_food = JUNKFOOD | FRIED
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
+	payday_modifier = 1
 
 /datum/species/human/qualifies_for_rank(rank, list/features)
 	return TRUE	//Pure humans are always allowed in all roles.

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -15,6 +15,7 @@
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
 	burnmod = 0.5 // = 1/2x generic burn damage
+	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	inherent_factions = list("slime")
 	species_language_holder = /datum/language_holder/jelly

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -11,6 +11,7 @@
 	mutant_organs = list(/obj/item/organ/tail/lizard)
 	coldmod = 1.5
 	heatmod = 0.67
+	payday_modifier = 0.75
 	default_features = list("mcolor" = "0F0", "tail_lizard" = "Smooth", "snout" = "Round", "horns" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None", "legs" = "Normal Legs")
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	attack_verb = "slash"

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -19,6 +19,7 @@
 	species_language_holder = /datum/language_holder/moth
 	wings_icon = "Megamoth"
 	has_innate_wings = TRUE
+	payday_modifier = 0.75
 
 /datum/species/moth/regenerate_organs(mob/living/carbon/C,datum/species/old_species,replace_current=TRUE,list/excluded_zones)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -14,6 +14,7 @@
 	burnmod = 1.5
 	heatmod = 1.5
 	brutemod = 1.5
+	payday_modifier = 0.75
 	breathid = "tox"
 	damage_overlay_type = ""//let's not show bloody wounds or burns over bones.
 	var/internal_fire = FALSE //If the bones themselves are burning clothes won't help you much

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -11,6 +11,7 @@
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	burnmod = 1.25
 	heatmod = 1.5
+	payday_modifier = 0.75
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/plant
 	disliked_food = MEAT | DAIRY
 	liked_food = VEGETABLES | FRUIT | GRAIN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a payday_modifier variable to bank_accounts.
This can be used to increase or decrease the money a account receives each payday.

Also adds an payday_modifier to species.dm which defaults to 1 but I overwrote it in most species files to 0.75, expect for humans.
This means all crew members, expect humans, earn 25% less now.

EDIT: Cobby said its OK to PR this, just in case some maintainer sees this as race change which require maintainer approval:
![image](https://user-images.githubusercontent.com/33846895/82688129-9ccda780-9c58-11ea-82bc-661acffcf73f.png)


## Why It's Good For The Game

Currently most people earn way too much money anyways. This PR fixes this at least by a bit.
However the main intend is to encourage roleplaying by adding a bit of racial conflict.
It also seems kinda realistic from an IC perspective that NT would try to save cost by paying non humans less.

## Changelog
:cl:
tweak: Nanotrasen checked the last few expenses reports and decided to reduce payday spending. Because of this, the salary of all non human employees has been reduced by 25%. Please consult your local Head of Personal for more information.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
