### PR TITLE
Players require the Rod of Asclepius to perform concurrent surgeries.

### DIFF
--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -60,7 +60,12 @@
 
 #define SURGERY_SLOWDOWN_CAP_MULTIPLIER 2 //increase to make surgery slower but fail less, and decrease to make surgery faster but fail more
 
-/datum/surgery_step/proc/initiate(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
+/datum/surgery_step/proc/initiate(mob/living/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
+	// Only followers of Asclepius have the ability to use Healing Touch and perform miracle feats of surgery.
+	// Prevents people from performing multiple simultaneous surgeries unless they're holding a Rod of Asclepius.
+	if(LAZYLEN(user.do_afters) && !user.has_status_effect(STATUS_EFFECT_HIPPOCRATIC_OATH))
+		return
+
 	surgery.step_in_progress = TRUE
 	var/speed_mod = 1
 	var/fail_prob = 0//100 - fail_prob = success_prob


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #51298 

Performing multiple concurrent surgeries should be a miracle feat, as such this functionality has been moved to the Rod of Asclepius.

Now only the Descendents of Asclepius who have taken the Hipppocratic Oath are able to perform the [Healing Touch](https://traumacentergame.fandom.com/wiki/Healing_Touch).

Adds a check to /datum/surgery_step/proc/initiate as suggested by @Rohesie to prevent starting a new surgery step if one is already in progress.

However, the check also looks for the Rod of Asclepius' Hippocratic Oath buff. If it finds it, the user CAN perform multiple surgeries at once.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

See #51298 - I would say that multiple concurrent surgeries is an oversight. Fixing it removes various cheese methods to max out the surgery skill against the spirit of the skill and stops cheesing for the #50656 surgery skillcape. Moving its functionality to the Rod of Asclepius gives the Rod a fun little niche.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Only the Descendents of Asclepius who have taken the Hippocratic Oath may perform the Healing Touch miracle and conduct multiple concurrent surgeries. Everyone else is limited to a single surgery step at a time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
