### PR TITLE
Fixes SMES not charging from self-recharging cells.

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -240,6 +240,10 @@
 	var/last_chrg = inputting
 	var/last_onln = outputting
 
+	//check for slime cores in stock parts and use them to self-charge
+	for(var/obj/item/stock_parts/cell/high/slime/SC in component_parts)
+		charge += min(capcity-charge, SC.chargerate) // If capacity-charge is smaller than the attempted charge rate, this avoids overcharging
+
 	//inputting
 	if(terminal && input_attempt)
 		input_available = terminal.surplus()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -242,7 +242,7 @@
 
 	//check for slime cores in stock parts and use them to self-charge
 	for(var/obj/item/stock_parts/cell/high/slime/SC in component_parts)
-		charge += min(capcity-charge, SC.chargerate) // If capacity-charge is smaller than the attempted charge rate, this avoids overcharging
+		charge += min(capacity-charge, SC.chargerate) // If capacity-charge is smaller than the attempted charge rate, this avoids overcharging
 
 	//inputting
 	if(terminal && input_attempt)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -240,9 +240,10 @@
 	var/last_chrg = inputting
 	var/last_onln = outputting
 
-	//check for slime cores in stock parts and use them to self-charge
-	for(var/obj/item/stock_parts/cell/high/slime/SC in component_parts)
-		charge += min(capacity-charge, SC.chargerate) // If capacity-charge is smaller than the attempted charge rate, this avoids overcharging
+	//check for self-recharging cells in stock parts and use them to self-charge
+	for(var/obj/item/stock_parts/cell/C in component_parts)
+		if(C.self_recharge)
+			charge += min(capacity-charge, C.chargerate) // If capacity-charge is smaller than the attempted charge rate, this avoids overcharging
 
 	//inputting
 	if(terminal && input_attempt)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

SMES units don't handle yellow slime cores used as cells. As a result, yellow slime core self-charging properties do not function in SMES units.

This attempts to fix that adding a small logic loop that checks for slime core batteries and charges the SMES accordingly. This logic loop is outside of the ordinary charging loop because... Well... The slime cores are charging whether you want them to or not. It's totally unrelated to your charge transfer setting (which is more linked to how much charge they pull out of the powernet).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes a consistency issue. Yellow slime cores do still charge inside SMES units (using VV) so the SMES might as well act like it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: SMES units now self-charge when containing yellow slime cores.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
