### PR TITLE
Unfucks smallscreen, removes my stupidity

### DIFF
--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -32,7 +32,7 @@
 	winset(chief, "mapwindow.map", "zoom-mode=[chief.prefs.scaling_method]")
 
 /datum/viewData/proc/isZooming()
-	return (width || height)
+	return (!!width || !!height) //Fear it
 
 /datum/viewData/proc/resetToDefault()
 	width = 0
@@ -80,8 +80,6 @@
 /datum/viewData/proc/apply()
 	chief.change_view(getView())
 	safeApplyFormat()
-	if(chief.prefs.auto_fit_viewport)
-		chief.fit_viewport()
 
 /datum/viewData/proc/supress()
 	is_suppressed = TRUE

--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -32,7 +32,7 @@
 	winset(chief, "mapwindow.map", "zoom-mode=[chief.prefs.scaling_method]")
 
 /datum/viewData/proc/isZooming()
-	return (!!width || !!height) //Fear it
+	return (width || height)
 
 /datum/viewData/proc/resetToDefault()
 	width = 0
@@ -80,8 +80,6 @@
 /datum/viewData/proc/apply()
 	chief.change_view(getView())
 	safeApplyFormat()
-	if(chief.prefs.auto_fit_viewport)
-		chief.fit_viewport()
 
 /datum/viewData/proc/supress()
 	is_suppressed = TRUE

--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -80,6 +80,8 @@
 /datum/viewData/proc/apply()
 	chief.change_view(getView())
 	safeApplyFormat()
+	if(chief.prefs.auto_fit_viewport)
+		chief.fit_viewport()
 
 /datum/viewData/proc/supress()
 	is_suppressed = TRUE

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -11,7 +11,8 @@
 	var/datum/action/innate/camera_off/off_action = new
 	var/datum/action/innate/camera_jump/jump_action = new
 	var/list/actions = list()
-
+	///Should we supress any view changes?
+	var/should_supress = TRUE
 	light_color = LIGHT_COLOR_RED
 
 /obj/machinery/computer/camera_advanced/Initialize()
@@ -162,7 +163,8 @@
 	user.remote_control = eyeobj
 	user.reset_perspective(eyeobj)
 	eyeobj.setLoc(eyeobj.loc)
-	user.client.view_size.supress()
+	if(should_supress)
+		user.client.view_size.supress()
 
 /mob/camera/aiEye/remote
 	name = "Inactive Camera Eye"

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -12,7 +12,7 @@
 	var/datum/action/innate/camera_jump/jump_action = new
 	var/list/actions = list()
 	///Should we supress any view changes?
-	var/should_supress = TRUE
+	var/should_supress_view_changes  = TRUE
 	light_color = LIGHT_COLOR_RED
 
 /obj/machinery/computer/camera_advanced/Initialize()
@@ -163,7 +163,7 @@
 	user.remote_control = eyeobj
 	user.reset_perspective(eyeobj)
 	eyeobj.setLoc(eyeobj.loc)
-	if(should_supress)
+	if(should_supress_view_changes )
 		user.client.view_size.supress()
 
 /mob/camera/aiEye/remote

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -890,12 +890,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	. = ..()
 
 /client/proc/rescale_view(change, min, max)
-	var/viewscale = getviewsize(view)
-	var/x = viewscale[1]
-	var/y = viewscale[2]
-	x = clamp(x+change, min, max)
-	y = clamp(y+change, min,max)
-	view_size.setDefault("[x]x[y]")
+	view_size.setTo(clamp(change, min, max), clamp(change, min, max))
 
 /client/proc/update_movement_keys(datum/preferences/direct_prefs)
 	var/datum/preferences/D = prefs || direct_prefs

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -290,6 +290,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["ambientocclusion"], ambientocclusion)
 	WRITE_FILE(S["auto_fit_viewport"], auto_fit_viewport)
 	WRITE_FILE(S["widescreenpref"], widescreenpref)
+	WRITE_FILE(S["pixel_size"], pixel_size)
+	WRITE_FILE(S["scaling_method"], scaling_method)
 	WRITE_FILE(S["menuoptions"], menuoptions)
 	WRITE_FILE(S["enable_tips"], enable_tips)
 	WRITE_FILE(S["tip_delay"], tip_delay)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -513,7 +513,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set hidden = TRUE
 	var/max_view = client.prefs.unlock_content ? GHOST_MAX_VIEW_RANGE_MEMBER : GHOST_MAX_VIEW_RANGE_DEFAULT
 	if(input)
-		client.rescale_view(input, 15, (max_view*2)+1)
+		client.rescale_view(input, 0, ((max_view*2)+1) - 15)
 
 /mob/dead/observer/verb/boo()
 	set category = "Ghost"

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -74,7 +74,7 @@
 	update_client_colour()
 	update_mouse_pointer()
 	if(client)
-		client.change_view(CONFIG_GET(string/default_view)) // Resets the client.view in case it was changed
+		client.change_view(getScreenSize(client.prefs.widescreenpref)) // Resets the client.view in case it was changed.
 
 		if(client.player_details.player_actions.len)
 			for(var/datum/action/A in client.player_details.player_actions)

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -2,7 +2,7 @@
 	name = "navigation computer"
 	desc = "Used to designate a precise transit location for a spacecraft."
 	jump_action = null
-	should_supress = FALSE
+	should_supress_view_changes  = FALSE
 	var/datum/action/innate/shuttledocker_rotate/rotate_action = new
 	var/datum/action/innate/shuttledocker_place/place_action = new
 	var/shuttleId = ""

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -2,6 +2,7 @@
 	name = "navigation computer"
 	desc = "Used to designate a precise transit location for a spacecraft."
 	jump_action = null
+	should_supress = FALSE
 	var/datum/action/innate/shuttledocker_rotate/rotate_action = new
 	var/datum/action/innate/shuttledocker_place/place_action = new
 	var/shuttleId = ""


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So uh #51260 fixed but also broke part of #51208, namely the part in login().
I didn't see it in testing because it was a hotfix, but as it currently stands a players's view will reset quite often.

I've changed it to use getScreenSize along with prefs.widescreen,  which should work.
I've made absolutely sure that isZooming() is doing what it should, perhaps more then I should have
Removed an instance of setDefault(), I decided it was dumb
I never actually set up pixel_size and scaling_method to save, that is fixed now.
And I tweaked a ghost verb to work properly with my changes to rescale_view()

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
My stupidity should not effect players visuals.
Fixes #51264
FIxes #51265
Fixes #51273
## Changelog
:cl: LemonInTheDark
fix: Fixed smallscreen resizing on restart or when you die.
fix: Pixel size and scaling method will properly save now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
