### PR TITLE
Fixed orm after merge #50951

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -116,7 +116,7 @@
 		user.put_in_active_hand(I)
 
 /// Proc specifically for inserting items, returns the amount of materials entered.
-/datum/component/material_container/proc/insert_item(obj/item/I, var/multiplier = 1, amt)
+/datum/component/material_container/proc/insert_item(obj/item/I, amt=1, multiplier = 1)
 	if(!I)
 		return FALSE
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -152,7 +152,7 @@
 		var/material_amount = materials.get_item_material_amount(I)
 		if(!material_amount)
 			return
-		materials.insert_item(I, multiplier = (amount_produced / 100))
+		materials.insert_item(I, material_amount, multiplier = (amount_produced / 100))
 		materials.retrieve_all()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Looks like a simple typo.  Orm dosn't work anymore and it looks like it was because the arguments of item_insert were swapped

This shouldn't break anything else?  I tested the orm, coin and stacker locally and it all seemed to work fine.

## Why It's Good For The Game
Miners can now use the orm again...yea!

## Changelog
:cl:
fix: Swapped a few arguments out of the materials container
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
