### PR TITLE
Identification Console PR

### DIFF
--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -39,6 +39,7 @@
 	hard_drive.store_file(new/datum/computer_file/program/alarm_monitor())
 	hard_drive.store_file(new/datum/computer_file/program/supermatter_monitor())
 
+
 // ===== RESEARCH CONSOLE =====
 /obj/machinery/modular_computer/console/preset/research
 	console_department = "Research"
@@ -66,6 +67,22 @@
 	var/obj/item/computer_hardware/hard_drive/hard_drive = cpu.all_components[MC_HDD]
 	hard_drive.store_file(new/datum/computer_file/program/chatclient())
 	hard_drive.store_file(new/datum/computer_file/program/card_mod())
+
+
+// ===== IDENTIFICATION CONSOLE =====
+/obj/machinery/modular_computer/console/preset/id
+	console_department = "Identification"
+	name = "indentification console"
+	desc = "A stationary computer. This one comes preloaded with identification programs."
+	_has_id_slot = TRUE
+	_has_printer = TRUE
+
+/obj/machinery/modular_computer/console/preset/command/install_programs()
+	var/obj/item/computer_hardware/hard_drive/hard_drive = cpu.all_components[MC_HDD]
+	hard_drive.store_file(new/datum/computer_file/program/chatclient())
+	hard_drive.store_file(new/datum/computer_file/program/card_mod())
+	hard_drive.store_file(new/datum/computer_file/program/job_management())
+	hard_drive.store_file(new/datum/computer_file/program/crew_manifest())
 
 // ===== CIVILIAN CONSOLE =====
 /obj/machinery/modular_computer/console/preset/civilian

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -39,7 +39,6 @@
 	hard_drive.store_file(new/datum/computer_file/program/alarm_monitor())
 	hard_drive.store_file(new/datum/computer_file/program/supermatter_monitor())
 
-
 // ===== RESEARCH CONSOLE =====
 /obj/machinery/modular_computer/console/preset/research
 	console_department = "Research"

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -73,7 +73,7 @@
 /obj/machinery/modular_computer/console/preset/id
 	console_department = "Identification"
 	name = "identification console"
-	desc = "A stationary computer. This one comes preloaded with identification programs."
+	desc = "A stationary computer. This one comes preloaded with identification modification programs."
 	_has_id_slot = TRUE
 	_has_printer = TRUE
 

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -72,7 +72,7 @@
 // ===== IDENTIFICATION CONSOLE =====
 /obj/machinery/modular_computer/console/preset/id
 	console_department = "Identification"
-	name = "indentification console"
+	name = "identification console"
 	desc = "A stationary computer. This one comes preloaded with identification programs."
 	_has_id_slot = TRUE
 	_has_printer = TRUE

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -77,7 +77,7 @@
 	_has_id_slot = TRUE
 	_has_printer = TRUE
 
-/obj/machinery/modular_computer/console/preset/command/install_programs()
+/obj/machinery/modular_computer/console/preset/id/install_programs()
 	var/obj/item/computer_hardware/hard_drive/hard_drive = cpu.all_components[MC_HDD]
 	hard_drive.store_file(new/datum/computer_file/program/chatclient())
 	hard_drive.store_file(new/datum/computer_file/program/card_mod())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It simply adds a new Modular Console Preset to the existing ones, fully outfitted to replace the current Identification Console in the Head of Personnel's Office and in the Bridge, and in most of the maps' Customs desks. Note that it doesn't replace them, it's just an asset right now so we can replace them with another PR, at the pace the map maintainers feel confident with. It has the ID Card Modification, Job Manager and Crew Manifest softwares on it by default, alongside the regular Chat Client.
The new Modular Console Preset can be found under **/obj/machinery/modular_computer/console/preset/id**, for all your map editing needs.
I'm planning to see if I can't make changes to the Departmental Consoles later on as well, so we basically can get rid of a console in every Head of Staff's office (except the HoP because there's only one), but that will require some additional coding to make it so it's not straight up some Identification Consoles that people with All-Access could use to print even more All-Access cards.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I've basically just implemented something that I feel was meant to be implemented a while ago through the use of TGUI and Modular Computers, but never actually got done. The console doesn't have the glitches of the current Identification console, when you remove your ID after logging in and it just goes to a page saying that the address couldn't be found. The UI is much simpler, looks a lot better and is just overall an improvement.

Here's what the new UI looks like, for those of you that don't feel like checking out the PR in-game to know what it looks like:
![image](https://user-images.githubusercontent.com/58045821/83289786-8ae98880-a1b3-11ea-97ee-eccc114d5c3c.png)
![image](https://user-images.githubusercontent.com/58045821/83289803-9341c380-a1b3-11ea-860d-987fdc579639.png)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: New Modular Console Preset added: /obj/machinery/modular_computer/console/preset/id
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
