### PR TITLE
Makes Bluespace Anomalies not Stupid

### DIFF
--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -2,7 +2,7 @@
 	name = "Anomaly: Bluespace"
 	typepath = /datum/round_event/anomaly/anomaly_bluespace
 
-	max_occurrences = 1
+	max_occurrences = 8
 	weight = 15
 
 /datum/round_event/anomaly/anomaly_bluespace


### PR DESCRIPTION


## About The Pull Request

This changes the amount of time bluespace anomalies can occur from once a round to 8 times a round. 

## Why It's Good For The Game

Someone pointed out to me that bluespace anomalies can only happen once a round, and this means you can realistically only gain one core, if any a round *most* of the time. This will allow bluespace cores to perhaps be a little more common, so people can actually use some of the stuff that requires it besides one person. 
## Changelog
:cl:

balance: Increased potential Bluespace Anomaly occurrences from 1 to 8 per round

/:cl:


