### PR TITLE
Updates the in-game podcloning guide

### DIFF
--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -7,10 +7,10 @@
 	unique = TRUE   // FALSE - Normal book, TRUE - Should not be treated as normal book, unable to be copied, unable to be modified
 
 /obj/item/book/manual/hydroponics_pod_people
-	name = "The Human Harvest - From seed to market"
+	name = "The Human Harvest: From Seed to Market"
 	icon_state ="bookHydroponicsPodPeople"
 	author = "Farmer John" // Whoever wrote the paper or book, can be changed by pen or PC. It is not automatically assigned.
-	title = "The Human Harvest - From seed to market"
+	title = "The Human Harvest: From Seed to Market"
 	//book contents below
 	dat = {"<html>
 				<head>
@@ -26,15 +26,17 @@
 				<body>
 				<h3>Growing Humans</h3>
 
-				Why would you want to grow humans? Well I'm expecting most readers to be in the slave trade, but a few might actually
-				want to revive fallen comrades. Growing pod people is easy, but prone to disaster.
+				Why would you want to grow humans? Well, I'm expecting most readers to be in the slave trade, but a few might actually
+				want to revive fallen comrades. Growing pod people is actually quite simple:
 				<p>
 				<ol>
-				<li>Find a dead person who is in need of cloning. </li>
-				<li>Take a blood sample with a syringe. </li>
-				<li>Inject a seed pack with the blood sample. </li>
+				<li>Find a dead person who is in need of revival. </li>
+				<li>Take a blood sample with a syringe (samples of their blood taken BEFORE they died will also work). </li>
+				<li>Inject a packet of replica pod seeds (which can be acquired by either mutating cabbages into replica pods (and then harvesting said replica pods) or by purchasing them from certain corporate entities) with the blood sample. </li>
+				<li>It is imperative to understand that injecting the replica pod plant with blood AFTER it has been planted WILL NOT WORK; you have to inject the SEED PACKET, NOT the TRAY. </li>
 				<li>Plant the seeds. </li>
-				<li>Tend to the plants water and nutrition levels until it is time to harvest the cloned human.</li>
+				<li>Tend to the replica pod's water and nutrition levels until it is time to harvest the podcloned humanoid. </li>
+				<li>Note that if the corpse's mind (or spirit, or soul, or whatever the hell your local chaplain calls it) is already in a new body or has left this plane of existence entirely, you will just receive seed packets upon harvesting the replica pod plant, not a podperson. </li>
 				</ol>
 				<p>
 				It really is that easy! Good luck!


### PR DESCRIPTION
## About The Pull Request

See the title (and the code changes).

## Why It's Good For The Game

The current guide leaves out a few pieces of very important advice, and still assumes that normal cloning is a thing.

Also, its title wasn't fully capitalized.

## Changelog
:cl: ATHATH
tweak: The in-game podcloning guide (The Human Harvest: From Seed to Market) has been updated.
/:cl: