### PR TITLE
New configuration option to enable the `notify` command

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -442,6 +442,9 @@
 /datum/config_entry/string/chat_announce_new_game
 	config_entry_value = null
 
+/datum/config_entry/string/chat_new_game_notifications
+	config_entry_value = null
+
 /datum/config_entry/flag/debug_admin_hrefs
 
 /datum/config_entry/number/mc_tick_rate/base_mc_tick_rate

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -58,7 +58,7 @@ SUBSYSTEM_DEF(discord)
 		pass() // The list can just stay as its default (blank). Pass() exists because it needs a catch
 	var/notifymsg = jointext(people_to_notify, ", ")
 	if(notifymsg)
-		send2chat(trim(notifymsg), CONFIG_GET(string/chat_announce_new_game)) // Sends the message to the discord, using same config option as the roundstart notification
+		send2chat(trim(notifymsg), CONFIG_GET(string/chat_new_game_notifications)) // Sends the message to the discord, using same config option as the roundstart notification
 	fdel(notify_file) // Deletes the file
 	return ..()
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -457,7 +457,7 @@ MINUTE_CLICK_LIMIT 400
 ## If using TGS4, the string option can be set as a chat channel tag to limit the message to channels with that tag name (case-sensitive). This will have no effect on TGS3.
 ## i.e. CHAT_ANNOUNCE_NEW_GAME chat_channel_tag
 
-## Send a message with the station name starting a new game. Also required for the notify function
+## Send a message with the station name starting a new game.
 #CHAT_ANNOUNCE_NEW_GAME
 
 ## Ping users who use the `notify` command when a new game starts.

--- a/config/config.txt
+++ b/config/config.txt
@@ -451,15 +451,17 @@ MINUTE_CLICK_LIMIT 400
 #ERROR_MSG_DELAY 50
 
 
-## Chat Announce Options
-## Various messages to be sent to game chats
-## Uncommenting these will enable them, by default they will be broadcast to Game chat channels on TGS3 or non-admin channels on TGS4
-## If using TGS4, the string option can be set as a chat channel tag to limit the message to channels of that tag type (case-sensitive)
+## Game Chat Message Options
+## Various messages to be sent to connected chat channels.
+## Uncommenting these will enable them, by default they will be broadcast to Game chat channels on TGS3 or non-admin channels on TGS4.
+## If using TGS4, the string option can be set as a chat channel tag to limit the message to channels with that tag name (case-sensitive). This will have no effect on TGS3.
 ## i.e. CHAT_ANNOUNCE_NEW_GAME chat_channel_tag
 
 ## Send a message with the station name starting a new game. Also required for the notify function
 #CHAT_ANNOUNCE_NEW_GAME
 
+## Ping users who use the `notify` command when a new game starts.
+#CHAT_NEW_GAME_NOTIFICATIONS
 
 ## Allow admin hrefs that don't use the new token system, will eventually be removed
 DEBUG_ADMIN_HREFS


### PR DESCRIPTION
`CHAT_NEW_GAME_NOTIFICATIONS`

I can't find the commit that untied the original config to the announcement, but this is how it originally was: https://github.com/tgstation/tgstation/commit/db68cd1f9d51709af36d8ed2af71c18e01e32e53#diff-d91ba57ba114207ed6985097e129dd9cR137

Whoever did it obviously didn't read the send2irc (now send2chat) doc comment

Closes #51416