### PR TITLE
Mice/Royal Rats can heal off cheese.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -95,6 +95,16 @@
 		evolve()
 		return
 
+/mob/living/simple_animal/mouse/ClickOn(atom/A, params)
+	if(istype(A, /obj/item/reagent_containers/food/snacks/cheesewedge))
+		if(health == maxHealth)
+			to_chat(src,"<span class='warning'>You don't need to eat or heal.</span>")
+			return
+		to_chat(src,"<span class='green'>You nibble some cheese, restoring your health.</span>")
+		health = maxHealth
+		qdel(A)
+	..()
+
 /**
   *Checks the mouse cap, if it's above the cap, doesn't spawn a mouse. If below, spawns a mouse and adds it to cheeserats.
   */

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -96,12 +96,12 @@
 		return
 
 /mob/living/simple_animal/mouse/ClickOn(atom/A, params)
-	if(istype(A, /obj/item/reagent_containers/food/snacks/cheesewedge))
+	if(istype(A, /obj/item/reagent_containers/food/snacks/cheesewedge) && src.canUseTopic(A, BE_CLOSE, NO_DEXTERITY))
 		if(health == maxHealth)
 			to_chat(src,"<span class='warning'>You don't need to eat or heal.</span>")
 			return
 		to_chat(src,"<span class='green'>You nibble some cheese, restoring your health.</span>")
-		health = maxHealth
+		adjustHealth(-(maxHealth-health))
 		qdel(A)
 	..()
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -95,7 +95,8 @@
 		evolve()
 		return
 
-/mob/living/simple_animal/mouse/ClickOn(atom/A, params)
+/mob/living/simple_animal/mouse/UnarmedAttack(atom/A, proximity)
+	. = ..()
 	if(istype(A, /obj/item/reagent_containers/food/snacks/cheesewedge) && canUseTopic(A, BE_CLOSE, NO_DEXTERITY))
 		if(health == maxHealth)
 			to_chat(src,"<span class='warning'>You don't need to eat or heal.</span>")

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -96,14 +96,15 @@
 		return
 
 /mob/living/simple_animal/mouse/ClickOn(atom/A, params)
-	if(istype(A, /obj/item/reagent_containers/food/snacks/cheesewedge) && src.canUseTopic(A, BE_CLOSE, NO_DEXTERITY))
+	if(istype(A, /obj/item/reagent_containers/food/snacks/cheesewedge) && canUseTopic(A, BE_CLOSE, NO_DEXTERITY))
 		if(health == maxHealth)
 			to_chat(src,"<span class='warning'>You don't need to eat or heal.</span>")
 			return
 		to_chat(src,"<span class='green'>You nibble some cheese, restoring your health.</span>")
 		adjustHealth(-(maxHealth-health))
 		qdel(A)
-	..()
+		return
+	return ..()
 
 /**
   *Checks the mouse cap, if it's above the cap, doesn't spawn a mouse. If below, spawns a mouse and adds it to cheeserats.

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -80,7 +80,7 @@
 			to_chat(src, "<span class='warning'>You feel fine, no need to eat anything!</span>")
 			return
 		to_chat(src, "<span class='green'>You eat \the [src], restoring some health.</span>")
-		src.heal_bodypart_damage(10)
+		heal_bodypart_damage(10)
 		qdel(target)
 
 /**
@@ -254,5 +254,5 @@
 			to_chat(src, "<span class='warning'>You feel fine, no need to eat anything!</span>")
 			return
 		to_chat(src, "<span class='green'>You eat \the [src], restoring some health.</span>")
-		src.heal_bodypart_damage(5)
+		heal_bodypart_damage(5)
 		qdel(target)

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -73,6 +73,16 @@
 	else if(istype(user,/mob/living/simple_animal/hostile/regalrat))
 		. += "<span class='warning'>Who is this foolish false king? This will not stand!</span>"
 
+/mob/living/simple_animal/hostile/regalrat/AttackingTarget()
+	. = ..()
+	if(istype(target, /obj/item/reagent_containers/food/snacks/cheesewedge))
+		if (health >= maxHealth)
+			to_chat(src, "<span class='warning'>You feel fine, no need to eat anything!</span>")
+			return
+		to_chat(src, "<span class='green'>You eat \the [src], restoring some health.</span>")
+		src.heal_bodypart_damage(10)
+		qdel(target)
+
 /**
   *This action creates trash, money, dirt, and cheese.
   */
@@ -236,3 +246,13 @@
 				visible_message("<span class='warning'>[src] chews through the [C]. It looks unharmed!</span>")
 				playsound(src, 'sound/effects/sparks2.ogg', 100, TRUE)
 				C.deconstruct()
+
+/mob/living/simple_animal/hostile/rat/AttackingTarget()
+	. = ..()
+	if(istype(target, /obj/item/reagent_containers/food/snacks/cheesewedge))
+		if (health >= maxHealth)
+			to_chat(src, "<span class='warning'>You feel fine, no need to eat anything!</span>")
+			return
+		to_chat(src, "<span class='green'>You eat \the [src], restoring some health.</span>")
+		src.heal_bodypart_damage(5)
+		qdel(target)


### PR DESCRIPTION

## About The Pull Request

By request, rats and royal rats can now eat cheese wedges, in order to regain small amounts of health. rodents are, after all, ravenous mammalian savages, and should be capable of  eating great deals of cheese, in an ideal world. 

## Why It's Good For The Game

Allows for regal rats to provide an infrequent, but viable source of healing for it's subordinate rats, as well as itself.

## Changelog
:cl:
add: Sentient regal and regular rats can now eat cheese wedges to recover a small amount of health.
/:cl:
