### PR TITLE
Fixes Get-Current-Logs

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -114,3 +114,7 @@
 
 //How many things you can spawn at once with spawn verb/create panel
 #define ADMIN_SPAWN_CAP 100
+
+// LOG BROWSE TYPES
+#define BROWSE_ROOT_ALL_LOGS 1
+#define BROWSE_ROOT_CURRENT_LOGS 2

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -3,9 +3,14 @@
 	for(var/file in args)
 		src << browse_rsc(file)
 
-/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list("txt","log","htm", "html"))
+/client/proc/browse_files(root_type=BROWSE_ROOT_ALL_LOGS, max_iterations=10, list/valid_extensions=list("txt","log","htm", "html"))
 	// wow why was this ever a parameter
-	root = "data/logs/"
+	var/root = "data/logs/"
+	switch(root_type)
+		if(BROWSE_ROOT_ALL_LOGS)
+			root = "data/logs/"
+		if(BROWSE_ROOT_CURRENT_LOGS)
+			root = "[GLOB.log_directory]/"
 	var/path = root
 
 	for(var/i=0, i<max_iterations, i++)

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -11,10 +11,10 @@
 	set desc = "View/retrieve logfiles for the current round."
 	set category = "Admin"
 
-	browseserverlogs("[GLOB.log_directory]/")
+	browseserverlogs(current=TRUE)
 
-/client/proc/browseserverlogs(path = "data/logs/")
-	path = browse_files(path)
+/client/proc/browseserverlogs(current=FALSE)
+	var/path = browse_files(current ? BROWSE_ROOT_CURRENT_LOGS : BROWSE_ROOT_ALL_LOGS)
 	if(!path)
 		return
 


### PR DESCRIPTION
GLOB.log_directory is protected, and if that doesn't work this security is pointless anyway.