### PR TITLE
Fixes glow/antiglow

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -192,7 +192,6 @@
 	var/obj/effect/dummy/luminescent_glow/glowth //shamelessly copied from luminescents
 	var/glow = 2.5
 	var/range = 2.5
-	var/hue = 0
 	power_coeff = 1
 	conflicts = list(/datum/mutation/human/glow/anti)
 

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -185,13 +185,14 @@
 
 /datum/mutation/human/glow
 	name = "Glowy"
-	desc = "An odd mutation the will cause its owner to glow."
+	desc = "You permanently emit a light with a random color and intensity."
 	quality = POSITIVE
 	text_gain_indication = "<span class='notice'>Your skin begins to glow softly.</span>"
 	instability = 5
 	var/obj/effect/dummy/luminescent_glow/glowth //shamelessly copied from luminescents
 	var/glow = 2.5
 	var/range = 2.5
+	var/glow_color
 	power_coeff = 1
 	conflicts = list(/datum/mutation/human/glow/anti)
 
@@ -199,6 +200,7 @@
 	. = ..()
 	if(.)
 		return
+	glow_color = glow_color()
 	glowth = new(owner)
 	modify()
 
@@ -206,14 +208,12 @@
 	if(!glowth)
 		return
 	var/power = GET_MUTATION_POWER(src)
-	var/colour = glow_color("#[dna.features["mcolor"]]")
-	glowth.set_light(range * power, glow, colour)
 
-/// Returns the color for the glow effect. Colour is based on the mutant color.
-/datum/mutation/human/glow/proc/glow_color(col)
-	var/_hsv = RGBtoHSV(col)
-	var/list_hsv = ReadHSV(_hsv)
-	return HSVtoRGB(hsv(list_hsv[1], list_hsv[2], 255))
+	glowth.set_light(range * power, glow, glow_color)
+
+/// Returns the color for the glow effect
+/datum/mutation/human/glow/proc/glow_color()
+	return pick(COLOR_RED, COLOR_BLUE, COLOR_YELLOW, COLOR_GREEN, COLOR_PURPLE, COLOR_ORANGE)
 
 /datum/mutation/human/glow/on_losing(mob/living/carbon/human/owner)
 	. = ..()
@@ -228,14 +228,9 @@
 	glow = -3.5 //Slightly stronger, since negating light tends to be harder than making it.
 	conflicts = list(/datum/mutation/human/glow)
 	locked = TRUE
-	hue = 180 // Since it's shadows we need to rotate it, otherwise it appears inverted.
 
-/datum/mutation/human/glow/anti/glow_color(col)
-	var/rbg_list = ReadRGB(col)
-	var/red = (rbg_list[2] + rbg_list[3]) / 2
-	var/green = (rbg_list[1] + rbg_list[3]) / 2
-	var/blue = (rbg_list[2] + rbg_list[1]) / 2
-	return ..(rgb(red,green,blue))
+/datum/mutation/human/glow/anti/glow_color()
+	return COLOR_WHITE
 
 /datum/mutation/human/strong
 	name = "Strength"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -185,13 +185,14 @@
 
 /datum/mutation/human/glow
 	name = "Glowy"
-	desc = "You permanently emit a light with a random color and intensity."
+	desc = "An odd mutation the will cause its owner to glow."
 	quality = POSITIVE
 	text_gain_indication = "<span class='notice'>Your skin begins to glow softly.</span>"
 	instability = 5
 	var/obj/effect/dummy/luminescent_glow/glowth //shamelessly copied from luminescents
 	var/glow = 2.5
 	var/range = 2.5
+	var/hue = 0
 	power_coeff = 1
 	conflicts = list(/datum/mutation/human/glow/anti)
 
@@ -206,7 +207,14 @@
 	if(!glowth)
 		return
 	var/power = GET_MUTATION_POWER(src)
-	glowth.set_light(range * power, glow, "#[dna.features["mcolor"]]")
+	var/colour = glow_color("#[dna.features["mcolor"]]")
+	glowth.set_light(range * power, glow, colour)
+
+/// Returns the color for the glow effect. Colour is based on the mutant color.
+/datum/mutation/human/glow/proc/glow_color(col)
+	var/_hsv = RGBtoHSV(col)
+	var/list_hsv = ReadHSV(_hsv)
+	return HSVtoRGB(hsv(list_hsv[1], list_hsv[2], 255))
 
 /datum/mutation/human/glow/on_losing(mob/living/carbon/human/owner)
 	. = ..()
@@ -221,6 +229,14 @@
 	glow = -3.5 //Slightly stronger, since negating light tends to be harder than making it.
 	conflicts = list(/datum/mutation/human/glow)
 	locked = TRUE
+	hue = 180 // Since it's shadows we need to rotate it, otherwise it appears inverted.
+
+/datum/mutation/human/glow/anti/glow_color(col)
+	var/rbg_list = ReadRGB(col)
+	var/red = (rbg_list[2] + rbg_list[3]) / 2
+	var/green = (rbg_list[1] + rbg_list[3]) / 2
+	var/blue = (rbg_list[2] + rbg_list[1]) / 2
+	return ..(rgb(red,green,blue))
 
 /datum/mutation/human/strong
 	name = "Strength"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -225,7 +225,7 @@
 	name = "Anti-Glow"
 	desc = "Your skin seems to attract and absorb nearby light creating 'darkness' around you."
 	text_gain_indication = "<span class='notice'>Your light around you seems to disappear.</span>"
-	glow = -3.5 //Slightly stronger, since negating light tends to be harder than making it.
+	glow = -1.5
 	conflicts = list(/datum/mutation/human/glow)
 	locked = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Glow will now emit a light of a random color, just like it's description says.
Antiglow will now always consume all light equally. This results in the shadow usually being a lot stronger, which is why I dropped the light power even further.
Fixes https://github.com/tgstation/tgstation/issues/51364

## Why It's Good For The Game

I think I've strucken a good balance this time. It's easy to remove the shadow by getting light near the mutant and it's still possible to evade ranged attacks with it.

Glow
![image](https://user-images.githubusercontent.com/47324920/83309727-57861880-a20a-11ea-9c5f-bb475195a572.png)
Noglow
![image](https://user-images.githubusercontent.com/47324920/83309742-6076ea00-a20a-11ea-9ba1-5e11fca2690f.png)
Antiglow
![image](https://user-images.githubusercontent.com/47324920/83310120-4d184e80-a20b-11ea-9c38-1d4d555df4f4.png)
Antiglow vs Flashlight
![image](https://user-images.githubusercontent.com/47324920/83309888-b5b2fb80-a20a-11ea-9109-f57c05041998.png)
Potency Antiglow vs Flashlight
![image](https://user-images.githubusercontent.com/47324920/83310181-7cc75680-a20b-11ea-8cb0-ce4a8d6adf0c.png)


I could also implement a solution where the color of the light depends on mcolor but that usually looks worse and results in many small issues like black mcolor generating a way stronger shadow than everything else.
I already had this implemented, check previous commits to see the code. Let me know if this is prefered.

## Changelog
:cl:
tweak: Glow will now always be a random color.
tweak: Antiglow will now absorb all light equally.
/:cl:
