### PR TITLE
Adds a retractor to roundstart MD medkits

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -110,6 +110,7 @@
 		/obj/item/hemostat = 1,
 		/obj/item/retractor = 1,
 		/obj/item/cautery = 1,
+		/obj/item/reagent_containers/hypospray/medipen = 1,
 		/obj/item/healthanalyzer = 1)
 	generate_items_inside(items_inside,src)
 

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -105,10 +105,10 @@
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/stack/medical/suture = 2,
 		/obj/item/stack/medical/mesh = 2,
-		/obj/item/reagent_containers/hypospray/medipen = 1,
 		/obj/item/surgical_drapes = 1,
 		/obj/item/scalpel = 1,
 		/obj/item/hemostat = 1,
+		/obj/item/retractor = 1,
 		/obj/item/cautery = 1,
 		/obj/item/healthanalyzer = 1)
 	generate_items_inside(items_inside,src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Exactly what it says on the tin.

## Why It's Good For The Game
In it's current state, the Medical Doctor starts with a kit containing the bare minimum tools for surgery, being only able to tend wounds.

Adding a retractor will serve as a good quality of life improvement for doctors, allowing them to quickly respond to any lost limbs or gouged eyes without having to run to the techfab.

## Changelog
:cl:
tweak: Doctors' medkits now contain a retractor. Remember, you can gain experience by dissecting!
/:cl: Doctor Moffy

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
