### PR TITLE
More flexible system for innate/roundstart skills.

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -11,8 +11,17 @@
 #define SKILL_LVL 1
 #define SKILL_EXP 2
 
+// Level experience requirements
+#define SKILL_EXP_NONE 0
+#define SKILL_EXP_NOVICE 100
+#define SKILL_EXP_APPRENTICE 250
+#define SKILL_EXP_JOURNEYMAN 500
+#define SKILL_EXP_EXPERT 900
+#define SKILL_EXP_MASTER 1500
+#define SKILL_EXP_LEGENDARY 2500
+
 //Allows us to get EXP from level, or level from EXP
-#define SKILL_EXP_LIST list(0, 100, 250, 500, 900, 1500, 2500)
+#define SKILL_EXP_LIST list(SKILL_EXP_NONE, SKILL_EXP_NOVICE, SKILL_EXP_APPRENTICE, SKILL_EXP_JOURNEYMAN, SKILL_EXP_EXPERT, SKILL_EXP_MASTER, SKILL_EXP_LEGENDARY)
 
 //Skill modifier types
 #define SKILL_SPEED_MODIFIER "skill_speed_modifier"//ideally added/subtracted in speed calculations to make you do stuff faster

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -7,9 +7,9 @@
 	var/list/access = list()				//Useful for servers which either have fewer players, so each person needs to fill more than one role, or servers which like to give more access, so players can't hide forever in their super secure departments (I'm looking at you, chemistry!)
 
 	/// Innate skill levels unlocked at roundstart. Based on config.jobs_have_minimal_access config setting, for example with a skeleton crew. Format is list(/datum/skill/foo = SKILL_EXP_NOVICE) with exp as an integer or as per code/_DEFINES/skills.dm
-	var/list/skills = list()
+	var/list/skills
 	/// Innate skill levels unlocked at roundstart. Based on config.jobs_have_minimal_access config setting, for example with a full crew. Format is list(/datum/skill/foo = SKILL_EXP_NOVICE) with exp as an integer or as per code/_DEFINES/skills.dm
-	var/list/minimal_skills = list()
+	var/list/minimal_skills
 
 	//Determines who can demote this position
 	var/department_head = list()

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -6,6 +6,12 @@
 	var/list/minimal_access = list()		//Useful for servers which prefer to only have access given to the places a job absolutely needs (Larger server population)
 	var/list/access = list()				//Useful for servers which either have fewer players, so each person needs to fill more than one role, or servers which like to give more access, so players can't hide forever in their super secure departments (I'm looking at you, chemistry!)
 
+	/// Innate skill levels unlocked at roundstart. Based on config.jobs_have_minimal_access config setting with a full crew.
+	var/list/skills = list()
+	/// Innate skill levels unlocked at roundstart. Based on config.jobs_have_minimal_access config setting with a skeleton crew.
+	var/list/minimal_skills = list()
+
+
 	//Determines who can demote this position
 	var/department_head = list()
 
@@ -60,10 +66,6 @@
 
 	var/display_order = JOB_DISPLAY_ORDER_DEFAULT
 
-
-	///Levels unlocked at roundstart in physiology
-	var/list/roundstart_experience
-
 //Only override this proc
 //H is usually a human unless an /equip override transformed it
 /datum/job/proc/after_spawn(mob/living/H, mob/M, latejoin = FALSE)
@@ -71,11 +73,21 @@
 	if(mind_traits)
 		for(var/t in mind_traits)
 			ADD_TRAIT(H.mind, t, JOB_TRAIT)
+
+	var/list/roundstart_experience
+
+	if(!config)	//Needed for robots.
+		roundstart_experience = minimal_skills
+
+	if(CONFIG_GET(flag/jobs_have_minimal_access))
+		roundstart_experience = minimal_skills
+	else
+		roundstart_experience = skill
+
 	if(roundstart_experience && ishuman(H))
 		var/mob/living/carbon/human/experiencer = H
 		for(var/i in roundstart_experience)
 			experiencer.mind.adjust_experience(i, roundstart_experience[i], TRUE)
-
 
 /datum/job/proc/announce(mob/living/carbon/human/H)
 	if(head_announce)
@@ -257,4 +269,3 @@
 	if(CONFIG_GET(flag/security_has_maint_access))
 		return list(ACCESS_MAINT_TUNNELS)
 	return list()
-

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -6,11 +6,10 @@
 	var/list/minimal_access = list()		//Useful for servers which prefer to only have access given to the places a job absolutely needs (Larger server population)
 	var/list/access = list()				//Useful for servers which either have fewer players, so each person needs to fill more than one role, or servers which like to give more access, so players can't hide forever in their super secure departments (I'm looking at you, chemistry!)
 
-	/// Innate skill levels unlocked at roundstart. Based on config.jobs_have_minimal_access config setting, for example with a skeleton crew.
+	/// Innate skill levels unlocked at roundstart. Based on config.jobs_have_minimal_access config setting, for example with a skeleton crew. Format is list(/datum/skill/foo = SKILL_EXP_NOVICE) with exp as an integer or as per code/_DEFINES/skills.dm
 	var/list/skills = list()
-	/// Innate skill levels unlocked at roundstart. Based on config.jobs_have_minimal_access config setting, for example with a full crew.
+	/// Innate skill levels unlocked at roundstart. Based on config.jobs_have_minimal_access config setting, for example with a full crew. Format is list(/datum/skill/foo = SKILL_EXP_NOVICE) with exp as an integer or as per code/_DEFINES/skills.dm
 	var/list/minimal_skills = list()
-
 
 	//Determines who can demote this position
 	var/department_head = list()

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -6,9 +6,9 @@
 	var/list/minimal_access = list()		//Useful for servers which prefer to only have access given to the places a job absolutely needs (Larger server population)
 	var/list/access = list()				//Useful for servers which either have fewer players, so each person needs to fill more than one role, or servers which like to give more access, so players can't hide forever in their super secure departments (I'm looking at you, chemistry!)
 
-	/// Innate skill levels unlocked at roundstart. Based on config.jobs_have_minimal_access config setting with a full crew.
+	/// Innate skill levels unlocked at roundstart. Based on config.jobs_have_minimal_access config setting, for example with a skeleton crew.
 	var/list/skills = list()
-	/// Innate skill levels unlocked at roundstart. Based on config.jobs_have_minimal_access config setting with a skeleton crew.
+	/// Innate skill levels unlocked at roundstart. Based on config.jobs_have_minimal_access config setting, for example with a full crew.
 	var/list/minimal_skills = list()
 
 
@@ -82,7 +82,7 @@
 	if(CONFIG_GET(flag/jobs_have_minimal_access))
 		roundstart_experience = minimal_skills
 	else
-		roundstart_experience = skill
+		roundstart_experience = skills
 
 	if(roundstart_experience && ishuman(H))
 		var/mob/living/carbon/human/experiencer = H

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -75,6 +75,9 @@
 
 	var/list/roundstart_experience
 
+	if(!ishuman(H))
+		return
+
 	if(!config)	//Needed for robots.
 		roundstart_experience = minimal_skills
 
@@ -83,7 +86,7 @@
 	else
 		roundstart_experience = skills
 
-	if(roundstart_experience && ishuman(H))
+	if(roundstart_experience)
 		var/mob/living/carbon/human/experiencer = H
 		for(var/i in roundstart_experience)
 			experiencer.mind.adjust_experience(i, roundstart_experience[i], TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just a minor tweak to allow skills to follow the same general game logic that access levels do.

Removes the old style of roundstart_experience, replacing it with a list of skills and minimal_skills.

Acts identically in function to access and access_minimal, allowing coders to set unique roundstart skills per job based on whether it's a normal or skeleton crew shift. Vars can still be further modified in job_changes.dm to set unique per-map starting skill levels if necessary.

## Why It's Good For The Game

Allows for more flexibility in proposed future skill changes.

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
