### PR TITLE
Fix botany grafts & glitchy-infinite-plant-spawney-ness

### DIFF
--- a/code/modules/hydroponics/grafts.dm
+++ b/code/modules/hydroponics/grafts.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "graft_plant"
 	attack_verb = list("planted", "vegitized", "cropped", "reaped", "farmed")
-	///This stored the trait taken from the parent plant. Defaults to perenial growth.
+	///The stored trait taken from the parent plant. Defaults to perenial growth.
 	var/datum/plant_gene/trait/stored_trait
 	///Determines the appearance of the graft. Rudimentary right now so it just picks randomly.
 	var/graft_appearance
@@ -30,14 +30,22 @@
 	var/yield
 
 
-/obj/item/graft/Initialize()
+/obj/item/graft/Initialize(mapload, datum/plant_gene/trait/trait_path)
 	. = ..()
-	stored_trait = new /datum/plant_gene/trait/repeated_harvest //Default gene is repeated harvest.
+	//Default gene is repeated harvest.
+	if(trait_path)
+		stored_trait = new trait_path
+	else
+		stored_trait = new /datum/plant_gene/trait/repeated_harvest 
 	icon_state = pick(
 		10 ; "graft_plant" , \
 		5 ; "graft_flower" , \
 		4 ; "graft_mushroom" , \
 		1 ; "graft_doom" )
+
+/obj/item/graft/Destroy()
+	QDEL_NULL(stored_trait)
+	return ..()
 
 /obj/item/graft/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/plant_analyzer) && user.a_intent == INTENT_HELP)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -525,7 +525,7 @@
 					possible_reagents += reag
 				var/datum/plant_gene/reagent/reagent_gene = pick(possible_reagents) //Let this serve as a lession to delete your WIP comments before merge.
 				if(reagent_gene.can_add(myseed))
-					myseed.genes += reagent_gene
+					myseed.genes += reagent_gene.Copy()
 					myseed.reagents_from_genes()
 					continue
 

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -56,7 +56,7 @@
 	var/weed_chance = 5
 	///Determines if the plant has had a graft removed or not.
 	var/grafted = FALSE
-	///Trait to be applied when grafting a plant.
+	///Type-path of trait to be applied when grafting a plant.
 	var/graft_gene
 
 /obj/item/seeds/Initialize(mapload, nogenes = 0)
@@ -562,9 +562,7 @@
   * Returns the created graft.
   */
 /obj/item/seeds/proc/create_graft()
-	var/obj/item/graft/snip = new
-	if(graft_gene)
-		snip.stored_trait = graft_gene
+	var/obj/item/graft/snip = new(loc, graft_gene)
 	snip.parent_seed = src
 	snip.parent_name = plantname
 	snip.name += "([plantname])"
@@ -592,7 +590,7 @@
 /obj/item/seeds/proc/apply_graft(obj/item/graft/snip)
 	var/datum/plant_gene/trait/new_trait = snip.stored_trait
 	if(new_trait?.can_add(src))
-		genes += new_trait
+		genes += new_trait.Copy()
 
 	// Adjust stats based on graft stats.
 	src.lifespan	= round(clamp(max(src.lifespan,		(src.lifespan	+(2/3)*(snip.lifespan	-src.lifespan)		)),0,100))


### PR DESCRIPTION
## About The Pull Request
This fixes two bugs:
1) Non-default grafts (so any plant with a unique trait) would store a type-path where an object instance was expected, so the created graft would never be able to apply to other plants
I fixed it by actually creating the objects.

2) Cross-pollination was causing multiple plants to hold onto the same trait instance. This meant that if one of the plant's lost the trait (through gene-shears or something similar), the trait would be qdel'd and eventually become null on the other plants gene list. Harvesting a plant after this happens causes a runtime and stuff breaks.

This _might_ fix the following issues, but i can't be sure they weren't magically produced another way:
- https://github.com/tgstation/tgstation/issues/51133 
- https://github.com/tgstation/tgstation/issues/51193

## Changelog
:cl:
fix: Botany grafts for traits other than 'perennial growth' are no longer non-functional
fix: Cross-pollination can no longer result in plants entering an infinitely-harvestable state
/:cl:

