### PR TITLE
mindshields no longer implant fake memories

### DIFF
--- a/code/game/gamemodes/gang/gang_things.dm
+++ b/code/game/gamemodes/gang/gang_things.dm
@@ -9,7 +9,7 @@
 /obj/item/gang_induction_package/attack_self(mob/living/user)
 	..()
 	if(HAS_TRAIT(user, TRAIT_MINDSHIELD))
-		to_chat(user, "You are mindshielded, so you cannot join a family.")
+		to_chat(user, "Your mind vehemently refuses to accept the family's ideologies.")
 		return
 	if(user.mind.has_antag_datum(/datum/antagonist/ert/families))
 		to_chat(user, "As a police officer, you can't join this family. However, you pretend to accept it to keep your cover up.")

--- a/code/game/gamemodes/gang/gang_things.dm
+++ b/code/game/gamemodes/gang/gang_things.dm
@@ -9,7 +9,7 @@
 /obj/item/gang_induction_package/attack_self(mob/living/user)
 	..()
 	if(HAS_TRAIT(user, TRAIT_MINDSHIELD))
-		to_chat(user, "You attended a seminar on not signing up for a gang, and are not interested.")
+		to_chat(user, "You are mindshielded, so you cannot join a family.")
 		return
 	if(user.mind.has_antag_datum(/datum/antagonist/ert/families))
 		to_chat(user, "As a police officer, you can't join this family. However, you pretend to accept it to keep your cover up.")


### PR DESCRIPTION
## About The Pull Request

changed the message that you receive when you try to use a gang induction package as a mindshielded person to no longer imply that your mindshield has given you fake memories of attending an anti-gang seminar

## Why It's Good For The Game

mindshield implants don't brainwash people (which is why we don't call them loyalty implants anymore and why they don't turn traitors, blood brothers, wizards, changelings, etc. into NT loyalists)

we told goof about this when he made his families PR, but he ignored us, so I'm just PRing this myself

## Changelog
:cl: ATHATH
tweak: The message that you receive when you try to use a gang induction package as a mindshielded person no longer implies that your mindshield has given you fake memories of attending an anti-gang seminar.
/:cl: