### PR TITLE
A fix for botany sprites showing ERRORs.

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -354,7 +354,7 @@
 		else
 			plant_overlay.icon_state = myseed.icon_harvest
 	else
-		var/t_growthstate = min(round((age / myseed.maturation) * myseed.growthstages), myseed.growthstages)
+		var/t_growthstate = clamp(round((age / myseed.maturation) * myseed.growthstages), 1, 10)
 		plant_overlay.icon_state = "[myseed.icon_grow][t_growthstate]"
 	add_overlay(plant_overlay)
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -354,7 +354,7 @@
 		else
 			plant_overlay.icon_state = myseed.icon_harvest
 	else
-		var/t_growthstate = clamp(round((age / myseed.maturation) * myseed.growthstages), 1, 10)
+		var/t_growthstate = clamp(min(round((age / myseed.maturation) * myseed.growthstages), myseed.growthstages), 1, 10)
 		plant_overlay.icon_state = "[myseed.icon_grow][t_growthstate]"
 	add_overlay(plant_overlay)
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -354,7 +354,7 @@
 		else
 			plant_overlay.icon_state = myseed.icon_harvest
 	else
-		var/t_growthstate = clamp(min(round((age / myseed.maturation) * myseed.growthstages), myseed.growthstages), 1, 10)
+		var/t_growthstate = clamp(round((age / myseed.maturation) * myseed.growthstages), 1, myseed.growthstages)
 		plant_overlay.icon_state = "[myseed.icon_grow][t_growthstate]"
 	add_overlay(plant_overlay)
 


### PR DESCRIPTION
## About The Pull Request

Turns out that all along, plants were suffering from a rounding error, resulting in some plants with small enough growth stages to not show up when planted. This was due to taking a minimum of a rounded var, which with few enough growth stages would round to zero.

Fixes #50866, Fixes #51079, Fixes #50960.

## Why It's Good For The Game
 🖐️ 🐛 💥 

## Changelog
:cl:
fix: Plant sprites no longer ERROR when just planted.
/:cl:
