### PR TITLE
Increases the price of EMP kit, allows you to buy individual EMPS

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1006,7 +1006,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "EMP Grenades and Implanter Kit"
 	desc = "A box that contains five EMP grenades and an EMP implant with three uses."
 	item = /obj/item/storage/box/syndie_kit/emp
-	cost = 5 //bargain bc you get 5 nades for the price of 5, as well as the implant
+	cost = 4
 
 /datum/uplink_item/explosives/virus_grenade
 	name = "Fungal Tuberculosis Grenade"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -995,12 +995,18 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 6
 	restricted = TRUE
 
+/datum/uplink_item/explosives/emp_nade
+	name = "EMP Grenade"
+	desc = "An electromagnetic pulse grenade. Useful to disrupt communications, \
+			security's energy weapons and silicon lifeforms when you're in a tight spot."
+	item = /obj/item/grenade/empgrenade
+	cost = 1
+
 /datum/uplink_item/explosives/emp
 	name = "EMP Grenades and Implanter Kit"
-	desc = "A box that contains five EMP grenades and an EMP implant with three uses. Useful to disrupt communications, \
-			security's energy weapons and silicon lifeforms when you're in a tight spot."
+	desc = "A box that contains five EMP grenades and an EMP implant with three uses."
 	item = /obj/item/storage/box/syndie_kit/emp
-	cost = 2
+	cost = 5 //bargain bc you get 5 nades for the price of 5, as well as the implant
 
 /datum/uplink_item/explosives/virus_grenade
 	name = "Fungal Tuberculosis Grenade"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases the price of EMP kits from 2 to 4 TC, and adds individual grenades to the uplink for 1 TC. I'm happy with these figures, but am open to discussion.

## Why It's Good For The Game

I saw athaths PR and it sort of reminded me of how fucking good EMPs are. I hate myself for making this but here we are.

EMPs are incredibly strong. You can kill a borg with just one, and the AI with several used outside of the core. A box of them can be used to cripple a department; fucking with doors, making scrubbers panic syphon, and messing with APCs. I remember several rounds where I shut down half of a station by buying only EMP kits and throwing them everywhere. 2 TC for 5 plus an implanter is ridiculous.

They're still pretty cheap after this, but not negligibly so. 

## Changelog
:cl:
add: You can now buy individual EMP grenades as a traitor for 1 TC.
balance: EMP grenade kits now cost 4 TC, up from 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
