### PR TITLE
Fixes some (particularly midround) dynamic rulesets' highpop requirements.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -89,7 +89,7 @@
 	delay = 1 MINUTES	// Prevents rule start while head is offstation.
 	cost = 20
 	requirements = list(101,101,70,40,30,20,20,20,20,20)
-	high_population_requirement = 50
+	high_population_requirement = 20
 	flags = HIGHLANDER_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/revs)
 	var/required_heads_of_staff = 3

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -276,7 +276,7 @@
 	weight = 1
 	cost = 20
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
-	high_population_requirement = 50
+	high_population_requirement = 10
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/wizard/ready(forced = FALSE)
@@ -351,7 +351,7 @@
 	weight = 4
 	cost = 10
 	requirements = list(101,101,101,80,60,50,30,20,10,10)
-	high_population_requirement = 50
+	high_population_requirement = 10
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/blob/generate_ruleset_body(mob/applicant)
@@ -374,7 +374,7 @@
 	weight = 3
 	cost = 10
 	requirements = list(101,101,101,70,50,40,20,15,10,10)
-	high_population_requirement = 50
+	high_population_requirement = 10
 	repeatable = TRUE
 	var/list/vents = list()
 
@@ -421,7 +421,7 @@
 	weight = 3
 	cost = 10
 	requirements = list(101,101,101,70,50,40,20,15,10,10)
-	high_population_requirement = 50
+	high_population_requirement = 10
 	repeatable = TRUE
 	var/list/spawn_locs = list()
 
@@ -468,7 +468,7 @@
 	weight = 4
 	cost = 10
 	requirements = list(101,101,101,80,60,50,30,20,10,10)
-	high_population_requirement = 50
+	high_population_requirement = 10
 	repeatable = TRUE
 	var/list/spawn_locs = list()
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -59,7 +59,7 @@
 	cost = 15
 	scaling_cost = 15
 	requirements = list(40,30,30,20,20,15,15,15,10,10)
-	high_population_requirement = 15
+	high_population_requirement = 10
 	antag_cap = list(2,2,2,2,2,2,2,2,2,2)	// Can pick 3 per team, but rare enough it doesn't matter.
 	var/list/datum/team/brother_team/pre_brother_teams = list()
 	var/const/min_team_size = 2


### PR DESCRIPTION
## About The Pull Request

Dynamic rulesets have a variety of requirements that must be met in order for them to occur. One of these requirements is the minimum threat requirement. This determines the amount of currently left-over threat that must currently exist in order for the ruleset to trigger. There are two variables involved in this, both specific to each dynamic ruleset: the list "requirements" and the int "high_population_requirement". The requirements list has 10 elements, each representing the minimum amount of threat necessary to draft that rule at a specific population range, that range increasing by 6 for each subsequent element. For example, the first entry in the requirements list represents the minimum threat for a round with 0-5 players, the second the minimum threat for a round with 6-11 players, etc.. The final element of the list contains the minimum threat for 54 players or more.

_However,_ if the population is greater than 55, this check is overridden, and instead the minimum threat to draft the ruleset is based on the ruleset's high_population_requirement variable. Normally, this variable should be equal to or less than the final entry in the requirements list, usually 10, as it doesn't make much sense for really any ruleset to get less likely at higher threat levels. However, many dynamic rulesets, particularly the midround rulesets and likely due to a misunderstanding of the variable's purpose compounded by copy-pasting, had this variable set much higher than the final entry in the requirements list, at an almost entirely uniform "50". This artificially restricted these rulesets (latejoin revs, midround wiz, midround blob, midround nightmare, etc.) from triggering at high populations, as higher threat levels are fairly unlikely after roundstart rulesets are drafted. This PR fixes that oversight, changing the rulesets' high_population_requirement variables to something more reasonable.

## Why It's Good For The Game

Variety is good, it doesn't make sense for dynamic rounds to get _more_ homogeneous on high populations, and the original state of these variables doesn't seem like it was intentional. 

## Changelog
:cl:
fix: Midround dynamic rulesets should be more varied and somewhat more likely during high-population dynamic rounds.
/:cl: