### PR TITLE
Adds 2 new operators for spawn chatbar verb

### DIFF
--- a/code/__HELPERS/type_processing.dm
+++ b/code/__HELPERS/type_processing.dm
@@ -53,7 +53,7 @@
 /proc/filter_fancy_list(list/L, filter as text)
 	var/list/matches = new
 	var/end_len = -1
-	var/list/endcheck = splittext(filter, "~")
+	var/list/endcheck = splittext(filter, "!")
 	if(endcheck.len > 1)
 		filter = endcheck[1]
 		end_len = length_char(filter)

--- a/code/__HELPERS/type_processing.dm
+++ b/code/__HELPERS/type_processing.dm
@@ -52,8 +52,14 @@
 
 /proc/filter_fancy_list(list/L, filter as text)
 	var/list/matches = new
+	var/end_len = -1
+	var/list/endcheck = splittext(filter, "~")
+	if(endcheck.len > 1)
+		filter = endcheck[1]
+		end_len = length_char(filter)
+
 	for(var/key in L)
 		var/value = L[key]
-		if(findtext("[key]", filter) || findtext("[value]", filter))
+		if(findtext("[key]", filter, -end_len) || findtext("[value]", filter, -end_len))
 			matches[key] = value
 	return matches

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1076,6 +1076,12 @@ proc/pick_closest_path(value, list/matches = get_fancy_list_of_atom_types())
 		if (isnull(value))
 			return
 	value = trim(value)
+
+	var/random = FALSE
+	if(findtext(value, "?"))
+		value = replacetext(value, "?", "")
+		random = TRUE
+
 	if(!isnull(value) && value != "")
 		matches = filter_fancy_list(matches, value)
 
@@ -1085,10 +1091,12 @@ proc/pick_closest_path(value, list/matches = get_fancy_list_of_atom_types())
 	var/chosen
 	if(matches.len==1)
 		chosen = matches[1]
+	else if(random)
+		chosen = pick(matches) || null
 	else
 		chosen = input("Select a type", "Pick Type", matches[1]) as null|anything in sortList(matches)
-		if(!chosen)
-			return
+	if(!chosen)
+		return
 	chosen = matches[chosen]
 	return chosen
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Per the PR title, this adds a few quality of life tweaks to my favorite chat verb, spawn. Appending a ! lets you select only paths that end in what you're searching for, and ? picks a random path from whatever results you get.

Picture you just want to spawn a human, so you type 'spawn "carbon/human' and hit enter. Guess what you get? Everything with carbon/human in the path, AKA all its derivatives!
[![dreamseeker_2020-05-22_21-41-05.png](https://i.imgur.com/1aNrFCMl.jpg)](https://i.imgur.com/1aNrFCM.png)
That sucks if you know what you're looking for, so type 'spawn "carbon/human!' and it'll only search for paths that END in "carbon/human", which as of right now will actually spawn you a standard human mob without even bothering you with a menu. Nice!

Feeling risky? Try a random spawn! Append "?" to your search to automatically spawn one of the paths your search returns, like 'spawn "item/grenade/?' for a random grenade!
[![dreamseeker_2020-05-22_21-48-05.png](https://i.imgur.com/toMtRzPl.jpg)](https://i.imgur.com/toMtRzP.png)

Hell, you can even mix and match the quantity operator, :, along with ! and ? however you want, they're all compatible! For example, 'spawn "item/grenade?:10' yields 10 of the same random grenade.
[![dreamseeker_2020-05-22_21-49-37.png](https://i.imgur.com/GioYJe6l.jpg)](https://i.imgur.com/GioYJe6.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it 10x easier for me to spawn humans, frag grenades, other fun things for testing and badminnery
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
admin: You can now use ! and ? at the end of 'spawn' chatbar verb commands to search for only the ends of paths, or to automatically select a random type of the paths your search returns! Happy badminning!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
