### PR TITLE
liquid contents bugfixes

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -249,7 +249,7 @@
 	// Cell recharging trait. Charges all mob's power cells to (potency*rate)% mark when eaten.
 	// Generates sparks on squash.
 	// Small (potency*rate) chance to shock squish or slip target for (potency*rate) damage.
-	// Also affects plant batteries (see capatative cell production datum)
+	// Also affects plant batteries (see the capatative cell production datum)
 	name = "Electrical Activity"
 	rate = 0.2
 

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -216,13 +216,9 @@
 /datum/plant_gene/trait/squash
 	// Allows the plant to be squashed when thrown or slipped on, leaving a colored mess and trash type item behind.
 	// Also splashes everything in target turf with reagents and applies other trait effects (teleporting, etc) to the target by on_squash.
-	// For code, see grown.dm
+	// For code, see grown.dm (and the handle_slip() proc in this file)
 	name = "Liquid Contents"
 	examine_line = "<span class='info'>It has a lot of liquid contents inside.</span>"
-
-/datum/plant_gene/trait/squash/on_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/C)
-	// Squash the plant on slip.
-	G.squash(C)
 
 /datum/plant_gene/trait/slip
 	// Makes plant slippery, unless it has a grown-type trash. Then the trash gets slippery.
@@ -246,6 +242,8 @@
 /datum/plant_gene/trait/slip/proc/handle_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/M)
 	for(var/datum/plant_gene/trait/T in G.seed.genes)
 		T.on_slip(G, M)
+	if(G.seed && G.seed.get_gene(/datum/plant_gene/trait/squash)) //squash() deletes the plant product, so we need to make sure that it is called LAST, or else the plant can get deleted before the on_slip() effects of other plant traits can be called
+		G.squash(M)
 
 /datum/plant_gene/trait/cell_charge
 	// Cell recharging trait. Charges all mob's power cells to (potency*rate)% mark when eaten.

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -216,7 +216,7 @@
 /datum/plant_gene/trait/squash
 	// Allows the plant to be squashed when thrown or slipped on, leaving a colored mess and trash type item behind.
 	// Also splashes everything in target turf with reagents and applies other trait effects (teleporting, etc) to the target by on_squash.
-	// For code, see grown.dm (and anything that checks for the presence of this trait)
+	// For code, see grown.dm (and everything that checks for the presence of this trait)
 	name = "Liquid Contents"
 	examine_line = "<span class='info'>It has a lot of liquid contents inside.</span>"
 

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -357,8 +357,7 @@
 	if(isliving(target))
 		var/teleport_radius = max(round(G.seed.potency / 10), 1)
 		var/turf/T = get_turf(target)
-		new /obj/effect/decal/cleanable/molten_object(T) //Leave a pile of goo behind for dramatic effect... //we could teleport the goo to a different location (like we do to the plant in on_slip()), but I have a feeling that that would be misinterpreted as a bug
-		do_teleport(target, T, teleport_radius, channel = TELEPORT_CHANNEL_BLUESPACE)
+		do_teleport(target, T, teleport_radius, channel = TELEPORT_CHANNEL_BLUESPACE)	
 
 /datum/plant_gene/trait/teleport/on_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/C)
 	to_chat(C, "<span class='warning'>You slip through spacetime!</span>")

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -242,7 +242,7 @@
 /datum/plant_gene/trait/slip/proc/handle_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/M)
 	for(var/datum/plant_gene/trait/T in G.seed.genes)
 		T.on_slip(G, M)
-	if(G.seed && G.seed.get_gene(/datum/plant_gene/trait/squash)) //squash() deletes the plant product, so we need to make sure that it is called LAST, or else the plant can get deleted before the on_slip() effects of other plant traits can be called
+	if(G.seed && G.seed.get_gene(/datum/plant_gene/trait/squash)) //squash() deletes the plant, so we need to make sure that it is called LAST, or else the plant can get deleted before the on_slip() effects of other plant traits can be called
 		G.squash(M)
 
 /datum/plant_gene/trait/cell_charge


### PR DESCRIPTION
## About The Pull Request

fixes a bunch of bugs that'd cause the liquid contents trait (and sometimes the bluespace activity trait) to delete a plant before all of its traits' effects could proc and/or cause some effects to trigger twice

yes, this code looks snowflakey/cursed, but it's how the other interactions with this trait are handled (control+f for "squash()" here for examples: https://github.com/tgstation/tgstation/blob/master/code/modules/hydroponics/grown.dm).

also, the bluespace activity trait won't have a 50% chance to destroy the plant when you slip on it anymore (if the plant has the liquid contents trait, that chance will instead be 100%). it also won't leave behind any special bluespace residue when you squash it, as the plant should already be leaving behind residue/juices (because it was squashed).

## Why It's Good For The Game

now, if a plant with slippery skin is stepped on, hypodermic prickles, electrical activity, etc. will ALWAYS proc before liquid contents deletes the plant.

also bugs/inconsistency bad.

## Changelog
:cl: ATHATH
fix: If a plant with slippery skin is stepped on, hypodermic prickles, electrical activity, etc. will now ALWAYS proc before liquid contents deletes the plant.
fix: A bunch of bugs that'd cause the liquid contents trait (and sometimes the bluespace activity trait) to delete a plant before all of its traits' effects could proc and/or cause some effects to trigger twice have been fixed.
/:cl: