### PR TITLE
A few small Cargo bounty tweaks

### DIFF
--- a/code/modules/cargo/bounties/engineering.dm
+++ b/code/modules/cargo/bounties/engineering.dm
@@ -29,6 +29,11 @@
 	description = "Station 49 is looking to kickstart their research program. Ship them a tank full of Tritium."
 	gas_type = /datum/gas/tritium
 
+/datum/bounty/item/engineering/gas/hydrogen_tank
+	name = "Full Tank of Hydrogen"
+	description = "Our R&D department is working on the development of more efficient electrical batteries using hydrogen as a catalyst. Ship us a tank full of it."
+	gas_type = /datum/gas/hydrogen
+
 /datum/bounty/item/engineering/energy_ball
 	name = "Contained Tesla Ball"
 	description = "Station 24 is being overrun by hordes of angry Mothpeople. They are requesting the ultimate bug zapper."

--- a/code/modules/cargo/bounties/mech.dm
+++ b/code/modules/cargo/bounties/mech.dm
@@ -37,8 +37,3 @@
 	name = "Durand"
 	reward = 20000
 	wanted_types = list(/obj/mecha/combat/durand)
-
-/datum/bounty/item/mech/phazon
-	name = "Phazon"
-	reward = 50000
-	wanted_types = list(/obj/mecha/combat/phazon)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the Phazon bounty from cargo's random pool and adds one requiring a tank (that's 20 moles) of hydrogen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As it is right now, only one Bluespace anomaly can run randomly per round. That might change in the future, but given the rarity of them in general, being asked by Cargo to fork over your only core for a mech you don't even get to use kinda sucks. The other mechs are easy enough to make that this shouldn't impact cargo's budget much. Hydrogen being a bounty gives more incentive to farm it at least once or twice.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Nanotrasen is experimenting further regarding the interaction between hydrogen and plasma. A new cargo bounty has been added for a single tank of hydrogen.
del: Centcom no longer needs Phazon mechs delivered to them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
