### PR TITLE
Makes some tweaks to Icebox's EVA and mining areas.

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -2300,6 +2300,16 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"afq" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "afr" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -2572,6 +2582,19 @@
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"age" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/item/stack/ore/silver,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "agf" = (
 /obj/machinery/light{
 	dir = 4
@@ -11072,6 +11095,16 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"azU" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "azV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -23326,11 +23359,18 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "bdB" = (
-/obj/structure/sign/warning/docking{
-	pixel_y = 32
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "bdC" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
@@ -24627,6 +24667,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"bgR" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/structure/closet/wardrobe/miner,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "bgS" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -25774,6 +25825,19 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bjy" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "bjz" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/central)
@@ -26187,6 +26251,13 @@
 "bky" = (
 /turf/closed/wall,
 /area/maintenance/starboard)
+"bkz" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "bkA" = (
 /obj/effect/landmark/event_spawn,
 /mob/living/simple_animal/bot/secbot{
@@ -26975,6 +27046,22 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"bmu" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"bmv" = (
+/obj/effect/turf_decal/caution{
+	dir = 8
+	},
+/turf/open/floor/plating/icemoon,
+/area/icemoon/surface/outdoors)
 "bmw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -27485,7 +27572,13 @@
 /area/quartermaster/office)
 "bnB" = (
 /obj/structure/cable,
-/obj/machinery/light/small{
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27659,6 +27752,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"bnT" = (
+/obj/structure/ladder,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "bnU" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Public Mining Storage"
@@ -28297,6 +28395,14 @@
 	dir = 8
 	},
 /area/science/research)
+"bpr" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "bps" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -28545,6 +28651,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"bqb" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "bqc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -29219,6 +29332,12 @@
 /obj/structure/closet/secure_closet/psychology,
 /turf/open/floor/plasteel/white,
 /area/medical/psychology)
+"brC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "brD" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -29400,6 +29519,46 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
+"bsa" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/shovel{
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"bsb" = (
+/obj/structure/rack,
+/obj/item/pickaxe{
+	pixel_x = 5
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"bsc" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"bsd" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "bse" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -29407,6 +29566,25 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
+"bsf" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"bsg" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "bsh" = (
 /turf/closed/wall,
 /area/teleporter)
@@ -29817,17 +29995,11 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "bte" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "btf" = (
 /obj/machinery/requests_console{
 	department = "Medbay";
@@ -30075,6 +30247,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"btF" = (
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
+/area/icemoon/surface/outdoors)
 "btG" = (
 /obj/machinery/camera{
 	c_tag = "Public Mining Storage";
@@ -31165,10 +31341,32 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"bwm" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on"
+	},
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/plating/icemoon,
+/area/icemoon/surface/outdoors)
 "bwn" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/storage/mining)
+"bwo" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on"
+	},
+/turf/open/floor/plating/icemoon,
+/area/icemoon/surface/outdoors)
+"bwp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/shoes/winterboots,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "bwq" = (
 /obj/machinery/teleport/station,
 /turf/open/floor/plating,
@@ -33452,17 +33650,6 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/quartermaster/miningdock)
-"bBI" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/closet/wardrobe/miner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bBJ" = (
 /obj/machinery/firealarm{
@@ -36626,10 +36813,6 @@
 	},
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors)
-"bJb" = (
-/obj/structure/ladder,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "bJc" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -37027,42 +37210,9 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"bKk" = (
-/obj/item/stack/ore/silver,
-/obj/item/stack/ore/silver,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bKl" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "bKm" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall,
-/area/quartermaster/miningdock)
-"bKn" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/pickaxe{
-	pixel_x = 5
-	},
-/obj/item/shovel{
-	pixel_x = -5
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bKo" = (
 /obj/machinery/light,
@@ -37070,10 +37220,6 @@
 /area/quartermaster/miningdock)
 "bKp" = (
 /obj/structure/closet/crate,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bKq" = (
-/obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bKr" = (
@@ -63895,9 +64041,9 @@ boP
 boP
 boP
 boP
+bwo
 asU
-asU
-asU
+bwo
 boP
 boP
 boP
@@ -70591,7 +70737,7 @@ boP
 boP
 boP
 boP
-boP
+btF
 boP
 boP
 boP
@@ -70844,7 +70990,7 @@ bkD
 boP
 boP
 boP
-boP
+btF
 boP
 boP
 boP
@@ -71101,11 +71247,11 @@ aPz
 boP
 boP
 boP
+bte
 boP
 boP
 boP
-boP
-boP
+bwm
 boP
 boP
 boP
@@ -71358,7 +71504,7 @@ bkF
 boP
 boP
 boP
-boP
+btF
 boP
 boP
 boP
@@ -71564,7 +71710,7 @@ boP
 boP
 aah
 boP
-asU
+bwo
 aCS
 ajV
 ajV
@@ -71619,7 +71765,7 @@ boP
 boP
 boP
 boP
-boP
+btF
 boP
 boP
 boP
@@ -71872,11 +72018,11 @@ bkF
 boP
 boP
 boP
+bwm
 boP
 boP
 boP
-boP
-boP
+bte
 boP
 boP
 boP
@@ -72133,7 +72279,7 @@ boP
 boP
 boP
 boP
-boP
+btF
 boP
 boP
 boP
@@ -72643,11 +72789,11 @@ bkE
 boP
 boP
 boP
+bwm
 boP
 boP
 boP
-boP
-boP
+bte
 boP
 boP
 boP
@@ -72900,11 +73046,11 @@ bkF
 boP
 boP
 boP
-boP
+btF
 boP
 boP
 bnv
-boP
+btF
 boP
 boP
 boP
@@ -74455,9 +74601,9 @@ boP
 boP
 boP
 boP
-bgC
-asU
-bgC
+boP
+boP
+boP
 boP
 boP
 boP
@@ -74711,11 +74857,11 @@ boP
 boP
 boP
 boP
-bxy
-bxy
-bti
-bxy
-bxy
+boP
+bgC
+bmv
+bgC
+boP
 boP
 boP
 bCq
@@ -74967,13 +75113,13 @@ boP
 boP
 boP
 boP
-boP
 bxy
-byE
-dUO
-byE
 bxy
-boP
+bxy
+bti
+bxy
+bxy
+bxy
 boP
 bCq
 bPS
@@ -75224,13 +75370,13 @@ boP
 boP
 boP
 boP
-boP
 bxy
-dUO
-dUO
-dUO
+age
+bHA
+bnB
+bHA
+bsd
 bxy
-boP
 boP
 bLv
 akZ
@@ -75480,14 +75626,14 @@ bxu
 bxx
 bxu
 bxu
-bdB
 boP
 bxy
-bnB
-bJb
+azU
+byE
 dUO
+byE
+bsf
 bxy
-boP
 boP
 bLv
 bPS
@@ -75738,13 +75884,13 @@ bzP
 bAS
 bxu
 boP
-boP
 bxy
+bdB
 dUO
+bnT
 dUO
-dUO
+bsf
 bxy
-boP
 boP
 bLv
 bPT
@@ -75995,13 +76141,13 @@ bzR
 byd
 bxx
 boP
-boP
 bxy
+azU
 byE
 dUO
 byE
+bsf
 bxy
-boP
 boP
 bLv
 bPS
@@ -76252,13 +76398,13 @@ bzR
 byc
 bxx
 boP
-boP
 bxy
+bgR
+bkz
+bpr
+bkz
+bsg
 bxy
-bti
-bxy
-bxy
-boP
 boP
 bCq
 ala
@@ -76509,13 +76655,13 @@ bzT
 byl
 bxx
 boP
-boP
+bxy
 bxy
 bHz
-dUO
-bKk
+bqb
+brC
 bxy
-boP
+bxy
 boP
 bCq
 alg
@@ -77281,10 +77427,10 @@ bym
 bxu
 bxy
 bxy
-bte
-bHA
+bjy
+bmu
 nXT
-bKl
+bsa
 bxy
 asU
 asU
@@ -77541,7 +77687,7 @@ agv
 byE
 byE
 dUO
-byE
+bsb
 bGi
 boP
 boP
@@ -77798,7 +77944,7 @@ bzY
 bBa
 bEQ
 bGM
-bKn
+bsc
 bGi
 boP
 boP
@@ -78505,13 +78651,13 @@ boP
 boP
 boP
 boP
-asU
+bwo
 asU
 asU
 boP
 asU
 aVm
-asU
+bwo
 boP
 boP
 boP
@@ -78565,11 +78711,11 @@ bwY
 byJ
 bwe
 bwW
-bBI
+afq
 bGn
 bGn
 bGn
-bKq
+byE
 bxy
 boP
 boP
@@ -90312,7 +90458,7 @@ boP
 boP
 boP
 boP
-asU
+bwo
 abp
 abp
 abp
@@ -92745,9 +92891,9 @@ boP
 boP
 boP
 bMd
+bwo
 asU
-asU
-asU
+bwo
 boP
 boP
 boP
@@ -96496,7 +96642,7 @@ boP
 boP
 boP
 boP
-asU
+bwo
 amw
 amw
 amw
@@ -100197,7 +100343,7 @@ cNW
 cNW
 cOT
 cOT
-asU
+bwo
 boP
 boP
 boP
@@ -105022,7 +105168,7 @@ aNa
 boP
 bky
 btp
-ddf
+bwp
 boF
 bon
 brz
@@ -105842,7 +105988,7 @@ cmx
 cnj
 cnj
 cnj
-asU
+bwo
 boP
 boP
 boP
@@ -107352,9 +107498,9 @@ bky
 boP
 boP
 boP
+bwo
 asU
-asU
-asU
+bwo
 boP
 boP
 boP
@@ -107885,7 +108031,7 @@ boP
 boP
 boP
 boP
-asU
+bwo
 asU
 asU
 boP
@@ -112749,9 +112895,9 @@ boP
 boP
 boP
 boP
+bte
 boP
-boP
-boP
+bte
 boP
 aAe
 aAe

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -10,12 +10,78 @@
 	},
 /turf/closed/mineral/random/snow,
 /area/icemoon/underground/unexplored/rivers)
+"ab" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"ac" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"ad" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"ae" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"af" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"ag" = (
+/obj/machinery/power/apc{
+	name = "Mining EVA APC";
+	pixel_x = 1;
+	pixel_y = -23
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "ah" = (
 /turf/closed/mineral/random/snow,
 /area/icemoon/underground/unexplored/rivers)
+"ai" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"aj" = (
+/obj/structure/ladder,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "ak" = (
 /turf/closed/mineral/random/snow/high_chance,
 /area/icemoon/underground/unexplored/rivers)
+"al" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"am" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/door/airlock/external{
+	glass = 1;
+	name = "Mining External Airlock";
+	opacity = 0;
+	req_access_txt = "54"
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"an" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plasteel,
+/area/mine/production)
 "ao" = (
 /obj/machinery/computer/shuttle/labor/one_way{
 	dir = 4
@@ -29,14 +95,114 @@
 "aq" = (
 /turf/closed/wall,
 /area/mine/laborcamp)
+"ar" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
+"as" = (
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/mine/production)
+"at" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -5;
+	pixel_y = 30
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plasteel,
+/area/mine/production)
 "au" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"av" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/item/paper/fluff/stations/lavaland/orm_notice,
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/mine/production)
+"aw" = (
+/obj/machinery/camera{
+	c_tag = "EVA";
+	dir = 4;
+	network = list("mine")
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/item/clothing/head/beanie/orange,
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"ax" = (
+/obj/item/beacon,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/mine/production)
+"ay" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/mine/production)
 "az" = (
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"aA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/mine/production)
+"aB" = (
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/item/clothing/head/beanie/stripedred,
+/turf/open/floor/plasteel,
+/area/mine/laborcamp/security)
 "aC" = (
 /obj/structure/sign/poster/official/safety_report{
 	pixel_x = -32
@@ -49,6 +215,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"aD" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/mine/production)
+"aE" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/mine/production)
 "aF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "labor";
@@ -63,6 +250,14 @@
 /obj/item/kitchen/fork,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"aH" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/mine/production)
 "aJ" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -169,32 +364,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/production)
-"bs" = (
-/obj/machinery/camera{
-	c_tag = "EVA";
-	dir = 4;
-	network = list("mine")
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/eva)
 "bt" = (
 /turf/open/floor/plasteel,
 /area/mine/eva)
@@ -313,18 +482,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
-"bN" = (
-/obj/structure/sign/warning/docking,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/mine/production)
-"bO" = (
-/obj/item/beacon,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "bP" = (
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -455,17 +612,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
-"cj" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	glass = 1;
-	name = "Mining Shuttle Airlock";
-	opacity = 0
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "ck" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -493,19 +639,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"co" = (
-/obj/machinery/power/apc{
-	name = "Mining EVA APC";
-	pixel_x = 1;
-	pixel_y = -23
-	},
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/mine/eva)
 "cp" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable,
@@ -579,22 +712,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/mine/production)
-"cJ" = (
-/obj/machinery/door/airlock{
-	name = "Closet"
-	},
-/turf/open/floor/plating,
-/area/mine/production)
-"cK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/mine/production)
-"cL" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
 /area/mine/production)
 "cM" = (
 /turf/closed/wall,
@@ -688,37 +805,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"db" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"dc" = (
-/obj/structure/closet/crate,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/mine/production)
-"dd" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/obj/structure/table,
-/obj/item/paper/fluff/stations/lavaland/orm_notice,
-/turf/open/floor/plasteel,
-/area/mine/production)
-"de" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "df" = (
@@ -1382,16 +1468,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"eJ" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -2435,10 +2511,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/mine/production)
-"so" = (
-/obj/structure/ladder,
-/turf/open/floor/plasteel,
-/area/mine/eva)
 "sp" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -2779,10 +2851,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Al" = (
-/obj/structure/ore_box,
-/turf/open/floor/plasteel,
-/area/mine/eva)
 "Aw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -3574,18 +3642,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
-"QQ" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/mine/laborcamp/security)
 "QW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3907,17 +3963,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"WE" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	glass = 1;
-	name = "Mining Shuttle Airlock";
-	opacity = 0
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "WM" = (
 /obj/machinery/shower{
 	pixel_y = 22
@@ -12707,7 +12752,7 @@ yr
 cb
 UJ
 cG
-QQ
+aB
 Hd
 qt
 rj
@@ -21184,9 +21229,9 @@ ah
 ah
 ah
 ah
-bN
-cj
-br
+ah
+ah
+ah
 ah
 ah
 ah
@@ -21440,11 +21485,11 @@ ah
 ah
 ah
 ah
-ah
-br
-bP
-br
-ah
+aA
+aA
+aA
+aA
+aA
 ah
 ah
 ah
@@ -21698,9 +21743,9 @@ ah
 ah
 ah
 br
-br
-WE
-br
+ax
+aD
+aE
 br
 ah
 ah
@@ -21954,11 +21999,11 @@ ah
 ah
 ah
 bq
-br
-bO
-ck
-cD
-br
+bq
+ay
+bP
+aH
+bq
 bq
 bq
 bq
@@ -22985,8 +23030,8 @@ bf
 bF
 bS
 bF
-bf
-cJ
+ac
+ac
 bq
 cZ
 ds
@@ -23238,12 +23283,12 @@ ah
 ah
 bf
 bn
-bs
+aw
 bG
 bT
-co
-bf
-cK
+ab
+ad
+ag
 bq
 bq
 ia
@@ -23499,8 +23544,8 @@ PL
 LL
 bU
 cp
-bf
-cL
+ae
+ai
 bq
 IF
 du
@@ -23757,9 +23802,9 @@ bH
 bV
 cq
 bf
+bf
 bq
-bq
-db
+ar
 bP
 bP
 bP
@@ -24014,9 +24059,9 @@ bI
 bW
 aV
 bf
-so
+aj
 bq
-dc
+as
 bP
 dM
 dW
@@ -24272,13 +24317,13 @@ bX
 bg
 bf
 bt
-bq
-dd
+am
+bP
 bP
 dN
 dX
 em
-eJ
+av
 dV
 eY
 bq
@@ -24529,8 +24574,8 @@ bY
 cs
 bt
 bt
-bq
-de
+an
+df
 dv
 bq
 dV
@@ -24784,10 +24829,10 @@ bf
 bK
 bW
 Ur
-Al
-bt
+af
+al
 bq
-df
+at
 dw
 dO
 dY

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -79,7 +79,8 @@
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "an" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "ao" = (
@@ -809,6 +810,7 @@
 /area/mine/production)
 "df" = (
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "dg" = (
@@ -934,12 +936,14 @@
 /area/mine/production)
 "du" = (
 /obj/effect/turf_decal/loading_area,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "dv" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "dw" = (
@@ -23805,7 +23809,7 @@ bf
 bf
 bq
 ar
-bP
+Rx
 bP
 bP
 bP
@@ -24062,7 +24066,7 @@ bf
 aj
 bq
 as
-bP
+Rx
 dM
 dW
 AB
@@ -24319,7 +24323,7 @@ bf
 bt
 am
 bP
-bP
+Rx
 dN
 dX
 em

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
@@ -16,9 +16,22 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"f" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mine/eva)
 "g" = (
 /obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
+/area/mine/eva)
+"h" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
 /area/mine/eva)
 "i" = (
 /obj/effect/turf_decal/tile/brown,
@@ -30,6 +43,13 @@
 "j" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"k" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Station Maintenance";
+	req_access_txt = "48"
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
@@ -46,12 +66,50 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"n" = (
+/obj/machinery/space_heater,
+/obj/item/trash/waffles,
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "o" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/mine/eva)
+"p" = (
+/obj/structure/showcase/machinery/tv{
+	desc = "A slightly battered looking TV. Sadly, being surrounded by a metric ton of rubble prevents it from getting a signal."
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"q" = (
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"r" = (
+/obj/structure/chair/sofa{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "s" = (
 /obj/structure/ore_box,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"t" = (
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"u" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "v" = (
@@ -63,15 +121,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"w" = (
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"x" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "y" = (
 /turf/closed/wall,
 /area/mine/eva)
 "z" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/mine/eva)
 "A" = (
 /obj/machinery/telecomms/relay/preset/mining,
@@ -18788,16 +18855,16 @@ a
 a
 y
 o
-V
+h
 V
 y
-C
+u
 l
+x
+y
+n
 C
-y
-y
-y
-y
+q
 y
 a
 a
@@ -19044,7 +19111,7 @@ a
 a
 a
 y
-z
+f
 V
 V
 y
@@ -19052,9 +19119,9 @@ W
 C
 e
 y
-y
-y
-y
+p
+C
+r
 y
 a
 a
@@ -19308,10 +19375,10 @@ Q
 C
 C
 C
-y
-y
-y
-y
+k
+C
+C
+t
 y
 a
 a
@@ -19825,7 +19892,7 @@ C
 C
 C
 I
-C
+w
 Y
 a
 a
@@ -20339,7 +20406,7 @@ C
 C
 C
 j
-C
+u
 Y
 a
 a
@@ -21361,9 +21428,9 @@ c
 K
 K
 y
-C
+w
 i
-C
+z
 y
 y
 y


### PR DESCRIPTION
Yes, Space, I finally did it, or at least began it.

## About The Pull Request

This PR makes some tweaks to how Icebox handles it's external areas. On the whole, Icebox really does just use Box's existing EVA areas, and in some instances this makes sense (Around arrivals, Escape, in mait, etc). In others however, in particular with mining, since there's no mining shuttle running between the two locations, I felt that it could use a few tweaks considering that with several areas there's really no reason for them to be identical external airlocks. Better pictures of the map than I can provide can be found with mapDiffBot, but here's the most of them:

- The Mining Shuttle dock on the 2nd floor has been replaced with an observation deck overlooking the snowy outcrop.
- The Mining EVA area has been partially redone, with the mini-closet swapped out for more unloading space, and the heater has been placed with the equipment. (Personally, I wanted to give more room around the stairs in that area, but that would mean I'd probably functionally rebuild that whole EVA room, so this'll work for now I suppose.
- Across the station, most EVA Exits have been provided a marker beacon for locating the station in a blizzard (based on light beacons found on antarctic research stations).
- The Cargo shuttle runway now contains several beacons in the snow, as well as wear marks for where the shuttle should often arrive/depart.
- An extra winter coat and boots has been provided at the EVA door near mait, to dry off.
- EVA construction has some extra beacons just like those used by the EVA doors.
-The 3rd Floor now has a small, disused break room.


## Why It's Good For The Game

As I previously mentioned, several of the EVA exits are identical to how they were laid out on box originally. While this works fine for the meantime, considering the different nature of the station being landlocked, I tried adjusting several of these areas to better suit a more interior based architecture, removing doors where applicable and trying to keep the interior areas more interlocked, while the external access I left in I wanted to try and better match the snow theme with more survival lights and ways for the station to feel lived in in the tighter, enclosed space.

## Changelog
:cl:
tweak: Icebox's mining, EVA Exits, and cargo shuttle areas have been adjusted to distinguish them from boxstation.
/:cl:
