### PR TITLE
Makes the TRAIT_STUNRESISTANCE trait actually worth a damn

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -225,7 +225,10 @@
 	L.Jitter(20)
 	L.confused = max(confusion_amt, L.confused)
 	L.stuttering = max(8, L.stuttering)
-	L.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)
+	if(HAS_TRAIT(target, TRAIT_STUNRESISTANCE))
+		L.apply_damage(round(stamina_loss_amt/2), STAMINA, BODY_ZONE_CHEST) //halves the stamina damage from the baton strike
+	else
+		L.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)
 
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	addtimer(CALLBACK(src, .proc/apply_stun_effect_end, L), apply_stun_delay)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -225,7 +225,7 @@
 	L.Jitter(20)
 	L.confused = max(confusion_amt, L.confused)
 	L.stuttering = max(8, L.stuttering)
-	if(HAS_TRAIT(target, TRAIT_STUNRESISTANCE))
+	if(HAS_TRAIT(L, TRAIT_STUNRESISTANCE))
 		L.apply_damage(round(stamina_loss_amt/2), STAMINA, BODY_ZONE_CHEST) //halves the stamina damage from the baton strike
 	else
 		L.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)


### PR DESCRIPTION
## About The Pull Request

The TRAIT_STUNRESISTANCE trait, in addition to its other (mostly baton-related) effects, now halves the stamina damage you receive from stun batons.

## Why It's Good For The Game

Currently, the TRAIT_STUNRESISTANCE trait doesn't do its job of being a stun baton resistance trait/counter very well, as even though it reduces the knockdown from stun batons, it doesn't reduce the stamina damage from stun batons, causing you to still be 2HKO'd by them and still be slowed down (from (stamina) damage slowdown) by the first stun baton strike you receive.

This PR fixes that issue, making the TRAIT_STUNRESISTANCE trait (and, in turn, the pump-up reagent) the baton counter it was meant to be.

## Changelog
:cl: ATHATH
balance: The TRAIT_STUNRESISTANCE trait, in addition to its other (mostly baton-related) effects, now halves the stamina damage you receive from stun batons. In layman's terms, pump-up got buffed to actually give you some half-decent protection against stun batons.
/:cl:
