### PR TITLE
replaces the mulebot 16 second hardstun with an 8 second knockdown

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -659,7 +659,7 @@
 				if(!paicard)
 					log_combat(src, L, "knocked down")
 					visible_message("<span class='danger'>[src] knocks over [L]!</span>")
-					L.Knockdown(80)
+					L.Knockdown(8 SECONDS)
 	return ..()
 
 // called from mob/living/carbon/human/Crossed()

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -659,7 +659,7 @@
 				if(!paicard)
 					log_combat(src, L, "knocked down")
 					visible_message("<span class='danger'>[src] knocks over [L]!</span>")
-					L.Paralyze(160)
+					L.Knockdown(80)
 	return ..()
 
 // called from mob/living/carbon/human/Crossed()


### PR DESCRIPTION
## About The Pull Request

This PR replaces the 16 second hardstun that non-pAI mulebots with cut avoidance wires apply to living creatures they bump into with a much more tame 8 second knockdown.

## Why It's Good For The Game

unga bunga hardstun bad knockdown good

In all seriousness, there will always be ways to cheese out a "bump" from a hacked non-pAI mulebot, and this PR can act as insurance against/reign in the disgusting power of easy bump methods that might be found in the future and/or might already exist (wink wink nudge nudge).

![sorry](https://user-images.githubusercontent.com/42606352/82789677-50d55b00-9e30-11ea-852d-4d0b4dfa8d14.jpg)

## Changelog
:cl: ATHATH
balance: The 16 second hardstun that non-pAI mulebots with cut avoidance wires apply to living creatures they bump into has been replaced with a much more tame 8 second knockdown.
/:cl: