### PR TITLE
Fixes dynamic giving midround/latejoin roles to protected roles.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -323,6 +323,10 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 					stack_trace("Invalid dynamic configuration variable [variable] in [ruleset.ruletype] [ruleset.name].")
 					continue
 				ruleset.vars[variable] = rule_conf[variable]
+		if(CONFIG_GET(flag/protect_roles_from_antagonist))
+			ruleset.restricted_roles |= ruleset.protected_roles
+		if(CONFIG_GET(flag/protect_assistant_from_antagonist))
+			ruleset.restricted_roles |= "Assistant"
 	for(var/i in GLOB.new_player_list)
 		var/mob/dead/new_player/player = i
 		if(player.ready == PLAYER_READY_TO_PLAY && player.mind)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -139,11 +139,6 @@
 /// Do everything you need to do before job is assigned here.
 /// IMPORTANT: ASSIGN special_role HERE
 /datum/dynamic_ruleset/proc/pre_execute()
-	SHOULD_CALL_PARENT(TRUE)
-	if(CONFIG_GET(flag/protect_roles_from_antagonist))
-		restricted_roles |= protected_roles
-	if(CONFIG_GET(flag/protect_assistant_from_antagonist))
-		restricted_roles |= "Assistant"
 	return TRUE
 
 /// Called on post_setup on roundstart and when the rule executes on midround and latejoin.


### PR DESCRIPTION
## About The Pull Request
Fixes a dynamic bug which caused security, captain etc. to get traitor roles when restricted_roles is set in the config.

## Changelog
:cl:
fix: Dynamic will no longer give antagonist roles to jobs who shouldn't have them when restricted roles is set in the config.
/:cl: