### PR TITLE
improves dynamic ruleset scaling code

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -106,8 +106,6 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/only_ruleset_executed = FALSE
 	/// Dynamic configuration, loaded on pre_setup
 	var/list/configuration = null
-	/// Antags rolled by rules so far, to keep track of and discourage scaling past a certain ratio of crew/antags especially on lowpop.
-	var/antags_rolled = 0
 
 /datum/game_mode/dynamic/admin_panel()
 	var/list/dat = list("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Game Mode Panel</title></head><body><h1><B>Game Mode Panel</B></h1>")

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -112,12 +112,18 @@
 		indice_pop = min(requirements.len,round(population/pop_per_requirement)+1)
 		return (threat_level >= requirements[indice_pop])
 
-/// Called when a suitable rule is picked during roundstart(). Will some times attempt to scale a rule up when there is threat remaining. Returns the amount of scaled steps.
+/// Called when a suitable rule is picked during roundstart(). Will some times attempt to scale a rule up when there is threat remaining. Returns the additional threat from scaling up.
 /datum/dynamic_ruleset/proc/scale_up(extra_rulesets = 0, remaining_threat_level = 0)
 	remaining_threat_level -= cost
 	if(scaling_cost && scaling_cost <= remaining_threat_level) // Only attempts to scale the modes with a scaling cost explicitly set.
-		var/new_prob
-		var/pop_to_antags = (mode.antags_rolled + (antag_cap[indice_pop] * (scaled_times + 1))) / mode.roundstart_pop_ready
+		var/antags_rolled = 0
+		var/new_prob = 0
+		var/pop_to_antags
+		for(var/R in (mode.executed_rules + list(src))) // we care about the antags we *will* assign, too
+			var/datum/dynamic_ruleset/ruleset = R
+			antags_rolled += (1 + ruleset.scaled_times) * ruleset.antag_cap[indice_pop]
+
+		pop_to_antags = antags_rolled / mode.roundstart_pop_ready
 		log_game("DYNAMIC: [name] roundstart ruleset attempting to scale up with [extra_rulesets] rulesets waiting and [remaining_threat_level] threat remaining.")
 		for(var/i in 1 to 3) //Can scale a max of 3 times
 			if(remaining_threat_level >= scaling_cost && pop_to_antags < 0.25)
@@ -126,9 +132,9 @@
 					break
 				remaining_threat_level -= scaling_cost
 				scaled_times++
-				pop_to_antags = (mode.antags_rolled + (antag_cap[indice_pop] * (scaled_times + 1))) / mode.roundstart_pop_ready
-		log_game("DYNAMIC: [name] roundstart ruleset failed scaling up at [new_prob ? new_prob : 0]% chance after [scaled_times]/3 successful scaleups. [remaining_threat_level] threat remaining, antag to crew ratio: [pop_to_antags*100]%.")
-		mode.antags_rolled += (1 + scaled_times) * antag_cap[indice_pop]
+				pop_to_antags += antag_cap[indice_pop] / mode.roundstart_pop_ready // we added new antags, gotta update the ratio
+
+		log_game("DYNAMIC: [name] roundstart ruleset failed scaling up at [new_prob]% chance after [scaled_times]/3 successful scaleups. [remaining_threat_level] threat remaining, antag to crew ratio: [pop_to_antags*100]%.")
 		return scaled_times * scaling_cost
 
 /// This is called if persistent variable is true everytime SSTicker ticks.

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -116,25 +116,23 @@
 /datum/dynamic_ruleset/proc/scale_up(extra_rulesets = 0, remaining_threat_level = 0)
 	remaining_threat_level -= cost
 	if(scaling_cost && scaling_cost <= remaining_threat_level) // Only attempts to scale the modes with a scaling cost explicitly set.
-		var/antags_rolled = 0
+		var/antag_fraction = 0
 		var/new_prob = 0
-		var/pop_to_antags
 		for(var/R in (mode.executed_rules + list(src))) // we care about the antags we *will* assign, too
 			var/datum/dynamic_ruleset/ruleset = R
-			antags_rolled += (1 + ruleset.scaled_times) * ruleset.antag_cap[indice_pop]
+			antag_fraction += ((1 + ruleset.scaled_times) * ruleset.antag_cap[indice_pop]) / mode.roundstart_pop_ready
 
-		pop_to_antags = antags_rolled / mode.roundstart_pop_ready
 		log_game("DYNAMIC: [name] roundstart ruleset attempting to scale up with [extra_rulesets] rulesets waiting and [remaining_threat_level] threat remaining.")
 		for(var/i in 1 to 3) //Can scale a max of 3 times
-			if(remaining_threat_level >= scaling_cost && pop_to_antags < 0.25)
-				new_prob = base_prob + (remaining_threat_level) - (scaled_times * scaling_cost) - (extra_rulesets * EXTRA_RULESET_PENALTY) - (pop_to_antags * POP_SCALING_PENALTY)
+			if(remaining_threat_level >= scaling_cost && antag_fraction < 0.25)
+				new_prob = base_prob + (remaining_threat_level) - (scaled_times * scaling_cost) - (extra_rulesets * EXTRA_RULESET_PENALTY) - (antag_fraction * POP_SCALING_PENALTY)
 				if (!prob(new_prob))
 					break
 				remaining_threat_level -= scaling_cost
 				scaled_times++
-				pop_to_antags += antag_cap[indice_pop] / mode.roundstart_pop_ready // we added new antags, gotta update the ratio
+				antag_fraction += antag_cap[indice_pop] / mode.roundstart_pop_ready // we added new antags, gotta update the %
 
-		log_game("DYNAMIC: [name] roundstart ruleset failed scaling up at [new_prob]% chance after [scaled_times]/3 successful scaleups. [remaining_threat_level] threat remaining, antag to crew ratio: [pop_to_antags*100]%.")
+		log_game("DYNAMIC: [name] roundstart ruleset failed scaling up at [new_prob]% chance after [scaled_times]/3 successful scaleups. [remaining_threat_level] threat remaining, % of players that are antags: [antag_fraction*100]%.")
 		return scaled_times * scaling_cost
 
 /// This is called if persistent variable is true everytime SSTicker ticks.

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -176,7 +176,6 @@
 	. = ..()
 	if(GLOB.wizardstart.len == 0)
 		return FALSE
-	mode.antags_rolled += 1
 	var/mob/M = pick_n_take(candidates)
 	if (M)
 		assigned += M.mind
@@ -219,7 +218,6 @@
 /datum/dynamic_ruleset/roundstart/bloodcult/pre_execute()
 	. = ..()
 	var/cultists = antag_cap[indice_pop]
-	mode.antags_rolled += cultists
 	for(var/cultists_number = 1 to cultists)
 		if(candidates.len <= 0)
 			break
@@ -280,7 +278,6 @@
 	. = ..()
 	// If ready() did its job, candidates should have 5 or more members in it
 	var/operatives = antag_cap[indice_pop]
-	mode.antags_rolled += operatives
 	for(var/operatives_number = 1 to operatives)
 		if(candidates.len <= 0)
 			break
@@ -367,7 +364,6 @@
 /datum/dynamic_ruleset/roundstart/revs/pre_execute()
 	. = ..()
 	var/max_candidates = antag_cap[indice_pop]
-	mode.antags_rolled += max_candidates
 	for(var/i = 1 to max_candidates)
 		if(candidates.len <= 0)
 			break
@@ -534,7 +530,6 @@
 /datum/dynamic_ruleset/roundstart/devil/pre_execute()
 	. = ..()
 	var/num_devils = antag_cap[indice_pop]
-	mode.antags_rolled += num_devils
 
 	for(var/j = 0, j < num_devils, j++)
 		if (!candidates.len)
@@ -592,7 +587,6 @@
 /datum/dynamic_ruleset/roundstart/monkey/pre_execute()
 	. = ..()
 	var/carriers_to_make = max(round(mode.roundstart_pop_ready / players_per_carrier, 1), 1)
-	mode.antags_rolled += carriers_to_make
 
 	for(var/j = 0, j < carriers_to_make, j++)
 		if (!candidates.len)


### PR DESCRIPTION
it used to rely on bullshit boilerplate that half of the roundstart rulesets didn't implement anyway. this fixes that. there should be slightly fewer antags on dynamic rounds that roll roundstart traitors + changelings || traitors + BBs || changelings + BBs, especially on lowpop. maybe. who gives a shit

## Changelog
:cl:
tweak: Dynamic roundstart ruleset scaling on second-rolled roundstart rulesets has been slightly tweaked.
/:cl: