### PR TITLE
Let Me Tell You A Story

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -12,7 +12,6 @@
 	bubble_icon = "alien"
 	type_of_meat = /obj/item/reagent_containers/food/snacks/meat/slab/xeno
 
-	var/obj/item/card/id/wear_id = null // Fix for station bounced radios -- Skie
 	var/has_fine_manipulation = 0
 	var/move_delay_add = 0 // movement delay to add
 


### PR DESCRIPTION
Come, let me tell you a story of the old days----of SHITCODE.

AGhhhhh.

Once upon a time, SS13 code was terrible (who are we joking, it still is, but that's a story for another day), and when any carbon subtype, minus humans, talked over radio, it would runtime.

Of course, coders set about fixing this problem---can't have nonsense like that, so...of course, the most logical thing was done.

Instead of solving the awfulness that was not only using the wrong istype check and a wonderful colon override as well: https://github.com/tgstation/tgstation/blob/9eb0e80ae7f57040b9178c637efb4bac33ce3d16/code/game/objects/radio/radio.dm#L148

A "Fix" was applied instead: https://github.com/tgstation/tgstation/commit/9eb0e80ae7f57040b9178c637efb4bac33ce3d16#diff-b5f801c8078b7d8dd9f0661b359dfa9e

Whereby `var/obj/item/card/id/wear_id = null` was added to monkeys and aliens to "fix" them having an ID holder and not throwing a runtime.........Thus ensuring:

Fox would find it one day and call this utterly moronic and while also ensuring that all future carbon mobs created without implementing this same "fix" would have the same exact problem.

Then radio code got rewritten to be non-stupid and this still hung around until today.

The End