### PR TITLE
Defibrilator and Defibrilator HUD bug fixes

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -344,6 +344,7 @@
 #define WABBAJACK     (1<<6)
 
 // Reasons a defibrilation might fail
+#define DEFIB_POSSIBLE (1<<0)
 #define DEFIB_FAIL_SUICIDE (1<<1)
 #define DEFIB_FAIL_HELLBOUND (1<<2)
 #define DEFIB_FAIL_HUSK (1<<3)
@@ -355,8 +356,7 @@
 #define DEFIB_FAIL_NO_INTELLIGENCE (1<<9)
 
 // Bit mask of possible return values by can_defib that would result in a revivable patient
-// `| 1` is added to account for can_defib() returning TRUE, meaning there's no issues
-#define DEFIB_REVIVABLE_STATES (DEFIB_FAIL_NO_HEART | DEFIB_FAIL_FAILING_HEART | DEFIB_FAIL_HUSK | DEFIB_FAIL_TISSUE_DAMAGE | DEFIB_FAIL_FAILING_BRAIN | 1)
+#define DEFIB_REVIVABLE_STATES (DEFIB_FAIL_NO_HEART | DEFIB_FAIL_FAILING_HEART | DEFIB_FAIL_HUSK | DEFIB_FAIL_TISSUE_DAMAGE | DEFIB_FAIL_FAILING_BRAIN | DEFIB_POSSIBLE)
 
 #define SLEEP_CHECK_DEATH(X) sleep(X); if(QDELETED(src) || stat == DEAD) return;
 #define INTERACTING_WITH(X, Y) (Y in X.do_afters)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -343,5 +343,20 @@
 //Wabbacjack staff projectiles
 #define WABBAJACK     (1<<6)
 
+// Reasons a defibrilation might fail
+#define DEFIB_FAIL_SUICIDE (1<<1)
+#define DEFIB_FAIL_HELLBOUND (1<<2)
+#define DEFIB_FAIL_HUSK (1<<3)
+#define DEFIB_FAIL_TISSUE_DAMAGE (1<<4)
+#define DEFIB_FAIL_FAILING_HEART (1<<5)
+#define DEFIB_FAIL_NO_HEART (1<<6)
+#define DEFIB_FAIL_FAILING_BRAIN (1<<7)
+#define DEFIB_FAIL_NO_BRAIN (1<<8)
+#define DEFIB_FAIL_NO_INTELLIGENCE (1<<9)
+
+// Bit mask of possible return values by can_defib that would result in a revivable patient
+// `| 1` is added to account for can_defib() returning TRUE, meaning there's no issues
+#define DEFIB_REVIVABLE_STATES (DEFIB_FAIL_NO_HEART | DEFIB_FAIL_FAILING_HEART | DEFIB_FAIL_HUSK | DEFIB_FAIL_TISSUE_DAMAGE | DEFIB_FAIL_FAILING_BRAIN | 1)
+
 #define SLEEP_CHECK_DEATH(X) sleep(X); if(QDELETED(src) || stat == DEAD) return;
 #define INTERACTING_WITH(X, Y) (Y in X.do_afters)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -189,7 +189,7 @@
 	if(HAS_TRAIT(src, TRAIT_XENO_HOST))
 		holder.icon_state = "hudxeno"
 	else if(stat == DEAD || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))
-		if(key || get_ghost(FALSE, TRUE))
+		if((key || get_ghost(FALSE, TRUE)) && (can_defib() & DEFIB_REVIVABLE_STATES))
 			holder.icon_state = "huddefib"
 		else
 			holder.icon_state = "huddead"

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -444,7 +444,7 @@
 		do_harm(H, user)
 		return
 
-	if(H.can_defib() == TRUE)
+	if(H.can_defib() == DEFIB_POSSIBLE)
 		H.notify_ghost_cloning("Your heart is being defibrillated!")
 		H.grab_ghost() // Shove them back in their body.
 

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -444,7 +444,7 @@
 		do_harm(H, user)
 		return
 
-	if(H.can_defib())
+	if(H.can_defib() != TRUE)
 		H.notify_ghost_cloning("Your heart is being defibrillated!")
 		H.grab_ghost() // Shove them back in their body.
 
@@ -545,8 +545,6 @@
 	if(do_after(user, 30, target = H)) //beginning to place the paddles on patient's chest to allow some time for people to move away to stop the process
 		user.visible_message("<span class='notice'>[user] places [src] on [H]'s chest.</span>", "<span class='warning'>You place [src] on [H]'s chest.</span>")
 		playsound(src, 'sound/machines/defib_charge.ogg', 75, FALSE)
-		var/total_burn	= 0
-		var/total_brute	= 0
 		var/obj/item/organ/heart = H.getorgan(/obj/item/organ/heart)
 		if(do_after(user, 20, target = H)) //placed on chest and short delay to shock for dramatic effect, revive time is 5sec total
 			for(var/obj/item/carried_item in H.contents)
@@ -561,35 +559,36 @@
 				H.visible_message("<span class='warning'>[H]'s body convulses a bit.</span>")
 				playsound(src, "bodyfall", 50, TRUE)
 				playsound(src, 'sound/machines/defib_zap.ogg', 75, TRUE, -1)
-				total_brute	= H.getBruteLoss()
-				total_burn	= H.getFireLoss()
 				shock_touching(30, H)
-				var/failed
 
-				if (H.suiciding)
-					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Recovery of patient impossible. Further attempts futile.</span>"
-				else if (H.hellbound)
-					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's soul appears to be on another plane of existence. Further attempts futile.</span>"
-				else if (!heart)
-					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's heart is missing.</span>"
-				else if (heart.organ_flags & ORGAN_FAILING)
-					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's heart too damaged, replace or repair and try again.</span>"
-				else if(total_burn >= MAX_REVIVE_FIRE_DAMAGE || total_brute >= MAX_REVIVE_BRUTE_DAMAGE || HAS_TRAIT(H, TRAIT_HUSK))
-					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Tissue damage too severe, repair and try again.</span>"
-				else
-					var/obj/item/organ/brain/BR = H.getorgan(/obj/item/organ/brain)
-					if(BR)
-						if(BR.organ_flags & ORGAN_FAILING)
-							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's brain is too damaged, repair and try again. </span>"
-						if(BR.suicided || BR.brainmob?.suiciding)
-							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - No intelligence pattern can be detected in patient's brain. Further attempts futile.</span>"
-					else
-						failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's brain is missing. Further attempts futile.</span>"
+				var/defib_result = H.can_defib()
+				var/fail_reason
 
-				if(failed)
-					user.visible_message(failed)
+				switch (defib_result)
+					if (DEFIB_FAIL_SUICIDE)
+						fail_reason = "Recovery of patient impossible. Further attempts futile."
+					if (DEFIB_FAIL_HELLBOUND)
+						fail_reason = "Patient's soul appears to be on another plane of existence. Further attempts futile."
+					if (DEFIB_FAIL_NO_HEART)
+						fail_reason = "Patient's heart is missing."
+					if (DEFIB_FAIL_FAILING_HEART, DEFIB_FAIL_HUSK)
+						fail_reason = "Patient's heart too damaged, replace or repair and try again."
+					if (DEFIB_FAIL_TISSUE_DAMAGE)
+						fail_reason = "Tissue damage too severe, repair and try again."
+					if (DEFIB_FAIL_FAILING_BRAIN)
+						fail_reason = "Patient's brain is too damaged, repair and try again."
+					if (DEFIB_FAIL_NO_INTELLIGENCE)
+						fail_reason = "No intelligence pattern can be detected in patient's brain. Further attempts futile."
+					if (DEFIB_FAIL_NO_BRAIN)
+						fail_reason = "Patient's brain is missing. Further attempts futile."
+
+				if(fail_reason)
+					user.visible_message("<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - [fail_reason]</span>")
 					playsound(src, 'sound/machines/defib_failed.ogg', 50, FALSE)
 				else
+					var/total_brute = H.getBruteLoss()
+					var/total_burn = H.getFireLoss()
+
 					//If the body has been fixed so that they would not be in crit when defibbed, give them oxyloss to put them back into crit
 					if (H.health > HALFWAYCRITDEATH)
 						H.adjustOxyLoss(H.health - HALFWAYCRITDEATH, 0)

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -444,7 +444,7 @@
 		do_harm(H, user)
 		return
 
-	if(H.can_defib() != TRUE)
+	if(H.can_defib() == TRUE)
 		H.notify_ghost_cloning("Your heart is being defibrillated!")
 		H.grab_ghost() // Shove them back in their body.
 

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -571,9 +571,9 @@
 						fail_reason = "Patient's soul appears to be on another plane of existence. Further attempts futile."
 					if (DEFIB_FAIL_NO_HEART)
 						fail_reason = "Patient's heart is missing."
-					if (DEFIB_FAIL_FAILING_HEART, DEFIB_FAIL_HUSK)
+					if (DEFIB_FAIL_FAILING_HEART)
 						fail_reason = "Patient's heart too damaged, replace or repair and try again."
-					if (DEFIB_FAIL_TISSUE_DAMAGE)
+					if (DEFIB_FAIL_TISSUE_DAMAGE, DEFIB_FAIL_HUSK)
 						fail_reason = "Tissue damage too severe, repair and try again."
 					if (DEFIB_FAIL_FAILING_BRAIN)
 						fail_reason = "Patient's brain is too damaged, repair and try again."

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -875,7 +875,7 @@
 	if (BR.suicided || BR.brainmob.suiciding)
 		return DEFIB_FAIL_SUICIDE
 
-	return TRUE
+	return DEFIB_POSSIBLE
 
 /mob/living/carbon/harvest(mob/living/user)
 	if(QDELETED(src))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -853,27 +853,31 @@
 	if ((getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE) || (getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE))
 		return DEFIB_FAIL_TISSUE_DAMAGE
 
-	var/obj/item/organ/heart = getorgan(/obj/item/organ/heart)
+	// Plasmamen do not need a heart to live
+	if (!isplasmaman(src))
+		var/obj/item/organ/heart = getorgan(/obj/item/organ/heart)
 
-	if (!heart)
-		return DEFIB_FAIL_NO_HEART
+		if (!heart)
+			return DEFIB_FAIL_NO_HEART
 
-	if (heart.organ_flags & ORGAN_FAILING)
-		return DEFIB_FAIL_FAILING_HEART
+		if (heart.organ_flags & ORGAN_FAILING)
+			return DEFIB_FAIL_FAILING_HEART
 
-	var/obj/item/organ/brain/BR = getorgan(/obj/item/organ/brain)
+	// Carbons with HARS do not need a brain
+	if (!dna?.check_mutation(HARS))
+		var/obj/item/organ/brain/BR = getorgan(/obj/item/organ/brain)
 
-	if (QDELETED(BR))
-		return DEFIB_FAIL_NO_BRAIN
+		if (QDELETED(BR))
+			return DEFIB_FAIL_NO_BRAIN
 
-	if (BR.organ_flags & ORGAN_FAILING)
-		return DEFIB_FAIL_FAILING_BRAIN
+		if (BR.organ_flags & ORGAN_FAILING)
+			return DEFIB_FAIL_FAILING_BRAIN
 
-	if (!BR.brainmob)
-		return DEFIB_FAIL_NO_INTELLIGENCE
+		if (!BR.brainmob)
+			return DEFIB_FAIL_NO_INTELLIGENCE
 
-	if (BR.suicided || BR.brainmob.suiciding)
-		return DEFIB_FAIL_SUICIDE
+		if (BR.suicided || BR.brainmob.suiciding)
+			return DEFIB_FAIL_SUICIDE
 
 	return DEFIB_POSSIBLE
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -841,16 +841,40 @@
 		return 0
 
 /mob/living/carbon/proc/can_defib()
+	if (suiciding)
+		return DEFIB_FAIL_SUICIDE
+
+	if (hellbound)
+		return DEFIB_FAIL_HELLBOUND
+
+	if (HAS_TRAIT(src, TRAIT_HUSK))
+		return DEFIB_FAIL_HUSK
+
+	if ((getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE) || (getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE))
+		return DEFIB_FAIL_TISSUE_DAMAGE
+
 	var/obj/item/organ/heart = getorgan(/obj/item/organ/heart)
-	if(suiciding || hellbound || HAS_TRAIT(src, TRAIT_HUSK))
-		return
-	if((getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE) || (getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE))
-		return
-	if(!heart || (heart.organ_flags & ORGAN_FAILING))
-		return
+
+	if (!heart)
+		return DEFIB_FAIL_NO_HEART
+
+	if (heart.organ_flags & ORGAN_FAILING)
+		return DEFIB_FAIL_FAILING_HEART
+
 	var/obj/item/organ/brain/BR = getorgan(/obj/item/organ/brain)
-	if(QDELETED(BR) || (BR.organ_flags & ORGAN_FAILING) || BR.suicided)
-		return
+
+	if (QDELETED(BR))
+		return DEFIB_FAIL_NO_BRAIN
+
+	if (BR.organ_flags & ORGAN_FAILING)
+		return DEFIB_FAIL_FAILING_BRAIN
+
+	if (!BR.brainmob)
+		return DEFIB_FAIL_NO_INTELLIGENCE
+
+	if (BR.suicided || BR.brainmob.suiciding)
+		return DEFIB_FAIL_SUICIDE
+
 	return TRUE
 
 /mob/living/carbon/harvest(mob/living/user)

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -30,3 +30,5 @@
 	var/datum/antagonist/changeling/changeling = mind.has_antag_datum(/datum/antagonist/changeling)
 	if(changeling)
 		changeling.regain_powers()
+
+	med_hud_set_status()

--- a/code/modules/mob/living/logout.dm
+++ b/code/modules/mob/living/logout.dm
@@ -3,3 +3,4 @@
 	..()
 	if(!key && mind)	//key and mind have become separated.
 		mind.active = 0	//This is to stop say, a mind.transfer_to call on a corpse causing a ghost to re-enter its body.
+	med_hud_set_status()

--- a/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/code/modules/research/nanites/nanite_programs/healing.dm
@@ -224,8 +224,8 @@
 		return FALSE
 	var/mob/living/carbon/C = host_mob
 	if(C.get_ghost())
-		return FALSE
-	return C.can_defib() == TRUE
+		return DEFIB_POSSIBLE
+	return C.can_defib() == DEFIB_POSSIBLE
 
 /datum/nanite_program/defib/proc/zap()
 	var/mob/living/carbon/C = host_mob

--- a/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/code/modules/research/nanites/nanite_programs/healing.dm
@@ -224,7 +224,7 @@
 		return FALSE
 	var/mob/living/carbon/C = host_mob
 	if(C.get_ghost())
-		return DEFIB_POSSIBLE
+		return FALSE
 	return C.can_defib() == DEFIB_POSSIBLE
 
 /datum/nanite_program/defib/proc/zap()

--- a/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/code/modules/research/nanites/nanite_programs/healing.dm
@@ -225,7 +225,7 @@
 	var/mob/living/carbon/C = host_mob
 	if(C.get_ghost())
 		return FALSE
-	return C.can_defib()
+	return C.can_defib() == TRUE
 
 /datum/nanite_program/defib/proc/zap()
 	var/mob/living/carbon/C = host_mob


### PR DESCRIPTION
## About The Pull Request
The medical HUDs will report an icon when someone is defibbable. This occasionally will report inconsistent results, meaning its usefulness is diminished. It will sometimes report bodies as defibbable even though they have committed suicide, for example. This PR fixes this--if it is impossible for a carbon to be recovered, it will show as a skull. If it is somehow possible to be defibbed (such as simply having a lot of brute/burn damage), it will correctly show the defib icon.

This code also changes the return type of `/mob/living/carbon/proc/can_defib` to return either TRUE or a bit flag detailing why the carbon cannot be defibbed. This is then used to remove code that duplicates these checks to tell the user why the defibrilation failed.

## Why It's Good For The Game

Doctors should be able to trust the medical HUD.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed the medical HUD sometimes reporting undefibbable bodies as defibbable and vice versa.
fix: Fixed plasmamen needing hearts in order to be defibbed.
fix: Fixed crew with HARS needing a brain to be defibbed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
