### PR TITLE
Update precommit hooks to work in GitHub Desktop

### DIFF
--- a/tools/hooks/dmi.merge
+++ b/tools/hooks/dmi.merge
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 exec tools/hooks/python.sh -m merge_driver_dmi "$@"

--- a/tools/hooks/pre-commit.hook
+++ b/tools/hooks/pre-commit.hook
@@ -1,2 +1,3 @@
 #!/bin/sh
+# `sh` must be used here instead of `bash` to support GitHub Desktop.
 exec tools/hooks/python.sh -m precommit

--- a/tools/hooks/pre-commit.hook
+++ b/tools/hooks/pre-commit.hook
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 exec tools/hooks/python.sh -m precommit

--- a/tools/hooks/python.sh
+++ b/tools/hooks/python.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# `sh` must be used here instead of `bash` to support GitHub Desktop.
 set -e
 if command -v python3 >/dev/null 2>&1; then
 	PY=python3

--- a/tools/hooks/python.sh
+++ b/tools/hooks/python.sh
@@ -1,17 +1,21 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 if command -v python3 >/dev/null 2>&1; then
 	PY=python3
-else
+elif command -v python >/dev/null 2>&1; then
 	PY=python
+elif command -v py >/dev/null 2>&1; then
+	PY=py
+else
+	echo "Please install Python 3.6 or later."
 fi
 PATHSEP=$($PY - <<'EOF'
 import sys, os
 if sys.version_info.major != 3 or sys.version_info.minor < 6:
-	sys.stderr.write("Python 3.6+ is required: " + sys.version + "\n")
+	sys.stderr.write("Python 3.6 or later is required, but you have:\n" + sys.version + "\n")
 	exit(1)
 print(os.pathsep)
 EOF
 )
 export PYTHONPATH=tools/mapmerge2/${PATHSEP}${PYTHONPATH}
-$PY "$@"
+exec $PY "$@"


### PR DESCRIPTION
Turns out GitHub Desktop actually does bundle a `sh.exe`, just not a bash.

Also tries to look for the `py` launcher to help people who didn't check the "Add Python to PATH" option.