### PR TITLE
Fixes dynamic giving antagonist roles to protected jobs (for real this time)

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -312,11 +312,10 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			if ("Midround")
 				if (ruleset.weight)
 					midround_rules += ruleset
-		if(configuration)
-			if(!configuration[ruleset.ruletype])
-				continue
-			if(!configuration[ruleset.ruletype][ruleset.name])
-				continue
+		// Wouldn't it be funny if you wanted to make a multiline if to make it more readable you needed to escape the newlines?
+		if( configuration \
+		 && configuration[ruleset.ruletype] \
+		 && configuration[ruleset.ruletype][ruleset.name])
 			var/rule_conf = configuration[ruleset.ruletype][ruleset.name]
 			for(var/variable in rule_conf)
 				if(isnull(ruleset.vars[variable]))


### PR DESCRIPTION
## About The Pull Request
I ended up reversing the situation with dynamic configs. 
The rules needed to have a config after the last PR to work because of a few continues.
Also I don't really like how I fixed that in this but I couldn't think of anything else that didn't make it unnecessarily complicated

## Why It's Good For The Game
Fixes dynamic (again) and stops roles that shouldn't have antagonist roles from getting them.

## Changelog
:cl:
fix: Fixed dynamic giving antagonist roles to jobs that shouldn't get them (again).
/:cl:
