### PR TITLE
Increase Sleeping Carp Price by 1tc

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -596,7 +596,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat \
 			and gain the ability to swat bullets from the air, but you will also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/book/granter/martial/carp
-	cost = 12
+	cost = 13
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This simply increases the price of Sleeping Carp by 1tc,
## Why It's Good For The Game

While there were nerfs made to sleeping carp, which has justified a reduction in price,  the nerfs to sleeping carp do not hamper the overly simple and powerful combination of carp+gloves of the northstar, and instead allowed for the combination to occur every round. 

This was decided to increase carp by 1tc because Gloves of the North-star are not particularly strong on their ow, requiring a martial art to really excel. Sleeping Carp however does remain relatively strong on its own even post nerf, and still just about as awful with gloves. 

This will push Carp+Northstar combos back to something they should have remained, a special occasion when you get a discount, not something you can do every round if you wished to. 

## Changelog
:cl:
balance: Increased the price of Sleeping Carp by 1tc 
:cl:

