### PR TITLE
Lets the Space heater and Electrolyzer work without an APC

### DIFF
--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -14,7 +14,7 @@
 	circuit = /obj/item/circuitboard/machine/electrolyzer
 	ui_x = 400
 	ui_y = 305
-
+	use_power = NO_POWER_USE		/// We don't use area power, we always use the cell
 	///used to check if there is a cell in the machine
 	var/obj/item/stock_parts/cell/cell
 	///check if the machine is on or off

--- a/code/game/machinery/embedded_controller/access_controller.dm
+++ b/code/game/machinery/embedded_controller/access_controller.dm
@@ -209,7 +209,7 @@
 
 /obj/machinery/doorButtons/airlock_controller/proc/do_openDoor(obj/machinery/door/airlock/A)
 	if(A && A.open())
-		if(machine_stat | (NOPOWER) && !lostPower && A && !QDELETED(A))
+		if(!(machine_stat & NOPOWER) && !lostPower && A && !QDELETED(A))
 			A.bolt()
 	goIdle(TRUE)
 

--- a/code/game/machinery/embedded_controller/access_controller.dm
+++ b/code/game/machinery/embedded_controller/access_controller.dm
@@ -209,7 +209,7 @@
 
 /obj/machinery/doorButtons/airlock_controller/proc/do_openDoor(obj/machinery/door/airlock/A)
 	if(A && A.open())
-		if(!(machine_stat & NOPOWER) && !lostPower && A && !QDELETED(A))
+		if(machine_stat | (NOPOWER) && !lostPower && A && !QDELETED(A))
 			A.bolt()
 	goIdle(TRUE)
 

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -15,7 +15,7 @@
 	circuit = /obj/item/circuitboard/machine/space_heater
 	ui_x = 400
 	ui_y = 305
-
+	use_power = NO_POWER_USE		/// We don't use area power, we always use the cell
 	var/obj/item/stock_parts/cell/cell
 	var/on = FALSE
 	var/mode = HEATER_MODE_STANDBY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Not sure what changed, but both devices get their power completely from an installed powercell.  However, for some reason, if its not in an area with a powered APC, you cannot use the interface and you cannot turn it on.  Fixed this by setting a flag.

## Why It's Good For The Game
It be nice to use the space heater in a room that is damaged so us poor lizard people don't freeze to death.

## Changelog
:cl:
fix: flag change to the space heater and electrolyzer 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
