### PR TITLE
Bug Fix: Windows Batch File

### DIFF
--- a/tools/hooks/install.bat
+++ b/tools/hooks/install.bat
@@ -2,7 +2,7 @@
 cd %~dp0
 for %%f in (*.hook) do (
 	echo Installing hook: %%~nf
-	copy %%f ..\..\.git\hooks\%%~nf >nul
+	copy %%f ..\..\.git\hooks\ >nul
 )
 for %%f in (*.merge) do (
 	echo Installing merge driver: %%~nf


### PR DESCRIPTION
Batch file had an extra command of Name file without extension resulting in the batch script copying the install file but giving it no extension. this resulted in Git for Windows erring out when trying to commit.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I was working on a map update and wanting to follow the process properly and the "Preferred" method of the git map merge tools would not install correctly. The batch file would copy over a file with no extension to .git/hooks directory. git for windows would error out saying the hook did not exist since it lacked a file extension and refuse to upload the commit.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less windows savvy mappers will now be able to contribute to the mapping projects

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Batch Script Installer for Git mapmerge hooks not installing properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
