### PR TITLE
Fixes a minor oversight with the seed vault lavaland ruin + minor map tweaks.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -47,7 +47,7 @@
 "aj" = (
 /obj/structure/table/wood,
 /obj/item/gun/energy/floragun{
-	pixel_z = 6
+	pixel_y = 6
 	},
 /obj/item/gun/energy/floragun{
 	pixel_y = 4

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -271,22 +271,15 @@
 /area/ruin/powered/seedvault)
 "aL" = (
 /obj/structure/table/wood,
-/obj/item/storage/bag/plants{
-	pixel_x = -5
+/obj/item/geneshears{
+	pixel_x = 6
 	},
-/obj/item/storage/bag/plants{
-	pixel_y = -5
+/obj/item/geneshears,
+/obj/item/geneshears{
+	pixel_x = -6
 	},
-/obj/item/storage/bag/plants{
-	pixel_y = 5
-	},
-/obj/item/storage/bag/plants{
-	pixel_x = 5
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/obj/item/geneshears,
+/turf/open/floor/vault,
 /area/ruin/powered/seedvault)
 "aM" = (
 /obj/structure/table/wood,
@@ -308,17 +301,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered/seedvault)
-"aP" = (
-/obj/structure/table/wood,
-/obj/item/geneshears{
-	pixel_x = 6
-	},
-/obj/item/geneshears,
-/obj/item/geneshears{
-	pixel_x = -6
-	},
-/turf/open/floor/vault,
-/area/ruin/powered/seedvault)
 "aQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer,
@@ -332,14 +314,22 @@
 /area/ruin/powered/seedvault)
 "aS" = (
 /obj/structure/table/wood,
-/obj/item/secateurs{
-	pixel_x = -6
+/obj/item/storage/bag/plants{
+	pixel_x = -5
 	},
-/obj/item/secateurs{
-	pixel_x = 6
+/obj/item/storage/bag/plants{
+	pixel_y = -5
 	},
-/obj/item/secateurs,
-/turf/open/floor/vault,
+/obj/item/storage/bag/plants{
+	pixel_y = 5
+	},
+/obj/item/storage/bag/plants{
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/powered/seedvault)
 "aT" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -700,6 +690,20 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
+"GN" = (
+/obj/structure/table/wood,
+/obj/item/secateurs{
+	pixel_x = -6
+	},
+/obj/item/secateurs{
+	pixel_x = 6
+	},
+/obj/item/secateurs,
+/obj/item/secateurs{
+	pixel_x = -6
+	},
+/turf/open/floor/vault,
+/area/ruin/powered/seedvault)
 "KF" = (
 /obj/machinery/door/airlock/titanium,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -884,7 +888,7 @@ ac
 ac
 PH
 ah
-aL
+aS
 ac
 aG
 ac
@@ -1064,7 +1068,7 @@ ac
 ac
 aI
 aA
-aP
+aL
 ac
 by
 bA
@@ -1086,7 +1090,7 @@ aX
 aE
 aA
 aA
-aS
+GN
 ac
 bm
 br

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -24,9 +24,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered/seedvault)
 "ag" = (
-/obj/item/storage/toolbox/syndicate,
 /obj/structure/table/wood,
 /obj/effect/turf_decal/trimline/green/filled/line,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/storage/toolbox/syndicate,
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered/seedvault)
 "ah" = (
@@ -43,9 +46,15 @@
 /area/ruin/powered/seedvault)
 "aj" = (
 /obj/structure/table/wood,
-/obj/item/gun/energy/floragun,
-/obj/item/gun/energy/floragun,
-/obj/item/gun/energy/floragun,
+/obj/item/gun/energy/floragun{
+	pixel_z = 6
+	},
+/obj/item/gun/energy/floragun{
+	pixel_y = 4
+	},
+/obj/item/gun/energy/floragun{
+	pixel_y = 2
+	},
 /obj/item/gun/energy/floragun,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -262,8 +271,22 @@
 /area/ruin/powered/seedvault)
 "aL" = (
 /obj/structure/table/wood,
-/obj/item/secateurs,
-/turf/open/floor/vault,
+/obj/item/storage/bag/plants{
+	pixel_x = -5
+	},
+/obj/item/storage/bag/plants{
+	pixel_y = -5
+	},
+/obj/item/storage/bag/plants{
+	pixel_y = 5
+	},
+/obj/item/storage/bag/plants{
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/powered/seedvault)
 "aM" = (
 /obj/structure/table/wood,
@@ -285,6 +308,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered/seedvault)
+"aP" = (
+/obj/structure/table/wood,
+/obj/item/geneshears{
+	pixel_x = 6
+	},
+/obj/item/geneshears,
+/obj/item/geneshears{
+	pixel_x = -6
+	},
+/turf/open/floor/vault,
+/area/ruin/powered/seedvault)
 "aQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer,
@@ -298,14 +332,14 @@
 /area/ruin/powered/seedvault)
 "aS" = (
 /obj/structure/table/wood,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
+/obj/item/secateurs{
+	pixel_x = -6
 	},
-/turf/open/floor/plasteel/dark,
+/obj/item/secateurs{
+	pixel_x = 6
+	},
+/obj/item/secateurs,
+/turf/open/floor/vault,
 /area/ruin/powered/seedvault)
 "aT" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -850,7 +884,7 @@ ac
 ac
 PH
 ah
-aS
+aL
 ac
 aG
 ac
@@ -1030,7 +1064,7 @@ ac
 ac
 aI
 aA
-aL
+aP
 ac
 by
 bA
@@ -1052,7 +1086,7 @@ aX
 aE
 aA
 aA
-aL
+aS
 ac
 bm
 br


### PR DESCRIPTION
My botany changes are slightly more finalized

## About The Pull Request

With the new changes and added tools to botany, namely the gene shears, I may have slightly forgotten to give them to the seed vault ruin, and as a result, chaos and disorder and panic has swept over the land of the plant people for upwards of 6 weeks. Yeah I uh, probably shouldn't be enabling that.

In addition, I did some small tweaks to item placement within the ruin, and I provided 10 sheets of glass, as they can individually be used to prevent cross-pollination as a luxury. 

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/41715314/83116791-48805880-a09a-11ea-8914-46b864c60d10.png)
Parts of this probably shouldn't happen.

## Changelog
:cl:
tweak: The Seed Vault ruin now comes equip with the complete modern arsenal of new botany tools and equipment.
/:cl:
