### PR TITLE
Medbots Now Only Heal Brute UNLESS They Are Made With Special Medkit

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -236,6 +236,7 @@
 	icon_state = "radfirstaid"
 	inhand_icon_state = "firstaid-rad"
 	custom_premium_price = 1100
+	damagetype_healed = "all"
 
 /obj/item/storage/firstaid/advanced/PopulateContents()
 	if(empty)
@@ -251,6 +252,7 @@
 	name = "combat medical kit"
 	desc = "I hope you've got insurance."
 	icon_state = "bezerk"
+	damagetype_healed = "all"
 
 /obj/item/storage/firstaid/tactical/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Medbots now only heal brute unless they are built with a special medkit. Thanks to tlal for the simpler alternative.

Brute kits heal 10% more brute than normal medbots.

Advanced kits can be used to build pre-nerf  variants of the medbots (they heal all damage types). What they heal each iteration is random though (if you could be treated for brute/tox, you may get tox healed first).

This is specific to the craftable medbots, derelict medbots and beserk medbots will heal "normally" (see above since order has been randomized).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes the bots hyperspecified to a function which is in line with how other bots function without having to revamp how people use the medbot.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Cobby
balance: craftable medbots now only heal brute unless they are built with specialized medkits.
balance: medbots built with the brute medkit heal 10% more
balance: medbots built with the advance medkit heal all damage types
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
