### PR TITLE
Makes Breathmasks and (normal) Gasmasks printable at Auto/Protolathes

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -290,6 +290,23 @@
 	category = list("initial","Misc","Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
 
+/datum/design/breathmask
+	name = "Breath Mask"
+	id = "breathmask"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/glass = 1000)
+	build_path = /obj/item/clothing/mask/breath
+	category = list("initial","Misc","Equipment")
+
+/datum/design/gas_mask
+	name = "Gas Mask"
+	id = "gas_mask"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/iron = 2000)
+	build_path = /obj/item/clothing/mask/gas
+	category = list("hacked","Misc","Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_SCIENCE
+
 /datum/design/metal
 	name = "Metal"
 	id = "metal"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -294,7 +294,7 @@
 	name = "Breath Mask"
 	id = "breathmask"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/glass = 1000)
+	materials = list(/datum/material/plastic = 1000)
 	build_path = /obj/item/clothing/mask/breath
 	category = list("initial","Misc","Equipment")
 


### PR DESCRIPTION
## About The Pull Request

Breath masks (the ones you start with in your internals box) can now be printed at all Autolathes and Protolathes for half a plastic sheet. (1000 cm2)

Gas masks (the ones you find in red lockers and maintenance) can now be printed at hacked Autolathes and the Science, Cargo, and Engineering Protolathes for one metal sheet. (2000 cm2)

That's it. Really.

## Why It's Good For The Game

I thought it was weird that the 'lathes can make gas tanks, but not masks. I also thought it was weird that the only type of gas mask that you could print was the fairly niche Welding Gas Mask after a fair amount of research.

Sure, for the most part breath/gas masks aren't that hard to find, but it's nice to have the consistency of being able to replace your old mask at the Autolathe instead of digging around the various blue/red lockers littered around the station.

## Changelog
:cl:
add: Spare breath masks can now be printed at all Autolathes and Protolathes.
add: Standard gas masks can now be printed in hacked Autolathes plus all Science, Engineering, and Cargo Protolathes.
/:cl: