### PR TITLE
Prevents examines from spamming the world log.

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1156,8 +1156,7 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 	I = icon(I, icon_state, dir, frame, moving)
 
 	key = "[generate_asset_name(I)].png"
-	if(!SSassets.cache[key])
-		register_asset(key, I, FALSE)
+	register_asset(key, I, FALSE)
 	for (var/thing2 in targets)
 		send_asset(thing2, key)
 

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1156,7 +1156,8 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 	I = icon(I, icon_state, dir, frame, moving)
 
 	key = "[generate_asset_name(I)].png"
-	register_asset(key, I)
+	if(!SSassets.cache[key])
+		register_asset(key, I)
 	for (var/thing2 in targets)
 		send_asset(thing2, key)
 

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1132,7 +1132,7 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 	if (!isicon(I))
 		if (isfile(thing)) //special snowflake
 			var/name = sanitize_filename("[generate_asset_name(thing)].png")
-			register_asset(name, thing)
+			register_asset(name, thing, FALSE)
 			for (var/thing2 in targets)
 				send_asset(thing2, key)
 			return "<img class='icon icon-misc' src=\"[url_encode(name)]\">"
@@ -1157,7 +1157,7 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 
 	key = "[generate_asset_name(I)].png"
 	if(!SSassets.cache[key])
-		register_asset(key, I)
+		register_asset(key, I, FALSE)
 	for (var/thing2 in targets)
 		send_asset(thing2, key)
 

--- a/code/modules/asset_cache/asset_cache.dm
+++ b/code/modules/asset_cache/asset_cache.dm
@@ -82,7 +82,7 @@ Note: If your code uses output() with assets you will need to call asset_flush o
 
 //This proc "registers" an asset, it adds it to the cache for further use, you cannot touch it from this point on or you'll fuck things up.
 //icons and virtual assets get copied to the dyn rsc before use
-/proc/register_asset(asset_name, asset)
+/proc/register_asset(asset_name, asset, log_dupes = TRUE)
 	var/datum/asset_cache_item/ACI = new(asset_name, asset)
 	
 	//this is technically never something that was supported and i want metrics on how often it happens if at all.
@@ -90,7 +90,7 @@ Note: If your code uses output() with assets you will need to call asset_flush o
 		var/datum/asset_cache_item/OACI = SSassets.cache[asset_name]
 		if (OACI.md5 != ACI.md5)
 			stack_trace("ERROR: new asset added to the asset cache with the same name as another asset: [asset_name] existing asset md5: [OACI.md5] new asset md5:[ACI.md5]")
-		else
+		else if(log_dupes)
 			var/list/stacktrace = gib_stack_trace()
 			log_asset("WARNING: dupe asset added to the asset cache: [asset_name] existing asset md5: [OACI.md5] new asset md5:[ACI.md5]\n[stacktrace.Join("\n")]")
 	SSassets.cache[asset_name] = ACI


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

register_asset now has an argument (TRUE by default) that tells it to log duplicate assets.
icon2html no longer logs dupes.

## Why It's Good For The Game

stack_trace's are still showing up in world.log after https://github.com/tgstation/tgstation/pull/50991.
If there is a way to get a stack trace without that, please tell me.

This still logs dupes of assets for relevant assets (for example /datum/asset) while not spamming pretty irrelevant information.