### PR TITLE
Swarmer Balance Changes

### DIFF
--- a/code/_onclick/hud/swarmer.dm
+++ b/code/_onclick/hud/swarmer.dm
@@ -5,7 +5,7 @@
 
 /obj/screen/swarmer/FabricateTrap
 	icon_state = "ui_trap"
-	name = "Create trap (Costs 5 Resources)"
+	name = "Create trap (Costs 4 Resources)"
 	desc = "Creates a trap that will nonlethally shock any non-swarmer that attempts to cross it. (Costs 5 resources)"
 
 /obj/screen/swarmer/FabricateTrap/Click()
@@ -15,7 +15,7 @@
 
 /obj/screen/swarmer/Barricade
 	icon_state = "ui_barricade"
-	name = "Create barricade (Costs 5 Resources)"
+	name = "Create barricade (Costs 4 Resources)"
 	desc = "Creates a destructible barricade that will stop any non swarmer from passing it. Also allows disabler beams to pass through. (Costs 5 resources)"
 
 /obj/screen/swarmer/Barricade/Click()
@@ -25,7 +25,7 @@
 
 /obj/screen/swarmer/Replicate
 	icon_state = "ui_replicate"
-	name = "Replicate (Costs 50 Resources)"
+	name = "Replicate (Costs 40 Resources)"
 	desc = "Creates another of our kind."
 
 /obj/screen/swarmer/Replicate/Click()

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -62,8 +62,8 @@
 	initial_language_holder = /datum/language_holder/swarmer
 	bubble_icon = "swarmer"
 	mob_biotypes = MOB_ROBOTIC
-	health = 40
-	maxHealth = 40
+	health = 50
+	maxHealth = 50
 	status_flags = CANPUSH
 	icon_state = "swarmer"
 	icon_living = "swarmer"
@@ -75,8 +75,8 @@
 	maxbodytemp = 500
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 0
-	melee_damage_lower = 15
-	melee_damage_upper = 15
+	melee_damage_lower = 20
+	melee_damage_upper = 40
 	melee_damage_type = STAMINA
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	hud_possible = list(ANTAG_HUD, DIAG_STAT_HUD, DIAG_HUD)
@@ -92,7 +92,6 @@
 	AIStatus = AI_OFF
 	pass_flags = PASSTABLE
 	mob_size = MOB_SIZE_TINY
-	ventcrawler = VENTCRAWLER_ALWAYS
 	ranged = 1
 	projectiletype = /obj/projectile/beam/disabler
 	ranged_cooldown_time = 20
@@ -171,7 +170,7 @@
 	return FALSE //would logically be TRUE, but we don't want AI swarmers eating player spawn chances.
 
 /obj/effect/mob_spawn/swarmer/IntegrateAmount()
-	return 50
+	return 40
 
 /turf/closed/indestructible/swarmer_act()
 	return FALSE
@@ -385,7 +384,7 @@
 			return FALSE
 
 /obj/item/deactivated_swarmer/IntegrateAmount()
-	return 50
+	return 40
 
 /obj/machinery/hydroponics/soil/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, "<span class='warning'>This object does not contain enough materials to work with.</span>")
@@ -584,25 +583,25 @@
 /mob/living/simple_animal/hostile/swarmer/proc/CreateTrap()
 	set name = "Create trap"
 	set category = "Swarmer"
-	set desc = "Creates a simple trap that will non-lethally electrocute anything that steps on it. Costs 5 resources."
+	set desc = "Creates a simple trap that will non-lethally electrocute anything that steps on it. Costs 4 resources."
 	if(locate(/obj/structure/swarmer/trap) in loc)
 		to_chat(src, "<span class='warning'>There is already a trap here. Aborting.</span>")
 		return
-	Fabricate(/obj/structure/swarmer/trap, 5)
+	Fabricate(/obj/structure/swarmer/trap, 4)
 
 
 /mob/living/simple_animal/hostile/swarmer/proc/CreateBarricade()
 	set name = "Create barricade"
 	set category = "Swarmer"
-	set desc = "Creates a barricade that will stop anything but swarmers and disabler beams from passing through."
+	set desc = "Creates a barricade that will stop anything but swarmers and disabler beams from passing through.  Costs 4 resources."
 	if(locate(/obj/structure/swarmer/blockade) in loc)
 		to_chat(src, "<span class='warning'>There is already a blockade here. Aborting.</span>")
 		return
-	if(resources < 5)
+	if(resources < 4)
 		to_chat(src, "<span class='warning'>We do not have the resources for this!</span>")
 		return
 	if(do_mob(src, src, 10))
-		Fabricate(/obj/structure/swarmer/blockade, 5)
+		Fabricate(/obj/structure/swarmer/blockade, 4)
 
 
 /obj/structure/swarmer/blockade
@@ -624,7 +623,7 @@
 	set category = "Swarmer"
 	set desc = "Creates a shell for a new swarmer. Swarmers will self activate."
 	to_chat(src, "<span class='info'>We are attempting to replicate ourselves. We will need to stand still until the process is complete.</span>")
-	if(resources < 50)
+	if(resources < 40)
 		to_chat(src, "<span class='warning'>We do not have the resources for this!</span>")
 		return
 	if(!isturf(loc))
@@ -632,7 +631,7 @@
 		return
 	if(do_mob(src, src, 100))
 		var/createtype = SwarmerTypeToCreate()
-		if(createtype && Fabricate(createtype, 50))
+		if(createtype && Fabricate(createtype, 40))
 			playsound(loc,'sound/items/poster_being_created.ogg',50, TRUE, -1)
 
 
@@ -648,7 +647,7 @@
 		return
 	to_chat(src, "<span class='info'>Attempting to repair damage to our body, stand by...</span>")
 	if(do_mob(src, src, 100))
-		adjustHealth(-100)
+		adjustHealth(-maxHealth)
 		to_chat(src, "<span class='info'>We successfully repaired ourselves.</span>")
 
 /mob/living/simple_animal/hostile/swarmer/proc/ToggleLight()

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -62,8 +62,8 @@
 	initial_language_holder = /datum/language_holder/swarmer
 	bubble_icon = "swarmer"
 	mob_biotypes = MOB_ROBOTIC
-	health = 50
-	maxHealth = 50
+	health = 120
+	maxHealth = 120
 	status_flags = CANPUSH
 	icon_state = "swarmer"
 	icon_living = "swarmer"

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -94,7 +94,7 @@
 	mob_size = MOB_SIZE_TINY
 	ranged = 1
 	projectiletype = /obj/projectile/beam/disabler
-	ranged_cooldown_time = 20
+	ranged_cooldown_time = 10
 	projectilesound = 'sound/weapons/taser2.ogg'
 	loot = list(/obj/effect/decal/cleanable/robot_debris, /obj/item/stack/ore/bluespace_crystal)
 	del_on_death = 1
@@ -110,6 +110,7 @@
 	verbs -= /mob/living/verb/pulled
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)
 		diag_hud.add_to_hud(src)
+	AddComponent(/datum/component/gps, "Obscure Signal")
 
 /mob/living/simple_animal/hostile/swarmer/med_hud_set_health()
 	var/image/holder = hud_list[DIAG_HUD]

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -62,8 +62,8 @@
 	initial_language_holder = /datum/language_holder/swarmer
 	bubble_icon = "swarmer"
 	mob_biotypes = MOB_ROBOTIC
-	health = 120
-	maxHealth = 120
+	health = 40
+	maxHealth = 40
 	status_flags = CANPUSH
 	icon_state = "swarmer"
 	icon_living = "swarmer"
@@ -92,6 +92,7 @@
 	AIStatus = AI_OFF
 	pass_flags = PASSTABLE
 	mob_size = MOB_SIZE_TINY
+	ventcrawler = VENTCRAWLER_ALWAYS
 	ranged = 1
 	projectiletype = /obj/projectile/beam/disabler
 	ranged_cooldown_time = 10

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -407,6 +407,10 @@
 /obj/machinery/shieldwall/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, "<span class='warning'>This object does not contain solid matter. Aborting.</span>")
 	return FALSE
+	
+/obj/machinery/ore_silo/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, "<span class='warning'>Attempting to dismantle this machine would result in an immediate counterattack. Aborting.</span>")
+	return FALSE
 
 ////END CTRL CLICK FOR SWARMERS////
 

--- a/code/modules/antagonists/swarmer/swarmer_event.dm
+++ b/code/modules/antagonists/swarmer/swarmer_event.dm
@@ -7,10 +7,10 @@
 	min_players = 15
 
 /datum/round_event/spawn_swarmer/announce(fake)
-	priority_announce("<br><br>Our long-range sensors have detected an odd signal emanating from your station's gateway. We recommend immediate investigation of your gateway, as something may have come through.", "<span class='big bold'>[command_name()] High-Priority Update</span>")
+	priority_announce("Our long-range sensors have detected an odd signal emanating from your station's gateway. We recommend immediate investigation of your gateway, as something may have come through.", "<span class='big bold'>[command_name()] High-Priority Update</span>")
 
 /datum/round_event/spawn_swarmer
-	announceWhen = 15
+	announceWhen = 50
 
 /datum/round_event/spawn_swarmer/start()
 	if(!GLOB.the_gateway)

--- a/code/modules/antagonists/swarmer/swarmer_event.dm
+++ b/code/modules/antagonists/swarmer/swarmer_event.dm
@@ -1,28 +1,18 @@
 /datum/round_event_control/spawn_swarmer
 	name = "Spawn Swarmer Shell"
 	typepath = /datum/round_event/spawn_swarmer
-	weight = 7
+	weight = 8
 	max_occurrences = 1 //Only once okay fam
 	earliest_start = 30 MINUTES
 	min_players = 15
 
+/datum/round_event/spawn_swarmer/announce(fake)
+	priority_announce("<br><br>Our long-range sensors have detected an odd signal emanating from your station's gateway. We recommend immediate investigation of your gateway, as something may have come through.", "<span class='big bold'>[command_name()] High-Priority Update</span>")
 
 /datum/round_event/spawn_swarmer
+	announceWhen = 15
 
 /datum/round_event/spawn_swarmer/start()
-	if(find_swarmer())
-		return 0
 	if(!GLOB.the_gateway)
 		return 0
 	new /obj/effect/mob_spawn/swarmer(get_turf(GLOB.the_gateway))
-	if(prob(25)) //25% chance to announce it to the crew
-		var/swarmer_report = "<span class='big bold'>[command_name()] High-Priority Update</span>"
-		swarmer_report += "<br><br>Our long-range sensors have detected an odd signal emanating from your station's gateway. We recommend immediate investigation of your gateway, as something may have come through."
-		print_command_report(swarmer_report, announce=TRUE)
-
-/datum/round_event/spawn_swarmer/proc/find_swarmer()
-	for(var/i in GLOB.mob_living_list)
-		var/mob/living/L = i
-		if(istype(L, /mob/living/simple_animal/hostile/swarmer) && L.client) //If there is a swarmer with an active client, we've found our swarmer
-			return 1
-	return 0


### PR DESCRIPTION
## About The Pull Request

This PR updates Swarmers, giving them some much-needed balance tweaks and updates to fit the current state of the game.

**WHAT WAS WRONG WITH SWARMERS**

- No counterplay.  Swarmers currently do not announce their arrival at all (though there appears to be busted code here to make it only announce 25% of the time?  I've never heard it go off.), usually only seen by the AI once they're done eating the sat.  Once found out, they could easily use the vents to be anywhere and everywhere, making stopping them a nigh impossible task and almost always forcing a shuttle call.

- Outdated balancing.  Swarmers were never updated with the changes made to stamina damage and disablers sans a recent PR to their structures, making their disabler shots and melee attacks basically worthless.

**THE CHANGES**

NERFS:
- Swarmers now have an announcement shortly after spawning which will always go off.  The time has been set to give the spawned swarmer enough time to leave the gateway area before being outed.
- Swarmers now have GPS signals (Obscure Signal), preventing them from hiding in shoddy locations in maint and making entire armies while everyone is oblivious.
- Swarmers can no longer break the Ore Silo

BUFFS:
+ Swarmers have had their damage numbers tweaked.  They can fire twice as fast, and their stamina damage melee has been buffed from 15 flat stamina damage to 20-40 stamina damage.
+ Swarmer building costs have been cut down across the board.  Traps and barriers now cost 4 resources each down from 5 each, and replicating costs 40 resources down from 50.

OTHER:
- The swarmer event has been buffed from 7 weight to 8 weight.

Note, I'd also like to register them up for Dynamic's midround antagonist spawns, but as a PR is currently being pushed to solve issues with that system, those changes will not be included in this PR.

## Why It's Good For The Game

Understandably, swarmers are commonly referred to as an example of a roundender.  While round-ending events are fine and dandy, a fully-serviceable crew operating under good circumstances should be able to stave off such a threat, and only forced to leave should this not be true.  Swarmers in their current state, unless the swarmers are very stupid, cannot be stopped and will force a shuttle call guaranteed, regardless of the current state the station is in.  This PR attempts to make the swarmer threat have counterplay from the crew's side, while buffing swarmer capabilities to be able to be more confrontational with the crew.  Hopefully, this should make swarmer gameplay on both sides more interesting.

## Changelog
:cl:
balance: Swarmer threats are now announced to the crew, and swarmers themselves have received a number of software updates from an unknown source
/:cl: