### PR TITLE
Adds a performant circle drawing helper proc

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1600,8 +1600,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		center = get_turf(center)
 		if(!center)
 			CRASH("get_circle_edge_turfs called with an invalid arguments")
-	if(radius < 1)
-		CRASH("get_circle_edge_turfs called a non-positive radius")
+	if(!isnum(radius) || radius < 1)
+		CRASH("get_circle_edge_turfs called with a non-positive radius")
 
 	. = list()
 	var/squared_radius = radius * radius

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1594,6 +1594,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
   *
   * Takes advantage of 8-way symmetry for optimization purposes.
   * If it reaches the edge of the map the circle will have a hole there.
+  * Since it prioritizes drawing a better circle shape there might be uncovered turfs between one range and the next, but they will never overlap.
   */
 /proc/get_circle_edge_turfs(turf/center, radius = 1)
 	if(!isturf(center))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1584,3 +1584,95 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 			return "."
 		if(189)
 			return "-"
+
+/**
+  * Algorithm to compile and return a list of edge turfs in a circle.
+  *
+  * Arguments:
+  * * turf/center - If an atom, it will be converted to a turf.
+  * * radius - Distance to center. A value of 1 will produce a 3x3 hollow square. Non-positive values will error out.
+  *
+  * Takes advantage of 8-way symmetry for optimization purposes.
+  * If it reaches the edge of the map the circle will have a hole there.
+  */
+/proc/get_circle_edge_turfs(turf/center, radius = 1)
+	if(!isturf(center))
+		center = get_turf(center)
+		if(!center)
+			CRASH("get_circle_edge_turfs called with an invalid arguments")
+	if(radius < 1)
+		CRASH("get_circle_edge_turfs called a non-positive radius")
+
+	. = list()
+	var/squared_radius = radius * radius
+
+	var/turf/turf_to_add = locate(center.x, center.y - radius, center.z)
+	if(turf_to_add) //In case we reach the map limit.
+		. += turf_to_add
+
+	turf_to_add = locate(center.x, center.y + radius, center.z)
+	if(turf_to_add)
+		. += turf_to_add
+
+	turf_to_add = locate(center.x + radius, center.y, center.z)
+	if(turf_to_add)
+		. += turf_to_add
+
+	turf_to_add = locate(center.x - radius, center.y, center.z)
+	if(turf_to_add)
+		. += turf_to_add
+
+	var/x = 1
+	var/y = radius
+	while(x < y)
+		turf_to_add = locate(center.x + x, center.y + y, center.z)
+		if(turf_to_add)
+			. += turf_to_add
+
+		turf_to_add = locate(center.x + x, center.y - y, center.z)
+		if(turf_to_add)
+			. += turf_to_add
+
+		turf_to_add = locate(center.x - x, center.y + y, center.z)
+		if(turf_to_add)
+			. += turf_to_add
+
+		turf_to_add = locate(center.x - x, center.y - y, center.z)
+		if(turf_to_add)
+			. += turf_to_add
+
+		turf_to_add = locate(center.x + y, center.y + x, center.z)
+		if(turf_to_add)
+			. += turf_to_add
+
+		turf_to_add = locate(center.x + y, center.y - x, center.z)
+		if(turf_to_add)
+			. += turf_to_add
+
+		turf_to_add = locate(center.x - y, center.y + x, center.z)
+		if(turf_to_add)
+			. += turf_to_add
+
+		turf_to_add = locate(center.x - y, center.y - x, center.z)
+		if(turf_to_add)
+			. += turf_to_add
+
+		x++
+		y = round(sqrt(squared_radius - (x * x)) + 0.5, 1)
+
+	if(x == y)
+		turf_to_add = locate(center.x + x, center.y + y, center.z)
+		if(turf_to_add)
+			. += turf_to_add
+
+		turf_to_add = locate(center.x + x, center.y - y, center.z)
+		if(turf_to_add)
+			. += turf_to_add
+
+		turf_to_add = locate(center.x - x, center.y + y, center.z)
+		if(turf_to_add)
+			. += turf_to_add
+
+		turf_to_add = locate(center.x - x, center.y - y, center.z)
+		if(turf_to_add)
+			. += turf_to_add


### PR DESCRIPTION
Mostly because I want to suggest a better-looking and performant expansion of effects in #51199 but I can see this being used elsewhere for stuff expanding in waves from the center.

Examples of circles of radius 1, 3, 5, 7, 9 and 11:
![dreamseeker_kEbLO2FJ6t](https://user-images.githubusercontent.com/42041276/83206414-41535c00-a127-11ea-900f-4379fbf0546f.png)

Examples of circles of radius 2, 4, 6, 8, 10,  and 12:
![dreamseeker_Q2RrCJGso9](https://user-images.githubusercontent.com/42041276/83206710-c76fa280-a127-11ea-920e-10a8c2df5c44.png)

EDIT: Since the algorithm leaves uncovered turfs it cannot be used as an expansion algorithm, but it can still be used for generating circular-shaped force-fields and other visual effects.

Example of holes between the ranges:
![dreamseeker_kd6eYhA5Su](https://user-images.githubusercontent.com/42041276/83212533-3eac3300-a136-11ea-8eba-d7ff24c22a82.png)
