### PR TITLE
Simplifies ear damage, allows empaths to properly spot deafness

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -235,6 +235,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define GENERIC_ITEM_TRAIT "generic_item"
 #define UNCONSCIOUS_BLIND "unconscious_blind"
 #define EYE_DAMAGE "eye_damage"
+#define EAR_DAMAGE "ear_damage"
 #define GENETIC_MUTATION "genetic"
 #define OBESITY "obesity"
 #define MAGIC_TRAIT "magic"

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -260,14 +260,14 @@
 		M.fields["name"]		= H.real_name
 		M.fields["blood_type"]	= H.dna.blood_type
 		M.fields["b_dna"]		= H.dna.unique_enzymes
-		M.fields["mi_dis"]		= H.get_trait_string(!medical, CAT_QUIRK_MINOR_DISABILITY)
-		M.fields["mi_dis_d"]	= H.get_trait_string(medical, CAT_QUIRK_MINOR_DISABILITY)
-		M.fields["ma_dis"]		= H.get_trait_string(!medical, CAT_QUIRK_MAJOR_DISABILITY)
-		M.fields["ma_dis_d"]	= H.get_trait_string(medical, CAT_QUIRK_MAJOR_DISABILITY)
+		M.fields["mi_dis"]		= H.get_quirk_string(!medical, CAT_QUIRK_MINOR_DISABILITY)
+		M.fields["mi_dis_d"]	= H.get_quirk_string(medical, CAT_QUIRK_MINOR_DISABILITY)
+		M.fields["ma_dis"]		= H.get_quirk_string(!medical, CAT_QUIRK_MAJOR_DISABILITY)
+		M.fields["ma_dis_d"]	= H.get_quirk_string(medical, CAT_QUIRK_MAJOR_DISABILITY)
 		M.fields["cdi"]			= "None"
 		M.fields["cdi_d"]		= "No diseases have been diagnosed at the moment."
-		M.fields["notes"]		= H.get_trait_string(!medical, CAT_QUIRK_NOTES)
-		M.fields["notes_d"]		= H.get_trait_string(medical, CAT_QUIRK_NOTES)
+		M.fields["notes"]		= H.get_quirk_string(!medical, CAT_QUIRK_NOTES)
+		M.fields["notes_d"]		= H.get_quirk_string(medical, CAT_QUIRK_NOTES)
 		medical += M
 
 		//Security Record

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -45,17 +45,19 @@ Bonus
 	if(!..())
 		return
 	var/mob/living/carbon/M = A.affected_mob
+	var/obj/item/organ/ears/ears = M.getorganslot(ORGAN_SLOT_EARS)
+	if(!ears)
+		return //cutting off your ears to cure the deafness: the ultimate own
 	switch(A.stage)
 		if(3, 4)
 			if(prob(base_message_chance) && !suppress_warning)
 				to_chat(M, "<span class='warning'>[pick("You hear a ringing in your ear.", "Your ears pop.")]</span>")
 		if(5)
 			if(power >= 2)
-				var/obj/item/organ/ears/ears = M.getorganslot(ORGAN_SLOT_EARS)
-				if(istype(ears) && ears.damage < ears.maxHealth)
+				if(ears.damage < ears.maxHealth)
 					to_chat(M, "<span class='userdanger'>Your ears pop painfully and start bleeding!</span>")
 					ears.damage = max(ears.damage, ears.maxHealth)
 					M.emote("scream")
 			else
 				to_chat(M, "<span class='userdanger'>Your ears pop and begin ringing loudly!</span>")
-				M.minimumDeafTicks(20)
+				ears.deaf = min(20, ears.deaf + 15)

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -79,14 +79,16 @@
 /datum/symptom/sensory_restoration/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(4, 5)
-			M.restoreEars() //this is mostly just copy+pasted from oculine and inacusiate
+			var/obj/item/organ/ears/ears = M.getorganslot(ORGAN_SLOT_EARS)
+			if(ears)
+				ears.adjustEarDamage(-4, -4)
 			M.adjust_blindness(-2)
 			M.adjust_blurriness(-2)
 			var/obj/item/organ/eyes/eyes = M.getorganslot(ORGAN_SLOT_EYES)
-			if(!eyes)
+			if(!eyes) // only dealing with eye stuff from here on out
 				return
 			eyes.applyOrganDamage(-2)
 			if(HAS_TRAIT_FROM(M, TRAIT_BLIND, EYE_DAMAGE))

--- a/code/datums/elements/earhealing.dm
+++ b/code/datums/elements/earhealing.dm
@@ -26,10 +26,8 @@
 /datum/element/earhealing/process()
 	for(var/i in user_by_item)
 		var/mob/living/carbon/user = user_by_item[i]
-		if(HAS_TRAIT(user, TRAIT_DEAF))
-			continue
 		var/obj/item/organ/ears/ears = user.getorganslot(ORGAN_SLOT_EARS)
-		if(!ears)
+		if(!ears || HAS_TRAIT_NOT_FROM(user, TRAIT_DEAF, EAR_DAMAGE))
 			continue
 		ears.deaf = max(ears.deaf - 0.25, (ears.damage < ears.maxHealth ? 0 : 1)) // Do not clear deafness if our ears are too damaged
 		ears.damage = max(ears.damage - 0.025, 0)

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -67,7 +67,7 @@
 		return
 	on_process()
 
-/mob/living/proc/get_trait_string(medical, category) //helper string. gets a string of all the traits the mob has
+/mob/living/proc/get_quirk_string(medical, category) //helper string. gets a string of all the traits the mob has
 	var/list/dat = list()
 	switch(category)
 		if(CAT_QUIRK_ALL)

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -67,7 +67,14 @@
 		return
 	on_process()
 
-/mob/living/proc/get_quirk_string(medical, category) //helper string. gets a string of all the traits the mob has
+/**
+  * get_quirk_string() is used to get a printable string of all the quirk traits someone has for certain criteria
+  *
+  * Arguments:
+  * * Medical- If we want the long, fancy descriptions that show up in medical records, or if not, just the name
+  * * Category- Which types of quirks we want to print out. Defaults to everything
+  */
+/mob/living/proc/get_quirk_string(medical, category = CAT_QUIRK_ALL) //helper string. gets a string of all the quirks the mob has
 	var/list/dat = list()
 	switch(category)
 		if(CAT_QUIRK_ALL)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -182,7 +182,7 @@
 	playsound(chassis, 'sound/items/airhorn.ogg', 100, TRUE)
 	chassis.occupant_message("<font color='red' size='5'>HONK</font>")
 	for(var/mob/living/carbon/M in ohearers(6, chassis))
-		if(HAS_TRAIT(M, TRAIT_DEAF))
+		if(!M.can_hear())
 			continue
 		var/turf/turf_check = get_turf(M)
 		if(isspaceturf(turf_check) && !turf_check.Adjacent(src)) //in space nobody can hear you honk.

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -182,17 +182,17 @@
 	playsound(chassis, 'sound/items/airhorn.ogg', 100, TRUE)
 	chassis.occupant_message("<font color='red' size='5'>HONK</font>")
 	for(var/mob/living/carbon/M in ohearers(6, chassis))
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			if(istype(H.ears, /obj/item/clothing/ears/earmuffs))
-				continue
+		if(HAS_TRAIT(M, TRAIT_DEAF))
+			continue
 		var/turf/turf_check = get_turf(M)
 		if(isspaceturf(turf_check) && !turf_check.Adjacent(src)) //in space nobody can hear you honk.
 			continue
 		to_chat(M, "<font color='red' size='7'>HONK</font>")
 		M.SetSleeping(0)
 		M.stuttering += 20
-		M.adjustEarDamage(0, 30)
+		var/obj/item/organ/ears/ears = M.getorganslot(ORGAN_SLOT_EARS)
+		if(ears)
+			ears.adjustEarDamage(0, 30)
 		M.Paralyze(60)
 		if(prob(30))
 			M.Stun(200)

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -221,11 +221,8 @@
 /obj/item/bikehorn/golden/proc/flip_mobs(mob/living/carbon/M, mob/user)
 	var/turf/T = get_turf(src)
 	for(M in ohearers(7, T))
-		if(ishuman(M) && M.can_hear())
-			var/mob/living/carbon/human/H = M
-			if(istype(H.ears, /obj/item/clothing/ears/earmuffs))
-				continue
-		M.emote("flip")
+		if(M.can_hear())
+			M.emote("flip")
 	flip_cooldown = world.time + 7
 
 //canned laughter

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -204,9 +204,9 @@ GENE SCANNER
 				trauma_text += trauma_desc
 			render_list += "<span class='alert ml-1'>Cerebral traumas detected: subject appears to be suffering from [english_list(trauma_text)].</span>\n"
 		if(C.roundstart_quirks.len)
-			render_list += "<span class='info ml-1'>Subject Major Disabilities: [C.get_trait_string(FALSE, CAT_QUIRK_MAJOR_DISABILITY)].</span>\n"
+			render_list += "<span class='info ml-1'>Subject Major Disabilities: [C.get_quirk_string(FALSE, CAT_QUIRK_MAJOR_DISABILITY)].</span>\n"
 			if(advanced)
-				render_list += "<span class='info ml-1'>Subject Minor Disabilities: [C.get_trait_string(FALSE, CAT_QUIRK_MINOR_DISABILITY)].</span>\n"
+				render_list += "<span class='info ml-1'>Subject Minor Disabilities: [C.get_quirk_string(FALSE, CAT_QUIRK_MINOR_DISABILITY)].</span>\n"
 	if(advanced)
 		render_list += "<span class='info ml-1'>Brain Activity Level: [(200 - M.getOrganLoss(ORGAN_SLOT_BRAIN))/2]%.</span>\n"
 
@@ -255,6 +255,8 @@ GENE SCANNER
 			message = ""
 			if(HAS_TRAIT_FROM(C, TRAIT_DEAF, GENETIC_MUTATION))
 				message = "\n<span class='alert ml-2'>Subject is genetically deaf.</span>"
+			else if(HAS_TRAIT_FROM(C, TRAIT_DEAF, EAR_DAMAGE))
+				message = "\n<span class='alert ml-2'>Subject is deaf from ear damage.</span>"
 			else if(HAS_TRAIT(C, TRAIT_DEAF))
 				message = "\n<span class='alert ml-2'>Subject is deaf.</span>"
 			else

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -14,7 +14,9 @@
 		if(iscarbon(M))
 			var/mob/living/carbon/C = M
 			if(!C.mind || !C.mind.has_antag_datum(/datum/antagonist/changeling))
-				C.adjustEarDamage(0, 30)
+				var/obj/item/organ/ears/ears = C.getorganslot(ORGAN_SLOT_EARS)
+				if(ears)
+					ears.adjustEarDamage(0, 30)
 				C.confused += 25
 				C.Jitter(50)
 			else

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -300,7 +300,9 @@
 		else if(istype(I, /obj/item/bikehorn))
 			to_chat(target, "<span class='userdanger'>HONK</span>")
 			SEND_SOUND(target, 'sound/items/airhorn.ogg')
-			target.adjustEarDamage(0,3)
+			var/obj/item/organ/ears/ears = user.getorganslot(ORGAN_SLOT_EARS)
+			if(ears)
+				ears.adjustEarDamage(0, 3)
 			GiveHint(target)
 		cooldown = world.time +cooldown_time
 		return

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -111,6 +111,7 @@ In all, this is a lot like the monkey code. /N
 	..()
 	if(QDELETED(src))
 		return
+	var/obj/item/organ/ears/ears = getorganslot(ORGAN_SLOT_EARS)
 	switch (severity)
 		if (EXPLODE_DEVASTATE)
 			gib()
@@ -118,13 +119,15 @@ In all, this is a lot like the monkey code. /N
 
 		if (EXPLODE_HEAVY)
 			take_overall_damage(60, 60)
-			adjustEarDamage(30,120)
+			if(ears)
+				ears.adjustEarDamage(30,120)
 
 		if(EXPLODE_LIGHT)
 			take_overall_damage(30,0)
 			if(prob(50))
 				Unconscious(20)
-			adjustEarDamage(15,60)
+			if(ears)
+				ears.adjustEarDamage(15,60)
 
 /mob/living/carbon/alien/soundbang_act(intensity = 1, stun_pwr = 20, damage_pwr = 5, deafen_pwr = 15)
 	return 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -862,9 +862,6 @@
 			reagents.addiction_list = list()
 	cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
 	..()
-	// heal ears after healing traits, since ears check TRAIT_DEAF trait
-	// when healing.
-	restoreEars()
 
 /mob/living/carbon/can_be_revived()
 	. = ..()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -399,16 +399,16 @@
 			Paralyze((stun_pwr*effect_amount)*0.1)
 			Knockdown(stun_pwr*effect_amount)
 
-		if(istype(ears) && (deafen_pwr || damage_pwr))
+		if(ears && (deafen_pwr || damage_pwr))
 			var/ear_damage = damage_pwr * effect_amount
 			var/deaf = deafen_pwr * effect_amount
-			adjustEarDamage(ear_damage,deaf)
+			ears.adjustEarDamage(ear_damage,deaf)
 
 			if(ears.damage >= 15)
 				to_chat(src, "<span class='warning'>Your ears start to ring badly!</span>")
 				if(prob(ears.damage - 5))
 					to_chat(src, "<span class='userdanger'>You can't hear anything!</span>")
-					ears.damage = min(ears.damage, ears.maxHealth)
+					ears.damage = min(ears.damage, ears.maxHealth) // does this actually do anything useful? all this would do is set an upper bound on damage, is this supposed to be a max?
 					// you need earmuffs, inacusiate, or replacement
 			else if(ears.damage >= 5)
 				to_chat(src, "<span class='warning'>Your ears start to ring!</span>")
@@ -434,7 +434,7 @@
 /mob/living/carbon/can_hear()
 	. = FALSE
 	var/obj/item/organ/ears/ears = getorganslot(ORGAN_SLOT_EARS)
-	if(istype(ears) && !ears.deaf)
+	if(ears && !HAS_TRAIT(src, TRAIT_DEAF))
 		. = TRUE
 
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -365,8 +365,6 @@
 	if (!isnull(trait_exam))
 		. += trait_exam
 
-	var/traitstring = get_trait_string()
-
 	var/perpname = get_face_name(get_id_name(""))
 	if(perpname && (HAS_TRAIT(user, TRAIT_SECURITY_HUD) || HAS_TRAIT(user, TRAIT_MEDICAL_HUD)))
 		var/datum/data/record/R = find_record("name", perpname, GLOB.data_core.general)
@@ -388,9 +386,10 @@
 			R = find_record("name", perpname, GLOB.data_core.medical)
 			if(R)
 				. += "<a href='?src=[REF(src)];hud=m;evaluation=1'>\[Medical evaluation\]</a><br>"
-			if(traitstring)
+			var/quirkstring = get_quirk_string(TRUE, CAT_QUIRK_ALL)
+			if(quirkstring)
 				. += "<span class='notice ml-1'>Detected physiological traits:</span>"
-				. += "<span class='notice ml-2'>[traitstring]</span>"
+				. += "<span class='notice ml-2'>[quirkstring]</span>"
 
 		if(HAS_TRAIT(user, TRAIT_SECURITY_HUD))
 			if(!user.stat && user != src)
@@ -407,8 +406,8 @@
 					"<a href='?src=[REF(src)];hud=s;add_crime=1'>\[Add crime\]</a>",
 					"<a href='?src=[REF(src)];hud=s;view_comment=1'>\[View comment log\]</a>",
 					"<a href='?src=[REF(src)];hud=s;add_comment=1'>\[Add comment\]</a>"), "")
-	else if(isobserver(user) && traitstring)
-		. += "<span class='info'><b>Traits:</b> [traitstring]</span>"
+	else if(isobserver(user))
+		. += "<span class='info'><b>Traits:</b> [get_quirk_string(FALSE, CAT_QUIRK_ALL)]</span>"
 	. += "*---------*</span>"
 
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -825,7 +825,7 @@
 	for(var/datum/mutation/human/HM in dna.mutations)
 		if(HM.quality != POSITIVE)
 			dna.remove_mutation(HM.name)
-	..()
+	return ..()
 
 /mob/living/carbon/human/check_weakness(obj/item/weapon, mob/living/attacker)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -402,7 +402,7 @@
 //200 max knockdown for EXPLODE_HEAVY
 //160 max knockdown for EXPLODE_LIGHT
 
-
+	var/obj/item/organ/ears/ears = getorganslot(ORGAN_SLOT_EARS)
 	switch (severity)
 		if (EXPLODE_DEVASTATE)
 			if(bomb_armor < EXPLODE_GIB_THRESHOLD) //gibs the mob if their bomb armor is lower than EXPLODE_GIB_THRESHOLD
@@ -431,8 +431,8 @@
 				brute_loss = 30*(2 - round(bomb_armor*0.01, 0.05))
 				burn_loss = brute_loss				//damage gets reduced from 120 to up to 60 combined brute+burn
 			damage_clothes(200 - bomb_armor, BRUTE, "bomb")
-			if (!istype(ears, /obj/item/clothing/ears/earmuffs))
-				adjustEarDamage(30, 120)
+			if (ears && !HAS_TRAIT_FROM(src, TRAIT_DEAF, CLOTHING_TRAIT))
+				ears.adjustEarDamage(30, 120)
 			Unconscious(20)							//short amount of time for follow up attacks against elusive enemies like wizards
 			Knockdown(200 - (bomb_armor * 1.6)) 	//between ~4 and ~20 seconds of knockdown depending on bomb armor
 
@@ -441,8 +441,8 @@
 			if(bomb_armor)
 				brute_loss = 15*(2 - round(bomb_armor*0.01, 0.05))
 			damage_clothes(max(50 - bomb_armor, 0), BRUTE, "bomb")
-			if (!istype(ears, /obj/item/clothing/ears/earmuffs))
-				adjustEarDamage(15,60)
+			if (ears && !HAS_TRAIT_FROM(src, TRAIT_DEAF, CLOTHING_TRAIT))
+				ears.adjustEarDamage(15,60)
 			Knockdown(160 - (bomb_armor * 1.6))		//100 bomb armor will prevent knockdown altogether
 
 	take_overall_damage(brute_loss,burn_loss)
@@ -876,7 +876,7 @@
 		to_chat(src, "<span class='info'>Your [damaged_message] [damaged_plural ? "are" : "is"] hurt.</span>")
 
 	if(roundstart_quirks.len)
-		to_chat(src, "<span class='notice'>You have these quirks: [get_trait_string(FALSE, CAT_QUIRK_ALL)].</span>")
+		to_chat(src, "<span class='notice'>You have these quirks: [get_quirk_string(FALSE, CAT_QUIRK_ALL)].</span>")
 
 /mob/living/carbon/human/damage_clothes(damage_amount, damage_type = BRUTE, damage_flag = 0, def_zone)
 	if(damage_type != BRUTE && damage_type != BURN)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -288,7 +288,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			oldorgan.Remove(C,TRUE)
 			QDEL_NULL(oldorgan)
 
-		if(!oldorgan && should_have && !(initial(neworgan.zone) in excluded_zones))
+		if(oldorgan)
+			oldorgan.setOrganDamage(0)
+		else if(should_have && !(initial(neworgan.zone) in excluded_zones))
 			used_neworgan = TRUE
 			neworgan.Insert(C, TRUE, FALSE)
 

--- a/code/modules/mob/living/carbon/monkey/monkey_defense.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey_defense.dm
@@ -180,6 +180,7 @@
 	..()
 	if(QDELETED(src))
 		return
+	var/obj/item/organ/ears/ears = getorganslot(ORGAN_SLOT_EARS)
 	switch (severity)
 		if (EXPLODE_DEVASTATE)
 			gib()
@@ -188,14 +189,16 @@
 		if (EXPLODE_HEAVY)
 			take_overall_damage(60, 60)
 			damage_clothes(200, BRUTE, "bomb")
-			adjustEarDamage(30, 120)
+			if (ears && !HAS_TRAIT_FROM(src, TRAIT_DEAF, CLOTHING_TRAIT))
+				ears.adjustEarDamage(30, 120)
 			if(prob(70))
 				Unconscious(200)
 
 		if(EXPLODE_LIGHT)
 			take_overall_damage(30, 0)
 			damage_clothes(50, BRUTE, "bomb")
-			adjustEarDamage(15,60)
+			if (ears && !HAS_TRAIT_FROM(src, TRAIT_DEAF, CLOTHING_TRAIT))
+				ears.adjustEarDamage(15,60)
 			if (prob(50))
 				Unconscious(160)
 

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -193,7 +193,9 @@ Maintenance panel panel is [open ? "opened" : "closed"]"},
 	if(spam_flag == 0)
 		if(ishuman(C))
 			C.stuttering = 20
-			C.adjustEarDamage(0, 5) //far less damage than the H.O.N.K.
+			var/obj/item/organ/ears/ears = C.getorganslot(ORGAN_SLOT_EARS)
+			if (ears && !HAS_TRAIT_FROM(C, TRAIT_DEAF, CLOTHING_TRAIT))
+				ears.adjustEarDamage(0, 5) //far less damage than the H.O.N.K.
 			C.Jitter(50)
 			C.Paralyze(60)
 			var/mob/living/carbon/human/H = C

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -664,11 +664,12 @@
 
 /datum/reagent/medicine/inacusiate
 	name = "Inacusiate"
-	description = "Instantly restores all hearing to the patient, but does not work on patients without ears, cure genetic deafness, or cure chronic deafness." //by "chronic" deafness, we mean people with the "deaf" quirk
+	description = "Rapidly repairs damage to the patient's ears to cure deafness, assuming the source of said deafness isn't from genetic mutations, chronic deafness, or a total defecit of ears." //by "chronic" deafness, we mean people with the "deaf" quirk
 	color = "#606060" // ditto
 
 /datum/reagent/medicine/inacusiate/on_mob_life(mob/living/carbon/M)
-	M.restoreEars()
+	var/obj/item/organ/ears/ears = M.getorganslot(ORGAN_SLOT_EARS)
+	ears.adjustEarDamage(-4, -4)
 	..()
 
 /datum/reagent/medicine/atropine

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -28,11 +28,11 @@
 	var/damage_multiplier = 1
 
 /obj/item/organ/ears/on_life()
+	. = ..()
 	// if we have non-damage related deafness like mutations, quirks or clothing (earmuffs), don't bother processing here. Ear healing from earmuffs or chems happen elsewhere
 	if(HAS_TRAIT_NOT_FROM(owner, TRAIT_DEAF, EAR_DAMAGE))
 		return
 
-	..()
 	if((damage < maxHealth) && (organ_flags & ORGAN_FAILING))	//ear damage can be repaired from the failing condition
 		organ_flags &= ~ORGAN_FAILING
 

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -28,66 +28,34 @@
 	var/damage_multiplier = 1
 
 /obj/item/organ/ears/on_life()
-	if(!iscarbon(owner))
+	// if we have non-damage related deafness like mutations, quirks or clothing (earmuffs), don't bother processing here. Ear healing from earmuffs or chems happen elsewhere
+	if(HAS_TRAIT_NOT_FROM(owner, TRAIT_DEAF, EAR_DAMAGE))
 		return
+
 	..()
-	var/mob/living/carbon/C = owner
 	if((damage < maxHealth) && (organ_flags & ORGAN_FAILING))	//ear damage can be repaired from the failing condition
 		organ_flags &= ~ORGAN_FAILING
-	// genetic deafness prevents the body from using the ears, even if healthy
-	if(HAS_TRAIT(C, TRAIT_DEAF))
-		deaf = max(deaf, 1)
-	else if(!(organ_flags & ORGAN_FAILING)) // if this organ is failing, do not clear deaf stacks.
+
+	if((organ_flags & ORGAN_FAILING))
+		deaf = max(deaf, 1) // if we're failing we always have at least 1 deaf stack (and thus deafness)
+	else // only clear deaf stacks if we're not failing
 		deaf = max(deaf - 1, 0)
-		if(prob(damage / 30) && (damage > low_threshold))
+		if((damage > low_threshold) && prob(damage / 30))
 			adjustEarDamage(0, 4)
-			SEND_SOUND(C, sound('sound/weapons/flash_ring.ogg'))
-			to_chat(C, "<span class='warning'>The ringing in your ears grows louder, blocking out any external noises for a moment.</span>")
-	else if((organ_flags & ORGAN_FAILING) && (deaf == 0))
-		deaf = 1	//stop being not deaf you deaf idiot
+			SEND_SOUND(owner, sound('sound/weapons/flash_ring.ogg'))
+			to_chat(owner, "<span class='warning'>The ringing in your ears grows louder, blocking out any external noises for a moment.</span>")
 
-/obj/item/organ/ears/proc/restoreEars()
-	deaf = 0
-	damage = 0
-	organ_flags &= ~ORGAN_FAILING
-
-	var/mob/living/carbon/C = owner
-
-	if(iscarbon(owner) && HAS_TRAIT(C, TRAIT_DEAF))
-		deaf = 1
+	if(deaf)
+		ADD_TRAIT(owner, TRAIT_DEAF, EAR_DAMAGE)
+	else
+		REMOVE_TRAIT(owner, TRAIT_DEAF, EAR_DAMAGE)
 
 /obj/item/organ/ears/proc/adjustEarDamage(ddmg, ddeaf)
 	damage = max(damage + (ddmg*damage_multiplier), 0)
 	deaf = max(deaf + (ddeaf*damage_multiplier), 0)
 
-/obj/item/organ/ears/proc/minimumDeafTicks(value)
-	deaf = max(deaf, value)
-
 /obj/item/organ/ears/invincible
 	damage_multiplier = 0
-
-
-/mob/proc/restoreEars()
-
-/mob/living/carbon/restoreEars()
-	var/obj/item/organ/ears/ears = getorgan(/obj/item/organ/ears)
-	if(ears)
-		ears.restoreEars()
-
-/mob/proc/adjustEarDamage()
-
-/mob/living/carbon/adjustEarDamage(ddmg, ddeaf)
-	var/obj/item/organ/ears/ears = getorgan(/obj/item/organ/ears)
-	if(ears)
-		ears.adjustEarDamage(ddmg, ddeaf)
-
-/mob/proc/minimumDeafTicks()
-
-/mob/living/carbon/minimumDeafTicks(value)
-	var/obj/item/organ/ears/ears = getorgan(/obj/item/organ/ears)
-	if(ears)
-		ears.minimumDeafTicks(value)
-
 
 /obj/item/organ/ears/cat
 	name = "cat ears"

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -184,25 +184,35 @@
 		return
 
 	else
-		if(!getorganslot(ORGAN_SLOT_LUNGS))
-			var/obj/item/organ/lungs/L = new()
+		var/obj/item/organ/lungs/L = getorganslot(ORGAN_SLOT_LUNGS)
+		if(!L)
+			L = new()
 			L.Insert(src)
+		L.setOrganDamage(0)
 
-		if(!getorganslot(ORGAN_SLOT_HEART))
-			var/obj/item/organ/heart/H = new()
+		var/obj/item/organ/heart/H = getorganslot(ORGAN_SLOT_HEART)
+		if(!H)
+			H = new()
 			H.Insert(src)
+		H.setOrganDamage(0)
 
-		if(!getorganslot(ORGAN_SLOT_TONGUE))
-			var/obj/item/organ/tongue/T = new()
+		var/obj/item/organ/tongue/T = getorganslot(ORGAN_SLOT_TONGUE)
+		if(!T)
+			T = new()
 			T.Insert(src)
+		T.setOrganDamage(0)
 
-		if(!getorganslot(ORGAN_SLOT_EYES))
-			var/obj/item/organ/eyes/E = new()
-			E.Insert(src)
+		var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
+		if(!eyes)
+			eyes = new()
+			eyes.Insert(src)
+		eyes.setOrganDamage(0)
 
-		if(!getorganslot(ORGAN_SLOT_EARS))
-			var/obj/item/organ/ears/ears = new()
+		var/obj/item/organ/ears/ears = getorganslot(ORGAN_SLOT_EARS)
+		if(!ears)
+			ears = new()
 			ears.Insert(src)
+		ears.setOrganDamage(0)
 
 
 /** get_availability


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ears currently behave strangely compared to other organs, especially their most closely related sensory organ, eyes. They only assign a deafness trait for quirks, mutations, and clothing (which prevents empaths from noticing hearing damage deafness), have lots of unnecessary procs for dealing/assessing damage, and several audible events check istype() for earmuffs specifically for whether a mob can hear something.

This cuts down on all of that. I removed most ear related procs from mobs, tied deafness explicitly to TRAIT_DEAF (and added a new source for hearing damage), and generally neatened up related code. As a direct result, empaths can now detect deafness from hearing damage, as I assume was intended. I also fixed a bug with examining with med HUD's or as an observer not showing a person's quirks, though I'm not sure people will really care about the info with med HUDs. Also, full revives/regenerating organs now remove all damage from existing organs rather than only trying to replace missing ones

In addition, Inacusiate and Sensory Restoration no longer instantly cure all hearing damage when applied, they now rapidly decrease both ear damage and deafness each tick. This isn't really a fix, but I figured I'd throw it in since I think cobby wanted to move away from instant fix microdose chems, and I punted the restoreEars() procs anyway

Fixes: #51435 
Fixes: #48974
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Brings ears in line with how other organs operate, makes them easier to understand, and restores (what I assume to be) intended functionality for the empath quirk and medhud/observer examines
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Empaths are able to detect deafness derived from hearing damage
tweak: Inacusiate and Sensory Restoration no longer instantly heal all hearing damage when applied, instead rapidly removing both ear damage and deafness.
fix: MedHUDs and observers now display quirks as intended on examine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
