### PR TITLE
reactive incendiary armor can now be created

### DIFF
--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -10,7 +10,8 @@
 	var/static/list/anomaly_armour_types = list(
 		/obj/effect/anomaly/grav	                = /obj/item/clothing/suit/armor/reactive/repulse,
 		/obj/effect/anomaly/flux 	           		= /obj/item/clothing/suit/armor/reactive/tesla,
-		/obj/effect/anomaly/bluespace 	            = /obj/item/clothing/suit/armor/reactive/teleport
+		/obj/effect/anomaly/bluespace 	            = /obj/item/clothing/suit/armor/reactive/teleport,
+		/obj/effect/anomaly/pyro                    = /obj/item/clothing/suit/armor/reactive/fire
 		)
 
 	if(istype(I, /obj/item/assembly/signaler/anomaly))


### PR DESCRIPTION
## About The Pull Request

Using a pyroclastic anomaly core on a reactive armour shell will now create reactive incendiary armor, not reactive stealth armor.

## Why It's Good For The Game

This is probably just an oversight.

## Changelog
:cl: ATHATH
fix: Using a pyroclastic anomaly core on a reactive armour shell will now create reactive incendiary armor, not reactive stealth armor.
/:cl: