### PR TITLE
Stops this medibot nerf madness [compromise PR]

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -183,9 +183,9 @@
 				continue
 			tech_boosters++
 		if(tech_boosters)
-			heal_amount = (round(tech_boosters/2,0.1)*initial(heal_amount))+initial(heal_amount) //every 2 tend wounds tech gives you an extra 100% healing, adjusting for unique branches (combo is bonus)
+			heal_amount = (round(tech_boosters/4,0.1)*initial(heal_amount))+initial(heal_amount) //every tend wounds tech gives you an extra 25% healing, adjusting for unique branches (combo is bonus)
 			if(oldheal_amount < heal_amount)
-				speak("Surgerical Knowledge Found! Efficiency is increased by [round(heal_amount/oldheal_amount*100)]%!")
+				speak("Surgical knowledge found! Efficiency multiplied by [round(heal_amount/oldheal_amount*100)]%!")
 	update_controls()
 	return
 


### PR DESCRIPTION
## About The Pull Request

This PR halves the effectiveness of tend wounds upgrades for medibots, but keeps their base healing rate the same.

It also adjusts the message that medibots say when you upgrade them to both use percentages properly and spell "surgical" correctly.

## Why It's Good For The Game

This PR has been made as an alternative to Cobby's nerf PRs.

It also makes it so that fully-upgraded medibots can't tend wounds faster than a legendary surgeon with upgraded tools (note that while I've been told that that is a thing, I haven't verified that claim yet).

## Changelog
:cl: ATHATH
balance: The effectiveness of tend wounds upgrades for medibots has been halved, but the base healing rate of medibots is still the same. [compromise PR]
fix: Adjusted the message that medibots say when you upgrade them to both use percentages properly and spell "surgical" correctly.
/:cl: