### PR TITLE
removes deprecated game_mode proc check_win() 

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -266,9 +266,6 @@
 	return 0
 
 
-/datum/game_mode/proc/check_win() //universal trigger to be called at mob death, nuke explosion, etc. To be called from everywhere.
-	return 0
-
 /datum/game_mode/proc/send_intercept()
 	var/intercepttext = "<b><i>Central Command Status Summary</i></b><hr>"
 	intercepttext += "<b>Central Command has intercepted and partially decoded a Syndicate transmission with vital information regarding their movements. The following report outlines the most \

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -164,6 +164,33 @@ GLOBAL_VAR_INIT(deaths_during_shift, 0)
 /datum/game_mode/gang/proc/five_minute_warning()
 	priority_announce("Julio G coming to you live from Radio Los Spess! The space cops are closing in on [station_name()] and will arrive in about 5 minutes! Better clear on out of there if you don't want to get hurt!", "Radio Los Spess", 'sound/voice/beepsky/radio.ogg')
 
+ /datum/game_mode/gang/set_round_result()
+	var/alive_gangsters = 0
+	var/alive_cops = 0
+	for(var/G in gangbangers)
+		var/datum/mind/gangbanger = G
+		if(!ishuman(gangbanger.current))
+			continue
+		var/mob/living/carbon/human/H = gangbanger.current
+		if(H.stat)
+			continue
+		alive_gangsters++
+	for(var/B in pigs)
+		var/datum/mind/bacon = B
+		if(!ishuman(bacon.current)) // always returns false
+			continue
+		var/mob/living/carbon/human/H = bacon.current
+		if(H.stat)
+			continue
+		alive_cops++
+	if(alive_gangsters > alive_cops)
+		SSticker.mode_result = "win - gangs survived"
+		SSticker.news_report = GANG_OPERATING
+		return TRUE
+	SSticker.mode_result = "loss - police destroyed the gangs"
+	SSticker.news_report = GANG_DESTROYED
+	return FALSE
+
 /datum/game_mode/gang/process()
 	check_wanted_level()
 	check_counter++

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -164,31 +164,6 @@ GLOBAL_VAR_INIT(deaths_during_shift, 0)
 /datum/game_mode/gang/proc/five_minute_warning()
 	priority_announce("Julio G coming to you live from Radio Los Spess! The space cops are closing in on [station_name()] and will arrive in about 5 minutes! Better clear on out of there if you don't want to get hurt!", "Radio Los Spess", 'sound/voice/beepsky/radio.ogg')
 
-/datum/game_mode/gang/check_win()
-	var/alive_gangsters = 0
-	var/alive_cops = 0
-	for(var/datum/mind/gangbanger in gangbangers)
-		if(!ishuman(gangbanger.current))
-			continue
-		var/mob/living/carbon/human/H = gangbanger.current
-		if(H.stat)
-			continue
-		alive_gangsters++
-	for(var/datum/mind/bacon in pigs)
-		if(!ishuman(bacon.current)) // always returns false
-			continue
-		var/mob/living/carbon/human/H = bacon.current
-		if(H.stat)
-			continue
-		alive_cops++
-	if(alive_gangsters > alive_cops)
-		SSticker.mode_result = "win - gangs survived"
-		SSticker.news_report = GANG_OPERATING
-		return TRUE
-	SSticker.mode_result = "loss - police destroyed the gangs"
-	SSticker.news_report = GANG_DESTROYED
-	return FALSE
-
 /datum/game_mode/gang/process()
 	check_wanted_level()
 	check_counter++
@@ -197,7 +172,6 @@ GLOBAL_VAR_INIT(deaths_during_shift, 0)
 			fuckingdone = TRUE
 			send_in_the_fuzz()
 		check_counter = 0
-		SSticker.mode.check_win()
 
 		check_tagged_turfs()
 		check_gang_clothes()

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -164,7 +164,7 @@ GLOBAL_VAR_INIT(deaths_during_shift, 0)
 /datum/game_mode/gang/proc/five_minute_warning()
 	priority_announce("Julio G coming to you live from Radio Los Spess! The space cops are closing in on [station_name()] and will arrive in about 5 minutes! Better clear on out of there if you don't want to get hurt!", "Radio Los Spess", 'sound/voice/beepsky/radio.ogg')
 
- /datum/game_mode/gang/set_round_result()
+/datum/game_mode/gang/set_round_result()
 	var/alive_gangsters = 0
 	var/alive_cops = 0
 	for(var/G in gangbangers)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -54,11 +54,6 @@
 	..()
 	nukes_left--
 
-/datum/game_mode/nuclear/check_win()
-	if (nukes_left == 0)
-		return TRUE
-	return ..()
-
 /datum/game_mode/nuclear/check_finished()
 	//Keep the round going if ops are dead but bomb is ticking.
 	if(nuke_team.operatives_dead())

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -4,7 +4,7 @@
 // Just make sure the converter is a head before you call it!
 // To remove a rev (from brainwashing or w/e), call SSticker.mode:remove_revolutionary(_THE_PLAYERS_MIND_),
 // this will also check they're not a head, so it can just be called freely
-// If the game somtimes isn't registering a win properly, then SSticker.mode.check_win() isn't being called somewhere.
+// If the game somtimes isn't registering a win properly, then our check_finished is fucked up.
 
 
 /datum/game_mode/revolution
@@ -26,7 +26,6 @@
 	<span class='notice'>Crew</span>: Prevent the revolutionaries from taking over the station."
 
 	var/finished = 0
-	var/check_counter = 0
 	var/max_headrevs = 3
 	var/datum/team/revolution/revolution
 	var/list/datum/mind/headrev_candidates = list()
@@ -108,33 +107,19 @@
 	..()
 
 
-/datum/game_mode/revolution/process()
-	check_counter++
-	if(check_counter >= 5)
-		if(!finished)
-			SSticker.mode.check_win()
-		check_counter = 0
-	return FALSE
-
-//////////////////////////////////////
-//Checks if the revs have won or not//
-//////////////////////////////////////
-/datum/game_mode/revolution/check_win()
+///////////////////////////////////////////
+//Checks who won and if the round is over//
+///////////////////////////////////////////
+/datum/game_mode/revolution/check_finished()
 	if(check_rev_victory())
 		finished = 1
 	else if(check_heads_victory())
 		finished = 2
-	return
-
-///////////////////////////////
-//Checks if the round is over//
-///////////////////////////////
-/datum/game_mode/revolution/check_finished()
 	if(CONFIG_GET(keyed_list/continuous)["revolution"])
 		if(finished)
 			SSshuttle.clearHostileEnvironment(src)
 		return ..()
-	if(finished != 0 && end_when_heads_dead)
+	if(finished && end_when_heads_dead)
 		return TRUE
 	else
 		return ..()
@@ -201,6 +186,7 @@
 	end_when_heads_dead = FALSE
 	var/endtime = null
 	var/fuckingdone = FALSE
+	var/check_counter = 0
 
 /datum/game_mode/revolution/speedy/pre_setup()
 	endtime = world.time + 20 MINUTES
@@ -208,6 +194,7 @@
 
 /datum/game_mode/revolution/speedy/process()
 	. = ..()
+	check_counter++
 	if(check_counter == 0)
 		if (world.time > endtime && !fuckingdone)
 			fuckingdone = TRUE

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -195,7 +195,8 @@
 /datum/game_mode/revolution/speedy/process()
 	. = ..()
 	check_counter++
-	if(check_counter == 0)
+	if(check_counter == 5)
+		check_counter = 0
 		if (world.time > endtime && !fuckingdone)
 			fuckingdone = TRUE
 			for (var/obj/machinery/nuclearbomb/N in GLOB.nuke_list)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -15,9 +15,6 @@
 		var/datum/brain_trauma/BT = T
 		BT.on_death()
 
-	if(SSticker.mode)
-		SSticker.mode.check_win() //Calls the rounds wincheck, mainly for wizard, malf, and changeling now
-
 /mob/living/carbon/proc/inflate_gib() // Plays an animation that makes mobs appear to inflate before finally gibbing
 	addtimer(CALLBACK(src, .proc/gib, null, null, TRUE, TRUE), 25)
 	var/matrix/M = matrix()

--- a/code/modules/mob/living/simple_animal/slime/death.dm
+++ b/code/modules/mob/living/simple_animal/slime/death.dm
@@ -24,9 +24,6 @@
 	set_stat(DEAD)
 	cut_overlays()
 
-	if(SSticker.mode)
-		SSticker.mode.check_win()
-
 	return ..(gibbed)
 
 /mob/living/simple_animal/slime/gib()


### PR DESCRIPTION
## About The Pull Request

gussies up another fuckish part of gamemode-related code, this time the proc check_win(). it used to handle when the round should end and was called every time a person or a slime (??) died, but then... something gamemode-related was changed, the ticker subsystem maybe, and now check_finished() is called periodically and is used for what check_win() seems like it was supposed to do in the days of old. revolution was the only gamemode using it correctly, so i fixed it to use check_finished(). it served its purpose when it was relevant, so i guess my feelings on this straddle the line between a respectful send-off of a departed war hero and a mercy killing

## Why It's Good For The Game

useless code bad. brings forward the day when gamemode code gets rebuilt from scratch to be less awful for my soul. it's humanitarian

## Changelog
:cl:
code: removed deprecated check_win() proc
/:cl:

note: will cause merge conflicts with #51244 since that PR of mine also deletes lines from families code