### PR TITLE
restores racial equality to the revolution

### DIFF
--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -294,16 +294,10 @@
 		if(head_revolutionaries.len < max_headrevs && head_revolutionaries.len < round(heads.len - ((8 - sec.len) / 3)))
 			var/list/datum/mind/non_heads = members - head_revolutionaries
 			var/list/datum/mind/promotable = list()
-			var/list/datum/mind/nonhuman_promotable = list()
 			for(var/datum/mind/khrushchev in non_heads)
 				if(khrushchev.current && !khrushchev.current.incapacitated() && !khrushchev.current.restrained() && khrushchev.current.client && khrushchev.current.stat != DEAD)
 					if(ROLE_REV in khrushchev.current.client.prefs.be_special)
-						if(ishuman(khrushchev.current))
-							promotable += khrushchev
-						else
-							nonhuman_promotable += khrushchev
-			if(!promotable.len && nonhuman_promotable.len) //if only nonhuman revolutionaries remain, promote one of them to the leadership.
-				promotable = nonhuman_promotable
+						promotable += khrushchev
 			if(promotable.len)
 				var/datum/mind/new_leader = pick(promotable)
 				var/datum/antagonist/rev/rev = new_leader.has_antag_datum(/datum/antagonist/rev)


### PR DESCRIPTION
## About The Pull Request

sometimes, during a revolution, converted revolutionaries will be "promoted" to headrevs if the number of heads of staff / security officers increases significantly enough that another head revolutionary is warranted for balance concerns. for some dumbass reason, nonhuman revolutionaries are only promoted if there aren't any eligible human revolutionaries. this is stupid; this PR removes the check.

## Why It's Good For The Game

"This is why those humans who want to escape their own slavery must first of all rally to the lizard revolt — not, obviously, in species solidarity, but in a joint galactic rejection of the commodity and of the state."

-Guy Debord, _The Decline and Fall of the Spectacle-Commodity Economy_, 2505

## Changelog
:cl:
tweak: Nonhuman revolutionaries are now just as likely as human revolutionaries to be promoted to headrevs.
/:cl: