### PR TITLE
buffs emps

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -133,7 +133,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	charge -= 1000 / severity
+	charge -= 6000 / severity
 	if (charge < 0)
 		charge = 0
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -133,7 +133,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	charge -= 6000 / severity
+	charge -= 4000 / severity
 	if (charge < 0)
 		charge = 0
 


### PR DESCRIPTION
## About The Pull Request

multiplies the amount of charge that an EMP will take away from a cell by 4

## Why It's Good For The Game

EMPs take away a kind of pathetic amount of charge from cells. Like, a heavy EMP will  currentlyonly take away **10%** of a high-capacity cell's charge (which is why batons are barely affected by EMPs).

## Changelog
:cl:
balance: emps now drain more charge from cells
/:cl:
