### PR TITLE
Removes Shotgun Ability

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -576,9 +576,7 @@
 	spillable = FALSE
 	isGlass = FALSE
 	custom_price = 45
-	var/pierced = FALSE
 	obj_flags = CAN_BE_HIT
-
 
 /obj/item/reagent_containers/food/drinks/soda_cans/random/Initialize()
 	..()
@@ -618,25 +616,7 @@
 		crushed_can.icon_state = icon_state
 		qdel(src)
 		return TRUE
-	var/chugged = reagents.total_volume
 	. = ..()
-	if(is_drainable() && pierced && chugged)
-		M.changeNext_move(CLICK_CD_RAPID)
-		if(iscarbon(M))
-			var/mob/living/carbon/broh = M
-			broh.adjustOxyLoss(2)
-			broh.losebreath++
-			switch(broh.losebreath)
-				if(-INFINITY to 0)
-				if(1 to 2)
-					if(prob(30))
-						user.visible_message("<b>[broh]</b>'s eyes water as [broh.p_they()] chug the can of [src]!")
-				if(3 to 6)
-					if(prob(20))
-						user.visible_message("<b>[broh]</b> makes \an [pick(list("uncomfortable", "gross", "troubling"))] gurgling noise as [broh.p_they()] chug the can of [src]!")
-				if(9 to INFINITY)
-					broh.vomit(2, stun=FALSE)
-
 
 /obj/item/reagent_containers/food/drinks/soda_cans/bullet_act(obj/projectile/P)
 	. = ..()
@@ -658,24 +638,6 @@
 	if(!is_drainable())
 		open_soda(user)
 	return ..()
-
-/obj/item/reagent_containers/food/drinks/soda_cans/attacked_by(obj/item/I, mob/living/user)
-	if(I.sharpness && !pierced && user && user.a_intent != INTENT_HARM)
-		user.visible_message("<b>[user]</b> pierces [src] with [I].", "<span class='notice'>You pierce \the [src] with [I].</span>")
-		playsound(src, "can_open", 50, TRUE)
-		pierced = TRUE
-		return
-	else if(I.force)
-		user.visible_message("<b>[user]</b> crushes [src] with [I]! Party foul!", "<span class='warning'>You crush \the [src] with [I]! Party foul!</span>")
-		playsound(src, "can_open", 50, TRUE)
-		var/obj/item/trash/can/crushed_can = new /obj/item/trash/can(src.loc)
-		crushed_can.icon_state = icon_state
-		var/atom/throw_target = get_edge_target_turf(crushed_can, pick(GLOB.alldirs))
-		crushed_can.throw_at(throw_target, rand(1,3), 7)
-		qdel(src)
-		return
-
-	. = ..()
 
 /obj/item/reagent_containers/food/drinks/soda_cans/cola
 	name = "Space Cola"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
#49990 was originally supposed to include shotgunning canned beverages by piercing them so you could chug them super quick, but I ended up axing that part of the PR. Apparently, the code never got the memo that it got axed, so this finishes that job
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Shotgunning wasn't supposed to be added and is not at all balanced or properly done
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
del: You can no longer shotgun canned beverages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
