### PR TITLE
Nerfs wizard minswap

### DIFF
--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -44,12 +44,14 @@
 		to_chat(user, "<span class='warning'>The devilish contract doesn't include the 'mind swappable' package, please try again another lifetime.</span>")
 		user.death(FALSE) //fancy suicide
 		user.ghostize(FALSE)
+		return
 
 	//You should not be able to enter a statue that is nearly indestructible
 	if(HAS_TRAIT_FROM(victim, TRAIT_MUTE, STATUE_MUTE)) // that means it is a statue okay?
 		to_chat(user, "<span class='warning'>Your mind leaves your body but the stone resists your influence stranding you in the ethereal plane!</span>")
 		user.death(FALSE) //fancy suicide
 		user.ghostize(FALSE)
+		return
 
 	//MIND TRANSFER BEGIN
 	var/mob/dead/observer/ghost = victim.ghostize()

--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -42,15 +42,11 @@
 	//You should not be able to enter one of the most powerful side-antags as a fucking wizard.
 	if(istype(victim,/mob/living/simple_animal/slaughter))
 		to_chat(user, "<span class='warning'>The devilish contract doesn't include the 'mind swappable' package, please try again another lifetime.</span>")
-		user.death(FALSE) //fancy suicide
-		user.ghostize(FALSE)
 		return
 
 	//You should not be able to enter a statue that is nearly indestructible
 	if(HAS_TRAIT_FROM(victim, TRAIT_MUTE, STATUE_MUTE)) // that means it is a statue okay?
-		to_chat(user, "<span class='warning'>Your mind leaves your body but the stone resists your influence stranding you in the ethereal plane!</span>")
-		user.death(FALSE) //fancy suicide
-		user.ghostize(FALSE)
+		to_chat(user, "<span class='warning'>Your mind leaves your body but the stone resists your influence!/span>")
 		return
 
 	//MIND TRANSFER BEGIN

--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -39,6 +39,18 @@
 		if(stand.summoner)
 			victim = stand.summoner
 
+	//You should not be able to enter one of the most powerful side-antags as a fucking wizard.
+	if(istype(victim,/mob/living/simple_animal/slaughter))
+		to_chat(user, "<span class='warning'>The devilish contract doesn't include the 'mind swappable' package, please try again another lifetime.</span>")
+		user.death(FALSE) //fancy suicide
+		user.ghostize(FALSE)
+
+	//You should not be able to enter a statue that is nearly indestructible
+	if(HAS_TRAIT_FROM(victim, TRAIT_MUTE, STATUE_MUTE)) // that means it is a statue okay?
+		to_chat(user, "<span class='warning'>Your mind leaves your body but the stone resists your influence stranding you in the ethereal plane!</span>")
+		user.death(FALSE) //fancy suicide
+		user.ghostize(FALSE)
+
 	//MIND TRANSFER BEGIN
 	var/mob/dead/observer/ghost = victim.ghostize()
 	user.mind.transfer_to(victim)


### PR DESCRIPTION
## About The Pull Request
Makes mindswapping into petrified people OR mindswapping into summoned demons rejects you.

## Why It's Good For The Game

Giving our most powerful antags neigh-invincibility OR giving them the strength and abilities of one of the most-powerful side antags is not fun, since fighting a slaughter demon is hard enough, imagine fighting one that has fireball.

## Changelog
:cl:
balance: Wizard can no longer mindswap into a statue to become neigh invicible, fire throwing bastard.
balance: Wizard can no longer mindswap into laughter or slaughter demons to gain a free jaunt and an unlimited heals for killing people. You know one thing that wizard is good at...
/:cl:
