### PR TITLE
remove unnecessary var/id from /datum/material

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -44,12 +44,6 @@
 		GLOB.surgeries_list += new path()
 	sortList(GLOB.surgeries_list, /proc/cmp_typepaths_asc)
 
-	//Materials
-	for(var/path in subtypesof(/datum/material))
-		var/datum/material/D = new path()
-		GLOB.materials_list[D.id] = D
-	sortList(GLOB.materials_list, /proc/cmp_typepaths_asc)
-
 	// Keybindings
 	init_keybindings()
 

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -17,7 +17,6 @@ GLOBAL_LIST_EMPTY(singularities)				    //list of all singularities on the stati
 
 GLOBAL_LIST(chemical_reactions_list)				//list of all /datum/chemical_reaction datums. Used during chemical reactions
 GLOBAL_LIST(chemical_reagents_list)				//list of all /datum/reagent datums indexed by reagent id. Used by chemistry stuff
-GLOBAL_LIST_EMPTY(materials_list)				//list of all /datum/material datums indexed by material id.
 GLOBAL_LIST_EMPTY(tech_list)					//list of all /datum/tech datums indexed by id.
 GLOBAL_LIST_EMPTY(surgeries_list)				//list of all surgeries by name, associated with their path.
 GLOBAL_LIST_EMPTY(crafting_recipes)				//list of all table craft recipes

--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -8,8 +8,6 @@ Simple datum which is instanced once per type and is used for every object of sa
 /datum/material
 	var/name = "material"
 	var/desc = "its..stuff."
-	///Var that's mostly used by science machines to identify specific materials, should most likely be phased out at some point
-	var/id = "mat"
 	///Base color of the material, is used for greyscale. Item isn't changed in color if this is null.
 	var/color
 	///Base alpha of the material, is used for greyscale icons.

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -1,7 +1,6 @@
 ///Has no special properties.
 /datum/material/iron
 	name = "iron"
-	id = "iron"
 	desc = "Common iron ore often found in sedimentary and igneous layers of the crust."
 	color = "#878687"
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
@@ -11,7 +10,6 @@
 ///Breaks extremely easily but is transparent.
 /datum/material/glass
 	name = "glass"
-	id = "glass"
 	desc = "Glass forged by melting sand."
 	color = "#88cdf1"
 	alpha = 150
@@ -30,7 +28,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Has no special properties. Could be good against vampires in the future perhaps.
 /datum/material/silver
 	name = "silver"
-	id = "silver"
 	desc = "Silver"
 	color = list(255/255, 284/255, 302/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
@@ -41,7 +38,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Slight force increase
 /datum/material/gold
 	name = "gold"
-	id = "gold"
 	desc = "Gold"
 	color = list(340/255, 240/255, 50/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0) //gold is shiny, but not as bright as bananium
 	strength_modifier = 1.2
@@ -54,7 +50,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Has no special properties
 /datum/material/diamond
 	name = "diamond"
-	id = "diamond"
 	desc = "Highly pressurized carbon"
 	color = list(48/255, 272/255, 301/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
@@ -67,7 +62,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Is slightly radioactive
 /datum/material/uranium
 	name = "uranium"
-	id = "uranium"
 	desc = "Uranium"
 	color = rgb(48, 237, 26)
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
@@ -87,7 +81,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Adds firestacks on hit (Still needs support to turn into gas on destruction)
 /datum/material/plasma
 	name = "plasma"
-	id = "plasma"
 	desc = "Isn't plasma a state of matter? Oh whatever."
 	color = list(298/255, 46/255, 352/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
@@ -110,7 +103,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Can cause bluespace effects on use. (Teleportation) (Not yet implemented)
 /datum/material/bluespace
 	name = "bluespace crystal"
-	id = "bluespace_crystal"
 	desc = "Crystals with bluespace properties"
 	color = list(119/255, 217/255, 396/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
 	alpha = 200
@@ -122,7 +114,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Honks and slips
 /datum/material/bananium
 	name = "bananium"
-	id = "bananium"
 	desc = "Material with hilarious properties"
 	color = list(460/255, 464/255, 0, 0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0) //obnoxiously bright yellow
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
@@ -146,7 +137,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Mediocre force increase
 /datum/material/titanium
 	name = "titanium"
-	id = "titanium"
 	desc = "Titanium"
 	color = "#b3c0c7"
 	strength_modifier = 1.3
@@ -158,7 +148,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/runite
 	name = "runite"
-	id = "runite"
 	desc = "Runite"
 	color = "#3F9995"
 	strength_modifier = 1.3
@@ -171,7 +160,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Force decrease
 /datum/material/plastic
 	name = "plastic"
-	id = "plastic"
 	desc = "Plastic"
 	color = "#caccd9"
 	strength_modifier = 0.85
@@ -184,7 +172,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Force decrease and mushy sound effect. (Not yet implemented)
 /datum/material/biomass
 	name = "biomass"
-	id = "biomass"
 	desc = "Organic matter"
 	color = "#735b4d"
 	strength_modifier = 0.8
@@ -192,7 +179,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/wood
 	name = "wood"
-	id = "wood"
 	desc = "Flexible, durable, but flamable. Hard to come across in space."
 	color = "#bb8e53"
 	strength_modifier = 0.5
@@ -217,7 +203,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Stronk force increase
 /datum/material/adamantine
 	name = "adamantine"
-	id = "adamantine"
 	desc = "A powerful material made out of magic, I mean science!"
 	color = "#6d7e8e"
 	strength_modifier = 1.5
@@ -230,7 +215,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///RPG Magic.
 /datum/material/mythril
 	name = "mythril"
-	id = "mythril"
 	desc = "How this even exists is byond me"
 	color = "#f2d5d7"
 	categories = list(MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
@@ -253,7 +237,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 //formed when freon react with o2, emits a lot of plasma when heated
 /datum/material/hot_ice
 	name = "hot ice"
-	id = "hot ice"
 	desc = "A weird kind of ice, feels warm to the touch"
 	color = "#88cdf1"
 	alpha = 150
@@ -272,7 +255,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/metalhydrogen
 	name = "Metal Hydrogen"
-	id = "metal hydrogen"
 	desc = "Solid metallic hydrogen. Some say it should be impossible"
 	color = "#f2d5d7"
 	alpha = 150
@@ -286,7 +268,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 //I don't like sand. It's coarse, and rough, and irritating, and it gets everywhere.
 /datum/material/sand
 	name = "sand"
-	id = "sand"
 	desc = "You know, it's amazing just how structurally sound sand can be."
 	color = "#EDC9AF"
 	categories = list(MAT_CATEGORY_RIGID = TRUE)
@@ -302,7 +283,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 //And now for our lavaland dwelling friends, sand, but in stone form! Truly revolutionary.
 /datum/material/sandstone
 	name = "sandstone"
-	id = "sandstone"
 	desc = "Bialtaakid 'ant taerif ma hdha."
 	color = "#B77D31"
 	categories = list(MAT_CATEGORY_RIGID = TRUE)
@@ -315,7 +295,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/snow
 	name = "snow"
-	id = "snow"
 	desc = "There's no business like snow business."
 	color = "#FFFFFF"
 	categories = list(MAT_CATEGORY_RIGID = TRUE)
@@ -328,7 +307,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/runedmetal
 	name = "runed metal"
-	id = "runed metal"
 	desc = "Mir'ntrath barhah Nar'sie."
 	color = "#3C3434"
 	categories = list(MAT_CATEGORY_RIGID = TRUE)
@@ -340,7 +318,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/bronze
 	name = "bronze"
-	id = "bronze"
 	desc = "Clock Cult? Never heard of it."
 	color = "#92661A"
 	categories = list(MAT_CATEGORY_RIGID = TRUE)
@@ -351,7 +328,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/paper
 	name = "paper"
-	id = "paper"
 	desc = "Ten thousand folds of pure starchy power."
 	color = "#E5DCD5"
 	categories = list(MAT_CATEGORY_RIGID = TRUE)
@@ -377,7 +353,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/cardboard
 	name = "cardboard"
-	id = "cardboard"
 	desc = "They say cardboard is used by hobos to make incredible things."
 	color = "#5F625C"
 	categories = list(MAT_CATEGORY_RIGID = TRUE)
@@ -401,7 +376,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/bone
 	name = "bone"
-	id = "bone"
 	desc = "Man, building with this will make you the coolest caveman on the block."
 	color = "#e3dac9"
 	categories = list(MAT_CATEGORY_RIGID = TRUE)
@@ -412,7 +386,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/bamboo
 	name = "bamboo"
-	id = "bamboo"
 	desc = "If it's good enough for pandas, it's good enough for you."
 	color = "#339933"
 	categories = list(MAT_CATEGORY_RIGID = TRUE)

--- a/code/datums/materials/meat.dm
+++ b/code/datums/materials/meat.dm
@@ -1,7 +1,6 @@
 ///It's gross, gets the name of it's owner, and is all kinds of fucked up
 /datum/material/meat
 	name = "meat"
-	id = "meat"
 	desc = "Meat"
 	color = rgb(214, 67, 67)
 	categories = list(MAT_CATEGORY_RIGID = TRUE)

--- a/code/datums/materials/pizza.dm
+++ b/code/datums/materials/pizza.dm
@@ -1,6 +1,5 @@
 /datum/material/pizza
 	name = "pizza"
-	id = "pizza"
 	desc = "~Jamme, jamme, n'coppa, jamme ja! Jamme, jamme, n'coppa jamme ja, funi-culi funi-cala funi-culi funi-cala!! Jamme jamme ja funiculi funicula!~"
 	color = "#FF9F23"
 	categories = list(MAT_CATEGORY_RIGID = TRUE)

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -145,8 +145,10 @@ RLD
 				to_chat(user, no_ammo_message)
 			return FALSE
 
-		silo_mats.mat_container.use_materials(list(/datum/material/iron = 500), amount)
-		silo_mats.silo_log(src, "consume", -amount, "build", list(GLOB.materials_list["iron"] = 500))
+		silo_mats.mat_container.use_materials(list(mat = 500), amount)
+		var/list/log_mat_list = list()
+		log_mat_list[SSmaterials.GetMaterialRef(/datum/material/iron)] = 500
+		silo_mats.silo_log(src, "consume", -amount, "build", log_mat_list)
 		return TRUE
 
 /obj/item/construction/proc/checkResource(amount, mob/user)

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -145,10 +145,10 @@ RLD
 				to_chat(user, no_ammo_message)
 			return FALSE
 
-		silo_mats.mat_container.use_materials(list(mat = 500), amount)
-		var/list/log_mat_list = list()
-		log_mat_list[SSmaterials.GetMaterialRef(/datum/material/iron)] = 500
-		silo_mats.silo_log(src, "consume", -amount, "build", log_mat_list)
+		var/list/materials = list()
+		materials[SSmaterials.GetMaterialRef(/datum/material/iron)] = 500
+		silo_mats.mat_container.use_materials(materials, amount)
+		silo_mats.silo_log(src, "consume", -amount, "build", materials)
 		return TRUE
 
 /obj/item/construction/proc/checkResource(amount, mob/user)


### PR DESCRIPTION
## About The Pull Request
Removes a var that isn't really meant to be used. It was left in for compatibility reasons, but somehow the only thing using it is the RCD (and only when in silo mode.) The changes leave the logs the same, so really nothing is changing here.

These changes do not change the output of the log at all. I left it the same.

## Why It's Good For The Game
🥳 decipher this

## Changelog
:cl:
code: remove unnecessary var/id from /datum/material
/:cl: