### PR TITLE
You can altClick to take out DNA Disks from DNA consoles

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -1988,9 +1988,15 @@
 	tgui_view_state["storageConsSubMode"] = "mutations"
 	tgui_view_state["storageDiskSubMode"] = "mutations"
 
-/*
- * Ejects the DNA Disk from the console.
- */
+/**
+  * Ejects the DNA Disk from the console.
+	*
+	* Will insert into the user's hand if possible, otherwise will drop it at the
+	* console's location.
+	*
+	* Arguments:
+  * * user - The mob that is attempting to eject the diskette.
+  */
 /obj/machinery/computer/scan_consolenew/proc/eject_disk(mob/user)
 	// Check for diskette.
 	if(!diskette)

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -191,13 +191,11 @@
 
 
 /obj/machinery/computer/scan_consolenew/AltClick(mob/user)
-	if(diskette && user.canUseTopic(src, !issilicon(user)))
-		to_chat(user, "<span class='notice'>You take out [diskette] from [src].</span>")
-		if(!istype(user) || !Adjacent(user) || !user.put_in_active_hand(diskette))
-			diskette.forceMove(drop_location())
-		diskette = null
-	return
+	// Make sure the user can interact with the machine.
+	if(!user.canUseTopic(src, !issilicon(user)))
+		return
 
+	eject_disk(user)
 
 /obj/machinery/computer/scan_consolenew/Initialize()
 	. = ..()
@@ -1058,13 +1056,7 @@
 
 		// Eject stored diskette from console
 		if("eject_disk")
-			// GUARD CHECK - This code shouldn't even be callable without a diskette
-			//  inserted. Unexpected result
-			if(!diskette)
-				return
-
-			diskette.forceMove(drop_location())
-			diskette = null
+			eject_disk(usr)
 			return
 
 		// Create a Genetic Makeup injector. These injectors are timed and thus are
@@ -1996,6 +1988,20 @@
 	tgui_view_state["storageConsSubMode"] = "mutations"
 	tgui_view_state["storageDiskSubMode"] = "mutations"
 
+/*
+ * Ejects the DNA Disk from the console.
+ */
+/obj/machinery/computer/scan_consolenew/proc/eject_disk(mob/user)
+	// Check for diskette.
+	if(!diskette)
+		return
+
+	to_chat(user, "<span class='notice'>You eject [diskette] from [src].</span>")
+
+	// If the disk shouldn't pop into the user's hand for any reason, drop it on the console instead.
+	if(!istype(user) || !Adjacent(user) || !user.put_in_active_hand(diskette))
+		diskette.forceMove(drop_location())
+	diskette = null
 
 #undef INJECTOR_TIMEOUT
 #undef NUMBER_OF_BUFFERS

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -189,6 +189,16 @@
 
 	return ..()
 
+
+/obj/machinery/computer/scan_consolenew/AltClick(mob/user)
+	if(diskette && user.canUseTopic(src, !issilicon(user)))
+		to_chat(user, "<span class='notice'>You take out [diskette] from [src].</span>")
+		if(!istype(user) || !Adjacent(user) || !user.put_in_active_hand(diskette))
+			diskette.forceMove(drop_location())
+		diskette = null
+	return
+
+
 /obj/machinery/computer/scan_consolenew/Initialize()
 	. = ..()
 


### PR DESCRIPTION
You can now altClick to take out a disk from a DNA Console, instead of having to use the GUI and clicking eject.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously, you had to use the interface and click the eject button to take out a disk from a DNA console. Now you can just altClick and it will attempt to put the disk in a free hand.

## Why It's Good For The Game

Quality of Life changes for DNA Consoles.

## Changelog
:cl: Kathy Ryals
tweak: You can now altClick to take out a disk from a DNA Console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
