### PR TITLE
Fixes neckgrabs being only escapable if RNGesus comes down and saves you from your fate

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -70,7 +70,7 @@
 #define GRAB_KILL					3
 
 //Grab breakout odds
-#define BASE_GRAB_RESIST_CHANCE 	30
+#define BASE_GRAB_RESIST_CHANCE 	60 //base chance for whether or not you can escape from a grab
 
 //slowdown when in softcrit. Note that crawling slowdown will also apply at the same time!
 #define SOFTCRIT_ADD_SLOWDOWN 2

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -799,7 +799,7 @@
 							"<span class='warning'>You struggle as you fail to break free of [pulledby]'s grip!</span>", null, null, pulledby)
 			to_chat(pulledby, "<span class='danger'>[src] struggles as they fail to break free of your grip!</span>")
 		if(moving_resist && client) //we resisted by trying to move
-			client.move_delay = world.time + 20
+			client.move_delay = world.time + 40
 	else
 		pulledby.stop_pulling()
 		return FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -784,8 +784,8 @@
 		var/altered_grab_state = pulledby.grab_state
 		if((resting || HAS_TRAIT(src, TRAIT_GRABWEAKNESS)) && pulledby.grab_state < GRAB_KILL) //If resting, resisting out of a grab is equivalent to 1 grab state higher. won't make the grab state exceed the normal max, however
 			altered_grab_state++
-		var/resist_chance = BASE_GRAB_RESIST_CHANCE // see defines/combat.dm
-		resist_chance = max((resist_chance/altered_grab_state)-sqrt((getBruteLoss()+getFireLoss()+getOxyLoss()+getToxLoss()+getCloneLoss())*0.5+getStaminaLoss()), 0) //stamina loss is weighted twice as heavily as the other damage types in this calculation
+		var/resist_chance = BASE_GRAB_RESIST_CHANCE /// see defines/combat.dm, this should be baseline 60%
+		resist_chance = (resist_chance/altered_grab_state) ///Resist chance divided by the value imparted by your grab state. It isn't until you reach neckgrab that you gain a penalty to escaping a grab.
 		if(prob(resist_chance))
 			visible_message("<span class='danger'>[src] breaks free of [pulledby]'s grip!</span>", \
 							"<span class='danger'>You break free of [pulledby]'s grip!</span>", null, null, pulledby)
@@ -794,7 +794,7 @@
 			pulledby.stop_pulling()
 			return FALSE
 		else
-			adjustStaminaLoss(rand(8,15))//8 is from 7.5 rounded up
+			adjustStaminaLoss(rand(15,20))//failure to escape still imparts a pretty serious penalty
 			visible_message("<span class='danger'>[src] struggles as they fail to break free of [pulledby]'s grip!</span>", \
 							"<span class='warning'>You struggle as you fail to break free of [pulledby]'s grip!</span>", null, null, pulledby)
 			to_chat(pulledby, "<span class='danger'>[src] struggles as they fail to break free of your grip!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The baseline chance to escape a grab is 60%. This is only ever altered by the state of the grab. 

Aggressive grabs are 60% (no change), neckgrabs are 30% and killgrabs are 20%.

Every time you resist and fail to escape, you take anywhere from 15 to 20 stamina damage. This is to make up for the fact that I've really nerfed grabs. Additionally, you can attempt to resist every 4 seconds instead of every 2, so you have half as many attempts as you did before. This should even out to what it was previously, but expect more first attempt escapes. 

## Why It's Good For The Game

Due to the math alterations in https://github.com/tgstation/tgstation/pull/49544, at a baseline it is statistically improbable to escape from a neckgrab while on the floor. Since neckgrabs put you on the floor, this just means neckgrabs are statistically extremely unlikely to be escaped just at a baseline, since they're treated as killgrabs as a baseline, you literally don't even have an opportunity to treat it as a neckgrab. That's a pretty major flaw of the current design, but we'll fix that some time later, I can't be arsed right now.

As a result, various people have been abusing the neckgrab for the better part of a month to killgrab literally anyone off a single shove. It's been quietly abused for some time, and while I would like to help do a much bigger change to grabs, that can wait since this is getting fucking ridiculous and I'm tired of literally any carbon threat dying to a single shovestun, since upgrading an aggressive grab is almost perfectly the same amount of time you are stunned off a shove. Neckgrabs are a form of restrain, so you cannot use your hands whatsoever while under the effects of a neckgrab. You're just toast until you somehow manage to escape.

However, trying to escape will slowly stamina crit you, which will reduce your chances of escaping even further. Essentially this is deathspiral. You quite literally need to escape on the first attempt or you don't at all.

Obviously this needs to be fixed, since it's quite literally anyone with hands can do and far more power than what the average player should have. We killed off quickgrabs after all, and this is honestly no different.

## Changelog
:cl:
fix: Neckgrabs and especially floor neckgrabs are no longer near impossible to escape.
balance: Resisting a grab is more consistent across the board, but you get less chances at resisting a grab and take more stamina damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
