### PR TITLE
Adds two new biogenerator chemicals to botany.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1534,15 +1534,15 @@
 
 /datum/reagent/plantnutriment/liquidearthquake
 	name = "Liquid Earthquake"
-	description = "A specialized nutriment, which deceases the plant's yield and endurance, but increases the plant's production speed."
-	color = "#912e00" // RBG: 160, 111, 167
+	description = "A specialized nutriment, which increases the plant's production speed, as well as it's susceptibility to weeds."
+	color = "#912e00" // RBG: 145, 46, 0
 	tox_prob = 25
 
 /datum/reagent/plantnutriment/liquidearthquake/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray)
 	. = ..()
 	if(myseed && chems.has_reagent(src.type, 1))
-		myseed.adjust_yield(-round(chems.get_reagent_amount(src.type) * 0.1))
-		myseed.adjust_endurance(-round(chems.get_reagent_amount(src.type) * 0.3))
+		myseed.adjust_weed_rate(round(chems.get_reagent_amount(src.type) * 0.1))
+		myseed.adjust_weed_chance(round(chems.get_reagent_amount(src.type) * 0.3))
 		myseed.adjust_production(-round(chems.get_reagent_amount(src.type) * 0.075))
 
 // GOON OTHERS

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1519,8 +1519,31 @@
 		myseed.adjust_potency(round(chems.get_reagent_amount(src.type) * 0.1))
 		myseed.adjust_yield(round(chems.get_reagent_amount(src.type) * 0.2))
 
+/datum/reagent/plantnutriment/endurogrow
+	name = "Enduro Grow"
+	description = "A specialized nutriment, which decreases product quantity and potency, but strengthens the plants endurance."
+	color = "#a06fa7" // RBG: 160, 111, 167
+	tox_prob = 15
 
+/datum/reagent/plantnutriment/endurogrow/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray)
+	. = ..()
+	if(myseed && chems.has_reagent(src.type, 1))
+		myseed.adjust_potency(-round(chems.get_reagent_amount(src.type) * 0.1))
+		myseed.adjust_yield(-round(chems.get_reagent_amount(src.type) * 0.075))
+		myseed.adjust_endurance(round(chems.get_reagent_amount(src.type) * 0.35))
 
+/datum/reagent/plantnutriment/liquidearthquake
+	name = "Liquid Earthquake"
+	description = "A specialized nutriment, which deceases the plant's yield and endurance, but increases the plant's production speed."
+	color = "#912e00" // RBG: 160, 111, 167
+	tox_prob = 25
+
+/datum/reagent/plantnutriment/liquidearthquake/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray)
+	. = ..()
+	if(myseed && chems.has_reagent(src.type, 1))
+		myseed.adjust_yield(-round(chems.get_reagent_amount(src.type) * 0.1))
+		myseed.adjust_endurance(-round(chems.get_reagent_amount(src.type) * 0.3))
+		myseed.adjust_production(-round(chems.get_reagent_amount(src.type) * 0.075))
 
 // GOON OTHERS
 

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -90,6 +90,22 @@
 	make_reagents = list(/datum/reagent/plantnutriment/robustharvestnutriment = 30)
 	category = list("initial","Botany Chemicals")
 
+/datum/design/end_gro
+	name = "30u Enduro Grow"
+	id = "end_gro"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 30)
+	make_reagents = list(/datum/reagent/plantnutriment/endurogrow = 30)
+	category = list("initial","Botany Chemicals")
+
+/datum/design/liq_earth
+	name = "30u Liquid Earthquake"
+	id = "liq_earth"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 30)
+	make_reagents = list(/datum/reagent/plantnutriment/liquidearthquake = 30)
+	category = list("initial","Botany Chemicals")
+
 /datum/design/weed_killer
 	name = "30u Weed Killer"
 	id = "weed_killer"


### PR DESCRIPTION
This will help ease the burden of justice off of the minds of the wicked, or something poetic like that.

## About The Pull Request
This adds two new chemicals, produced purely by the biogenerator.
**Enduro Grow:**
This chemical ravages a plants yield and potency, but in exchange, it provides an improvement in the plants endurance stat. Something that was difficult to improve with the new system was plant endurance, which was altered by either plant grafting, or by mutations, neither of which enabled a very active way to enable this.  This meant for some plants, you were left waiting for a long time either harvesting multiple grafts to boost a plants endurance average upwards, or waiting for mutations to hopefully raise endurance. By comparison, this chemical will more often then not shave off large portions of the plants potency and yield in order to boost lifespan (Not to self, I should have gone with like a warlock theme for the name)

Liquid Earthquake:
On the flipside, there also exists very few ways to increase the plants production speed as well, outside of saltpetre. I wanted for there to be a self-sustainable way to improve a plants production speed, but come with an applicable downside as well, so I included an increase in both weed change and weed rate to accompany it. 

## Why It's Good For The Game

Both chemicals are working to make good on that promise that turbotany is less reliant on chemistry in order to perform effectively. Both of these chemicals being grown through the biogenerator enables it as a way to allow botany to do more within their own department, BUT, in the spirit of inter-departmental cooperation, there exists a better alternative should you chose to ask for help from chemistry.

In addition, both chemicals have unique and distinct upsides in the new system. Having fast production speed is exceptionally helpful for mass production of plants, but there are no good ways to naturally lower weed rate and chance, so you're trading momentary gain for potential longterm downsides. Having high endurance allows for a greater deal of genetic manipulation of a plant, 

## Changelog
:cl:
add: Adds Liquid Earthquake, a botany biogenerator chem that increases production speed, but increases plant weed susceptibility.
add: Adds Enduro Grow, a botany biogenerator chem that improves a plant's endurance stat, but decreases it's yield and potency.
/:cl: