### PR TITLE
fixes AIs who abuse shunting to infinite doomsday shuffling Yakety Sax 

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -173,6 +173,8 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 		return
 	if (active || owner_AI.stat == DEAD)
 		return //prevent the AI from activating an already active doomsday or while they are dead
+	if (owner_AI.shunted)
+		return //prevent AI from activating doomsday while shunted, fucking abusers
 	active = TRUE
 	set_us_up_the_bomb(owner)
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1069,6 +1069,7 @@
 		return
 	if(!is_station_level(z))
 		return
+	malf.ShutOffDoomsdayDevice()
 	occupier = new /mob/living/silicon/ai(src, malf.laws, malf) //DEAR GOD WHY?	//IKR????
 	occupier.adjustOxyLoss(malf.getOxyLoss())
 	if(!findtext(occupier.name, "APC Copy"))


### PR DESCRIPTION

## About The Pull Request
This PR fixes an issue that allows malf AIs to shunt and activate doomsday, but also activate doomsday then shunt. This PR has been unit tested for both required cases.
## Why It's Good For The Game
Its completely unintended behavior and I was told to fix this by @zxaber. 
## Changelog
:cl:
fix: Prevents doomsday activation while shunting and disabled doomsday if a malf shunts after activation.
/:cl:
