### PR TITLE
Tiny, most likely unnoticeable tgui fix

### DIFF
--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -66,7 +66,7 @@
 	// If there was no ui to update, there's no static data to update either.
 	if(!ui)
 		return
-	ui.push_data(null, ui_static_data(), TRUE)
+	ui.push_data(null, ui_static_data(user), TRUE)
 
 /**
  * public


### PR DESCRIPTION
`update_static_data` now passes `user` to `push_data()`.

I'm pretty sure no UIs currently use `user` in `ui_static_data` for... Anything. So that's why no one noticed this before. Well, better to pass it than not.