### PR TITLE
Rebalances The Medibot, "Hold on I'm Coming (to give you surgery bonuses???)"

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -184,6 +184,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_DWARF				"dwarf"
 #define TRAIT_SILENT_FOOTSTEPS	"silent_footsteps" //makes your footsteps completely silent
 #define TRAIT_NICE_SHOT			"nice_shot" //hnnnnnnnggggg..... you're pretty good....
+#define TRAIT_SURGERYPLUS "surgery_plus_trait" //provides a variety of bonuses to surgeries.
 
 //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it

--- a/code/modules/surgery/coronary_bypass.dm
+++ b/code/modules/surgery/coronary_bypass.dm
@@ -58,7 +58,10 @@
 			"<span class='notice'>[user] begins to graft something onto [target]'s heart!</span>")
 
 /datum/surgery_step/coronary_bypass/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
-	target.setOrganLoss(ORGAN_SLOT_HEART, 60)
+	if(HAS_TRAIT(target,TRAIT_SURGERYPLUS))
+		target.setOrganLoss(ORGAN_SLOT_HEART, 50)
+	else
+		target.setOrganLoss(ORGAN_SLOT_HEART, 60)
 	var/obj/item/organ/heart/heart = target.getorganslot(ORGAN_SLOT_HEART)
 	if(heart)	//slightly worrying if we lost our heart mid-operation, but that's life
 		heart.operated = TRUE
@@ -73,6 +76,10 @@
 		display_results(user, target, "<span class='warning'>You screw up in attaching the graft, and it tears off, tearing part of the heart!</span>",
 			"<span class='warning'>[user] screws up, causing blood to spurt out of [H]'s chest profusely!</span>",
 			"<span class='warning'>[user] screws up, causing blood to spurt out of [H]'s chest profusely!</span>")
-		H.adjustOrganLoss(ORGAN_SLOT_HEART, 20)
-		H.bleed_rate += 30
+		if(HAS_TRAIT(target,TRAIT_SURGERYPLUS))
+			H.adjustOrganLoss(ORGAN_SLOT_HEART, 15)
+			H.bleed_rate += 20
+		else
+			H.adjustOrganLoss(ORGAN_SLOT_HEART, 20)
+			H.bleed_rate += 30
 	return FALSE

--- a/code/modules/surgery/experimental_dissection.dm
+++ b/code/modules/surgery/experimental_dissection.dm
@@ -72,10 +72,15 @@
 /datum/surgery_step/dissection/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	user.visible_message("<span class='notice'>[user] dissects [target], enhancing their medical knowledge!", "<span class='notice'>You dissect [target] and receive some healing experience!</span>")
 	var/obj/item/bodypart/L = target.get_bodypart(BODY_ZONE_CHEST)
-	target.apply_damage(80, BRUTE, L)
+
 	ADD_TRAIT(target, TRAIT_DISSECTED, "[surgery.name]")
 	repeatable = FALSE
 	experience_given = check_value(target, surgery)
+	if(HAS_TRAIT(target,TRAIT_SURGERYPLUS))
+		experience_given *= 1.05
+		target.apply_damage(66, BRUTE, L)
+	else
+		target.apply_damage(80, BRUTE, L)
 	return ..()
 
 /datum/surgery_step/dissection/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/eye_surgery.dm
+++ b/code/modules/surgery/eye_surgery.dm
@@ -33,12 +33,20 @@
 	target.cure_blind(list(EYE_DAMAGE))
 	target.set_blindness(0)
 	target.cure_nearsighted(list(EYE_DAMAGE))
-	target.blur_eyes(35)	//this will fix itself slowly.
+	if(HAS_TRAIT(target,TRAIT_SURGERYPLUS))
+		target.blur_eyes(25)	//this will fix itself slowly.
+	else
+		target.blur_eyes(35)
 	E.setOrganDamage(0)
 	return ..()
 
 /datum/surgery_step/fix_eyes/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(target.getorgan(/obj/item/organ/brain))
+	if(HAS_TRAIT(target,TRAIT_SURGERYPLUS))
+		display_results(user, target, "<span class='warning'>You nearly stabbed [target] right in the brain!</span>",
+			"<span class='warning'>[user] nearly stabs [target] in the brain!</span>",
+			"<span class='warning'>[user] nearly stabs [target] in the brain!</span>")
+		target.adjustBruteLoss(10)
+	else if(target.getorgan(/obj/item/organ/brain))
 		display_results(user, target, "<span class='warning'>You accidentally stab [target] right in the brain!</span>",
 			"<span class='warning'>[user] accidentally stabs [target] right in the brain!</span>",
 			"<span class='warning'>[user] accidentally stabs [target] right in the brain!</span>")

--- a/code/modules/surgery/gastrectomy.dm
+++ b/code/modules/surgery/gastrectomy.dm
@@ -34,7 +34,10 @@
 
 /datum/surgery_step/gastrectomy/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/mob/living/carbon/human/H = target
-	H.setOrganLoss(ORGAN_SLOT_STOMACH, 20) // Stomachs have a threshold for being able to even digest food, so I might tweak this number
+	if(HAS_TRAIT(target,TRAIT_SURGERYPLUS))
+		H.setOrganLoss(ORGAN_SLOT_STOMACH, 10) // Stomachs have a threshold for being able to even digest food, so I might tweak this number
+	else
+		H.setOrganLoss(ORGAN_SLOT_STOMACH, 20)
 	display_results(user, target, "<span class='notice'>You successfully remove the damaged part of [target]'s stomach.</span>",
 		"<span class='notice'>[user] successfully removes the damaged part of [target]'s stomach.</span>",
 		"<span class='notice'>[user] successfully removes the damaged part of [target]'s stomach.</span>")

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -66,6 +66,9 @@
 		else //less healing bonus for the dead since they're expected to have lots of damage to begin with (to make TW into defib not TOO simple)
 			urhealedamt_brute += round((target.getBruteLoss()/ (missinghpbonus*5)),0.1)
 			urhealedamt_burn += round((target.getFireLoss()/ (missinghpbonus*5)),0.1)
+	if(HAS_TRAIT(target,TRAIT_SURGERYPLUS))
+		urhealedamt_brute *= 1.2
+		urhealedamt_burn *= 1.2
 	if(!get_location_accessible(target, target_zone))
 		urhealedamt_brute *= 0.55
 		urhealedamt_burn *= 0.55

--- a/code/modules/surgery/hepatectomy.dm
+++ b/code/modules/surgery/hepatectomy.dm
@@ -33,7 +33,10 @@
 
 /datum/surgery_step/hepatectomy/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/mob/living/carbon/human/H = target
-	H.setOrganLoss(ORGAN_SLOT_LIVER, 10) //not bad, not great
+	if(HAS_TRAIT(target,TRAIT_SURGERYPLUS))
+		H.setOrganLoss(ORGAN_SLOT_LIVER, 5)
+	else
+		H.setOrganLoss(ORGAN_SLOT_LIVER, 10) //not bad, not great
 	display_results(user, target, "<span class='notice'>You successfully remove the damaged part of [target]'s liver.</span>",
 		"<span class='notice'>[user] successfully removes the damaged part of [target]'s liver.</span>",
 		"<span class='notice'>[user] successfully removes the damaged part of [target]'s liver.</span>")

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -21,7 +21,7 @@
 			"<span class='notice'>[user] begins to cut away [target]'s excess fat.</span>",
 			"<span class='notice'>[user] begins to cut [target]'s [target_zone] with [tool].</span>")
 
-/datum/surgery_step/cut_fat/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
+/datum/surgery_step/cut_fat/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	display_results(user, target, "<span class='notice'>You cut [target]'s excess fat loose.</span>",
 			"<span class='notice'>[user] cuts [target]'s excess fat loose!</span>",
 			"<span class='notice'>[user] finishes the cut on [target]'s [target_zone].</span>")

--- a/code/modules/surgery/lobectomy.dm
+++ b/code/modules/surgery/lobectomy.dm
@@ -30,7 +30,10 @@
 		var/mob/living/carbon/human/H = target
 		var/obj/item/organ/lungs/L = H.getorganslot(ORGAN_SLOT_LUNGS)
 		L.operated = TRUE
-		H.setOrganLoss(ORGAN_SLOT_LUNGS, 60)
+		if(HAS_TRAIT(target,TRAIT_SURGERYPLUS))
+			H.setOrganLoss(ORGAN_SLOT_LUNGS, 50)
+		else
+			H.setOrganLoss(ORGAN_SLOT_LUNGS, 60)
 		display_results(user, target, "<span class='notice'>You successfully excise [H]'s most damaged lobe.</span>",
 			"<span class='notice'>Successfully removes a piece of [H]'s lungs.</span>",
 			"")

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -7,9 +7,14 @@
 	time = 16
 
 /datum/surgery_step/incise/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	display_results(user, target, "<span class='notice'>You begin to make an incision in [target]'s [parse_zone(target_zone)]...</span>",
-		"<span class='notice'>[user] begins to make an incision in [target]'s [parse_zone(target_zone)].</span>",
-		"<span class='notice'>[user] begins to make an incision in [target]'s [parse_zone(target_zone)].</span>")
+	if(HAS_TRAIT(target,TRAIT_SURGERYPLUS))
+		display_results(user, target, "<span class='notice'>You begin to <i>carefully</i> make an incision in [target]'s [parse_zone(target_zone)]...</span>",
+			"<span class='notice'>[user] begins to <i>carefully</i> make an incision in [target]'s [parse_zone(target_zone)].</span>",
+			"<span class='notice'>[user] begins to <i>carefully</i> make an incision in [target]'s [parse_zone(target_zone)].</span>")
+	else
+		display_results(user, target, "<span class='notice'>You begin to make an incision in [target]'s [parse_zone(target_zone)]...</span>",
+			"<span class='notice'>[user] begins to make an incision in [target]'s [parse_zone(target_zone)].</span>",
+			"<span class='notice'>[user] begins to make an incision in [target]'s [parse_zone(target_zone)].</span>")
 
 /datum/surgery_step/incise/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.get_sharpness())
@@ -18,7 +23,7 @@
 	return TRUE
 
 /datum/surgery_step/incise/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
-	if ishuman(target)
+	if (ishuman(target) && !HAS_TRAIT(target,TRAIT_SURGERYPLUS))
 		var/mob/living/carbon/human/H = target
 		if (!(NOBLOOD in H.dna.species.species_traits))
 			display_results(user, target, "<span class='notice'>Blood pools around the incision in [H]'s [parse_zone(target_zone)].</span>",

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -24,11 +24,12 @@
 			"<span class='notice'>[user] finishes the operation on [target]'s face.</span>")
 	else
 		var/list/names = list()
+		var/numchoices = HAS_TRAIT(target,TRAIT_SURGERYPLUS) ? 15 : 10
 		if(!isabductor(user))
-			for(var/i in 1 to 10)
+			for(var/i in 1 to numchoices)
 				names += target.dna.species.random_name(target.gender, TRUE)
 		else
-			for(var/_i in 1 to 9)
+			for(var/_i in 1 to numchoices)
 				names += "Subject [target.gender == MALE ? "i" : "o"]-[pick("a", "b", "c", "d", "e")]-[rand(10000, 99999)]"
 			names += target.dna.species.random_name(target.gender, TRUE) //give one normal name in case they want to do regular plastic surgery
 		var/chosen_name = input(user, "Choose a new name to assign.", "Plastic Surgery") as null|anything in names

--- a/code/modules/surgery/revival.dm
+++ b/code/modules/surgery/revival.dm
@@ -57,6 +57,8 @@
 		"<span class='notice'>[user] prepares to shock [target]'s brain with [tool].</span>",
 		"<span class='notice'>[user] prepares to shock [target]'s brain with [tool].</span>")
 	target.notify_ghost_cloning("Someone is trying to zap your brain. Re-enter your corpse if you want to be revived!", source = target)
+	if(HAS_TRAIT(target,TRAIT_SURGERYPLUS))
+		time -= (20 SECONDS)
 
 /datum/surgery_step/revive/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
 	display_results(user, target, "<span class='notice'>You successfully shock [target]'s brain with [tool]...</span>",

--- a/code/modules/surgery/stomachpump.dm
+++ b/code/modules/surgery/stomachpump.dm
@@ -44,6 +44,8 @@
 				"<span class='notice'>[user] forces [H] to vomit, cleansing their stomach of some chemicals!</span>",
 				"[user] forces [H] to vomit!")
 		H.vomit(20, FALSE, TRUE, 1, TRUE, FALSE, purge = TRUE) //called with purge as true to lose more reagents
+		if(HAS_TRAIT(target,TRAIT_SURGERYPLUS))
+			target.reagents?.remove_all(5) //additional purging that is irretrievable (in case someone had the crazy idea to make reagents extractable via vomit).
 		if(istype(surgery,/datum/surgery/stomach_pump))
 			var/datum/surgery/stomach_pump/stom_pump = surgery
 			if(stom_pump.accumulated_experience > MEDICAL_SKILL_MEDIUM*10) //capped so you can't dope bodies and purge for ezxp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Assume none of this is true for anything but the "normal" medibots you craft. Derelict and others function like old.

- Medibots now only heal brute/burn

- Medibots heal considerably less

- Medibots heal per tech has been lessened.

**BUT WAIT THERE'S MORE**

- Medibots now will "prepare you for surgery". This gives you a special trait which provides bonuses to a variety of surgical successes (and sometimes even lessens failures!).

- Leveling Medibots now increases the time you have this buff!

- If you do not have the buff, medibots will try to give it to you even if you aren't wounded!

Examples include TW healing 20% more per run, Stomach pump removing more reagents, Organ healing setting your damage to lower thresholds, and more!

Minorly, I have raised the abductor plastic surgery choice to 10 from 9.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I am not a fan of the crutch that is medibots but I also wanted it to be a tangible bonus to having medbay interact with Roboticists, so I (hopefully) solidified them as a role that would benefit medical staff rather than act as a replacement.

Removing the ox/tox was because it made little sense for those to be healed by the robot since there is not even an equivalent to these for surgery by doctors. These damages are by design chemistry oriented.

"who do I go see if I have minor damage then if not the bots?" chemistry, the roaming paramedics, doctors if you're terribly pressed, or that guy with the toolbox and bedsheets. You could theoretically still use the medibot but it's going to take more time now and you're losing value if you aren't taking advantage of the buff.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Cobby
balance: crafted medibots now "prepare you for surgery", providing you with additional benefits when undergoing surgery. Duration scales with tech like healing.
balance: crafted medibots heal less and only brute/burn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
